### PR TITLE
core/resource: Phase 5 of RFC #2972 — physically split Value into Concrete/Deferred axis

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -15,7 +15,7 @@ use carina_core::executor::{ExecutionInput, ExecutionResult};
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer, ReadRequest};
 use carina_core::resolver::resolve_refs_with_state_and_remote;
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::value::format_value;
 use carina_state::{LockInfo, StateBackend, StateFile, resolve_backend};
 
@@ -158,7 +158,12 @@ mod upstream_snapshot_tests {
     fn binding(name: &str, attrs: &[(&str, &str)]) -> (String, HashMap<String, Value>) {
         let map = attrs
             .iter()
-            .map(|(k, v)| (k.to_string(), Value::String(v.to_string())))
+            .map(|(k, v)| {
+                (
+                    k.to_string(),
+                    Value::Concrete(ConcreteValue::String(v.to_string())),
+                )
+            })
             .collect();
         (name.to_string(), map)
     }
@@ -510,7 +515,7 @@ pub async fn run_apply(
                 .attributes
                 .get("bucket")
                 .and_then(|v| match v {
-                    Value::String(s) => Some(s.clone()),
+                    Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                     _ => None,
                 })
                 .ok_or("Missing bucket name in backend configuration")?;
@@ -569,7 +574,7 @@ pub async fn run_apply(
                     .attributes
                     .get("auto_create")
                     .and_then(|v| match v {
-                        Value::Bool(b) => Some(*b),
+                        Value::Concrete(ConcreteValue::Bool(b)) => Some(*b),
                         _ => None,
                     })
                     .unwrap_or(true);

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -18,11 +18,11 @@ fn build_state_after_apply_finds_write_only_with_provider_prefix() {
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
     resource.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     resource.set_attr(
         "ipv4_netmask_length".to_string(),
-        Value::String("16".to_string()),
+        Value::Concrete(ConcreteValue::String("16".to_string())),
     );
 
     let sorted_resources = vec![resource];
@@ -31,7 +31,7 @@ fn build_state_after_apply_finds_write_only_with_provider_prefix() {
     let mut applied_attrs = HashMap::new();
     applied_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     let applied_state = State::existing(sorted_resources[0].id.clone(), applied_attrs);
     let mut applied_states = HashMap::new();
@@ -97,24 +97,26 @@ fn build_state_after_apply_preserves_block_name_attribute() {
     let mut resource = Resource::with_provider("awscc", "iam.role", "test-role");
     resource.set_attr(
         "role_name".to_string(),
-        Value::String("test-role".to_string()),
+        Value::Concrete(ConcreteValue::String("test-role".to_string())),
     );
     resource.set_attr(
         "policies".to_string(),
-        Value::List(vec![Value::Map(
-            vec![
-                (
-                    "policy_name".to_string(),
-                    Value::String("test-policy".to_string()),
-                ),
-                (
-                    "policy_document".to_string(),
-                    Value::String("{}".to_string()),
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        )]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        Value::Concrete(ConcreteValue::String("test-policy".to_string())),
+                    ),
+                    (
+                        "policy_document".to_string(),
+                        Value::Concrete(ConcreteValue::String("{}".to_string())),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        )])),
     );
 
     let sorted_resources = vec![resource];
@@ -124,24 +126,26 @@ fn build_state_after_apply_preserves_block_name_attribute() {
     let mut applied_attrs = HashMap::new();
     applied_attrs.insert(
         "role_name".to_string(),
-        Value::String("test-role".to_string()),
+        Value::Concrete(ConcreteValue::String("test-role".to_string())),
     );
     applied_attrs.insert(
         "policies".to_string(),
-        Value::List(vec![Value::Map(
-            vec![
-                (
-                    "policy_name".to_string(),
-                    Value::String("test-policy".to_string()),
-                ),
-                (
-                    "policy_document".to_string(),
-                    Value::String("{}".to_string()),
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        )]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        Value::Concrete(ConcreteValue::String("test-policy".to_string())),
+                    ),
+                    (
+                        "policy_document".to_string(),
+                        Value::Concrete(ConcreteValue::String("{}".to_string())),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        )])),
     );
     let applied_state = State::existing(sorted_resources[0].id.clone(), applied_attrs)
         .with_identifier("some-identifier");
@@ -231,48 +235,52 @@ fn block_name_attribute_no_diff_when_hydrated() {
     let mut resource = Resource::with_provider("awscc", "iam.role", "test-role");
     resource.set_attr(
         "role_name".to_string(),
-        Value::String("test-role".to_string()),
+        Value::Concrete(ConcreteValue::String("test-role".to_string())),
     );
     resource.set_attr(
         "policies".to_string(),
-        Value::List(vec![Value::Map(
-            vec![
-                (
-                    "policy_name".to_string(),
-                    Value::String("test-policy".to_string()),
-                ),
-                (
-                    "policy_document".to_string(),
-                    Value::String("{}".to_string()),
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        )]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        Value::Concrete(ConcreteValue::String("test-policy".to_string())),
+                    ),
+                    (
+                        "policy_document".to_string(),
+                        Value::Concrete(ConcreteValue::String("{}".to_string())),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        )])),
     );
 
     // Current state: simulate hydration restoring the policies attribute
     let mut state_attrs = HashMap::new();
     state_attrs.insert(
         "role_name".to_string(),
-        Value::String("test-role".to_string()),
+        Value::Concrete(ConcreteValue::String("test-role".to_string())),
     );
     state_attrs.insert(
         "policies".to_string(),
-        Value::List(vec![Value::Map(
-            vec![
-                (
-                    "policy_name".to_string(),
-                    Value::String("test-policy".to_string()),
-                ),
-                (
-                    "policy_document".to_string(),
-                    Value::String("{}".to_string()),
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        )]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        Value::Concrete(ConcreteValue::String("test-policy".to_string())),
+                    ),
+                    (
+                        "policy_document".to_string(),
+                        Value::Concrete(ConcreteValue::String("{}".to_string())),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        )])),
     );
     let current = State::existing(resource.id.clone(), state_attrs).with_identifier("some-id");
 
@@ -337,18 +345,20 @@ fn block_name_attribute_state_roundtrip() {
     let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam");
     resource.set_attr(
         "operating_regions".to_string(),
-        Value::List(vec![Value::Map(
-            vec![(
-                "region_name".to_string(),
-                Value::String("ap-northeast-1".to_string()),
-            )]
-            .into_iter()
-            .collect(),
-        )]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(
+                vec![(
+                    "region_name".to_string(),
+                    Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+        )])),
     );
     resource.set_attr(
         "description".to_string(),
-        Value::String("test IPAM".to_string()),
+        Value::Concrete(ConcreteValue::String("test IPAM".to_string())),
     );
 
     let sorted_resources = vec![resource];
@@ -357,18 +367,20 @@ fn block_name_attribute_state_roundtrip() {
     let mut applied_attrs = HashMap::new();
     applied_attrs.insert(
         "description".to_string(),
-        Value::String("test IPAM".to_string()),
+        Value::Concrete(ConcreteValue::String("test IPAM".to_string())),
     );
     applied_attrs.insert(
         "operating_regions".to_string(),
-        Value::List(vec![Value::Map(
-            vec![(
-                "region_name".to_string(),
-                Value::String("ap-northeast-1".to_string()),
-            )]
-            .into_iter()
-            .collect(),
-        )]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(
+                vec![(
+                    "region_name".to_string(),
+                    Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+        )])),
     );
     let applied_state = State::existing(sorted_resources[0].id.clone(), applied_attrs)
         .with_identifier("ipam-12345");
@@ -419,12 +431,14 @@ fn block_name_attribute_state_roundtrip() {
         .expect("should have operating_regions");
 
     // Verify the value structure is preserved
-    if let Value::List(items) = operating_regions {
+    if let Value::Concrete(ConcreteValue::List(items)) = operating_regions {
         assert_eq!(items.len(), 1);
-        if let Value::Map(map) = &items[0] {
+        if let Value::Concrete(ConcreteValue::Map(map)) = &items[0] {
             assert_eq!(
                 map.get("region_name"),
-                Some(&Value::String("ap-northeast-1".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "ap-northeast-1".to_string()
+                )))
             );
         } else {
             panic!("Expected Map in list, got {:?}", items[0]);
@@ -461,7 +475,7 @@ fn format_duration_zero() {
 #[test]
 fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
     use carina_state::StateFile;
 
     // Build a state file with a resource that has a binding and attributes
@@ -494,7 +508,9 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     let export_params = vec![ExportParameter {
         name: "account_id".to_string(),
         type_expr: TypeExpr::Unknown,
-        value: Some(Value::String("registry_prod.account_id".to_string())),
+        value: Some(Value::Concrete(ConcreteValue::String(
+            "registry_prod.account_id".to_string(),
+        ))),
     }];
 
     // Mirror production callers: the resource is in sorted_resources
@@ -524,7 +540,7 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
     // referencing `<module_call>.<attr>` failed with
     // `unresolved reference <call>.<attr>`.
     use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
-    use carina_core::resource::{AccessPath, ResourceKind, Value};
+    use carina_core::resource::{AccessPath, DeferredValue, ResourceKind, Value};
     use carina_state::StateFile;
 
     let state = {
@@ -564,18 +580,18 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
     };
     virtual_resource.attributes.insert(
         "role_arn".to_string(),
-        Value::ResourceRef {
+        Value::Deferred(DeferredValue::ResourceRef {
             path: AccessPath::new("github_actions_carina.role", "arn"),
-        },
+        }),
     );
     let sorted_resources = vec![role_resource, virtual_resource];
 
     let export_params = vec![ExportParameter {
         name: "role_arn".to_string(),
         type_expr: TypeExpr::Unknown,
-        value: Some(Value::ResourceRef {
+        value: Some(Value::Deferred(DeferredValue::ResourceRef {
             path: AccessPath::new("github_actions_carina", "role_arn"),
-        }),
+        })),
     }];
 
     let exports = resolve_exports(&export_params, &sorted_resources, &state).unwrap();
@@ -601,7 +617,7 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
     // role's `arn` from state. Pins the resolver's transitive walk so a
     // regression that broke after a single hop would surface.
     use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
-    use carina_core::resource::{AccessPath, ResourceKind, Value};
+    use carina_core::resource::{AccessPath, DeferredValue, ResourceKind, Value};
     use carina_state::StateFile;
 
     let state = {
@@ -637,9 +653,9 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
     };
     inner_virtual.attributes.insert(
         "role_arn".to_string(),
-        Value::ResourceRef {
+        Value::Deferred(DeferredValue::ResourceRef {
             path: AccessPath::new("outer.inner.role", "arn"),
-        },
+        }),
     );
 
     let mut outer_virtual = Resource::new("_virtual", "outer");
@@ -650,9 +666,9 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
     };
     outer_virtual.attributes.insert(
         "public_role_arn".to_string(),
-        Value::ResourceRef {
+        Value::Deferred(DeferredValue::ResourceRef {
             path: AccessPath::new("outer.inner", "role_arn"),
-        },
+        }),
     );
 
     let sorted_resources = vec![role_resource, inner_virtual, outer_virtual];
@@ -660,9 +676,9 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
     let export_params = vec![ExportParameter {
         name: "role_arn".to_string(),
         type_expr: TypeExpr::Unknown,
-        value: Some(Value::ResourceRef {
+        value: Some(Value::Deferred(DeferredValue::ResourceRef {
             path: AccessPath::new("outer", "public_role_arn"),
-        }),
+        })),
     }];
 
     let exports = resolve_exports(&export_params, &sorted_resources, &state).unwrap();

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -16,7 +16,7 @@ use carina_core::deps::{
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
 use carina_core::provider::Provider;
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_state::{LockInfo, StateBackend, resolve_backend};
 
 use carina_core::parser::ProviderContext;
@@ -75,7 +75,7 @@ pub async fn run_destroy(
     // Get the state bucket name for protection check (S3 backend only)
     if let Some(config) = backend_config {
         protected_bucket = config.attributes.get("bucket").and_then(|v| match v {
-            Value::String(s) => Some(s.clone()),
+            Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
             _ => None,
         });
     }
@@ -297,7 +297,7 @@ async fn run_destroy_locked(
             if let Some(backend_rt) = backend.resource_type()
                 && r.id.resource_type == backend_rt
                 && let Some(ref bucket_name) = protected_bucket
-                && let Some(Value::String(name)) = r.get_attr("bucket")
+                && let Some(Value::Concrete(ConcreteValue::String(name))) = r.get_attr("bucket")
                 && name == bucket_name
             {
                 protected_resources.push(r);

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -468,14 +468,20 @@ fn split_validation_message(joined: &str) -> Vec<AppError> {
 mod tests {
     use super::*;
     use carina_core::parser::ProviderConfig;
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
     use indexmap::IndexMap;
     use std::collections::HashMap;
 
     fn s3_backend_config(bucket: &str, region: &str) -> BackendConfig {
         let mut attributes = HashMap::new();
-        attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
-        attributes.insert("region".to_string(), Value::String(region.to_string()));
+        attributes.insert(
+            "bucket".to_string(),
+            Value::Concrete(ConcreteValue::String(bucket.to_string())),
+        );
+        attributes.insert(
+            "region".to_string(),
+            Value::Concrete(ConcreteValue::String(region.to_string())),
+        );
         BackendConfig {
             backend_type: "s3".to_string(),
             attributes,

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -9,7 +9,7 @@ use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::effect::Effect;
 use carina_core::parser::{BackendConfig, ProviderConfig, ProviderContext, UpstreamState};
 use carina_core::plan::Plan;
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};
 use carina_core::value::{
     redact_secrets_in_plan, redact_secrets_in_resource, redact_secrets_in_state,
 };
@@ -193,7 +193,7 @@ pub async fn run_plan(
                 .attributes
                 .get("bucket")
                 .and_then(|v| match v {
-                    Value::String(s) => Some(s.clone()),
+                    Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                     _ => None,
                 })
                 .ok_or("Backend bucket name not specified")?;
@@ -206,7 +206,7 @@ pub async fn run_plan(
                 r.id.resource_type == backend_resource_type
                     && r.attributes
                         .get("bucket")
-                        .is_some_and(|v| matches!(v, Value::String(s) if s == &bucket_name))
+                        .is_some_and(|v| matches!(v, Value::Concrete(ConcreteValue::String(s)) if s == &bucket_name))
             });
 
             if !has_bucket_resource {
@@ -214,7 +214,7 @@ pub async fn run_plan(
                     .attributes
                     .get("auto_create")
                     .and_then(|v| match v {
-                        Value::Bool(b) => Some(*b),
+                        Value::Concrete(ConcreteValue::Bool(b)) => Some(*b),
                         _ => None,
                     })
                     .unwrap_or(true);
@@ -412,7 +412,7 @@ pub async fn run_plan(
 /// For each `remote_state` block, reads the referenced state file and builds a
 /// map of resource bindings to their attributes. The result maps each remote_state
 /// binding name to a `HashMap<String, Value>` where keys are resource binding names
-/// and values are `Value::Map` of that resource's attributes.
+/// and values are `Value::Concrete(ConcreteValue::Map)` of that resource's attributes.
 /// Resolve export value expressions for plan display.
 pub(crate) fn resolve_export_values_for_display(
     export_params: &[carina_core::parser::InferredExportParam],
@@ -449,11 +449,11 @@ pub(crate) fn resolve_export_value(
     use carina_core::resolver::resolve_ref_value;
 
     match value {
-        Value::ResourceRef { .. } => {
+        Value::Deferred(DeferredValue::ResourceRef { .. }) => {
             resolve_ref_value(value, bindings).unwrap_or_else(|_| value.clone())
         }
         // Cross-file: "binding.attr" parsed as String instead of ResourceRef
-        Value::String(s) if s.contains('.') && !s.contains(' ') => {
+        Value::Concrete(ConcreteValue::String(s)) if s.contains('.') && !s.contains(' ') => {
             let parts: Vec<&str> = s.splitn(2, '.').collect();
             if parts.len() == 2
                 && let Some(attrs) = bindings.get(parts[0])
@@ -463,19 +463,19 @@ pub(crate) fn resolve_export_value(
             }
             value.clone()
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             let resolved: Vec<Value> = items
                 .iter()
                 .map(|item| resolve_export_value(item, bindings))
                 .collect();
-            Value::List(resolved)
+            Value::Concrete(ConcreteValue::List(resolved))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let resolved: indexmap::IndexMap<String, Value> = map
                 .iter()
                 .map(|(k, v)| (k.clone(), resolve_export_value(v, bindings)))
                 .collect();
-            Value::Map(resolved)
+            Value::Concrete(ConcreteValue::Map(resolved))
         }
         _ => value.clone(),
     }
@@ -532,7 +532,7 @@ pub fn compute_export_diffs(
         // plan display; surface as `None` so the diff prints without
         // a type tag.
         let type_expr = param.type_expr.clone().into_known();
-        // Plan display tolerates `Value::Unknown` in the export rhs
+        // Plan display tolerates `Value::Deferred(DeferredValue::Unknown)` in the export rhs
         // (the deferred-for body will resolve it later). Map both the
         // skip variants and the Unknown error to `None`; the diff
         // surfaces as a "value not yet known" change without a JSON.
@@ -833,7 +833,7 @@ mod load_upstream_states_tests {
 
         assert_eq!(
             result["orgs"]["account_id"],
-            Value::String("123".to_string())
+            Value::Concrete(ConcreteValue::String("123".to_string()))
         );
     }
 
@@ -1053,7 +1053,7 @@ let internal = upstream_state {{ source = '{}' }}"#,
         );
         assert_eq!(
             bindings["bootstrap"]["oidc_provider_arn"],
-            Value::String("arn:...".to_string()),
+            Value::Concrete(ConcreteValue::String("arn:...".to_string())),
             "B's exports must come through unchanged"
         );
     }
@@ -1196,7 +1196,7 @@ exports { region: String = "ap-northeast-1" }"#,
         .expect("upstream bindings");
         assert_eq!(
             bindings["a"]["region"],
-            Value::String("ap-northeast-1".to_string())
+            Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string()))
         );
     }
 }
@@ -1260,7 +1260,7 @@ mod export_diff_tests {
 
     #[test]
     fn compute_export_diffs_added_when_state_empty() {
-        let params = vec![param("count", Value::Int(42))];
+        let params = vec![param("count", Value::Concrete(ConcreteValue::Int(42)))];
         let current = HashMap::new();
         let changes = compute_export_diffs(&params, &current);
         assert_eq!(changes.len(), 1);
@@ -1269,7 +1269,7 @@ mod export_diff_tests {
 
     #[test]
     fn compute_export_diffs_modified_when_value_differs() {
-        let params = vec![param("count", Value::Int(42))];
+        let params = vec![param("count", Value::Concrete(ConcreteValue::Int(42)))];
         let mut current = HashMap::new();
         current.insert("count".to_string(), serde_json::json!(7));
         let changes = compute_export_diffs(&params, &current);
@@ -1279,7 +1279,7 @@ mod export_diff_tests {
 
     #[test]
     fn compute_export_diffs_unchanged_when_value_matches() {
-        let params = vec![param("count", Value::Int(42))];
+        let params = vec![param("count", Value::Concrete(ConcreteValue::Int(42)))];
         let mut current = HashMap::new();
         current.insert("count".to_string(), serde_json::json!(42));
         let changes = compute_export_diffs(&params, &current);
@@ -1299,8 +1299,8 @@ mod export_diff_tests {
     #[test]
     fn compute_export_diffs_mixed_sorted_by_name() {
         let params = vec![
-            param("added", Value::Int(1)),
-            param("modified", Value::Int(2)),
+            param("added", Value::Concrete(ConcreteValue::Int(1))),
+            param("modified", Value::Concrete(ConcreteValue::Int(2))),
         ];
         let mut current = HashMap::new();
         current.insert("modified".to_string(), serde_json::json!(99));
@@ -1321,12 +1321,14 @@ mod plan_serialization_error_tests {
     //! the actionable wording and that every effect shape (top-level
     //! attributes, nested List/Map, Replace cascade) propagates the
     //! error.
-    use carina_core::resource::{AccessPath, Resource, UnknownReason, Value};
+    use carina_core::resource::{
+        AccessPath, ConcreteValue, DeferredValue, Resource, UnknownReason, Value,
+    };
     use carina_core::value::{SerializationError, redact_secrets_in_resource, value_to_json};
 
     fn upstream_unknown() -> Value {
         let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-        Value::Unknown(UnknownReason::UpstreamRef { path })
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path }))
     }
 
     #[test]
@@ -1345,7 +1347,10 @@ mod plan_serialization_error_tests {
 
     #[test]
     fn value_to_json_errors_on_unknown_inside_list_or_map() {
-        let list_val = Value::List(vec![Value::String("a".into()), upstream_unknown()]);
+        let list_val = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("a".into())),
+            upstream_unknown(),
+        ]));
         assert!(matches!(
             value_to_json(&list_val).unwrap_err(),
             SerializationError::UnknownNotAllowed { .. }
@@ -1354,7 +1359,7 @@ mod plan_serialization_error_tests {
         let mut m: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
         m.insert("Name".into(), upstream_unknown());
         assert!(matches!(
-            value_to_json(&Value::Map(m)).unwrap_err(),
+            value_to_json(&Value::Concrete(ConcreteValue::Map(m))).unwrap_err(),
             SerializationError::UnknownNotAllowed { .. }
         ));
     }
@@ -1377,7 +1382,8 @@ mod plan_serialization_error_tests {
             (UnknownReason::ForKey, "ForKey"),
             (UnknownReason::ForIndex, "ForIndex"),
         ] {
-            let err = value_to_json(&Value::Unknown(variant.clone())).unwrap_err();
+            let err = value_to_json(&Value::Deferred(DeferredValue::Unknown(variant.clone())))
+                .unwrap_err();
             match err {
                 SerializationError::UnknownNotAllowed { reason, .. } => {
                     assert_eq!(reason, variant, "expected {label} round-trip");

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use carina_core::effect::Effect;
 use carina_core::executor::ExecutionResult;
 use carina_core::plan::Plan;
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 use carina_state::{LockInfo, ResourceState, StateBackend, StateFile};
 
@@ -34,9 +34,10 @@ pub(crate) fn apply_name_overrides(resources: &mut [Resource], state_file: &Opti
     for resource in resources.iter_mut() {
         if let Some(name_overrides) = overrides.get(&resource.id) {
             for (attr, value) in name_overrides {
-                resource
-                    .attributes
-                    .insert(attr.clone(), Value::String(value.clone()));
+                resource.attributes.insert(
+                    attr.clone(),
+                    Value::Concrete(ConcreteValue::String(value.clone())),
+                );
             }
         }
     }
@@ -147,7 +148,7 @@ pub(crate) fn resolve_exports(
 ///
 /// Returns:
 /// - `Ok(Some(json))` for a representable concrete value
-/// - `Ok(None)` for `Value::Secret` (state.exports must not embed
+/// - `Ok(None)` for `Value::Deferred(DeferredValue::Secret)` (state.exports must not embed
 ///   plaintext secrets, so exports of secret-typed values are skipped)
 /// - `Err(SerializationError)` for variants that should not have
 ///   reached this boundary — the resolver / canonicalize / for-expand
@@ -156,16 +157,20 @@ pub(crate) fn resolve_exports(
 pub(crate) fn dsl_value_to_json(
     value: &carina_core::resource::Value,
 ) -> Result<Option<serde_json::Value>, carina_core::value::SerializationError> {
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, DeferredValue, Value};
     use carina_core::value::{SerializationContext, SerializationError};
     let ctx = SerializationContext::StateWriteback;
     match value {
-        Value::String(s) => Ok(Some(serde_json::Value::String(s.clone()))),
-        Value::Bool(b) => Ok(Some(serde_json::Value::Bool(*b))),
-        Value::Int(i) => Ok(Some(serde_json::Value::Number((*i).into()))),
-        Value::Float(f) => Ok(serde_json::Number::from_f64(*f).map(serde_json::Value::Number)),
-        Value::Duration(d) => Ok(Some(serde_json::Value::Number((d.as_secs() as i64).into()))),
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::String(s)) => Ok(Some(serde_json::Value::String(s.clone()))),
+        Value::Concrete(ConcreteValue::Bool(b)) => Ok(Some(serde_json::Value::Bool(*b))),
+        Value::Concrete(ConcreteValue::Int(i)) => Ok(Some(serde_json::Value::Number((*i).into()))),
+        Value::Concrete(ConcreteValue::Float(f)) => {
+            Ok(serde_json::Number::from_f64(*f).map(serde_json::Value::Number))
+        }
+        Value::Concrete(ConcreteValue::Duration(d)) => {
+            Ok(Some(serde_json::Value::Number((d.as_secs() as i64).into())))
+        }
+        Value::Concrete(ConcreteValue::List(items)) => {
             // `Result::transpose` flips `Result<Option<T>, E>` to
             // `Option<Result<T, E>>`, so `filter_map` drops the
             // `Ok(None)` skips and propagates `Err`.
@@ -176,13 +181,13 @@ pub(crate) fn dsl_value_to_json(
                 .collect::<Result<_, _>>()?;
             Ok(Some(serde_json::Value::Array(json_items)))
         }
-        Value::StringList(items) => Ok(Some(serde_json::Value::Array(
+        Value::Concrete(ConcreteValue::StringList(items)) => Ok(Some(serde_json::Value::Array(
             items
                 .iter()
                 .map(|s| serde_json::Value::String(s.clone()))
                 .collect(),
         ))),
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let json_map: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| dsl_value_to_json(v).map(|jv| jv.map(|j| (k.clone(), j))))
@@ -190,26 +195,34 @@ pub(crate) fn dsl_value_to_json(
                 .collect::<Result<_, _>>()?;
             Ok(Some(serde_json::Value::Object(json_map)))
         }
-        Value::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {
-            reason: reason.clone(),
-            context: ctx,
-        }),
-        Value::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
-            path: path.to_dot_string(),
-            context: ctx,
-        }),
-        Value::BindingRef { binding } => Err(SerializationError::UnresolvedResourceRef {
-            path: binding.clone(),
-            context: ctx,
-        }),
-        Value::Interpolation(_) => {
+        Value::Deferred(DeferredValue::Unknown(reason)) => {
+            Err(SerializationError::UnknownNotAllowed {
+                reason: reason.clone(),
+                context: ctx,
+            })
+        }
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            Err(SerializationError::UnresolvedResourceRef {
+                path: path.to_dot_string(),
+                context: ctx,
+            })
+        }
+        Value::Deferred(DeferredValue::BindingRef { binding }) => {
+            Err(SerializationError::UnresolvedResourceRef {
+                path: binding.clone(),
+                context: ctx,
+            })
+        }
+        Value::Deferred(DeferredValue::Interpolation(_)) => {
             Err(SerializationError::UnresolvedInterpolation { context: ctx })
         }
-        Value::FunctionCall { name, .. } => Err(SerializationError::UnresolvedFunctionCall {
-            name: name.clone(),
-            context: ctx,
-        }),
-        Value::Secret(_) => Ok(None),
+        Value::Deferred(DeferredValue::FunctionCall { name, .. }) => {
+            Err(SerializationError::UnresolvedFunctionCall {
+                name: name.clone(),
+                context: ctx,
+            })
+        }
+        Value::Deferred(DeferredValue::Secret(_)) => Ok(None),
     }
 }
 
@@ -364,17 +377,19 @@ pub(crate) fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceI
 #[cfg(test)]
 mod stage4_unknown_err_tests {
     use super::*;
-    use carina_core::resource::{AccessPath, UnknownReason, Value};
+    use carina_core::resource::{AccessPath, ConcreteValue, DeferredValue, UnknownReason, Value};
     use carina_core::value::{SerializationContext, SerializationError};
 
     /// RFC #2371 stage 4 contract pin: `dsl_value_to_json` returns
-    /// `Err(SerializationError::UnknownNotAllowed)` for `Value::Unknown`.
+    /// `Err(SerializationError::UnknownNotAllowed)` for `Value::Deferred(DeferredValue::Unknown)`.
     /// State files must never carry the variant (constraint b); a
     /// silent fallback would re-introduce v1 corruption.
     #[test]
     fn unknown_returns_err_in_dsl_value_to_json() {
         let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-        let v = Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+        let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+            path: path.clone(),
+        }));
         let err = dsl_value_to_json(&v).unwrap_err();
         match err {
             SerializationError::UnknownNotAllowed {
@@ -387,14 +402,14 @@ mod stage4_unknown_err_tests {
         }
     }
 
-    /// `Value::ResourceRef` reaching apply-time export resolution
+    /// `Value::Deferred(DeferredValue::ResourceRef)` reaching apply-time export resolution
     /// is a resolver bug — surface as `UnresolvedResourceRef` instead
     /// of silently dropping the export. (#2385)
     #[test]
     fn resource_ref_returns_unresolved_err() {
-        let v = Value::ResourceRef {
+        let v = Value::Deferred(DeferredValue::ResourceRef {
             path: AccessPath::with_fields("net", "vpc", vec!["vpc_id".into()]),
-        };
+        });
         let err = dsl_value_to_json(&v).unwrap_err();
         assert!(
             matches!(
@@ -408,12 +423,14 @@ mod stage4_unknown_err_tests {
         );
     }
 
-    /// `Value::Interpolation` reaching apply-time is a resolver /
+    /// `Value::Deferred(DeferredValue::Interpolation)` reaching apply-time is a resolver /
     /// canonicalize bug — surface as `UnresolvedInterpolation`. (#2386)
     #[test]
     fn interpolation_returns_unresolved_err() {
         use carina_core::resource::InterpolationPart;
-        let v = Value::Interpolation(vec![InterpolationPart::Literal("x".into())]);
+        let v = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("x".into()),
+        ]));
         let err = dsl_value_to_json(&v).unwrap_err();
         assert!(
             matches!(
@@ -426,14 +443,14 @@ mod stage4_unknown_err_tests {
         );
     }
 
-    /// `Value::FunctionCall` reaching apply-time is a resolver bug —
+    /// `Value::Deferred(DeferredValue::FunctionCall)` reaching apply-time is a resolver bug —
     /// surface as `UnresolvedFunctionCall`. (#2386)
     #[test]
     fn function_call_returns_unresolved_err() {
-        let v = Value::FunctionCall {
+        let v = Value::Deferred(DeferredValue::FunctionCall {
             name: "join".into(),
             args: vec![],
-        };
+        });
         let err = dsl_value_to_json(&v).unwrap_err();
         assert!(
             matches!(
@@ -447,11 +464,13 @@ mod stage4_unknown_err_tests {
         );
     }
 
-    /// `Value::Secret` continues to be skipped silently — exports must
+    /// `Value::Deferred(DeferredValue::Secret)` continues to be skipped silently — exports must
     /// not embed plaintext secrets in state.
     #[test]
     fn secret_returns_ok_none() {
-        let v = Value::Secret(Box::new(Value::String("password".into())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("password".into()),
+        ))));
         assert!(matches!(dsl_value_to_json(&v), Ok(None)));
     }
 }

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -11,7 +11,7 @@ use carina_core::effect::Effect;
 use carina_core::parser::ProviderContext;
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, LockInfo, ResourceState, StateBackend,
@@ -474,7 +474,7 @@ async fn run_state_bucket_delete(
         .attributes
         .get("bucket")
         .and_then(|v| match v {
-            Value::String(s) => Some(s.as_str()),
+            Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
             _ => None,
         })
         .ok_or("Backend configuration missing 'bucket' attribute")?;

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -18,7 +18,7 @@ use carina_core::plan_tree::shorten_attr_name;
 use carina_core::plan_tree::{
     build_dependency_graph, build_single_parent_tree, extract_compact_hint,
 };
-use carina_core::resource::{ResourceId, Value};
+use carina_core::resource::{ConcreteValue, DeferredValue, ResourceId, Value};
 use carina_core::schema::SchemaRegistry;
 use carina_core::value::format_value_pretty;
 #[cfg(test)]
@@ -52,7 +52,7 @@ fn format_compact_name(
 }
 
 /// Format a value in a deferred for-expression template.
-/// Placeholder values (`Value::Unknown`) are shown dimmed; resolved
+/// Placeholder values (`Value::Deferred(DeferredValue::Unknown)`) are shown dimmed; resolved
 /// values are shown normally.
 fn format_deferred_value(value: &Value) -> String {
     /// Catch-all placeholder text for value variants whose contents
@@ -63,24 +63,24 @@ fn format_deferred_value(value: &Value) -> String {
     const DEFERRED_FALLBACK: &str = "(known after upstream apply)";
 
     match value {
-        Value::Unknown(reason) => {
+        Value::Deferred(DeferredValue::Unknown(reason)) => {
             format!("{}", carina_core::value::render_unknown(reason).dimmed())
         }
-        Value::String(s) => format!("'{}'", s),
-        Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Duration(d) => carina_core::value::render_duration(*d),
-        Value::ResourceRef { path } => path.to_dot_string().to_string(),
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::String(s)) => format!("'{}'", s),
+        Value::Concrete(ConcreteValue::Int(i)) => i.to_string(),
+        Value::Concrete(ConcreteValue::Float(f)) => f.to_string(),
+        Value::Concrete(ConcreteValue::Bool(b)) => b.to_string(),
+        Value::Concrete(ConcreteValue::Duration(d)) => carina_core::value::render_duration(*d),
+        Value::Deferred(DeferredValue::ResourceRef { path }) => path.to_dot_string().to_string(),
+        Value::Concrete(ConcreteValue::List(items)) => {
             let formatted: Vec<String> = items.iter().map(format_deferred_value).collect();
             format!("[{}]", formatted.join(", "))
         }
-        Value::StringList(items) => {
+        Value::Concrete(ConcreteValue::StringList(items)) => {
             let formatted: Vec<String> = items.iter().map(|s| format!("'{}'", s)).collect();
             format!("[{}]", formatted.join(", "))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let formatted: Vec<String> = map
                 .iter()
                 .map(|(k, v)| format!("{} = {}", k, format_deferred_value(v)))
@@ -94,21 +94,21 @@ fn format_deferred_value(value: &Value) -> String {
 /// Format an export value for plan display.
 fn format_export_value(value: &Value) -> String {
     match value {
-        Value::String(s) => format!("'{}'", s),
-        Value::Int(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Duration(d) => carina_core::value::render_duration(*d),
-        Value::ResourceRef { path } => path.to_dot_string().to_string(),
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::String(s)) => format!("'{}'", s),
+        Value::Concrete(ConcreteValue::Int(i)) => i.to_string(),
+        Value::Concrete(ConcreteValue::Float(f)) => f.to_string(),
+        Value::Concrete(ConcreteValue::Bool(b)) => b.to_string(),
+        Value::Concrete(ConcreteValue::Duration(d)) => carina_core::value::render_duration(*d),
+        Value::Deferred(DeferredValue::ResourceRef { path }) => path.to_dot_string().to_string(),
+        Value::Concrete(ConcreteValue::List(items)) => {
             let formatted: Vec<String> = items.iter().map(format_export_value).collect();
             format!("[{}]", formatted.join(", "))
         }
-        Value::StringList(items) => {
+        Value::Concrete(ConcreteValue::StringList(items)) => {
             let formatted: Vec<String> = items.iter().map(|s| format!("'{}'", s)).collect();
             format!("[{}]", formatted.join(", "))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let formatted: Vec<String> = map
                 .iter()
                 .map(|(k, v)| format!("{} = {}", k, format_export_value(v)))
@@ -1658,10 +1658,16 @@ pub fn format_effect(effect: &Effect) -> String {
     }
 }
 
-/// Check if both old and new values are `Value::Map`.
+/// Check if both old and new values are `Value::Concrete(ConcreteValue::Map)`.
 #[cfg(test)]
 fn is_both_maps(old_value: Option<&Value>, new_value: &Value) -> bool {
-    matches!((old_value, new_value), (Some(Value::Map(_)), Value::Map(_)))
+    matches!(
+        (old_value, new_value),
+        (
+            Some(Value::Concrete(ConcreteValue::Map(_))),
+            Value::Concrete(ConcreteValue::Map(_))
+        )
+    )
 }
 
 /// Format a key-level diff between two map values.
@@ -1675,11 +1681,11 @@ fn is_both_maps(old_value: Option<&Value>, new_value: &Value) -> bool {
 #[cfg(test)]
 fn format_map_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &str) -> String {
     let new_map = match new_value {
-        Value::Map(m) => m,
+        Value::Concrete(ConcreteValue::Map(m)) => m,
         _ => return format_value(new_value),
     };
     let old_map = match old_value {
-        Some(Value::Map(m)) => m,
+        Some(Value::Concrete(ConcreteValue::Map(m))) => m,
         _ => {
             // No old map; treat all new keys as added
             let empty = indexmap::IndexMap::new();
@@ -1750,11 +1756,11 @@ fn format_map_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &s
 #[cfg(test)]
 fn format_list_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &str) -> String {
     let new_items = match new_value {
-        Value::List(items) => items,
+        Value::Concrete(ConcreteValue::List(items)) => items,
         _ => return format_value(new_value),
     };
     let old_items = match old_value {
-        Some(Value::List(items)) => items,
+        Some(Value::Concrete(ConcreteValue::List(items))) => items,
         _ => &vec![] as &Vec<Value>,
     };
 
@@ -1830,7 +1836,7 @@ fn format_list_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &
 
     // Show unchanged items (exact matches from new list order)
     for (ni, new_item) in new_items.iter().enumerate() {
-        if let Value::Map(map) = new_item
+        if let Value::Concrete(ConcreteValue::Map(map)) = new_item
             && new_matched[ni]
         {
             let mut keys: Vec<_> = map.keys().collect();
@@ -1845,7 +1851,11 @@ fn format_list_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &
 
     // Show modified items (paired by similarity)
     for &(oi, ni) in &paired {
-        if let (Value::Map(old_map), Value::Map(new_map)) = (&old_items[oi], &new_items[ni]) {
+        if let (
+            Value::Concrete(ConcreteValue::Map(old_map)),
+            Value::Concrete(ConcreteValue::Map(new_map)),
+        ) = (&old_items[oi], &new_items[ni])
+        {
             let mut keys: Vec<_> = new_map.keys().collect();
             keys.sort();
             let fields: Vec<String> = keys
@@ -1878,7 +1888,7 @@ fn format_list_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &
 
     // Show added items
     for &ni in &added {
-        if let Value::Map(map) = &new_items[ni] {
+        if let Value::Concrete(ConcreteValue::Map(map)) = &new_items[ni] {
             let mut keys: Vec<_> = map.keys().collect();
             keys.sort();
             let fields: Vec<String> = keys
@@ -1896,7 +1906,7 @@ fn format_list_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &
 
     // Show removed items
     for &oi in &removed {
-        if let Value::Map(map) = &old_items[oi] {
+        if let Value::Concrete(ConcreteValue::Map(map)) = &old_items[oi] {
             let mut keys: Vec<_> = map.keys().collect();
             keys.sort();
             let fields: Vec<String> = keys
@@ -2031,14 +2041,18 @@ fn format_cascading_update_diff(
 
 /// Check whether a Value references the given binding name.
 ///
-/// Returns true for `Value::ResourceRef` with matching `binding_name`,
-/// or `Value::List` / `Value::Map` containing such a reference.
+/// Returns true for `Value::Deferred(DeferredValue::ResourceRef)` with matching `binding_name`,
+/// or `Value::Concrete(ConcreteValue::List)` / `Value::Concrete(ConcreteValue::Map)` containing such a reference.
 #[cfg(test)]
 fn value_references_binding(value: &Value, binding: &str) -> bool {
     match value {
-        Value::ResourceRef { path } => path.binding() == binding,
-        Value::List(items) => items.iter().any(|v| value_references_binding(v, binding)),
-        Value::Map(map) => map.values().any(|v| value_references_binding(v, binding)),
+        Value::Deferred(DeferredValue::ResourceRef { path }) => path.binding() == binding,
+        Value::Concrete(ConcreteValue::List(items)) => {
+            items.iter().any(|v| value_references_binding(v, binding))
+        }
+        Value::Concrete(ConcreteValue::Map(map)) => {
+            map.values().any(|v| value_references_binding(v, binding))
+        }
         _ => false,
     }
 }

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use carina_core::effect::{CascadingUpdate, Effect};
 use carina_core::plan::Plan;
-use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 
 fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) -> Resource {
     let mut r = Resource::new(resource_type, name);
@@ -419,7 +419,7 @@ fn test_extract_compact_hint_string_fallback() {
     let mut r = Resource::new("ec2.route", "hash456");
     r.set_attr(
         "destination_cidr_block".to_string(),
-        Value::String("0.0.0.0/0".to_string()),
+        Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
     );
 
     let hint = extract_compact_hint(&r, None);
@@ -440,7 +440,7 @@ fn test_extract_compact_hint_prefers_string_over_resource_ref() {
     let mut r = Resource::new("ec2.route", "hash_mixed");
     r.set_attr(
         "destination".to_string(),
-        Value::String("10.0.0.0/8".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
     );
     r.set_attr(
         "gateway_id".to_string(),
@@ -458,7 +458,9 @@ fn test_extract_compact_hint_service_name_shortening() {
     let mut r = Resource::new("ec2.vpc_endpoint", "hash_svc");
     r.set_attr(
         "service_name".to_string(),
-        Value::String("com.amazonaws.ap-northeast-1.ecr.dkr".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "com.amazonaws.ap-northeast-1.ecr.dkr".to_string(),
+        )),
     );
 
     let hint = extract_compact_hint(&r, None);
@@ -468,7 +470,9 @@ fn test_extract_compact_hint_service_name_shortening() {
     let mut r2 = Resource::new("ec2.vpc_endpoint", "hash_svc2");
     r2.set_attr(
         "service_name".to_string(),
-        Value::String("com.amazonaws.ap-northeast-1.s3".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "com.amazonaws.ap-northeast-1.s3".to_string(),
+        )),
     );
 
     let hint2 = extract_compact_hint(&r2, None);
@@ -485,7 +489,7 @@ fn test_extract_compact_hint_all_refs_match_parent() {
     );
     r.set_attr(
         "description".to_string(),
-        Value::String("Allow HTTPS from VPC".to_string()),
+        Value::Concrete(ConcreteValue::String("Allow HTTPS from VPC".to_string())),
     );
 
     // When parent is endpoint_sg, should skip group_id and use description
@@ -499,15 +503,17 @@ fn test_extract_compact_hint_prefers_string_for_vpc_endpoint() {
     let mut r = Resource::new("ec2.vpc_endpoint", "hash_ep");
     r.set_attr(
         "service_name".to_string(),
-        Value::String("com.amazonaws.ap-northeast-1.ecr.dkr".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "com.amazonaws.ap-northeast-1.ecr.dkr".to_string(),
+        )),
     );
     r.set_attr(
         "security_group_ids".to_string(),
-        Value::List(vec![Value::resource_ref(
+        Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
             "endpoint_sg".to_string(),
             "group_id".to_string(),
             vec![],
-        )]),
+        )])),
     );
     r.set_attr(
         "vpc_id".to_string(),
@@ -595,7 +601,7 @@ fn test_print_plan_compact_with_anonymous_resources() {
     let mut anon = Resource::new("ec2.route", "hash_anon");
     anon.set_attr(
         "destination_cidr_block".to_string(),
-        Value::String("0.0.0.0/0".to_string()),
+        Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
     );
     anon.set_attr(
         "route_table_id".to_string(),
@@ -625,11 +631,11 @@ fn test_extract_compact_hint_list_containing_resource_ref() {
     let mut r = Resource::new("ec2.vpc_endpoint", "hash_list_ref");
     r.set_attr(
         "security_group_ids".to_string(),
-        Value::List(vec![Value::resource_ref(
+        Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
             "endpoint_sg".to_string(),
             "group_id".to_string(),
             vec![],
-        )]),
+        )])),
     );
 
     let hint = extract_compact_hint(&r, None);
@@ -646,11 +652,11 @@ fn test_extract_compact_hint_list_ref_skips_parent() {
     let mut r = Resource::new("ec2.vpc_endpoint", "hash_list_parent");
     r.set_attr(
         "security_group_ids".to_string(),
-        Value::List(vec![Value::resource_ref(
+        Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
             "endpoint_sg".to_string(),
             "group_id".to_string(),
             vec![],
-        )]),
+        )])),
     );
 
     let hint = extract_compact_hint(&r, Some("endpoint_sg"));
@@ -677,7 +683,9 @@ fn test_extract_compact_hint_resolves_dsl_enum() {
     let mut r = Resource::new("ec2.Subnet", "hash_enum");
     r.set_attr(
         "availability_zone".to_string(),
-        Value::String("awscc.AvailabilityZone.ap_northeast_1a".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "awscc.AvailabilityZone.ap_northeast_1a".to_string(),
+        )),
     );
 
     let hint = extract_compact_hint(&r, None);
@@ -695,7 +703,10 @@ fn test_extract_compact_hint_resolves_dsl_enum() {
 fn test_extract_compact_hint_skips_internal_attributes() {
     let mut r = Resource::new("ec2.Vpc", "hash_internal");
     r.binding = Some("vpc".to_string());
-    r.set_attr("_hash".to_string(), Value::String("abc123".to_string()));
+    r.set_attr(
+        "_hash".to_string(),
+        Value::Concrete(ConcreteValue::String("abc123".to_string())),
+    );
 
     let hint = extract_compact_hint(&r, None);
     assert_eq!(hint, None, "Internal attributes should be skipped");
@@ -710,23 +721,26 @@ fn test_cascading_update_shows_attribute_diffs() {
         ResourceId::new("ec2.Vpc", "vpc"),
         HashMap::from([(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         )]),
     );
     let vpc_to = Resource::new("ec2.Vpc", "vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet_from = State::existing(
         ResourceId::new("ec2.Subnet", "subnet"),
         HashMap::from([
             (
                 "vpc_id".to_string(),
-                Value::String("vpc-old123".to_string()),
+                Value::Concrete(ConcreteValue::String("vpc-old123".to_string())),
             ),
             (
                 "cidr_block".to_string(),
-                Value::String("10.0.1.0/24".to_string()),
+                Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
             ),
         ]),
     );
@@ -735,7 +749,10 @@ fn test_cascading_update_shows_attribute_diffs() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("cidr_block", Value::String("10.0.1.0/24".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+        );
 
     let replace_effect = Effect::Replace {
         id: ResourceId::new("ec2.Vpc", "vpc"),
@@ -782,11 +799,11 @@ fn test_format_cascading_update_attr_diff() {
             HashMap::from([
                 (
                     "vpc_id".to_string(),
-                    Value::String("vpc-old123".to_string()),
+                    Value::Concrete(ConcreteValue::String("vpc-old123".to_string())),
                 ),
                 (
                     "cidr_block".to_string(),
-                    Value::String("10.0.1.0/24".to_string()),
+                    Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
                 ),
             ]),
         )),
@@ -795,7 +812,10 @@ fn test_format_cascading_update_attr_diff() {
                 "vpc_id",
                 Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
             )
-            .with_attribute("cidr_block", Value::String("10.0.1.0/24".to_string())),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+            ),
     };
 
     let output = format_cascading_update_diff(&cascade, "    ", "vpc");
@@ -836,25 +856,35 @@ fn test_replace_changed_create_only_same_value_shown_as_known_after_apply() {
     use std::collections::HashMap;
 
     let from_attrs = HashMap::from([
-        ("vpc_id".to_string(), Value::String("vpc-123".to_string())),
+        (
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        ),
         (
             "cidr_block".to_string(),
-            Value::String("10.0.1.0/24".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
         ),
     ]);
     let to_attrs = HashMap::from([
-        ("_binding".to_string(), Value::String("subnet".to_string())),
-        ("vpc_id".to_string(), Value::String("vpc-123".to_string())),
+        (
+            "_binding".to_string(),
+            Value::Concrete(ConcreteValue::String("subnet".to_string())),
+        ),
+        (
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        ),
         (
             "cidr_block".to_string(),
-            Value::String("10.0.1.0/24".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
         ),
     ]);
 
     // Verify the precondition: the values are semantically equal
     assert!(
-        Value::String("vpc-123".to_string())
-            .semantically_equal(&Value::String("vpc-123".to_string())),
+        Value::Concrete(ConcreteValue::String("vpc-123".to_string())).semantically_equal(
+            &Value::Concrete(ConcreteValue::String("vpc-123".to_string()))
+        ),
         "precondition: old and new vpc_id should be semantically equal"
     );
 
@@ -895,11 +925,11 @@ fn test_replace_cascade_ref_hints_show_binding() {
 
     let from_attrs = HashMap::from([(
         "vpc_id".to_string(),
-        Value::String("vpc-0bf023ff87bf1aa0c".to_string()),
+        Value::Concrete(ConcreteValue::String("vpc-0bf023ff87bf1aa0c".to_string())),
     )]);
     let to_attrs = HashMap::from([(
         "vpc_id".to_string(),
-        Value::String("vpc-0bf023ff87bf1aa0c".to_string()),
+        Value::Concrete(ConcreteValue::String("vpc-0bf023ff87bf1aa0c".to_string())),
     )]);
 
     let hints = vec![("vpc_id".to_string(), "vpc.vpc_id".to_string())];
@@ -945,15 +975,15 @@ fn test_format_cascading_update_diff_excludes_non_ref_attributes() {
             HashMap::from([
                 (
                     "vpc_id".to_string(),
-                    Value::String("vpc-old123".to_string()),
+                    Value::Concrete(ConcreteValue::String("vpc-old123".to_string())),
                 ),
                 (
                     "availability_zone".to_string(),
-                    Value::String("ap-northeast-1a".to_string()),
+                    Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
                 ),
                 (
                     "cidr_block".to_string(),
-                    Value::String("10.0.1.0/24".to_string()),
+                    Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
                 ),
             ]),
         )),
@@ -964,9 +994,14 @@ fn test_format_cascading_update_diff_excludes_non_ref_attributes() {
             )
             .with_attribute(
                 "availability_zone",
-                Value::String("awscc.AvailabilityZone.ap_northeast_1a".to_string()),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.AvailabilityZone.ap_northeast_1a".to_string(),
+                )),
             )
-            .with_attribute("cidr_block", Value::String("10.0.1.0/24".to_string())),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+            ),
     };
 
     let replaced_binding = "vpc";
@@ -1005,16 +1040,18 @@ fn test_format_cascading_update_diff_includes_list_with_ref() {
             ResourceId::new("ec2.Instance", "instance"),
             HashMap::from([(
                 "security_group_ids".to_string(),
-                Value::List(vec![Value::String("sg-old123".to_string())]),
+                Value::Concrete(ConcreteValue::List(vec![Value::String(
+                    "sg-old123".to_string(),
+                )])),
             )]),
         )),
         to: Resource::new("ec2.Instance", "instance").with_attribute(
             "security_group_ids",
-            Value::List(vec![Value::resource_ref(
+            Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
                 "sg".to_string(),
                 "group_id".to_string(),
                 vec![],
-            )]),
+            )])),
         ),
     };
 
@@ -1060,7 +1097,7 @@ fn test_mixed_plan_tree_with_delete_effect() {
         ResourceId::new("ec2.Vpc", "vpc"),
         HashMap::from([(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         )]),
     );
 
@@ -1070,7 +1107,7 @@ fn test_mixed_plan_tree_with_delete_effect() {
         ResourceId::new("ec2.SecurityGroup", "sg"),
         HashMap::from([(
             "ref_vpc".to_string(),
-            Value::String("vpc-old123".to_string()),
+            Value::Concrete(ConcreteValue::String("vpc-old123".to_string())),
         )]),
     );
 
@@ -1160,7 +1197,7 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
         ResourceId::new("ec2.Vpc", "vpc"),
         HashMap::from([(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         )]),
     );
 
@@ -1172,11 +1209,11 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
     // This is the resolved value — a plain string, NOT a ResourceRef
     sg.set_attr(
         "vpc_id".to_string(),
-        Value::String("vpc-0123456789abcdef0".to_string()),
+        Value::Concrete(ConcreteValue::String("vpc-0123456789abcdef0".to_string())),
     );
     sg.set_attr(
         "group_description".to_string(),
-        Value::String("Test security group".to_string()),
+        Value::Concrete(ConcreteValue::String("Test security group".to_string())),
     );
     // _dependency_bindings is saved by resolve_refs_with_state() before
     // ResourceRef values are resolved to strings.
@@ -1474,19 +1511,19 @@ fn colored_value_preserves_vertical_map_layout() {
 
 #[test]
 fn format_export_value_duration_renders_canonical() {
-    // Regression: simplify + Round 1 added the Value::Duration arm so
+    // Regression: simplify + Round 1 added the Value::Concrete(ConcreteValue::Duration) arm so
     // exports of a Duration attribute don't fall through to the
     // wildcard "(known after apply)" placeholder. Pin the canonical
     // form here so a future refactor cannot silently regress to either
     // the wildcard or the {:?} Debug shape.
-    let v = Value::Duration(std::time::Duration::from_secs(60));
+    let v = Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(60)));
     assert_eq!(format_export_value(&v), "1min");
 }
 
 #[test]
 fn format_deferred_value_duration_renders_canonical() {
     // Same shape as format_export_value but on the deferred-for path.
-    let v = Value::Duration(std::time::Duration::from_secs(60));
+    let v = Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(60)));
     let result = format_deferred_value(&v);
     // The deferred path may inject ANSI dimming for Unknown variants,
     // but a resolved Duration must render verbatim.

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -842,7 +842,7 @@ fn plan_snapshot_upstream_state_map_subscript() {
 /// dot-notation form `${X.field.key}` / bare `X.field.key`. Pre-fix the
 /// dot form passed validate but rendered the literal substring
 /// `orgs.accounts.registry_dev` into the output (the parser fell back
-/// to `Value::String` because the head wasn't a known binding in the
+/// to `Value::Concrete(ConcreteValue::String)` because the head wasn't a known binding in the
 /// current file). Symmetric with the #2435 subscript fix; both forms
 /// must now resolve to the upstream's concrete map value.
 #[test]
@@ -958,20 +958,20 @@ fn plan_snapshot_exports_multifile() {
 fn plan_snapshot_export_changes_mixed() {
     use crate::commands::plan::ExportChange;
     use carina_core::parser::TypeExpr;
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
 
     let (plan, schemas, moved_origins) = build_plan_from_fixture("no_changes");
     let export_changes = vec![
         ExportChange::Added {
             name: "new_export".to_string(),
             type_expr: Some(TypeExpr::String),
-            new_value: Value::String("hello".to_string()),
+            new_value: Value::Concrete(ConcreteValue::String("hello".to_string())),
         },
         ExportChange::Modified {
             name: "changed".to_string(),
             type_expr: Some(TypeExpr::Int),
             old_json: serde_json::json!(42),
-            new_value: Value::Int(100),
+            new_value: Value::Concrete(ConcreteValue::Int(100)),
         },
         ExportChange::Removed {
             name: "obsolete".to_string(),

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -10,7 +10,9 @@ use carina_core::effect::Effect;
 use carina_core::parser::{ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
-use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{
+    ConcreteValue, DeferredValue, Directives, Resource, ResourceId, State, Value,
+};
 use carina_core::schema::{ResourceSchema, SchemaRegistry};
 use carina_state::{BackendError, LockInfo, ResourceState, StateBackend, StateFile};
 
@@ -112,7 +114,10 @@ async fn refresh_pending_states_updates_saved_state_from_provider_read() {
         id.clone(),
         State::existing(
             id.clone(),
-            HashMap::from([("status".to_string(), Value::String("before".to_string()))]),
+            HashMap::from([(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("before".to_string())),
+            )]),
         )
         .with_identifier(identifier),
     )]);
@@ -121,7 +126,10 @@ async fn refresh_pending_states_updates_saved_state_from_provider_read() {
         identifier,
         State::existing(
             id.clone(),
-            HashMap::from([("status".to_string(), Value::String("after".to_string()))]),
+            HashMap::from([(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("after".to_string())),
+            )]),
         )
         .with_identifier(identifier),
     );
@@ -168,7 +176,10 @@ async fn refresh_pending_states_removes_not_found_resource_from_saved_state() {
         id.clone(),
         State::existing(
             id.clone(),
-            HashMap::from([("status".to_string(), Value::String("before".to_string()))]),
+            HashMap::from([(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("before".to_string())),
+            )]),
         )
         .with_identifier(identifier),
     )]);
@@ -214,7 +225,7 @@ async fn refresh_pending_states_does_not_overwrite_with_stale_snapshot_when_refr
             id.clone(),
             HashMap::from([(
                 "status".to_string(),
-                Value::String("stale-current".to_string()),
+                Value::Concrete(ConcreteValue::String("stale-current".to_string())),
             )]),
         )
         .with_identifier(identifier),
@@ -259,8 +270,10 @@ fn plan_file_serde_round_trip() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::with_provider("aws", "s3.Bucket", "my-bucket")
-            .with_attribute("bucket", Value::String("my-bucket".to_string())),
+        Resource::with_provider("aws", "s3.Bucket", "my-bucket").with_attribute(
+            "bucket",
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+        ),
     ));
     plan.add(Effect::Delete {
         id: ResourceId::with_provider("aws", "s3.Bucket", "old-bucket"),
@@ -272,8 +285,10 @@ fn plan_file_serde_round_trip() {
     });
 
     let sorted_resources = vec![
-        Resource::with_provider("aws", "s3.Bucket", "my-bucket")
-            .with_attribute("bucket", Value::String("my-bucket".to_string())),
+        Resource::with_provider("aws", "s3.Bucket", "my-bucket").with_attribute(
+            "bucket",
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+        ),
     ];
 
     let current_states = vec![CurrentStateEntry {
@@ -292,7 +307,9 @@ fn plan_file_serde_round_trip() {
             name: "aws".to_string(),
             attributes: IndexMap::from([(
                 "region".to_string(),
-                Value::String("aws.Region.ap_northeast_1".to_string()),
+                Value::Concrete(ConcreteValue::String(
+                    "aws.Region.ap_northeast_1".to_string(),
+                )),
             )]),
             default_tags: IndexMap::new(),
             source: None,
@@ -303,10 +320,13 @@ fn plan_file_serde_round_trip() {
         backend_config: Some(BackendConfig {
             backend_type: "s3".to_string(),
             attributes: HashMap::from([
-                ("bucket".to_string(), Value::String("my-state".to_string())),
+                (
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String("my-state".to_string())),
+                ),
                 (
                     "key".to_string(),
-                    Value::String("prod/carina.state".to_string()),
+                    Value::Concrete(ConcreteValue::String("prod/carina.state".to_string())),
                 ),
             ]),
         }),
@@ -339,7 +359,7 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
     resource.set_attr(
         "bucket_name_prefix".to_string(),
-        Value::String("my-app-".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-".to_string())),
     );
 
     let mut resources = vec![resource];
@@ -350,7 +370,7 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
 
     // bucket_name should be generated with the prefix
     let bucket_name = match resources[0].get_attr("bucket_name").unwrap() {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         _ => panic!("expected String"),
     };
     assert!(bucket_name.starts_with("my-app-"));
@@ -369,7 +389,7 @@ fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
     resource.set_attr(
         "nonexistent_attr_prefix".to_string(),
-        Value::String("some-value".to_string()),
+        Value::Concrete(ConcreteValue::String("some-value".to_string())),
     );
 
     let mut resources = vec![resource];
@@ -390,11 +410,11 @@ fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
     resource.set_attr(
         "bucket_name_prefix".to_string(),
-        Value::String("my-app-".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-".to_string())),
     );
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("my-actual-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-actual-bucket".to_string())),
     );
 
     let mut resources = vec![resource];
@@ -414,7 +434,7 @@ fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
     resource.set_attr(
         "bucket_name_prefix".to_string(),
-        Value::String("".to_string()),
+        Value::Concrete(ConcreteValue::String("".to_string())),
     );
 
     let mut resources = vec![resource];
@@ -430,14 +450,16 @@ fn test_resolve_names_handles_block_name_before_prefix() {
     let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam");
     resource.set_attr(
         "operating_region".to_string(),
-        Value::List(vec![Value::Map(
-            vec![(
-                "region_name".to_string(),
-                Value::String("us-east-1".to_string()),
-            )]
-            .into_iter()
-            .collect(),
-        )]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(
+                vec![(
+                    "region_name".to_string(),
+                    Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+        )])),
     );
 
     let mut resources = vec![resource];
@@ -456,7 +478,7 @@ fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
         .insert("bucket_name".to_string(), "my-app-".to_string());
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("my-app-temporary".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-temporary".to_string())),
     );
 
     let mut state_file = StateFile::new();
@@ -475,7 +497,9 @@ fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
     // Should reuse the state name, not the temporary one
     assert_eq!(
         resources[0].get_attr("bucket_name"),
-        Some(&Value::String("my-app-existing1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-app-existing1".to_string()
+        )))
     );
 }
 
@@ -487,7 +511,7 @@ fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
         .insert("bucket_name".to_string(), "new-prefix-".to_string());
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("new-prefix-abcd1234".to_string()),
+        Value::Concrete(ConcreteValue::String("new-prefix-abcd1234".to_string())),
     );
 
     let mut state_file = StateFile::new();
@@ -506,7 +530,9 @@ fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
     // Should keep the newly generated name since prefix changed
     assert_eq!(
         resources[0].get_attr("bucket_name"),
-        Some(&Value::String("new-prefix-abcd1234".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "new-prefix-abcd1234".to_string()
+        )))
     );
 }
 
@@ -518,7 +544,7 @@ fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
         .insert("bucket_name".to_string(), "my-app-".to_string());
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("my-app-abcd1234".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-abcd1234".to_string())),
     );
 
     let mut resources = vec![resource];
@@ -527,7 +553,9 @@ fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
     // No state, so keep the generated name
     assert_eq!(
         resources[0].get_attr("bucket_name"),
-        Some(&Value::String("my-app-abcd1234".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-app-abcd1234".to_string()
+        )))
     );
 }
 
@@ -561,7 +589,10 @@ fn test_detailed_exitcode_read_only_no_changes() {
 
 fn make_awscc_provider(region_dsl: &str) -> ProviderConfig {
     let mut attrs = IndexMap::new();
-    attrs.insert("region".to_string(), Value::String(region_dsl.to_string()));
+    attrs.insert(
+        "region".to_string(),
+        Value::Concrete(ConcreteValue::String(region_dsl.to_string())),
+    );
     ProviderConfig {
         name: "awscc".to_string(),
         attributes: attrs,
@@ -580,13 +611,13 @@ fn test_anonymous_id_different_regions_produce_different_identifiers() {
     let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "");
     r1.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
     let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "");
     r2.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
     // Use two different provider configs with different regions
@@ -617,13 +648,13 @@ fn test_anonymous_id_same_region_same_create_only_collides() {
     let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "");
     r1.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
     let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "");
     r2.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
     let providers = vec![make_awscc_provider("awscc.Region.us_east_1")];
@@ -640,13 +671,13 @@ fn test_anonymous_id_different_create_only_same_region_no_collision() {
     let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "");
     r1.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
     let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "");
     r2.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.1.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     );
 
     let providers = vec![make_awscc_provider("awscc.Region.us_east_1")];
@@ -664,7 +695,7 @@ fn test_anonymous_id_named_resources_are_skipped() {
     let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "my_vpc");
     r1.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
     let providers = vec![make_awscc_provider("awscc.Region.us_east_1")];
@@ -681,8 +712,10 @@ fn test_find_state_bucket_resource_matching_type() {
         providers: vec![],
         backend: None,
         resources: vec![
-            Resource::with_provider("aws", "s3.Bucket", "my-bucket")
-                .with_attribute("bucket", Value::String("my-bucket".to_string())),
+            Resource::with_provider("aws", "s3.Bucket", "my-bucket").with_attribute(
+                "bucket",
+                Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+            ),
         ],
         variables: IndexMap::new(),
         uses: vec![],
@@ -759,8 +792,14 @@ fn validate_data_source_with_read_keyword_passes() {
 #[ignore = "requires provider binary for resource type validation"]
 fn validate_regular_resource_without_read_keyword_passes() {
     let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket")
-        .with_attribute("bucket", Value::String("my-bucket".to_string()))
-        .with_attribute("region", Value::String("ap-northeast-1".to_string()));
+        .with_attribute(
+            "bucket",
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+        )
+        .with_attribute(
+            "region",
+            Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+        );
     let result = validate_resources(&[resource]);
     assert!(
         result.is_ok(),
@@ -828,7 +867,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
     let mut resource_run1 = Resource::with_provider("awscc", "s3.Bucket", "");
     resource_run1.set_attr(
         "bucket_name_prefix".to_string(),
-        Value::String("my-app-".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-".to_string())),
     );
 
     let providers = vec![make_awscc_provider("awscc.Region.ap_northeast_1")];
@@ -843,7 +882,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
         "bucket_name should be in prefixes"
     );
     let run1_bucket_name = match resources_run1[0].get_attr("bucket_name") {
-        Some(Value::String(s)) => s.clone(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
         _ => panic!("bucket_name should be a string"),
     };
     assert!(
@@ -864,7 +903,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
         resources_run1[0].id.clone(),
         vec![(
             "bucket_name".to_string(),
-            Value::String(run1_bucket_name.clone()),
+            Value::Concrete(ConcreteValue::String(run1_bucket_name.clone())),
         )]
         .into_iter()
         .collect(),
@@ -882,7 +921,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
     let mut resource_run2 = Resource::with_provider("awscc", "s3.Bucket", "");
     resource_run2.set_attr(
         "bucket_name_prefix".to_string(),
-        Value::String("my-app-".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-".to_string())),
     );
 
     // 2. resolve_names (resolve_attr_prefixes) - generates NEW random suffix
@@ -904,7 +943,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
     reconcile_prefixed_names(&mut resources_run2, &Some(state_file.clone()));
 
     let reconciled_bucket_name = match resources_run2[0].get_attr("bucket_name") {
-        Some(Value::String(s)) => s.clone(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
         _ => panic!("bucket_name should be a string after reconciliation"),
     };
     assert_eq!(
@@ -932,22 +971,24 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     let mut resource_run1 = Resource::with_provider("awscc", "iam.role", "");
     resource_run1.set_attr(
         "role_name_prefix".to_string(),
-        Value::String("carina-acc-test-".to_string()),
+        Value::Concrete(ConcreteValue::String("carina-acc-test-".to_string())),
     );
     resource_run1.set_attr(
         "path".to_string(),
-        Value::String("/carina/acceptance-test/".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "/carina/acceptance-test/".to_string(),
+        )),
     );
     resource_run1.set_attr(
         "assume_role_policy_document".to_string(),
-        Value::Map(
+        Value::Concrete(ConcreteValue::Map(
             vec![(
                 "version".to_string(),
-                Value::String("2012-10-17".to_string()),
+                Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
             )]
             .into_iter()
             .collect(),
-        ),
+        )),
     );
 
     let mut resources_run1 = vec![resource_run1];
@@ -957,7 +998,7 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
 
     // Simulate state after apply
     let run1_role_name = match resources_run1[0].get_attr("role_name") {
-        Some(Value::String(s)) => s.clone(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
         _ => panic!("role_name should be set after prefix resolution"),
     };
     let applied_state = State::existing(
@@ -965,11 +1006,13 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
         vec![
             (
                 "role_name".to_string(),
-                Value::String(run1_role_name.clone()),
+                Value::Concrete(ConcreteValue::String(run1_role_name.clone())),
             ),
             (
                 "path".to_string(),
-                Value::String("/carina/acceptance-test/".to_string()),
+                Value::Concrete(ConcreteValue::String(
+                    "/carina/acceptance-test/".to_string(),
+                )),
             ),
         ]
         .into_iter()
@@ -986,22 +1029,24 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     let mut resource_run2 = Resource::with_provider("awscc", "iam.role", "");
     resource_run2.set_attr(
         "role_name_prefix".to_string(),
-        Value::String("carina-acc-test-".to_string()),
+        Value::Concrete(ConcreteValue::String("carina-acc-test-".to_string())),
     );
     resource_run2.set_attr(
         "path".to_string(),
-        Value::String("/carina/acceptance-test/".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "/carina/acceptance-test/".to_string(),
+        )),
     );
     resource_run2.set_attr(
         "assume_role_policy_document".to_string(),
-        Value::Map(
+        Value::Concrete(ConcreteValue::Map(
             vec![(
                 "version".to_string(),
-                Value::String("2012-10-17".to_string()),
+                Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
             )]
             .into_iter()
             .collect(),
-        ),
+        )),
     );
 
     let mut resources_run2 = vec![resource_run2];
@@ -1038,12 +1083,15 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     );
     resource_run1.set_attr(
         "resource_type".to_string(),
-        Value::String("VPC".to_string()),
+        Value::Concrete(ConcreteValue::String("VPC".to_string())),
     );
-    resource_run1.set_attr("traffic_type".to_string(), Value::String("ALL".to_string()));
+    resource_run1.set_attr(
+        "traffic_type".to_string(),
+        Value::Concrete(ConcreteValue::String("ALL".to_string())),
+    );
     resource_run1.set_attr(
         "log_destination_type".to_string(),
-        Value::String("s3".to_string()),
+        Value::Concrete(ConcreteValue::String("s3".to_string())),
     );
     resource_run1.set_attr(
         "log_destination".to_string(),
@@ -1051,18 +1099,24 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     );
     resource_run1.set_attr(
         "destination_options".to_string(),
-        Value::Map(
+        Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "file_format".to_string(),
-                    Value::String("plain-text".to_string()),
+                    Value::Concrete(ConcreteValue::String("plain-text".to_string())),
                 ),
-                ("hive_compatible_partitions".to_string(), Value::Bool(false)),
-                ("per_hour_partition".to_string(), Value::Bool(false)),
+                (
+                    "hive_compatible_partitions".to_string(),
+                    Value::Concrete(ConcreteValue::Bool(false)),
+                ),
+                (
+                    "per_hour_partition".to_string(),
+                    Value::Concrete(ConcreteValue::Bool(false)),
+                ),
             ]
             .into_iter()
             .collect(),
-        ),
+        )),
     );
 
     let mut resources_run1 = vec![resource_run1];
@@ -1086,12 +1140,15 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     );
     resource_run2.set_attr(
         "resource_type".to_string(),
-        Value::String("VPC".to_string()),
+        Value::Concrete(ConcreteValue::String("VPC".to_string())),
     );
-    resource_run2.set_attr("traffic_type".to_string(), Value::String("ALL".to_string()));
+    resource_run2.set_attr(
+        "traffic_type".to_string(),
+        Value::Concrete(ConcreteValue::String("ALL".to_string())),
+    );
     resource_run2.set_attr(
         "log_destination_type".to_string(),
-        Value::String("s3".to_string()),
+        Value::Concrete(ConcreteValue::String("s3".to_string())),
     );
     resource_run2.set_attr(
         "log_destination".to_string(),
@@ -1099,18 +1156,24 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     );
     resource_run2.set_attr(
         "destination_options".to_string(),
-        Value::Map(
+        Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "file_format".to_string(),
-                    Value::String("plain-text".to_string()),
+                    Value::Concrete(ConcreteValue::String("plain-text".to_string())),
                 ),
-                ("hive_compatible_partitions".to_string(), Value::Bool(false)),
-                ("per_hour_partition".to_string(), Value::Bool(false)),
+                (
+                    "hive_compatible_partitions".to_string(),
+                    Value::Concrete(ConcreteValue::Bool(false)),
+                ),
+                (
+                    "per_hour_partition".to_string(),
+                    Value::Concrete(ConcreteValue::Bool(false)),
+                ),
             ]
             .into_iter()
             .collect(),
-        ),
+        )),
     );
 
     let mut resources_run2 = vec![resource_run2];
@@ -1163,7 +1226,10 @@ async fn detect_drift_returns_none_when_no_drift() {
 
     let state = State::existing(
         id.clone(),
-        HashMap::from([("name".to_string(), Value::String("my-bucket".to_string()))]),
+        HashMap::from([(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+        )]),
     )
     .with_identifier(identifier);
 
@@ -1184,7 +1250,10 @@ async fn detect_drift_returns_messages_when_drift_detected() {
 
     let planned = State::existing(
         id.clone(),
-        HashMap::from([("name".to_string(), Value::String("my-bucket".to_string()))]),
+        HashMap::from([(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+        )]),
     )
     .with_identifier(identifier);
 
@@ -1193,7 +1262,7 @@ async fn detect_drift_returns_messages_when_drift_detected() {
         id.clone(),
         HashMap::from([(
             "name".to_string(),
-            Value::String("changed-bucket".to_string()),
+            Value::Concrete(ConcreteValue::String("changed-bucket".to_string())),
         )]),
     )
     .with_identifier(identifier);
@@ -1232,8 +1301,10 @@ fn orphaned_state_resource_produces_delete_effect() {
 
     // Config only has "keep-bucket" -- "removed-bucket" was deleted from .crn
     let desired = vec![
-        Resource::with_provider("aws", "s3.Bucket", "keep-bucket")
-            .with_attribute("bucket", Value::String("keep-bucket".to_string())),
+        Resource::with_provider("aws", "s3.Bucket", "keep-bucket").with_attribute(
+            "bucket",
+            Value::Concrete(ConcreteValue::String("keep-bucket".to_string())),
+        ),
     ];
 
     let desired_ids: HashSet<ResourceId> = desired.iter().map(|r| r.id.clone()).collect();
@@ -1247,7 +1318,7 @@ fn orphaned_state_resource_produces_delete_effect() {
                 resource.id.clone(),
                 HashMap::from([(
                     "bucket".to_string(),
-                    Value::String("keep-bucket".to_string()),
+                    Value::Concrete(ConcreteValue::String("keep-bucket".to_string())),
                 )]),
             )
             .with_identifier("keep-bucket"),
@@ -1595,7 +1666,10 @@ impl Provider for RecordingProvider {
         // Return a state with a new identifier to simulate resource creation
         let mut attrs = request.resource.attributes.clone();
         // Simulate AWS returning a new ID
-        attrs.insert("vpc_id".to_string(), Value::String("vpc-NEW".to_string()));
+        attrs.insert(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-NEW".to_string())),
+        );
         let id = id.clone();
         let state = State::existing(id, carina_core::resource::attrs_to_hashmap(&attrs))
             .with_identifier("vpc-NEW");
@@ -1706,13 +1780,15 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
         id.clone(),
         HashMap::from([(
             "bucket_name".to_string(),
-            Value::String("my-bucket".to_string()),
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
         )]),
     )
     .with_identifier("my-bucket");
 
-    let new_resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket")
-        .with_attribute("bucket_name", Value::String("my-bucket-tmp123".to_string()));
+    let new_resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket").with_attribute(
+        "bucket_name",
+        Value::Concrete(ConcreteValue::String("my-bucket-tmp123".to_string())),
+    );
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
@@ -1776,7 +1852,10 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     // --- Unresolved resources (before ref resolution) ---
     let vpc_unresolved = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet_unresolved = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -1784,14 +1863,23 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("cidr_block", Value::String("10.1.2.0/24".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.2.0/24".to_string())),
+        );
 
     // --- Resolved resources (after ref resolution with old state) ---
     // The subnet's vpc_id has been eagerly resolved to "vpc-OLD"
     let subnet_resolved = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
-        .with_attribute("vpc_id", Value::String("vpc-OLD".to_string()))
-        .with_attribute("cidr_block", Value::String("10.1.2.0/24".to_string()));
+        .with_attribute(
+            "vpc_id",
+            Value::Concrete(ConcreteValue::String("vpc-OLD".to_string())),
+        )
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.2.0/24".to_string())),
+        );
 
     // --- Current states ---
     let mut current_states = HashMap::new();
@@ -1799,19 +1887,25 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-OLD".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-OLD".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-OLD"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-OLD".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-OLD".to_string())),
+    );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -1849,10 +1943,13 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     bindings.set(
         "vpc",
         HashMap::from([
-            ("vpc_id".to_string(), Value::String("vpc-OLD".to_string())),
+            (
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String("vpc-OLD".to_string())),
+            ),
             (
                 "cidr_block".to_string(),
-                Value::String("10.0.0.0/16".to_string()),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
             ),
         ]),
         BindingValueSource::Local,
@@ -1860,10 +1957,13 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     bindings.set(
         "subnet",
         HashMap::from([
-            ("vpc_id".to_string(), Value::String("vpc-OLD".to_string())),
+            (
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String("vpc-OLD".to_string())),
+            ),
             (
                 "cidr_block".to_string(),
-                Value::String("10.1.1.0/24".to_string()),
+                Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
             ),
         ]),
         BindingValueSource::Local,
@@ -1904,7 +2004,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
 
     assert_eq!(
         *vpc_id_in_update,
-        Value::String("vpc-NEW".to_string()),
+        Value::Concrete(ConcreteValue::String("vpc-NEW".to_string())),
         "Subnet update should reference the NEW vpc_id (vpc-NEW), not the stale old one (vpc-OLD)"
     );
 }
@@ -1997,10 +2097,10 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
 
     // Config only has "keep-bucket" -- "orphan-bucket" was removed from .crn
     let mut parsed = carina_core::parser::InferredFile {
-        resources: vec![
-            Resource::new("s3.Bucket", "keep-bucket")
-                .with_attribute("bucket", Value::String("keep-bucket".to_string())),
-        ],
+        resources: vec![Resource::new("s3.Bucket", "keep-bucket").with_attribute(
+            "bucket",
+            Value::Concrete(ConcreteValue::String("keep-bucket".to_string())),
+        )],
         ..carina_core::parser::InferredFile::default()
     };
 
@@ -2224,11 +2324,11 @@ fn refresh_false_uses_cached_state_from_state_file() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("my-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
     resource.set_attr(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
 
     let desired = vec![resource];
@@ -2251,7 +2351,9 @@ fn refresh_false_uses_cached_state_from_state_file() {
     );
     assert_eq!(
         cached_state.attributes.get("bucket_name"),
-        Some(&Value::String("my-bucket".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-bucket".to_string()
+        ))),
         "Attributes should come from state file"
     );
 
@@ -2340,7 +2442,7 @@ fn refresh_false_without_state_file_treats_resources_as_new() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "new-bucket");
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("new-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("new-bucket".to_string())),
     );
 
     let desired = vec![resource];
@@ -2382,7 +2484,10 @@ fn import_effect_preserves_resource_metadata_in_state() {
     // directives, prefixes, desired_keys, binding, and dependency_bindings.
 
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc")
-        .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()))
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+        )
         .with_binding("my_vpc_binding");
     resource.directives.force_delete = true;
     resource
@@ -2397,7 +2502,7 @@ fn import_effect_preserves_resource_metadata_in_state() {
         id.clone(),
         HashMap::from([(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         )]),
     )
     .with_identifier(identifier);
@@ -2470,9 +2575,12 @@ fn build_state_after_apply_persists_write_only_attributes() {
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
     resource.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    resource.set_attr("ipv4_netmask_length".to_string(), Value::Int(16));
+    resource.set_attr(
+        "ipv4_netmask_length".to_string(),
+        Value::Concrete(ConcreteValue::Int(16)),
+    );
 
     let id = resource.id.clone();
 
@@ -2484,7 +2592,7 @@ fn build_state_after_apply_persists_write_only_attributes() {
             identifier: Some("vpc-123".to_string()),
             attributes: HashMap::from([(
                 "cidr_block".to_string(),
-                Value::String("10.0.0.0/16".to_string()),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
             )]),
             exists: true,
             dependency_bindings: BTreeSet::new(),
@@ -2545,9 +2653,12 @@ fn build_state_after_apply_write_only_detects_value_change() {
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
     resource.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/24".to_string())),
     );
-    resource.set_attr("ipv4_netmask_length".to_string(), Value::Int(24));
+    resource.set_attr(
+        "ipv4_netmask_length".to_string(),
+        Value::Concrete(ConcreteValue::Int(24)),
+    );
 
     let id = resource.id.clone();
 
@@ -2559,7 +2670,7 @@ fn build_state_after_apply_write_only_detects_value_change() {
             identifier: Some("vpc-123".to_string()),
             attributes: HashMap::from([(
                 "cidr_block".to_string(),
-                Value::String("10.0.0.0/24".to_string()),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/24".to_string())),
             )]),
             exists: true,
             dependency_bindings: BTreeSet::new(),
@@ -2615,17 +2726,25 @@ fn plan_file_serialization_redacts_secrets() {
     };
 
     // Build a plan with secrets in resources, states, and effects
-    let secret_password = Value::Secret(Box::new(Value::String("super-secret-pw".to_string())));
+    let secret_password = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("super-secret-pw".to_string()),
+    ))));
 
     let resource_with_secret = Resource::with_provider("awscc", "rds.db_instance", "my-db")
-        .with_attribute("name", Value::String("my-db".to_string()))
+        .with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("my-db".to_string())),
+        )
         .with_attribute("master_password", secret_password.clone());
 
     let mut plan = Plan::new();
     plan.add(Effect::Create(resource_with_secret.clone()));
 
     let mut state_attrs = HashMap::new();
-    state_attrs.insert("name".to_string(), Value::String("my-db".to_string()));
+    state_attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-db".to_string())),
+    );
     state_attrs.insert("master_password".to_string(), secret_password.clone());
     let state_with_secret = State::existing(
         ResourceId::with_provider("awscc", "rds.db_instance", "my-db"),
@@ -2762,7 +2881,7 @@ async fn persist_exports_only_clears_state_exports_when_params_empty() {
 #[tokio::test]
 async fn persist_exports_only_writes_state_with_new_exports() {
     use carina_core::parser::{InferredExportParam, TypeExpr};
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
 
     let captured = Arc::new(Mutex::new(None));
     let backend = CapturingBackend {
@@ -2773,7 +2892,9 @@ async fn persist_exports_only_writes_state_with_new_exports() {
     let export_params = vec![InferredExportParam {
         name: "account_id".to_string(),
         type_expr: TypeExpr::Unknown,
-        value: Some(Value::String("123456789012".to_string())),
+        value: Some(Value::Concrete(ConcreteValue::String(
+            "123456789012".to_string(),
+        ))),
     }];
 
     let result = crate::commands::apply::persist_exports_only(

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -21,7 +21,9 @@ use carina_core::provider::{
     ProviderRouter,
 };
 use carina_core::resolver::{resolve_refs_for_plan, resolve_refs_with_state_and_remote};
-use carina_core::resource::{Resource, ResourceId, State, Value, contains_resource_ref};
+use carina_core::resource::{
+    ConcreteValue, DeferredValue, Resource, ResourceId, State, Value, contains_resource_ref,
+};
 use carina_core::schema::{SchemaRegistry, resolve_block_names};
 use carina_core::utils;
 use carina_core::validation;
@@ -256,7 +258,7 @@ pub fn validate_attribute_param_ref_types_with_ctx(
 }
 
 /// Reject any resolved value that still carries
-/// `Value::Unknown(UnknownReason::EmptyInterpolation)`. The parser
+/// `Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation))`. The parser
 /// accepts mid-edit `${}` to keep the AST intact (#2480) and the LSP
 /// surfaces it as a per-location warning, but `carina validate` /
 /// `plan` / `apply` must refuse to proceed — letting the marker flow
@@ -301,7 +303,7 @@ where
 }
 
 /// Recursively walk a `Value` tree looking for any
-/// `Value::Unknown(UnknownReason::EmptyInterpolation)`. Returns `true`
+/// `Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation))`. Returns `true`
 /// when one is found at any depth — inside lists, maps, secrets,
 /// function-call arguments, or as the `Expr` segment of an
 /// `Interpolation`. Mirrors the variant coverage of the sibling
@@ -310,15 +312,21 @@ where
 fn value_contains_empty_interpolation(value: &Value) -> bool {
     use carina_core::resource::{InterpolationPart, UnknownReason};
     match value {
-        Value::Unknown(UnknownReason::EmptyInterpolation) => true,
-        Value::Interpolation(parts) => parts.iter().any(|p| match p {
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation)) => true,
+        Value::Deferred(DeferredValue::Interpolation(parts)) => parts.iter().any(|p| match p {
             InterpolationPart::Expr(v) => value_contains_empty_interpolation(v),
             InterpolationPart::Literal(_) => false,
         }),
-        Value::List(items) => items.iter().any(value_contains_empty_interpolation),
-        Value::Map(entries) => entries.values().any(value_contains_empty_interpolation),
-        Value::Secret(inner) => value_contains_empty_interpolation(inner),
-        Value::FunctionCall { args, .. } => args.iter().any(value_contains_empty_interpolation),
+        Value::Concrete(ConcreteValue::List(items)) => {
+            items.iter().any(value_contains_empty_interpolation)
+        }
+        Value::Concrete(ConcreteValue::Map(entries)) => {
+            entries.values().any(value_contains_empty_interpolation)
+        }
+        Value::Deferred(DeferredValue::Secret(inner)) => value_contains_empty_interpolation(inner),
+        Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
+            args.iter().any(value_contains_empty_interpolation)
+        }
         _ => false,
     }
 }
@@ -548,8 +556,8 @@ impl<'a> PlanPreprocessor<'a> {
         provider_configs: &[ProviderConfig],
     ) {
         // RFC #2371 stage 2 + #2387: strip every attribute the WASM
-        // provider boundary refuses to serialize — `Value::Unknown`
-        // (#2378) and `Value::ResourceRef` plus the wrappers that hide
+        // provider boundary refuses to serialize — `Value::Deferred(DeferredValue::Unknown)`
+        // (#2378) and `Value::Deferred(DeferredValue::ResourceRef)` plus the wrappers that hide
         // a ref (`Interpolation` / `FunctionCall` / `Secret`-of-ref,
         // #2387) — before `normalize_desired` runs, then restore them
         // at their original index. After this pass, `core_to_wit_value`
@@ -558,13 +566,13 @@ impl<'a> PlanPreprocessor<'a> {
             value_contains_unknown(v) || contains_resource_ref(v)
         });
         // Hard assert (not debug_assert): RFC #2371 constraint b says
-        // state files never carry `Value::Unknown`, and the
+        // state files never carry `Value::Deferred(DeferredValue::Unknown)`, and the
         // strip-and-restore design depends on it. A release-mode
         // violation would degrade silently into a WASM-boundary panic
         // far from the source — fail fast here instead.
         assert!(
             !current_states_contain_unknown(current_states),
-            "Value::Unknown found in current_states — RFC #2371 constraint b violated"
+            "Value::Deferred(DeferredValue::Unknown) found in current_states — RFC #2371 constraint b violated"
         );
         self.normalizer.normalize_desired(resources);
         self.normalizer.normalize_state(current_states);
@@ -598,9 +606,9 @@ struct StrippedAttribute {
 /// predicate that covers two kinds the WASM provider boundary refuses
 /// to serialize:
 ///
-/// - `value_contains_unknown` — `Value::Unknown` (RFC #2371 stage 2 /
+/// - `value_contains_unknown` — `Value::Deferred(DeferredValue::Unknown)` (RFC #2371 stage 2 /
 ///   #2377)
-/// - `contains_resource_ref` — `Value::ResourceRef` plus the wrappers
+/// - `contains_resource_ref` — `Value::Deferred(DeferredValue::ResourceRef)` plus the wrappers
 ///   that recursively contain one (`Interpolation` / `FunctionCall` /
 ///   `Secret` / nested `List` / `Map`); without this strip the
 ///   `core_to_wit_value` `_` debug-format fallback would silently
@@ -669,17 +677,19 @@ fn restore_stripped_attributes(
 }
 
 fn value_contains_unknown(value: &carina_core::resource::Value) -> bool {
-    use carina_core::resource::{InterpolationPart, Value};
+    use carina_core::resource::{ConcreteValue, DeferredValue, InterpolationPart, Value};
     match value {
-        Value::Unknown(_) => true,
-        Value::List(items) => items.iter().any(value_contains_unknown),
-        Value::Map(map) => map.values().any(value_contains_unknown),
-        Value::Interpolation(parts) => parts.iter().any(|p| match p {
+        Value::Deferred(DeferredValue::Unknown(_)) => true,
+        Value::Concrete(ConcreteValue::List(items)) => items.iter().any(value_contains_unknown),
+        Value::Concrete(ConcreteValue::Map(map)) => map.values().any(value_contains_unknown),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => parts.iter().any(|p| match p {
             InterpolationPart::Expr(v) => value_contains_unknown(v),
             _ => false,
         }),
-        Value::FunctionCall { args, .. } => args.iter().any(value_contains_unknown),
-        Value::Secret(inner) => value_contains_unknown(inner),
+        Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
+            args.iter().any(value_contains_unknown)
+        }
+        Value::Deferred(DeferredValue::Secret(inner)) => value_contains_unknown(inner),
         _ => false,
     }
 }
@@ -798,18 +808,18 @@ fn resolve_value_alias(
     factory: &dyn ProviderFactory,
 ) {
     match value {
-        Value::String(s) if utils::is_dsl_enum_format(s) => {
+        Value::Concrete(ConcreteValue::String(s)) if utils::is_dsl_enum_format(s) => {
             let raw = utils::convert_enum_value(s);
             if let Some(canonical) = factory.get_enum_alias_reverse(resource_type, attr_name, raw) {
                 *s = canonical;
             }
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             for item in items.iter_mut() {
                 resolve_value_alias(item, resource_type, attr_name, factory);
             }
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let map_keys: Vec<String> = map.keys().cloned().collect();
             for map_key in map_keys {
                 if let Some(v) = map.get_mut(&map_key) {
@@ -1345,7 +1355,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
     // Type-level canonicalization for `Union[String, list(String)]`
     // fields (IAM-style `string_or_list_of_strings`). Done after refs
     // resolve so concrete `String` / `List` shapes can be folded to the
-    // canonical `Value::StringList` form before differ / display see
+    // canonical `Value::Concrete(ConcreteValue::StringList)` form before differ / display see
     // them. See #2481, #2511.
     carina_core::value::canonicalize_resources_with_schemas(&mut resources, ctx.schemas());
     // Same canonicalization for the actual-side state values (#2481, #2513).
@@ -1601,7 +1611,7 @@ fn resolve_import_target(
             continue;
         }
         if let Some(attr) = name_attr
-            && let Some(Value::String(s)) = resource.get_attr(attr)
+            && let Some(Value::Concrete(ConcreteValue::String(s))) = resource.get_attr(attr)
             && s == to.name_str()
         {
             fallback_id = Some(resource.id.clone());

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -9,7 +9,9 @@ fn test_resolve_enum_aliases_ip_protocol_all() {
     let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule");
     resource.set_attr(
         "ip_protocol".to_string(),
-        Value::String("awscc.ec2.security_group_egress.IpProtocol.all".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.security_group_egress.IpProtocol.all".to_string(),
+        )),
     );
 
     let mut resources = vec![resource];
@@ -17,7 +19,7 @@ fn test_resolve_enum_aliases_ip_protocol_all() {
 
     assert_eq!(
         resources[0].get_attr("ip_protocol"),
-        Some(&Value::String("-1".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String("-1".to_string()))),
         "Alias 'all' should be resolved to canonical AWS value '-1'"
     );
 }
@@ -29,7 +31,9 @@ fn test_resolve_enum_aliases_no_alias() {
     let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule");
     resource.set_attr(
         "ip_protocol".to_string(),
-        Value::String("awscc.ec2.security_group_egress.IpProtocol.tcp".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.security_group_egress.IpProtocol.tcp".to_string(),
+        )),
     );
 
     let mut resources = vec![resource];
@@ -38,9 +42,9 @@ fn test_resolve_enum_aliases_no_alias() {
     // "tcp" has no alias, so it remains as the namespaced DSL value
     assert_eq!(
         resources[0].get_attr("ip_protocol"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "awscc.ec2.security_group_egress.IpProtocol.tcp".to_string()
-        )),
+        ))),
     );
 }
 
@@ -51,7 +55,9 @@ fn test_resolve_enum_aliases_aws_provider() {
     let mut resource = Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule");
     resource.set_attr(
         "ip_protocol".to_string(),
-        Value::String("aws.ec2.security_group_ingress.IpProtocol.all".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "aws.ec2.security_group_ingress.IpProtocol.all".to_string(),
+        )),
     );
 
     let mut resources = vec![resource];
@@ -59,7 +65,7 @@ fn test_resolve_enum_aliases_aws_provider() {
 
     assert_eq!(
         resources[0].get_attr("ip_protocol"),
-        Some(&Value::String("-1".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String("-1".to_string()))),
     );
 }
 
@@ -72,7 +78,9 @@ fn test_resolve_enum_aliases_in_states() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "ip_protocol".to_string(),
-        Value::String("awscc.ec2.security_group_egress.IpProtocol.all".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.security_group_egress.IpProtocol.all".to_string(),
+        )),
     );
     let state = State::existing(id.clone(), attrs);
     let mut current_states = HashMap::new();
@@ -82,7 +90,7 @@ fn test_resolve_enum_aliases_in_states() {
 
     assert_eq!(
         current_states[&id].attributes.get("ip_protocol"),
-        Some(&Value::String("-1".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String("-1".to_string()))),
     );
 }
 
@@ -94,30 +102,38 @@ fn test_resolve_enum_aliases_in_struct_field() {
     let mut egress_map = IndexMap::new();
     egress_map.insert(
         "ip_protocol".to_string(),
-        Value::String("awscc.ec2.SecurityGroup.IpProtocol.all".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.SecurityGroup.IpProtocol.all".to_string(),
+        )),
     );
     egress_map.insert(
         "cidr_ip".to_string(),
-        Value::String("0.0.0.0/0".to_string()),
+        Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
     );
     resource.set_attr(
         "security_group_egress".to_string(),
-        Value::List(vec![Value::Map(egress_map)]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(egress_map),
+        )])),
     );
 
     let mut resources = vec![resource];
     resolve_enum_aliases(&mut resources);
 
-    if let Value::List(items) = resources[0].get_attr("security_group_egress").unwrap() {
-        if let Value::Map(m) = &items[0] {
+    if let Value::Concrete(ConcreteValue::List(items)) =
+        resources[0].get_attr("security_group_egress").unwrap()
+    {
+        if let Value::Concrete(ConcreteValue::Map(m)) = &items[0] {
             assert_eq!(
                 m.get("ip_protocol"),
-                Some(&Value::String("-1".to_string())),
+                Some(&Value::Concrete(ConcreteValue::String("-1".to_string()))),
                 "Alias in struct field should be resolved"
             );
             assert_eq!(
                 m.get("cidr_ip"),
-                Some(&Value::String("0.0.0.0/0".to_string())),
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "0.0.0.0/0".to_string()
+                ))),
                 "Non-alias values should not be changed"
             );
         } else {
@@ -150,7 +166,9 @@ fn test_normalize_state_prevents_false_enum_diff() {
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
     resource.set_attr(
         "instance_tenancy".to_string(),
-        Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.Vpc.InstanceTenancy.default".to_string(),
+        )),
     );
 
     // State with raw AWS value (as returned by provider.read())
@@ -158,7 +176,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
     let mut state_attrs = HashMap::new();
     state_attrs.insert(
         "instance_tenancy".to_string(),
-        Value::String("default".to_string()),
+        Value::Concrete(ConcreteValue::String("default".to_string())),
     );
     let state = State::existing(id.clone(), state_attrs);
     let mut current_states = HashMap::new();
@@ -240,9 +258,12 @@ fn test_merge_default_tags_prevents_false_diff() {
     let mut tags = IndexMap::new();
     tags.insert(
         "Environment".to_string(),
-        Value::String("production".to_string()),
+        Value::Concrete(ConcreteValue::String("production".to_string())),
     );
-    state_attrs.insert("tags".to_string(), Value::Map(tags));
+    state_attrs.insert(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(tags)),
+    );
     let state = State::existing(id.clone(), state_attrs);
     let mut current_states = HashMap::new();
     current_states.insert(id.clone(), state);
@@ -251,7 +272,7 @@ fn test_merge_default_tags_prevents_false_diff() {
         let mut m = IndexMap::new();
         m.insert(
             "Environment".to_string(),
-            Value::String("production".to_string()),
+            Value::Concrete(ConcreteValue::String("production".to_string())),
         );
         m
     };
@@ -328,20 +349,27 @@ fn test_resolve_enum_aliases_non_enum_values_unchanged() {
     let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg");
     resource.set_attr(
         "group_description".to_string(),
-        Value::String("My security group".to_string()),
+        Value::Concrete(ConcreteValue::String("My security group".to_string())),
     );
-    resource.set_attr("vpc_id".to_string(), Value::String("vpc-12345".to_string()));
+    resource.set_attr(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-12345".to_string())),
+    );
 
     let mut resources = vec![resource];
     resolve_enum_aliases(&mut resources);
 
     assert_eq!(
         resources[0].get_attr("group_description"),
-        Some(&Value::String("My security group".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "My security group".to_string()
+        ))),
     );
     assert_eq!(
         resources[0].get_attr("vpc_id"),
-        Some(&Value::String("vpc-12345".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345".to_string()
+        ))),
     );
 }
 
@@ -349,7 +377,7 @@ fn test_resolve_enum_aliases_non_enum_values_unchanged() {
 fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{Resource, ResourceId, Value};
+    use carina_core::resource::{ConcreteValue, Resource, ResourceId, Value};
     use carina_core::schema::ResourceSchema;
 
     // Schema with name_attribute = "bucket_name"
@@ -361,7 +389,7 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "s3_bucket_1d43a664");
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("carina-rs-state".to_string()),
+        Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
     );
     let mut plan = Plan::new();
     plan.add(Effect::Create(resource));
@@ -450,13 +478,13 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
     mizzy.kind = ResourceKind::DataSource;
     mizzy.attributes.insert(
         "identity_store_id".to_string(),
-        Value::ResourceRef {
+        Value::Deferred(DeferredValue::ResourceRef {
             path: AccessPath::new("sso", "identity_store_id"),
-        },
+        }),
     );
     mizzy.attributes.insert(
         "user_name".to_string(),
-        Value::String("gosukenator@gmail.com".into()),
+        Value::Concrete(ConcreteValue::String("gosukenator@gmail.com".into())),
     );
 
     // current_states after phase 1: sso has been refreshed and its
@@ -466,7 +494,7 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
         sso.id.clone(),
         HashMap::from([(
             "identity_store_id".to_string(),
-            Value::String(identity_store_id.into()),
+            Value::Concrete(ConcreteValue::String(identity_store_id.into())),
         )]),
     );
     current_states.insert(sso.id.clone(), sso_state);
@@ -484,13 +512,17 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
     let resolved_mizzy = &resolved[0];
     assert_eq!(
         resolved_mizzy.get_attr("identity_store_id"),
-        Some(&Value::String(identity_store_id.into())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            identity_store_id.into()
+        ))),
         "identity_store_id should be resolved to the concrete state value, \
          not a ResourceRef"
     );
     assert_eq!(
         resolved_mizzy.get_attr("user_name"),
-        Some(&Value::String("gosukenator@gmail.com".into())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "gosukenator@gmail.com".into()
+        ))),
         "literal inputs should pass through untouched"
     );
 }
@@ -569,23 +601,33 @@ fn module_and_provider_wrappers_return_vec_app_error() {
 
 #[test]
 fn strip_and_restore_unknown_attributes_round_trip() {
-    use carina_core::resource::{AccessPath, UnknownReason, Value};
+    use carina_core::resource::{AccessPath, ConcreteValue, DeferredValue, UnknownReason, Value};
     use indexmap::IndexMap;
 
     let mut r = carina_core::resource::Resource::new("test.t", "n");
     let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-    r.attributes
-        .insert("group_description".into(), Value::String("web".into()));
+    r.attributes.insert(
+        "group_description".into(),
+        Value::Concrete(ConcreteValue::String("web".into())),
+    );
     r.attributes.insert(
         "vpc_id".into(),
-        Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() }),
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+            path: path.clone(),
+        })),
     );
     let mut tags: IndexMap<String, Value> = IndexMap::new();
-    tags.insert("Name".into(), Value::String("web-sg".into()));
-    r.attributes.insert("tags".into(), Value::Map(tags));
+    tags.insert(
+        "Name".into(),
+        Value::Concrete(ConcreteValue::String("web-sg".into())),
+    );
+    r.attributes
+        .insert("tags".into(), Value::Concrete(ConcreteValue::Map(tags)));
     r.attributes.insert(
         "nested_unknown".into(),
-        Value::List(vec![Value::Unknown(UnknownReason::UpstreamRef { path })]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Deferred(
+            DeferredValue::Unknown(UnknownReason::UpstreamRef { path }),
+        )])),
     );
     let mut resources = vec![r];
     let order_before: Vec<String> = resources[0].attributes.keys().cloned().collect();
@@ -611,14 +653,17 @@ fn strip_and_restore_unknown_attributes_round_trip() {
     // The restored Unknown values are still typed (not coerced to string).
     assert!(matches!(
         resources[0].get_attr("vpc_id"),
-        Some(Value::Unknown(_))
+        Some(Value::Deferred(DeferredValue::Unknown(_)))
     ));
     match resources[0].get_attr("nested_unknown") {
-        Some(Value::List(items)) => {
-            assert!(matches!(items[0], Value::Unknown(_)));
+        Some(Value::Concrete(ConcreteValue::List(items))) => {
+            assert!(matches!(
+                items[0],
+                Value::Deferred(DeferredValue::Unknown(_))
+            ));
         }
         other => panic!(
-            "nested_unknown should still be Value::List, got {:?}",
+            "nested_unknown should still be Value::Concrete(ConcreteValue::List), got {:?}",
             other
         ),
     }
@@ -626,30 +671,46 @@ fn strip_and_restore_unknown_attributes_round_trip() {
 
 #[test]
 fn value_contains_unknown_recurses() {
-    use carina_core::resource::{AccessPath, InterpolationPart, UnknownReason, Value};
+    use carina_core::resource::{
+        AccessPath, ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
+    };
     let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-    let unknown = || Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+    let unknown = || {
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+            path: path.clone(),
+        }))
+    };
 
     assert!(super::value_contains_unknown(&unknown()));
-    assert!(super::value_contains_unknown(&Value::List(vec![unknown()])));
-    assert!(super::value_contains_unknown(&Value::Map({
-        let mut m = indexmap::IndexMap::new();
-        m.insert("k".into(), unknown());
-        m
-    })));
-    assert!(super::value_contains_unknown(&Value::Interpolation(vec![
-        InterpolationPart::Expr(unknown()),
-    ])));
-    assert!(super::value_contains_unknown(&Value::FunctionCall {
-        name: "f".into(),
-        args: vec![unknown()],
-    }));
-    assert!(super::value_contains_unknown(&Value::Secret(Box::new(
-        unknown()
-    ))));
+    assert!(super::value_contains_unknown(&Value::Concrete(
+        ConcreteValue::List(vec![unknown()])
+    )));
+    assert!(super::value_contains_unknown(&Value::Concrete(
+        ConcreteValue::Map({
+            let mut m = indexmap::IndexMap::new();
+            m.insert("k".into(), unknown());
+            m
+        })
+    )));
+    assert!(super::value_contains_unknown(&Value::Deferred(
+        DeferredValue::Interpolation(vec![InterpolationPart::Expr(unknown()),])
+    )));
+    assert!(super::value_contains_unknown(&Value::Deferred(
+        DeferredValue::FunctionCall {
+            name: "f".into(),
+            args: vec![unknown()],
+        }
+    )));
+    assert!(super::value_contains_unknown(&Value::Deferred(
+        DeferredValue::Secret(Box::new(unknown()))
+    )));
 
-    assert!(!super::value_contains_unknown(&Value::String("x".into())));
-    assert!(!super::value_contains_unknown(&Value::Int(1)));
+    assert!(!super::value_contains_unknown(&Value::Concrete(
+        ConcreteValue::String("x".into())
+    )));
+    assert!(!super::value_contains_unknown(&Value::Concrete(
+        ConcreteValue::Int(1)
+    )));
 }
 
 #[test]
@@ -659,25 +720,32 @@ fn restore_unknown_attributes_after_normalize_injection() {
     // their original `insert_index`; injected attributes end up
     // trailing them. Verifies that `min(len)` clamping doesn't reorder
     // the originals when the post-normalize map has different length.
-    use carina_core::resource::{AccessPath, UnknownReason, Value};
+    use carina_core::resource::{AccessPath, ConcreteValue, DeferredValue, UnknownReason, Value};
 
     let mut r = carina_core::resource::Resource::new("test.t", "n");
     let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-    r.attributes
-        .insert("a".into(), Value::String("a-val".into()));
+    r.attributes.insert(
+        "a".into(),
+        Value::Concrete(ConcreteValue::String("a-val".into())),
+    );
     r.attributes.insert(
         "b".into(),
-        Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() }),
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+            path: path.clone(),
+        })),
     );
-    r.attributes
-        .insert("c".into(), Value::String("c-val".into()));
+    r.attributes.insert(
+        "c".into(),
+        Value::Concrete(ConcreteValue::String("c-val".into())),
+    );
     let mut resources = vec![r];
 
     let stripped = super::strip_attributes_matching(&mut resources, &super::value_contains_unknown);
     // After strip: ["a", "c"]. Simulate normalize injecting "z".
-    resources[0]
-        .attributes
-        .insert("z".into(), Value::String("z-val".into()));
+    resources[0].attributes.insert(
+        "z".into(),
+        Value::Concrete(ConcreteValue::String("z-val".into())),
+    );
     super::restore_stripped_attributes(&mut resources, stripped);
 
     let order: Vec<String> = resources[0].attributes.keys().cloned().collect();
@@ -697,20 +765,28 @@ fn restore_unknown_attributes_after_normalize_injection() {
 fn strip_and_restore_for_expression_unknowns_round_trip() {
     // The strip-and-restore helpers must cover every `UnknownReason`
     // variant — the WASM provider boundary must never see a
-    // `Value::Unknown` of any reason.
-    use carina_core::resource::{UnknownReason, Value};
+    // `Value::Deferred(DeferredValue::Unknown)` of any reason.
+    use carina_core::resource::{ConcreteValue, DeferredValue, UnknownReason, Value};
 
     let mut r = carina_core::resource::Resource::new("test.t", "n");
-    r.attributes
-        .insert("name".into(), Value::String("static".into()));
-    r.attributes
-        .insert("target_id".into(), Value::Unknown(UnknownReason::ForValue));
+    r.attributes.insert(
+        "name".into(),
+        Value::Concrete(ConcreteValue::String("static".into())),
+    );
+    r.attributes.insert(
+        "target_id".into(),
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
+    );
     r.attributes.insert(
         "items".into(),
-        Value::List(vec![Value::Unknown(UnknownReason::ForKey)]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Deferred(
+            DeferredValue::Unknown(UnknownReason::ForKey),
+        )])),
     );
-    r.attributes
-        .insert("index".into(), Value::Unknown(UnknownReason::ForIndex));
+    r.attributes.insert(
+        "index".into(),
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex)),
+    );
     let mut resources = vec![r];
     let order_before: Vec<String> = resources[0].attributes.keys().cloned().collect();
 
@@ -731,29 +807,35 @@ fn strip_and_restore_for_expression_unknowns_round_trip() {
     );
     assert!(matches!(
         resources[0].get_attr("target_id"),
-        Some(Value::Unknown(UnknownReason::ForValue))
+        Some(Value::Deferred(DeferredValue::Unknown(
+            UnknownReason::ForValue
+        )))
     ));
     assert!(matches!(
         resources[0].get_attr("index"),
-        Some(Value::Unknown(UnknownReason::ForIndex))
+        Some(Value::Deferred(DeferredValue::Unknown(
+            UnknownReason::ForIndex
+        )))
     ));
 }
 
 #[test]
 fn value_contains_unknown_covers_for_variants() {
-    use carina_core::resource::{UnknownReason, Value};
-    assert!(super::value_contains_unknown(&Value::Unknown(
-        UnknownReason::ForValue
+    use carina_core::resource::{ConcreteValue, DeferredValue, UnknownReason, Value};
+    assert!(super::value_contains_unknown(&Value::Deferred(
+        DeferredValue::Unknown(UnknownReason::ForValue)
     )));
-    assert!(super::value_contains_unknown(&Value::Unknown(
-        UnknownReason::ForKey
+    assert!(super::value_contains_unknown(&Value::Deferred(
+        DeferredValue::Unknown(UnknownReason::ForKey)
     )));
-    assert!(super::value_contains_unknown(&Value::Unknown(
-        UnknownReason::ForIndex
+    assert!(super::value_contains_unknown(&Value::Deferred(
+        DeferredValue::Unknown(UnknownReason::ForIndex)
     )));
-    assert!(super::value_contains_unknown(&Value::List(vec![
-        Value::Unknown(UnknownReason::ForValue),
-    ])));
+    assert!(super::value_contains_unknown(&Value::Concrete(
+        ConcreteValue::List(vec![Value::Deferred(DeferredValue::Unknown(
+            UnknownReason::ForValue
+        )),])
+    )));
 }
 
 // ----- #2387: strip-and-restore round trip for ResourceRef -----
@@ -761,42 +843,58 @@ fn value_contains_unknown_covers_for_variants() {
 #[test]
 fn strip_and_restore_resource_ref_round_trip() {
     // The strip-and-restore pass must remove any attribute that
-    // recursively contains a `Value::ResourceRef` so the WASM
+    // recursively contains a `Value::Deferred(DeferredValue::ResourceRef)` so the WASM
     // boundary's `core_to_wit_value` never sees one (#2387). This
-    // mirrors the stage-2 `Value::Unknown` round-trip test for the
+    // mirrors the stage-2 `Value::Deferred(DeferredValue::Unknown)` round-trip test for the
     // ResourceRef predicate.
-    use carina_core::resource::{AccessPath, InterpolationPart, Value, contains_resource_ref};
+    use carina_core::resource::{
+        AccessPath, ConcreteValue, DeferredValue, InterpolationPart, Value, contains_resource_ref,
+    };
     use indexmap::IndexMap;
 
     let mut r = carina_core::resource::Resource::new("test.t", "n");
     let path = AccessPath::with_fields("admins", "group_id", vec![]);
-    r.attributes
-        .insert("name".into(), Value::String("static".into()));
-    r.attributes
-        .insert("group_id".into(), Value::ResourceRef { path: path.clone() });
+    r.attributes.insert(
+        "name".into(),
+        Value::Concrete(ConcreteValue::String("static".into())),
+    );
+    r.attributes.insert(
+        "group_id".into(),
+        Value::Deferred(DeferredValue::ResourceRef { path: path.clone() }),
+    );
     let mut nested_map: IndexMap<String, Value> = IndexMap::new();
-    nested_map.insert("ref".into(), Value::ResourceRef { path: path.clone() });
-    r.attributes.insert("policy".into(), Value::Map(nested_map));
+    nested_map.insert(
+        "ref".into(),
+        Value::Deferred(DeferredValue::ResourceRef { path: path.clone() }),
+    );
+    r.attributes.insert(
+        "policy".into(),
+        Value::Concrete(ConcreteValue::Map(nested_map)),
+    );
     r.attributes.insert(
         "label".into(),
-        Value::Interpolation(vec![
+        Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("prefix-".into()),
-            InterpolationPart::Expr(Value::ResourceRef { path: path.clone() }),
-        ]),
+            InterpolationPart::Expr(Value::Deferred(DeferredValue::ResourceRef {
+                path: path.clone(),
+            })),
+        ])),
     );
     r.attributes.insert(
         "joined".into(),
-        Value::FunctionCall {
+        Value::Deferred(DeferredValue::FunctionCall {
             name: "join".into(),
             args: vec![
-                Value::String(",".into()),
-                Value::ResourceRef { path: path.clone() },
+                Value::Concrete(ConcreteValue::String(",".into())),
+                Value::Deferred(DeferredValue::ResourceRef { path: path.clone() }),
             ],
-        },
+        }),
     );
     r.attributes.insert(
         "secret_ref".into(),
-        Value::Secret(Box::new(Value::ResourceRef { path: path.clone() })),
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
+            DeferredValue::ResourceRef { path: path.clone() },
+        )))),
     );
     let mut resources = vec![r];
     let order_before: Vec<String> = resources[0].attributes.keys().cloned().collect();
@@ -821,19 +919,19 @@ fn strip_and_restore_resource_ref_round_trip() {
     // to a debug-format String — the failure mode #2387 prevents).
     assert!(matches!(
         resources[0].get_attr("group_id"),
-        Some(Value::ResourceRef { .. })
+        Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
     ));
     assert!(matches!(
         resources[0].get_attr("label"),
-        Some(Value::Interpolation(_))
+        Some(Value::Deferred(DeferredValue::Interpolation(_)))
     ));
     assert!(matches!(
         resources[0].get_attr("joined"),
-        Some(Value::FunctionCall { .. })
+        Some(Value::Deferred(DeferredValue::FunctionCall { .. }))
     ));
     assert!(matches!(
         resources[0].get_attr("secret_ref"),
-        Some(Value::Secret(_))
+        Some(Value::Deferred(DeferredValue::Secret(_)))
     ));
 }
 
@@ -842,20 +940,26 @@ fn strip_unified_predicate_covers_unknown_and_ref() {
     // The `prepare` pass uses the unified predicate
     // `value_contains_unknown(v) || contains_resource_ref(v)`. Verify
     // it strips both kinds in a single pass, in original order.
-    use carina_core::resource::{AccessPath, UnknownReason, Value, contains_resource_ref};
+    use carina_core::resource::{
+        AccessPath, ConcreteValue, DeferredValue, UnknownReason, Value, contains_resource_ref,
+    };
 
     let mut r = carina_core::resource::Resource::new("test.t", "n");
     let path = AccessPath::with_fields("admins", "group_id", vec![]);
-    r.attributes
-        .insert("name".into(), Value::String("static".into()));
+    r.attributes.insert(
+        "name".into(),
+        Value::Concrete(ConcreteValue::String("static".into())),
+    );
     r.attributes.insert(
         "vpc_id".into(),
-        Value::Unknown(UnknownReason::UpstreamRef {
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
             path: AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]),
-        }),
+        })),
     );
-    r.attributes
-        .insert("group_id".into(), Value::ResourceRef { path: path.clone() });
+    r.attributes.insert(
+        "group_id".into(),
+        Value::Deferred(DeferredValue::ResourceRef { path: path.clone() }),
+    );
     let mut resources = vec![r];
 
     let stripped = super::strip_attributes_matching(&mut resources, &|v| {
@@ -868,11 +972,11 @@ fn strip_unified_predicate_covers_unknown_and_ref() {
     super::restore_stripped_attributes(&mut resources, stripped);
     assert!(matches!(
         resources[0].get_attr("vpc_id"),
-        Some(Value::Unknown(_))
+        Some(Value::Deferred(DeferredValue::Unknown(_)))
     ));
     assert!(matches!(
         resources[0].get_attr("group_id"),
-        Some(Value::ResourceRef { .. })
+        Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
     ));
 }
 
@@ -896,13 +1000,15 @@ fn parsed_with_attr(attr_name: &str, attr_value: Value) -> ParsedFile {
 
 #[test]
 fn validate_rejects_top_level_empty_interpolation() {
-    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+    use carina_core::resource::{DeferredValue, InterpolationPart, UnknownReason, Value};
 
-    let value = Value::Interpolation(vec![
+    let value = Value::Deferred(DeferredValue::Interpolation(vec![
         InterpolationPart::Literal("arn:aws:iam::".to_string()),
-        InterpolationPart::Expr(Value::Unknown(UnknownReason::EmptyInterpolation)),
+        InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
+            UnknownReason::EmptyInterpolation,
+        ))),
         InterpolationPart::Literal(":root".to_string()),
-    ]);
+    ]));
     let parsed = parsed_with_attr("aws", value);
 
     let errors = validate_no_empty_interpolations(&parsed);
@@ -930,12 +1036,15 @@ fn validate_rejects_top_level_empty_interpolation() {
 
 #[test]
 fn validate_rejects_empty_interpolation_inside_secret() {
-    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+    use carina_core::resource::{DeferredValue, InterpolationPart, UnknownReason, Value};
 
-    let inner = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
-        UnknownReason::EmptyInterpolation,
-    ))]);
-    let parsed = parsed_with_attr("password", Value::Secret(Box::new(inner)));
+    let inner = Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation)),
+    )]));
+    let parsed = parsed_with_attr(
+        "password",
+        Value::Deferred(DeferredValue::Secret(Box::new(inner))),
+    );
 
     let errors = validate_no_empty_interpolations(&parsed);
     assert_eq!(
@@ -948,15 +1057,17 @@ fn validate_rejects_empty_interpolation_inside_secret() {
 
 #[test]
 fn validate_rejects_empty_interpolation_inside_function_call() {
-    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
-
-    let bad = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
-        UnknownReason::EmptyInterpolation,
-    ))]);
-    let fn_call = Value::FunctionCall {
-        name: "join".to_string(),
-        args: vec![Value::String("-".to_string()), bad],
+    use carina_core::resource::{
+        ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
     };
+
+    let bad = Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation)),
+    )]));
+    let fn_call = Value::Deferred(DeferredValue::FunctionCall {
+        name: "join".to_string(),
+        args: vec![Value::Concrete(ConcreteValue::String("-".to_string())), bad],
+    });
     let parsed = parsed_with_attr("name", fn_call);
 
     let errors = validate_no_empty_interpolations(&parsed);
@@ -970,16 +1081,20 @@ fn validate_rejects_empty_interpolation_inside_function_call() {
 
 #[test]
 fn validate_rejects_empty_interpolation_nested_in_map() {
-    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+    use carina_core::resource::{
+        ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
+    };
     use indexmap::IndexMap;
 
-    let inner = Value::Interpolation(vec![
+    let inner = Value::Deferred(DeferredValue::Interpolation(vec![
         InterpolationPart::Literal("prefix-".to_string()),
-        InterpolationPart::Expr(Value::Unknown(UnknownReason::EmptyInterpolation)),
-    ]);
+        InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
+            UnknownReason::EmptyInterpolation,
+        ))),
+    ]));
     let mut map = IndexMap::new();
     map.insert("key".to_string(), inner);
-    let parsed = parsed_with_attr("tags", Value::Map(map));
+    let parsed = parsed_with_attr("tags", Value::Concrete(ConcreteValue::Map(map)));
 
     let errors = validate_no_empty_interpolations(&parsed);
     assert_eq!(
@@ -992,12 +1107,14 @@ fn validate_rejects_empty_interpolation_nested_in_map() {
 
 #[test]
 fn validate_rejects_empty_interpolation_nested_in_list() {
-    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+    use carina_core::resource::{
+        ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
+    };
 
-    let inner = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
-        UnknownReason::EmptyInterpolation,
-    ))]);
-    let parsed = parsed_with_attr("items", Value::List(vec![inner]));
+    let inner = Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation)),
+    )]));
+    let parsed = parsed_with_attr("items", Value::Concrete(ConcreteValue::List(vec![inner])));
 
     let errors = validate_no_empty_interpolations(&parsed);
     assert_eq!(
@@ -1011,11 +1128,11 @@ fn validate_rejects_empty_interpolation_nested_in_list() {
 #[test]
 fn validate_rejects_empty_interpolation_in_export_value() {
     use carina_core::parser::ParsedExportParam;
-    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+    use carina_core::resource::{DeferredValue, InterpolationPart, UnknownReason, Value};
 
-    let bad = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
-        UnknownReason::EmptyInterpolation,
-    ))]);
+    let bad = Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation)),
+    )]));
     let parsed = ParsedFile {
         export_params: vec![ParsedExportParam {
             name: "url".to_string(),
@@ -1046,11 +1163,11 @@ fn validate_rejects_empty_interpolation_in_export_value() {
 #[test]
 fn validate_rejects_empty_interpolation_in_attribute_param_default() {
     use carina_core::parser::AttributeParameter;
-    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+    use carina_core::resource::{DeferredValue, InterpolationPart, UnknownReason, Value};
 
-    let bad = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
-        UnknownReason::EmptyInterpolation,
-    ))]);
+    let bad = Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation)),
+    )]));
     let parsed = ParsedFile {
         attribute_params: vec![AttributeParameter {
             name: "region".to_string(),
@@ -1071,13 +1188,15 @@ fn validate_rejects_empty_interpolation_in_attribute_param_default() {
 
 #[test]
 fn validate_passes_when_no_empty_interpolation() {
-    use carina_core::resource::{InterpolationPart, Value};
+    use carina_core::resource::{ConcreteValue, DeferredValue, InterpolationPart, Value};
 
     // Non-empty interpolation: must not error.
-    let value = Value::Interpolation(vec![
+    let value = Value::Deferred(DeferredValue::Interpolation(vec![
         InterpolationPart::Literal("prefix-".to_string()),
-        InterpolationPart::Expr(Value::String("real-value".to_string())),
-    ]);
+        InterpolationPart::Expr(Value::Concrete(ConcreteValue::String(
+            "real-value".to_string(),
+        ))),
+    ]));
     let parsed = parsed_with_attr("aws", value);
 
     let errors = validate_no_empty_interpolations(&parsed);

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use carina_core::provider::{
     BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer,
 };
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField, legacy_validator,
     noop_validator,
@@ -335,7 +335,7 @@ test.r.mode_holder {
 fn region_schemas() -> SchemaRegistry {
     fn validate_region(v: &Value) -> Result<(), String> {
         const VALID: &[&str] = &["ap-northeast-1", "us-west-2"];
-        if let Value::String(s) = v {
+        if let Value::Concrete(ConcreteValue::String(s)) = v {
             let normalized = carina_core::utils::extract_enum_value(s).replace('_', "-");
             if VALID.contains(&normalized.as_str()) {
                 return Ok(());
@@ -1035,8 +1035,10 @@ awsccmock.ec2.subnet {
 // wrong reason).
 fn vpc_id_validate_2358(v: &Value) -> Result<(), String> {
     match v {
-        Value::String(s) if s.starts_with("vpc-") => Ok(()),
-        Value::String(s) => Err(format!("Invalid vpc_id '{}': must start with 'vpc-'", s)),
+        Value::Concrete(ConcreteValue::String(s)) if s.starts_with("vpc-") => Ok(()),
+        Value::Concrete(ConcreteValue::String(s)) => {
+            Err(format!("Invalid vpc_id '{}': must start with 'vpc-'", s))
+        }
         _ => Ok(()),
     }
 }
@@ -1169,7 +1171,7 @@ exports {
 fn literal_valid_string_assignment_to_custom_receiver_still_validates() {
     // Existing `awscc.ec2.SecurityGroup { vpc_id = 'vpc-12345678' }`
     // pattern remains valid: a literal string in source becomes
-    // `Value::String(...)`, which validation handles via the schema-
+    // `Value::Concrete(ConcreteValue::String(...))`, which validation handles via the schema-
     // attached `validate` closure on the Custom type — not via
     // `is_type_expr_compatible_with_schema`. The strictness fix must
     // not regress this path.

--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
 fn render_first_error(
@@ -55,7 +55,9 @@ fn invalid_enum_variant_namespaced_display() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "versioning".to_string(),
-        Value::String("aws.s3.Bucket.VersioningStatus.NotReal".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "aws.s3.Bucket.VersioningStatus.NotReal".to_string(),
+        )),
     );
     insta::assert_snapshot!(render_first_error(&schema, attrs, false));
 }
@@ -68,7 +70,9 @@ fn invalid_enum_variant_bare_display() {
         namespace: None,
         dsl_aliases: vec![],
     };
-    let err = t.validate(&Value::String("zzz".to_string())).unwrap_err();
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .unwrap_err();
     insta::assert_snapshot!(err.to_string());
 }
 
@@ -83,7 +87,9 @@ fn invalid_enum_variant_with_dsl_aliases_display() {
             ("Suspended".to_string(), "suspended".to_string()),
         ],
     };
-    let err = t.validate(&Value::String("zzz".to_string())).unwrap_err();
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .unwrap_err();
     insta::assert_snapshot!(err.to_string());
 }
 
@@ -102,7 +108,10 @@ fn string_literal_expected_enum_string_enum_display() {
         .required(),
     );
     let mut attrs = HashMap::new();
-    attrs.insert("target_type".to_string(), Value::String("aaa".to_string()));
+    attrs.insert(
+        "target_type".to_string(),
+        Value::Concrete(ConcreteValue::String("aaa".to_string())),
+    );
     insta::assert_snapshot!(render_first_error(&schema, attrs, true));
 }
 
@@ -110,8 +119,10 @@ fn string_literal_expected_enum_string_enum_display() {
 fn string_literal_expected_enum_custom_namespaced_display() {
     fn validate_mode(v: &Value) -> Result<(), String> {
         match v {
-            Value::String(s) if s == "test.r.Mode.fast" => Ok(()),
-            Value::String(s) => Err(format!("invalid Mode '{}': expected fast", s)),
+            Value::Concrete(ConcreteValue::String(s)) if s == "test.r.Mode.fast" => Ok(()),
+            Value::Concrete(ConcreteValue::String(s)) => {
+                Err(format!("invalid Mode '{}': expected fast", s))
+            }
             _ => Err("expected String".to_string()),
         }
     }
@@ -131,6 +142,9 @@ fn string_literal_expected_enum_custom_namespaced_display() {
         .required(),
     );
     let mut attrs = HashMap::new();
-    attrs.insert("mode".to_string(), Value::String("aaa".to_string()));
+    attrs.insert(
+        "mode".to_string(),
+        Value::Concrete(ConcreteValue::String("aaa".to_string())),
+    );
     insta::assert_snapshot!(render_first_error(&schema, attrs, true));
 }

--- a/carina-cli/tests/share_provider_attrs.rs
+++ b/carina-cli/tests/share_provider_attrs.rs
@@ -9,7 +9,7 @@
 use std::path::PathBuf;
 
 use carina_core::config_loader::load_configuration;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 
 #[test]
 fn share_provider_attrs_resolves_default_tags() {
@@ -47,22 +47,27 @@ fn share_provider_attrs_resolves_default_tags() {
     );
 
     let tags = &provider.default_tags;
-    assert_eq!(tags.get("ManagedBy"), Some(&Value::String("carina".into())),);
+    assert_eq!(
+        tags.get("ManagedBy"),
+        Some(&Value::Concrete(ConcreteValue::String("carina".into()))),
+    );
     assert_eq!(
         tags.get("Project"),
-        Some(&Value::String("carina-rs".into())),
+        Some(&Value::Concrete(ConcreteValue::String("carina-rs".into()))),
     );
     assert_eq!(
         tags.get("Repository"),
-        Some(&Value::String("carina-rs/infra".into())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "carina-rs/infra".into()
+        ))),
     );
     assert_eq!(
         tags.get("Environment"),
-        Some(&Value::String("dev".into())),
+        Some(&Value::Concrete(ConcreteValue::String("dev".into()))),
         "Environment must come from the module-call argument; got {tags:?}",
     );
     assert_eq!(
         tags.get("Component"),
-        Some(&Value::String("registry".into())),
+        Some(&Value::Concrete(ConcreteValue::String("registry".into()))),
     );
 }

--- a/carina-cli/tests/state_value_round_trip.rs
+++ b/carina-cli/tests/state_value_round_trip.rs
@@ -89,8 +89,8 @@ fn fixture_attributes_round_trip_through_value_codec() {
                 };
 
                 // Lower: Value → JSON via the production codec.
-                // Some inputs (e.g. a hypothetical `Value::Secret` or
-                // `Value::Unknown` in a fixture) intentionally error
+                // Some inputs (e.g. a hypothetical `Value::Deferred(DeferredValue::Secret)` or
+                // `Value::Deferred(DeferredValue::Unknown)` in a fixture) intentionally error
                 // here. None of the in-tree fixtures contain such
                 // values, but if a future fixture adds one, surface
                 // the error rather than swallow it.

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -594,7 +594,7 @@ let vpc = aws.ec2.Vpc {
 #[cfg(test)]
 mod resolved_bindings_tests {
     use super::*;
-    use crate::resource::{Resource, ResourceId, State, Value};
+    use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
     use std::collections::BTreeSet;
 
     fn make_resource(name: &str, binding: Option<&str>, attrs: Vec<(&str, Value)>) -> Resource {
@@ -609,7 +609,10 @@ mod resolved_bindings_tests {
         let resources = vec![make_resource(
             "my-vpc",
             Some("vpc"),
-            vec![("cidr_block", Value::String("10.0.0.0/16".to_string()))],
+            vec![(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )],
         )];
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -619,7 +622,9 @@ mod resolved_bindings_tests {
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
             attrs.get("cidr_block"),
-            Some(&Value::String("10.0.0.0/16".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "10.0.0.0/16".to_string()
+            )))
         );
         assert_eq!(resolved.source("vpc"), Some(BindingValueSource::Local));
     }
@@ -630,7 +635,10 @@ mod resolved_bindings_tests {
         let resources = vec![make_resource(
             "my-vpc",
             Some("vpc"),
-            vec![("cidr_block", Value::String("10.0.0.0/16".to_string()))],
+            vec![(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )],
         )];
         let mut states: HashMap<ResourceId, State> = HashMap::new();
         states.insert(
@@ -640,9 +648,15 @@ mod resolved_bindings_tests {
                 identifier: None,
                 exists: true,
                 attributes: vec![
-                    ("id".to_string(), Value::String("vpc-abc".to_string())),
+                    (
+                        "id".to_string(),
+                        Value::Concrete(ConcreteValue::String("vpc-abc".to_string())),
+                    ),
                     // conflicting key — DSL value should win
-                    ("cidr_block".to_string(), Value::String("WRONG".to_string())),
+                    (
+                        "cidr_block".to_string(),
+                        Value::Concrete(ConcreteValue::String("WRONG".to_string())),
+                    ),
                 ]
                 .into_iter()
                 .collect(),
@@ -656,12 +670,16 @@ mod resolved_bindings_tests {
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
             attrs.get("id"),
-            Some(&Value::String("vpc-abc".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "vpc-abc".to_string()
+            ))),
             "state-only attribute must be merged in",
         );
         assert_eq!(
             attrs.get("cidr_block"),
-            Some(&Value::String("10.0.0.0/16".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "10.0.0.0/16".to_string()
+            ))),
             "DSL value must win when both sides define a key",
         );
     }
@@ -674,7 +692,10 @@ mod resolved_bindings_tests {
         let states: HashMap<ResourceId, State> = HashMap::new();
         let mut remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
         let mut network_attrs = HashMap::new();
-        network_attrs.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+        network_attrs.insert(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        );
         remote.insert("network".to_string(), network_attrs);
 
         let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
@@ -682,7 +703,9 @@ mod resolved_bindings_tests {
         let attrs = resolved.get("network").expect("upstream binding present");
         assert_eq!(
             attrs.get("vpc_id"),
-            Some(&Value::String("vpc-123".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "vpc-123".to_string()
+            )))
         );
         assert_eq!(
             resolved.source("network"),
@@ -695,7 +718,10 @@ mod resolved_bindings_tests {
         let resources = vec![make_resource(
             "anonymous",
             None,
-            vec![("cidr_block", Value::String("10.0.0.0/16".to_string()))],
+            vec![(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )],
         )];
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -713,22 +739,30 @@ mod resolved_bindings_tests {
         let resources = vec![make_resource(
             "my-local",
             Some("shared"),
-            vec![("kind", Value::String("local".to_string()))],
+            vec![(
+                "kind",
+                Value::Concrete(ConcreteValue::String("local".to_string())),
+            )],
         )];
         let states: HashMap<ResourceId, State> = HashMap::new();
         let mut remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote.insert(
             "shared".to_string(),
-            vec![("kind".to_string(), Value::String("upstream".to_string()))]
-                .into_iter()
-                .collect(),
+            vec![(
+                "kind".to_string(),
+                Value::Concrete(ConcreteValue::String("upstream".to_string())),
+            )]
+            .into_iter()
+            .collect(),
         );
 
         let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
         let attrs = resolved.get("shared").expect("shared binding present");
         assert_eq!(
             attrs.get("kind"),
-            Some(&Value::String("upstream".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "upstream".to_string()
+            ))),
             "upstream binding must override local one with the same name",
         );
         assert_eq!(
@@ -746,7 +780,10 @@ mod resolved_bindings_tests {
         let resources = vec![make_resource(
             "my-vpc",
             Some("vpc"),
-            vec![("cidr_block", Value::String("10.0.0.0/16".to_string()))],
+            vec![(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )],
         )];
         let mut states: HashMap<ResourceId, State> = HashMap::new();
         states.insert(
@@ -755,9 +792,12 @@ mod resolved_bindings_tests {
                 id: rid,
                 identifier: None,
                 exists: false,
-                attributes: vec![("id".to_string(), Value::String("vpc-stale".to_string()))]
-                    .into_iter()
-                    .collect(),
+                attributes: vec![(
+                    "id".to_string(),
+                    Value::Concrete(ConcreteValue::String("vpc-stale".to_string())),
+                )]
+                .into_iter()
+                .collect(),
                 dependency_bindings: BTreeSet::new(),
             },
         );
@@ -781,10 +821,13 @@ mod resolved_bindings_tests {
         // `ResolvedBindings` API has to preserve it byte-for-byte.
         let mut resolved = ResolvedBindings::default();
         let resource_attrs: HashMap<String, Value> = vec![
-            ("name".to_string(), Value::String("vpc-dsl".to_string())),
+            (
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("vpc-dsl".to_string())),
+            ),
             (
                 "cidr_block".to_string(),
-                Value::String("10.0.0.0/16".to_string()),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
             ),
         ]
         .into_iter()
@@ -795,9 +838,15 @@ mod resolved_bindings_tests {
             exists: true,
             attributes: vec![
                 // overrides DSL value
-                ("name".to_string(), Value::String("vpc-applied".to_string())),
+                (
+                    "name".to_string(),
+                    Value::Concrete(ConcreteValue::String("vpc-applied".to_string())),
+                ),
                 // adds a state-only key
-                ("id".to_string(), Value::String("vpc-abc".to_string())),
+                (
+                    "id".to_string(),
+                    Value::Concrete(ConcreteValue::String("vpc-abc".to_string())),
+                ),
             ]
             .into_iter()
             .collect(),
@@ -809,13 +858,22 @@ mod resolved_bindings_tests {
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
             attrs.get("name"),
-            Some(&Value::String("vpc-applied".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "vpc-applied".to_string()
+            ))),
             "state must win over resource_attrs on conflict",
         );
-        assert_eq!(attrs.get("id"), Some(&Value::String("vpc-abc".to_string())));
+        assert_eq!(
+            attrs.get("id"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "vpc-abc".to_string()
+            )))
+        );
         assert_eq!(
             attrs.get("cidr_block"),
-            Some(&Value::String("10.0.0.0/16".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "10.0.0.0/16".to_string()
+            ))),
         );
         assert_eq!(resolved.source("vpc"), Some(BindingValueSource::Local));
     }
@@ -846,7 +904,10 @@ mod resolved_bindings_tests {
         let resources = vec![make_resource(
             "vpc",
             Some("vpc"),
-            vec![("cidr_block", Value::String("10.0.0.0/16".to_string()))],
+            vec![(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )],
         )];
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -857,9 +918,12 @@ mod resolved_bindings_tests {
             id: ResourceId::new("test.resource", "subnet"),
             identifier: None,
             exists: true,
-            attributes: vec![("id".to_string(), Value::String("subnet-1".to_string()))]
-                .into_iter()
-                .collect(),
+            attributes: vec![(
+                "id".to_string(),
+                Value::Concrete(ConcreteValue::String("subnet-1".to_string())),
+            )]
+            .into_iter()
+            .collect(),
             dependency_bindings: BTreeSet::new(),
         };
         child.record_applied(Some("subnet"), &HashMap::new(), &extra_state);
@@ -878,10 +942,12 @@ mod resolved_bindings_tests {
         // (e.g. post-apply state-writeback hydrating exports). Verify
         // it overwrites any existing entry and records the given source.
         let mut resolved = ResolvedBindings::default();
-        let initial: HashMap<String, Value> =
-            vec![("kind".to_string(), Value::String("first".to_string()))]
-                .into_iter()
-                .collect();
+        let initial: HashMap<String, Value> = vec![(
+            "kind".to_string(),
+            Value::Concrete(ConcreteValue::String("first".to_string())),
+        )]
+        .into_iter()
+        .collect();
         resolved.set("registry", initial, BindingValueSource::Upstream);
         assert_eq!(
             resolved.source("registry"),
@@ -889,13 +955,15 @@ mod resolved_bindings_tests {
         );
         assert_eq!(
             resolved.get("registry").and_then(|a| a.get("kind")),
-            Some(&Value::String("first".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("first".to_string())))
         );
 
-        let replacement: HashMap<String, Value> =
-            vec![("kind".to_string(), Value::String("second".to_string()))]
-                .into_iter()
-                .collect();
+        let replacement: HashMap<String, Value> = vec![(
+            "kind".to_string(),
+            Value::Concrete(ConcreteValue::String("second".to_string())),
+        )]
+        .into_iter()
+        .collect();
         resolved.set("registry", replacement, BindingValueSource::Local);
         assert_eq!(
             resolved.source("registry"),
@@ -904,7 +972,9 @@ mod resolved_bindings_tests {
         );
         assert_eq!(
             resolved.get("registry").and_then(|a| a.get("kind")),
-            Some(&Value::String("second".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "second".to_string()
+            )))
         );
     }
 }

--- a/carina-core/src/builtins/cidr_subnet.rs
+++ b/carina-core/src/builtins/cidr_subnet.rs
@@ -2,7 +2,7 @@
 
 use std::net::Ipv4Addr;
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -28,7 +28,7 @@ pub(crate) fn builtin_cidr_subnet(args: &[Value]) -> Result<Value, String> {
     }
 
     let prefix_str = match &args[0] {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         other => {
             return Err(format!(
                 "cidr_subnet() first argument (prefix) must be a string, got {}",
@@ -38,7 +38,7 @@ pub(crate) fn builtin_cidr_subnet(args: &[Value]) -> Result<Value, String> {
     };
 
     let newbits = match &args[1] {
-        Value::Int(n) => *n,
+        Value::Concrete(ConcreteValue::Int(n)) => *n,
         other => {
             return Err(format!(
                 "cidr_subnet() second argument (newbits) must be an integer, got {}",
@@ -48,7 +48,7 @@ pub(crate) fn builtin_cidr_subnet(args: &[Value]) -> Result<Value, String> {
     };
 
     let netnum = match &args[2] {
-        Value::Int(n) => *n,
+        Value::Concrete(ConcreteValue::Int(n)) => *n,
         other => {
             return Err(format!(
                 "cidr_subnet() third argument (netnum) must be an integer, got {}",
@@ -58,7 +58,7 @@ pub(crate) fn builtin_cidr_subnet(args: &[Value]) -> Result<Value, String> {
     };
 
     let result = calculate_cidr_subnet(&prefix_str, newbits, netnum)?;
-    Ok(Value::String(result))
+    Ok(Value::Concrete(ConcreteValue::String(result)))
 }
 
 /// Parse a CIDR string into (Ipv4Addr, prefix_length).
@@ -150,13 +150,13 @@ fn calculate_cidr_subnet(prefix: &str, newbits: i64, netnum: i64) -> Result<Stri
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     fn cidr_subnet(prefix: &str, newbits: i64, netnum: i64) -> Result<Value, String> {
         let args = vec![
-            Value::String(prefix.to_string()),
-            Value::Int(newbits),
-            Value::Int(netnum),
+            Value::Concrete(ConcreteValue::String(prefix.to_string())),
+            Value::Concrete(ConcreteValue::Int(newbits)),
+            Value::Concrete(ConcreteValue::Int(netnum)),
         ];
         evaluate_builtin("cidr_subnet", &args)
     }
@@ -165,15 +165,15 @@ mod tests {
     fn basic_subnet_calculation() {
         assert_eq!(
             cidr_subnet("10.0.0.0/16", 8, 0).unwrap(),
-            Value::String("10.0.0.0/24".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.0.0/24".to_string()))
         );
         assert_eq!(
             cidr_subnet("10.0.0.0/16", 8, 1).unwrap(),
-            Value::String("10.0.1.0/24".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string()))
         );
         assert_eq!(
             cidr_subnet("10.0.0.0/16", 8, 2).unwrap(),
-            Value::String("10.0.2.0/24".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.2.0/24".to_string()))
         );
     }
 
@@ -181,7 +181,7 @@ mod tests {
     fn subnet_255() {
         assert_eq!(
             cidr_subnet("10.0.0.0/16", 8, 255).unwrap(),
-            Value::String("10.0.255.0/24".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.255.0/24".to_string()))
         );
     }
 
@@ -189,15 +189,15 @@ mod tests {
     fn slash_8_to_slash_16() {
         assert_eq!(
             cidr_subnet("10.0.0.0/8", 8, 0).unwrap(),
-            Value::String("10.0.0.0/16".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string()))
         );
         assert_eq!(
             cidr_subnet("10.0.0.0/8", 8, 1).unwrap(),
-            Value::String("10.1.0.0/16".to_string())
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string()))
         );
         assert_eq!(
             cidr_subnet("10.0.0.0/8", 8, 255).unwrap(),
-            Value::String("10.255.0.0/16".to_string())
+            Value::Concrete(ConcreteValue::String("10.255.0.0/16".to_string()))
         );
     }
 
@@ -205,15 +205,15 @@ mod tests {
     fn slash_24_to_slash_28() {
         assert_eq!(
             cidr_subnet("192.168.1.0/24", 4, 0).unwrap(),
-            Value::String("192.168.1.0/28".to_string())
+            Value::Concrete(ConcreteValue::String("192.168.1.0/28".to_string()))
         );
         assert_eq!(
             cidr_subnet("192.168.1.0/24", 4, 1).unwrap(),
-            Value::String("192.168.1.16/28".to_string())
+            Value::Concrete(ConcreteValue::String("192.168.1.16/28".to_string()))
         );
         assert_eq!(
             cidr_subnet("192.168.1.0/24", 4, 15).unwrap(),
-            Value::String("192.168.1.240/28".to_string())
+            Value::Concrete(ConcreteValue::String("192.168.1.240/28".to_string()))
         );
     }
 
@@ -221,11 +221,11 @@ mod tests {
     fn slash_0_base() {
         assert_eq!(
             cidr_subnet("0.0.0.0/0", 8, 0).unwrap(),
-            Value::String("0.0.0.0/8".to_string())
+            Value::Concrete(ConcreteValue::String("0.0.0.0/8".to_string()))
         );
         assert_eq!(
             cidr_subnet("0.0.0.0/0", 8, 10).unwrap(),
-            Value::String("10.0.0.0/8".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string()))
         );
     }
 
@@ -234,11 +234,11 @@ mod tests {
         // /24 + 8 newbits = /32
         assert_eq!(
             cidr_subnet("192.168.1.0/24", 8, 0).unwrap(),
-            Value::String("192.168.1.0/32".to_string())
+            Value::Concrete(ConcreteValue::String("192.168.1.0/32".to_string()))
         );
         assert_eq!(
             cidr_subnet("192.168.1.0/24", 8, 42).unwrap(),
-            Value::String("192.168.1.42/32".to_string())
+            Value::Concrete(ConcreteValue::String("192.168.1.42/32".to_string()))
         );
     }
 
@@ -246,11 +246,11 @@ mod tests {
     fn newbits_1_halves_network() {
         assert_eq!(
             cidr_subnet("10.0.0.0/16", 1, 0).unwrap(),
-            Value::String("10.0.0.0/17".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.0.0/17".to_string()))
         );
         assert_eq!(
             cidr_subnet("10.0.0.0/16", 1, 1).unwrap(),
-            Value::String("10.0.128.0/17".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.128.0/17".to_string()))
         );
     }
 
@@ -300,7 +300,10 @@ mod tests {
     fn partial_application_with_two_args() {
         use crate::builtins::evaluate_builtin_for_tests;
         use crate::eval_value::EvalValue;
-        let args = vec![Value::String("10.0.0.0/16".to_string()), Value::Int(8)];
+        let args = vec![
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            Value::Concrete(ConcreteValue::Int(8)),
+        ];
         let result = evaluate_builtin_for_tests("cidr_subnet", &args).unwrap();
         match result {
             EvalValue::Closure {
@@ -319,16 +322,20 @@ mod tests {
     #[test]
     fn error_wrong_arg_types() {
         // First arg not string
-        let args = vec![Value::Int(10), Value::Int(8), Value::Int(0)];
+        let args = vec![
+            Value::Concrete(ConcreteValue::Int(10)),
+            Value::Concrete(ConcreteValue::Int(8)),
+            Value::Concrete(ConcreteValue::Int(0)),
+        ];
         let result = evaluate_builtin("cidr_subnet", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be a string"));
 
         // Second arg not int
         let args = vec![
-            Value::String("10.0.0.0/16".to_string()),
-            Value::String("8".to_string()),
-            Value::Int(0),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            Value::Concrete(ConcreteValue::String("8".to_string())),
+            Value::Concrete(ConcreteValue::Int(0)),
         ];
         let result = evaluate_builtin("cidr_subnet", &args);
         assert!(result.is_err());
@@ -336,9 +343,9 @@ mod tests {
 
         // Third arg not int
         let args = vec![
-            Value::String("10.0.0.0/16".to_string()),
-            Value::Int(8),
-            Value::String("0".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            Value::Concrete(ConcreteValue::Int(8)),
+            Value::Concrete(ConcreteValue::String("0".to_string())),
         ];
         let result = evaluate_builtin("cidr_subnet", &args);
         assert!(result.is_err());
@@ -357,7 +364,7 @@ mod tests {
         // Even if the input has host bits set, they are masked off
         assert_eq!(
             cidr_subnet("10.0.0.5/16", 8, 1).unwrap(),
-            Value::String("10.0.1.0/24".to_string())
+            Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string()))
         );
     }
 }

--- a/carina-core/src/builtins/concat.rs
+++ b/carina-core/src/builtins/concat.rs
@@ -1,6 +1,6 @@
 //! `concat(items, base_list)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -29,7 +29,7 @@ pub(crate) fn builtin_concat(args: &[Value]) -> Result<Value, String> {
     }
 
     let items = match &args[0] {
-        Value::List(items) => items,
+        Value::Concrete(ConcreteValue::List(items)) => items,
         other => {
             return Err(format!(
                 "concat() first argument must be a list, got {}",
@@ -39,7 +39,7 @@ pub(crate) fn builtin_concat(args: &[Value]) -> Result<Value, String> {
     };
 
     let base = match &args[1] {
-        Value::List(items) => items,
+        Value::Concrete(ConcreteValue::List(items)) => items,
         other => {
             return Err(format!(
                 "concat() second argument must be a list, got {}",
@@ -51,30 +51,36 @@ pub(crate) fn builtin_concat(args: &[Value]) -> Result<Value, String> {
     // base_list first, then items appended
     let mut result = base.clone();
     result.extend(items.iter().cloned());
-    Ok(Value::List(result))
+    Ok(Value::Concrete(ConcreteValue::List(result)))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn concat_basic() {
         // concat(items, base_list) => base_list ++ items
         let args = vec![
-            Value::List(vec![Value::Int(3), Value::Int(4)]),
-            Value::List(vec![Value::Int(1), Value::Int(2)]),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(3)),
+                Value::Concrete(ConcreteValue::Int(4)),
+            ])),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ])),
         ];
         let result = evaluate_builtin("concat", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::Int(1),
-                Value::Int(2),
-                Value::Int(3),
-                Value::Int(4),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+                Value::Concrete(ConcreteValue::Int(3)),
+                Value::Concrete(ConcreteValue::Int(4)),
+            ]))
         );
     }
 
@@ -82,20 +88,22 @@ mod tests {
     fn concat_strings() {
         // concat(items=["c"], base=["a", "b"]) => ["a", "b", "c"]
         let args = vec![
-            Value::List(vec![Value::String("c".to_string())]),
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-            ]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("c".to_string()),
+            )])),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+            ])),
         ];
         let result = evaluate_builtin("concat", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-                Value::String("c".to_string()),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+                Value::Concrete(ConcreteValue::String("c".to_string())),
+            ]))
         );
     }
 
@@ -103,17 +111,22 @@ mod tests {
     fn concat_mixed_types() {
         // concat(items=[true], base=[1, "two"]) => [1, "two", true]
         let args = vec![
-            Value::List(vec![Value::Bool(true)]),
-            Value::List(vec![Value::Int(1), Value::String("two".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Bool(true),
+            )])),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::String("two".to_string())),
+            ])),
         ];
         let result = evaluate_builtin("concat", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::Int(1),
-                Value::String("two".to_string()),
-                Value::Bool(true),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::String("two".to_string())),
+                Value::Concrete(ConcreteValue::Bool(true)),
+            ]))
         );
     }
 
@@ -121,35 +134,58 @@ mod tests {
     fn concat_empty_first() {
         // concat(items=[], base=[1, 2]) => [1, 2]
         let args = vec![
-            Value::List(vec![]),
-            Value::List(vec![Value::Int(1), Value::Int(2)]),
+            Value::Concrete(ConcreteValue::List(vec![])),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ])),
         ];
         let result = evaluate_builtin("concat", &args).unwrap();
-        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Int(2)]));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2))
+            ]))
+        );
     }
 
     #[test]
     fn concat_empty_second() {
         // concat(items=[1, 2], base=[]) => [1, 2]
         let args = vec![
-            Value::List(vec![Value::Int(1), Value::Int(2)]),
-            Value::List(vec![]),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ])),
+            Value::Concrete(ConcreteValue::List(vec![])),
         ];
         let result = evaluate_builtin("concat", &args).unwrap();
-        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Int(2)]));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2))
+            ]))
+        );
     }
 
     #[test]
     fn concat_both_empty() {
-        let args = vec![Value::List(vec![]), Value::List(vec![])];
+        let args = vec![
+            Value::Concrete(ConcreteValue::List(vec![])),
+            Value::Concrete(ConcreteValue::List(vec![])),
+        ];
         let result = evaluate_builtin("concat", &args).unwrap();
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::Concrete(ConcreteValue::List(vec![])));
     }
 
     #[test]
     fn concat_partial_application_one_arg() {
         use crate::builtins::evaluate_builtin_for_tests;
-        let args = vec![Value::List(vec![Value::Int(1)])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Int(1),
+        )]))];
         let result = evaluate_builtin_for_tests("concat", &args).unwrap();
         assert!(result.is_closure());
     }
@@ -157,9 +193,9 @@ mod tests {
     #[test]
     fn concat_wrong_arg_count_three() {
         let args = vec![
-            Value::List(vec![]),
-            Value::List(vec![]),
-            Value::List(vec![]),
+            Value::Concrete(ConcreteValue::List(vec![])),
+            Value::Concrete(ConcreteValue::List(vec![])),
+            Value::Concrete(ConcreteValue::List(vec![])),
         ];
         let result = evaluate_builtin("concat", &args);
         assert!(result.is_err());
@@ -169,8 +205,10 @@ mod tests {
     #[test]
     fn concat_first_arg_not_list() {
         let args = vec![
-            Value::String("not a list".to_string()),
-            Value::List(vec![Value::Int(1)]),
+            Value::Concrete(ConcreteValue::String("not a list".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(1),
+            )])),
         ];
         let result = evaluate_builtin("concat", &args);
         assert!(result.is_err());
@@ -184,8 +222,10 @@ mod tests {
     #[test]
     fn concat_second_arg_not_list() {
         let args = vec![
-            Value::List(vec![Value::Int(1)]),
-            Value::String("not a list".to_string()),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(1),
+            )])),
+            Value::Concrete(ConcreteValue::String("not a list".to_string())),
         ];
         let result = evaluate_builtin("concat", &args);
         assert!(result.is_err());

--- a/carina-core/src/builtins/decrypt.rs
+++ b/carina-core/src/builtins/decrypt.rs
@@ -5,7 +5,7 @@
 //! before parsing begins.
 
 use crate::parser::ProviderContext;
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -37,7 +37,7 @@ pub(crate) fn builtin_decrypt_with_config(
             .to_string()
     })?;
     let plaintext = decryptor(ciphertext, key)?;
-    Ok(Value::String(plaintext))
+    Ok(Value::Concrete(ConcreteValue::String(plaintext)))
 }
 
 /// Parse and validate arguments for `decrypt()`.
@@ -52,7 +52,7 @@ fn parse_decrypt_args(args: &[Value]) -> Result<(&str, Option<&str>), String> {
     }
 
     let ciphertext = match &args[0] {
-        Value::String(s) => s.as_str(),
+        Value::Concrete(ConcreteValue::String(s)) => s.as_str(),
         other => {
             return Err(format!(
                 "decrypt() first argument must be a string (ciphertext), got {}",
@@ -63,7 +63,7 @@ fn parse_decrypt_args(args: &[Value]) -> Result<(&str, Option<&str>), String> {
 
     let key = if args.len() == 2 {
         match &args[1] {
-            Value::String(s) => Some(s.as_str()),
+            Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
             other => {
                 return Err(format!(
                     "decrypt() second argument must be a string (key), got {}",
@@ -84,7 +84,7 @@ mod tests {
 
     use crate::builtins::evaluate_builtin_with_config_to_value as evaluate_builtin_with_config;
     use crate::parser::ProviderContext;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, DeferredValue, Value};
 
     use super::builtin_decrypt;
 
@@ -103,9 +103,14 @@ mod tests {
             Ok(format!("decrypted:{ciphertext}"))
         }));
 
-        let args = vec![Value::String("AQICAHh".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "AQICAHh".to_string(),
+        ))];
         let result = evaluate_builtin_with_config("decrypt", &args, &config).unwrap();
-        assert_eq!(result, Value::String("decrypted:AQICAHh".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("decrypted:AQICAHh".to_string()))
+        );
     }
 
     #[test]
@@ -116,13 +121,15 @@ mod tests {
         }));
 
         let args = vec![
-            Value::String("AQICAHh".to_string()),
-            Value::String("alias/my-key".to_string()),
+            Value::Concrete(ConcreteValue::String("AQICAHh".to_string())),
+            Value::Concrete(ConcreteValue::String("alias/my-key".to_string())),
         ];
         let result = evaluate_builtin_with_config("decrypt", &args, &config).unwrap();
         assert_eq!(
             result,
-            Value::String("decrypted:AQICAHh:key=alias/my-key".to_string())
+            Value::Concrete(ConcreteValue::String(
+                "decrypted:AQICAHh:key=alias/my-key".to_string()
+            ))
         );
     }
 
@@ -130,7 +137,9 @@ mod tests {
     fn decrypt_without_decryptor_returns_error() {
         let config = ProviderContext::default();
 
-        let args = vec![Value::String("AQICAHh".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "AQICAHh".to_string(),
+        ))];
         let result = evaluate_builtin_with_config("decrypt", &args, &config);
         assert!(result.is_err());
         assert!(
@@ -142,7 +151,9 @@ mod tests {
 
     #[test]
     fn decrypt_fallback_without_config_returns_error() {
-        let args = vec![Value::String("AQICAHh".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "AQICAHh".to_string(),
+        ))];
         let result = builtin_decrypt(&args);
         assert!(result.is_err());
         assert!(
@@ -165,9 +176,9 @@ mod tests {
     fn decrypt_error_on_too_many_args() {
         let config = ProviderContext::default();
         let args = vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
-            Value::String("c".to_string()),
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
+            Value::Concrete(ConcreteValue::String("c".to_string())),
         ];
         let result = evaluate_builtin_with_config("decrypt", &args, &config);
         assert!(result.is_err());
@@ -177,7 +188,7 @@ mod tests {
     #[test]
     fn decrypt_error_on_non_string_ciphertext() {
         let config = ProviderContext::default();
-        let args = vec![Value::Int(42)];
+        let args = vec![Value::Concrete(ConcreteValue::Int(42))];
         let result = evaluate_builtin_with_config("decrypt", &args, &config);
         assert!(result.is_err());
         assert!(
@@ -190,7 +201,10 @@ mod tests {
     #[test]
     fn decrypt_error_on_non_string_key() {
         let config = ProviderContext::default();
-        let args = vec![Value::String("cipher".to_string()), Value::Int(42)];
+        let args = vec![
+            Value::Concrete(ConcreteValue::String("cipher".to_string())),
+            Value::Concrete(ConcreteValue::Int(42)),
+        ];
         let result = evaluate_builtin_with_config("decrypt", &args, &config);
         assert!(result.is_err());
         assert!(
@@ -209,14 +223,16 @@ mod tests {
         // decrypt() then wrap with secret()
         let decrypted = evaluate_builtin_with_config(
             "decrypt",
-            &[Value::String("cipher".to_string())],
+            &[Value::Concrete(ConcreteValue::String("cipher".to_string()))],
             &config,
         )
         .unwrap();
         let secret = evaluate_builtin_with_config("secret", &[decrypted], &config).unwrap();
         assert_eq!(
             secret,
-            Value::Secret(Box::new(Value::String("my-secret-password".to_string())))
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("my-secret-password".to_string())
+            ))))
         );
     }
 }

--- a/carina-core/src/builtins/env.rs
+++ b/carina-core/src/builtins/env.rs
@@ -1,6 +1,6 @@
 //! `env(name)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -24,7 +24,7 @@ pub(crate) fn builtin_env(args: &[Value]) -> Result<Value, String> {
     }
 
     let name = match &args[0] {
-        Value::String(s) => s,
+        Value::Concrete(ConcreteValue::String(s)) => s,
         other => {
             return Err(format!(
                 "env() argument must be a string, got {}",
@@ -41,7 +41,7 @@ pub(crate) fn builtin_env(args: &[Value]) -> Result<Value, String> {
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn env_reads_set_variable() {
@@ -49,9 +49,12 @@ mod tests {
         unsafe {
             std::env::set_var(var_name, "hello_world");
         }
-        let args = vec![Value::String(var_name.to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(var_name.to_string()))];
         let result = evaluate_builtin("env", &args).unwrap();
-        assert_eq!(result, Value::String("hello_world".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello_world".to_string()))
+        );
         unsafe {
             std::env::remove_var(var_name);
         }
@@ -64,7 +67,7 @@ mod tests {
         unsafe {
             std::env::remove_var(var_name);
         }
-        let args = vec![Value::String(var_name.to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(var_name.to_string()))];
         let result = evaluate_builtin("env", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("is not set"));
@@ -72,7 +75,7 @@ mod tests {
 
     #[test]
     fn env_error_on_non_string_arg() {
-        let args = vec![Value::Int(42)];
+        let args = vec![Value::Concrete(ConcreteValue::Int(42))];
         let result = evaluate_builtin("env", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("argument must be a string"));
@@ -89,8 +92,8 @@ mod tests {
     #[test]
     fn env_error_on_too_many_args() {
         let args = vec![
-            Value::String("A".to_string()),
-            Value::String("B".to_string()),
+            Value::Concrete(ConcreteValue::String("A".to_string())),
+            Value::Concrete(ConcreteValue::String("B".to_string())),
         ];
         let result = evaluate_builtin("env", &args);
         assert!(result.is_err());
@@ -103,9 +106,12 @@ mod tests {
         unsafe {
             std::env::set_var(var_name, "");
         }
-        let args = vec![Value::String(var_name.to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(var_name.to_string()))];
         let result = evaluate_builtin("env", &args).unwrap();
-        assert_eq!(result, Value::String("".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("".to_string()))
+        );
         unsafe {
             std::env::remove_var(var_name);
         }

--- a/carina-core/src/builtins/flatten.rs
+++ b/carina-core/src/builtins/flatten.rs
@@ -1,6 +1,6 @@
 //! `flatten(list)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -24,7 +24,7 @@ pub(crate) fn builtin_flatten(args: &[Value]) -> Result<Value, String> {
     }
 
     let items = match &args[0] {
-        Value::List(items) => items,
+        Value::Concrete(ConcreteValue::List(items)) => items,
         other => {
             return Err(format!(
                 "flatten() argument must be a List, got {}",
@@ -36,123 +36,155 @@ pub(crate) fn builtin_flatten(args: &[Value]) -> Result<Value, String> {
     let mut result = Vec::new();
     for item in items {
         match item {
-            Value::List(inner) => result.extend(inner.iter().cloned()),
+            Value::Concrete(ConcreteValue::List(inner)) => result.extend(inner.iter().cloned()),
             other => result.push(other.clone()),
         }
     }
 
-    Ok(Value::List(result))
+    Ok(Value::Concrete(ConcreteValue::List(result)))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn flatten_nested_lists() {
-        let args = vec![Value::List(vec![
-            Value::List(vec![Value::Int(1), Value::Int(2)]),
-            Value::List(vec![Value::Int(3), Value::Int(4)]),
-        ])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ])),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(3)),
+                Value::Concrete(ConcreteValue::Int(4)),
+            ])),
+        ]))];
         let result = evaluate_builtin("flatten", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::Int(1),
-                Value::Int(2),
-                Value::Int(3),
-                Value::Int(4),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+                Value::Concrete(ConcreteValue::Int(3)),
+                Value::Concrete(ConcreteValue::Int(4)),
+            ]))
         );
     }
 
     #[test]
     fn flatten_string_lists() {
-        let args = vec![Value::List(vec![
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-            ]),
-            Value::List(vec![Value::String("c".to_string())]),
-        ])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+            ])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("c".to_string()),
+            )])),
+        ]))];
         let result = evaluate_builtin("flatten", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-                Value::String("c".to_string()),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+                Value::Concrete(ConcreteValue::String("c".to_string())),
+            ]))
         );
     }
 
     #[test]
     fn flatten_mixed_list_and_non_list() {
-        let args = vec![Value::List(vec![
-            Value::List(vec![Value::Int(1), Value::Int(2)]),
-            Value::Int(3),
-            Value::List(vec![Value::Int(4)]),
-        ])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ])),
+            Value::Concrete(ConcreteValue::Int(3)),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(4),
+            )])),
+        ]))];
         let result = evaluate_builtin("flatten", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::Int(1),
-                Value::Int(2),
-                Value::Int(3),
-                Value::Int(4),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+                Value::Concrete(ConcreteValue::Int(3)),
+                Value::Concrete(ConcreteValue::Int(4)),
+            ]))
         );
     }
 
     #[test]
     fn flatten_empty_list() {
-        let args = vec![Value::List(vec![])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![]))];
         let result = evaluate_builtin("flatten", &args).unwrap();
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::Concrete(ConcreteValue::List(vec![])));
     }
 
     #[test]
     fn flatten_no_nested_lists() {
-        let args = vec![Value::List(vec![
-            Value::Int(1),
-            Value::Int(2),
-            Value::Int(3),
-        ])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::Int(2)),
+            Value::Concrete(ConcreteValue::Int(3)),
+        ]))];
         let result = evaluate_builtin("flatten", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3),])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+                Value::Concrete(ConcreteValue::Int(3)),
+            ]))
         );
     }
 
     #[test]
     fn flatten_single_level_only() {
         // Nested [[1, [2, 3]]] should flatten to [1, [2, 3]], not [1, 2, 3]
-        let args = vec![Value::List(vec![Value::List(vec![
-            Value::Int(1),
-            Value::List(vec![Value::Int(2), Value::Int(3)]),
-        ])])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::List(vec![Value::Int(2), Value::Int(3)])),
+            ]),
+        )]))];
         let result = evaluate_builtin("flatten", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::Int(1),
-                Value::List(vec![Value::Int(2), Value::Int(3)]),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::Int(2)),
+                    Value::Concrete(ConcreteValue::Int(3))
+                ])),
+            ]))
         );
     }
 
     #[test]
     fn flatten_empty_inner_lists() {
-        let args = vec![Value::List(vec![
-            Value::List(vec![Value::Int(1)]),
-            Value::List(vec![]),
-            Value::List(vec![Value::Int(2)]),
-        ])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(1),
+            )])),
+            Value::Concrete(ConcreteValue::List(vec![])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(2),
+            )])),
+        ]))];
         let result = evaluate_builtin("flatten", &args).unwrap();
-        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Int(2),]));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ]))
+        );
     }
 
     #[test]
@@ -165,8 +197,12 @@ mod tests {
     #[test]
     fn flatten_wrong_arg_count_two() {
         let args = vec![
-            Value::List(vec![Value::Int(1)]),
-            Value::List(vec![Value::Int(2)]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(1),
+            )])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(2),
+            )])),
         ];
         let result = evaluate_builtin("flatten", &args);
         assert!(result.is_err());
@@ -175,7 +211,9 @@ mod tests {
 
     #[test]
     fn flatten_invalid_type() {
-        let args = vec![Value::String("not a list".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "not a list".to_string(),
+        ))];
         let result = evaluate_builtin("flatten", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be a List"));

--- a/carina-core/src/builtins/join.rs
+++ b/carina-core/src/builtins/join.rs
@@ -1,6 +1,6 @@
 //! `join(separator, list)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -24,7 +24,7 @@ pub(crate) fn builtin_join(args: &[Value]) -> Result<Value, String> {
     }
 
     let separator = match &args[0] {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         other => {
             return Err(format!(
                 "join() first argument must be a string, got {}",
@@ -34,7 +34,7 @@ pub(crate) fn builtin_join(args: &[Value]) -> Result<Value, String> {
     };
 
     let items = match &args[1] {
-        Value::List(items) => items,
+        Value::Concrete(ConcreteValue::List(items)) => items,
         other => {
             return Err(format!(
                 "join() second argument must be a list, got {}",
@@ -46,86 +46,106 @@ pub(crate) fn builtin_join(args: &[Value]) -> Result<Value, String> {
     let joined: String = items
         .iter()
         .map(|v| match v {
-            Value::String(s) => s.clone(),
-            Value::Int(n) => n.to_string(),
-            Value::Float(f) => f.to_string(),
-            Value::Bool(b) => b.to_string(),
-            Value::Duration(d) => crate::value::render_duration(*d),
+            Value::Concrete(ConcreteValue::String(s)) => s.clone(),
+            Value::Concrete(ConcreteValue::Int(n)) => n.to_string(),
+            Value::Concrete(ConcreteValue::Float(f)) => f.to_string(),
+            Value::Concrete(ConcreteValue::Bool(b)) => b.to_string(),
+            Value::Concrete(ConcreteValue::Duration(d)) => crate::value::render_duration(*d),
             other => format!("{:?}", other),
         })
         .collect::<Vec<_>>()
         .join(&separator);
 
-    Ok(Value::String(joined))
+    Ok(Value::Concrete(ConcreteValue::String(joined)))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn join_basic() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-                Value::String("c".to_string()),
-            ]),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+                Value::Concrete(ConcreteValue::String("c".to_string())),
+            ])),
         ];
         let result = evaluate_builtin("join", &args).unwrap();
-        assert_eq!(result, Value::String("a-b-c".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("a-b-c".to_string()))
+        );
     }
 
     #[test]
     fn join_empty_separator() {
         let args = vec![
-            Value::String("".to_string()),
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-            ]),
+            Value::Concrete(ConcreteValue::String("".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+            ])),
         ];
         let result = evaluate_builtin("join", &args).unwrap();
-        assert_eq!(result, Value::String("ab".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("ab".to_string()))
+        );
     }
 
     #[test]
     fn join_empty_list() {
-        let args = vec![Value::String("-".to_string()), Value::List(vec![])];
+        let args = vec![
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![])),
+        ];
         let result = evaluate_builtin("join", &args).unwrap();
-        assert_eq!(result, Value::String("".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("".to_string()))
+        );
     }
 
     #[test]
     fn join_single_element() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::List(vec![Value::String("only".to_string())]),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("only".to_string()),
+            )])),
         ];
         let result = evaluate_builtin("join", &args).unwrap();
-        assert_eq!(result, Value::String("only".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("only".to_string()))
+        );
     }
 
     #[test]
     fn join_mixed_types() {
         let args = vec![
-            Value::String(", ".to_string()),
-            Value::List(vec![
-                Value::String("hello".to_string()),
-                Value::Int(42),
-                Value::Bool(true),
-            ]),
+            Value::Concrete(ConcreteValue::String(", ".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("hello".to_string())),
+                Value::Concrete(ConcreteValue::Int(42)),
+                Value::Concrete(ConcreteValue::Bool(true)),
+            ])),
         ];
         let result = evaluate_builtin("join", &args).unwrap();
-        assert_eq!(result, Value::String("hello, 42, true".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello, 42, true".to_string()))
+        );
     }
 
     #[test]
     fn join_partial_application() {
         use crate::builtins::evaluate_builtin_for_tests;
-        let args = vec![Value::String("-".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("-".to_string()))];
         let result = evaluate_builtin_for_tests("join", &args).unwrap();
         assert!(result.is_closure());
     }
@@ -133,8 +153,10 @@ mod tests {
     #[test]
     fn join_non_string_separator() {
         let args = vec![
-            Value::Int(1),
-            Value::List(vec![Value::String("a".to_string())]),
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("a".to_string()),
+            )])),
         ];
         let result = evaluate_builtin("join", &args);
         assert!(result.is_err());
@@ -148,8 +170,8 @@ mod tests {
     #[test]
     fn join_non_list_second_arg() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("not a list".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("not a list".to_string())),
         ];
         let result = evaluate_builtin("join", &args);
         assert!(result.is_err());

--- a/carina-core/src/builtins/keys_values.rs
+++ b/carina-core/src/builtins/keys_values.rs
@@ -1,6 +1,6 @@
 //! `keys(map)` and `values(map)` built-in functions
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -20,10 +20,12 @@ pub(crate) fn builtin_keys(args: &[Value]) -> Result<Value, String> {
     }
 
     match &args[0] {
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut keys: Vec<String> = map.keys().cloned().collect();
             keys.sort();
-            Ok(Value::List(keys.into_iter().map(Value::String).collect()))
+            Ok(Value::Concrete(ConcreteValue::List(
+                keys.into_iter().map(Value::String).collect(),
+            )))
         }
         other => Err(format!(
             "keys() argument must be a Map, got {}",
@@ -48,12 +50,12 @@ pub(crate) fn builtin_values(args: &[Value]) -> Result<Value, String> {
     }
 
     match &args[0] {
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut keys: Vec<String> = map.keys().cloned().collect();
             keys.sort();
-            Ok(Value::List(
+            Ok(Value::Concrete(ConcreteValue::List(
                 keys.into_iter().map(|k| map[&k].clone()).collect(),
-            ))
+            )))
         }
         other => Err(format!(
             "values() argument must be a Map, got {}",
@@ -67,41 +69,46 @@ mod tests {
     use indexmap::IndexMap;
 
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn keys_basic() {
-        let args = vec![Value::Map(IndexMap::from([
-            ("b".to_string(), Value::Int(2)),
-            ("a".to_string(), Value::Int(1)),
-            ("c".to_string(), Value::Int(3)),
-        ]))];
+        let args = vec![Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            ("b".to_string(), Value::Concrete(ConcreteValue::Int(2))),
+            ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
+            ("c".to_string(), Value::Concrete(ConcreteValue::Int(3))),
+        ])))];
         let result = evaluate_builtin("keys", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-                Value::String("c".to_string()),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+                Value::Concrete(ConcreteValue::String("c".to_string())),
+            ]))
         );
     }
 
     #[test]
     fn keys_empty_map() {
-        let args = vec![Value::Map(IndexMap::new())];
+        let args = vec![Value::Concrete(ConcreteValue::Map(IndexMap::new()))];
         let result = evaluate_builtin("keys", &args).unwrap();
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::Concrete(ConcreteValue::List(vec![])));
     }
 
     #[test]
     fn keys_single_entry() {
-        let args = vec![Value::Map(IndexMap::from([(
+        let args = vec![Value::Concrete(ConcreteValue::Map(IndexMap::from([(
             "only".to_string(),
-            Value::String("value".to_string()),
-        )]))];
+            Value::Concrete(ConcreteValue::String("value".to_string())),
+        )])))];
         let result = evaluate_builtin("keys", &args).unwrap();
-        assert_eq!(result, Value::List(vec![Value::String("only".to_string())]));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("only".to_string())
+            )]))
+        );
     }
 
     #[test]
@@ -113,7 +120,10 @@ mod tests {
 
     #[test]
     fn keys_wrong_arg_count_two() {
-        let args = vec![Value::Map(IndexMap::new()), Value::Map(IndexMap::new())];
+        let args = vec![
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+        ];
         let result = evaluate_builtin("keys", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("expects 1 argument"));
@@ -121,7 +131,9 @@ mod tests {
 
     #[test]
     fn keys_invalid_type() {
-        let args = vec![Value::List(vec![Value::Int(1)])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Int(1),
+        )]))];
         let result = evaluate_builtin("keys", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be a Map"));
@@ -129,37 +141,47 @@ mod tests {
 
     #[test]
     fn values_basic() {
-        let args = vec![Value::Map(IndexMap::from([
-            ("b".to_string(), Value::Int(2)),
-            ("a".to_string(), Value::Int(1)),
-            ("c".to_string(), Value::Int(3)),
-        ]))];
+        let args = vec![Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            ("b".to_string(), Value::Concrete(ConcreteValue::Int(2))),
+            ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
+            ("c".to_string(), Value::Concrete(ConcreteValue::Int(3))),
+        ])))];
         let result = evaluate_builtin("values", &args).unwrap();
         // Values should be ordered by sorted keys: a=1, b=2, c=3
         assert_eq!(
             result,
-            Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+                Value::Concrete(ConcreteValue::Int(3))
+            ]))
         );
     }
 
     #[test]
     fn values_empty_map() {
-        let args = vec![Value::Map(IndexMap::new())];
+        let args = vec![Value::Concrete(ConcreteValue::Map(IndexMap::new()))];
         let result = evaluate_builtin("values", &args).unwrap();
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::Concrete(ConcreteValue::List(vec![])));
     }
 
     #[test]
     fn values_mixed_types() {
-        let args = vec![Value::Map(IndexMap::from([
-            ("name".to_string(), Value::String("test".to_string())),
-            ("count".to_string(), Value::Int(42)),
-        ]))];
+        let args = vec![Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            (
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            ("count".to_string(), Value::Concrete(ConcreteValue::Int(42))),
+        ])))];
         let result = evaluate_builtin("values", &args).unwrap();
         // Sorted by key: count=42, name="test"
         assert_eq!(
             result,
-            Value::List(vec![Value::Int(42), Value::String("test".to_string()),])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(42)),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ]))
         );
     }
 
@@ -172,7 +194,10 @@ mod tests {
 
     #[test]
     fn values_wrong_arg_count_two() {
-        let args = vec![Value::Map(IndexMap::new()), Value::Map(IndexMap::new())];
+        let args = vec![
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+        ];
         let result = evaluate_builtin("values", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("expects 1 argument"));
@@ -180,7 +205,9 @@ mod tests {
 
     #[test]
     fn values_invalid_type() {
-        let args = vec![Value::String("not a map".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "not a map".to_string(),
+        ))];
         let result = evaluate_builtin("values", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be a Map"));

--- a/carina-core/src/builtins/length.rs
+++ b/carina-core/src/builtins/length.rs
@@ -1,6 +1,6 @@
 //! `length(value)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -21,9 +21,15 @@ pub(crate) fn builtin_length(args: &[Value]) -> Result<Value, String> {
     }
 
     match &args[0] {
-        Value::List(items) => Ok(Value::Int(items.len() as i64)),
-        Value::Map(map) => Ok(Value::Int(map.len() as i64)),
-        Value::String(s) => Ok(Value::Int(s.len() as i64)),
+        Value::Concrete(ConcreteValue::List(items)) => {
+            Ok(Value::Concrete(ConcreteValue::Int(items.len() as i64)))
+        }
+        Value::Concrete(ConcreteValue::Map(map)) => {
+            Ok(Value::Concrete(ConcreteValue::Int(map.len() as i64)))
+        }
+        Value::Concrete(ConcreteValue::String(s)) => {
+            Ok(Value::Concrete(ConcreteValue::Int(s.len() as i64)))
+        }
         other => Err(format!(
             "length() argument must be a List, Map, or String, got {}",
             value_type_name(other)
@@ -36,55 +42,55 @@ mod tests {
     use indexmap::IndexMap;
 
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn length_list() {
-        let args = vec![Value::List(vec![
-            Value::Int(1),
-            Value::Int(2),
-            Value::Int(3),
-        ])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::Int(2)),
+            Value::Concrete(ConcreteValue::Int(3)),
+        ]))];
         let result = evaluate_builtin("length", &args).unwrap();
-        assert_eq!(result, Value::Int(3));
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(3)));
     }
 
     #[test]
     fn length_empty_list() {
-        let args = vec![Value::List(vec![])];
+        let args = vec![Value::Concrete(ConcreteValue::List(vec![]))];
         let result = evaluate_builtin("length", &args).unwrap();
-        assert_eq!(result, Value::Int(0));
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(0)));
     }
 
     #[test]
     fn length_map() {
-        let args = vec![Value::Map(IndexMap::from([
-            ("a".to_string(), Value::Int(1)),
-            ("b".to_string(), Value::Int(2)),
-        ]))];
+        let args = vec![Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
+            ("b".to_string(), Value::Concrete(ConcreteValue::Int(2))),
+        ])))];
         let result = evaluate_builtin("length", &args).unwrap();
-        assert_eq!(result, Value::Int(2));
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(2)));
     }
 
     #[test]
     fn length_empty_map() {
-        let args = vec![Value::Map(IndexMap::new())];
+        let args = vec![Value::Concrete(ConcreteValue::Map(IndexMap::new()))];
         let result = evaluate_builtin("length", &args).unwrap();
-        assert_eq!(result, Value::Int(0));
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(0)));
     }
 
     #[test]
     fn length_string() {
-        let args = vec![Value::String("hello".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("hello".to_string()))];
         let result = evaluate_builtin("length", &args).unwrap();
-        assert_eq!(result, Value::Int(5));
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(5)));
     }
 
     #[test]
     fn length_empty_string() {
-        let args = vec![Value::String("".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("".to_string()))];
         let result = evaluate_builtin("length", &args).unwrap();
-        assert_eq!(result, Value::Int(0));
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(0)));
     }
 
     #[test]
@@ -97,8 +103,12 @@ mod tests {
     #[test]
     fn length_wrong_arg_count_two() {
         let args = vec![
-            Value::List(vec![Value::Int(1)]),
-            Value::List(vec![Value::Int(2)]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(1),
+            )])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Int(2),
+            )])),
         ];
         let result = evaluate_builtin("length", &args);
         assert!(result.is_err());
@@ -107,7 +117,7 @@ mod tests {
 
     #[test]
     fn length_invalid_type() {
-        let args = vec![Value::Int(42)];
+        let args = vec![Value::Concrete(ConcreteValue::Int(42))];
         let result = evaluate_builtin("length", &args);
         assert!(result.is_err());
         assert!(

--- a/carina-core/src/builtins/lookup.rs
+++ b/carina-core/src/builtins/lookup.rs
@@ -1,6 +1,6 @@
 //! `lookup(map, key, default)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -25,7 +25,7 @@ pub(crate) fn builtin_lookup(args: &[Value]) -> Result<Value, String> {
     }
 
     let map = match &args[0] {
-        Value::Map(m) => m,
+        Value::Concrete(ConcreteValue::Map(m)) => m,
         other => {
             return Err(format!(
                 "lookup() first argument must be a map, got {}",
@@ -35,7 +35,7 @@ pub(crate) fn builtin_lookup(args: &[Value]) -> Result<Value, String> {
     };
 
     let key = match &args[1] {
-        Value::String(s) => s,
+        Value::Concrete(ConcreteValue::String(s)) => s,
         other => {
             return Err(format!(
                 "lookup() second argument must be a string, got {}",
@@ -52,72 +52,107 @@ mod tests {
     use indexmap::IndexMap;
 
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn lookup_key_found() {
-        let map = Value::Map(IndexMap::from([
-            ("a".to_string(), Value::String("one".to_string())),
-            ("b".to_string(), Value::String("two".to_string())),
-        ]));
+        let map = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            (
+                "a".to_string(),
+                Value::Concrete(ConcreteValue::String("one".to_string())),
+            ),
+            (
+                "b".to_string(),
+                Value::Concrete(ConcreteValue::String("two".to_string())),
+            ),
+        ])));
         let args = vec![
             map,
-            Value::String("a".to_string()),
-            Value::String("default".to_string()),
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("default".to_string())),
         ];
         let result = evaluate_builtin("lookup", &args).unwrap();
-        assert_eq!(result, Value::String("one".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("one".to_string()))
+        );
     }
 
     #[test]
     fn lookup_key_not_found() {
-        let map = Value::Map(IndexMap::from([
-            ("a".to_string(), Value::String("one".to_string())),
-            ("b".to_string(), Value::String("two".to_string())),
-        ]));
+        let map = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            (
+                "a".to_string(),
+                Value::Concrete(ConcreteValue::String("one".to_string())),
+            ),
+            (
+                "b".to_string(),
+                Value::Concrete(ConcreteValue::String("two".to_string())),
+            ),
+        ])));
         let args = vec![
             map,
-            Value::String("c".to_string()),
-            Value::String("default".to_string()),
+            Value::Concrete(ConcreteValue::String("c".to_string())),
+            Value::Concrete(ConcreteValue::String("default".to_string())),
         ];
         let result = evaluate_builtin("lookup", &args).unwrap();
-        assert_eq!(result, Value::String("default".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("default".to_string()))
+        );
     }
 
     #[test]
     fn lookup_empty_map() {
-        let map = Value::Map(IndexMap::new());
+        let map = Value::Concrete(ConcreteValue::Map(IndexMap::new()));
         let args = vec![
             map,
-            Value::String("key".to_string()),
-            Value::String("fallback".to_string()),
+            Value::Concrete(ConcreteValue::String("key".to_string())),
+            Value::Concrete(ConcreteValue::String("fallback".to_string())),
         ];
         let result = evaluate_builtin("lookup", &args).unwrap();
-        assert_eq!(result, Value::String("fallback".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("fallback".to_string()))
+        );
     }
 
     #[test]
     fn lookup_int_default() {
-        let map = Value::Map(IndexMap::from([("x".to_string(), Value::Int(42))]));
-        let args = vec![map, Value::String("missing".to_string()), Value::Int(0)];
+        let map = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+            "x".to_string(),
+            Value::Concrete(ConcreteValue::Int(42)),
+        )])));
+        let args = vec![
+            map,
+            Value::Concrete(ConcreteValue::String("missing".to_string())),
+            Value::Concrete(ConcreteValue::Int(0)),
+        ];
         let result = evaluate_builtin("lookup", &args).unwrap();
-        assert_eq!(result, Value::Int(0));
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(0)));
     }
 
     #[test]
     fn lookup_returns_non_string_value() {
-        let map = Value::Map(IndexMap::from([("count".to_string(), Value::Int(99))]));
-        let args = vec![map, Value::String("count".to_string()), Value::Int(0)];
+        let map = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+            "count".to_string(),
+            Value::Concrete(ConcreteValue::Int(99)),
+        )])));
+        let args = vec![
+            map,
+            Value::Concrete(ConcreteValue::String("count".to_string())),
+            Value::Concrete(ConcreteValue::Int(0)),
+        ];
         let result = evaluate_builtin("lookup", &args).unwrap();
-        assert_eq!(result, Value::Int(99));
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(99)));
     }
 
     #[test]
     fn lookup_partial_application() {
         use crate::builtins::evaluate_builtin_for_tests;
         let args = vec![
-            Value::Map(IndexMap::new()),
-            Value::String("key".to_string()),
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+            Value::Concrete(ConcreteValue::String("key".to_string())),
         ];
         let result = evaluate_builtin_for_tests("lookup", &args).unwrap();
         assert!(result.is_closure());
@@ -126,9 +161,9 @@ mod tests {
     #[test]
     fn lookup_non_map_first_arg() {
         let args = vec![
-            Value::String("not a map".to_string()),
-            Value::String("key".to_string()),
-            Value::String("default".to_string()),
+            Value::Concrete(ConcreteValue::String("not a map".to_string())),
+            Value::Concrete(ConcreteValue::String("key".to_string())),
+            Value::Concrete(ConcreteValue::String("default".to_string())),
         ];
         let result = evaluate_builtin("lookup", &args);
         assert!(result.is_err());
@@ -138,9 +173,9 @@ mod tests {
     #[test]
     fn lookup_non_string_key() {
         let args = vec![
-            Value::Map(IndexMap::new()),
-            Value::Int(1),
-            Value::String("default".to_string()),
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::String("default".to_string())),
         ];
         let result = evaluate_builtin("lookup", &args);
         assert!(result.is_err());

--- a/carina-core/src/builtins/map.rs
+++ b/carina-core/src/builtins/map.rs
@@ -2,7 +2,7 @@
 
 use indexmap::IndexMap;
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -26,7 +26,7 @@ pub(crate) fn builtin_map(args: &[Value]) -> Result<Value, String> {
     }
 
     let accessor = match &args[0] {
-        Value::String(s) if s.starts_with('.') => &s[1..],
+        Value::Concrete(ConcreteValue::String(s)) if s.starts_with('.') => &s[1..],
         _ => {
             return Err(
                 "map() first argument must be a field accessor string starting with '.' (e.g., \".field_name\")".to_string(),
@@ -35,26 +35,28 @@ pub(crate) fn builtin_map(args: &[Value]) -> Result<Value, String> {
     };
 
     match &args[1] {
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             let mapped: Result<Vec<Value>, String> = items
                 .iter()
                 .map(|item| match item {
-                    Value::Map(map) => map.get(accessor).cloned().ok_or_else(|| {
-                        format!("map(): field '{}' not found in map element", accessor)
-                    }),
+                    Value::Concrete(ConcreteValue::Map(map)) => {
+                        map.get(accessor).cloned().ok_or_else(|| {
+                            format!("map(): field '{}' not found in map element", accessor)
+                        })
+                    }
                     other => Err(format!(
                         "map() expects list of maps, got list of {}",
                         value_type_name(other)
                     )),
                 })
                 .collect();
-            Ok(Value::List(mapped?))
+            Ok(Value::Concrete(ConcreteValue::List(mapped?)))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mapped: Result<IndexMap<String, Value>, String> = map
                 .iter()
                 .map(|(k, v)| match v {
-                    Value::Map(inner) => inner
+                    Value::Concrete(ConcreteValue::Map(inner)) => inner
                         .get(accessor)
                         .cloned()
                         .map(|val| (k.clone(), val))
@@ -70,7 +72,7 @@ pub(crate) fn builtin_map(args: &[Value]) -> Result<Value, String> {
                     )),
                 })
                 .collect();
-            Ok(Value::Map(mapped?))
+            Ok(Value::Concrete(ConcreteValue::Map(mapped?)))
         }
         other => Err(format!(
             "map() second argument must be a list or map, got {}",
@@ -84,34 +86,48 @@ mod tests {
     use indexmap::IndexMap;
 
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     fn make_map(pairs: Vec<(&str, Value)>) -> Value {
-        Value::Map(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+        Value::Concrete(ConcreteValue::Map(
+            pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        ))
     }
 
     #[test]
     fn map_list_of_maps_extracts_field() {
         let args = vec![
-            Value::String(".subnet_id".to_string()),
-            Value::List(vec![
+            Value::Concrete(ConcreteValue::String(".subnet_id".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![
                 make_map(vec![
-                    ("name", Value::String("subnet-a".to_string())),
-                    ("subnet_id", Value::String("id-1".to_string())),
+                    (
+                        "name",
+                        Value::Concrete(ConcreteValue::String("subnet-a".to_string())),
+                    ),
+                    (
+                        "subnet_id",
+                        Value::Concrete(ConcreteValue::String("id-1".to_string())),
+                    ),
                 ]),
                 make_map(vec![
-                    ("name", Value::String("subnet-b".to_string())),
-                    ("subnet_id", Value::String("id-2".to_string())),
+                    (
+                        "name",
+                        Value::Concrete(ConcreteValue::String("subnet-b".to_string())),
+                    ),
+                    (
+                        "subnet_id",
+                        Value::Concrete(ConcreteValue::String("id-2".to_string())),
+                    ),
                 ]),
-            ]),
+            ])),
         ];
         let result = evaluate_builtin("map", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::String("id-1".to_string()),
-                Value::String("id-2".to_string()),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("id-1".to_string())),
+                Value::Concrete(ConcreteValue::String("id-2".to_string())),
+            ]))
         );
     }
 
@@ -121,23 +137,44 @@ mod tests {
         outer.insert(
             "a".to_string(),
             make_map(vec![
-                ("name", Value::String("foo".to_string())),
-                ("id", Value::String("1".to_string())),
+                (
+                    "name",
+                    Value::Concrete(ConcreteValue::String("foo".to_string())),
+                ),
+                (
+                    "id",
+                    Value::Concrete(ConcreteValue::String("1".to_string())),
+                ),
             ]),
         );
         outer.insert(
             "b".to_string(),
             make_map(vec![
-                ("name", Value::String("bar".to_string())),
-                ("id", Value::String("2".to_string())),
+                (
+                    "name",
+                    Value::Concrete(ConcreteValue::String("bar".to_string())),
+                ),
+                (
+                    "id",
+                    Value::Concrete(ConcreteValue::String("2".to_string())),
+                ),
             ]),
         );
-        let args = vec![Value::String(".id".to_string()), Value::Map(outer)];
+        let args = vec![
+            Value::Concrete(ConcreteValue::String(".id".to_string())),
+            Value::Concrete(ConcreteValue::Map(outer)),
+        ];
         let result = evaluate_builtin("map", &args).unwrap();
         match result {
-            Value::Map(m) => {
-                assert_eq!(m.get("a"), Some(&Value::String("1".to_string())));
-                assert_eq!(m.get("b"), Some(&Value::String("2".to_string())));
+            Value::Concrete(ConcreteValue::Map(m)) => {
+                assert_eq!(
+                    m.get("a"),
+                    Some(&Value::Concrete(ConcreteValue::String("1".to_string())))
+                );
+                assert_eq!(
+                    m.get("b"),
+                    Some(&Value::Concrete(ConcreteValue::String("2".to_string())))
+                );
             }
             other => panic!("Expected Map, got {:?}", other),
         }
@@ -145,9 +182,12 @@ mod tests {
 
     #[test]
     fn map_empty_list() {
-        let args = vec![Value::String(".field".to_string()), Value::List(vec![])];
+        let args = vec![
+            Value::Concrete(ConcreteValue::String(".field".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![])),
+        ];
         let result = evaluate_builtin("map", &args).unwrap();
-        assert_eq!(result, Value::List(vec![]));
+        assert_eq!(result, Value::Concrete(ConcreteValue::List(vec![])));
     }
 
     #[test]
@@ -160,7 +200,7 @@ mod tests {
     #[test]
     fn map_partial_application_one_arg() {
         use crate::builtins::evaluate_builtin_for_tests;
-        let args = vec![Value::String(".field".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(".field".to_string()))];
         let result = evaluate_builtin_for_tests("map", &args).unwrap();
         assert!(result.is_closure());
     }
@@ -168,9 +208,9 @@ mod tests {
     #[test]
     fn map_error_wrong_arg_count_three() {
         let args = vec![
-            Value::List(vec![]),
-            Value::String(".field".to_string()),
-            Value::String("extra".to_string()),
+            Value::Concrete(ConcreteValue::List(vec![])),
+            Value::Concrete(ConcreteValue::String(".field".to_string())),
+            Value::Concrete(ConcreteValue::String("extra".to_string())),
         ];
         let result = evaluate_builtin("map", &args);
         assert!(result.is_err());
@@ -179,7 +219,10 @@ mod tests {
 
     #[test]
     fn map_error_accessor_without_dot() {
-        let args = vec![Value::String("field".to_string()), Value::List(vec![])];
+        let args = vec![
+            Value::Concrete(ConcreteValue::String("field".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![])),
+        ];
         let result = evaluate_builtin("map", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("field accessor"));
@@ -187,7 +230,10 @@ mod tests {
 
     #[test]
     fn map_error_accessor_not_string() {
-        let args = vec![Value::Int(42), Value::List(vec![])];
+        let args = vec![
+            Value::Concrete(ConcreteValue::Int(42)),
+            Value::Concrete(ConcreteValue::List(vec![])),
+        ];
         let result = evaluate_builtin("map", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("field accessor"));
@@ -196,8 +242,10 @@ mod tests {
     #[test]
     fn map_error_non_map_elements_in_list() {
         let args = vec![
-            Value::String(".field".to_string()),
-            Value::List(vec![Value::String("not a map".to_string())]),
+            Value::Concrete(ConcreteValue::String(".field".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("not a map".to_string()),
+            )])),
         ];
         let result = evaluate_builtin("map", &args);
         assert!(result.is_err());
@@ -207,11 +255,11 @@ mod tests {
     #[test]
     fn map_error_missing_field() {
         let args = vec![
-            Value::String(".missing".to_string()),
-            Value::List(vec![make_map(vec![(
+            Value::Concrete(ConcreteValue::String(".missing".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![make_map(vec![(
                 "name",
-                Value::String("foo".to_string()),
-            )])]),
+                Value::Concrete(ConcreteValue::String("foo".to_string())),
+            )])])),
         ];
         let result = evaluate_builtin("map", &args);
         assert!(result.is_err());
@@ -221,8 +269,8 @@ mod tests {
     #[test]
     fn map_error_second_arg_not_collection() {
         let args = vec![
-            Value::String(".field".to_string()),
-            Value::String("not a collection".to_string()),
+            Value::Concrete(ConcreteValue::String(".field".to_string())),
+            Value::Concrete(ConcreteValue::String("not a collection".to_string())),
         ];
         let result = evaluate_builtin("map", &args);
         assert!(result.is_err());

--- a/carina-core/src/builtins/min_max.rs
+++ b/carina-core/src/builtins/min_max.rs
@@ -1,6 +1,6 @@
 //! `min(a, b)` and `max(a, b)` built-in functions
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -51,35 +51,35 @@ fn compare_values(
     prefer_first: fn(f64, f64) -> bool,
 ) -> Result<Value, String> {
     match (a, b) {
-        (Value::Int(x), Value::Int(y)) => {
+        (Value::Concrete(ConcreteValue::Int(x)), Value::Concrete(ConcreteValue::Int(y))) => {
             let (fx, fy) = (*x as f64, *y as f64);
             if prefer_first(fx, fy) {
-                Ok(Value::Int(*x))
+                Ok(Value::Concrete(ConcreteValue::Int(*x)))
             } else {
-                Ok(Value::Int(*y))
+                Ok(Value::Concrete(ConcreteValue::Int(*y)))
             }
         }
-        (Value::Float(x), Value::Float(y)) => {
+        (Value::Concrete(ConcreteValue::Float(x)), Value::Concrete(ConcreteValue::Float(y))) => {
             if prefer_first(*x, *y) {
-                Ok(Value::Float(*x))
+                Ok(Value::Concrete(ConcreteValue::Float(*x)))
             } else {
-                Ok(Value::Float(*y))
+                Ok(Value::Concrete(ConcreteValue::Float(*y)))
             }
         }
-        (Value::Int(x), Value::Float(y)) => {
+        (Value::Concrete(ConcreteValue::Int(x)), Value::Concrete(ConcreteValue::Float(y))) => {
             let fx = *x as f64;
             if prefer_first(fx, *y) {
-                Ok(Value::Float(fx))
+                Ok(Value::Concrete(ConcreteValue::Float(fx)))
             } else {
-                Ok(Value::Float(*y))
+                Ok(Value::Concrete(ConcreteValue::Float(*y)))
             }
         }
-        (Value::Float(x), Value::Int(y)) => {
+        (Value::Concrete(ConcreteValue::Float(x)), Value::Concrete(ConcreteValue::Int(y))) => {
             let fy = *y as f64;
             if prefer_first(*x, fy) {
-                Ok(Value::Float(*x))
+                Ok(Value::Concrete(ConcreteValue::Float(*x)))
             } else {
-                Ok(Value::Float(fy))
+                Ok(Value::Concrete(ConcreteValue::Float(fy)))
             }
         }
         _ => Err(format!(
@@ -94,50 +94,99 @@ fn compare_values(
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     // ── min() tests ──
 
     #[test]
     fn min_two_ints() {
-        let result = evaluate_builtin("min", &[Value::Int(3), Value::Int(5)]).unwrap();
-        assert_eq!(result, Value::Int(3));
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::Int(3)),
+                Value::Concrete(ConcreteValue::Int(5)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(3)));
     }
 
     #[test]
     fn min_two_ints_reversed() {
-        let result = evaluate_builtin("min", &[Value::Int(5), Value::Int(3)]).unwrap();
-        assert_eq!(result, Value::Int(3));
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::Int(5)),
+                Value::Concrete(ConcreteValue::Int(3)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(3)));
     }
 
     #[test]
     fn min_two_ints_equal() {
-        let result = evaluate_builtin("min", &[Value::Int(4), Value::Int(4)]).unwrap();
-        assert_eq!(result, Value::Int(4));
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::Int(4)),
+                Value::Concrete(ConcreteValue::Int(4)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(4)));
     }
 
     #[test]
     fn min_two_floats() {
-        let result = evaluate_builtin("min", &[Value::Float(2.5), Value::Float(1.0)]).unwrap();
-        assert_eq!(result, Value::Float(1.0));
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::Float(2.5)),
+                Value::Concrete(ConcreteValue::Float(1.0)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Float(1.0)));
     }
 
     #[test]
     fn min_int_and_float() {
-        let result = evaluate_builtin("min", &[Value::Int(1), Value::Float(2.5)]).unwrap();
-        assert_eq!(result, Value::Float(1.0));
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Float(2.5)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Float(1.0)));
     }
 
     #[test]
     fn min_float_and_int() {
-        let result = evaluate_builtin("min", &[Value::Float(3.5), Value::Int(2)]).unwrap();
-        assert_eq!(result, Value::Float(2.0));
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::Float(3.5)),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Float(2.0)));
     }
 
     #[test]
     fn min_negative_ints() {
-        let result = evaluate_builtin("min", &[Value::Int(-3), Value::Int(5)]).unwrap();
-        assert_eq!(result, Value::Int(-3));
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::Int(-3)),
+                Value::Concrete(ConcreteValue::Int(5)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(-3)));
     }
 
     #[test]
@@ -150,20 +199,34 @@ mod tests {
     #[test]
     fn min_partial_application_one_arg() {
         use crate::builtins::evaluate_builtin_for_tests;
-        let result = evaluate_builtin_for_tests("min", &[Value::Int(1)]).unwrap();
+        let result =
+            evaluate_builtin_for_tests("min", &[Value::Concrete(ConcreteValue::Int(1))]).unwrap();
         assert!(result.is_closure());
     }
 
     #[test]
     fn min_wrong_arg_count_three() {
-        let result = evaluate_builtin("min", &[Value::Int(1), Value::Int(2), Value::Int(3)]);
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2)),
+                Value::Concrete(ConcreteValue::Int(3)),
+            ],
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("expects 2 arguments"));
     }
 
     #[test]
     fn min_invalid_type_string() {
-        let result = evaluate_builtin("min", &[Value::String("a".to_string()), Value::Int(1)]);
+        let result = evaluate_builtin(
+            "min",
+            &[
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::Int(1)),
+            ],
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be Int or Float"));
     }
@@ -172,44 +235,93 @@ mod tests {
 
     #[test]
     fn max_two_ints() {
-        let result = evaluate_builtin("max", &[Value::Int(3), Value::Int(5)]).unwrap();
-        assert_eq!(result, Value::Int(5));
+        let result = evaluate_builtin(
+            "max",
+            &[
+                Value::Concrete(ConcreteValue::Int(3)),
+                Value::Concrete(ConcreteValue::Int(5)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(5)));
     }
 
     #[test]
     fn max_two_ints_reversed() {
-        let result = evaluate_builtin("max", &[Value::Int(5), Value::Int(3)]).unwrap();
-        assert_eq!(result, Value::Int(5));
+        let result = evaluate_builtin(
+            "max",
+            &[
+                Value::Concrete(ConcreteValue::Int(5)),
+                Value::Concrete(ConcreteValue::Int(3)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(5)));
     }
 
     #[test]
     fn max_two_ints_equal() {
-        let result = evaluate_builtin("max", &[Value::Int(4), Value::Int(4)]).unwrap();
-        assert_eq!(result, Value::Int(4));
+        let result = evaluate_builtin(
+            "max",
+            &[
+                Value::Concrete(ConcreteValue::Int(4)),
+                Value::Concrete(ConcreteValue::Int(4)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(4)));
     }
 
     #[test]
     fn max_two_floats() {
-        let result = evaluate_builtin("max", &[Value::Float(2.5), Value::Float(1.0)]).unwrap();
-        assert_eq!(result, Value::Float(2.5));
+        let result = evaluate_builtin(
+            "max",
+            &[
+                Value::Concrete(ConcreteValue::Float(2.5)),
+                Value::Concrete(ConcreteValue::Float(1.0)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Float(2.5)));
     }
 
     #[test]
     fn max_int_and_float() {
-        let result = evaluate_builtin("max", &[Value::Int(1), Value::Float(2.5)]).unwrap();
-        assert_eq!(result, Value::Float(2.5));
+        let result = evaluate_builtin(
+            "max",
+            &[
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Float(2.5)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Float(2.5)));
     }
 
     #[test]
     fn max_float_and_int() {
-        let result = evaluate_builtin("max", &[Value::Float(3.5), Value::Int(2)]).unwrap();
-        assert_eq!(result, Value::Float(3.5));
+        let result = evaluate_builtin(
+            "max",
+            &[
+                Value::Concrete(ConcreteValue::Float(3.5)),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Float(3.5)));
     }
 
     #[test]
     fn max_negative_ints() {
-        let result = evaluate_builtin("max", &[Value::Int(-3), Value::Int(5)]).unwrap();
-        assert_eq!(result, Value::Int(5));
+        let result = evaluate_builtin(
+            "max",
+            &[
+                Value::Concrete(ConcreteValue::Int(-3)),
+                Value::Concrete(ConcreteValue::Int(5)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(result, Value::Concrete(ConcreteValue::Int(5)));
     }
 
     #[test]
@@ -221,7 +333,13 @@ mod tests {
 
     #[test]
     fn max_invalid_type_bool() {
-        let result = evaluate_builtin("max", &[Value::Bool(true), Value::Int(1)]);
+        let result = evaluate_builtin(
+            "max",
+            &[
+                Value::Concrete(ConcreteValue::Bool(true)),
+                Value::Concrete(ConcreteValue::Int(1)),
+            ],
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("must be Int or Float"));
     }

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -22,7 +22,7 @@ mod upper_lower;
 
 use crate::eval_value::EvalValue;
 use crate::parser::ProviderContext;
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 
 /// Coarse-grained return type for a built-in function. Used by the LSP to
 /// filter value-position completion candidates to those whose return type
@@ -39,20 +39,20 @@ use crate::resource::Value;
 /// built-in currently returns those types; add them when one does.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinReturnType {
-    /// Returns a plain `Value::String` (no semantic subtype).
+    /// Returns a plain `Value::Concrete(ConcreteValue::String)` (no semantic subtype).
     String,
-    /// Returns a `Value::Int`.
+    /// Returns a `Value::Concrete(ConcreteValue::Int)`.
     Int,
-    /// Returns a `Value::List` of some element type.
+    /// Returns a `Value::Concrete(ConcreteValue::List)` of some element type.
     List,
-    /// Returns a `Value::Map`.
+    /// Returns a `Value::Concrete(ConcreteValue::Map)`.
     Map,
     /// Return shape depends on the arguments (e.g. `lookup`, `min`, `max`,
     /// `map`). Matches any base type the attribute accepts, but still fails
     /// to match `Custom` / `StringEnum` attributes — the caller has no
     /// evidence the returned value satisfies those semantic constraints.
     Any,
-    /// Returns a `Value::Secret` wrapper.
+    /// Returns a `Value::Deferred(DeferredValue::Secret)` wrapper.
     Secret,
 }
 
@@ -412,20 +412,20 @@ pub(crate) fn evaluate_builtin_with_config_to_value(
 /// Return a human-readable type name for a Value
 fn value_type_name(value: &Value) -> &'static str {
     match value {
-        Value::String(_) => "String",
-        Value::Int(_) => "Int",
-        Value::Float(_) => "Float",
-        Value::Bool(_) => "Bool",
-        Value::Duration(_) => "Duration",
-        Value::List(_) => "List",
-        Value::StringList(_) => "StringList",
-        Value::Map(_) => "Map",
-        Value::ResourceRef { .. } => "ResourceRef",
-        Value::BindingRef { .. } => "BindingRef",
-        Value::Interpolation(_) => "Interpolation",
-        Value::FunctionCall { .. } => "FunctionCall",
-        Value::Secret(_) => "Secret",
-        Value::Unknown(_) => "Unknown",
+        Value::Concrete(ConcreteValue::String(_)) => "String",
+        Value::Concrete(ConcreteValue::Int(_)) => "Int",
+        Value::Concrete(ConcreteValue::Float(_)) => "Float",
+        Value::Concrete(ConcreteValue::Bool(_)) => "Bool",
+        Value::Concrete(ConcreteValue::Duration(_)) => "Duration",
+        Value::Concrete(ConcreteValue::List(_)) => "List",
+        Value::Concrete(ConcreteValue::StringList(_)) => "StringList",
+        Value::Concrete(ConcreteValue::Map(_)) => "Map",
+        Value::Deferred(DeferredValue::ResourceRef { .. }) => "ResourceRef",
+        Value::Deferred(DeferredValue::BindingRef { .. }) => "BindingRef",
+        Value::Deferred(DeferredValue::Interpolation(_)) => "Interpolation",
+        Value::Deferred(DeferredValue::FunctionCall { .. }) => "FunctionCall",
+        Value::Deferred(DeferredValue::Secret(_)) => "Secret",
+        Value::Deferred(DeferredValue::Unknown(_)) => "Unknown",
     }
 }
 

--- a/carina-core/src/builtins/replace.rs
+++ b/carina-core/src/builtins/replace.rs
@@ -1,6 +1,6 @@
 //! `replace(search, replacement, string)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -28,7 +28,7 @@ pub(crate) fn builtin_replace(args: &[Value]) -> Result<Value, String> {
     }
 
     let search = match &args[0] {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         other => {
             return Err(format!(
                 "replace() first argument must be a string, got {}",
@@ -38,7 +38,7 @@ pub(crate) fn builtin_replace(args: &[Value]) -> Result<Value, String> {
     };
 
     let replacement = match &args[1] {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         other => {
             return Err(format!(
                 "replace() second argument must be a string, got {}",
@@ -48,7 +48,7 @@ pub(crate) fn builtin_replace(args: &[Value]) -> Result<Value, String> {
     };
 
     let input = match &args[2] {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         other => {
             return Err(format!(
                 "replace() third argument must be a string, got {}",
@@ -57,99 +57,122 @@ pub(crate) fn builtin_replace(args: &[Value]) -> Result<Value, String> {
         }
     };
 
-    Ok(Value::String(input.replace(&search, &replacement)))
+    Ok(Value::Concrete(ConcreteValue::String(
+        input.replace(&search, &replacement),
+    )))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn replace_basic() {
         // replace(search, replacement, string)
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("_".to_string()),
-            Value::String("hello-world".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("_".to_string())),
+            Value::Concrete(ConcreteValue::String("hello-world".to_string())),
         ];
         let result = evaluate_builtin("replace", &args).unwrap();
-        assert_eq!(result, Value::String("hello_world".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello_world".to_string()))
+        );
     }
 
     #[test]
     fn replace_multiple_occurrences() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("_".to_string()),
-            Value::String("a-b-c-d".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("_".to_string())),
+            Value::Concrete(ConcreteValue::String("a-b-c-d".to_string())),
         ];
         let result = evaluate_builtin("replace", &args).unwrap();
-        assert_eq!(result, Value::String("a_b_c_d".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("a_b_c_d".to_string()))
+        );
     }
 
     #[test]
     fn replace_no_match() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("_".to_string()),
-            Value::String("hello".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("_".to_string())),
+            Value::Concrete(ConcreteValue::String("hello".to_string())),
         ];
         let result = evaluate_builtin("replace", &args).unwrap();
-        assert_eq!(result, Value::String("hello".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello".to_string()))
+        );
     }
 
     #[test]
     fn replace_empty_search() {
         let args = vec![
-            Value::String("".to_string()),
-            Value::String("-".to_string()),
-            Value::String("abc".to_string()),
+            Value::Concrete(ConcreteValue::String("".to_string())),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("abc".to_string())),
         ];
         let result = evaluate_builtin("replace", &args).unwrap();
         // Rust's replace("", x) inserts x between every char and at boundaries
-        assert_eq!(result, Value::String("-a-b-c-".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("-a-b-c-".to_string()))
+        );
     }
 
     #[test]
     fn replace_with_empty() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("".to_string()),
-            Value::String("hello-world".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("".to_string())),
+            Value::Concrete(ConcreteValue::String("hello-world".to_string())),
         ];
         let result = evaluate_builtin("replace", &args).unwrap();
-        assert_eq!(result, Value::String("helloworld".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("helloworld".to_string()))
+        );
     }
 
     #[test]
     fn replace_multi_char() {
         let args = vec![
-            Value::String("::".to_string()),
-            Value::String(".".to_string()),
-            Value::String("foo::bar::baz".to_string()),
+            Value::Concrete(ConcreteValue::String("::".to_string())),
+            Value::Concrete(ConcreteValue::String(".".to_string())),
+            Value::Concrete(ConcreteValue::String("foo::bar::baz".to_string())),
         ];
         let result = evaluate_builtin("replace", &args).unwrap();
-        assert_eq!(result, Value::String("foo.bar.baz".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("foo.bar.baz".to_string()))
+        );
     }
 
     #[test]
     fn replace_empty_input() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("_".to_string()),
-            Value::String("".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("_".to_string())),
+            Value::Concrete(ConcreteValue::String("".to_string())),
         ];
         let result = evaluate_builtin("replace", &args).unwrap();
-        assert_eq!(result, Value::String("".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("".to_string()))
+        );
     }
 
     #[test]
     fn replace_partial_application() {
         use crate::builtins::evaluate_builtin_for_tests;
         let args = vec![
-            Value::String("hello".to_string()),
-            Value::String("-".to_string()),
+            Value::Concrete(ConcreteValue::String("hello".to_string())),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
         ];
         let result = evaluate_builtin_for_tests("replace", &args).unwrap();
         assert!(result.is_closure());
@@ -158,9 +181,9 @@ mod tests {
     #[test]
     fn replace_non_string_first_arg() {
         let args = vec![
-            Value::Int(1),
-            Value::String("_".to_string()),
-            Value::String("hello".to_string()),
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::String("_".to_string())),
+            Value::Concrete(ConcreteValue::String("hello".to_string())),
         ];
         let result = evaluate_builtin("replace", &args);
         assert!(result.is_err());
@@ -174,9 +197,9 @@ mod tests {
     #[test]
     fn replace_non_string_second_arg() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::Int(1),
-            Value::String("hello".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::String("hello".to_string())),
         ];
         let result = evaluate_builtin("replace", &args);
         assert!(result.is_err());
@@ -190,9 +213,9 @@ mod tests {
     #[test]
     fn replace_non_string_third_arg() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("_".to_string()),
-            Value::Int(1),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("_".to_string())),
+            Value::Concrete(ConcreteValue::Int(1)),
         ];
         let result = evaluate_builtin("replace", &args);
         assert!(result.is_err());

--- a/carina-core/src/builtins/secret.rs
+++ b/carina-core/src/builtins/secret.rs
@@ -1,6 +1,6 @@
 //! `secret(value)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{DeferredValue, Value};
 
 /// `secret(value)` - Mark a value as secret.
 ///
@@ -9,37 +9,48 @@ use crate::resource::Value;
 ///
 /// Examples:
 /// ```text
-/// secret("my-password")       // => Value::Secret(Value::String("my-password"))
-/// secret(env("DB_PASSWORD"))  // => Value::Secret(Value::String(<env value>))
+/// secret("my-password")       // => Value::Deferred(DeferredValue::Secret(Value::String("my-password")))
+/// secret(env("DB_PASSWORD"))  // => Value::Deferred(DeferredValue::Secret(Value::String(<env value>)))
 /// ```
 pub(crate) fn builtin_secret(args: &[Value]) -> Result<Value, String> {
     if args.len() != 1 {
         return Err(format!("secret() expects 1 argument, got {}", args.len()));
     }
 
-    Ok(Value::Secret(Box::new(args[0].clone())))
+    Ok(Value::Deferred(DeferredValue::Secret(Box::new(
+        args[0].clone(),
+    ))))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, DeferredValue, Value};
 
     #[test]
     fn secret_wraps_string_value() {
-        let args = vec![Value::String("my-password".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "my-password".to_string(),
+        ))];
         let result = evaluate_builtin("secret", &args).unwrap();
         assert_eq!(
             result,
-            Value::Secret(Box::new(Value::String("my-password".to_string())))
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("my-password".to_string())
+            ))))
         );
     }
 
     #[test]
     fn secret_wraps_any_value() {
-        let args = vec![Value::Int(42)];
+        let args = vec![Value::Concrete(ConcreteValue::Int(42))];
         let result = evaluate_builtin("secret", &args).unwrap();
-        assert_eq!(result, Value::Secret(Box::new(Value::Int(42))));
+        assert_eq!(
+            result,
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::Int(42)
+            ))))
+        );
     }
 
     #[test]
@@ -53,8 +64,8 @@ mod tests {
     #[test]
     fn secret_error_on_too_many_args() {
         let args = vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
         ];
         let result = evaluate_builtin("secret", &args);
         assert!(result.is_err());

--- a/carina-core/src/builtins/split.rs
+++ b/carina-core/src/builtins/split.rs
@@ -1,6 +1,6 @@
 //! `split(separator, string)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -24,7 +24,7 @@ pub(crate) fn builtin_split(args: &[Value]) -> Result<Value, String> {
     }
 
     let separator = match &args[0] {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         other => {
             return Err(format!(
                 "split() first argument must be a string, got {}",
@@ -34,7 +34,7 @@ pub(crate) fn builtin_split(args: &[Value]) -> Result<Value, String> {
     };
 
     let input = match &args[1] {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         other => {
             return Err(format!(
                 "split() second argument must be a string, got {}",
@@ -45,115 +45,130 @@ pub(crate) fn builtin_split(args: &[Value]) -> Result<Value, String> {
 
     let parts: Vec<Value> = input
         .split(&separator)
-        .map(|s| Value::String(s.to_string()))
+        .map(|s| Value::Concrete(ConcreteValue::String(s.to_string())))
         .collect();
 
-    Ok(Value::List(parts))
+    Ok(Value::Concrete(ConcreteValue::List(parts)))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn split_basic() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("a-b-c".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("a-b-c".to_string())),
         ];
         let result = evaluate_builtin("split", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-                Value::String("c".to_string()),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+                Value::Concrete(ConcreteValue::String("c".to_string())),
+            ]))
         );
     }
 
     #[test]
     fn split_empty_separator() {
         let args = vec![
-            Value::String("".to_string()),
-            Value::String("abc".to_string()),
+            Value::Concrete(ConcreteValue::String("".to_string())),
+            Value::Concrete(ConcreteValue::String("abc".to_string())),
         ];
         let result = evaluate_builtin("split", &args).unwrap();
         // Rust's split("") yields ["", "a", "b", "c", ""]
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::String("".to_string()),
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-                Value::String("c".to_string()),
-                Value::String("".to_string()),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("".to_string())),
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+                Value::Concrete(ConcreteValue::String("c".to_string())),
+                Value::Concrete(ConcreteValue::String("".to_string())),
+            ]))
         );
     }
 
     #[test]
     fn split_no_match() {
         let args = vec![
-            Value::String(",".to_string()),
-            Value::String("no-commas-here".to_string()),
+            Value::Concrete(ConcreteValue::String(",".to_string())),
+            Value::Concrete(ConcreteValue::String("no-commas-here".to_string())),
         ];
         let result = evaluate_builtin("split", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![Value::String("no-commas-here".to_string())])
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("no-commas-here".to_string())
+            )]))
         );
     }
 
     #[test]
     fn split_empty_string() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("".to_string())),
         ];
         let result = evaluate_builtin("split", &args).unwrap();
-        assert_eq!(result, Value::List(vec![Value::String("".to_string())]));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("".to_string())
+            )]))
+        );
     }
 
     #[test]
     fn split_multi_char_separator() {
         let args = vec![
-            Value::String("::".to_string()),
-            Value::String("a::b::c".to_string()),
+            Value::Concrete(ConcreteValue::String("::".to_string())),
+            Value::Concrete(ConcreteValue::String("a::b::c".to_string())),
         ];
         let result = evaluate_builtin("split", &args).unwrap();
         assert_eq!(
             result,
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-                Value::String("c".to_string()),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+                Value::Concrete(ConcreteValue::String("c".to_string())),
+            ]))
         );
     }
 
     #[test]
     fn split_single_element() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::String("only".to_string()),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::String("only".to_string())),
         ];
         let result = evaluate_builtin("split", &args).unwrap();
-        assert_eq!(result, Value::List(vec![Value::String("only".to_string())]));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("only".to_string())
+            )]))
+        );
     }
 
     #[test]
     fn split_partial_application() {
         use crate::builtins::evaluate_builtin_for_tests;
-        let args = vec![Value::String("-".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("-".to_string()))];
         let result = evaluate_builtin_for_tests("split", &args).unwrap();
         assert!(result.is_closure());
     }
 
     #[test]
     fn split_non_string_separator() {
-        let args = vec![Value::Int(1), Value::String("a-b".to_string())];
+        let args = vec![
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::String("a-b".to_string())),
+        ];
         let result = evaluate_builtin("split", &args);
         assert!(result.is_err());
         assert!(
@@ -166,8 +181,10 @@ mod tests {
     #[test]
     fn split_non_string_second_arg() {
         let args = vec![
-            Value::String("-".to_string()),
-            Value::List(vec![Value::String("a".to_string())]),
+            Value::Concrete(ConcreteValue::String("-".to_string())),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("a".to_string()),
+            )])),
         ];
         let result = evaluate_builtin("split", &args);
         assert!(result.is_err());

--- a/carina-core/src/builtins/trim.rs
+++ b/carina-core/src/builtins/trim.rs
@@ -1,6 +1,6 @@
 //! `trim(string)` built-in function
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -23,7 +23,7 @@ pub(crate) fn builtin_trim(args: &[Value]) -> Result<Value, String> {
     }
 
     let s = match &args[0] {
-        Value::String(s) => s,
+        Value::Concrete(ConcreteValue::String(s)) => s,
         other => {
             return Err(format!(
                 "trim() argument must be a string, got {}",
@@ -32,75 +32,109 @@ pub(crate) fn builtin_trim(args: &[Value]) -> Result<Value, String> {
         }
     };
 
-    Ok(Value::String(s.trim().to_string()))
+    Ok(Value::Concrete(ConcreteValue::String(s.trim().to_string())))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn trim_both_sides() {
-        let args = vec![Value::String("  hello  ".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "  hello  ".to_string(),
+        ))];
         let result = evaluate_builtin("trim", &args).unwrap();
-        assert_eq!(result, Value::String("hello".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello".to_string()))
+        );
     }
 
     #[test]
     fn trim_leading_only() {
-        let args = vec![Value::String("  hello".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "  hello".to_string(),
+        ))];
         let result = evaluate_builtin("trim", &args).unwrap();
-        assert_eq!(result, Value::String("hello".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello".to_string()))
+        );
     }
 
     #[test]
     fn trim_trailing_only() {
-        let args = vec![Value::String("hello  ".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "hello  ".to_string(),
+        ))];
         let result = evaluate_builtin("trim", &args).unwrap();
-        assert_eq!(result, Value::String("hello".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello".to_string()))
+        );
     }
 
     #[test]
     fn trim_no_whitespace() {
-        let args = vec![Value::String("hello".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("hello".to_string()))];
         let result = evaluate_builtin("trim", &args).unwrap();
-        assert_eq!(result, Value::String("hello".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello".to_string()))
+        );
     }
 
     #[test]
     fn trim_empty_string() {
-        let args = vec![Value::String("".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("".to_string()))];
         let result = evaluate_builtin("trim", &args).unwrap();
-        assert_eq!(result, Value::String("".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("".to_string()))
+        );
     }
 
     #[test]
     fn trim_whitespace_only() {
-        let args = vec![Value::String("   ".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("   ".to_string()))];
         let result = evaluate_builtin("trim", &args).unwrap();
-        assert_eq!(result, Value::String("".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("".to_string()))
+        );
     }
 
     #[test]
     fn trim_tabs_and_newlines() {
-        let args = vec![Value::String("\n\t hello \t\n".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "\n\t hello \t\n".to_string(),
+        ))];
         let result = evaluate_builtin("trim", &args).unwrap();
-        assert_eq!(result, Value::String("hello".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello".to_string()))
+        );
     }
 
     #[test]
     fn trim_preserves_inner_whitespace() {
-        let args = vec![Value::String("  hello world  ".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "  hello world  ".to_string(),
+        ))];
         let result = evaluate_builtin("trim", &args).unwrap();
-        assert_eq!(result, Value::String("hello world".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello world".to_string()))
+        );
     }
 
     #[test]
     fn trim_wrong_arg_count() {
         let args = vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
         ];
         let result = evaluate_builtin("trim", &args);
         assert!(result.is_err());
@@ -117,7 +151,7 @@ mod tests {
 
     #[test]
     fn trim_non_string_arg() {
-        let args = vec![Value::Int(42)];
+        let args = vec![Value::Concrete(ConcreteValue::Int(42))];
         let result = evaluate_builtin("trim", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("argument must be a string"));

--- a/carina-core/src/builtins/upper_lower.rs
+++ b/carina-core/src/builtins/upper_lower.rs
@@ -1,6 +1,6 @@
 //! `upper(string)` and `lower(string)` built-in functions
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 use super::value_type_name;
 
@@ -22,7 +22,9 @@ pub(crate) fn builtin_upper(args: &[Value]) -> Result<Value, String> {
     }
 
     match &args[0] {
-        Value::String(s) => Ok(Value::String(s.to_uppercase())),
+        Value::Concrete(ConcreteValue::String(s)) => {
+            Ok(Value::Concrete(ConcreteValue::String(s.to_uppercase())))
+        }
         other => Err(format!(
             "upper() argument must be a string, got {}",
             value_type_name(other)
@@ -48,7 +50,9 @@ pub(crate) fn builtin_lower(args: &[Value]) -> Result<Value, String> {
     }
 
     match &args[0] {
-        Value::String(s) => Ok(Value::String(s.to_lowercase())),
+        Value::Concrete(ConcreteValue::String(s)) => {
+            Ok(Value::Concrete(ConcreteValue::String(s.to_lowercase())))
+        }
         other => Err(format!(
             "lower() argument must be a string, got {}",
             value_type_name(other)
@@ -59,48 +63,67 @@ pub(crate) fn builtin_lower(args: &[Value]) -> Result<Value, String> {
 #[cfg(test)]
 mod tests {
     use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn upper_basic() {
-        let args = vec![Value::String("hello".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("hello".to_string()))];
         let result = evaluate_builtin("upper", &args).unwrap();
-        assert_eq!(result, Value::String("HELLO".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("HELLO".to_string()))
+        );
     }
 
     #[test]
     fn upper_already_uppercase() {
-        let args = vec![Value::String("HELLO".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("HELLO".to_string()))];
         let result = evaluate_builtin("upper", &args).unwrap();
-        assert_eq!(result, Value::String("HELLO".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("HELLO".to_string()))
+        );
     }
 
     #[test]
     fn upper_mixed_case() {
-        let args = vec![Value::String("Hello World".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "Hello World".to_string(),
+        ))];
         let result = evaluate_builtin("upper", &args).unwrap();
-        assert_eq!(result, Value::String("HELLO WORLD".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("HELLO WORLD".to_string()))
+        );
     }
 
     #[test]
     fn upper_empty_string() {
-        let args = vec![Value::String("".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("".to_string()))];
         let result = evaluate_builtin("upper", &args).unwrap();
-        assert_eq!(result, Value::String("".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("".to_string()))
+        );
     }
 
     #[test]
     fn upper_with_numbers_and_symbols() {
-        let args = vec![Value::String("abc-123_def".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "abc-123_def".to_string(),
+        ))];
         let result = evaluate_builtin("upper", &args).unwrap();
-        assert_eq!(result, Value::String("ABC-123_DEF".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("ABC-123_DEF".to_string()))
+        );
     }
 
     #[test]
     fn upper_wrong_arg_count() {
         let args = vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
         ];
         let result = evaluate_builtin("upper", &args);
         assert!(result.is_err());
@@ -109,7 +132,7 @@ mod tests {
 
     #[test]
     fn upper_non_string_arg() {
-        let args = vec![Value::Int(42)];
+        let args = vec![Value::Concrete(ConcreteValue::Int(42))];
         let result = evaluate_builtin("upper", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("argument must be a string"));
@@ -117,37 +140,56 @@ mod tests {
 
     #[test]
     fn lower_basic() {
-        let args = vec![Value::String("HELLO".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("HELLO".to_string()))];
         let result = evaluate_builtin("lower", &args).unwrap();
-        assert_eq!(result, Value::String("hello".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello".to_string()))
+        );
     }
 
     #[test]
     fn lower_already_lowercase() {
-        let args = vec![Value::String("hello".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("hello".to_string()))];
         let result = evaluate_builtin("lower", &args).unwrap();
-        assert_eq!(result, Value::String("hello".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello".to_string()))
+        );
     }
 
     #[test]
     fn lower_mixed_case() {
-        let args = vec![Value::String("Hello World".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "Hello World".to_string(),
+        ))];
         let result = evaluate_builtin("lower", &args).unwrap();
-        assert_eq!(result, Value::String("hello world".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("hello world".to_string()))
+        );
     }
 
     #[test]
     fn lower_empty_string() {
-        let args = vec![Value::String("".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String("".to_string()))];
         let result = evaluate_builtin("lower", &args).unwrap();
-        assert_eq!(result, Value::String("".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("".to_string()))
+        );
     }
 
     #[test]
     fn lower_with_numbers_and_symbols() {
-        let args = vec![Value::String("ABC-123_DEF".to_string())];
+        let args = vec![Value::Concrete(ConcreteValue::String(
+            "ABC-123_DEF".to_string(),
+        ))];
         let result = evaluate_builtin("lower", &args).unwrap();
-        assert_eq!(result, Value::String("abc-123_def".to_string()));
+        assert_eq!(
+            result,
+            Value::Concrete(ConcreteValue::String("abc-123_def".to_string()))
+        );
     }
 
     #[test]
@@ -159,7 +201,7 @@ mod tests {
 
     #[test]
     fn lower_non_string_arg() {
-        let args = vec![Value::Bool(true)];
+        let args = vec![Value::Concrete(ConcreteValue::Bool(true))];
         let result = evaluate_builtin("lower", &args);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("argument must be a string"));

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -142,7 +142,7 @@ pub fn load_configuration_with_config(
         // Per-file resolve_resource_refs_with_config (line 78) only sees
         // bindings within each file; cross-file dot-notation strings in
         // export_params (e.g., "registry_prod.account_id") remain as
-        // Value::String. This second pass converts them to ResourceRef.
+        // Value::Concrete(ConcreteValue::String). This second pass converts them to ResourceRef.
         if let Err(e) = parser::resolve_resource_refs_with_config(&mut merged, config) {
             return Err(e.to_string());
         }

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::effect::Effect;
-use crate::resource::{Resource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
 
 /// Extract binding names that a resource depends on.
 ///
@@ -45,15 +45,15 @@ pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
 fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
     fn walk(value: &Value, deps: &mut HashSet<String>) {
         match value {
-            Value::ResourceRef { path } => {
+            Value::Deferred(DeferredValue::ResourceRef { path }) => {
                 deps.insert(path.binding().to_string());
             }
-            Value::BindingRef { binding } => {
+            Value::Deferred(DeferredValue::BindingRef { binding }) => {
                 deps.insert(binding.clone());
             }
-            Value::List(items) => items.iter().for_each(|v| walk(v, deps)),
-            Value::Map(map) => map.values().for_each(|v| walk(v, deps)),
-            Value::Interpolation(parts) => {
+            Value::Concrete(ConcreteValue::List(items)) => items.iter().for_each(|v| walk(v, deps)),
+            Value::Concrete(ConcreteValue::Map(map)) => map.values().for_each(|v| walk(v, deps)),
+            Value::Deferred(DeferredValue::Interpolation(parts)) => {
                 use crate::resource::InterpolationPart;
                 for part in parts {
                     if let InterpolationPart::Expr(v) = part {
@@ -61,15 +61,17 @@ fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
                     }
                 }
             }
-            Value::FunctionCall { args, .. } => args.iter().for_each(|v| walk(v, deps)),
-            Value::Secret(inner) => walk(inner, deps),
-            Value::String(_)
-            | Value::Int(_)
-            | Value::Float(_)
-            | Value::Bool(_)
-            | Value::Duration(_)
-            | Value::StringList(_)
-            | Value::Unknown(_) => {}
+            Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
+                args.iter().for_each(|v| walk(v, deps))
+            }
+            Value::Deferred(DeferredValue::Secret(inner)) => walk(inner, deps),
+            Value::Concrete(ConcreteValue::String(_))
+            | Value::Concrete(ConcreteValue::Int(_))
+            | Value::Concrete(ConcreteValue::Float(_))
+            | Value::Concrete(ConcreteValue::Bool(_))
+            | Value::Concrete(ConcreteValue::Duration(_))
+            | Value::Concrete(ConcreteValue::StringList(_))
+            | Value::Deferred(DeferredValue::Unknown(_)) => {}
         }
     }
     walk(value, deps);

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -11,7 +11,7 @@ use indexmap::IndexMap;
 use crate::diff_helpers::{compute_map_diff, compute_unchanged_count};
 use crate::effect::Effect;
 use crate::non_empty::NonEmptyVec;
-use crate::resource::{ResourceId, Value};
+use crate::resource::{ConcreteValue, DeferredValue, ResourceId, Value};
 use crate::schema::SchemaRegistry;
 use crate::value::{format_value, format_value_with_key, is_list_of_maps, map_similarity};
 
@@ -388,11 +388,11 @@ fn build_create_rows(
         .attributes
         .get("_default_tag_keys")
         .and_then(|v| match v {
-            Value::List(items) => Some(
+            Value::Concrete(ConcreteValue::List(items)) => Some(
                 items
                     .iter()
                     .filter_map(|item| match item {
-                        Value::String(s) => Some(s.clone()),
+                        Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                         _ => None,
                     })
                     .collect(),
@@ -413,26 +413,28 @@ fn build_create_rows(
         // Expand tags map into individual rows with default_tags annotation
         if key.as_str() == "tags"
             && !default_tag_keys.is_empty()
-            && let Value::Map(map) = value
+            && let Value::Concrete(ConcreteValue::Map(map)) = value
         {
             rows.push(build_expanded_tags_row(map, &default_tag_keys));
             continue;
         }
-        // `Value::List` (any element type) goes through PrettyAttribute so
+        // `Value::Concrete(ConcreteValue::List)` (any element type) goes through PrettyAttribute so
         // `format_value_pretty` can apply its 80-col threshold and YAML-style
-        // vertical layout. `Value::Map` keeps the existing MapExpanded path
+        // vertical layout. `Value::Concrete(ConcreteValue::Map)` keeps the existing MapExpanded path
         // because that variant carries per-entry annotation slots that
         // PrettyAttribute does not represent (used by tags/default_tags).
-        if let Value::List(_) = value {
+        if let Value::Concrete(ConcreteValue::List(_)) = value {
             rows.push(DetailRow::PrettyAttribute {
                 key: key.to_string(),
                 value: value.clone(),
             });
-        } else if let Value::Map(map) = value {
+        } else if let Value::Concrete(ConcreteValue::Map(map)) = value {
             rows.push(build_expanded_map_row(key, map));
         } else {
             let ref_binding = match value {
-                Value::ResourceRef { path } => Some(path.binding().to_string()),
+                Value::Deferred(DeferredValue::ResourceRef { path }) => {
+                    Some(path.binding().to_string())
+                }
                 _ => None,
             };
             rows.push(DetailRow::Attribute {
@@ -792,11 +794,13 @@ fn build_delete_rows(
         keys.sort();
         for key in keys {
             let value = &attrs[key];
-            if let Value::Map(map) = value {
+            if let Value::Concrete(ConcreteValue::Map(map)) = value {
                 rows.push(build_expanded_map_row(key, map));
             } else {
                 let ref_binding = match value {
-                    Value::ResourceRef { path } => Some(path.binding().to_string()),
+                    Value::Deferred(DeferredValue::ResourceRef { path }) => {
+                        Some(path.binding().to_string())
+                    }
                     _ => None,
                 };
                 rows.push(DetailRow::Attribute {
@@ -835,11 +839,11 @@ fn compute_map_diff_entries(
     detail: DetailLevel,
 ) -> Vec<MapDiffEntryIR> {
     let new_map = match new_value {
-        Value::Map(m) => m,
+        Value::Concrete(ConcreteValue::Map(m)) => m,
         _ => return Vec::new(),
     };
     let old_map = match old_value {
-        Some(Value::Map(m)) => m,
+        Some(Value::Concrete(ConcreteValue::Map(m))) => m,
         _ => {
             let empty: IndexMap<String, Value> = IndexMap::new();
             let diff = compute_map_diff(&empty, new_map);
@@ -861,7 +865,9 @@ fn compute_map_diff_entries(
         match item {
             crate::diff_helpers::MapDiffItem::Changed(e) => {
                 // If both old and new are maps, recursively diff
-                if matches!(&e.old_value, Value::Map(_)) && matches!(&e.new_value, Value::Map(_)) {
+                if matches!(&e.old_value, Value::Concrete(ConcreteValue::Map(_)))
+                    && matches!(&e.new_value, Value::Concrete(ConcreteValue::Map(_)))
+                {
                     let nested = compute_map_diff_entries(Some(&e.old_value), &e.new_value, detail);
                     // #2910: `from_vec` returns None for the all-empty
                     // recursive case (every grandchild was itself
@@ -952,11 +958,11 @@ fn compute_list_of_maps_diff_parts(
     Vec<ListOfMapsDiffItem>,
 ) {
     let new_items = match new_value {
-        Value::List(items) => items,
+        Value::Concrete(ConcreteValue::List(items)) => items,
         _ => return (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
     };
     let old_items = match old_value {
-        Some(Value::List(items)) => items,
+        Some(Value::Concrete(ConcreteValue::List(items))) => items,
         _ => &vec![] as &Vec<Value>,
     };
 
@@ -1028,7 +1034,7 @@ fn compute_list_of_maps_diff_parts(
     // Build output parts
     let mut unchanged = Vec::new();
     for (ni, new_item) in new_items.iter().enumerate() {
-        if let Value::Map(map) = new_item
+        if let Value::Concrete(ConcreteValue::Map(map)) = new_item
             && new_matched[ni]
         {
             let mut keys: Vec<_> = map.keys().collect();
@@ -1043,7 +1049,11 @@ fn compute_list_of_maps_diff_parts(
 
     let mut modified = Vec::new();
     for &(oi, ni) in &paired {
-        if let (Value::Map(old_map), Value::Map(new_map)) = (&old_items[oi], &new_items[ni]) {
+        if let (
+            Value::Concrete(ConcreteValue::Map(old_map)),
+            Value::Concrete(ConcreteValue::Map(new_map)),
+        ) = (&old_items[oi], &new_items[ni])
+        {
             let mut keys: Vec<_> = new_map.keys().collect();
             keys.sort();
             let mut fields: Vec<ListOfMapsDiffField> = Vec::new();
@@ -1061,7 +1071,9 @@ fn compute_list_of_maps_diff_parts(
                     continue;
                 }
                 let old_val = old_map.get(k);
-                if matches!(old_val, Some(Value::Map(_))) && matches!(&new_map[k], Value::Map(_)) {
+                if matches!(old_val, Some(Value::Concrete(ConcreteValue::Map(_))))
+                    && matches!(&new_map[k], Value::Concrete(ConcreteValue::Map(_)))
+                {
                     let nested = compute_map_diff_entries(old_val, &new_map[k], detail);
                     fields.push(ListOfMapsDiffField::NestedMapChanged {
                         key: k.to_string(),
@@ -1144,13 +1156,13 @@ pub fn hidden_unchanged_summary(count: usize, noun_singular: &str) -> String {
 
 /// Build alphabetically-sorted `ListOfMapsDiffItem`s from a list of map
 /// indices into `items`. Non-map entries at the listed indices are silently
-/// skipped — only `Value::Map` items contribute fields. This is what the
+/// skipped — only `Value::Concrete(ConcreteValue::Map)` items contribute fields. This is what the
 /// renderer consumes for the added/removed slots of a list-of-maps diff.
 fn collect_added_removed_items(indices: &[usize], items: &[Value]) -> Vec<ListOfMapsDiffItem> {
     indices
         .iter()
         .filter_map(|&i| {
-            if let Value::Map(map) = &items[i] {
+            if let Value::Concrete(ConcreteValue::Map(map)) = &items[i] {
                 let mut entries: Vec<(&String, &Value)> = map.iter().collect();
                 entries.sort_by(|a, b| a.0.cmp(b.0));
                 let fields = entries
@@ -1166,13 +1178,17 @@ fn collect_added_removed_items(indices: &[usize], items: &[Value]) -> Vec<ListOf
 }
 
 /// Check whether the diff at this attribute should render via the
-/// per-key `MapDiff` walk. True when `new_value` is a `Value::Map` and
+/// per-key `MapDiff` walk. True when `new_value` is a `Value::Concrete(ConcreteValue::Map)` and
 /// `old_value` is either absent (attribute being added — #2936) or
-/// itself a `Value::Map`. A non-Map old value (type mismatch, e.g.
+/// itself a `Value::Concrete(ConcreteValue::Map)`. A non-Map old value (type mismatch, e.g.
 /// string → map) keeps the inline `prev → next` form so the prior
 /// scalar stays visible.
 fn should_render_as_map_diff(old_value: Option<&Value>, new_value: &Value) -> bool {
-    matches!(new_value, Value::Map(_)) && matches!(old_value, None | Some(Value::Map(_)))
+    matches!(new_value, Value::Concrete(ConcreteValue::Map(_)))
+        && matches!(
+            old_value,
+            None | Some(Value::Concrete(ConcreteValue::Map(_)))
+        )
 }
 
 /// Compute a string-list diff for a single attribute (#2943).
@@ -1248,8 +1264,14 @@ mod tests {
     #[test]
     fn test_create_basic_attributes() {
         let resource = Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("bucket", Value::String("my-bucket".to_string()))
-            .with_attribute("region", Value::String("us-east-1".to_string()));
+            .with_attribute(
+                "bucket",
+                Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+            )
+            .with_attribute(
+                "region",
+                Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+            );
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert_eq!(rows.len(), 2);
@@ -1263,13 +1285,15 @@ mod tests {
             ResourceId::new("s3.Bucket", "my-bucket"),
             [(
                 "versioning".to_string(),
-                Value::String("Disabled".to_string()),
+                Value::Concrete(ConcreteValue::String("Disabled".to_string())),
             )]
             .into_iter()
             .collect(),
         );
-        let to = Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("versioning", Value::String("Enabled".to_string()));
+        let to = Resource::new("s3.Bucket", "my-bucket").with_attribute(
+            "versioning",
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        );
         let effect = Effect::Update {
             id: ResourceId::new("s3.Bucket", "my-bucket"),
             from: Box::new(from),
@@ -1287,20 +1311,35 @@ mod tests {
         let from = State::existing(
             ResourceId::new("s3.Bucket", "my-bucket"),
             [
-                ("name".to_string(), Value::String("test".to_string())),
-                ("region".to_string(), Value::String("us-east-1".to_string())),
+                (
+                    "name".to_string(),
+                    Value::Concrete(ConcreteValue::String("test".to_string())),
+                ),
+                (
+                    "region".to_string(),
+                    Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+                ),
                 (
                     "versioning".to_string(),
-                    Value::String("Disabled".to_string()),
+                    Value::Concrete(ConcreteValue::String("Disabled".to_string())),
                 ),
             ]
             .into_iter()
             .collect(),
         );
         let to = Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("name", Value::String("test".to_string()))
-            .with_attribute("region", Value::String("us-east-1".to_string()))
-            .with_attribute("versioning", Value::String("Enabled".to_string()));
+            .with_attribute(
+                "name",
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            )
+            .with_attribute(
+                "region",
+                Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+            )
+            .with_attribute(
+                "versioning",
+                Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+            );
         let effect = Effect::Update {
             id: ResourceId::new("s3.Bucket", "my-bucket"),
             from: Box::new(from),
@@ -1326,20 +1365,35 @@ mod tests {
         let from = State::existing(
             ResourceId::new("s3.Bucket", "my-bucket"),
             [
-                ("authored".to_string(), Value::String("a".to_string())),
-                ("server_only".to_string(), Value::String("s".to_string())),
+                (
+                    "authored".to_string(),
+                    Value::Concrete(ConcreteValue::String("a".to_string())),
+                ),
+                (
+                    "server_only".to_string(),
+                    Value::Concrete(ConcreteValue::String("s".to_string())),
+                ),
                 (
                     "trigger_diff".to_string(),
-                    Value::String("old-value".to_string()),
+                    Value::Concrete(ConcreteValue::String("old-value".to_string())),
                 ),
             ]
             .into_iter()
             .collect(),
         );
         let to = Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("authored", Value::String("a".to_string()))
-            .with_attribute("server_only", Value::String("s".to_string()))
-            .with_attribute("trigger_diff", Value::String("new-value".to_string()));
+            .with_attribute(
+                "authored",
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+            )
+            .with_attribute(
+                "server_only",
+                Value::Concrete(ConcreteValue::String("s".to_string())),
+            )
+            .with_attribute(
+                "trigger_diff",
+                Value::Concrete(ConcreteValue::String("new-value".to_string())),
+            );
         let effect = Effect::Update {
             id: ResourceId::new("s3.Bucket", "my-bucket"),
             from: Box::new(from),
@@ -1400,7 +1454,7 @@ mod tests {
             id.clone(),
             [(
                 "bucket".to_string(),
-                Value::String("old-bucket".to_string()),
+                Value::Concrete(ConcreteValue::String("old-bucket".to_string())),
             )]
             .into_iter()
             .collect(),
@@ -1415,17 +1469,22 @@ mod tests {
         let from = State::existing(
             ResourceId::new("s3.Bucket", "my-bucket"),
             [
-                ("name".to_string(), Value::String("test".to_string())),
+                (
+                    "name".to_string(),
+                    Value::Concrete(ConcreteValue::String("test".to_string())),
+                ),
                 (
                     "removed_attr".to_string(),
-                    Value::String("old-val".to_string()),
+                    Value::Concrete(ConcreteValue::String("old-val".to_string())),
                 ),
             ]
             .into_iter()
             .collect(),
         );
-        let to = Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("name", Value::String("test".to_string()));
+        let to = Resource::new("s3.Bucket", "my-bucket").with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        );
         let effect = Effect::Update {
             id: ResourceId::new("s3.Bucket", "my-bucket"),
             from: Box::new(from),
@@ -1440,10 +1499,16 @@ mod tests {
     #[test]
     fn test_create_map_expanded() {
         let mut tags = IndexMap::new();
-        tags.insert("Name".to_string(), Value::String("test".to_string()));
-        tags.insert("Environment".to_string(), Value::String("prod".to_string()));
-        let resource =
-            Resource::new("s3.Bucket", "my-bucket").with_attribute("tags", Value::Map(tags));
+        tags.insert(
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        );
+        tags.insert(
+            "Environment".to_string(),
+            Value::Concrete(ConcreteValue::String("prod".to_string())),
+        );
+        let resource = Resource::new("s3.Bucket", "my-bucket")
+            .with_attribute("tags", Value::Concrete(ConcreteValue::Map(tags)));
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert_eq!(rows.len(), 1);
@@ -1452,10 +1517,16 @@ mod tests {
                 assert_eq!(key, "tags");
                 assert_eq!(entries.len(), 2);
                 assert_eq!(entries[0].key, "Environment");
-                assert_eq!(entries[0].value, Value::String("prod".to_string()));
+                assert_eq!(
+                    entries[0].value,
+                    Value::Concrete(ConcreteValue::String("prod".to_string()))
+                );
                 assert!(entries[0].annotation.is_none());
                 assert_eq!(entries[1].key, "Name");
-                assert_eq!(entries[1].value, Value::String("test".to_string()));
+                assert_eq!(
+                    entries[1].value,
+                    Value::Concrete(ConcreteValue::String("test".to_string()))
+                );
                 assert!(entries[1].annotation.is_none());
             }
             other => panic!("expected MapExpanded, got {:?}", other),
@@ -1470,22 +1541,39 @@ mod tests {
     #[test]
     fn test_create_map_expanded_carries_raw_value_for_nested_list_of_maps() {
         let mut statement1 = IndexMap::new();
-        statement1.insert("sid".to_string(), Value::String("AllowRead".to_string()));
-        statement1.insert("effect".to_string(), Value::String("Allow".to_string()));
+        statement1.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String("AllowRead".to_string())),
+        );
+        statement1.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
         let mut statement2 = IndexMap::new();
-        statement2.insert("sid".to_string(), Value::String("DenyWrite".to_string()));
-        statement2.insert("effect".to_string(), Value::String("Deny".to_string()));
+        statement2.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String("DenyWrite".to_string())),
+        );
+        statement2.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Deny".to_string())),
+        );
         let mut policy = IndexMap::new();
         policy.insert(
             "version".to_string(),
-            Value::String("2012-10-17".to_string()),
+            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
         );
         policy.insert(
             "statement".to_string(),
-            Value::List(vec![Value::Map(statement1), Value::Map(statement2.clone())]),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Map(statement1)),
+                Value::Concrete(ConcreteValue::Map(statement2.clone())),
+            ])),
         );
-        let resource = Resource::new("iam.RolePolicy", "test")
-            .with_attribute("policy_document", Value::Map(policy));
+        let resource = Resource::new("iam.RolePolicy", "test").with_attribute(
+            "policy_document",
+            Value::Concrete(ConcreteValue::Map(policy)),
+        );
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         let entries = rows
@@ -1502,14 +1590,17 @@ mod tests {
             .find(|e| e.key == "statement")
             .expect("expected `statement` entry");
         match &stmt_entry.value {
-            Value::List(items) => {
+            Value::Concrete(ConcreteValue::List(items)) => {
                 assert_eq!(items.len(), 2, "list-of-maps preserved as raw Value");
                 assert!(
-                    matches!(items[0], Value::Map(_)),
-                    "inner element kept as Value::Map, not stringified"
+                    matches!(items[0], Value::Concrete(ConcreteValue::Map(_))),
+                    "inner element kept as Value::Concrete(ConcreteValue::Map), not stringified"
                 );
             }
-            other => panic!("expected Value::List, got {:?}", other),
+            other => panic!(
+                "expected Value::Concrete(ConcreteValue::List), got {:?}",
+                other
+            ),
         }
     }
 
@@ -1525,13 +1616,19 @@ mod tests {
             explicit_dependencies: std::collections::HashSet::new(),
         };
         let mut tags = IndexMap::new();
-        tags.insert("Name".to_string(), Value::String("test".to_string()));
+        tags.insert(
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        );
         let mut delete_attrs: HashMap<ResourceId, HashMap<String, Value>> = HashMap::new();
         delete_attrs.insert(
             id.clone(),
-            [("tags".to_string(), Value::Map(tags))]
-                .into_iter()
-                .collect(),
+            [(
+                "tags".to_string(),
+                Value::Concrete(ConcreteValue::Map(tags)),
+            )]
+            .into_iter()
+            .collect(),
         );
         let rows = build_detail_rows(&effect, None, DetailLevel::Full, Some(&delete_attrs), None);
         assert_eq!(rows.len(), 1);
@@ -1540,7 +1637,10 @@ mod tests {
                 assert_eq!(key, "tags");
                 assert_eq!(entries.len(), 1);
                 assert_eq!(entries[0].key, "Name");
-                assert_eq!(entries[0].value, Value::String("test".to_string()));
+                assert_eq!(
+                    entries[0].value,
+                    Value::Concrete(ConcreteValue::String("test".to_string()))
+                );
             }
             other => panic!("expected MapExpanded, got {:?}", other),
         }
@@ -1552,13 +1652,15 @@ mod tests {
             ResourceId::new("ec2.Vpc", "my-vpc"),
             [(
                 "cidr_block".to_string(),
-                Value::String("10.0.0.0/16".to_string()),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
             )]
             .into_iter()
             .collect(),
         );
-        let to = Resource::new("ec2.Vpc", "my-vpc")
-            .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        let to = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
         let effect = Effect::Replace {
             id: ResourceId::new("ec2.Vpc", "my-vpc"),
             from: Box::new(from),
@@ -1585,19 +1687,22 @@ mod tests {
 
         let refs_vpc = Value::resource_ref("vpc", "id", vec![]);
 
-        let interpolation = Value::Interpolation(vec![
+        let interpolation = Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("vpc-".to_string()),
             InterpolationPart::Expr(refs_vpc.clone()),
-        ]);
+        ]));
         assert!(value_references_binding(&interpolation, "vpc"));
 
-        let function_call = Value::FunctionCall {
+        let function_call = Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
-            args: vec![Value::String(",".to_string()), refs_vpc.clone()],
-        };
+            args: vec![
+                Value::Concrete(ConcreteValue::String(",".to_string())),
+                refs_vpc.clone(),
+            ],
+        });
         assert!(value_references_binding(&function_call, "vpc"));
 
-        let secret = Value::Secret(Box::new(refs_vpc));
+        let secret = Value::Deferred(DeferredValue::Secret(Box::new(refs_vpc)));
         assert!(value_references_binding(&secret, "vpc"));
 
         // Closure variant removed from `Value` (issue #2230): closures
@@ -1605,7 +1710,7 @@ mod tests {
 
         // Still false when the binding is genuinely absent.
         assert!(!value_references_binding(
-            &Value::String("plain".to_string()),
+            &Value::Concrete(ConcreteValue::String("plain".to_string())),
             "vpc"
         ));
     }
@@ -1613,10 +1718,20 @@ mod tests {
     #[test]
     fn create_row_list_of_maps_emits_pretty_attribute() {
         let mut entry = indexmap::IndexMap::new();
-        entry.insert("sid".to_string(), Value::String("S1".to_string()));
-        entry.insert("effect".to_string(), Value::String("Allow".to_string()));
-        let resource = Resource::new("iam.RolePolicy", "test")
-            .with_attribute("statement", Value::List(vec![Value::Map(entry)]));
+        entry.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String("S1".to_string())),
+        );
+        entry.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
+        let resource = Resource::new("iam.RolePolicy", "test").with_attribute(
+            "statement",
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(entry),
+            )])),
+        );
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
 
@@ -1629,15 +1744,20 @@ mod tests {
             "expected PrettyAttribute row for statement, got: {rows:?}"
         );
         assert!(
-            matches!(pretty_value.unwrap(), Value::List(_)),
-            "PrettyAttribute should carry the raw Value::List"
+            matches!(
+                pretty_value.unwrap(),
+                Value::Concrete(ConcreteValue::List(_))
+            ),
+            "PrettyAttribute should carry the raw Value::Concrete(ConcreteValue::List)"
         );
     }
 
     #[test]
     fn create_row_scalar_attribute_unchanged() {
-        let resource = Resource::new("iam.Role", "test")
-            .with_attribute("role_name", Value::String("foo".to_string()));
+        let resource = Resource::new("iam.Role", "test").with_attribute(
+            "role_name",
+            Value::Concrete(ConcreteValue::String("foo".to_string())),
+        );
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert!(
@@ -1655,10 +1775,14 @@ mod tests {
         // format_value_pretty's 80-col threshold can apply.
         let resource = Resource::new("iam.Role", "test").with_attribute(
             "managed_policy_arns",
-            Value::List(vec![
-                Value::String("arn:aws:iam::aws:policy/Policy1".to_string()),
-                Value::String("arn:aws:iam::aws:policy/Policy2".to_string()),
-            ]),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:iam::aws:policy/Policy1".to_string(),
+                )),
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:iam::aws:policy/Policy2".to_string(),
+                )),
+            ])),
         );
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -1674,8 +1798,8 @@ mod tests {
             "expected PrettyAttribute row for list-of-string attribute, got: {rows:?}"
         );
         assert!(
-            matches!(pretty.unwrap(), Value::List(_)),
-            "PrettyAttribute should carry the raw Value::List"
+            matches!(pretty.unwrap(), Value::Concrete(ConcreteValue::List(_))),
+            "PrettyAttribute should carry the raw Value::Concrete(ConcreteValue::List)"
         );
     }
 
@@ -1684,8 +1808,8 @@ mod tests {
         // Pins down `tags = []` behavior — a regression that re-introduces
         // an `!items.is_empty()` guard would silently bypass the routing
         // for empty lists, breaking the formatting-path uniformity.
-        let resource =
-            Resource::new("iam.Role", "test").with_attribute("tags", Value::List(vec![]));
+        let resource = Resource::new("iam.Role", "test")
+            .with_attribute("tags", Value::Concrete(ConcreteValue::List(vec![])));
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert!(

--- a/carina-core/src/diff_helpers.rs
+++ b/carina-core/src/diff_helpers.rs
@@ -182,21 +182,34 @@ pub fn compute_string_list_diff(old: &[String], new: &[String]) -> StringListDif
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resource::ConcreteValue;
 
     #[test]
     fn test_compute_unchanged_count_basic() {
         let from: HashMap<String, Value> = [
-            ("name".to_string(), Value::String("test".to_string())),
-            ("region".to_string(), Value::String("us-east-1".to_string())),
-            ("size".to_string(), Value::Int(10)),
+            (
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            (
+                "region".to_string(),
+                Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+            ),
+            ("size".to_string(), Value::Concrete(ConcreteValue::Int(10))),
         ]
         .into_iter()
         .collect();
 
         let to: HashMap<String, Value> = [
-            ("name".to_string(), Value::String("test".to_string())),
-            ("region".to_string(), Value::String("us-west-2".to_string())),
-            ("size".to_string(), Value::Int(10)),
+            (
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            (
+                "region".to_string(),
+                Value::Concrete(ConcreteValue::String("us-west-2".to_string())),
+            ),
+            ("size".to_string(), Value::Concrete(ConcreteValue::Int(10))),
         ]
         .into_iter()
         .collect();
@@ -207,15 +220,27 @@ mod tests {
     #[test]
     fn test_compute_unchanged_count_excludes_internal() {
         let from: HashMap<String, Value> = [
-            ("name".to_string(), Value::String("test".to_string())),
-            ("_internal".to_string(), Value::String("hidden".to_string())),
+            (
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            (
+                "_internal".to_string(),
+                Value::Concrete(ConcreteValue::String("hidden".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
 
         let to: HashMap<String, Value> = [
-            ("name".to_string(), Value::String("test".to_string())),
-            ("_internal".to_string(), Value::String("hidden".to_string())),
+            (
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            (
+                "_internal".to_string(),
+                Value::Concrete(ConcreteValue::String("hidden".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
@@ -226,15 +251,27 @@ mod tests {
     #[test]
     fn test_compute_unchanged_count_with_exclude_set() {
         let from: HashMap<String, Value> = [
-            ("name".to_string(), Value::String("test".to_string())),
-            ("region".to_string(), Value::String("us-east-1".to_string())),
+            (
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            (
+                "region".to_string(),
+                Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
 
         let to: HashMap<String, Value> = [
-            ("name".to_string(), Value::String("test".to_string())),
-            ("region".to_string(), Value::String("us-east-1".to_string())),
+            (
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            ),
+            (
+                "region".to_string(),
+                Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
@@ -247,8 +284,14 @@ mod tests {
     fn test_compute_map_diff_added_only() {
         let old: IndexMap<String, Value> = IndexMap::new();
         let new: IndexMap<String, Value> = [
-            ("key1".to_string(), Value::String("val1".to_string())),
-            ("key2".to_string(), Value::String("val2".to_string())),
+            (
+                "key1".to_string(),
+                Value::Concrete(ConcreteValue::String("val1".to_string())),
+            ),
+            (
+                "key2".to_string(),
+                Value::Concrete(ConcreteValue::String("val2".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
@@ -263,10 +306,12 @@ mod tests {
 
     #[test]
     fn test_compute_map_diff_removed_only() {
-        let old: IndexMap<String, Value> =
-            [("key1".to_string(), Value::String("val1".to_string()))]
-                .into_iter()
-                .collect();
+        let old: IndexMap<String, Value> = [(
+            "key1".to_string(),
+            Value::Concrete(ConcreteValue::String("val1".to_string())),
+        )]
+        .into_iter()
+        .collect();
         let new: IndexMap<String, Value> = IndexMap::new();
 
         let diff = compute_map_diff(&old, &new);
@@ -279,14 +324,26 @@ mod tests {
     #[test]
     fn test_compute_map_diff_changed() {
         let old: IndexMap<String, Value> = [
-            ("key1".to_string(), Value::String("old_val".to_string())),
-            ("key2".to_string(), Value::String("same".to_string())),
+            (
+                "key1".to_string(),
+                Value::Concrete(ConcreteValue::String("old_val".to_string())),
+            ),
+            (
+                "key2".to_string(),
+                Value::Concrete(ConcreteValue::String("same".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
         let new: IndexMap<String, Value> = [
-            ("key1".to_string(), Value::String("new_val".to_string())),
-            ("key2".to_string(), Value::String("same".to_string())),
+            (
+                "key1".to_string(),
+                Value::Concrete(ConcreteValue::String("new_val".to_string())),
+            ),
+            (
+                "key2".to_string(),
+                Value::Concrete(ConcreteValue::String("same".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
@@ -298,27 +355,45 @@ mod tests {
         assert_eq!(diff.changed[0].key, "key1");
         assert_eq!(
             diff.changed[0].old_value,
-            Value::String("old_val".to_string())
+            Value::Concrete(ConcreteValue::String("old_val".to_string()))
         );
         assert_eq!(
             diff.changed[0].new_value,
-            Value::String("new_val".to_string())
+            Value::Concrete(ConcreteValue::String("new_val".to_string()))
         );
     }
 
     #[test]
     fn test_compute_map_diff_mixed() {
         let old: IndexMap<String, Value> = [
-            ("keep".to_string(), Value::String("same".to_string())),
-            ("change".to_string(), Value::String("old".to_string())),
-            ("remove".to_string(), Value::String("gone".to_string())),
+            (
+                "keep".to_string(),
+                Value::Concrete(ConcreteValue::String("same".to_string())),
+            ),
+            (
+                "change".to_string(),
+                Value::Concrete(ConcreteValue::String("old".to_string())),
+            ),
+            (
+                "remove".to_string(),
+                Value::Concrete(ConcreteValue::String("gone".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
         let new: IndexMap<String, Value> = [
-            ("keep".to_string(), Value::String("same".to_string())),
-            ("change".to_string(), Value::String("new".to_string())),
-            ("add".to_string(), Value::String("fresh".to_string())),
+            (
+                "keep".to_string(),
+                Value::Concrete(ConcreteValue::String("same".to_string())),
+            ),
+            (
+                "change".to_string(),
+                Value::Concrete(ConcreteValue::String("new".to_string())),
+            ),
+            (
+                "add".to_string(),
+                Value::Concrete(ConcreteValue::String("fresh".to_string())),
+            ),
         ]
         .into_iter()
         .collect();

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::resource::{ConcreteValue, DeferredValue};
 
 #[test]
 fn cascade_dependent_updates_adds_update_for_dependent() {
@@ -12,7 +13,10 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -20,7 +24,10 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
+        );
 
     let unresolved_resources = vec![vpc.clone(), subnet.clone()];
 
@@ -29,19 +36,25 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -80,12 +93,14 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
         // The `to` should have unresolved ResourceRef
         assert!(matches!(
             cascading_updates[0].to.get_attr("vpc_id"),
-            Some(Value::ResourceRef { .. })
+            Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
         ));
         // The `from` should have the current state
         assert_eq!(
             cascading_updates[0].from.attributes.get("vpc_id"),
-            Some(&Value::String("vpc-old".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "vpc-old".to_string()
+            )))
         );
     } else {
         panic!("Expected Replace effect");
@@ -102,7 +117,10 @@ fn cascade_skips_resources_already_in_plan() {
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -110,7 +128,10 @@ fn cascade_skips_resources_already_in_plan() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("cidr_block", Value::String("10.1.2.0/24".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.2.0/24".to_string())),
+        );
 
     let unresolved_resources = vec![vpc.clone(), subnet.clone()];
 
@@ -118,17 +139,20 @@ fn cascade_skips_resources_already_in_plan() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -182,7 +206,10 @@ fn cascade_no_op_without_create_before_destroy() {
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -197,7 +224,7 @@ fn cascade_no_op_without_create_before_destroy() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         vpc_id.clone(),
@@ -238,7 +265,10 @@ fn cascade_transitive_dependencies() {
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -260,18 +290,24 @@ fn cascade_transitive_dependencies() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     subnet_attrs.insert(
         "subnet_id".to_string(),
-        Value::String("subnet-123".to_string()),
+        Value::Concrete(ConcreteValue::String("subnet-123".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -280,7 +316,7 @@ fn cascade_transitive_dependencies() {
     let mut instance_attrs = HashMap::new();
     instance_attrs.insert(
         "subnet_id".to_string(),
-        Value::String("subnet-123".to_string()),
+        Value::Concrete(ConcreteValue::String("subnet-123".to_string())),
     );
     current_states.insert(
         instance_id.clone(),
@@ -328,7 +364,10 @@ fn cascade_anonymous_resource_dependent() {
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     // Anonymous subnet (no _binding) with a ResourceRef to the VPC
     let subnet = Resource::new("ec2.Subnet", "my-subnet").with_attribute(
@@ -342,16 +381,22 @@ fn cascade_anonymous_resource_dependent() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         subnet_id.clone(),
         State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
@@ -406,7 +451,10 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -414,7 +462,10 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
+        );
 
     let unresolved_resources = vec![vpc.clone(), subnet.clone()];
 
@@ -423,19 +474,25 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -550,7 +607,10 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -558,8 +618,14 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("availability_zone", Value::String("us-east-1b".to_string()))
-        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+        .with_attribute(
+            "availability_zone",
+            Value::Concrete(ConcreteValue::String("us-east-1b".to_string())),
+        )
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
+        );
 
     let unresolved_resources = vec![vpc.clone(), subnet.clone()];
 
@@ -568,23 +634,29 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     subnet_attrs.insert(
         "availability_zone".to_string(),
-        Value::String("us-east-1a".to_string()),
+        Value::Concrete(ConcreteValue::String("us-east-1a".to_string())),
     );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -692,7 +764,10 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -700,7 +775,10 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
+        );
 
     let unresolved_resources = vec![vpc.clone(), subnet.clone()];
 
@@ -709,19 +787,25 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -797,7 +881,10 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -805,8 +892,14 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("tags", Value::String("new-tag".to_string()))
-        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+        .with_attribute(
+            "tags",
+            Value::Concrete(ConcreteValue::String("new-tag".to_string())),
+        )
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
+        );
 
     let unresolved_resources = vec![vpc.clone(), subnet.clone()];
 
@@ -815,20 +908,29 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
-    subnet_attrs.insert("tags".to_string(), Value::String("old-tag".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
+    subnet_attrs.insert(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::String("old-tag".to_string())),
+    );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -915,7 +1017,10 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let mut subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -923,7 +1028,10 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
+        );
     subnet.directives.prevent_destroy = true;
 
     let unresolved_resources = vec![vpc.clone(), subnet.clone()];
@@ -932,19 +1040,25 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),
@@ -1022,7 +1136,10 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
 
     let mut subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
@@ -1030,8 +1147,14 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         )
-        .with_attribute("tags", Value::String("new-tag".to_string()))
-        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+        .with_attribute(
+            "tags",
+            Value::Concrete(ConcreteValue::String("new-tag".to_string())),
+        )
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
+        );
     subnet.directives.prevent_destroy = true;
 
     let unresolved_resources = vec![vpc.clone(), subnet.clone()];
@@ -1040,20 +1163,29 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
     let mut vpc_attrs = HashMap::new();
     vpc_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
     current_states.insert(
         vpc_id.clone(),
         State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
     );
 
     let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
-    subnet_attrs.insert("tags".to_string(), Value::String("old-tag".to_string()));
+    subnet_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
+    subnet_attrs.insert(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::String("old-tag".to_string())),
+    );
     subnet_attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.1.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
     );
     current_states.insert(
         subnet_id.clone(),

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use indexmap::IndexMap;
 
 use crate::explicit::{self, ExplicitFields};
-use crate::resource::{ResourceId, Value, merge_with_saved};
+use crate::resource::{ConcreteValue, DeferredValue, ResourceId, Value, merge_with_saved};
 use crate::schema::{AttributeType, ResourceSchema};
 use crate::value::{SECRET_PREFIX, SecretHashContext, argon2id_hash, value_to_json_with_context};
 
@@ -23,14 +23,14 @@ use crate::value::{SECRET_PREFIX, SecretHashContext, argon2id_hash, value_to_jso
 /// Without type information, falls back to `Value::semantically_equal()`.
 ///
 /// When `secret_ctx` is provided, it is used for context-specific salt when
-/// comparing `Value::Secret` against state hash strings.
+/// comparing `Value::Deferred(DeferredValue::Secret)` against state hash strings.
 ///
 /// # Invariant: `Union[String, list(String)]` is canonicalized upstream
 ///
 /// For attributes typed as `Union[String, list(String)]` (the IAM-style
 /// `string_or_list_of_strings` shape — see #2481), **both** `a` and
-/// `b` reach this function as the canonical `Value::StringList` form,
-/// never as a mix of `Value::String` and `Value::List([String])`. The
+/// `b` reach this function as the canonical `Value::Concrete(ConcreteValue::StringList)` form,
+/// never as a mix of `Value::Concrete(ConcreteValue::String)` and `Value::Concrete(ConcreteValue::List([String]))`. The
 /// canonicalization happens upstream in
 /// `value::canonicalize_resources_with_schemas` (#2511) for the
 /// desired side and `value::canonicalize_states_with_schemas` (#2513)
@@ -52,11 +52,11 @@ pub(super) fn type_aware_equal(
     secret_ctx: Option<&SecretHashContext>,
 ) -> bool {
     // Secret comparison: compare the hash of the desired secret with the state hash string.
-    // State stores secrets as "_secret:argon2:<hex>", desired has Value::Secret(inner).
-    if let Value::Secret(inner) = a {
+    // State stores secrets as "_secret:argon2:<hex>", desired has Value::Deferred(DeferredValue::Secret(inner)).
+    if let Value::Deferred(DeferredValue::Secret(inner)) = a {
         return secret_matches_state(inner, b, secret_ctx);
     }
-    if let Value::Secret(inner) = b {
+    if let Value::Deferred(DeferredValue::Secret(inner)) = b {
         return secret_matches_state(inner, a, secret_ctx);
     }
 
@@ -66,47 +66,65 @@ pub(super) fn type_aware_equal(
             // for Maps/Lists so that nested Secret values are compared via their hashes.
             // semantically_equal uses PartialEq which doesn't handle Secret↔hash comparison.
             match (a, b) {
-                (Value::Map(ma), Value::Map(mb)) => {
-                    type_aware_maps_equal(ma, mb, |_key| None, secret_ctx)
-                }
-                (Value::List(la), Value::List(lb)) => {
-                    type_aware_lists_equal(la, lb, None, false, secret_ctx)
-                }
+                (
+                    Value::Concrete(ConcreteValue::Map(ma)),
+                    Value::Concrete(ConcreteValue::Map(mb)),
+                ) => type_aware_maps_equal(ma, mb, |_key| None, secret_ctx),
+                (
+                    Value::Concrete(ConcreteValue::List(la)),
+                    Value::Concrete(ConcreteValue::List(lb)),
+                ) => type_aware_lists_equal(la, lb, None, false, secret_ctx),
                 _ => a.semantically_equal(b),
             }
         }
         Some(at) => match (a, b, at) {
             // Int/Float coercion for numeric types
-            (Value::Int(i), Value::Float(f), AttributeType::Float | AttributeType::Int) => {
-                (*i as f64) == *f && (*i as f64) as i64 == *i
-            }
-            (Value::Float(f), Value::Int(i), AttributeType::Float | AttributeType::Int) => {
-                *f == (*i as f64) && (*i as f64) as i64 == *i
-            }
+            (
+                Value::Concrete(ConcreteValue::Int(i)),
+                Value::Concrete(ConcreteValue::Float(f)),
+                AttributeType::Float | AttributeType::Int,
+            ) => (*i as f64) == *f && (*i as f64) as i64 == *i,
+            (
+                Value::Concrete(ConcreteValue::Float(f)),
+                Value::Concrete(ConcreteValue::Int(i)),
+                AttributeType::Float | AttributeType::Int,
+            ) => *f == (*i as f64) && (*i as f64) as i64 == *i,
 
             // Lists: ordered or multiset comparison with inner type awareness
-            (Value::List(la), Value::List(lb), AttributeType::List { inner, ordered }) => {
-                type_aware_lists_equal(la, lb, Some(inner), *ordered, secret_ctx)
-            }
+            (
+                Value::Concrete(ConcreteValue::List(la)),
+                Value::Concrete(ConcreteValue::List(lb)),
+                AttributeType::List { inner, ordered },
+            ) => type_aware_lists_equal(la, lb, Some(inner), *ordered, secret_ctx),
 
             // Maps: recursive comparison with inner value type
-            (Value::Map(ma), Value::Map(mb), AttributeType::Map { value: inner, .. }) => {
-                type_aware_maps_equal(ma, mb, |_key| Some(inner.as_ref()), secret_ctx)
-            }
+            (
+                Value::Concrete(ConcreteValue::Map(ma)),
+                Value::Concrete(ConcreteValue::Map(mb)),
+                AttributeType::Map { value: inner, .. },
+            ) => type_aware_maps_equal(ma, mb, |_key| Some(inner.as_ref()), secret_ctx),
 
             // Struct: per-field type-aware comparison with default-value tolerance
-            (Value::Map(ma), Value::Map(mb), AttributeType::Struct { fields, .. }) => {
-                type_aware_struct_equal(ma, mb, fields, secret_ctx)
-            }
+            (
+                Value::Concrete(ConcreteValue::Map(ma)),
+                Value::Concrete(ConcreteValue::Map(mb)),
+                AttributeType::Struct { fields, .. },
+            ) => type_aware_struct_equal(ma, mb, fields, secret_ctx),
 
             // Union: try each member type; if any says equal, they're equal
             (_, _, AttributeType::Union(types)) => {
                 // Also check Int/Float coercion for unions containing numeric types
                 match (a, b) {
-                    (Value::Int(i), Value::Float(f)) | (Value::Float(f), Value::Int(i))
-                        if types
-                            .iter()
-                            .any(|t| matches!(t, AttributeType::Float | AttributeType::Int)) =>
+                    (
+                        Value::Concrete(ConcreteValue::Int(i)),
+                        Value::Concrete(ConcreteValue::Float(f)),
+                    )
+                    | (
+                        Value::Concrete(ConcreteValue::Float(f)),
+                        Value::Concrete(ConcreteValue::Int(i)),
+                    ) if types
+                        .iter()
+                        .any(|t| matches!(t, AttributeType::Float | AttributeType::Int)) =>
                     {
                         (*i as f64) == *f && (*i as f64) as i64 == *i
                     }
@@ -117,9 +135,11 @@ pub(super) fn type_aware_equal(
             }
 
             // StringEnum: extract enum values from namespaced identifiers and compare
-            (Value::String(sa), Value::String(sb), AttributeType::StringEnum { values, .. })
-                if sa != sb =>
-            {
+            (
+                Value::Concrete(ConcreteValue::String(sa)),
+                Value::Concrete(ConcreteValue::String(sb)),
+                AttributeType::StringEnum { values, .. },
+            ) if sa != sb => {
                 let valid_values: Vec<&str> = values.iter().map(String::as_str).collect();
                 let va = crate::utils::extract_enum_value_with_values(sa, &valid_values);
                 let vb = crate::utils::extract_enum_value_with_values(sb, &valid_values);
@@ -255,18 +275,33 @@ fn type_aware_struct_equal(
 /// - Custom: delegates to the base type
 fn is_type_default(value: &Value, attr_type: Option<&AttributeType>) -> bool {
     match (value, attr_type) {
-        (Value::Bool(false), Some(AttributeType::Bool) | None) => true,
-        (Value::Int(0), Some(AttributeType::Int)) => true,
-        (Value::Float(f), Some(AttributeType::Float)) if *f == 0.0 => true,
-        (Value::Duration(d), Some(AttributeType::Duration)) if d.is_zero() => true,
-        (Value::String(s), Some(AttributeType::String)) if s.is_empty() => true,
-        (Value::String(s), Some(AttributeType::StringEnum { .. })) if s.is_empty() => true,
-        (Value::List(l), Some(AttributeType::List { .. })) if l.is_empty() => true,
-        (Value::Map(m), Some(AttributeType::Map { .. } | AttributeType::Struct { .. }))
-            if m.is_empty() =>
+        (Value::Concrete(ConcreteValue::Bool(false)), Some(AttributeType::Bool) | None) => true,
+        (Value::Concrete(ConcreteValue::Int(0)), Some(AttributeType::Int)) => true,
+        (Value::Concrete(ConcreteValue::Float(f)), Some(AttributeType::Float)) if *f == 0.0 => true,
+        (Value::Concrete(ConcreteValue::Duration(d)), Some(AttributeType::Duration))
+            if d.is_zero() =>
         {
             true
         }
+        (Value::Concrete(ConcreteValue::String(s)), Some(AttributeType::String))
+            if s.is_empty() =>
+        {
+            true
+        }
+        (Value::Concrete(ConcreteValue::String(s)), Some(AttributeType::StringEnum { .. }))
+            if s.is_empty() =>
+        {
+            true
+        }
+        (Value::Concrete(ConcreteValue::List(l)), Some(AttributeType::List { .. }))
+            if l.is_empty() =>
+        {
+            true
+        }
+        (
+            Value::Concrete(ConcreteValue::Map(m)),
+            Some(AttributeType::Map { .. } | AttributeType::Struct { .. }),
+        ) if m.is_empty() => true,
         // Custom types: delegate to the base type
         (_, Some(AttributeType::Custom { base, .. })) => is_type_default(value, Some(base)),
         _ => false,
@@ -289,7 +324,7 @@ fn secret_matches_state(
     state_value: &Value,
     context: Option<&SecretHashContext>,
 ) -> bool {
-    let Value::String(state_str) = state_value else {
+    let Value::Concrete(ConcreteValue::String(state_str)) = state_value else {
         return false;
     };
 
@@ -308,7 +343,7 @@ fn secret_matches_state(
     // Case 2: State has plain-text value (from provider read / --refresh=true).
     // Compare the inner secret value directly against the raw state string.
     match inner {
-        Value::String(inner_str) => inner_str == state_str,
+        Value::Concrete(ConcreteValue::String(inner_str)) => inner_str == state_str,
         _ => false,
     }
 }

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -1,33 +1,34 @@
 use super::*;
 
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 use crate::schema::noop_validator;
 use indexmap::IndexMap;
 
 #[test]
 fn type_aware_int_float_coercion() {
     assert!(type_aware_equal(
-        &Value::Int(42),
-        &Value::Float(42.0),
+        &Value::Concrete(ConcreteValue::Int(42)),
+        &Value::Concrete(ConcreteValue::Float(42.0)),
         Some(&AttributeType::Float),
         None,
     ));
     assert!(type_aware_equal(
-        &Value::Float(42.0),
-        &Value::Int(42),
+        &Value::Concrete(ConcreteValue::Float(42.0)),
+        &Value::Concrete(ConcreteValue::Int(42)),
         Some(&AttributeType::Float),
         None,
     ));
     // Non-exact conversion should not be equal
     assert!(!type_aware_equal(
-        &Value::Int(42),
-        &Value::Float(42.5),
+        &Value::Concrete(ConcreteValue::Int(42)),
+        &Value::Concrete(ConcreteValue::Float(42.5)),
         Some(&AttributeType::Float),
         None,
     ));
     // Without type info, Int and Float are not equal
     assert!(!type_aware_equal(
-        &Value::Int(42),
-        &Value::Float(42.0),
+        &Value::Concrete(ConcreteValue::Int(42)),
+        &Value::Concrete(ConcreteValue::Float(42.0)),
         None,
         None,
     ));
@@ -37,8 +38,8 @@ fn type_aware_int_float_coercion() {
 fn type_aware_int_float_coercion_for_int_type() {
     // Int type also allows coercion (e.g., provider returns Float for an Int field)
     assert!(type_aware_equal(
-        &Value::Int(10),
-        &Value::Float(10.0),
+        &Value::Concrete(ConcreteValue::Int(10)),
+        &Value::Concrete(ConcreteValue::Float(10.0)),
         Some(&AttributeType::Int),
         None,
     ));
@@ -49,8 +50,14 @@ fn type_aware_list_with_inner_type() {
     let list_type = AttributeType::unordered_list(AttributeType::Float);
     // List of Int vs Float with coercion (unordered, so reordering is fine)
     assert!(type_aware_equal(
-        &Value::List(vec![Value::Int(1), Value::Int(2)]),
-        &Value::List(vec![Value::Float(2.0), Value::Float(1.0)]),
+        &Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::Int(2))
+        ])),
+        &Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Float(2.0)),
+            Value::Concrete(ConcreteValue::Float(1.0))
+        ])),
         Some(&list_type),
         None,
     ));
@@ -67,14 +74,23 @@ fn type_aware_struct_per_field() {
             StructField::new("name", AttributeType::String),
         ],
     };
-    let a = Value::Map(IndexMap::from([
-        ("count".to_string(), Value::Int(5)),
-        ("name".to_string(), Value::String("test".to_string())),
-    ]));
-    let b = Value::Map(IndexMap::from([
-        ("count".to_string(), Value::Float(5.0)),
-        ("name".to_string(), Value::String("test".to_string())),
-    ]));
+    let a = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        ("count".to_string(), Value::Concrete(ConcreteValue::Int(5))),
+        (
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
+    ])));
+    let b = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "count".to_string(),
+            Value::Concrete(ConcreteValue::Float(5.0)),
+        ),
+        (
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
+    ])));
     assert!(type_aware_equal(&a, &b, Some(&struct_type), None));
 }
 
@@ -82,8 +98,8 @@ fn type_aware_struct_per_field() {
 fn type_aware_union_numeric() {
     let union_type = AttributeType::Union(vec![AttributeType::Int, AttributeType::Float]);
     assert!(type_aware_equal(
-        &Value::Int(7),
-        &Value::Float(7.0),
+        &Value::Concrete(ConcreteValue::Int(7)),
+        &Value::Concrete(ConcreteValue::Float(7.0)),
         Some(&union_type),
         None,
     ));
@@ -101,8 +117,8 @@ fn type_aware_custom_delegates_to_base() {
         to_dsl: None,
     };
     assert!(type_aware_equal(
-        &Value::Int(8080),
-        &Value::Float(8080.0),
+        &Value::Concrete(ConcreteValue::Int(8080)),
+        &Value::Concrete(ConcreteValue::Float(8080.0)),
         Some(&custom_type),
         None,
     ));
@@ -118,10 +134,14 @@ fn type_aware_diff_no_change_with_schema() {
         AttributeSchema::new("port", AttributeType::Float),
     );
 
-    let desired = Resource::new("test.resource", "test").with_attribute("port", Value::Int(443));
+    let desired = Resource::new("test.resource", "test")
+        .with_attribute("port", Value::Concrete(ConcreteValue::Int(443)));
 
     let mut current_attrs = HashMap::new();
-    current_attrs.insert("port".to_string(), Value::Float(443.0));
+    current_attrs.insert(
+        "port".to_string(),
+        Value::Concrete(ConcreteValue::Float(443.0)),
+    );
     let current = State::existing(ResourceId::new("test.resource", "test"), current_attrs);
 
     // Without schema: detects a change (Int != Float)
@@ -155,19 +175,22 @@ fn type_aware_struct_ignores_default_bool_false() {
     };
 
     // Desired: only sse_algorithm specified (no bucket_key_enabled)
-    let desired = Value::Map(IndexMap::from([(
+    let desired = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
         "sse_algorithm".to_string(),
-        Value::String("AES256".to_string()),
-    )]));
+        Value::Concrete(ConcreteValue::String("AES256".to_string())),
+    )])));
 
     // Current (from AWS): includes bucket_key_enabled: false as default
-    let current = Value::Map(IndexMap::from([
-        ("bucket_key_enabled".to_string(), Value::Bool(false)),
+    let current = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "bucket_key_enabled".to_string(),
+            Value::Concrete(ConcreteValue::Bool(false)),
+        ),
         (
             "sse_algorithm".to_string(),
-            Value::String("AES256".to_string()),
+            Value::Concrete(ConcreteValue::String("AES256".to_string())),
         ),
-    ]));
+    ])));
 
     assert!(
         type_aware_equal(&desired, &current, Some(&struct_type), None),
@@ -188,19 +211,22 @@ fn type_aware_struct_does_not_ignore_non_default_bool() {
     };
 
     // Desired: only sse_algorithm
-    let desired = Value::Map(IndexMap::from([(
+    let desired = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
         "sse_algorithm".to_string(),
-        Value::String("AES256".to_string()),
-    )]));
+        Value::Concrete(ConcreteValue::String("AES256".to_string())),
+    )])));
 
     // Current: bucket_key_enabled is true (non-default) — should NOT be equal
-    let current = Value::Map(IndexMap::from([
-        ("bucket_key_enabled".to_string(), Value::Bool(true)),
+    let current = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "bucket_key_enabled".to_string(),
+            Value::Concrete(ConcreteValue::Bool(true)),
+        ),
         (
             "sse_algorithm".to_string(),
-            Value::String("AES256".to_string()),
+            Value::Concrete(ConcreteValue::String("AES256".to_string())),
         ),
-    ]));
+    ])));
 
     assert!(
         !type_aware_equal(&desired, &current, Some(&struct_type), None),
@@ -225,10 +251,10 @@ fn type_aware_string_enum_namespaced_vs_raw() {
     // Namespaced form vs raw string
     assert!(
         type_aware_equal(
-            &Value::String(
+            &Value::Concrete(ConcreteValue::String(
                 "awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256".to_string()
-            ),
-            &Value::String("AES256".to_string()),
+            )),
+            &Value::Concrete(ConcreteValue::String("AES256".to_string())),
             Some(&enum_type),
             None,
         ),
@@ -238,12 +264,12 @@ fn type_aware_string_enum_namespaced_vs_raw() {
     // Both in namespaced form
     assert!(
         type_aware_equal(
-            &Value::String(
+            &Value::Concrete(ConcreteValue::String(
                 "awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256".to_string()
-            ),
-            &Value::String(
+            )),
+            &Value::Concrete(ConcreteValue::String(
                 "awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256".to_string()
-            ),
+            )),
             Some(&enum_type),
             None,
         ),
@@ -253,10 +279,10 @@ fn type_aware_string_enum_namespaced_vs_raw() {
     // Different values should not match
     assert!(
         !type_aware_equal(
-            &Value::String(
+            &Value::Concrete(ConcreteValue::String(
                 "awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256".to_string()
-            ),
-            &Value::String("aws:kms".to_string()),
+            )),
+            &Value::Concrete(ConcreteValue::String("aws:kms".to_string())),
             Some(&enum_type),
             None,
         ),
@@ -285,16 +311,22 @@ fn type_aware_struct_ignores_default_string_enum_empty() {
     };
 
     // Desired: only name specified
-    let desired = Value::Map(IndexMap::from([(
+    let desired = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
         "name".to_string(),
-        Value::String("test".to_string()),
-    )]));
+        Value::Concrete(ConcreteValue::String("test".to_string())),
+    )])));
 
     // Current: includes status: "" as default
-    let current = Value::Map(IndexMap::from([
-        ("name".to_string(), Value::String("test".to_string())),
-        ("status".to_string(), Value::String(String::new())),
-    ]));
+    let current = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
+        (
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String(String::new())),
+        ),
+    ])));
 
     assert!(
         type_aware_equal(&desired, &current, Some(&struct_type), None),
@@ -326,16 +358,19 @@ fn type_aware_struct_ignores_default_custom_type() {
     };
 
     // Desired: only name specified
-    let desired = Value::Map(IndexMap::from([(
+    let desired = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
         "name".to_string(),
-        Value::String("test".to_string()),
-    )]));
+        Value::Concrete(ConcreteValue::String("test".to_string())),
+    )])));
 
     // Current: includes port: 0 as default
-    let current = Value::Map(IndexMap::from([
-        ("name".to_string(), Value::String("test".to_string())),
-        ("port".to_string(), Value::Int(0)),
-    ]));
+    let current = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
+        ("port".to_string(), Value::Concrete(ConcreteValue::Int(0))),
+    ])));
 
     assert!(
         type_aware_equal(&desired, &current, Some(&struct_type), None),
@@ -362,16 +397,22 @@ fn type_aware_struct_ignores_default_nested_struct_empty() {
     };
 
     // Desired: only name specified
-    let desired = Value::Map(IndexMap::from([(
+    let desired = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
         "name".to_string(),
-        Value::String("test".to_string()),
-    )]));
+        Value::Concrete(ConcreteValue::String("test".to_string())),
+    )])));
 
     // Current: includes inner: {} as default
-    let current = Value::Map(IndexMap::from([
-        ("name".to_string(), Value::String("test".to_string())),
-        ("inner".to_string(), Value::Map(IndexMap::new())),
-    ]));
+    let current = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
+        (
+            "inner".to_string(),
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+        ),
+    ])));
 
     assert!(
         type_aware_equal(&desired, &current, Some(&struct_type), None),
@@ -388,14 +429,14 @@ fn type_aware_ordered_list_detects_reorder() {
     };
 
     // Same elements, different order
-    let a = Value::List(vec![
-        Value::String("a".to_string()),
-        Value::String("b".to_string()),
-    ]);
-    let b = Value::List(vec![
-        Value::String("b".to_string()),
-        Value::String("a".to_string()),
-    ]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("a".to_string())),
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+        Value::Concrete(ConcreteValue::String("a".to_string())),
+    ]));
 
     assert!(
         !type_aware_equal(&a, &b, Some(&ordered_list_type), None),
@@ -403,10 +444,10 @@ fn type_aware_ordered_list_detects_reorder() {
     );
 
     // Same elements, same order should still be equal
-    let c = Value::List(vec![
-        Value::String("a".to_string()),
-        Value::String("b".to_string()),
-    ]);
+    let c = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("a".to_string())),
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+    ]));
     assert!(
         type_aware_equal(&a, &c, Some(&ordered_list_type), None),
         "Ordered list with same order should be equal"
@@ -421,14 +462,14 @@ fn type_aware_unordered_list_ignores_reorder() {
         ordered: false,
     };
 
-    let a = Value::List(vec![
-        Value::String("a".to_string()),
-        Value::String("b".to_string()),
-    ]);
-    let b = Value::List(vec![
-        Value::String("b".to_string()),
-        Value::String("a".to_string()),
-    ]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("a".to_string())),
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+        Value::Concrete(ConcreteValue::String("a".to_string())),
+    ]));
 
     assert!(
         type_aware_equal(&a, &b, Some(&unordered_list_type), None),
@@ -449,14 +490,17 @@ fn write_only_attr_in_desired_not_in_current_no_diff() {
     let desired = HashMap::from([
         (
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         ),
-        ("ipv4_netmask_length".to_string(), Value::Int(16)),
+        (
+            "ipv4_netmask_length".to_string(),
+            Value::Concrete(ConcreteValue::Int(16)),
+        ),
     ]);
     // CloudControl Read API does not return write-only attributes
     let current = HashMap::from([(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     )]);
 
     let changed = find_changed_attributes(&desired, &current, None, None, Some(&schema), None);
@@ -478,16 +522,22 @@ fn write_only_attr_in_both_same_value_no_diff() {
     let desired = HashMap::from([
         (
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         ),
-        ("ipv4_netmask_length".to_string(), Value::Int(16)),
+        (
+            "ipv4_netmask_length".to_string(),
+            Value::Concrete(ConcreteValue::Int(16)),
+        ),
     ]);
     let current = HashMap::from([
         (
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         ),
-        ("ipv4_netmask_length".to_string(), Value::Int(16)),
+        (
+            "ipv4_netmask_length".to_string(),
+            Value::Concrete(ConcreteValue::Int(16)),
+        ),
     ]);
 
     let changed = find_changed_attributes(&desired, &current, None, None, Some(&schema), None);
@@ -509,16 +559,22 @@ fn write_only_attr_in_both_different_value_detects_diff() {
     let desired = HashMap::from([
         (
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         ),
-        ("ipv4_netmask_length".to_string(), Value::Int(24)),
+        (
+            "ipv4_netmask_length".to_string(),
+            Value::Concrete(ConcreteValue::Int(24)),
+        ),
     ]);
     let current = HashMap::from([
         (
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         ),
-        ("ipv4_netmask_length".to_string(), Value::Int(16)),
+        (
+            "ipv4_netmask_length".to_string(),
+            Value::Concrete(ConcreteValue::Int(16)),
+        ),
     ]);
 
     let changed = find_changed_attributes(&desired, &current, None, None, Some(&schema), None);
@@ -539,13 +595,16 @@ fn non_write_only_attr_in_desired_not_in_current_detects_diff() {
     let desired = HashMap::from([
         (
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         ),
-        ("enable_dns".to_string(), Value::Bool(true)),
+        (
+            "enable_dns".to_string(),
+            Value::Concrete(ConcreteValue::Bool(true)),
+        ),
     ]);
     let current = HashMap::from([(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     )]);
 
     let changed = find_changed_attributes(&desired, &current, None, None, Some(&schema), None);
@@ -559,7 +618,9 @@ fn non_write_only_attr_in_desired_not_in_current_detects_diff() {
 fn secret_unchanged_same_hash() {
     use crate::value::value_to_json;
 
-    let secret_value = Value::Secret(Box::new(Value::String("my-password".to_string())));
+    let secret_value = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("my-password".to_string()),
+    ))));
     // Compute the hash that would be stored in state
     let hash_json = value_to_json(&secret_value).unwrap();
     let hash_str = hash_json.as_str().unwrap().to_string();
@@ -567,13 +628,13 @@ fn secret_unchanged_same_hash() {
     // State has the hash string, desired has the Secret wrapper
     assert!(type_aware_equal(
         &secret_value,
-        &Value::String(hash_str.clone()),
+        &Value::Concrete(ConcreteValue::String(hash_str.clone())),
         None,
         None,
     ));
     // Reversed order should also work
     assert!(type_aware_equal(
-        &Value::String(hash_str),
+        &Value::Concrete(ConcreteValue::String(hash_str)),
         &secret_value,
         None,
         None,
@@ -584,8 +645,12 @@ fn secret_unchanged_same_hash() {
 fn secret_changed_different_hash() {
     use crate::value::value_to_json;
 
-    let old_secret = Value::Secret(Box::new(Value::String("old-password".to_string())));
-    let new_secret = Value::Secret(Box::new(Value::String("new-password".to_string())));
+    let old_secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("old-password".to_string()),
+    ))));
+    let new_secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("new-password".to_string()),
+    ))));
     // Compute the hash for the OLD secret (stored in state)
     let old_hash_json = value_to_json(&old_secret).unwrap();
     let old_hash_str = old_hash_json.as_str().unwrap().to_string();
@@ -593,7 +658,7 @@ fn secret_changed_different_hash() {
     // New desired vs old state hash should be different
     assert!(!type_aware_equal(
         &new_secret,
-        &Value::String(old_hash_str),
+        &Value::Concrete(ConcreteValue::String(old_hash_str)),
         None,
         None,
     ));
@@ -603,12 +668,17 @@ fn secret_changed_different_hash() {
 fn secret_in_find_changed_attributes_no_change() {
     use crate::value::value_to_json;
 
-    let secret_value = Value::Secret(Box::new(Value::String("my-password".to_string())));
+    let secret_value = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("my-password".to_string()),
+    ))));
     let hash_json = value_to_json(&secret_value).unwrap();
     let hash_str = hash_json.as_str().unwrap().to_string();
 
     let desired = HashMap::from([("password".to_string(), secret_value)]);
-    let current = HashMap::from([("password".to_string(), Value::String(hash_str))]);
+    let current = HashMap::from([(
+        "password".to_string(),
+        Value::Concrete(ConcreteValue::String(hash_str)),
+    )]);
 
     let changed = find_changed_attributes(&desired, &current, None, None, None, None);
     assert!(
@@ -622,13 +692,20 @@ fn secret_in_find_changed_attributes_no_change() {
 fn secret_in_find_changed_attributes_changed() {
     use crate::value::value_to_json;
 
-    let old_secret = Value::Secret(Box::new(Value::String("old-password".to_string())));
-    let new_secret = Value::Secret(Box::new(Value::String("new-password".to_string())));
+    let old_secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("old-password".to_string()),
+    ))));
+    let new_secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("new-password".to_string()),
+    ))));
     let old_hash_json = value_to_json(&old_secret).unwrap();
     let old_hash_str = old_hash_json.as_str().unwrap().to_string();
 
     let desired = HashMap::from([("password".to_string(), new_secret)]);
-    let current = HashMap::from([("password".to_string(), Value::String(old_hash_str))]);
+    let current = HashMap::from([(
+        "password".to_string(),
+        Value::Concrete(ConcreteValue::String(old_hash_str)),
+    )]);
 
     let changed = find_changed_attributes(&desired, &current, None, None, None, None);
     assert!(
@@ -642,19 +719,30 @@ fn secret_in_map_no_change_when_hash_matches() {
     use crate::value::value_to_json;
 
     // Desired: tags map with a secret value
-    let secret_value = Value::Secret(Box::new(Value::String("super-secret".to_string())));
-    let desired_tags = Value::Map(IndexMap::from([
-        ("Name".to_string(), Value::String("test".to_string())),
+    let secret_value = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("super-secret".to_string()),
+    ))));
+    let desired_tags = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
         ("SecretTag".to_string(), secret_value.clone()),
-    ]));
+    ])));
 
     // State: tags map with the secret hash (as stored by from_provider_state)
     let hash_json = value_to_json(&secret_value).unwrap();
     let hash_str = hash_json.as_str().unwrap().to_string();
-    let state_tags = Value::Map(IndexMap::from([
-        ("Name".to_string(), Value::String("test".to_string())),
-        ("SecretTag".to_string(), Value::String(hash_str)),
-    ]));
+    let state_tags = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
+        (
+            "SecretTag".to_string(),
+            Value::Concrete(ConcreteValue::String(hash_str)),
+        ),
+    ])));
 
     let desired = HashMap::from([("tags".to_string(), desired_tags)]);
     let current = HashMap::from([("tags".to_string(), state_tags)]);
@@ -669,7 +757,7 @@ fn secret_in_map_no_change_when_hash_matches() {
 
 #[test]
 fn secret_with_context_no_change_when_hash_matches() {
-    use crate::resource::ResourceId;
+    use crate::resource::{ConcreteValue, DeferredValue, ResourceId};
     use crate::value::{SecretHashContext, value_to_json_with_context};
 
     let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db");
@@ -679,13 +767,18 @@ fn secret_with_context_no_change_when_hash_matches() {
         "master_password",
     );
 
-    let secret_value = Value::Secret(Box::new(Value::String("my-password".to_string())));
+    let secret_value = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("my-password".to_string()),
+    ))));
     // Hash with context (as from_provider_state would do)
     let hash_json = value_to_json_with_context(&secret_value, Some(&ctx)).unwrap();
     let hash_str = hash_json.as_str().unwrap().to_string();
 
     let desired = HashMap::from([("master_password".to_string(), secret_value)]);
-    let current = HashMap::from([("master_password".to_string(), Value::String(hash_str))]);
+    let current = HashMap::from([(
+        "master_password".to_string(),
+        Value::Concrete(ConcreteValue::String(hash_str)),
+    )]);
 
     // find_changed_attributes builds context from resource_id
     let changed = find_changed_attributes(&desired, &current, None, None, None, Some(&resource_id));
@@ -708,14 +801,21 @@ fn secret_with_context_detects_change() {
         "master_password",
     );
 
-    let old_secret = Value::Secret(Box::new(Value::String("old-password".to_string())));
-    let new_secret = Value::Secret(Box::new(Value::String("new-password".to_string())));
+    let old_secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("old-password".to_string()),
+    ))));
+    let new_secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("new-password".to_string()),
+    ))));
     // Hash the OLD secret with context
     let hash_json = value_to_json_with_context(&old_secret, Some(&ctx)).unwrap();
     let hash_str = hash_json.as_str().unwrap().to_string();
 
     let desired = HashMap::from([("master_password".to_string(), new_secret)]);
-    let current = HashMap::from([("master_password".to_string(), Value::String(hash_str))]);
+    let current = HashMap::from([(
+        "master_password".to_string(),
+        Value::Concrete(ConcreteValue::String(hash_str)),
+    )]);
 
     let changed = find_changed_attributes(&desired, &current, None, None, None, Some(&resource_id));
     assert!(
@@ -729,7 +829,9 @@ fn secret_same_password_different_resources_produces_different_hashes() {
     use crate::resource::ResourceId;
     use crate::value::{SecretHashContext, value_to_json_with_context};
 
-    let secret = Value::Secret(Box::new(Value::String("shared-password".to_string())));
+    let secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("shared-password".to_string()),
+    ))));
 
     let ctx1 = SecretHashContext::new("awscc.rds.db_instance", "db-1", "master_password");
     let ctx2 = SecretHashContext::new("awscc.rds.db_instance", "db-2", "master_password");
@@ -747,7 +849,7 @@ fn secret_same_password_different_resources_produces_different_hashes() {
     let desired1 = HashMap::from([("master_password".to_string(), secret.clone())]);
     let current1 = HashMap::from([(
         "master_password".to_string(),
-        Value::String(hash1.as_str().unwrap().to_string()),
+        Value::Concrete(ConcreteValue::String(hash1.as_str().unwrap().to_string())),
     )]);
     let changed1 = find_changed_attributes(&desired1, &current1, None, None, None, Some(&id1));
     assert!(
@@ -760,7 +862,7 @@ fn secret_same_password_different_resources_produces_different_hashes() {
     let desired2 = HashMap::from([("master_password".to_string(), secret)]);
     let current2 = HashMap::from([(
         "master_password".to_string(),
-        Value::String(hash1.as_str().unwrap().to_string()),
+        Value::Concrete(ConcreteValue::String(hash1.as_str().unwrap().to_string())),
     )]);
     let changed2 = find_changed_attributes(&desired2, &current2, None, None, None, Some(&id2));
     assert!(
@@ -774,8 +876,10 @@ fn secret_same_password_different_resources_produces_different_hashes() {
 /// the inner values are equal.
 #[test]
 fn secret_matches_plain_text_state_value() {
-    let secret = Value::Secret(Box::new(Value::String("my-password".to_string())));
-    let plain = Value::String("my-password".to_string());
+    let secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("my-password".to_string()),
+    ))));
+    let plain = Value::Concrete(ConcreteValue::String("my-password".to_string()));
     assert!(
         type_aware_equal(&secret, &plain, None, None),
         "Secret should match plain-text state when inner values are equal"
@@ -789,8 +893,10 @@ fn secret_matches_plain_text_state_value() {
 /// Secret with different inner value should NOT match plain-text state.
 #[test]
 fn secret_does_not_match_different_plain_text() {
-    let secret = Value::Secret(Box::new(Value::String("my-password".to_string())));
-    let plain = Value::String("other-password".to_string());
+    let secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("my-password".to_string()),
+    ))));
+    let plain = Value::Concrete(ConcreteValue::String("other-password".to_string()));
     assert!(
         !type_aware_equal(&secret, &plain, None, None),
         "Secret should not match different plain-text state"
@@ -810,22 +916,30 @@ fn secret_in_map_with_refresh_no_false_diff() {
     let resource_id = ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929");
 
     // Desired: tags map with a secret value (as written in .crn)
-    let desired_tags = Value::Map(IndexMap::from([
-        ("Name".to_string(), Value::String("test".to_string())),
+    let desired_tags = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
         (
             "SecretTag".to_string(),
-            Value::Secret(Box::new(Value::String("super-secret-value".to_string()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("super-secret-value".to_string()),
+            )))),
         ),
-    ]));
+    ])));
 
     // Current state from provider read (refresh=true): plain-text values
-    let current_tags = Value::Map(IndexMap::from([
-        ("Name".to_string(), Value::String("test".to_string())),
+    let current_tags = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
         (
             "SecretTag".to_string(),
-            Value::String("super-secret-value".to_string()),
+            Value::Concrete(ConcreteValue::String("super-secret-value".to_string())),
         ),
-    ]));
+    ])));
 
     // Build schema with tags as Map(String)
     let schema = ResourceSchema::new("ec2.Vpc").attribute(AttributeSchema::new(
@@ -864,20 +978,20 @@ fn string_or_list_of_strings_type() -> AttributeType {
 
 #[test]
 fn union_string_or_list_canonical_string_list_equal_to_self() {
-    // Two `Value::StringList` values with identical contents must be
+    // Two `Value::Concrete(ConcreteValue::StringList)` values with identical contents must be
     // equal under the differ for the `Union[String, list(String)]`
     // type. Sanity check that the canonical form is comparable at all.
     let union = string_or_list_of_strings_type();
-    let a = Value::StringList(vec!["repo:foo:*".to_string()]);
-    let b = Value::StringList(vec!["repo:foo:*".to_string()]);
+    let a = Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]));
+    let b = Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]));
     assert!(type_aware_equal(&a, &b, Some(&union), None));
 }
 
 #[test]
 fn union_string_or_list_canonical_string_list_diff_on_different_content() {
     let union = string_or_list_of_strings_type();
-    let a = Value::StringList(vec!["repo:foo:*".to_string()]);
-    let b = Value::StringList(vec!["repo:bar:*".to_string()]);
+    let a = Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]));
+    let b = Value::Concrete(ConcreteValue::StringList(vec!["repo:bar:*".to_string()]));
     assert!(!type_aware_equal(&a, &b, Some(&union), None));
 }
 
@@ -890,11 +1004,13 @@ fn union_string_or_list_non_canonical_mixed_shapes_fail_to_equal() {
     // paper over it. Adding a special-case equality here would defeat
     // the type-level canonicalization design.
     let union = string_or_list_of_strings_type();
-    let scalar = Value::String("repo:foo:*".to_string());
-    let canonical = Value::StringList(vec!["repo:foo:*".to_string()]);
+    let scalar = Value::Concrete(ConcreteValue::String("repo:foo:*".to_string()));
+    let canonical = Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]));
     assert!(!type_aware_equal(&scalar, &canonical, Some(&union), None));
 
-    let legacy_list = Value::List(vec![Value::String("repo:foo:*".to_string())]);
+    let legacy_list = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::String("repo:foo:*".to_string()),
+    )]));
     assert!(!type_aware_equal(
         &legacy_list,
         &canonical,
@@ -917,7 +1033,7 @@ fn union_string_or_list_through_custom_wrapper() {
         namespace: None,
         to_dsl: None,
     };
-    let a = Value::StringList(vec!["x".to_string()]);
-    let b = Value::StringList(vec!["x".to_string()]);
+    let a = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
+    let b = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
     assert!(type_aware_equal(&a, &b, Some(&custom), None));
 }

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::resource::ConcreteValue;
 use indexmap::IndexMap;
 
 #[test]
@@ -13,13 +14,15 @@ fn diff_create_when_not_exists() {
 
 #[test]
 fn diff_no_change_when_same() {
-    let desired = Resource::new("bucket", "test")
-        .with_attribute("region", Value::String("ap-northeast-1".to_string()));
+    let desired = Resource::new("bucket", "test").with_attribute(
+        "region",
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    );
 
     let mut attrs = HashMap::new();
     attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     let current = State::existing(ResourceId::new("bucket", "test"), attrs);
 
@@ -29,13 +32,15 @@ fn diff_no_change_when_same() {
 
 #[test]
 fn diff_update_when_different() {
-    let desired = Resource::new("bucket", "test")
-        .with_attribute("region", Value::String("us-east-1".to_string()));
+    let desired = Resource::new("bucket", "test").with_attribute(
+        "region",
+        Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+    );
 
     let mut attrs = HashMap::new();
     attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     let current = State::existing(ResourceId::new("bucket", "test"), attrs);
 
@@ -54,12 +59,16 @@ fn diff_update_when_different() {
 fn create_plan_from_resources() {
     let resources = vec![
         Resource::new("bucket", "new-bucket"),
-        Resource::new("bucket", "existing-bucket").with_attribute("versioning", Value::Bool(true)),
+        Resource::new("bucket", "existing-bucket")
+            .with_attribute("versioning", Value::Concrete(ConcreteValue::Bool(true))),
     ];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
-    attrs.insert("versioning".to_string(), Value::Bool(false));
+    attrs.insert(
+        "versioning".to_string(),
+        Value::Concrete(ConcreteValue::Bool(false)),
+    );
     current_states.insert(
         ResourceId::new("bucket", "existing-bucket"),
         State::existing(ResourceId::new("bucket", "existing-bucket"), attrs),
@@ -85,7 +94,10 @@ fn create_plan_from_resources() {
 fn create_plan_with_read_only_resource() {
     let resources = vec![
         Resource::new("bucket", "existing-bucket")
-            .with_attribute("name", Value::String("existing-bucket".to_string()))
+            .with_attribute(
+                "name",
+                Value::Concrete(ConcreteValue::String("existing-bucket".to_string())),
+            )
             .with_read_only(true),
         Resource::new("bucket", "new-bucket"),
     ];
@@ -111,24 +123,47 @@ fn create_plan_with_read_only_resource() {
 #[test]
 fn diff_update_when_list_of_maps_changed() {
     let mut ingress1 = IndexMap::new();
-    ingress1.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
-    ingress1.insert("from_port".to_string(), Value::Int(80));
-    ingress1.insert("to_port".to_string(), Value::Int(80));
+    ingress1.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
+    ingress1.insert(
+        "from_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(80)),
+    );
+    ingress1.insert(
+        "to_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(80)),
+    );
 
     let mut ingress2 = IndexMap::new();
-    ingress2.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
-    ingress2.insert("from_port".to_string(), Value::Int(443));
-    ingress2.insert("to_port".to_string(), Value::Int(443));
+    ingress2.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
+    ingress2.insert(
+        "from_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(443)),
+    );
+    ingress2.insert(
+        "to_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(443)),
+    );
 
     let desired = Resource::new("ec2_security_group", "test-sg").with_attribute(
         "security_group_ingress",
-        Value::List(vec![Value::Map(ingress1.clone()), Value::Map(ingress2)]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(ingress1.clone())),
+            Value::Concrete(ConcreteValue::Map(ingress2)),
+        ])),
     );
 
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
         "security_group_ingress".to_string(),
-        Value::List(vec![Value::Map(ingress1)]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(ingress1),
+        )])),
     );
     let current = State::existing(
         ResourceId::new("ec2_security_group", "test-sg"),
@@ -165,7 +200,7 @@ fn create_plan_detects_orphaned_resources_for_deletion() {
     let mut orphan_attrs = HashMap::new();
     orphan_attrs.insert(
         "name".to_string(),
-        Value::String("orphaned-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("orphaned-bucket".to_string())),
     );
     current_states.insert(
         ResourceId::new("bucket", "orphaned-bucket"),
@@ -204,7 +239,10 @@ fn read_only_resource_always_generates_read_effect() {
     // Even if the resource "exists", read-only resources should only generate Read effect
     let resources = vec![
         Resource::new("bucket", "existing-bucket")
-            .with_attribute("name", Value::String("existing-bucket".to_string()))
+            .with_attribute(
+                "name",
+                Value::Concrete(ConcreteValue::String("existing-bucket".to_string())),
+            )
             .with_read_only(true),
     ];
 
@@ -212,7 +250,7 @@ fn read_only_resource_always_generates_read_effect() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "name".to_string(),
-        Value::String("existing-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("existing-bucket".to_string())),
     );
     current_states.insert(
         ResourceId::new("bucket", "existing-bucket"),
@@ -241,14 +279,16 @@ fn read_only_resource_always_generates_read_effect() {
 #[test]
 fn no_false_update_without_name_attribute() {
     // Simulate AWSCC resource: desired has cidr_block but no "name"
-    let desired = Resource::new("ec2.Vpc", "vpc")
-        .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()));
+    let desired = Resource::new("ec2.Vpc", "vpc").with_attribute(
+        "cidr_block",
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+    );
 
     // Current state from provider read also has cidr_block but no "name"
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     let current = State::existing(ResourceId::new("ec2.Vpc", "vpc"), attrs);
 
@@ -264,16 +304,16 @@ fn no_false_update_without_name_attribute() {
 fn replace_when_create_only_attr_changed() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let resources = vec![
-        Resource::new("ec2.Vpc", "my-vpc")
-            .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string())),
-    ];
+    let resources = vec![Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+        "cidr_block",
+        Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+    )];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "my-vpc"),
@@ -315,13 +355,17 @@ fn replace_when_create_only_attr_changed() {
 fn normal_update_when_non_create_only_attr_changed() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let resources = vec![
-        Resource::new("ec2.Vpc", "my-vpc").with_attribute("enable_dns_support", Value::Bool(true)),
-    ];
+    let resources = vec![Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+        "enable_dns_support",
+        Value::Concrete(ConcreteValue::Bool(true)),
+    )];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
-    attrs.insert("enable_dns_support".to_string(), Value::Bool(false));
+    attrs.insert(
+        "enable_dns_support".to_string(),
+        Value::Concrete(ConcreteValue::Bool(false)),
+    );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "my-vpc"),
         State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
@@ -366,11 +410,14 @@ fn replace_when_schema_force_replace() {
     let resources = vec![
         Resource::new("ec2.internet_gateway", "my-igw").with_attribute(
             "tags",
-            Value::Map(
-                vec![("Name".to_string(), Value::String("new-name".to_string()))]
-                    .into_iter()
-                    .collect(),
-            ),
+            Value::Concrete(ConcreteValue::Map(
+                vec![(
+                    "Name".to_string(),
+                    Value::Concrete(ConcreteValue::String("new-name".to_string())),
+                )]
+                .into_iter()
+                .collect(),
+            )),
         ),
     ];
 
@@ -378,11 +425,14 @@ fn replace_when_schema_force_replace() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "tags".to_string(),
-        Value::Map(
-            vec![("Name".to_string(), Value::String("old-name".to_string()))]
-                .into_iter()
-                .collect(),
-        ),
+        Value::Concrete(ConcreteValue::Map(
+            vec![(
+                "Name".to_string(),
+                Value::Concrete(ConcreteValue::String("old-name".to_string())),
+            )]
+            .into_iter()
+            .collect(),
+        )),
     );
     current_states.insert(
         ResourceId::new("ec2.internet_gateway", "my-igw"),
@@ -426,17 +476,26 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
 
     let resources = vec![
         Resource::new("ec2.Vpc", "my-vpc")
-            .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()))
-            .with_attribute("enable_dns_support", Value::Bool(true)),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+            )
+            .with_attribute(
+                "enable_dns_support",
+                Value::Concrete(ConcreteValue::Bool(true)),
+            ),
     ];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    attrs.insert("enable_dns_support".to_string(), Value::Bool(false));
+    attrs.insert(
+        "enable_dns_support".to_string(),
+        Value::Concrete(ConcreteValue::Bool(false)),
+    );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "my-vpc"),
         State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
@@ -480,8 +539,10 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
 fn replace_carries_create_before_destroy_directives() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let mut resource = Resource::new("ec2.Vpc", "my-vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+    let mut resource = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+        "cidr_block",
+        Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+    );
     resource.directives.create_before_destroy = true;
 
     let resources = vec![resource];
@@ -490,7 +551,7 @@ fn replace_carries_create_before_destroy_directives() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "my-vpc"),
@@ -532,26 +593,50 @@ fn replace_carries_create_before_destroy_directives() {
 #[test]
 fn diff_no_change_when_list_of_maps_reordered() {
     let mut rule1 = IndexMap::new();
-    rule1.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
-    rule1.insert("from_port".to_string(), Value::Int(80));
-    rule1.insert("to_port".to_string(), Value::Int(80));
+    rule1.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
+    rule1.insert(
+        "from_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(80)),
+    );
+    rule1.insert(
+        "to_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(80)),
+    );
 
     let mut rule2 = IndexMap::new();
-    rule2.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
-    rule2.insert("from_port".to_string(), Value::Int(443));
-    rule2.insert("to_port".to_string(), Value::Int(443));
+    rule2.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
+    rule2.insert(
+        "from_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(443)),
+    );
+    rule2.insert(
+        "to_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(443)),
+    );
 
     // Desired: [rule1, rule2]
     let desired = Resource::new("ec2_security_group", "test-sg").with_attribute(
         "security_group_egress",
-        Value::List(vec![Value::Map(rule1.clone()), Value::Map(rule2.clone())]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(rule1.clone())),
+            Value::Concrete(ConcreteValue::Map(rule2.clone())),
+        ])),
     );
 
     // Current (from AWS): [rule2, rule1] — same content, different order
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
         "security_group_egress".to_string(),
-        Value::List(vec![Value::Map(rule2), Value::Map(rule1)]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(rule2)),
+            Value::Concrete(ConcreteValue::Map(rule1)),
+        ])),
     );
     let current = State::existing(
         ResourceId::new("ec2_security_group", "test-sg"),
@@ -573,15 +658,17 @@ fn replace_with_provider_prefixed_schema_key() {
     // In production, schemas are keyed by "awscc.ec2.Vpc" but resource_type is "ec2.Vpc"
     // The resource must have provider set so the generic lookup works
     let resources = vec![
-        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc")
-            .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string())),
+        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc").with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        ),
     ];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::with_provider("awscc", "ec2.Vpc", "my-vpc"),
@@ -624,54 +711,54 @@ fn replace_with_provider_prefixed_schema_key() {
 fn diff_no_change_when_struct_has_extra_fields_with_saved() {
     let desired = Resource::new("ec2.Subnet", "test-subnet").with_attribute(
         "private_dns_name_options_on_launch",
-        Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
                 "hostname_type".to_string(),
-                Value::String("ip-name".to_string()),
+                Value::Concrete(ConcreteValue::String("ip-name".to_string())),
             ),
             (
                 "enable_resource_name_dns_a_record".to_string(),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
-        ])),
+        ]))),
     );
 
     let current_attrs = HashMap::from([(
         "private_dns_name_options_on_launch".to_string(),
-        Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
                 "hostname_type".to_string(),
-                Value::String("ip-name".to_string()),
+                Value::Concrete(ConcreteValue::String("ip-name".to_string())),
             ),
             (
                 "enable_resource_name_dns_a_record".to_string(),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
             (
                 "enable_resource_name_dns_aaaa_record".to_string(),
-                Value::Bool(false),
+                Value::Concrete(ConcreteValue::Bool(false)),
             ),
-        ])),
+        ]))),
     )]);
     let current = State::existing(ResourceId::new("ec2.Subnet", "test-subnet"), current_attrs);
 
     let saved = IndexMap::from([
         (
             "hostname_type".to_string(),
-            Value::String("ip-name".to_string()),
+            Value::Concrete(ConcreteValue::String("ip-name".to_string())),
         ),
         (
             "enable_resource_name_dns_a_record".to_string(),
-            Value::Bool(true),
+            Value::Concrete(ConcreteValue::Bool(true)),
         ),
         (
             "enable_resource_name_dns_aaaa_record".to_string(),
-            Value::Bool(false),
+            Value::Concrete(ConcreteValue::Bool(false)),
         ),
     ]);
     let saved_map = HashMap::from([(
         "private_dns_name_options_on_launch".to_string(),
-        Value::Map(saved),
+        Value::Concrete(ConcreteValue::Map(saved)),
     )]);
 
     let result = diff(&desired, &current, Some(&saved_map), None, None);
@@ -687,55 +774,55 @@ fn diff_no_change_when_struct_has_extra_fields_with_saved() {
 fn diff_detects_drift_on_unmanaged_field() {
     let desired = Resource::new("ec2.Subnet", "test-subnet").with_attribute(
         "private_dns_name_options_on_launch",
-        Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
                 "hostname_type".to_string(),
-                Value::String("ip-name".to_string()),
+                Value::Concrete(ConcreteValue::String("ip-name".to_string())),
             ),
             (
                 "enable_resource_name_dns_a_record".to_string(),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
-        ])),
+        ]))),
     );
 
     // AWS returns aaaa_record: true (drifted from saved false)
     let current_attrs = HashMap::from([(
         "private_dns_name_options_on_launch".to_string(),
-        Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
                 "hostname_type".to_string(),
-                Value::String("ip-name".to_string()),
+                Value::Concrete(ConcreteValue::String("ip-name".to_string())),
             ),
             (
                 "enable_resource_name_dns_a_record".to_string(),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
             (
                 "enable_resource_name_dns_aaaa_record".to_string(),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
-        ])),
+        ]))),
     )]);
     let current = State::existing(ResourceId::new("ec2.Subnet", "test-subnet"), current_attrs);
 
     let saved = IndexMap::from([
         (
             "hostname_type".to_string(),
-            Value::String("ip-name".to_string()),
+            Value::Concrete(ConcreteValue::String("ip-name".to_string())),
         ),
         (
             "enable_resource_name_dns_a_record".to_string(),
-            Value::Bool(true),
+            Value::Concrete(ConcreteValue::Bool(true)),
         ),
         (
             "enable_resource_name_dns_aaaa_record".to_string(),
-            Value::Bool(false),
+            Value::Concrete(ConcreteValue::Bool(false)),
         ),
     ]);
     let saved_map = HashMap::from([(
         "private_dns_name_options_on_launch".to_string(),
-        Value::Map(saved),
+        Value::Concrete(ConcreteValue::Map(saved)),
     )]);
 
     let result = diff(&desired, &current, Some(&saved_map), None, None);
@@ -753,55 +840,55 @@ fn diff_detects_drift_on_unmanaged_field() {
 fn diff_no_change_when_bare_struct_with_extra_fields() {
     let desired = Resource::new("ec2.Subnet", "test-subnet").with_attribute(
         "private_dns_name_options_on_launch",
-        Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
                 "hostname_type".to_string(),
-                Value::String("ip-name".to_string()),
+                Value::Concrete(ConcreteValue::String("ip-name".to_string())),
             ),
             (
                 "enable_resource_name_dns_a_record".to_string(),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
-        ])),
+        ]))),
     );
 
     // Provider read returns Map with extra fields not in desired
     let current_attrs = HashMap::from([(
         "private_dns_name_options_on_launch".to_string(),
-        Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
                 "hostname_type".to_string(),
-                Value::String("ip-name".to_string()),
+                Value::Concrete(ConcreteValue::String("ip-name".to_string())),
             ),
             (
                 "enable_resource_name_dns_a_record".to_string(),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
             (
                 "enable_resource_name_dns_aaaa_record".to_string(),
-                Value::Bool(false),
+                Value::Concrete(ConcreteValue::Bool(false)),
             ),
-        ])),
+        ]))),
     )]);
     let current = State::existing(ResourceId::new("ec2.Subnet", "test-subnet"), current_attrs);
 
     // Saved state has the same Map with extra fields
     let saved_map = HashMap::from([(
         "private_dns_name_options_on_launch".to_string(),
-        Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
                 "hostname_type".to_string(),
-                Value::String("ip-name".to_string()),
+                Value::Concrete(ConcreteValue::String("ip-name".to_string())),
             ),
             (
                 "enable_resource_name_dns_a_record".to_string(),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
             (
                 "enable_resource_name_dns_aaaa_record".to_string(),
-                Value::Bool(false),
+                Value::Concrete(ConcreteValue::Bool(false)),
             ),
-        ])),
+        ]))),
     )]);
 
     let result = diff(&desired, &current, Some(&saved_map), None, None);
@@ -820,19 +907,19 @@ fn diff_works_without_saved_state() {
     // desired keys against current (not the other direction).
     let desired = Resource::new("ec2.Subnet", "test-subnet").with_attribute(
         "opts",
-        Value::Map(IndexMap::from([
-            ("a".to_string(), Value::Int(1)),
-            ("b".to_string(), Value::Int(2)),
-        ])),
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
+            ("b".to_string(), Value::Concrete(ConcreteValue::Int(2))),
+        ]))),
     );
 
     let current_attrs = HashMap::from([(
         "opts".to_string(),
-        Value::Map(IndexMap::from([
-            ("a".to_string(), Value::Int(1)),
-            ("b".to_string(), Value::Int(2)),
-            ("c".to_string(), Value::Int(3)),
-        ])),
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
+            ("b".to_string(), Value::Concrete(ConcreteValue::Int(2))),
+            ("c".to_string(), Value::Concrete(ConcreteValue::Int(3))),
+        ]))),
     )]);
     let current = State::existing(ResourceId::new("ec2.Subnet", "test-subnet"), current_attrs);
 
@@ -857,7 +944,7 @@ fn orphan_delete_preserves_binding_and_dependencies() {
     let mut orphan_attrs = HashMap::new();
     orphan_attrs.insert(
         "_binding".to_string(),
-        Value::String("my_subnet".to_string()),
+        Value::Concrete(ConcreteValue::String("my_subnet".to_string())),
     );
     orphan_attrs.insert(
         "vpc_id".to_string(),
@@ -954,72 +1041,104 @@ fn diff_no_change_for_struct_list_with_saved_state_egress_rules() {
     // "all" -> "-1" (alias resolved), "tcp" stays as namespaced identifier
     let desired = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg").with_attribute(
         "security_group_egress",
-        Value::List(vec![
-            Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([
                 (
                     "ip_protocol".to_string(),
-                    Value::String("awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string()),
+                    Value::Concrete(ConcreteValue::String(
+                        "awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string(),
+                    )),
                 ),
-                ("from_port".to_string(), Value::Int(443)),
-                ("to_port".to_string(), Value::Int(443)),
+                (
+                    "from_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(443)),
+                ),
+                (
+                    "to_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(443)),
+                ),
                 (
                     "cidr_ip".to_string(),
-                    Value::String("0.0.0.0/0".to_string()),
+                    Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
                 ),
                 (
                     "description".to_string(),
-                    Value::String("Allow HTTPS outbound".to_string()),
+                    Value::Concrete(ConcreteValue::String("Allow HTTPS outbound".to_string())),
                 ),
-            ])),
-            Value::Map(IndexMap::from([
-                ("ip_protocol".to_string(), Value::String("-1".to_string())),
+            ]))),
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([
+                (
+                    "ip_protocol".to_string(),
+                    Value::Concrete(ConcreteValue::String("-1".to_string())),
+                ),
                 (
                     "cidr_ip".to_string(),
-                    Value::String("10.0.0.0/8".to_string()),
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
                 ),
                 (
                     "description".to_string(),
-                    Value::String("Allow all to private ranges".to_string()),
+                    Value::Concrete(ConcreteValue::String(
+                        "Allow all to private ranges".to_string(),
+                    )),
                 ),
-            ])),
-        ]),
+            ]))),
+        ])),
     );
 
     // Current state (from AWS read, post-normalization, post-alias-resolution)
     // Same as desired, but the "all" rule also has from_port: -1, to_port: -1 from AWS
     let current_attrs = HashMap::from([(
         "security_group_egress".to_string(),
-        Value::List(vec![
-            Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([
                 (
                     "ip_protocol".to_string(),
-                    Value::String("awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string()),
+                    Value::Concrete(ConcreteValue::String(
+                        "awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string(),
+                    )),
                 ),
-                ("from_port".to_string(), Value::Int(443)),
-                ("to_port".to_string(), Value::Int(443)),
+                (
+                    "from_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(443)),
+                ),
+                (
+                    "to_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(443)),
+                ),
                 (
                     "cidr_ip".to_string(),
-                    Value::String("0.0.0.0/0".to_string()),
+                    Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
                 ),
                 (
                     "description".to_string(),
-                    Value::String("Allow HTTPS outbound".to_string()),
+                    Value::Concrete(ConcreteValue::String("Allow HTTPS outbound".to_string())),
                 ),
-            ])),
-            Value::Map(IndexMap::from([
-                ("ip_protocol".to_string(), Value::String("-1".to_string())),
-                ("from_port".to_string(), Value::Int(-1)),
-                ("to_port".to_string(), Value::Int(-1)),
+            ]))),
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([
+                (
+                    "ip_protocol".to_string(),
+                    Value::Concrete(ConcreteValue::String("-1".to_string())),
+                ),
+                (
+                    "from_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(-1)),
+                ),
+                (
+                    "to_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(-1)),
+                ),
                 (
                     "cidr_ip".to_string(),
-                    Value::String("10.0.0.0/8".to_string()),
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
                 ),
                 (
                     "description".to_string(),
-                    Value::String("Allow all to private ranges".to_string()),
+                    Value::Concrete(ConcreteValue::String(
+                        "Allow all to private ranges".to_string(),
+                    )),
                 ),
-            ])),
-        ]),
+            ]))),
+        ])),
     )]);
     let current = State::existing(
         ResourceId::with_provider("awscc", "ec2.SecurityGroup", "test-sg"),
@@ -1030,40 +1149,58 @@ fn diff_no_change_for_struct_list_with_saved_state_egress_rules() {
     // This is the state as written after apply: namespaced enum values, AWS-returned fields
     let saved = HashMap::from([(
         "security_group_egress".to_string(),
-        Value::List(vec![
-            Value::Map(IndexMap::from([
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([
                 (
                     "ip_protocol".to_string(),
-                    Value::String("awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string()),
+                    Value::Concrete(ConcreteValue::String(
+                        "awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string(),
+                    )),
                 ),
-                ("from_port".to_string(), Value::Int(443)),
-                ("to_port".to_string(), Value::Int(443)),
+                (
+                    "from_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(443)),
+                ),
+                (
+                    "to_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(443)),
+                ),
                 (
                     "cidr_ip".to_string(),
-                    Value::String("0.0.0.0/0".to_string()),
+                    Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
                 ),
                 (
                     "description".to_string(),
-                    Value::String("Allow HTTPS outbound".to_string()),
+                    Value::Concrete(ConcreteValue::String("Allow HTTPS outbound".to_string())),
                 ),
-            ])),
-            Value::Map(IndexMap::from([
+            ]))),
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([
                 (
                     "ip_protocol".to_string(),
-                    Value::String("awscc.ec2.SecurityGroup.IpProtocol.all".to_string()),
+                    Value::Concrete(ConcreteValue::String(
+                        "awscc.ec2.SecurityGroup.IpProtocol.all".to_string(),
+                    )),
                 ),
-                ("from_port".to_string(), Value::Int(-1)),
-                ("to_port".to_string(), Value::Int(-1)),
+                (
+                    "from_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(-1)),
+                ),
+                (
+                    "to_port".to_string(),
+                    Value::Concrete(ConcreteValue::Int(-1)),
+                ),
                 (
                     "cidr_ip".to_string(),
-                    Value::String("10.0.0.0/8".to_string()),
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
                 ),
                 (
                     "description".to_string(),
-                    Value::String("Allow all to private ranges".to_string()),
+                    Value::Concrete(ConcreteValue::String(
+                        "Allow all to private ranges".to_string(),
+                    )),
                 ),
-            ])),
-        ]),
+            ]))),
+        ])),
     )]);
 
     let result = diff(&desired, &current, Some(&saved), None, Some(&schema));
@@ -1106,40 +1243,61 @@ fn diff_false_positive_when_ordered_true_for_struct_list() {
     );
 
     // Same items in different order
-    let item_a = Value::Map(IndexMap::from([
-        ("ip_protocol".to_string(), Value::String("tcp".to_string())),
-        ("from_port".to_string(), Value::Int(443)),
-        ("to_port".to_string(), Value::Int(443)),
+    let item_a = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("tcp".to_string())),
+        ),
+        (
+            "from_port".to_string(),
+            Value::Concrete(ConcreteValue::Int(443)),
+        ),
+        (
+            "to_port".to_string(),
+            Value::Concrete(ConcreteValue::Int(443)),
+        ),
         (
             "cidr_ip".to_string(),
-            Value::String("0.0.0.0/0".to_string()),
+            Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
         ),
         (
             "description".to_string(),
-            Value::String("HTTPS".to_string()),
+            Value::Concrete(ConcreteValue::String("HTTPS".to_string())),
         ),
-    ]));
-    let item_b = Value::Map(IndexMap::from([
-        ("ip_protocol".to_string(), Value::String("-1".to_string())),
+    ])));
+    let item_b = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("-1".to_string())),
+        ),
         (
             "cidr_ip".to_string(),
-            Value::String("10.0.0.0/8".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
         ),
-        ("description".to_string(), Value::String("All".to_string())),
-        ("from_port".to_string(), Value::Int(-1)),
-        ("to_port".to_string(), Value::Int(-1)),
-    ]));
+        (
+            "description".to_string(),
+            Value::Concrete(ConcreteValue::String("All".to_string())),
+        ),
+        (
+            "from_port".to_string(),
+            Value::Concrete(ConcreteValue::Int(-1)),
+        ),
+        (
+            "to_port".to_string(),
+            Value::Concrete(ConcreteValue::Int(-1)),
+        ),
+    ])));
 
     let desired = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg").with_attribute(
         "security_group_egress",
-        Value::List(vec![item_a.clone(), item_b.clone()]),
+        Value::Concrete(ConcreteValue::List(vec![item_a.clone(), item_b.clone()])),
     );
     let current = State::existing(
         ResourceId::with_provider("awscc", "ec2.SecurityGroup", "test-sg"),
         HashMap::from([(
             "security_group_egress".to_string(),
             // AWS returns items in reversed order
-            Value::List(vec![item_b.clone(), item_a.clone()]),
+            Value::Concrete(ConcreteValue::List(vec![item_b.clone(), item_a.clone()])),
         )]),
     );
 

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -7,7 +7,9 @@ use crate::effect::{CascadingUpdate, Effect, TemporaryName};
 use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
-use crate::resource::{Directives, Resource, ResourceId, ResourceKind, State, Value};
+use crate::resource::{
+    ConcreteValue, DeferredValue, Directives, Resource, ResourceId, ResourceKind, State, Value,
+};
 use crate::schema::{
     ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
 };
@@ -96,12 +98,12 @@ fn generate_temporary_name(
 
     // Get the current value of the name attribute
     let original_value = match resource.get_attr(name_attr) {
-        Some(Value::String(s)) => s.clone(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
         _ => return None,
     };
 
     // Skip if the name_attribute value changed (new name is already different from old)
-    if let Some(Value::String(from_name)) = from.attributes.get(name_attr)
+    if let Some(Value::Concrete(ConcreteValue::String(from_name))) = from.attributes.get(name_attr)
         && *from_name != original_value
     {
         return None;
@@ -268,7 +270,7 @@ pub fn create_plan(
                         let mut modified = to;
                         modified.set_attr(
                             temp.attribute.clone(),
-                            Value::String(temp.temporary_value.clone()),
+                            Value::Concrete(ConcreteValue::String(temp.temporary_value.clone())),
                         );
                         modified
                     } else {
@@ -333,7 +335,7 @@ pub fn create_plan(
             }
             let identifier = state.identifier.clone().unwrap_or_default();
             let binding = state.attributes.get("_binding").and_then(|v| match v {
-                Value::String(s) => Some(s.clone()),
+                Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                 _ => None,
             });
             // Use stored dependency bindings from state file if available,
@@ -574,7 +576,7 @@ pub fn cascade_dependent_updates(
             let ref_attrs: Vec<String> = resource
                 .attributes
                 .iter()
-                .filter(|(_, v)| matches!(v, Value::ResourceRef { path } if path.binding() == dep))
+                .filter(|(_, v)| matches!(v, Value::Deferred(DeferredValue::ResourceRef{ path }) if path.binding() == dep))
                 .map(|(k, _)| k.clone())
                 .collect();
 
@@ -582,10 +584,14 @@ pub fn cascade_dependent_updates(
                 .attributes
                 .iter()
                 .filter_map(|(k, v)| match v {
-                    Value::ResourceRef { path } if path.binding() == dep => Some((
-                        k.clone(),
-                        format!("{}.{}", path.binding(), path.attribute()),
-                    )),
+                    Value::Deferred(DeferredValue::ResourceRef { path })
+                        if path.binding() == dep =>
+                    {
+                        Some((
+                            k.clone(),
+                            format!("{}.{}", path.binding(), path.attribute()),
+                        ))
+                    }
                     _ => None,
                 })
                 .collect();
@@ -664,7 +670,7 @@ pub fn cascade_dependent_updates(
                     .attributes
                     .iter()
                     .filter(|(_, v)| {
-                        matches!(v, Value::ResourceRef { path } if path.binding() == replaced_binding)
+                        matches!(v, Value::Deferred(DeferredValue::ResourceRef{ path }) if path.binding() == replaced_binding)
                     })
                     .map(|(k, _)| k.clone())
                     .collect();
@@ -702,7 +708,7 @@ pub fn cascade_dependent_updates(
                         .attributes
                         .iter()
                         .filter_map(|(k, v)| match v {
-                            Value::ResourceRef { path }
+                            Value::Deferred(DeferredValue::ResourceRef { path })
                                 if path.binding() == replaced_binding
                                     && create_only_refs.contains(k) =>
                             {

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use indexmap::IndexMap;
 
 use crate::explicit::ExplicitFields;
-use crate::resource::ResourceKind;
+use crate::resource::{ConcreteValue, ResourceKind};
 
 /// Build an `ExplicitFields::Struct` whose children are all `Leaf` —
 /// the shape `state v5 → v6` reads produce, and a convenient way to
@@ -23,8 +23,14 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
     use crate::schema::{AttributeSchema, AttributeType};
 
     let mut resource = Resource::new("s3.Bucket", "my-bucket")
-        .with_attribute("bucket_name", Value::String("my-bucket".to_string()))
-        .with_attribute("object_lock_enabled", Value::Bool(true));
+        .with_attribute(
+            "bucket_name",
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+        )
+        .with_attribute(
+            "object_lock_enabled",
+            Value::Concrete(ConcreteValue::Bool(true)),
+        );
     resource.directives.create_before_destroy = true;
 
     let resources = vec![resource];
@@ -33,9 +39,12 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "bucket_name".to_string(),
-        Value::String("my-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
-    attrs.insert("object_lock_enabled".to_string(), Value::Bool(false));
+    attrs.insert(
+        "object_lock_enabled".to_string(),
+        Value::Concrete(ConcreteValue::Bool(false)),
+    );
     current_states.insert(
         ResourceId::new("s3.Bucket", "my-bucket"),
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
@@ -84,7 +93,9 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
             // The `to` resource should have the temporary name
             assert_eq!(
                 to.get_attr("bucket_name"),
-                Some(&Value::String(temp.temporary_value.clone()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    temp.temporary_value.clone()
+                )))
             );
         }
         other => panic!("Expected Replace, got {:?}", other),
@@ -98,9 +109,12 @@ fn create_before_destroy_generates_temporary_name_with_can_rename() {
     let mut resource = Resource::new("logs.LogGroup", "my-log-group")
         .with_attribute(
             "log_group_name".to_string(),
-            Value::String("my-log-group".to_string()),
+            Value::Concrete(ConcreteValue::String("my-log-group".to_string())),
         )
-        .with_attribute("kms_key_id", Value::String("new-key".to_string()));
+        .with_attribute(
+            "kms_key_id",
+            Value::Concrete(ConcreteValue::String("new-key".to_string())),
+        );
     resource.directives.create_before_destroy = true;
 
     let resources = vec![resource];
@@ -109,11 +123,11 @@ fn create_before_destroy_generates_temporary_name_with_can_rename() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "log_group_name".to_string(),
-        Value::String("my-log-group".to_string()),
+        Value::Concrete(ConcreteValue::String("my-log-group".to_string())),
     );
     attrs.insert(
         "kms_key_id".to_string(),
-        Value::String("old-key".to_string()),
+        Value::Concrete(ConcreteValue::String("old-key".to_string())),
     );
     current_states.insert(
         ResourceId::new("logs.LogGroup", "my-log-group"),
@@ -163,17 +177,26 @@ fn no_temporary_name_without_create_before_destroy() {
     // Default directives (create_before_destroy = false)
     let resources = vec![
         Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("bucket_name", Value::String("my-bucket".to_string()))
-            .with_attribute("object_lock_enabled", Value::Bool(true)),
+            .with_attribute(
+                "bucket_name",
+                Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+            )
+            .with_attribute(
+                "object_lock_enabled",
+                Value::Concrete(ConcreteValue::Bool(true)),
+            ),
     ];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
     attrs.insert(
         "bucket_name".to_string(),
-        Value::String("my-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
-    attrs.insert("object_lock_enabled".to_string(), Value::Bool(false));
+    attrs.insert(
+        "object_lock_enabled".to_string(),
+        Value::Concrete(ConcreteValue::Bool(false)),
+    );
     current_states.insert(
         ResourceId::new("s3.Bucket", "my-bucket"),
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
@@ -218,8 +241,14 @@ fn no_temporary_name_when_name_prefix_is_used() {
     use crate::schema::{AttributeSchema, AttributeType};
 
     let mut resource = Resource::new("s3.Bucket", "my-bucket")
-        .with_attribute("bucket_name", Value::String("my-app-abc12345".to_string()))
-        .with_attribute("object_lock_enabled", Value::Bool(true));
+        .with_attribute(
+            "bucket_name",
+            Value::Concrete(ConcreteValue::String("my-app-abc12345".to_string())),
+        )
+        .with_attribute(
+            "object_lock_enabled",
+            Value::Concrete(ConcreteValue::Bool(true)),
+        );
     resource.directives.create_before_destroy = true;
     // Simulate that name_prefix was used
     resource
@@ -232,9 +261,12 @@ fn no_temporary_name_when_name_prefix_is_used() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "bucket_name".to_string(),
-        Value::String("my-app-abc12345".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-abc12345".to_string())),
     );
-    attrs.insert("object_lock_enabled".to_string(), Value::Bool(false));
+    attrs.insert(
+        "object_lock_enabled".to_string(),
+        Value::Concrete(ConcreteValue::Bool(false)),
+    );
     current_states.insert(
         ResourceId::new("s3.Bucket", "my-bucket"),
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
@@ -278,8 +310,10 @@ fn no_temporary_name_when_name_prefix_is_used() {
 fn no_temporary_name_without_name_attribute_in_schema() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let mut resource = Resource::new("ec2.Vpc", "my-vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+    let mut resource = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+        "cidr_block",
+        Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+    );
     resource.directives.create_before_destroy = true;
 
     let resources = vec![resource];
@@ -288,7 +322,7 @@ fn no_temporary_name_without_name_attribute_in_schema() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "my-vpc"),
@@ -333,8 +367,14 @@ fn no_temporary_name_when_name_attribute_changes() {
     // name_attribute itself changed: old-bucket → new-bucket
     // No temporary name needed since names are already different
     let mut resource = Resource::new("s3.Bucket", "my-bucket")
-        .with_attribute("bucket_name", Value::String("new-bucket".to_string()))
-        .with_attribute("object_lock_enabled", Value::Bool(true));
+        .with_attribute(
+            "bucket_name",
+            Value::Concrete(ConcreteValue::String("new-bucket".to_string())),
+        )
+        .with_attribute(
+            "object_lock_enabled",
+            Value::Concrete(ConcreteValue::Bool(true)),
+        );
     resource.directives.create_before_destroy = true;
 
     let resources = vec![resource];
@@ -343,9 +383,12 @@ fn no_temporary_name_when_name_attribute_changes() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "bucket_name".to_string(),
-        Value::String("old-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("old-bucket".to_string())),
     );
-    attrs.insert("object_lock_enabled".to_string(), Value::Bool(true));
+    attrs.insert(
+        "object_lock_enabled".to_string(),
+        Value::Concrete(ConcreteValue::Bool(true)),
+    );
     current_states.insert(
         ResourceId::new("s3.Bucket", "my-bucket"),
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
@@ -388,20 +431,22 @@ fn no_temporary_name_when_name_attribute_changes() {
 #[test]
 fn diff_detects_attribute_removal_with_prev_desired_keys() {
     // User previously had "region" and "tags" in .crn, now only has "region"
-    let desired = Resource::new("s3.Bucket", "test")
-        .with_attribute("region", Value::String("ap-northeast-1".to_string()));
+    let desired = Resource::new("s3.Bucket", "test").with_attribute(
+        "region",
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    );
 
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     current_attrs.insert(
         "tags".to_string(),
-        Value::Map(IndexMap::from([(
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
             "Name".to_string(),
-            Value::String("test".to_string()),
-        )])),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        )]))),
     );
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
@@ -432,11 +477,11 @@ fn diff_ignores_attributes_not_in_prev_desired_keys() {
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     current_attrs.insert(
         "arn".to_string(),
-        Value::String("arn:aws:s3:::test".to_string()),
+        Value::Concrete(ConcreteValue::String("arn:aws:s3:::test".to_string())),
     );
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
@@ -473,24 +518,31 @@ fn server_default_struct_field_does_not_appear_in_diff() {
     let mut desired_lc = IndexMap::new();
     desired_lc.insert(
         "rules".to_string(),
-        Value::List(vec![{
+        Value::Concrete(ConcreteValue::List(vec![{
             let mut rule = IndexMap::new();
-            rule.insert("id".to_string(), Value::String("expire".to_string()));
-            Value::Map(rule)
-        }]),
+            rule.insert(
+                "id".to_string(),
+                Value::Concrete(ConcreteValue::String("expire".to_string())),
+            );
+            Value::Concrete(ConcreteValue::Map(rule))
+        }])),
     );
-    let desired = Resource::new("s3.Bucket", "test")
-        .with_attribute("lifecycle_configuration", Value::Map(desired_lc.clone()));
+    let desired = Resource::new("s3.Bucket", "test").with_attribute(
+        "lifecycle_configuration",
+        Value::Concrete(ConcreteValue::Map(desired_lc.clone())),
+    );
 
     let mut current_lc = desired_lc;
     current_lc.insert(
         "transition_default_minimum_object_size".to_string(),
-        Value::String("all_storage_classes_128K".to_string()),
+        Value::Concrete(ConcreteValue::String(
+            "all_storage_classes_128K".to_string(),
+        )),
     );
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
         "lifecycle_configuration".to_string(),
-        Value::Map(current_lc),
+        Value::Concrete(ConcreteValue::Map(current_lc)),
     );
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
@@ -533,10 +585,10 @@ fn explicit_top_level_removal_still_detected() {
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
         "tags".to_string(),
-        Value::Map(IndexMap::from([(
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
             "Env".to_string(),
-            Value::String("prod".to_string()),
-        )])),
+            Value::Concrete(ConcreteValue::String("prod".to_string())),
+        )]))),
     );
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
@@ -560,20 +612,22 @@ fn explicit_top_level_removal_still_detected() {
 #[test]
 fn diff_no_change_without_prev_desired_keys() {
     // Without prev_desired_keys, removed attributes should NOT be detected
-    let desired = Resource::new("s3.Bucket", "test")
-        .with_attribute("region", Value::String("ap-northeast-1".to_string()));
+    let desired = Resource::new("s3.Bucket", "test").with_attribute(
+        "region",
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    );
 
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     current_attrs.insert(
         "tags".to_string(),
-        Value::Map(IndexMap::from([(
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
             "Name".to_string(),
-            Value::String("test".to_string()),
-        )])),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        )]))),
     );
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
@@ -589,23 +643,23 @@ fn diff_no_change_without_prev_desired_keys() {
 fn create_plan_detects_attribute_removal() {
     // Resource in .crn has no "tags", but current state (from AWS) has tags.
     // prev_desired_keys indicates user previously had "region" and "tags".
-    let resources = vec![
-        Resource::new("s3.Bucket", "test")
-            .with_attribute("region", Value::String("ap-northeast-1".to_string())),
-    ];
+    let resources = vec![Resource::new("s3.Bucket", "test").with_attribute(
+        "region",
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    )];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
     attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     attrs.insert(
         "tags".to_string(),
-        Value::Map(IndexMap::from([(
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
             "Name".to_string(),
-            Value::String("test".to_string()),
-        )])),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        )]))),
     );
     current_states.insert(
         ResourceId::new("s3.Bucket", "test"),
@@ -642,23 +696,23 @@ fn create_plan_filters_non_removable_attribute_removal() {
     use crate::schema::{AttributeSchema, AttributeType};
     // When schema is available, only removable attributes should trigger removal.
     // "region" is not removable, "tags" is removable.
-    let resources = vec![
-        Resource::new("s3.Bucket", "test")
-            .with_attribute("region", Value::String("ap-northeast-1".to_string())),
-    ];
+    let resources = vec![Resource::new("s3.Bucket", "test").with_attribute(
+        "region",
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    )];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
     attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     attrs.insert(
         "tags".to_string(),
-        Value::Map(IndexMap::from([(
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
             "Name".to_string(),
-            Value::String("test".to_string()),
-        )])),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        )]))),
     );
     current_states.insert(
         ResourceId::new("s3.Bucket", "test"),
@@ -718,17 +772,20 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
     use crate::schema::{AttributeSchema, AttributeType};
     // When the only "change" is a non-removable attribute removal,
     // the plan should have no effects (no spurious Update).
-    let resources = vec![
-        Resource::new("s3.Bucket", "test")
-            .with_attribute("bucket", Value::String("my-bucket".to_string())),
-    ];
+    let resources = vec![Resource::new("s3.Bucket", "test").with_attribute(
+        "bucket",
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+    )];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
-    attrs.insert("bucket".to_string(), Value::String("my-bucket".to_string()));
+    attrs.insert(
+        "bucket".to_string(),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+    );
     attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     current_states.insert(
         ResourceId::new("s3.Bucket", "test"),
@@ -771,17 +828,19 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
 #[test]
 fn diff_skips_internal_attributes_in_removal_detection() {
     // prev_desired_keys includes "_internal" but it should be skipped
-    let desired = Resource::new("s3.Bucket", "test")
-        .with_attribute("region", Value::String("ap-northeast-1".to_string()));
+    let desired = Resource::new("s3.Bucket", "test").with_attribute(
+        "region",
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    );
 
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
         "region".to_string(),
-        Value::String("ap-northeast-1".to_string()),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     current_attrs.insert(
         "_internal".to_string(),
-        Value::String("something".to_string()),
+        Value::Concrete(ConcreteValue::String("something".to_string())),
     );
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
@@ -805,7 +864,7 @@ fn prevent_destroy_blocks_delete_for_orphaned_resource() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "my-vpc"),
@@ -860,8 +919,10 @@ fn prevent_destroy_blocks_replace() {
 
     // Resource with prevent_destroy that has a create-only attribute change
     // (which would normally trigger a Replace)
-    let mut resource = Resource::new("ec2.Vpc", "my-vpc")
-        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+    let mut resource = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+        "cidr_block",
+        Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+    );
     resource.directives.prevent_destroy = true;
 
     let resources = vec![resource];
@@ -870,7 +931,7 @@ fn prevent_destroy_blocks_replace() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "my-vpc"),
@@ -919,8 +980,10 @@ fn prevent_destroy_blocks_replace() {
 fn prevent_destroy_does_not_block_update() {
     // Resource with prevent_destroy that has a normal (non-create-only) attribute change
     // Updates don't destroy the resource, so they should be allowed
-    let mut resource = Resource::new("s3.Bucket", "my-bucket")
-        .with_attribute("versioning", Value::String("Enabled".to_string()));
+    let mut resource = Resource::new("s3.Bucket", "my-bucket").with_attribute(
+        "versioning",
+        Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+    );
     resource.directives.prevent_destroy = true;
 
     let resources = vec![resource];
@@ -929,7 +992,7 @@ fn prevent_destroy_does_not_block_update() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "versioning".to_string(),
-        Value::String("Disabled".to_string()),
+        Value::Concrete(ConcreteValue::String("Disabled".to_string())),
     );
     current_states.insert(
         ResourceId::new("s3.Bucket", "my-bucket"),
@@ -966,8 +1029,10 @@ fn prevent_destroy_does_not_block_update() {
 fn prevent_destroy_does_not_block_create() {
     // Resource with prevent_destroy that doesn't exist yet
     // Creates don't destroy anything, so they should be allowed
-    let mut resource = Resource::new("s3.Bucket", "my-bucket")
-        .with_attribute("bucket", Value::String("my-bucket".to_string()));
+    let mut resource = Resource::new("s3.Bucket", "my-bucket").with_attribute(
+        "bucket",
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+    );
     resource.directives.prevent_destroy = true;
 
     let resources = vec![resource];
@@ -1005,7 +1070,7 @@ fn without_prevent_destroy_delete_works_normally() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "my-vpc"),
@@ -1042,7 +1107,7 @@ fn prevent_destroy_collects_multiple_errors() {
     let mut attrs1 = HashMap::new();
     attrs1.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "vpc-1"),
@@ -1051,7 +1116,7 @@ fn prevent_destroy_collects_multiple_errors() {
     let mut attrs2 = HashMap::new();
     attrs2.insert(
         "cidr_block".to_string(),
-        Value::String("10.1.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     );
     current_states.insert(
         ResourceId::new("ec2.Vpc", "vpc-2"),
@@ -1103,11 +1168,13 @@ fn virtual_resources_are_skipped_in_plan() {
     virtual_resource.binding = Some("web".to_string());
     virtual_resource.set_attr(
         "security_group".to_string(),
-        Value::String("sg-123".to_string()),
+        Value::Concrete(ConcreteValue::String("sg-123".to_string())),
     );
 
-    let real_resource = Resource::new("ec2.SecurityGroup", "sg")
-        .with_attribute("group_name", Value::String("my-sg".to_string()));
+    let real_resource = Resource::new("ec2.SecurityGroup", "sg").with_attribute(
+        "group_name",
+        Value::Concrete(ConcreteValue::String("my-sg".to_string())),
+    );
 
     let resources = vec![virtual_resource, real_resource];
 
@@ -1145,7 +1212,9 @@ fn wait_binding_lowers_to_wait_effect() {
         until_raw: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
         until_predicate: UntilPredicateAst {
             lhs_segments: vec!["cert".to_string(), "status".to_string()],
-            rhs: Value::String("aws.acm.Certificate.Status.Issued".to_string()),
+            rhs: Value::Concrete(ConcreteValue::String(
+                "aws.acm.Certificate.Status.Issued".to_string(),
+            )),
         },
         timeout_secs: Some(75 * 60),
         depends_on: vec![],
@@ -1188,7 +1257,9 @@ fn wait_binding_lowers_to_wait_effect() {
             attr: AttrPath {
                 segments: vec!["status".to_string()],
             },
-            value: Value::String("aws.acm.Certificate.Status.Issued".to_string()),
+            value: Value::Concrete(ConcreteValue::String(
+                "aws.acm.Certificate.Status.Issued".to_string()
+            )),
         }
     );
     assert_eq!(*timeout, std::time::Duration::from_secs(75 * 60));
@@ -1222,7 +1293,7 @@ fn wait_uses_schema_default_timeout_when_omitted() {
         until_raw: "cert.status == ISSUED".to_string(),
         until_predicate: UntilPredicateAst {
             lhs_segments: vec!["cert".to_string(), "status".to_string()],
-            rhs: Value::String("ISSUED".to_string()),
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
         },
         timeout_secs: None,
         depends_on: vec![],
@@ -1265,7 +1336,7 @@ fn wait_with_unknown_target_emits_plan_error() {
         until_raw: "nonexistent.status == ISSUED".to_string(),
         until_predicate: UntilPredicateAst {
             lhs_segments: vec!["nonexistent".to_string(), "status".to_string()],
-            rhs: Value::String("ISSUED".to_string()),
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
         },
         timeout_secs: None,
         depends_on: vec![],

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -330,16 +330,18 @@ mod tests {
 
     #[test]
     fn binding_name_returns_none_without_binding() {
-        use crate::resource::Value;
-        let resource = Resource::new("test", "no_binding")
-            .with_attribute("name", Value::String("test".to_string()));
+        use crate::resource::{ConcreteValue, Value};
+        let resource = Resource::new("test", "no_binding").with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        );
         let effect = Effect::Create(resource);
         assert_eq!(effect.binding_name(), None);
     }
 
     #[test]
     fn effect_serde_round_trip() {
-        use crate::resource::Value;
+        use crate::resource::{ConcreteValue, Value};
         use std::collections::HashMap;
 
         let effects = vec![
@@ -353,11 +355,13 @@ mod tests {
                     ResourceId::new("s3.Bucket", "my-bucket"),
                     HashMap::from([(
                         "versioning".to_string(),
-                        Value::String("Disabled".to_string()),
+                        Value::Concrete(ConcreteValue::String("Disabled".to_string())),
                     )]),
                 )),
-                to: Resource::new("s3.Bucket", "my-bucket")
-                    .with_attribute("versioning", Value::String("Enabled".to_string())),
+                to: Resource::new("s3.Bucket", "my-bucket").with_attribute(
+                    "versioning",
+                    Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+                ),
                 changed_attributes: vec!["versioning".to_string()],
             },
             Effect::Replace {
@@ -366,11 +370,13 @@ mod tests {
                     ResourceId::new("ec2.Vpc", "my-vpc"),
                     HashMap::from([(
                         "cidr_block".to_string(),
-                        Value::String("10.0.0.0/16".to_string()),
+                        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
                     )]),
                 )),
-                to: Resource::new("ec2.Vpc", "my-vpc")
-                    .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string())),
+                to: Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+                    "cidr_block",
+                    Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+                ),
                 directives: Directives::default(),
                 changed_create_only: vec!["cidr_block".to_string()],
                 cascading_updates: vec![],
@@ -472,7 +478,7 @@ mod tests {
 
     #[test]
     fn wait_variant_constructs() {
-        use crate::resource::Value;
+        use crate::resource::{ConcreteValue, Value};
         use crate::wait::predicate::{AttrPath, WaitPredicate};
         use std::time::Duration;
 
@@ -482,7 +488,7 @@ mod tests {
             target_identifier: None,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
-                value: Value::String("ISSUED".to_string()),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
             },
             until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             timeout: Duration::from_secs(75 * 60),
@@ -493,7 +499,7 @@ mod tests {
 
     #[test]
     fn wait_binding_name_returns_wait_binding() {
-        use crate::resource::Value;
+        use crate::resource::{ConcreteValue, Value};
         use crate::wait::predicate::{AttrPath, WaitPredicate};
         use std::time::Duration;
 
@@ -503,7 +509,7 @@ mod tests {
             target_identifier: None,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
-                value: Value::String("ISSUED".to_string()),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
             },
             until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             timeout: Duration::from_secs(60),
@@ -515,7 +521,7 @@ mod tests {
 
     #[test]
     fn wait_is_not_mutating() {
-        use crate::resource::Value;
+        use crate::resource::{ConcreteValue, Value};
         use crate::wait::predicate::{AttrPath, WaitPredicate};
         use std::time::Duration;
 
@@ -525,7 +531,7 @@ mod tests {
             target_identifier: None,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
-                value: Value::String("ISSUED".to_string()),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
             },
             until_surface: "cert.status == ISSUED".to_string(),
             timeout: Duration::from_secs(60),
@@ -538,7 +544,7 @@ mod tests {
 
     #[test]
     fn wait_serde_round_trip() {
-        use crate::resource::Value;
+        use crate::resource::{ConcreteValue, Value};
         use crate::wait::predicate::{AttrPath, WaitPredicate};
         use std::time::Duration;
 
@@ -548,7 +554,7 @@ mod tests {
             target_identifier: None,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
-                value: Value::String("ISSUED".to_string()),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
             },
             until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             timeout: Duration::from_secs(4500),

--- a/carina-core/src/eval_value.rs
+++ b/carina-core/src/eval_value.rs
@@ -107,11 +107,11 @@ impl From<Value> for EvalValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::Value;
+    use crate::resource::{ConcreteValue, Value};
 
     #[test]
     fn user_round_trips() {
-        let original = Value::String("hi".into());
+        let original = Value::Concrete(ConcreteValue::String("hi".into()));
         let eval = EvalValue::from_value(original.clone());
         assert_eq!(eval.into_value().unwrap(), original);
     }

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -11,7 +11,7 @@ use crate::provider::{
     CreateRequest, DeleteRequest, Provider, ReadRequest, UpdateRequest, build_update_patch,
 };
 use crate::resolver::resolve_ref_value;
-use crate::resource::{Resource, ResourceId, State, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};
 
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 
@@ -133,17 +133,19 @@ pub(super) fn resolve_resource_with_source(
     Ok(resolved)
 }
 
-/// Recursively unwrap `Value::Secret(inner)` to just the inner value.
+/// Recursively unwrap `Value::Deferred(DeferredValue::Secret(inner))` to just the inner value.
 /// This ensures the provider never sees the Secret wrapper.
 fn unwrap_secret(value: Value) -> Value {
     match value {
-        Value::Secret(inner) => unwrap_secret(*inner),
-        Value::List(items) => Value::List(items.into_iter().map(unwrap_secret).collect()),
-        Value::Map(map) => Value::Map(
+        Value::Deferred(DeferredValue::Secret(inner)) => unwrap_secret(*inner),
+        Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
+            items.into_iter().map(unwrap_secret).collect(),
+        )),
+        Value::Concrete(ConcreteValue::Map(map)) => Value::Concrete(ConcreteValue::Map(
             map.into_iter()
                 .map(|(k, v)| (k, unwrap_secret(v)))
                 .collect(),
-        ),
+        )),
         other => other,
     }
 }

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -9,7 +9,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use crate::deps::{find_failed_dependency, get_resource_dependencies};
 use crate::effect::Effect;
 use crate::provider::{CreateRequest, DeleteRequest, Provider, UpdateRequest};
-use crate::resource::{Resource, ResourceId, State, Value};
+use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use super::basic::{
     BasicEffectResult, ExecutionState, count_actionable_effects, execute_basic_effect,
@@ -1001,7 +1001,9 @@ pub(super) async fn execute_effects_phased(
                                 let new_identifier = state.identifier.as_deref().unwrap_or("");
                                 let rename_patch = single_attribute_patch(
                                     temp.attribute.clone(),
-                                    Value::String(temp.original_value.clone()),
+                                    Value::Concrete(ConcreteValue::String(
+                                        temp.original_value.clone(),
+                                    )),
                                 );
                                 let rename_request = UpdateRequest {
                                     from: state.clone(),

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -9,7 +9,7 @@ use crate::provider::{
     CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, UpdatePatch, UpdateRequest,
     build_update_patch,
 };
-use crate::resource::{Resource, ResourceId, State, Value};
+use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use super::basic::{BasicEffectResult, resolve_resource, resolve_resource_with_source};
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
@@ -238,7 +238,7 @@ pub(super) async fn execute_cbd_replace_parallel(
                         let new_identifier = state.identifier.as_deref().unwrap_or("");
                         let rename_patch = single_attribute_patch(
                             temp.attribute.clone(),
-                            Value::String(temp.original_value.clone()),
+                            Value::Concrete(ConcreteValue::String(temp.original_value.clone())),
                         );
                         let rename_request = UpdateRequest {
                             from: state.clone(),

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -4,7 +4,7 @@ use crate::provider::{
     BoxFuture, CreateRequest, DeleteRequest, ProviderError, ProviderResult, ReadRequest,
     UpdateRequest,
 };
-use crate::resource::{Directives, Resource, Value};
+use crate::resource::{ConcreteValue, Directives, Resource, Value};
 use parallel::{build_dependency_levels, build_dependency_map};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -1197,7 +1197,10 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     // VPC resource with binding "vpc"
     let mut vpc = Resource::new("test", "my-vpc");
     vpc.binding = Some("vpc".to_string());
-    vpc.set_attr("cidr_block", Value::String("10.0.0.0/16".to_string()));
+    vpc.set_attr(
+        "cidr_block",
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+    );
     let vpc_id = vpc.id.clone();
 
     // Subnet resource that references vpc.vpc_id
@@ -1206,7 +1209,10 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
         "vpc_id",
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
-    subnet.set_attr("cidr_block", Value::String("10.0.1.0/24".to_string()));
+    subnet.set_attr(
+        "cidr_block",
+        Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+    );
     subnet.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
     let subnet_id = subnet.id.clone();
 
@@ -1217,9 +1223,12 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     // VPC create returns state with vpc_id
     let vpc_state = State::existing(
         vpc_id.clone(),
-        vec![("vpc_id".to_string(), Value::String("vpc-12345".to_string()))]
-            .into_iter()
-            .collect(),
+        vec![(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-12345".to_string())),
+        )]
+        .into_iter()
+        .collect(),
     )
     .with_identifier("vpc-12345");
     provider.push_create(Ok(vpc_state));
@@ -1229,7 +1238,7 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
         subnet_id.clone(),
         vec![(
             "subnet_id".to_string(),
-            Value::String("subnet-67890".to_string()),
+            Value::Concrete(ConcreteValue::String("subnet-67890".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -1262,7 +1271,9 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     let subnet_attrs = &create_calls[1].1;
     assert_eq!(
         subnet_attrs.get("vpc_id"),
-        Some(&Value::String("vpc-12345".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-12345".to_string()
+        ))),
         "Subnet's vpc_id should be resolved from VPC state, got: {:?}",
         subnet_attrs.get("vpc_id")
     );
@@ -1548,7 +1559,7 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
         target_identifier: None,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
-            value: Value::String("ISSUED".to_string()),
+            value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
         },
         until_surface: "cert.status == ISSUED".to_string(),
         timeout: std::time::Duration::from_secs(60),
@@ -1562,7 +1573,7 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
     let mut create_attrs = HashMap::new();
     create_attrs.insert(
         "status".to_string(),
-        Value::String("PENDING_VALIDATION".to_string()),
+        Value::Concrete(ConcreteValue::String("PENDING_VALIDATION".to_string())),
     );
     provider.push_create(Ok(
         State::existing(cert_id.clone(), create_attrs).with_identifier("acm-cert-id")
@@ -1571,13 +1582,16 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
     let mut pending = HashMap::new();
     pending.insert(
         "status".to_string(),
-        Value::String("PENDING_VALIDATION".to_string()),
+        Value::Concrete(ConcreteValue::String("PENDING_VALIDATION".to_string())),
     );
     let mut issued = HashMap::new();
-    issued.insert("status".to_string(), Value::String("ISSUED".to_string()));
+    issued.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+    );
     issued.insert(
         "arn".to_string(),
-        Value::String("arn:aws:acm:...".to_string()),
+        Value::Concrete(ConcreteValue::String("arn:aws:acm:...".to_string())),
     );
     provider.push_read(Ok(State::existing(cert_id.clone(), pending.clone())));
     provider.push_read(Ok(State::existing(cert_id.clone(), pending)));
@@ -1630,7 +1644,7 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
         target_identifier: None,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
-            value: Value::String("ISSUED".to_string()),
+            value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
         },
         until_surface: "cert.status == ISSUED".to_string(),
         timeout: std::time::Duration::from_secs(60),
@@ -1639,7 +1653,10 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     });
 
     let mut issued = HashMap::new();
-    issued.insert("status".to_string(), Value::String("ISSUED".to_string()));
+    issued.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+    );
     provider.push_create(Ok(
         State::existing(cert_id.clone(), issued.clone()).with_identifier("acm-cert-id")
     ));

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -65,7 +65,7 @@ pub async fn execute_wait_effect(
 mod tests {
     use super::*;
     use crate::provider::{BoxFuture, CreateRequest, DeleteRequest, ReadRequest, UpdateRequest};
-    use crate::resource::{Resource, Value};
+    use crate::resource::{ConcreteValue, Resource, Value};
     use crate::wait::predicate::{AttrPath, WaitPredicate};
     use std::collections::HashMap;
     use std::sync::Mutex;
@@ -152,14 +152,17 @@ mod tests {
 
     fn state_with_status(status: &str) -> State {
         let mut attrs = HashMap::new();
-        attrs.insert("status".to_string(), Value::String(status.to_string()));
+        attrs.insert(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String(status.to_string())),
+        );
         State::existing(ResourceId::new("acm.Certificate", "cert"), attrs)
     }
 
     fn equals_status(value: &str) -> WaitPredicate {
         WaitPredicate::Equals {
             attr: AttrPath::single("status"),
-            value: Value::String(value.to_string()),
+            value: Value::Concrete(ConcreteValue::String(value.to_string())),
         }
     }
 
@@ -180,7 +183,9 @@ mod tests {
         let state = result.expect("wait should succeed");
         assert_eq!(
             state.attributes.get("status"),
-            Some(&Value::String("ISSUED".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "ISSUED".to_string()
+            )))
         );
         assert_eq!(provider.read_count(), 1);
     }

--- a/carina-core/src/explicit.rs
+++ b/carina-core/src/explicit.rs
@@ -7,7 +7,7 @@
 //!
 //! See `notes/specs/2026-05-10-explicit-fields-design.md`.
 
-use crate::resource::{Resource, Value};
+use crate::resource::{ConcreteValue, Resource, Value};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -52,18 +52,18 @@ pub fn build_from_resource(resource: &Resource) -> ExplicitFields {
 }
 
 /// Build an `ExplicitFields` tree describing the structural shape of a
-/// `Value`. `Value::Map` is treated as a struct (each key becomes a
-/// struct child); `Value::List` becomes a `List` whose element is the
+/// `Value`. `Value::Concrete(ConcreteValue::Map)` is treated as a struct (each key becomes a
+/// struct child); `Value::Concrete(ConcreteValue::List)` becomes a `List` whose element is the
 /// union of authoring across all elements; everything else is a `Leaf`.
 pub fn build_from_value(value: &Value) -> ExplicitFields {
     match value {
-        Value::Map(fields) => ExplicitFields::Struct {
+        Value::Concrete(ConcreteValue::Map(fields)) => ExplicitFields::Struct {
             children: fields
                 .iter()
                 .map(|(k, v)| (k.clone(), build_from_value(v)))
                 .collect(),
         },
-        Value::List(items) => ExplicitFields::List {
+        Value::Concrete(ConcreteValue::List(items)) => ExplicitFields::List {
             element: Box::new(
                 items
                     .iter()
@@ -118,26 +118,28 @@ pub fn merge(a: ExplicitFields, b: ExplicitFields) -> ExplicitFields {
 /// Idempotent: `project(project(v, e), e) == project(v, e)`.
 ///
 /// Shape-mismatch fallback: when `value` and `explicit` disagree on
-/// shape (e.g. `Value::String` paired with `ExplicitFields::Struct`),
+/// shape (e.g. `Value::Concrete(ConcreteValue::String)` paired with `ExplicitFields::Struct`),
 /// the value is returned unchanged. This is a conservative choice —
 /// better to over-show a value once than to silently hide real data.
 pub fn project(value: Value, explicit: &ExplicitFields) -> Value {
     match (value, explicit) {
         // user wrote whole leaf: keep entire current value
         (v, ExplicitFields::Leaf) => v,
-        (Value::Map(fields), ExplicitFields::Struct { children }) => {
+        (Value::Concrete(ConcreteValue::Map(fields)), ExplicitFields::Struct { children }) => {
             let projected: IndexMap<String, Value> = fields
                 .into_iter()
                 .filter_map(|(k, v)| children.get(&k).map(|sub| (k, project(v, sub))))
                 .collect();
-            Value::Map(projected)
+            Value::Concrete(ConcreteValue::Map(projected))
         }
-        (Value::List(items), ExplicitFields::List { element }) => Value::List(
-            items
-                .into_iter()
-                .map(|item| project(item, element))
-                .collect(),
-        ),
+        (Value::Concrete(ConcreteValue::List(items)), ExplicitFields::List { element }) => {
+            Value::Concrete(ConcreteValue::List(
+                items
+                    .into_iter()
+                    .map(|item| project(item, element))
+                    .collect(),
+            ))
+        }
         // shape mismatch (state inconsistent or schema drift): keep
         // value as-is to avoid hiding real data
         (v, _) => v,
@@ -212,16 +214,19 @@ mod tests {
 
     #[test]
     fn build_from_value_scalar_is_leaf() {
-        let v = Value::String("x".into());
+        let v = Value::Concrete(ConcreteValue::String("x".into()));
         assert_eq!(build_from_value(&v), ExplicitFields::Leaf);
     }
 
     #[test]
     fn build_from_value_struct_collects_children() {
         let mut fields = IndexMap::new();
-        fields.insert("a".into(), Value::String("x".into()));
-        fields.insert("b".into(), Value::Int(1));
-        let v = Value::Map(fields);
+        fields.insert(
+            "a".into(),
+            Value::Concrete(ConcreteValue::String("x".into())),
+        );
+        fields.insert("b".into(), Value::Concrete(ConcreteValue::Int(1)));
+        let v = Value::Concrete(ConcreteValue::Map(fields));
         let ExplicitFields::Struct { children } = build_from_value(&v) else {
             panic!("expected Struct");
         };
@@ -233,12 +238,15 @@ mod tests {
     #[test]
     fn build_from_value_list_unions_element_authoring() {
         let mut e1 = IndexMap::new();
-        e1.insert("a".into(), Value::Int(1));
-        e1.insert("b".into(), Value::Int(1));
+        e1.insert("a".into(), Value::Concrete(ConcreteValue::Int(1)));
+        e1.insert("b".into(), Value::Concrete(ConcreteValue::Int(1)));
         let mut e2 = IndexMap::new();
-        e2.insert("b".into(), Value::Int(2));
-        e2.insert("c".into(), Value::Int(2));
-        let v = Value::List(vec![Value::Map(e1), Value::Map(e2)]);
+        e2.insert("b".into(), Value::Concrete(ConcreteValue::Int(2)));
+        e2.insert("c".into(), Value::Concrete(ConcreteValue::Int(2)));
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(e1)),
+            Value::Concrete(ConcreteValue::Map(e2)),
+        ]));
         let ExplicitFields::List { element } = build_from_value(&v) else {
             panic!("expected List");
         };
@@ -253,8 +261,14 @@ mod tests {
     #[test]
     fn build_from_resource_skips_underscore_attrs() {
         let mut r = Resource::with_provider("aws", "s3.Bucket", "x");
-        r.set_attr("name".to_string(), Value::String("hi".into()));
-        r.set_attr("_internal".to_string(), Value::String("skip".into()));
+        r.set_attr(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("hi".into())),
+        );
+        r.set_attr(
+            "_internal".to_string(),
+            Value::Concrete(ConcreteValue::String("skip".into())),
+        );
         let ExplicitFields::Struct { children } = build_from_resource(&r) else {
             panic!("expected Struct at root");
         };
@@ -288,13 +302,19 @@ mod tests {
     #[test]
     fn project_struct_drops_unauthored_field() {
         let mut fields = IndexMap::new();
-        fields.insert("authored".into(), Value::String("keep".into()));
-        fields.insert("server_default".into(), Value::String("drop".into()));
-        let value = Value::Map(fields);
+        fields.insert(
+            "authored".into(),
+            Value::Concrete(ConcreteValue::String("keep".into())),
+        );
+        fields.insert(
+            "server_default".into(),
+            Value::Concrete(ConcreteValue::String("drop".into())),
+        );
+        let value = Value::Concrete(ConcreteValue::Map(fields));
         let explicit = ExplicitFields::Struct {
             children: HashMap::from([("authored".into(), ExplicitFields::Leaf)]),
         };
-        let Value::Map(projected) = project(value, &explicit) else {
+        let Value::Concrete(ConcreteValue::Map(projected)) = project(value, &explicit) else {
             panic!("expected Map");
         };
         assert_eq!(projected.len(), 1);
@@ -305,8 +325,8 @@ mod tests {
     #[test]
     fn project_leaf_keeps_whole_value() {
         let mut fields = IndexMap::new();
-        fields.insert("any".into(), Value::Int(1));
-        let value = Value::Map(fields);
+        fields.insert("any".into(), Value::Concrete(ConcreteValue::Int(1)));
+        let value = Value::Concrete(ConcreteValue::Map(fields));
         let result = project(value.clone(), &ExplicitFields::Leaf);
         assert_eq!(result, value);
     }
@@ -314,9 +334,9 @@ mod tests {
     #[test]
     fn project_is_idempotent() {
         let mut fields = IndexMap::new();
-        fields.insert("a".into(), Value::Int(1));
-        fields.insert("b".into(), Value::Int(2));
-        let value = Value::Map(fields);
+        fields.insert("a".into(), Value::Concrete(ConcreteValue::Int(1)));
+        fields.insert("b".into(), Value::Concrete(ConcreteValue::Int(2)));
+        let value = Value::Concrete(ConcreteValue::Map(fields));
         let explicit = ExplicitFields::Struct {
             children: HashMap::from([("a".into(), ExplicitFields::Leaf)]),
         };
@@ -328,23 +348,26 @@ mod tests {
     #[test]
     fn project_list_recurses_into_each_element() {
         let mut e1 = IndexMap::new();
-        e1.insert("authored".into(), Value::Int(1));
-        e1.insert("server".into(), Value::Int(2));
+        e1.insert("authored".into(), Value::Concrete(ConcreteValue::Int(1)));
+        e1.insert("server".into(), Value::Concrete(ConcreteValue::Int(2)));
         let mut e2 = IndexMap::new();
-        e2.insert("authored".into(), Value::Int(3));
-        e2.insert("server".into(), Value::Int(4));
-        let value = Value::List(vec![Value::Map(e1), Value::Map(e2)]);
+        e2.insert("authored".into(), Value::Concrete(ConcreteValue::Int(3)));
+        e2.insert("server".into(), Value::Concrete(ConcreteValue::Int(4)));
+        let value = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(e1)),
+            Value::Concrete(ConcreteValue::Map(e2)),
+        ]));
         let explicit = ExplicitFields::List {
             element: Box::new(ExplicitFields::Struct {
                 children: HashMap::from([("authored".into(), ExplicitFields::Leaf)]),
             }),
         };
-        let Value::List(items) = project(value, &explicit) else {
+        let Value::Concrete(ConcreteValue::List(items)) = project(value, &explicit) else {
             panic!("expected List");
         };
         assert_eq!(items.len(), 2);
         for item in &items {
-            let Value::Map(fields) = item else {
+            let Value::Concrete(ConcreteValue::Map(fields)) = item else {
                 panic!("expected Map element");
             };
             assert_eq!(fields.len(), 1);
@@ -355,7 +378,7 @@ mod tests {
     #[test]
     fn project_mismatched_shape_keeps_value() {
         // Authoring says Struct, value is a String — keep value as-is.
-        let value = Value::String("oops".into());
+        let value = Value::Concrete(ConcreteValue::String("oops".into()));
         let explicit = ExplicitFields::Struct {
             children: HashMap::new(),
         };
@@ -366,8 +389,11 @@ mod tests {
     #[test]
     fn project_attributes_drops_top_level_unauthored() {
         let attrs = HashMap::from([
-            ("a".to_string(), Value::Int(1)),
-            ("server_only".to_string(), Value::Int(99)),
+            ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
+            (
+                "server_only".to_string(),
+                Value::Concrete(ConcreteValue::Int(99)),
+            ),
         ]);
         let explicit = ExplicitFields::Struct {
             children: HashMap::from([("a".into(), ExplicitFields::Leaf)]),
@@ -379,7 +405,7 @@ mod tests {
 
     #[test]
     fn project_attributes_passes_through_when_explicit_is_leaf() {
-        let attrs = HashMap::from([("a".to_string(), Value::Int(1))]);
+        let attrs = HashMap::from([("a".to_string(), Value::Concrete(ConcreteValue::Int(1)))]);
         let result = project_attributes(attrs.clone(), &ExplicitFields::Leaf);
         assert_eq!(result, attrs);
     }

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::parser::ProviderConfig;
-use crate::resource::{Resource, ResourceId, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, Value};
 use crate::schema::SchemaRegistry;
 use crate::validation::is_string_compatible_type;
 
@@ -44,7 +44,7 @@ pub fn resolve_attr_prefixes(
             .iter()
             .filter_map(|(key, value)| {
                 if let Some(base_attr) = key.strip_suffix("_prefix")
-                    && let Value::String(prefix_value) = value
+                    && let Value::Concrete(ConcreteValue::String(prefix_value)) = value
                     && let Some(attr_schema) = schema.attributes.get(base_attr)
                     && is_string_compatible_type(&attr_schema.attr_type)
                 {
@@ -84,7 +84,10 @@ pub fn resolve_attr_prefixes(
 
             // Generate temporary name
             let generated_name = format!("{}{}", prefix_value, generate_random_suffix());
-            resource.set_attr(base_attr, Value::String(generated_name));
+            resource.set_attr(
+                base_attr,
+                Value::Concrete(ConcreteValue::String(generated_name)),
+            );
         }
     }
 
@@ -135,10 +138,12 @@ pub fn reconcile_prefixed_names(
                 if let Some(state_prefix) = state_info.prefixes.get(attr_name)
                     && state_prefix == prefix
                 {
-                    state_info
-                        .attribute_values
-                        .get(attr_name)
-                        .map(|name_str| (attr_name.clone(), Value::String(name_str.clone())))
+                    state_info.attribute_values.get(attr_name).map(|name_str| {
+                        (
+                            attr_name.clone(),
+                            Value::Concrete(ConcreteValue::String(name_str.clone())),
+                        )
+                    })
                 } else {
                     None
                 }
@@ -156,20 +161,20 @@ pub fn reconcile_prefixed_names(
 /// so the output is consistent across runs (HashMap iteration order is random).
 fn deterministic_value_string(value: &Value) -> String {
     match value {
-        Value::String(s) => format!("String({:?})", s),
-        Value::Int(i) => format!("Int({})", i),
-        Value::Float(f) => format!("Float({})", f),
-        Value::Bool(b) => format!("Bool({})", b),
-        Value::Duration(d) => format!("Duration({})", d.as_secs()),
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::String(s)) => format!("String({:?})", s),
+        Value::Concrete(ConcreteValue::Int(i)) => format!("Int({})", i),
+        Value::Concrete(ConcreteValue::Float(f)) => format!("Float({})", f),
+        Value::Concrete(ConcreteValue::Bool(b)) => format!("Bool({})", b),
+        Value::Concrete(ConcreteValue::Duration(d)) => format!("Duration({})", d.as_secs()),
+        Value::Concrete(ConcreteValue::List(items)) => {
             let parts: Vec<String> = items.iter().map(deterministic_value_string).collect();
             format!("List([{}])", parts.join(", "))
         }
-        Value::StringList(items) => {
+        Value::Concrete(ConcreteValue::StringList(items)) => {
             let parts: Vec<String> = items.iter().map(|s| format!("{:?}", s)).collect();
             format!("StringList([{}])", parts.join(", "))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut entries: Vec<(&String, &Value)> = map.iter().collect();
             entries.sort_by_key(|(k, _)| *k);
             let parts: Vec<String> = entries
@@ -178,13 +183,13 @@ fn deterministic_value_string(value: &Value) -> String {
                 .collect();
             format!("Map({{{}}})", parts.join(", "))
         }
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             format!("ResourceRef({})", path.to_dot_string())
         }
-        Value::BindingRef { binding } => {
+        Value::Deferred(DeferredValue::BindingRef { binding }) => {
             format!("BindingRef({})", binding)
         }
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             use crate::resource::InterpolationPart;
             let strs: Vec<String> = parts
                 .iter()
@@ -197,14 +202,14 @@ fn deterministic_value_string(value: &Value) -> String {
                 .collect();
             format!("Interpolation([{}])", strs.join(", "))
         }
-        Value::FunctionCall { name, args } => {
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
             let arg_strs: Vec<String> = args.iter().map(deterministic_value_string).collect();
             format!("FunctionCall({}({}))", name, arg_strs.join(", "))
         }
-        Value::Secret(inner) => {
+        Value::Deferred(DeferredValue::Secret(inner)) => {
             format!("Secret({})", deterministic_value_string(inner))
         }
-        Value::Unknown(reason) => {
+        Value::Deferred(DeferredValue::Unknown(reason)) => {
             use crate::resource::UnknownReason;
             match reason {
                 UnknownReason::UpstreamRef { path } => {
@@ -271,13 +276,13 @@ pub(crate) fn flatten_value_for_simhash(
     out: &mut std::collections::BTreeMap<String, String>,
 ) {
     match value {
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             for (k, v) in map {
                 let key = format!("{}.{}", prefix, k);
                 flatten_value_for_simhash(&key, v, out);
             }
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             for (i, item) in items.iter().enumerate() {
                 let key = format!("{}[{}]", prefix, i);
                 flatten_value_for_simhash(&key, item, out);
@@ -597,7 +602,7 @@ pub fn reconcile_anonymous_identifiers(
         // Collect this resource's create-only values
         let mut resource_co_values: HashMap<&str, String> = HashMap::new();
         for attr_name in &create_only_attrs {
-            if let Some(Value::String(v)) = resource.get_attr(attr_name) {
+            if let Some(Value::Concrete(ConcreteValue::String(v))) = resource.get_attr(attr_name) {
                 resource_co_values.insert(attr_name, v.clone());
             }
         }
@@ -759,7 +764,7 @@ pub fn detect_anonymous_to_named_renames(
         let create_only_attrs = schema.create_only_attributes();
         let mut resource_co_values: HashMap<&str, String> = HashMap::new();
         for attr_name in &create_only_attrs {
-            if let Some(Value::String(v)) = resource.get_attr(attr_name) {
+            if let Some(Value::Concrete(ConcreteValue::String(v))) = resource.get_attr(attr_name) {
                 resource_co_values.insert(attr_name, v.clone());
             }
         }

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -26,7 +26,7 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
     resource.set_attr(
         "bucket_name_prefix".to_string(),
-        Value::String("my-app-".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-".to_string())),
     );
 
     let schemas = registry_with_s3_bucket();
@@ -38,7 +38,7 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
 
     // bucket_name should be generated with the prefix
     let bucket_name = match resources[0].get_attr("bucket_name").unwrap() {
-        Value::String(s) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
         _ => panic!("expected String"),
     };
     assert!(bucket_name.starts_with("my-app-"));
@@ -56,7 +56,7 @@ fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
     resource.set_attr(
         "nonexistent_attr_prefix".to_string(),
-        Value::String("some-value".to_string()),
+        Value::Concrete(ConcreteValue::String("some-value".to_string())),
     );
 
     let schemas = registry_with_s3_bucket();
@@ -77,11 +77,11 @@ fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
     resource.set_attr(
         "bucket_name_prefix".to_string(),
-        Value::String("my-app-".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-".to_string())),
     );
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("my-actual-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-actual-bucket".to_string())),
     );
 
     let schemas = registry_with_s3_bucket();
@@ -96,7 +96,7 @@ fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
     resource.set_attr(
         "bucket_name_prefix".to_string(),
-        Value::String("".to_string()),
+        Value::Concrete(ConcreteValue::String("".to_string())),
     );
 
     let schemas = registry_with_s3_bucket();
@@ -114,7 +114,7 @@ fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
         .insert("bucket_name".to_string(), "my-app-".to_string());
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("my-app-temporary".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-temporary".to_string())),
     );
 
     let mut resources = vec![resource];
@@ -132,7 +132,9 @@ fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
     // Should reuse the state name, not the temporary one
     assert_eq!(
         resources[0].get_attr("bucket_name"),
-        Some(&Value::String("my-app-existing1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-app-existing1".to_string()
+        )))
     );
 }
 
@@ -144,7 +146,7 @@ fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
         .insert("bucket_name".to_string(), "new-prefix-".to_string());
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("new-prefix-abcd1234".to_string()),
+        Value::Concrete(ConcreteValue::String("new-prefix-abcd1234".to_string())),
     );
 
     let mut resources = vec![resource];
@@ -165,7 +167,9 @@ fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
     // Should keep the newly generated name since prefix changed
     assert_eq!(
         resources[0].get_attr("bucket_name"),
-        Some(&Value::String("new-prefix-abcd1234".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "new-prefix-abcd1234".to_string()
+        )))
     );
 }
 
@@ -177,7 +181,7 @@ fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
         .insert("bucket_name".to_string(), "my-app-".to_string());
     resource.set_attr(
         "bucket_name".to_string(),
-        Value::String("my-app-abcd1234".to_string()),
+        Value::Concrete(ConcreteValue::String("my-app-abcd1234".to_string())),
     );
 
     let mut resources = vec![resource];
@@ -186,7 +190,9 @@ fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
     // No state, so keep the generated name
     assert_eq!(
         resources[0].get_attr("bucket_name"),
-        Some(&Value::String("my-app-abcd1234".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-app-abcd1234".to_string()
+        )))
     );
 }
 
@@ -214,9 +220,12 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     let mut r1 = Resource::with_provider("awscc", "iam.role", "");
     r1.set_attr(
         "role_name".to_string(),
-        Value::String("my-role".to_string()),
+        Value::Concrete(ConcreteValue::String("my-role".to_string())),
     );
-    r1.set_attr("path".to_string(), Value::String("/".to_string()));
+    r1.set_attr(
+        "path".to_string(),
+        Value::Concrete(ConcreteValue::String("/".to_string())),
+    );
     let mut resources1 = vec![r1];
     compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
     let step1_id = resources1[0].id.name_str().to_string();
@@ -225,9 +234,12 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     let mut r2 = Resource::with_provider("awscc", "iam.role", "");
     r2.set_attr(
         "role_name".to_string(),
-        Value::String("my-role".to_string()),
+        Value::Concrete(ConcreteValue::String("my-role".to_string())),
     );
-    r2.set_attr("path".to_string(), Value::String("/carina/".to_string()));
+    r2.set_attr(
+        "path".to_string(),
+        Value::Concrete(ConcreteValue::String("/carina/".to_string())),
+    );
     let mut resources2 = vec![r2];
     compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
     let step2_id = resources2[0].id.name_str().to_string();
@@ -265,9 +277,12 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
     let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
     resource.set_attr(
         "role_name".to_string(),
-        Value::String("new-role".to_string()),
+        Value::Concrete(ConcreteValue::String("new-role".to_string())),
     );
-    resource.set_attr("path".to_string(), Value::String("/new/".to_string()));
+    resource.set_attr(
+        "path".to_string(),
+        Value::Concrete(ConcreteValue::String("/new/".to_string())),
+    );
 
     let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
@@ -303,9 +318,12 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
     let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
     resource.set_attr(
         "role_name".to_string(),
-        Value::String("my-role".to_string()),
+        Value::Concrete(ConcreteValue::String("my-role".to_string())),
     );
-    resource.set_attr("path".to_string(), Value::String("/".to_string()));
+    resource.set_attr(
+        "path".to_string(),
+        Value::Concrete(ConcreteValue::String("/".to_string())),
+    );
 
     let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
@@ -341,7 +359,7 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "ec2_vpc_aabbccdd");
     resource.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.1.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     );
 
     let original_id = resource.id.name_str().to_string();
@@ -378,7 +396,7 @@ fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
         name: "awscc".to_string(),
         attributes: vec![(
             "region".to_string(),
-            Value::String("ap-northeast-1".to_string()),
+            Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -393,7 +411,7 @@ fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
     let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
     r.set_attr(
         "policy_name".to_string(),
-        Value::String("inline".to_string()),
+        Value::Concrete(ConcreteValue::String("inline".to_string())),
     );
     r.module_source = Some(ModuleSource::Module {
         name: "github_oidc".to_string(),
@@ -431,7 +449,7 @@ fn test_anonymous_resource_no_create_only_properties() {
         name: "awscc".to_string(),
         attributes: vec![(
             "region".to_string(),
-            Value::String("ap-northeast-1".to_string()),
+            Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -444,7 +462,10 @@ fn test_anonymous_resource_no_create_only_properties() {
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
     let mut r = Resource::with_provider("awscc", "ec2.eip", "");
-    r.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    r.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
 
     let mut resources = vec![r];
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
@@ -465,7 +486,7 @@ fn test_anonymous_resource_no_create_only_deterministic() {
         name: "awscc".to_string(),
         attributes: vec![(
             "region".to_string(),
-            Value::String("ap-northeast-1".to_string()),
+            Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -479,7 +500,10 @@ fn test_anonymous_resource_no_create_only_deterministic() {
 
     let make_resource = || {
         let mut r = Resource::with_provider("awscc", "ec2.eip", "");
-        r.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+        r.set_attr(
+            "domain".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc".to_string())),
+        );
         r
     };
 
@@ -510,10 +534,16 @@ fn test_anonymous_resource_no_create_only_collision() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
-    r1.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    r1.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
 
     let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
-    r2.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    r2.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
 
     let mut resources = vec![r1, r2];
     let result = compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn);
@@ -553,24 +583,30 @@ fn test_identity_attribute_prevents_collision() {
     let mut r1 = Resource::with_provider("awscc", "route53.record_set", "");
     r1.set_attr(
         "name".to_string(),
-        Value::String("carina-rs.dev".to_string()),
+        Value::Concrete(ConcreteValue::String("carina-rs.dev".to_string())),
     );
     r1.set_attr(
         "hosted_zone_id".to_string(),
-        Value::String("Z123".to_string()),
+        Value::Concrete(ConcreteValue::String("Z123".to_string())),
     );
-    r1.set_attr("type".to_string(), Value::String("A".to_string()));
+    r1.set_attr(
+        "type".to_string(),
+        Value::Concrete(ConcreteValue::String("A".to_string())),
+    );
 
     let mut r2 = Resource::with_provider("awscc", "route53.record_set", "");
     r2.set_attr(
         "name".to_string(),
-        Value::String("carina-rs.dev".to_string()),
+        Value::Concrete(ConcreteValue::String("carina-rs.dev".to_string())),
     );
     r2.set_attr(
         "hosted_zone_id".to_string(),
-        Value::String("Z123".to_string()),
+        Value::Concrete(ConcreteValue::String("Z123".to_string())),
     );
-    r2.set_attr("type".to_string(), Value::String("AAAA".to_string()));
+    r2.set_attr(
+        "type".to_string(),
+        Value::Concrete(ConcreteValue::String("AAAA".to_string())),
+    );
 
     let mut resources = vec![r1, r2];
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn)
@@ -661,7 +697,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         name: "awscc".to_string(),
         attributes: vec![(
             "region".to_string(),
-            Value::String("ap-northeast-1".to_string()),
+            Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -675,11 +711,17 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
 
     // Step 1: compute identifier with tag_env="production"
     let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
-    r1.set_attr("domain".to_string(), Value::String("vpc".to_string()));
-    r1.set_attr("tag_name".to_string(), Value::String("my-eip".to_string()));
+    r1.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
+    r1.set_attr(
+        "tag_name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-eip".to_string())),
+    );
     r1.set_attr(
         "tag_env".to_string(),
-        Value::String("production".to_string()),
+        Value::Concrete(ConcreteValue::String("production".to_string())),
     );
     let mut resources1 = vec![r1];
     compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
@@ -687,9 +729,18 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
 
     // Step 2: compute identifier with tag_env="staging" (one attribute changed)
     let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
-    r2.set_attr("domain".to_string(), Value::String("vpc".to_string()));
-    r2.set_attr("tag_name".to_string(), Value::String("my-eip".to_string()));
-    r2.set_attr("tag_env".to_string(), Value::String("staging".to_string()));
+    r2.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
+    r2.set_attr(
+        "tag_name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-eip".to_string())),
+    );
+    r2.set_attr(
+        "tag_env".to_string(),
+        Value::Concrete(ConcreteValue::String("staging".to_string())),
+    );
     let mut resources2 = vec![r2];
     compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
     let new_id = resources2[0].id.name_str().to_string();
@@ -726,7 +777,10 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
 
     // Resource with a computed identifier
     let mut resource = Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344");
-    resource.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    resource.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
 
     let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
@@ -766,7 +820,10 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
 
     // Compute identifier without setting the create-only property
     let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
-    r1.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    r1.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
     let mut resources = vec![r1];
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
 
@@ -949,10 +1006,22 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
     // Compute 3 identifiers with different attributes
     let make_resource = |env: &str, team: &str| {
         let mut r = Resource::with_provider("awscc", "ec2.eip", "");
-        r.set_attr("domain".to_string(), Value::String("vpc".to_string()));
-        r.set_attr("tag_name".to_string(), Value::String("my-eip".to_string()));
-        r.set_attr("tag_env".to_string(), Value::String(env.to_string()));
-        r.set_attr("tag_team".to_string(), Value::String(team.to_string()));
+        r.set_attr(
+            "domain".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc".to_string())),
+        );
+        r.set_attr(
+            "tag_name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-eip".to_string())),
+        );
+        r.set_attr(
+            "tag_env".to_string(),
+            Value::Concrete(ConcreteValue::String(env.to_string())),
+        );
+        r.set_attr(
+            "tag_team".to_string(),
+            Value::Concrete(ConcreteValue::String(team.to_string())),
+        );
         r
     };
 
@@ -1043,7 +1112,10 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     let mut r = Resource::with_provider("awscc", "ec2.eip", "");
-    r.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    r.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
     let mut resources = vec![r];
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
     let id = resources[0].id.name_str().to_string();
@@ -1070,7 +1142,10 @@ fn test_reconcile_no_create_only_empty_state() {
     schemas.insert("awscc", schema);
 
     let mut resource = Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344");
-    resource.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    resource.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
     let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
@@ -1101,11 +1176,17 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
 
     let make_resource = |env: &str| {
         let mut r = Resource::with_provider("awscc", "ec2.internet_gateway", "");
-        r.set_attr("tag_name".to_string(), Value::String("my-igw".to_string()));
-        r.set_attr("tag_env".to_string(), Value::String(env.to_string()));
+        r.set_attr(
+            "tag_name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-igw".to_string())),
+        );
+        r.set_attr(
+            "tag_env".to_string(),
+            Value::Concrete(ConcreteValue::String(env.to_string())),
+        );
         r.set_attr(
             "tag_team".to_string(),
-            Value::String("platform".to_string()),
+            Value::Concrete(ConcreteValue::String("platform".to_string())),
         );
         r
     };
@@ -1157,13 +1238,22 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
     let mut vpc = Resource::with_provider("awscc", "ec2.Vpc", "");
     vpc.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    vpc.set_attr("tag_name".to_string(), Value::String("my-vpc".to_string()));
+    vpc.set_attr(
+        "tag_name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
+    );
 
     let mut eip = Resource::with_provider("awscc", "ec2.eip", "");
-    eip.set_attr("domain".to_string(), Value::String("vpc".to_string()));
-    eip.set_attr("tag_name".to_string(), Value::String("my-eip".to_string()));
+    eip.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
+    eip.set_attr(
+        "tag_name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-eip".to_string())),
+    );
 
     let mut resources = vec![vpc, eip];
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
@@ -1193,9 +1283,12 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
     let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
     resource.set_attr(
         "role_name".to_string(),
-        Value::String("my-role".to_string()),
+        Value::Concrete(ConcreteValue::String("my-role".to_string())),
     );
-    resource.set_attr("path".to_string(), Value::String("/new/".to_string()));
+    resource.set_attr(
+        "path".to_string(),
+        Value::Concrete(ConcreteValue::String("/new/".to_string())),
+    );
 
     let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
@@ -1245,7 +1338,7 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
         let mut r = Resource::with_provider("awscc", "s3.Bucket", "");
         r.set_attr(
             "bucket_name".to_string(),
-            Value::String(generated_name.to_string()),
+            Value::Concrete(ConcreteValue::String(generated_name.to_string())),
         );
         r.prefixes
             .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -1287,7 +1380,7 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
         let mut r = Resource::with_provider("awscc", "s3.Bucket", "");
         r.set_attr(
             "bucket_name".to_string(),
-            Value::String(generated_name.to_string()),
+            Value::Concrete(ConcreteValue::String(generated_name.to_string())),
         );
         r.prefixes
             .insert("bucket_name".to_string(), prefix.to_string());
@@ -1324,12 +1417,15 @@ fn test_reconcile_skips_let_bound_resources() {
     ingress_new.binding = Some("ingress_new".to_string());
     ingress_new.set_attr(
         "cidr_ip".to_string(),
-        Value::String("0.0.0.0/0".to_string()),
+        Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
     );
-    ingress_new.set_attr("ip_protocol".to_string(), Value::String("tcp".to_string()));
+    ingress_new.set_attr(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
     ingress_new.set_attr(
         "description".to_string(),
-        Value::String("Allow HTTPS".to_string()),
+        Value::Concrete(ConcreteValue::String("Allow HTTPS".to_string())),
     );
 
     let mut resources = vec![ingress_new];
@@ -1379,12 +1475,15 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
     );
     new_rule.set_attr(
         "cidr_ip".to_string(),
-        Value::String("0.0.0.0/0".to_string()),
+        Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
     );
-    new_rule.set_attr("ip_protocol".to_string(), Value::String("tcp".to_string()));
+    new_rule.set_attr(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
     new_rule.set_attr(
         "description".to_string(),
-        Value::String("Allow gRPC".to_string()),
+        Value::Concrete(ConcreteValue::String("Allow gRPC".to_string())),
     );
 
     let original_id = new_rule.id.name_str().to_string();
@@ -1451,7 +1550,9 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
         name: "awscc".to_string(),
         attributes: vec![(
             "region".to_string(),
-            Value::String("awscc.Region.ap_northeast_1".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "awscc.Region.ap_northeast_1".to_string(),
+            )),
         )]
         .into_iter()
         .collect(),
@@ -1465,17 +1566,23 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
 
     // Step 1: Create EIP with tags Environment=acceptance-test
     let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
-    r1.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    r1.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
     let mut tags1 = indexmap::IndexMap::new();
     tags1.insert(
         "Environment".to_string(),
-        Value::String("acceptance-test".to_string()),
+        Value::Concrete(ConcreteValue::String("acceptance-test".to_string())),
     );
     tags1.insert(
         "Purpose".to_string(),
-        Value::String("simhash-test".to_string()),
+        Value::Concrete(ConcreteValue::String("simhash-test".to_string())),
     );
-    r1.set_attr("tags".to_string(), Value::Map(tags1));
+    r1.set_attr(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(tags1)),
+    );
 
     let mut resources1 = vec![r1];
     compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
@@ -1483,17 +1590,23 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
 
     // Step 2: Change tag Environment=staging (only tags changed)
     let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
-    r2.set_attr("domain".to_string(), Value::String("vpc".to_string()));
+    r2.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
     let mut tags2 = indexmap::IndexMap::new();
     tags2.insert(
         "Environment".to_string(),
-        Value::String("staging".to_string()),
+        Value::Concrete(ConcreteValue::String("staging".to_string())),
     );
     tags2.insert(
         "Purpose".to_string(),
-        Value::String("simhash-test".to_string()),
+        Value::Concrete(ConcreteValue::String("simhash-test".to_string())),
     );
-    r2.set_attr("tags".to_string(), Value::Map(tags2));
+    r2.set_attr(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(tags2)),
+    );
 
     let mut resources2 = vec![r2];
     compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
@@ -1547,24 +1660,30 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
         Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_http");
     ingress_http.set_attr(
         "cidr_ip".to_string(),
-        Value::String("0.0.0.0/0".to_string()),
+        Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
     );
-    ingress_http.set_attr("ip_protocol".to_string(), Value::String("tcp".to_string()));
+    ingress_http.set_attr(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
     ingress_http.set_attr(
         "description".to_string(),
-        Value::String("Allow HTTP".to_string()),
+        Value::Concrete(ConcreteValue::String("Allow HTTP".to_string())),
     );
 
     let mut ingress_https =
         Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_https");
     ingress_https.set_attr(
         "cidr_ip".to_string(),
-        Value::String("0.0.0.0/0".to_string()),
+        Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
     );
-    ingress_https.set_attr("ip_protocol".to_string(), Value::String("tcp".to_string()));
+    ingress_https.set_attr(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
     ingress_https.set_attr(
         "description".to_string(),
-        Value::String("Allow HTTPS".to_string()),
+        Value::Concrete(ConcreteValue::String("Allow HTTPS".to_string())),
     );
 
     let mut resources = vec![ingress_http, ingress_https];
@@ -1628,7 +1747,10 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
     resource.binding = Some("sso".to_string());
-    resource.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![resource];
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -1658,7 +1780,10 @@ fn test_detect_rename_skips_when_binding_already_in_state() {
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
     resource.binding = Some("sso".to_string());
-    resource.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![resource];
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -1685,7 +1810,10 @@ fn test_detect_rename_ignores_anonymous_resources() {
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso_instance_new");
     // No binding set
-    resource.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![resource];
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -1712,7 +1840,10 @@ fn test_detect_rename_skips_ambiguous_matches() {
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
     resource.binding = Some("sso".to_string());
-    resource.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![resource];
 
     let state_entries = vec![
@@ -1748,7 +1879,10 @@ fn test_detect_rename_ignores_non_hash_state_names() {
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
     resource.binding = Some("sso".to_string());
-    resource.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![resource];
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -1791,7 +1925,10 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     // Step 1: generate the anonymous ID the previous `apply` would have
     // written to state, using the same inputs and the same code path.
     let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
-    anon.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    anon.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let mut anon_vec = vec![anon];
     compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
@@ -1803,7 +1940,10 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     // Step 2: user wraps the same resource in a `let` binding.
     let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
     let_bound.binding = Some("sso".to_string());
-    let_bound.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    let_bound.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![let_bound];
 
     // Step 3: state still has the orphan anonymous entry.
@@ -1838,11 +1978,23 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
 
     // Anonymous snapshot with many attributes.
     let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
-    anon.set_attr("name".to_string(), Value::String("old-name".to_string()));
+    anon.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("old-name".to_string())),
+    );
     let mut tags = indexmap::IndexMap::new();
-    tags.insert("k1".to_string(), Value::String("v1".to_string()));
-    tags.insert("k2".to_string(), Value::String("v2".to_string()));
-    anon.set_attr("tags".to_string(), Value::Map(tags));
+    tags.insert(
+        "k1".to_string(),
+        Value::Concrete(ConcreteValue::String("v1".to_string())),
+    );
+    tags.insert(
+        "k2".to_string(),
+        Value::Concrete(ConcreteValue::String("v2".to_string())),
+    );
+    anon.set_attr(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(tags)),
+    );
     let mut anon_vec = vec![anon];
     compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
@@ -1852,13 +2004,25 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
-        Value::String("completely-different".to_string()),
+        Value::Concrete(ConcreteValue::String("completely-different".to_string())),
     );
     let mut different_tags = indexmap::IndexMap::new();
-    different_tags.insert("other1".to_string(), Value::String("foo".to_string()));
-    different_tags.insert("other2".to_string(), Value::String("bar".to_string()));
-    different_tags.insert("other3".to_string(), Value::String("baz".to_string()));
-    let_bound.set_attr("tags".to_string(), Value::Map(different_tags));
+    different_tags.insert(
+        "other1".to_string(),
+        Value::Concrete(ConcreteValue::String("foo".to_string())),
+    );
+    different_tags.insert(
+        "other2".to_string(),
+        Value::Concrete(ConcreteValue::String("bar".to_string())),
+    );
+    different_tags.insert(
+        "other3".to_string(),
+        Value::Concrete(ConcreteValue::String("baz".to_string())),
+    );
+    let_bound.set_attr(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(different_tags)),
+    );
     let resources = vec![let_bound];
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -1891,7 +2055,10 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
 
     // Compute the exact-match name.
     let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
-    anon.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    anon.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let mut anon_vec = vec![anon];
     compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let exact_name = anon_vec[0].id.name_str().to_string();
@@ -1920,7 +2087,10 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
 
     let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
     let_bound.binding = Some("sso".to_string());
-    let_bound.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    let_bound.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![let_bound];
 
     let renames = detect_anonymous_to_named_renames(
@@ -1950,7 +2120,10 @@ fn test_detect_rename_no_create_only_skips_8_char_hash_entries() {
 
     let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
     let_bound.binding = Some("sso".to_string());
-    let_bound.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    let_bound.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![let_bound];
 
     // 8-hex suffix (standard hash scheme), not a SimHash.
@@ -1983,7 +2156,10 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
 
     // Compute the target SimHash.
     let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
-    anon.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    anon.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let mut anon_vec = vec![anon];
     compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
@@ -2002,7 +2178,10 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
 
     let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
     let_bound.binding = Some("sso".to_string());
-    let_bound.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
+    let_bound.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
     let resources = vec![let_bound];
 
     let renames = detect_anonymous_to_named_renames(
@@ -2037,7 +2216,10 @@ fn anonymous_identifier_includes_provider_prefix() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
-    r.set_attr("policy_name".to_string(), Value::String("foo".to_string()));
+    r.set_attr(
+        "policy_name".to_string(),
+        Value::Concrete(ConcreteValue::String("foo".to_string())),
+    );
     let mut resources = vec![r];
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
 
@@ -2072,7 +2254,7 @@ fn anonymous_identifier_provider_prefix_for_aws_provider() {
     let mut r = Resource::with_provider("aws", "s3.Bucket", "");
     r.set_attr(
         "bucket_name".to_string(),
-        Value::String("example".to_string()),
+        Value::Concrete(ConcreteValue::String("example".to_string())),
     );
     let mut resources = vec![r];
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
@@ -2106,7 +2288,7 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
     let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
     r.set_attr(
         "policy_name".to_string(),
-        Value::String("inline".to_string()),
+        Value::Concrete(ConcreteValue::String("inline".to_string())),
     );
     let mut resources = vec![r];
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -5,7 +5,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::parser::{ResourceTypePath, TypeExpr};
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 
 /// Dependency between resources
 #[derive(Debug, Clone)]
@@ -118,15 +118,15 @@ impl DependencyGraph {
 /// Format a Value for display
 fn format_value(value: &Value) -> String {
     match value {
-        Value::String(s) => {
+        Value::Concrete(ConcreteValue::String(s)) => {
             if s.len() > 50 {
                 format!("\"{}...\"", &s[..47])
             } else {
                 format!("\"{}\"", s)
             }
         }
-        Value::Int(n) => n.to_string(),
-        Value::Float(f) => {
+        Value::Concrete(ConcreteValue::Int(n)) => n.to_string(),
+        Value::Concrete(ConcreteValue::Float(f)) => {
             let s = f.to_string();
             if s.contains('.') {
                 s
@@ -134,9 +134,9 @@ fn format_value(value: &Value) -> String {
                 format!("{}.0", s)
             }
         }
-        Value::Bool(b) => b.to_string(),
-        Value::Duration(d) => crate::value::render_duration(*d),
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::Bool(b)) => b.to_string(),
+        Value::Concrete(ConcreteValue::Duration(d)) => crate::value::render_duration(*d),
+        Value::Concrete(ConcreteValue::List(items)) => {
             if items.is_empty() {
                 "[]".to_string()
             } else if items.len() <= 3 {
@@ -146,7 +146,7 @@ fn format_value(value: &Value) -> String {
                 format!("[{} items]", items.len())
             }
         }
-        Value::StringList(items) => {
+        Value::Concrete(ConcreteValue::StringList(items)) => {
             if items.is_empty() {
                 "[]".to_string()
             } else if items.len() <= 3 {
@@ -156,18 +156,18 @@ fn format_value(value: &Value) -> String {
                 format!("[{} items]", items.len())
             }
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             if map.is_empty() {
                 "{}".to_string()
             } else {
                 format!("{{...{} keys}}", map.len())
             }
         }
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             format!("{}.{}", path.binding(), path.attribute())
         }
-        Value::BindingRef { binding } => binding.clone(),
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::BindingRef { binding }) => binding.clone(),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             use crate::resource::InterpolationPart;
             let inner: String = parts
                 .iter()
@@ -178,12 +178,12 @@ fn format_value(value: &Value) -> String {
                 .collect();
             format!("\"{}\"", inner)
         }
-        Value::FunctionCall { name, args } => {
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
             let arg_strs: Vec<_> = args.iter().map(format_value).collect();
             format!("{}({})", name, arg_strs.join(", "))
         }
-        Value::Secret(_) => "(secret)".to_string(),
-        Value::Unknown(reason) => crate::value::render_unknown(reason),
+        Value::Deferred(DeferredValue::Secret(_)) => "(secret)".to_string(),
+        Value::Deferred(DeferredValue::Unknown(reason)) => crate::value::render_unknown(reason),
     }
 }
 
@@ -368,7 +368,7 @@ impl RootConfigSignature {
                 .attributes
                 .get("_type")
                 .and_then(|v| match v {
-                    Value::String(s) => Some(s.clone()),
+                    Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                     _ => None,
                 })
                 .unwrap_or_else(|| resource.id.resource_type.clone());
@@ -446,7 +446,7 @@ impl RootConfigSignature {
         binding_types: &HashMap<String, ResourceTypePath>,
     ) {
         match value {
-            Value::ResourceRef { path } => {
+            Value::Deferred(DeferredValue::ResourceRef { path }) => {
                 let target_type = binding_types.get(path.binding()).cloned();
                 graph.add_edge(
                     from.to_string(),
@@ -462,7 +462,7 @@ impl RootConfigSignature {
             // #2847) are dependencies just like attribute refs; the
             // displayed `attribute` slot stays empty so
             // `format_dep_detail` renders `target (via used_in)`.
-            Value::BindingRef { binding } => {
+            Value::Deferred(DeferredValue::BindingRef { binding }) => {
                 let target_type = binding_types.get(binding).cloned();
                 graph.add_edge(
                     from.to_string(),
@@ -474,17 +474,17 @@ impl RootConfigSignature {
                     },
                 );
             }
-            Value::List(items) => {
+            Value::Concrete(ConcreteValue::List(items)) => {
                 for item in items {
                     Self::collect_typed_dependencies(from, attr_key, item, graph, binding_types);
                 }
             }
-            Value::Map(map) => {
+            Value::Concrete(ConcreteValue::Map(map)) => {
                 for (k, v) in map {
                     Self::collect_typed_dependencies(from, k, v, graph, binding_types);
                 }
             }
-            Value::Interpolation(parts) => {
+            Value::Deferred(DeferredValue::Interpolation(parts)) => {
                 use crate::resource::InterpolationPart;
                 for part in parts {
                     if let InterpolationPart::Expr(v) = part {
@@ -492,7 +492,7 @@ impl RootConfigSignature {
                     }
                 }
             }
-            Value::FunctionCall { args, .. } => {
+            Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
                 for arg in args {
                     Self::collect_typed_dependencies(from, attr_key, arg, graph, binding_types);
                 }
@@ -782,7 +782,7 @@ impl ModuleSignature {
                 .attributes
                 .get("_type")
                 .and_then(|v| match v {
-                    Value::String(s) => Some(s.clone()),
+                    Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                     _ => None,
                 })
                 .unwrap_or_else(|| resource.id.resource_type.clone());
@@ -839,7 +839,9 @@ impl ModuleSignature {
             .iter()
             .map(|attr_param| {
                 let source_binding = attr_param.value.as_ref().and_then(|v| match v {
-                    Value::ResourceRef { path } => Some(path.binding().to_string()),
+                    Value::Deferred(DeferredValue::ResourceRef { path }) => {
+                        Some(path.binding().to_string())
+                    }
                     _ => None,
                 });
 
@@ -869,7 +871,7 @@ impl ModuleSignature {
         argument_types: &HashMap<String, TypeExpr>,
     ) {
         match value {
-            Value::ResourceRef { path } => {
+            Value::Deferred(DeferredValue::ResourceRef { path }) => {
                 let binding_name = path.binding();
                 let target_type = if let Some(arg_type) = argument_types.get(binding_name) {
                     // Argument parameter reference (lexically scoped)
@@ -895,7 +897,7 @@ impl ModuleSignature {
             // Bare-binding refs (`vpc_id = vpc` referencing argument
             // `vpc`, since #2847) — same dependency edge, empty
             // attribute slot.
-            Value::BindingRef { binding } => {
+            Value::Deferred(DeferredValue::BindingRef { binding }) => {
                 let target_type = if let Some(arg_type) = argument_types.get(binding) {
                     if let TypeExpr::Ref(p) = arg_type {
                         Some(p.clone())
@@ -915,7 +917,7 @@ impl ModuleSignature {
                     },
                 );
             }
-            Value::List(items) => {
+            Value::Concrete(ConcreteValue::List(items)) => {
                 for item in items {
                     Self::collect_typed_dependencies(
                         from,
@@ -927,7 +929,7 @@ impl ModuleSignature {
                     );
                 }
             }
-            Value::Map(map) => {
+            Value::Concrete(ConcreteValue::Map(map)) => {
                 for (k, v) in map {
                     Self::collect_typed_dependencies(
                         from,
@@ -939,7 +941,7 @@ impl ModuleSignature {
                     );
                 }
             }
-            Value::Interpolation(parts) => {
+            Value::Deferred(DeferredValue::Interpolation(parts)) => {
                 use crate::resource::InterpolationPart;
                 for part in parts {
                     if let InterpolationPart::Expr(v) = part {
@@ -954,7 +956,7 @@ impl ModuleSignature {
                     }
                 }
             }
-            Value::FunctionCall { args, .. } => {
+            Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
                 for arg in args {
                     Self::collect_typed_dependencies(
                         from,

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -6,7 +6,10 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use indexmap::IndexMap;
 
 use crate::parser::{ArgumentParameter, ModuleCall};
-use crate::resource::{Directives, Resource, ResourceId, ResourceKind, ResourceName, Value};
+use crate::resource::{
+    ConcreteValue, DeferredValue, Directives, Resource, ResourceId, ResourceKind, ResourceName,
+    Value,
+};
 
 use super::error::ModuleError;
 use super::resolver::ModuleResolver;
@@ -65,7 +68,7 @@ impl ModuleResolver<'_> {
         // `subject_patterns: list(String) = ["repo:${github_repo}:*"]`.
         // The parser registers each argument as a placeholder ResourceRef
         // binding while parsing the block, so the default lands here as a
-        // tree containing `Value::ResourceRef { binding: "<other_arg>" }`
+        // tree containing `Value::Deferred(DeferredValue::ResourceRef{ binding: "<other_arg>" })`
         // nodes.
         //
         // **Initial pass** seeds each entry with either the caller-
@@ -226,7 +229,7 @@ impl ModuleResolver<'_> {
                 // "test-role-${env}"` keeps a single-arg `Interpolation`
                 // with `Expr(String("dev"))` instead of
                 // `String("test-role-dev")`, and downstream consumers
-                // that match on `Value::String` (state diff, plan
+                // that match on `Value::Concrete(ConcreteValue::String)` (state diff, plan
                 // rendering) miss the resolved value. Symmetric with
                 // the default-evaluation path above. #2815 / #2817.
                 substituted.canonicalize_in_place();
@@ -282,31 +285,39 @@ impl ModuleResolver<'_> {
 ///
 /// Argument parameter names are registered as lexical bindings in the
 /// parser. A bare-name reference (`source_arn`) parses as
-/// [`Value::BindingRef`]; an attribute access (`source_arn.field`)
-/// parses as [`Value::ResourceRef`]. Both forms can target an argument
+/// [`Value::Deferred(DeferredValue::BindingRef)`]; an attribute access (`source_arn.field`)
+/// parses as [`Value::Deferred(DeferredValue::ResourceRef)`]. Both forms can target an argument
 /// parameter, so substitution covers both.
 pub(super) fn substitute_arguments(value: &Value, arguments: &HashMap<String, Value>) -> Value {
     match value {
-        Value::BindingRef { binding } if arguments.contains_key(binding) => arguments
-            .get(binding)
-            .cloned()
-            .unwrap_or_else(|| value.clone()),
-        Value::ResourceRef { path } if arguments.contains_key(path.binding()) => arguments
-            .get(path.binding())
-            .cloned()
-            .unwrap_or_else(|| value.clone()),
-        Value::List(items) => Value::List(
+        Value::Deferred(DeferredValue::BindingRef { binding })
+            if arguments.contains_key(binding) =>
+        {
+            arguments
+                .get(binding)
+                .cloned()
+                .unwrap_or_else(|| value.clone())
+        }
+        Value::Deferred(DeferredValue::ResourceRef { path })
+            if arguments.contains_key(path.binding()) =>
+        {
+            arguments
+                .get(path.binding())
+                .cloned()
+                .unwrap_or_else(|| value.clone())
+        }
+        Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
             items
                 .iter()
                 .map(|v| substitute_arguments(v, arguments))
                 .collect(),
-        ),
-        Value::Map(map) => Value::Map(
+        )),
+        Value::Concrete(ConcreteValue::Map(map)) => Value::Concrete(ConcreteValue::Map(
             map.iter()
                 .map(|(k, v)| (k.clone(), substitute_arguments(v, arguments)))
                 .collect(),
-        ),
-        Value::Interpolation(parts) => {
+        )),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             use crate::resource::InterpolationPart;
             let substituted_parts: Vec<InterpolationPart> = parts
                 .iter()
@@ -317,15 +328,17 @@ pub(super) fn substitute_arguments(value: &Value, arguments: &HashMap<String, Va
                     other => other.clone(),
                 })
                 .collect();
-            Value::Interpolation(substituted_parts)
+            Value::Deferred(DeferredValue::Interpolation(substituted_parts))
         }
-        Value::FunctionCall { name, args } => Value::FunctionCall {
-            name: name.clone(),
-            args: args
-                .iter()
-                .map(|v| substitute_arguments(v, arguments))
-                .collect(),
-        },
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
+            Value::Deferred(DeferredValue::FunctionCall {
+                name: name.clone(),
+                args: args
+                    .iter()
+                    .map(|v| substitute_arguments(v, arguments))
+                    .collect(),
+            })
+        }
         _ => value.clone(),
     }
 }
@@ -340,28 +353,32 @@ pub(super) fn rewrite_intra_module_refs(
     intra_module_bindings: &HashSet<String>,
 ) -> Value {
     match value {
-        Value::BindingRef { binding } if intra_module_bindings.contains(binding) => {
-            Value::BindingRef {
+        Value::Deferred(DeferredValue::BindingRef { binding })
+            if intra_module_bindings.contains(binding) =>
+        {
+            Value::Deferred(DeferredValue::BindingRef {
                 binding: format!("{}.{}", instance_prefix, binding),
-            }
+            })
         }
-        Value::ResourceRef { path } if intra_module_bindings.contains(path.binding()) => {
-            Value::ResourceRef {
+        Value::Deferred(DeferredValue::ResourceRef { path })
+            if intra_module_bindings.contains(path.binding()) =>
+        {
+            Value::Deferred(DeferredValue::ResourceRef {
                 path: crate::resource::AccessPath::with_fields_and_subscripts(
                     format!("{}.{}", instance_prefix, path.binding()),
                     path.attribute().to_string(),
                     path.field_path().to_vec(),
                     path.subscripts().to_vec(),
                 ),
-            }
+            })
         }
-        Value::List(items) => Value::List(
+        Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
             items
                 .iter()
                 .map(|v| rewrite_intra_module_refs(v, instance_prefix, intra_module_bindings))
                 .collect(),
-        ),
-        Value::Map(map) => Value::Map(
+        )),
+        Value::Concrete(ConcreteValue::Map(map)) => Value::Concrete(ConcreteValue::Map(
             map.iter()
                 .map(|(k, v)| {
                     (
@@ -370,8 +387,8 @@ pub(super) fn rewrite_intra_module_refs(
                     )
                 })
                 .collect(),
-        ),
-        Value::Interpolation(parts) => {
+        )),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             use crate::resource::InterpolationPart;
             let rewritten_parts: Vec<InterpolationPart> = parts
                 .iter()
@@ -382,15 +399,17 @@ pub(super) fn rewrite_intra_module_refs(
                     other => other.clone(),
                 })
                 .collect();
-            Value::Interpolation(rewritten_parts)
+            Value::Deferred(DeferredValue::Interpolation(rewritten_parts))
         }
-        Value::FunctionCall { name, args } => Value::FunctionCall {
-            name: name.clone(),
-            args: args
-                .iter()
-                .map(|v| rewrite_intra_module_refs(v, instance_prefix, intra_module_bindings))
-                .collect(),
-        },
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
+            Value::Deferred(DeferredValue::FunctionCall {
+                name: name.clone(),
+                args: args
+                    .iter()
+                    .map(|v| rewrite_intra_module_refs(v, instance_prefix, intra_module_bindings))
+                    .collect(),
+            })
+        }
         _ => value.clone(),
     }
 }
@@ -600,38 +619,38 @@ fn rewrite_ref_prefixes(
     remap: &std::collections::HashMap<(String, u64), u64>,
 ) -> Value {
     match value {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding = path.binding();
             if let Some((prefix, rest)) = binding.split_once('.')
                 && let Some((module, simhash)) = parse_synthetic_instance_prefix(prefix)
                 && let Some(&target) = remap.get(&(module.to_string(), simhash))
             {
                 let new_binding = format!("{}_{:016x}.{}", module, target, rest);
-                return Value::ResourceRef {
+                return Value::Deferred(DeferredValue::ResourceRef {
                     path: crate::resource::AccessPath::with_fields_and_subscripts(
                         new_binding,
                         path.attribute().to_string(),
                         path.field_path().to_vec(),
                         path.subscripts().to_vec(),
                     ),
-                };
+                });
             }
             value.clone()
         }
-        Value::List(items) => Value::List(
+        Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
             items
                 .iter()
                 .map(|v| rewrite_ref_prefixes(v, remap))
                 .collect(),
-        ),
-        Value::Map(map) => Value::Map(
+        )),
+        Value::Concrete(ConcreteValue::Map(map)) => Value::Concrete(ConcreteValue::Map(
             map.iter()
                 .map(|(k, v)| (k.clone(), rewrite_ref_prefixes(v, remap)))
                 .collect(),
-        ),
-        Value::Interpolation(parts) => {
+        )),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             use crate::resource::InterpolationPart;
-            Value::Interpolation(
+            Value::Deferred(DeferredValue::Interpolation(
                 parts
                     .iter()
                     .map(|p| match p {
@@ -641,15 +660,17 @@ fn rewrite_ref_prefixes(
                         }
                     })
                     .collect(),
-            )
+            ))
         }
-        Value::FunctionCall { name, args } => Value::FunctionCall {
-            name: name.clone(),
-            args: args
-                .iter()
-                .map(|v| rewrite_ref_prefixes(v, remap))
-                .collect(),
-        },
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
+            Value::Deferred(DeferredValue::FunctionCall {
+                name: name.clone(),
+                args: args
+                    .iter()
+                    .map(|v| rewrite_ref_prefixes(v, remap))
+                    .collect(),
+            })
+        }
         _ => value.clone(),
     }
 }

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -13,7 +13,9 @@ use indexmap::IndexMap;
 
 use super::*;
 use crate::parser::{ArgumentParameter, ModuleCall, ParsedFile, ProviderContext, TypeExpr};
-use crate::resource::{Directives, Resource, ResourceId, ResourceKind, Value};
+use crate::resource::{
+    ConcreteValue, DeferredValue, Directives, Resource, ResourceId, ResourceKind, Value,
+};
 
 fn create_test_module() -> ParsedFile {
     ParsedFile {
@@ -22,16 +24,19 @@ fn create_test_module() -> ParsedFile {
             id: ResourceId::new("security_group", "sg"),
             attributes: {
                 let mut attrs = HashMap::new();
-                attrs.insert("name".to_string(), Value::String("sg".to_string()));
+                attrs.insert(
+                    "name".to_string(),
+                    Value::Concrete(ConcreteValue::String("sg".to_string())),
+                );
                 attrs.insert(
                     "vpc_id".to_string(),
-                    Value::BindingRef {
+                    Value::Deferred(DeferredValue::BindingRef {
                         binding: "vpc_id".to_string(),
-                    },
+                    }),
                 );
                 attrs.insert(
                     "_type".to_string(),
-                    Value::String("aws.security_group".to_string()),
+                    Value::Concrete(ConcreteValue::String("aws.security_group".to_string())),
                 );
                 attrs.into_iter().collect()
             },
@@ -57,7 +62,7 @@ fn create_test_module() -> ParsedFile {
             ArgumentParameter {
                 name: "enable_flag".to_string(),
                 type_expr: TypeExpr::Bool,
-                default: Some(Value::Bool(true)),
+                default: Some(Value::Concrete(ConcreteValue::Bool(true))),
                 description: None,
                 validations: Vec::new(),
             },
@@ -79,35 +84,44 @@ fn create_test_module() -> ParsedFile {
 #[test]
 fn test_substitute_arguments() {
     let mut inputs = HashMap::new();
-    inputs.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+    inputs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+    );
 
     // Argument params are lexically scoped: binding_name is the param name itself
-    let value = Value::BindingRef {
+    let value = Value::Deferred(DeferredValue::BindingRef {
         binding: "vpc_id".to_string(),
-    };
+    });
     let result = substitute_arguments(&value, &inputs);
 
-    assert_eq!(result, Value::String("vpc-123".to_string()));
+    assert_eq!(
+        result,
+        Value::Concrete(ConcreteValue::String("vpc-123".to_string()))
+    );
 }
 
 #[test]
 fn test_substitute_arguments_nested() {
     let mut inputs = HashMap::new();
-    inputs.insert("port".to_string(), Value::Int(8080));
+    inputs.insert(
+        "port".to_string(),
+        Value::Concrete(ConcreteValue::Int(8080)),
+    );
 
-    let value = Value::List(vec![
-        Value::BindingRef {
+    let value = Value::Concrete(ConcreteValue::List(vec![
+        Value::Deferred(DeferredValue::BindingRef {
             binding: "port".to_string(),
-        },
-        Value::Int(443),
-    ]);
+        }),
+        Value::Concrete(ConcreteValue::Int(443)),
+    ]));
     let result = substitute_arguments(&value, &inputs);
 
     match result {
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             assert_eq!(items.len(), 2);
-            assert_eq!(items[0], Value::Int(8080));
-            assert_eq!(items[1], Value::Int(443));
+            assert_eq!(items[0], Value::Concrete(ConcreteValue::Int(8080)));
+            assert_eq!(items[1], Value::Concrete(ConcreteValue::Int(443)));
         }
         _ => panic!("Expected list"),
     }
@@ -128,7 +142,7 @@ fn create_test_module_with_anonymous_resource() -> ParsedFile {
                 let mut attrs = IndexMap::new();
                 attrs.insert(
                     "policy_name".to_string(),
-                    Value::String("inline".to_string()),
+                    Value::Concrete(ConcreteValue::String("inline".to_string())),
                 );
                 attrs
             },
@@ -213,7 +227,10 @@ fn test_expand_module_call() {
         binding_name: Some("my_instance".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("vpc_id".to_string(), Value::String("vpc-456".to_string()));
+            args.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String("vpc-456".to_string())),
+            );
             args
         },
     };
@@ -227,7 +244,9 @@ fn test_expand_module_call() {
     assert_eq!(sg.id.name_str(), "my_instance.sg");
     assert_eq!(
         sg.get_attr("vpc_id"),
-        Some(&Value::String("vpc-456".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-456".to_string()
+        )))
     );
     assert_eq!(
         sg.module_source,
@@ -252,9 +271,9 @@ fn create_module_with_intra_refs() -> ParsedFile {
                     let mut attrs = HashMap::new();
                     attrs.insert(
                         "cidr_block".to_string(),
-                        Value::BindingRef {
+                        Value::Deferred(DeferredValue::BindingRef {
                             binding: "cidr".to_string(),
-                        },
+                        }),
                     );
                     attrs.into_iter().collect()
                 },
@@ -323,7 +342,10 @@ fn test_multiple_module_instances_no_collision() {
         binding_name: Some("prod".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("cidr".to_string(), Value::String("10.0.0.0/16".to_string()));
+            args.insert(
+                "cidr".to_string(),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            );
             args
         },
     };
@@ -332,7 +354,10 @@ fn test_multiple_module_instances_no_collision() {
         binding_name: Some("staging".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("cidr".to_string(), Value::String("10.1.0.0/16".to_string()));
+            args.insert(
+                "cidr".to_string(),
+                Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+            );
             args
         },
     };
@@ -399,10 +424,13 @@ fn create_module_with_attributes() -> ParsedFile {
             id: ResourceId::new("security_group", "sg"),
             attributes: {
                 let mut attrs = HashMap::new();
-                attrs.insert("name".to_string(), Value::String("sg".to_string()));
+                attrs.insert(
+                    "name".to_string(),
+                    Value::Concrete(ConcreteValue::String("sg".to_string())),
+                );
                 attrs.insert(
                     "_type".to_string(),
-                    Value::String("aws.security_group".to_string()),
+                    Value::Concrete(ConcreteValue::String("aws.security_group".to_string())),
                 );
                 attrs.into_iter().collect()
             },
@@ -551,7 +579,7 @@ fn role_names(parsed: &ParsedFile) -> HashSet<String> {
         .iter()
         .filter(|r| r.id.resource_type == "iam.Role")
         .filter_map(|r| match r.get_attr("role_name")? {
-            Value::String(s) => Some(s.clone()),
+            Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
             _ => None,
         })
         .collect()
@@ -566,7 +594,7 @@ fn test_anonymous_module_calls_get_distinct_prefixes() {
             let mut args = HashMap::new();
             args.insert(
                 "github_repo".to_string(),
-                Value::String("carina-rs/infra".to_string()),
+                Value::Concrete(ConcreteValue::String("carina-rs/infra".to_string())),
             );
             args
         },
@@ -578,7 +606,7 @@ fn test_anonymous_module_calls_get_distinct_prefixes() {
             let mut args = HashMap::new();
             args.insert(
                 "github_repo".to_string(),
-                Value::String("carina-rs/other".to_string()),
+                Value::Concrete(ConcreteValue::String("carina-rs/other".to_string())),
             );
             args
         },
@@ -608,16 +636,21 @@ fn test_anonymous_module_call_prefix_is_locality_sensitive() {
         binding_name: None,
         arguments: {
             let mut args = HashMap::new();
-            args.insert("github_repo".to_string(), Value::String(repo.to_string()));
+            args.insert(
+                "github_repo".to_string(),
+                Value::Concrete(ConcreteValue::String(repo.to_string())),
+            );
             args.insert(
                 "role_name".to_string(),
-                Value::String("github-actions".to_string()),
+                Value::Concrete(ConcreteValue::String("github-actions".to_string())),
             );
             args.insert(
                 "managed_policy_arns".to_string(),
-                Value::List(vec![Value::String(
-                    "arn:aws:iam::aws:policy/AdministratorAccess".to_string(),
-                )]),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::String(
+                        "arn:aws:iam::aws:policy/AdministratorAccess".to_string(),
+                    ),
+                )])),
             );
             args
         },
@@ -1002,7 +1035,10 @@ fn test_expand_module_call_uses_dot_path_addressing() {
         binding_name: Some("my_instance".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("vpc_id".to_string(), Value::String("vpc-456".to_string()));
+            args.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String("vpc-456".to_string())),
+            );
             args
         },
     };
@@ -1031,7 +1067,10 @@ fn test_module_dot_path_bindings_and_refs() {
         binding_name: Some("prod".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("cidr".to_string(), Value::String("10.0.0.0/16".to_string()));
+            args.insert(
+                "cidr".to_string(),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            );
             args
         },
     };
@@ -1095,26 +1134,29 @@ fn test_substitute_arguments_interpolation() {
     use crate::resource::InterpolationPart;
 
     let mut inputs = HashMap::new();
-    inputs.insert("env_name".to_string(), Value::String("dev".to_string()));
+    inputs.insert(
+        "env_name".to_string(),
+        Value::Concrete(ConcreteValue::String("dev".to_string())),
+    );
 
     // Interpolation like "prefix-${env_name}-suffix" where env_name is a module argument
-    let value = Value::Interpolation(vec![
+    let value = Value::Deferred(DeferredValue::Interpolation(vec![
         InterpolationPart::Literal("prefix-".to_string()),
-        InterpolationPart::Expr(Value::BindingRef {
+        InterpolationPart::Expr(Value::Deferred(DeferredValue::BindingRef {
             binding: "env_name".to_string(),
-        }),
+        })),
         InterpolationPart::Literal("-suffix".to_string()),
-    ]);
+    ]));
     let result = substitute_arguments(&value, &inputs);
 
     // After substitution, the ResourceRef should be replaced with the argument value
     assert_eq!(
         result,
-        Value::Interpolation(vec![
+        Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("prefix-".to_string()),
-            InterpolationPart::Expr(Value::String("dev".to_string())),
+            InterpolationPart::Expr(Value::Concrete(ConcreteValue::String("dev".to_string()))),
             InterpolationPart::Literal("-suffix".to_string()),
-        ])
+        ]))
     );
 }
 
@@ -1132,11 +1174,14 @@ fn test_unknown_argument_rejected() {
         binding_name: Some("my_instance".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("vpc_id".to_string(), Value::String("vpc-456".to_string()));
+            args.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String("vpc-456".to_string())),
+            );
             // Unknown argument: not declared in the module
             args.insert(
                 "unknown_arg".to_string(),
-                Value::String("should-fail".to_string()),
+                Value::Concrete(ConcreteValue::String("should-fail".to_string())),
             );
             args
         },
@@ -1153,31 +1198,34 @@ fn test_unknown_argument_rejected() {
 #[test]
 fn test_substitute_arguments_function_call() {
     let mut inputs = HashMap::new();
-    inputs.insert("cidr".to_string(), Value::String("10.0.0.0/16".to_string()));
+    inputs.insert(
+        "cidr".to_string(),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+    );
 
     // FunctionCall like cidr_subnet(cidr, 8, 0) where cidr is a module argument
-    let value = Value::FunctionCall {
+    let value = Value::Deferred(DeferredValue::FunctionCall {
         name: "cidr_subnet".to_string(),
         args: vec![
-            Value::BindingRef {
+            Value::Deferred(DeferredValue::BindingRef {
                 binding: "cidr".to_string(),
-            },
-            Value::Int(8),
-            Value::Int(0),
+            }),
+            Value::Concrete(ConcreteValue::Int(8)),
+            Value::Concrete(ConcreteValue::Int(0)),
         ],
-    };
+    });
     let result = substitute_arguments(&value, &inputs);
 
     assert_eq!(
         result,
-        Value::FunctionCall {
+        Value::Deferred(DeferredValue::FunctionCall {
             name: "cidr_subnet".to_string(),
             args: vec![
-                Value::String("10.0.0.0/16".to_string()),
-                Value::Int(8),
-                Value::Int(0),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+                Value::Concrete(ConcreteValue::Int(8)),
+                Value::Concrete(ConcreteValue::Int(0)),
             ],
-        }
+        })
     );
 }
 
@@ -1193,24 +1241,24 @@ fn create_module_with_interpolation() -> ParsedFile {
                 let mut attrs = HashMap::new();
                 attrs.insert(
                     "cidr_block".to_string(),
-                    Value::BindingRef {
+                    Value::Deferred(DeferredValue::BindingRef {
                         binding: "cidr_block".to_string(),
-                    },
+                    }),
                 );
                 attrs.insert(
                     "name".to_string(),
-                    Value::Interpolation(vec![
+                    Value::Deferred(DeferredValue::Interpolation(vec![
                         InterpolationPart::Literal("test-".to_string()),
-                        InterpolationPart::Expr(Value::BindingRef {
+                        InterpolationPart::Expr(Value::Deferred(DeferredValue::BindingRef {
                             binding: "env_name".to_string(),
-                        }),
-                    ]),
+                        })),
+                    ])),
                 );
                 attrs.insert(
                     "env".to_string(),
-                    Value::BindingRef {
+                    Value::Deferred(DeferredValue::BindingRef {
                         binding: "env_name".to_string(),
-                    },
+                    }),
                 );
                 attrs.into_iter().collect()
             },
@@ -1271,9 +1319,12 @@ fn test_expand_module_call_with_interpolation() {
             let mut args = HashMap::new();
             args.insert(
                 "cidr_block".to_string(),
-                Value::String("10.0.0.0/16".to_string()),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
             );
-            args.insert("env_name".to_string(), Value::String("dev".to_string()));
+            args.insert(
+                "env_name".to_string(),
+                Value::Concrete(ConcreteValue::String("dev".to_string())),
+            );
             args
         },
     };
@@ -1286,18 +1337,25 @@ fn test_expand_module_call_with_interpolation() {
     // Simple argument substitution should work
     assert_eq!(
         vpc.get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
-    assert_eq!(vpc.get_attr("env"), Some(&Value::String("dev".to_string())));
+    assert_eq!(
+        vpc.get_attr("env"),
+        Some(&Value::Concrete(ConcreteValue::String("dev".to_string())))
+    );
 
     // Interpolation with argument substitutes and canonicalizes back to
-    // a flat `String` so downstream `Value::String` consumers (state
+    // a flat `String` so downstream `Value::Concrete(ConcreteValue::String)` consumers (state
     // diff, plan rendering) see the resolved value. Without the post-
     // substitution canonicalize, this would stay as
     // `Interpolation([Literal("test-"), Expr(String("dev"))])` (#2815, #2817).
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("test-dev".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "test-dev".to_string()
+        ))),
     );
 }
 
@@ -1318,7 +1376,7 @@ fn test_nested_module_two_level() {
         .iter()
         .filter_map(|r| {
             r.get_attr("_type").and_then(|v| match v {
-                Value::String(s) => Some(s.as_str()),
+                Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
                 _ => None,
             })
         })
@@ -1352,7 +1410,7 @@ fn test_nested_module_three_level() {
         .iter()
         .filter_map(|r| {
             r.get_attr("_type").and_then(|v| match v {
-                Value::String(s) => Some(s.as_str()),
+                Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
                 _ => None,
             })
         })
@@ -1404,16 +1462,19 @@ fn test_expand_module_call_with_function_call_argument() {
             let mut args = HashMap::new();
             args.insert(
                 "cidr_block".to_string(),
-                Value::FunctionCall {
+                Value::Deferred(DeferredValue::FunctionCall {
                     name: "cidr_subnet".to_string(),
                     args: vec![
-                        Value::String("10.0.0.0/16".to_string()),
-                        Value::Int(8),
-                        Value::Int(0),
+                        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+                        Value::Concrete(ConcreteValue::Int(8)),
+                        Value::Concrete(ConcreteValue::Int(0)),
                     ],
-                },
+                }),
             );
-            args.insert("env_name".to_string(), Value::String("dev".to_string()));
+            args.insert(
+                "env_name".to_string(),
+                Value::Concrete(ConcreteValue::String("dev".to_string())),
+            );
             args
         },
     };
@@ -1426,14 +1487,14 @@ fn test_expand_module_call_with_function_call_argument() {
     // FunctionCall argument should be substituted as-is (resolved at apply time)
     assert_eq!(
         vpc.get_attr("cidr_block"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "cidr_subnet".to_string(),
             args: vec![
-                Value::String("10.0.0.0/16".to_string()),
-                Value::Int(8),
-                Value::Int(0),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+                Value::Concrete(ConcreteValue::Int(8)),
+                Value::Concrete(ConcreteValue::Int(0)),
             ],
-        })
+        }))
     );
 }
 
@@ -1540,7 +1601,7 @@ fn create_module_with_port_validation() -> ParsedFile {
         arguments: vec![ArgumentParameter {
             name: "port".to_string(),
             type_expr: TypeExpr::Int,
-            default: Some(Value::Int(8080)),
+            default: Some(Value::Concrete(ConcreteValue::Int(8080))),
             description: Some("Web server port".to_string()),
             validations: vec![ValidationBlock {
                 condition: ValidateExpr::And(
@@ -1588,7 +1649,7 @@ fn test_argument_validation_passes_with_valid_value() {
         binding_name: Some("web".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("port".to_string(), Value::Int(443));
+            args.insert("port".to_string(), Value::Concrete(ConcreteValue::Int(443)));
             args
         },
     };
@@ -1634,7 +1695,7 @@ fn test_argument_validation_fails_with_invalid_value() {
         binding_name: Some("web".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("port".to_string(), Value::Int(0));
+            args.insert("port".to_string(), Value::Concrete(ConcreteValue::Int(0)));
             args
         },
     };
@@ -1674,7 +1735,7 @@ fn test_argument_validation_fails_with_negative_value() {
         binding_name: Some("web".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("port".to_string(), Value::Int(-1));
+            args.insert("port".to_string(), Value::Concrete(ConcreteValue::Int(-1)));
             args
         },
     };
@@ -1699,7 +1760,10 @@ fn test_argument_validation_fails_too_large() {
         binding_name: Some("web".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("port".to_string(), Value::Int(70000));
+            args.insert(
+                "port".to_string(),
+                Value::Concrete(ConcreteValue::Int(70000)),
+            );
             args
         },
     };
@@ -1755,7 +1819,7 @@ fn test_argument_validation_no_message_uses_default() {
         binding_name: Some("c".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("count".to_string(), Value::Int(0));
+            args.insert("count".to_string(), Value::Concrete(ConcreteValue::Int(0)));
             args
         },
     };
@@ -1824,7 +1888,9 @@ fn test_argument_validation_len_with_list() {
             let mut args = HashMap::new();
             args.insert(
                 "tags".to_string(),
-                Value::List(vec![Value::String("env:prod".to_string())]),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::String("env:prod".to_string()),
+                )])),
             );
             args
         },
@@ -1837,7 +1903,10 @@ fn test_argument_validation_len_with_list() {
         binding_name: Some("t".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("tags".to_string(), Value::List(vec![]));
+            args.insert(
+                "tags".to_string(),
+                Value::Concrete(ConcreteValue::List(vec![])),
+            );
             args
         },
     };
@@ -1864,16 +1933,16 @@ fn test_require_block_passes() {
             ArgumentParameter {
                 name: "enable_https".to_string(),
                 type_expr: TypeExpr::Bool,
-                default: Some(Value::Bool(true)),
+                default: Some(Value::Concrete(ConcreteValue::Bool(true))),
                 description: None,
                 validations: Vec::new(),
             },
             ArgumentParameter {
                 name: "cert_arn".to_string(),
                 type_expr: TypeExpr::String,
-                default: Some(Value::String(
+                default: Some(Value::Concrete(ConcreteValue::String(
                     "arn:aws:acm:us-east-1:123:cert/abc".to_string(),
-                )),
+                ))),
                 description: None,
                 validations: Vec::new(),
             },
@@ -1916,10 +1985,15 @@ fn test_require_block_passes() {
         binding_name: Some("w".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("enable_https".to_string(), Value::Bool(true));
+            args.insert(
+                "enable_https".to_string(),
+                Value::Concrete(ConcreteValue::Bool(true)),
+            );
             args.insert(
                 "cert_arn".to_string(),
-                Value::String("arn:aws:acm:us-east-1:123:cert/abc".to_string()),
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:acm:us-east-1:123:cert/abc".to_string(),
+                )),
             );
             args
         },
@@ -1940,14 +2014,14 @@ fn test_require_block_fails_with_not_expr() {
             ArgumentParameter {
                 name: "enable_https".to_string(),
                 type_expr: TypeExpr::Bool,
-                default: Some(Value::Bool(true)),
+                default: Some(Value::Concrete(ConcreteValue::Bool(true))),
                 description: None,
                 validations: Vec::new(),
             },
             ArgumentParameter {
                 name: "has_cert".to_string(),
                 type_expr: TypeExpr::Bool,
-                default: Some(Value::Bool(false)),
+                default: Some(Value::Concrete(ConcreteValue::Bool(false))),
                 description: None,
                 validations: Vec::new(),
             },
@@ -1986,8 +2060,14 @@ fn test_require_block_fails_with_not_expr() {
         binding_name: Some("w".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("enable_https".to_string(), Value::Bool(true));
-            args.insert("has_cert".to_string(), Value::Bool(false));
+            args.insert(
+                "enable_https".to_string(),
+                Value::Concrete(ConcreteValue::Bool(true)),
+            );
+            args.insert(
+                "has_cert".to_string(),
+                Value::Concrete(ConcreteValue::Bool(false)),
+            );
             args
         },
     };
@@ -2055,10 +2135,10 @@ fn test_require_block_len_function() {
             let mut args = HashMap::new();
             args.insert(
                 "subnet_ids".to_string(),
-                Value::List(vec![
-                    Value::String("subnet-a".to_string()),
-                    Value::String("subnet-b".to_string()),
-                ]),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::String("subnet-a".to_string())),
+                    Value::Concrete(ConcreteValue::String("subnet-b".to_string())),
+                ])),
             );
             args
         },
@@ -2073,7 +2153,9 @@ fn test_require_block_len_function() {
             let mut args = HashMap::new();
             args.insert(
                 "subnet_ids".to_string(),
-                Value::List(vec![Value::String("subnet-a".to_string())]),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::String("subnet-a".to_string()),
+                )])),
             );
             args
         },
@@ -2146,8 +2228,14 @@ fn test_require_block_multiple_constraints() {
         binding_name: Some("a".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("min_size".to_string(), Value::Int(1));
-            args.insert("max_size".to_string(), Value::Int(5));
+            args.insert(
+                "min_size".to_string(),
+                Value::Concrete(ConcreteValue::Int(1)),
+            );
+            args.insert(
+                "max_size".to_string(),
+                Value::Concrete(ConcreteValue::Int(5)),
+            );
             args
         },
     };
@@ -2159,8 +2247,14 @@ fn test_require_block_multiple_constraints() {
         binding_name: Some("a".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("min_size".to_string(), Value::Int(10));
-            args.insert("max_size".to_string(), Value::Int(5));
+            args.insert(
+                "min_size".to_string(),
+                Value::Concrete(ConcreteValue::Int(10)),
+            );
+            args.insert(
+                "max_size".to_string(),
+                Value::Concrete(ConcreteValue::Int(5)),
+            );
             args
         },
     };
@@ -2189,7 +2283,10 @@ fn test_argument_type_mismatch_int_for_string() {
         arguments: {
             let mut args = HashMap::new();
             // vpc_id expects string, pass int
-            args.insert("vpc_id".to_string(), Value::Int(42));
+            args.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::Int(42)),
+            );
             args
         },
     };
@@ -2216,11 +2313,14 @@ fn test_argument_type_mismatch_string_for_bool() {
         binding_name: Some("my_instance".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+            args.insert(
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+            );
             // enable_flag expects bool, pass string
             args.insert(
                 "enable_flag".to_string(),
-                Value::String("not-a-bool".to_string()),
+                Value::Concrete(ConcreteValue::String("not-a-bool".to_string())),
             );
             args
         },
@@ -2280,7 +2380,9 @@ fn test_argument_type_custom_validator() {
             let mut args = HashMap::new();
             args.insert(
                 "policy_arn".to_string(),
-                Value::String("arn:aws:iam::123456789012:policy/MyPolicy".to_string()),
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:iam::123456789012:policy/MyPolicy".to_string(),
+                )),
             );
             args
         },
@@ -2295,7 +2397,7 @@ fn test_argument_type_custom_validator() {
             let mut args = HashMap::new();
             args.insert(
                 "policy_arn".to_string(),
-                Value::String("not-an-arn".to_string()),
+                Value::Concrete(ConcreteValue::String("not-an-arn".to_string())),
             );
             args
         },
@@ -2353,10 +2455,14 @@ fn test_argument_type_list_of_custom_type() {
             let mut args = HashMap::new();
             args.insert(
                 "policy_arns".to_string(),
-                Value::List(vec![
-                    Value::String("arn:aws:iam::123:policy/A".to_string()),
-                    Value::String("arn:aws:iam::123:policy/B".to_string()),
-                ]),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::String(
+                        "arn:aws:iam::123:policy/A".to_string(),
+                    )),
+                    Value::Concrete(ConcreteValue::String(
+                        "arn:aws:iam::123:policy/B".to_string(),
+                    )),
+                ])),
             );
             args
         },
@@ -2371,10 +2477,12 @@ fn test_argument_type_list_of_custom_type() {
             let mut args = HashMap::new();
             args.insert(
                 "policy_arns".to_string(),
-                Value::List(vec![
-                    Value::String("arn:aws:iam::123:policy/A".to_string()),
-                    Value::String("not-an-arn".to_string()),
-                ]),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::String(
+                        "arn:aws:iam::123:policy/A".to_string(),
+                    )),
+                    Value::Concrete(ConcreteValue::String("not-an-arn".to_string())),
+                ])),
             );
             args
         },
@@ -2487,17 +2595,17 @@ m {
     );
 
     let policy = role_attr(&parsed, "assume_role_policy_document");
-    let Value::Map(policy_map) = policy else {
+    let Value::Concrete(ConcreteValue::Map(policy_map)) = policy else {
         panic!("assume_role_policy_document should be a Map, got {policy:?}");
     };
     let patterns = policy_map.get("patterns").expect("patterns should exist");
-    let Value::List(items) = patterns else {
+    let Value::Concrete(ConcreteValue::List(items)) = patterns else {
         panic!("patterns should be a List, got {patterns:?}");
     };
     assert_eq!(items.len(), 1);
     assert_eq!(
         items[0],
-        Value::String("repo:carina-rs/infra:*".to_string()),
+        Value::Concrete(ConcreteValue::String("repo:carina-rs/infra:*".to_string())),
         "default's ${{github_repo}} interpolation must resolve against the caller's value"
     );
 }
@@ -2532,13 +2640,13 @@ m {
 
     assert_eq!(
         role_attr(&parsed, "role_name"),
-        &Value::String("repo:carina-rs/infra:*".to_string()),
+        &Value::Concrete(ConcreteValue::String("repo:carina-rs/infra:*".to_string())),
         "block-form default's `${{github_repo}}` must resolve against the caller's value"
     );
 }
 
 // #2393 — bare-identifier default (`b: String = a`, no `${}` wrapping) is a
-// `Value::ResourceRef { binding: "a" }` after parse and must resolve to the
+// `Value::Deferred(DeferredValue::ResourceRef{ binding: "a" })` after parse and must resolve to the
 // caller-supplied value of `a`.
 #[test]
 fn test_argument_default_bare_identifier_resolves() {
@@ -2565,7 +2673,7 @@ m {
 
     assert_eq!(
         role_attr(&parsed, "role_name"),
-        &Value::String("p".to_string()),
+        &Value::Concrete(ConcreteValue::String("p".to_string())),
         "bare-identifier default `secondary = primary` must resolve to caller's `primary`"
     );
 }
@@ -2600,7 +2708,7 @@ m {}
 
     assert_eq!(
         role_attr(&parsed, "role_name"),
-        &Value::String("X-X!".to_string()),
+        &Value::Concrete(ConcreteValue::String("X-X!".to_string())),
         "transitive default chain `a → b → c` must collapse to a flat string"
     );
 }
@@ -2637,16 +2745,18 @@ m {
     );
 
     let policy = role_attr(&parsed, "assume_role_policy_document");
-    let Value::Map(policy_map) = policy else {
+    let Value::Concrete(ConcreteValue::Map(policy_map)) = policy else {
         panic!("policy should be Map, got {policy:?}");
     };
     let tags = policy_map.get("tags").expect("tags should exist");
-    let Value::Map(tag_map) = tags else {
+    let Value::Concrete(ConcreteValue::Map(tag_map)) = tags else {
         panic!("tags should be Map, got {tags:?}");
     };
     assert_eq!(
         tag_map.get("region"),
-        Some(&Value::String("ap-northeast-1-tag".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1-tag".to_string()
+        ))),
         "interpolation inside a nested map default must resolve recursively"
     );
 }
@@ -2681,21 +2791,24 @@ m {
 
     assert_eq!(
         role_attr(&parsed, "role_name"),
-        &Value::String("hello".to_string()),
+        &Value::Concrete(ConcreteValue::String("hello".to_string())),
     );
     let policy = role_attr(&parsed, "assume_role_policy_document");
-    let Value::Map(policy_map) = policy else {
+    let Value::Concrete(ConcreteValue::Map(policy_map)) = policy else {
         panic!("policy should be Map, got {policy:?}");
     };
-    assert_eq!(policy_map.get("y_value"), Some(&Value::Int(42)));
+    assert_eq!(
+        policy_map.get("y_value"),
+        Some(&Value::Concrete(ConcreteValue::Int(42)))
+    );
 }
 
 // #2393 — argument defaults whose RHS references *another* argument
 // (`prefix: String = later`) used to be resolved in strict declaration
 // order by `substitute_arguments` in `expander.rs`. A forward
 // reference therefore degraded — first to a literal
-// `Value::String("later")` (pre-#2817), then to an unresolved
-// `Value::ResourceRef("later")` (post-#2817 PR1).
+// `Value::Concrete(ConcreteValue::String("later"))` (pre-#2817), then to an unresolved
+// `Value::Deferred(DeferredValue::ResourceRef("later"))` (post-#2817 PR1).
 //
 // This pass adds a fixed-point loop around `substitute_arguments`
 // (#2817 follow-up): each iteration replaces every `ResourceRef`
@@ -2726,7 +2839,7 @@ m {}
 
     assert_eq!(
         role_attr(&parsed, "role_name"),
-        &Value::String("L".to_string()),
+        &Value::Concrete(ConcreteValue::String("L".to_string())),
         "forward-ref default `prefix = later` resolves to `later`'s value `'L'` \
          once the fix-point loop runs in `expander.rs::substitute_arguments`"
     );
@@ -2766,7 +2879,7 @@ m {}
         // terminates without panicking and produces a structured ref
         // the scope check can flag. Since #2847 these bare refs are
         // `BindingRef`, not `ResourceRef` with empty attribute.
-        Value::BindingRef { binding } => {
+        Value::Deferred(DeferredValue::BindingRef { binding }) => {
             assert!(
                 binding == "a" || binding == "b",
                 "expected cyclic ref to point at `a` or `b`, got: {binding:?}"
@@ -2809,7 +2922,7 @@ m {
     // Find the module's expanded `role` (the upstream Vpc has type Vpc, not Role).
     let role_name = role_attr(&parsed, "role_name");
     match role_name {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(
                 path.binding(),
                 "upstream",
@@ -3374,7 +3487,7 @@ fn create_module_with_environment_union() -> ParsedFile {
                 TypeExpr::StringLiteral("dev".to_string()),
                 TypeExpr::StringLiteral("prod".to_string()),
             ]),
-            default: Some(Value::String("dev".to_string())),
+            default: Some(Value::Concrete(ConcreteValue::String("dev".to_string()))),
             description: None,
             validations: Vec::new(),
         }],
@@ -3409,7 +3522,10 @@ fn caller_side_typo_against_string_literal_union_is_rejected() {
         arguments: {
             let mut args = HashMap::new();
             // Typo: 'dpv' is outside the declared 'dev' | 'prod' union.
-            args.insert("environment".to_string(), Value::String("dpv".to_string()));
+            args.insert(
+                "environment".to_string(),
+                Value::Concrete(ConcreteValue::String("dpv".to_string())),
+            );
             args
         },
     };
@@ -3439,7 +3555,10 @@ fn caller_side_value_in_string_literal_union_is_accepted() {
         binding_name: Some("my_env".to_string()),
         arguments: {
             let mut args = HashMap::new();
-            args.insert("environment".to_string(), Value::String("prod".to_string()));
+            args.insert(
+                "environment".to_string(),
+                Value::Concrete(ConcreteValue::String("prod".to_string())),
+            );
             args
         },
     };
@@ -3456,7 +3575,7 @@ fn caller_side_value_in_string_literal_union_is_accepted() {
 /// `main.crn` must be visible to identifier references in *sibling* `.crn`
 /// files in the same module directory. Before #2817, the per-file
 /// `ParseContext` could not see sibling-defined symbols, so `${env}` in
-/// `role.crn` lowered to a literal `Value::String("env")` — `role_name`
+/// `role.crn` lowered to a literal `Value::Concrete(ConcreteValue::String("env"))` — `role_name`
 /// rendered as `"test-role-env"` instead of `"test-role-dev"`. The
 /// directory-aware parse pipeline seeds every file's `ParseContext` with
 /// the union of declared names from all sibling files, so the normal

--- a/carina-core/src/module_resolver/typecheck.rs
+++ b/carina-core/src/module_resolver/typecheck.rs
@@ -1,7 +1,7 @@
 //! Type-checking of module call arguments against declared `TypeExpr`s.
 
 use crate::parser::{ArgumentParameter, ProviderContext, TypeExpr, validate_custom_type};
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 
 use super::error::ModuleError;
 
@@ -46,14 +46,14 @@ pub(super) enum TypeCheckResult {
 /// parser represents arguments-block names that propagate into nested
 /// module calls (#2549).
 ///
-/// `Value::BindingRef` is the canonical representation since #2847;
+/// `Value::Deferred(DeferredValue::BindingRef)` is the canonical representation since #2847;
 /// the type system guarantees no attribute/field/subscript can hide
 /// inside it.
 fn enclosing_arg_type<'a>(
     value: &Value,
     enclosing_args: Option<&'a [ArgumentParameter]>,
 ) -> Option<&'a TypeExpr> {
-    let Value::BindingRef { binding } = value else {
+    let Value::Deferred(DeferredValue::BindingRef { binding }) = value else {
         return None;
     };
     enclosing_args?
@@ -84,7 +84,9 @@ pub(super) fn check_type_match(
         // and behave like `Unknown` for typecheck purposes.
         _ if matches!(
             value,
-            Value::FunctionCall { .. } | Value::Unknown(_) | Value::BindingRef { .. }
+            Value::Deferred(DeferredValue::FunctionCall { .. })
+                | Value::Deferred(DeferredValue::Unknown(_))
+                | Value::Deferred(DeferredValue::BindingRef { .. })
         ) =>
         {
             TypeCheckResult::Ok
@@ -92,7 +94,9 @@ pub(super) fn check_type_match(
         TypeExpr::String => {
             if matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ) {
                 TypeCheckResult::Ok
             } else {
@@ -100,35 +104,35 @@ pub(super) fn check_type_match(
             }
         }
         TypeExpr::Int => {
-            if matches!(value, Value::Int(_)) {
+            if matches!(value, Value::Concrete(ConcreteValue::Int(_))) {
                 TypeCheckResult::Ok
             } else {
                 TypeCheckResult::Mismatch
             }
         }
         TypeExpr::Float => {
-            if matches!(value, Value::Float(_)) {
+            if matches!(value, Value::Concrete(ConcreteValue::Float(_))) {
                 TypeCheckResult::Ok
             } else {
                 TypeCheckResult::Mismatch
             }
         }
         TypeExpr::Bool => {
-            if matches!(value, Value::Bool(_)) {
+            if matches!(value, Value::Concrete(ConcreteValue::Bool(_))) {
                 TypeCheckResult::Ok
             } else {
                 TypeCheckResult::Mismatch
             }
         }
         TypeExpr::Duration => {
-            if matches!(value, Value::Duration(_)) {
+            if matches!(value, Value::Concrete(ConcreteValue::Duration(_))) {
                 TypeCheckResult::Ok
             } else {
                 TypeCheckResult::Mismatch
             }
         }
         TypeExpr::List(inner) => {
-            if let Value::List(items) = value {
+            if let Value::Concrete(ConcreteValue::List(items)) = value {
                 for item in items {
                     match check_type_match(inner, item, config, enclosing_args) {
                         TypeCheckResult::Ok => {}
@@ -141,7 +145,7 @@ pub(super) fn check_type_match(
             }
         }
         TypeExpr::Map(inner) => {
-            if let Value::Map(entries) = value {
+            if let Value::Concrete(ConcreteValue::Map(entries)) = value {
                 for v in entries.values() {
                     match check_type_match(inner, v, config, enclosing_args) {
                         TypeCheckResult::Ok => {}
@@ -157,7 +161,9 @@ pub(super) fn check_type_match(
         TypeExpr::Simple(name) => {
             if !matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ) {
                 TypeCheckResult::Mismatch
             } else if let Err(e) = validate_custom_type(name, value, config) {
@@ -170,7 +176,9 @@ pub(super) fn check_type_match(
         TypeExpr::Ref(_) | TypeExpr::SchemaType { .. } => {
             if matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ) {
                 TypeCheckResult::Ok
             } else {
@@ -178,7 +186,7 @@ pub(super) fn check_type_match(
             }
         }
         TypeExpr::Struct { fields } => {
-            let Value::Map(entries) = value else {
+            let Value::Concrete(ConcreteValue::Map(entries)) = value else {
                 return TypeCheckResult::Mismatch;
             };
             if crate::validation::struct_field_shape_errors(fields, entries).is_some() {
@@ -195,9 +203,9 @@ pub(super) fn check_type_match(
             TypeCheckResult::Ok
         }
         // Closed-set string literal type (`'dev'` etc., carina-rs/carina#2611).
-        // Only an exact-string `Value::String` match is accepted.
+        // Only an exact-string `Value::Concrete(ConcreteValue::String)` match is accepted.
         TypeExpr::StringLiteral(expected) => {
-            if matches!(value, Value::String(s) if s == expected) {
+            if matches!(value, Value::Concrete(ConcreteValue::String(s)) if s == expected) {
                 TypeCheckResult::Ok
             } else {
                 TypeCheckResult::Mismatch

--- a/carina-core/src/module_resolver/validation.rs
+++ b/carina-core/src/module_resolver/validation.rs
@@ -7,18 +7,18 @@
 use std::collections::HashMap;
 
 use crate::parser::{CompareOp, ValidateExpr};
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 /// Format a Value for use in error messages.
 pub(super) fn format_value_for_error(value: &Value) -> String {
     match value {
-        Value::String(s) => format!("\"{}\"", s),
-        Value::Int(n) => n.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Duration(d) => crate::value::render_duration(*d),
-        Value::List(items) => format!("[...] (length {})", items.len()),
-        Value::Map(map) => format!("{{...}} (length {})", map.len()),
+        Value::Concrete(ConcreteValue::String(s)) => format!("\"{}\"", s),
+        Value::Concrete(ConcreteValue::Int(n)) => n.to_string(),
+        Value::Concrete(ConcreteValue::Float(f)) => f.to_string(),
+        Value::Concrete(ConcreteValue::Bool(b)) => b.to_string(),
+        Value::Concrete(ConcreteValue::Duration(d)) => crate::value::render_duration(*d),
+        Value::Concrete(ConcreteValue::List(items)) => format!("[...] (length {})", items.len()),
+        Value::Concrete(ConcreteValue::Map(map)) => format!("{{...}} (length {})", map.len()),
         _ => format!("{:?}", value),
     }
 }
@@ -73,11 +73,13 @@ fn eval_validate(
         ValidateExpr::Var(name) => {
             if name == arg_name {
                 match arg_value {
-                    Value::Int(n) => Ok(ValidateValue::Int(*n)),
-                    Value::Float(f) => Ok(ValidateValue::Float(*f)),
-                    Value::Bool(b) => Ok(ValidateValue::Bool(*b)),
-                    Value::Duration(d) => Ok(ValidateValue::Duration(*d)),
-                    Value::String(s) => Ok(ValidateValue::String(s.clone())),
+                    Value::Concrete(ConcreteValue::Int(n)) => Ok(ValidateValue::Int(*n)),
+                    Value::Concrete(ConcreteValue::Float(f)) => Ok(ValidateValue::Float(*f)),
+                    Value::Concrete(ConcreteValue::Bool(b)) => Ok(ValidateValue::Bool(*b)),
+                    Value::Concrete(ConcreteValue::Duration(d)) => Ok(ValidateValue::Duration(*d)),
+                    Value::Concrete(ConcreteValue::String(s)) => {
+                        Ok(ValidateValue::String(s.clone()))
+                    }
                     other => Err(format!(
                         "unsupported value type for validation: {:?}",
                         other
@@ -224,9 +226,15 @@ fn eval_validate_function(
                 && var_name == arg_name
             {
                 return match arg_value {
-                    Value::String(s) => Ok(ValidateValue::Int(s.len() as i64)),
-                    Value::List(items) => Ok(ValidateValue::Int(items.len() as i64)),
-                    Value::Map(map) => Ok(ValidateValue::Int(map.len() as i64)),
+                    Value::Concrete(ConcreteValue::String(s)) => {
+                        Ok(ValidateValue::Int(s.len() as i64))
+                    }
+                    Value::Concrete(ConcreteValue::List(items)) => {
+                        Ok(ValidateValue::Int(items.len() as i64))
+                    }
+                    Value::Concrete(ConcreteValue::Map(map)) => {
+                        Ok(ValidateValue::Int(map.len() as i64))
+                    }
                     _ => Err(format!(
                         "{}() argument must be a string, list, or map",
                         name
@@ -292,11 +300,13 @@ fn eval_require(
         ValidateExpr::Var(name) => {
             if let Some(value) = args.get(name) {
                 match value {
-                    Value::Int(n) => Ok(RequireValue::Int(*n)),
-                    Value::Float(f) => Ok(RequireValue::Float(*f)),
-                    Value::Bool(b) => Ok(RequireValue::Bool(*b)),
-                    Value::Duration(d) => Ok(RequireValue::Duration(*d)),
-                    Value::String(s) => Ok(RequireValue::String(s.clone())),
+                    Value::Concrete(ConcreteValue::Int(n)) => Ok(RequireValue::Int(*n)),
+                    Value::Concrete(ConcreteValue::Float(f)) => Ok(RequireValue::Float(*f)),
+                    Value::Concrete(ConcreteValue::Bool(b)) => Ok(RequireValue::Bool(*b)),
+                    Value::Concrete(ConcreteValue::Duration(d)) => Ok(RequireValue::Duration(*d)),
+                    Value::Concrete(ConcreteValue::String(s)) => {
+                        Ok(RequireValue::String(s.clone()))
+                    }
                     other => Err(format!(
                         "unsupported value type for require expression: {:?}",
                         other
@@ -455,9 +465,15 @@ fn eval_require_function(
                 && let Some(value) = args.get(var_name)
             {
                 return match value {
-                    Value::String(s) => Ok(RequireValue::Int(s.len() as i64)),
-                    Value::List(items) => Ok(RequireValue::Int(items.len() as i64)),
-                    Value::Map(map) => Ok(RequireValue::Int(map.len() as i64)),
+                    Value::Concrete(ConcreteValue::String(s)) => {
+                        Ok(RequireValue::Int(s.len() as i64))
+                    }
+                    Value::Concrete(ConcreteValue::List(items)) => {
+                        Ok(RequireValue::Int(items.len() as i64))
+                    }
+                    Value::Concrete(ConcreteValue::Map(map)) => {
+                        Ok(RequireValue::Int(map.len() as i64))
+                    }
                     _ => Err(format!(
                         "{}() argument must be a string, list, or map",
                         name

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -6,7 +6,7 @@ use super::error::ParseWarning;
 use super::expressions::for_expr::ForBinding;
 use super::expressions::validate_expr::CompareOp;
 use super::util::snake_to_pascal;
-use crate::resource::{Resource, ResourceId, UnknownReason, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, UnknownReason, Value};
 use crate::version_constraint::VersionConstraint;
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
@@ -101,7 +101,7 @@ pub enum TypeExpr {
     Int,
     Float,
     /// Time duration. Surface form: `<integer><unit>` literal (`75min`,
-    /// `1h`, `30s`); internal form: `Value::Duration(std::time::Duration)`.
+    /// `1h`, `30s`); internal form: `Value::Concrete(ConcreteValue::Duration(std::time::Duration))`.
     Duration,
     /// Schema type identified by name (e.g., "ipv4_cidr", "ipv4_address", "arn")
     Simple(std::string::String),
@@ -123,14 +123,14 @@ pub enum TypeExpr {
     ///
     /// Field order matches source order and participates in `PartialEq` —
     /// two struct types with the same fields in different order are not
-    /// equal. A `Value::Map` satisfies a struct type when every field
+    /// equal. A `Value::Concrete(ConcreteValue::Map)` satisfies a struct type when every field
     /// name appears as a key with a value that matches the field's type,
     /// with no extra keys.
     Struct {
         fields: Vec<(String, TypeExpr)>,
     },
     /// Singleton string literal type: `'dev'` accepts only the value
-    /// `Value::String("dev")` (carina-rs/carina#2611). Composes with
+    /// `Value::Concrete(ConcreteValue::String("dev"))` (carina-rs/carina#2611). Composes with
     /// [`TypeExpr::Union`] to produce closed-set string types like
     /// `'dev' | 'prod'`, and with [`TypeExpr::List`] / `Map` to nest
     /// (`list('dev' | 'prod')`).
@@ -645,7 +645,7 @@ impl<E> File<E> {
     ) -> Option<&Resource> {
         self.resources.iter().find(|r| {
             r.id.resource_type == resource_type
-                && matches!(r.get_attr(attr_name), Some(Value::String(n)) if n == attr_value)
+                && matches!(r.get_attr(attr_name), Some(Value::Concrete(ConcreteValue::String(n))) if n == attr_value)
         })
     }
 
@@ -692,7 +692,7 @@ impl<E> File<E> {
 
             match (&deferred.binding, iterable_value) {
                 // Simple binding: only the value var is bound
-                (ForBinding::Simple(_), Value::List(items)) => {
+                (ForBinding::Simple(_), Value::Concrete(ConcreteValue::List(items))) => {
                     for (i, item) in items.iter().enumerate() {
                         let address = format!("{}[{}]", deferred.binding_name, i);
                         let mut resource = deferred.template_resource.clone();
@@ -704,7 +704,7 @@ impl<E> File<E> {
                     resolved_indices.push(idx);
                 }
                 // Indexed binding: both index and value vars are bound
-                (ForBinding::Indexed(_, _), Value::List(items)) => {
+                (ForBinding::Indexed(_, _), Value::Concrete(ConcreteValue::List(items))) => {
                     for (i, item) in items.iter().enumerate() {
                         let address = format!("{}[{}]", deferred.binding_name, i);
                         let mut resource = deferred.template_resource.clone();
@@ -716,7 +716,7 @@ impl<E> File<E> {
                     resolved_indices.push(idx);
                 }
                 // Map binding expands over maps, substituting both key and value vars
-                (ForBinding::Map(_, _), Value::Map(map)) => {
+                (ForBinding::Map(_, _), Value::Concrete(ConcreteValue::Map(map))) => {
                     let mut keys: Vec<&String> = map.keys().collect();
                     keys.sort();
                     for key in keys {
@@ -732,7 +732,7 @@ impl<E> File<E> {
                 }
                 // Shape mismatch: replace the original "not yet available" warning
                 // with a specific shape-mismatch warning, leave entry deferred.
-                (ForBinding::Map(_, _), Value::List(_)) => {
+                (ForBinding::Map(_, _), Value::Concrete(ConcreteValue::List(_))) => {
                     mismatched_indices.push(idx);
                     new_warnings.push(ParseWarning {
                         file: deferred.file.clone(),
@@ -744,8 +744,8 @@ impl<E> File<E> {
                         ),
                     });
                 }
-                (ForBinding::Simple(_), Value::Map(_))
-                | (ForBinding::Indexed(_, _), Value::Map(_)) => {
+                (ForBinding::Simple(_), Value::Concrete(ConcreteValue::Map(_)))
+                | (ForBinding::Indexed(_, _), Value::Concrete(ConcreteValue::Map(_))) => {
                     mismatched_indices.push(idx);
                     new_warnings.push(ParseWarning {
                         file: deferred.file.clone(),
@@ -804,11 +804,11 @@ fn substitute_attrs(
 
 /// Substitute deferred-for-expression placeholders in a Value tree.
 ///
-/// Replaces `Value::Unknown(UnknownReason::ForValue)` with `value`. If
+/// Replaces `Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue))` with `value`. If
 /// `index` is supplied (indexed-binding expansion), replaces
-/// `Value::Unknown(UnknownReason::ForIndex)` with the integer index. If
+/// `Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex))` with the integer index. If
 /// `key` is supplied (map-binding expansion), replaces
-/// `Value::Unknown(UnknownReason::ForKey)` with the key string. Recurses
+/// `Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey))` with the key string. Recurses
 /// into all compound Value variants so placeholders nested inside
 /// interpolations / function calls / secrets are reached.
 ///
@@ -821,45 +821,45 @@ pub(super) fn substitute_placeholder(
     value: &Value,
 ) {
     match v {
-        Value::Unknown(UnknownReason::ForValue) => {
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)) => {
             *v = value.clone();
         }
-        Value::Unknown(UnknownReason::ForKey) => {
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)) => {
             if let Some(k) = key {
-                *v = Value::String(k.to_string());
+                *v = Value::Concrete(ConcreteValue::String(k.to_string()));
             }
         }
-        Value::Unknown(UnknownReason::ForIndex) => {
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex)) => {
             if let Some(i) = index {
-                *v = Value::Int(i);
+                *v = Value::Concrete(ConcreteValue::Int(i));
             }
         }
         // Explicit arm (not wildcard) so a new `UnknownReason` variant
         // forces a compile-error decision here.
-        Value::Unknown(UnknownReason::UpstreamRef { .. }) => {}
-        Value::List(items) => {
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { .. })) => {}
+        Value::Concrete(ConcreteValue::List(items)) => {
             for item in items.iter_mut() {
                 substitute_placeholder(item, index, key, value);
             }
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             for val in map.values_mut() {
                 substitute_placeholder(val, index, key, value);
             }
         }
-        Value::FunctionCall { args, .. } => {
+        Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
             for arg in args.iter_mut() {
                 substitute_placeholder(arg, index, key, value);
             }
         }
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             for part in parts.iter_mut() {
                 if let crate::resource::InterpolationPart::Expr(inner) = part {
                     substitute_placeholder(inner, index, key, value);
                 }
             }
         }
-        Value::Secret(inner) => {
+        Value::Deferred(DeferredValue::Secret(inner)) => {
             substitute_placeholder(inner, index, key, value);
         }
         _ => {}
@@ -869,74 +869,103 @@ pub(super) fn substitute_placeholder(
 #[cfg(test)]
 mod substitute_placeholder_tests {
     use super::*;
-    use crate::resource::{AccessPath, InterpolationPart, UnknownReason, Value};
+    use crate::resource::{
+        AccessPath, ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
+    };
 
     #[test]
     fn replaces_for_value_with_bound_value() {
-        let mut v = Value::Unknown(UnknownReason::ForValue);
-        substitute_placeholder(&mut v, None, None, &Value::String("acct-1".into()));
-        assert_eq!(v, Value::String("acct-1".into()));
+        let mut v = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue));
+        substitute_placeholder(
+            &mut v,
+            None,
+            None,
+            &Value::Concrete(ConcreteValue::String("acct-1".into())),
+        );
+        assert_eq!(v, Value::Concrete(ConcreteValue::String("acct-1".into())));
     }
 
     #[test]
     fn replaces_for_key_with_key_string() {
-        let mut v = Value::Unknown(UnknownReason::ForKey);
-        substitute_placeholder(&mut v, None, Some("east"), &Value::String("ignored".into()));
-        assert_eq!(v, Value::String("east".into()));
+        let mut v = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey));
+        substitute_placeholder(
+            &mut v,
+            None,
+            Some("east"),
+            &Value::Concrete(ConcreteValue::String("ignored".into())),
+        );
+        assert_eq!(v, Value::Concrete(ConcreteValue::String("east".into())));
     }
 
     #[test]
     fn replaces_for_index_with_integer_index() {
-        let mut v = Value::Unknown(UnknownReason::ForIndex);
-        substitute_placeholder(&mut v, Some(7), None, &Value::String("ignored".into()));
-        assert_eq!(v, Value::Int(7));
+        let mut v = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex));
+        substitute_placeholder(
+            &mut v,
+            Some(7),
+            None,
+            &Value::Concrete(ConcreteValue::String("ignored".into())),
+        );
+        assert_eq!(v, Value::Concrete(ConcreteValue::Int(7)));
     }
 
     #[test]
     fn leaves_upstream_ref_unchanged() {
         let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-        let mut v = Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+        let mut v = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+            path: path.clone(),
+        }));
         substitute_placeholder(
             &mut v,
             Some(0),
             Some("k"),
-            &Value::String("anything".into()),
+            &Value::Concrete(ConcreteValue::String("anything".into())),
         );
-        // `Value::Unknown` never compares equal (see `impl PartialEq for Value`),
+        // `Value::Deferred(DeferredValue::Unknown)` never compares equal (see `impl PartialEq for Value`),
         // so destructure to verify the path survives.
         match v {
-            Value::Unknown(UnknownReason::UpstreamRef { path: p }) => assert_eq!(p, path),
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path: p })) => {
+                assert_eq!(p, path)
+            }
             other => panic!("UpstreamRef must pass through unchanged, got {:?}", other),
         }
     }
 
     #[test]
     fn recurses_into_compound_values() {
-        let mut v = Value::List(vec![
-            Value::Unknown(UnknownReason::ForValue),
-            Value::Map({
+        let mut v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
+            Value::Concrete(ConcreteValue::Map({
                 let mut m = indexmap::IndexMap::new();
-                m.insert("k".into(), Value::Unknown(UnknownReason::ForValue));
+                m.insert(
+                    "k".into(),
+                    Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
+                );
                 m
-            }),
-            Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
-                UnknownReason::ForValue,
-            ))]),
-        ]);
-        substitute_placeholder(&mut v, None, None, &Value::String("X".into()));
+            })),
+            Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+                Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
+            )])),
+        ]));
+        substitute_placeholder(
+            &mut v,
+            None,
+            None,
+            &Value::Concrete(ConcreteValue::String("X".into())),
+        );
         match &v {
-            Value::List(items) => {
-                assert_eq!(items[0], Value::String("X".into()));
+            Value::Concrete(ConcreteValue::List(items)) => {
+                assert_eq!(items[0], Value::Concrete(ConcreteValue::String("X".into())));
                 match &items[1] {
-                    Value::Map(m) => {
-                        assert_eq!(m["k"], Value::String("X".into()));
+                    Value::Concrete(ConcreteValue::Map(m)) => {
+                        assert_eq!(m["k"], Value::Concrete(ConcreteValue::String("X".into())));
                     }
                     other => panic!("expected Map, got {:?}", other),
                 }
                 match &items[2] {
-                    Value::Interpolation(parts) => match &parts[0] {
+                    Value::Deferred(DeferredValue::Interpolation(parts)) => match &parts[0] {
                         InterpolationPart::Expr(inner) => {
-                            assert_eq!(*inner, Value::String("X".into()));
+                            assert_eq!(*inner, Value::Concrete(ConcreteValue::String("X".into())));
                         }
                         _ => panic!("expected Expr part"),
                     },
@@ -949,10 +978,18 @@ mod substitute_placeholder_tests {
 
     #[test]
     fn legacy_string_sentinel_is_no_longer_recognised() {
-        // Only `Value::Unknown(For*)` is substituted. A bare string that
+        // Only `Value::Deferred(DeferredValue::Unknown(For*))` is substituted. A bare string that
         // happens to match the historical sentinel must be left alone.
-        let mut v = Value::String("(known after upstream apply)".into());
-        substitute_placeholder(&mut v, None, None, &Value::String("X".into()));
-        assert_eq!(v, Value::String("(known after upstream apply)".into()));
+        let mut v = Value::Concrete(ConcreteValue::String("(known after upstream apply)".into()));
+        substitute_placeholder(
+            &mut v,
+            None,
+            None,
+            &Value::Concrete(ConcreteValue::String("X".into())),
+        );
+        assert_eq!(
+            v,
+            Value::Concrete(ConcreteValue::String("(known after upstream apply)".into()))
+        );
     }
 }

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -12,7 +12,7 @@ use crate::parser::expressions::string_literal::parse_string_value;
 use crate::parser::expressions::validate_expr::parse_validate_expr;
 use crate::parser::parse_expression;
 use crate::parser::types::parse_type_expr;
-use crate::resource::{Directives, Resource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Directives, Resource, Value};
 use indexmap::IndexMap;
 
 /// Parse arguments block. See `register_argument_binding` for the
@@ -53,7 +53,7 @@ pub(in crate::parser) fn parse_arguments_block(
                                     let string_pair =
                                         first_inner(inner_attr, "string", "arg_description_attr")?;
                                     let value = parse_string_value(string_pair, ctx)?;
-                                    if let Value::String(s) = value {
+                                    if let Value::Concrete(ConcreteValue::String(s)) = value {
                                         description = Some(s);
                                     }
                                 }
@@ -90,7 +90,10 @@ pub(in crate::parser) fn parse_arguments_block(
                                                     )?;
                                                     let value =
                                                         parse_string_value(string_pair, ctx)?;
-                                                    if let Value::String(s) = value {
+                                                    if let Value::Concrete(ConcreteValue::String(
+                                                        s,
+                                                    )) = value
+                                                    {
                                                         error_msg = Some(s);
                                                     }
                                                 }
@@ -142,9 +145,9 @@ pub(in crate::parser) fn parse_arguments_block(
 /// empty `attribute` would be a type-level lie — the same shape that
 /// produced the empty-field diagnostic in #2847.
 fn register_argument_binding(ctx: &mut ParseContext, name: &str) {
-    let placeholder_ref = Value::BindingRef {
+    let placeholder_ref = Value::Deferred(DeferredValue::BindingRef {
         binding: name.to_string(),
-    };
+    });
     ctx.set_variable(name.to_string(), placeholder_ref);
     let placeholder = Resource::new("_argument", name);
     ctx.set_resource_binding(name.to_string(), placeholder);
@@ -242,25 +245,35 @@ pub(in crate::parser) fn parse_exports_block(
 pub(in crate::parser) fn extract_directives(
     attributes: &mut IndexMap<String, Value>,
 ) -> Result<Directives, ParseError> {
-    if let Some(Value::List(blocks)) = attributes.shift_remove("directives") {
+    if let Some(Value::Concrete(ConcreteValue::List(blocks))) =
+        attributes.shift_remove("directives")
+    {
         // Take the first directives block (there should only be one)
-        if let Some(Value::Map(map)) = blocks.into_iter().next() {
-            let force_delete = matches!(map.get("force_delete"), Some(Value::Bool(true)));
-            let create_before_destroy =
-                matches!(map.get("create_before_destroy"), Some(Value::Bool(true)));
-            let prevent_destroy = matches!(map.get("prevent_destroy"), Some(Value::Bool(true)));
+        if let Some(Value::Concrete(ConcreteValue::Map(map))) = blocks.into_iter().next() {
+            let force_delete = matches!(
+                map.get("force_delete"),
+                Some(Value::Concrete(ConcreteValue::Bool(true)))
+            );
+            let create_before_destroy = matches!(
+                map.get("create_before_destroy"),
+                Some(Value::Concrete(ConcreteValue::Bool(true)))
+            );
+            let prevent_destroy = matches!(
+                map.get("prevent_destroy"),
+                Some(Value::Concrete(ConcreteValue::Bool(true)))
+            );
             let depends_on = match map.get("depends_on") {
                 None => Vec::new(),
-                Some(Value::List(items)) => {
+                Some(Value::Concrete(ConcreteValue::List(items))) => {
                     let mut names = Vec::with_capacity(items.len());
                     for item in items {
                         match item {
-                            Value::BindingRef { binding } => {
+                            Value::Deferred(DeferredValue::BindingRef { binding }) => {
                                 // Bare binding identifier — the canonical
                                 // shape after #2847.
                                 names.push(binding.clone());
                             }
-                            Value::ResourceRef { path } => {
+                            Value::Deferred(DeferredValue::ResourceRef { path }) => {
                                 // `binding.attr` — attribute selectors are
                                 // rejected in MVP (only bare bindings allowed).
                                 return Err(ParseError::InvalidExpression {
@@ -273,7 +286,7 @@ pub(in crate::parser) fn extract_directives(
                                     ),
                                 });
                             }
-                            Value::String(name) => {
+                            Value::Concrete(ConcreteValue::String(name)) => {
                                 // Pre-#2847 indirection marker `${name}`.
                                 // Quoted strings are rejected upstream in
                                 // `check_directives_depends_on_elements`.

--- a/carina-core/src/parser/blocks/provider.rs
+++ b/carina-core/src/parser/blocks/provider.rs
@@ -9,7 +9,7 @@ use crate::parser::context::{ParseContext, next_pair};
 use crate::parser::error::ParseError;
 use crate::parser::expressions::validate_expr::parse_validate_expr;
 use crate::parser::parse_expression;
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 use crate::version_constraint::VersionConstraint;
 use indexmap::IndexMap;
 
@@ -44,7 +44,7 @@ pub(in crate::parser) fn parse_provider_block(
     // fall through to an empty map (#2717).
     let mut unresolved_attributes: IndexMap<String, Value> = IndexMap::new();
     let default_tags = match attributes.shift_remove("default_tags") {
-        Some(Value::Map(tags)) => tags,
+        Some(Value::Concrete(ConcreteValue::Map(tags))) => tags,
         Some(other) => {
             unresolved_attributes.insert("default_tags".to_string(), other);
             IndexMap::new()
@@ -53,14 +53,18 @@ pub(in crate::parser) fn parse_provider_block(
     };
 
     // Extract source from attributes if present
-    let source = if let Some(Value::String(s)) = attributes.shift_remove("source") {
+    let source = if let Some(Value::Concrete(ConcreteValue::String(s))) =
+        attributes.shift_remove("source")
+    {
         Some(s)
     } else {
         None
     };
 
     // Extract version from attributes if present
-    let version = if let Some(Value::String(v)) = attributes.shift_remove("version") {
+    let version = if let Some(Value::Concrete(ConcreteValue::String(v))) =
+        attributes.shift_remove("version")
+    {
         Some(VersionConstraint::parse(&v).map_err(|e| {
             pest::error::Error::new_from_pos(
                 pest::error::ErrorVariant::CustomError { message: e },
@@ -72,7 +76,9 @@ pub(in crate::parser) fn parse_provider_block(
     };
 
     // Extract revision from attributes if present
-    let revision = if let Some(Value::String(r)) = attributes.shift_remove("revision") {
+    let revision = if let Some(Value::Concrete(ConcreteValue::String(r))) =
+        attributes.shift_remove("revision")
+    {
         Some(r)
     } else {
         None

--- a/carina-core/src/parser/blocks/resource.rs
+++ b/carina-core/src/parser/blocks/resource.rs
@@ -11,7 +11,7 @@ use crate::parser::context::{ParseContext, extract_key_string, first_inner, next
 use crate::parser::error::ParseError;
 use crate::parser::parse_expression;
 use crate::parser::util::expression_is_plain_string_literal;
-use crate::resource::{Resource, ResourceId, ResourceKind, Value};
+use crate::resource::{ConcreteValue, Resource, ResourceId, ResourceKind, Value};
 use indexmap::IndexMap;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -44,7 +44,10 @@ pub(in crate::parser) fn parse_anonymous_resource(
     let resource_name = String::new();
 
     let mut attributes = attributes;
-    attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
+    attributes.insert(
+        "_type".to_string(),
+        Value::Concrete(ConcreteValue::String(namespaced_type.clone())),
+    );
 
     // Extract directives block from attributes (it's a meta-argument, not a real attribute)
     let directives = extract_directives(&mut attributes)?;
@@ -87,7 +90,7 @@ pub(in crate::parser) fn parse_block_contents_with_quoted(
 ) -> Result<IndexMap<String, Value>, ParseError> {
     // `IndexMap` so the order in which the user wrote attributes in the
     // .crn file flows all the way to `Resource.attributes` and to
-    // `Value::Map` payloads — anything that re-renders attributes
+    // `Value::Concrete(ConcreteValue::Map)` payloads — anything that re-renders attributes
     // (formatter, plan display, diagnostics) sees a stable order.
     let mut attributes: IndexMap<String, Value> = IndexMap::new();
     let mut nested_blocks: IndexMap<String, Vec<Value>> = IndexMap::new();
@@ -138,7 +141,7 @@ pub(in crate::parser) fn parse_block_contents_with_quoted(
                         nested_blocks
                             .entry(block_name)
                             .or_default()
-                            .push(Value::Map(block_attrs));
+                            .push(Value::Concrete(ConcreteValue::Map(block_attrs)));
                     }
                     _ => {}
                 }
@@ -158,7 +161,7 @@ pub(in crate::parser) fn parse_block_contents_with_quoted(
 
     // Convert nested blocks to list attributes
     for (name, blocks) in nested_blocks {
-        attributes.insert(name, Value::List(blocks));
+        attributes.insert(name, Value::Concrete(ConcreteValue::List(blocks)));
     }
 
     Ok(attributes)
@@ -210,7 +213,10 @@ pub(crate) fn parse_resource_expr(
     // Extract directives block from attributes (it's a meta-argument, not a real attribute)
     let directives = extract_directives(&mut attributes)?;
 
-    attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
+    attributes.insert(
+        "_type".to_string(),
+        Value::Concrete(ConcreteValue::String(namespaced_type.clone())),
+    );
 
     let id = ResourceId::with_provider(provider, resource_type, resource_name);
 
@@ -259,7 +265,10 @@ pub(crate) fn parse_read_resource_expr(
     // Extract directives block from attributes (it's a meta-argument, not a real attribute)
     let directives = extract_directives(&mut attributes)?;
 
-    attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
+    attributes.insert(
+        "_type".to_string(),
+        Value::Concrete(ConcreteValue::String(namespaced_type.clone())),
+    );
 
     let id = ResourceId::with_provider(provider, resource_type, resource_name);
 

--- a/carina-core/src/parser/blocks/use_stmt.rs
+++ b/carina-core/src/parser/blocks/use_stmt.rs
@@ -7,7 +7,7 @@ use crate::parser::ast::UseStatement;
 use crate::parser::context::{ParseContext, next_pair};
 use crate::parser::error::ParseError;
 use crate::parser::parse_expression;
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 /// Parse import expression (RHS of `let name = use { source = "path" }`)
 pub(in crate::parser) fn parse_use_expr(
@@ -37,7 +37,7 @@ pub(in crate::parser) fn parse_use_expr(
             });
         }
         let value = parse_expression(value_pair, ctx)?;
-        let Value::String(path) = value else {
+        let Value::Concrete(ConcreteValue::String(path)) = value else {
             return Err(ParseError::InvalidExpression {
                 line: attr_line,
                 message: "`use` block `source` must be a string literal".to_string(),

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -27,7 +27,7 @@ use super::resolve::{
     resolve_resource_refs,
 };
 use crate::eval_value::EvalValue;
-use crate::resource::{Resource, Value};
+use crate::resource::{DeferredValue, Resource, Value};
 use indexmap::IndexMap;
 use pest::Parser;
 
@@ -52,7 +52,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
 ///
 /// Each name in `seeds` is registered in the per-file [`ParseContext`]
 /// the same way `register_argument_binding` does: a placeholder
-/// `Value::ResourceRef { binding: <name>, attribute: "", … }` is
+/// `Value::Deferred(DeferredValue::ResourceRef{ binding: <name>, attribute: "", … })` is
 /// installed in `ctx.variables`, and a placeholder `Resource` is
 /// installed in `ctx.resource_bindings`. This means subsequent
 /// expressions resolve the name via the normal `ctx.get_variable` /
@@ -380,11 +380,11 @@ pub fn parse_with_seeded_bindings(
 /// the same `ctx.get_variable` / `ctx.is_resource_binding` paths that
 /// locally-declared `let` / `arguments` names use after parsing.
 ///
-/// Each seed is installed as a [`Value::BindingRef`] — a bare-binding
+/// Each seed is installed as a [`Value::Deferred(DeferredValue::BindingRef)`] — a bare-binding
 /// reference with no attribute slot. This is intentional: a seed
 /// represents "a name exists in scope; we know nothing more about it".
 /// When a downstream expression accesses `name.attr`, the parser
-/// composes a fresh [`Value::ResourceRef`] with the real attribute
+/// composes a fresh [`Value::Deferred(DeferredValue::ResourceRef)`] with the real attribute
 /// instead of mutating the seed. Storing the seed as `ResourceRef`
 /// with an empty `attribute` field would be a type-level lie and
 /// previously surfaced as the empty-field diagnostic in #2847.
@@ -393,9 +393,9 @@ pub fn parse_with_seeded_bindings(
 /// `parse(input, config)` wrapper, parser tests) pay no cost.
 fn seed_bindings(ctx: &mut ParseContext<'_>, seeds: &[&str]) {
     for &name in seeds {
-        let placeholder_ref = Value::BindingRef {
+        let placeholder_ref = Value::Deferred(DeferredValue::BindingRef {
             binding: name.to_string(),
-        };
+        });
         ctx.set_variable(name.to_string(), placeholder_ref);
         let placeholder = Resource::new("_seeded", name);
         ctx.set_resource_binding(name.to_string(), placeholder);

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -13,7 +13,7 @@ use crate::parser::{
     evaluate_static_value, first_inner, next_pair, parse_expression, parse_module_call,
     parse_read_resource_expr, parse_resource_expr,
 };
-use crate::resource::{Resource, UnknownReason, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, UnknownReason, Value};
 
 /// Binding pattern for a for expression
 #[derive(Debug, Clone, PartialEq)]
@@ -64,7 +64,7 @@ fn identifier_appears_in(text: &str, name: &str) -> bool {
 
 /// Whether `s` is shaped like a bare Carina identifier — the first byte is
 /// `A-Za-z_` and the rest are `A-Za-z0-9_`. Used to recover from the
-/// parser's collapse of unresolved identifiers into `Value::String(s)`
+/// parser's collapse of unresolved identifiers into `Value::Concrete(ConcreteValue::String(s))`
 /// when we need to decide whether to render an error as "identifier" vs
 /// "string literal". See #2101.
 fn is_bare_identifier(s: &str) -> bool {
@@ -180,7 +180,7 @@ pub(crate) fn parse_for_expr(
 
     // Expand based on iterable type
     match (&binding, &iterable) {
-        (ForBinding::Simple(var), Value::List(items)) => {
+        (ForBinding::Simple(var), Value::Concrete(ConcreteValue::List(items))) => {
             for (i, item) in items.iter().enumerate() {
                 let address = format!("{}[{}]", binding_name, i);
                 let mut iter_ctx = ctx.clone();
@@ -189,17 +189,21 @@ pub(crate) fn parse_for_expr(
                 collect(result, &mut resources, &mut module_calls);
             }
         }
-        (ForBinding::Indexed(idx_var, val_var), Value::List(items)) => {
+        (ForBinding::Indexed(idx_var, val_var), Value::Concrete(ConcreteValue::List(items))) => {
             for (i, item) in items.iter().enumerate() {
                 let address = format!("{}[{}]", binding_name, i);
                 let mut iter_ctx = ctx.clone();
-                bind(&mut iter_ctx, idx_var, Value::Int(i as i64));
+                bind(
+                    &mut iter_ctx,
+                    idx_var,
+                    Value::Concrete(ConcreteValue::Int(i as i64)),
+                );
                 bind(&mut iter_ctx, val_var, item.clone());
                 let result = parse_for_body(body_pair.clone(), &iter_ctx, &address)?;
                 collect(result, &mut resources, &mut module_calls);
             }
         }
-        (ForBinding::Map(key_var, val_var), Value::Map(map)) => {
+        (ForBinding::Map(key_var, val_var), Value::Concrete(ConcreteValue::Map(map))) => {
             // Sort keys for deterministic output
             let mut keys: Vec<&String> = map.keys().collect();
             keys.sort();
@@ -207,7 +211,11 @@ pub(crate) fn parse_for_expr(
                 let val = &map[key];
                 let address = crate::utils::map_key_address(binding_name, key);
                 let mut iter_ctx = ctx.clone();
-                bind(&mut iter_ctx, key_var, Value::String(key.clone()));
+                bind(
+                    &mut iter_ctx,
+                    key_var,
+                    Value::Concrete(ConcreteValue::String(key.clone())),
+                );
                 bind(&mut iter_ctx, val_var, val.clone());
                 let result = parse_for_body(body_pair.clone(), &iter_ctx, &address)?;
                 collect(result, &mut resources, &mut module_calls);
@@ -218,7 +226,7 @@ pub(crate) fn parse_for_expr(
         // by `upstream_exports::check_upstream_state_field_references`; for
         // a valid field the deferral is an implementation detail the user
         // doesn't need to hear about at validate time.
-        (_, Value::ResourceRef { path }) => {
+        (_, Value::Deferred(DeferredValue::ResourceRef { path })) => {
             // Build the for-expression header string
             let header = match &binding {
                 ForBinding::Simple(var) => {
@@ -235,7 +243,7 @@ pub(crate) fn parse_for_expr(
             // Try to parse the body once with placeholder values for the loop
             // variable(s) to extract the resource type and attribute template.
             let mut template_ctx = ctx.clone();
-            let placeholder = || Value::Unknown(UnknownReason::ForValue);
+            let placeholder = || Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue));
             let bind = |c: &mut ParseContext, name: &str, v: Value| {
                 if name != "_" {
                     c.set_variable(name.to_string(), v);
@@ -249,12 +257,16 @@ pub(crate) fn parse_for_expr(
                     bind(
                         &mut template_ctx,
                         idx,
-                        Value::Unknown(UnknownReason::ForIndex),
+                        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex)),
                     );
                     bind(&mut template_ctx, val, placeholder());
                 }
                 ForBinding::Map(k, v) => {
-                    bind(&mut template_ctx, k, Value::Unknown(UnknownReason::ForKey));
+                    bind(
+                        &mut template_ctx,
+                        k,
+                        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)),
+                    );
                     bind(&mut template_ctx, v, placeholder());
                 }
             }
@@ -290,7 +302,7 @@ pub(crate) fn parse_for_expr(
         }
         _ => {
             // Special case: the parser collapses bare unresolved identifiers
-            // (e.g. `for _ in org { ... }`) into `Value::String("org")` — the
+            // (e.g. `for _ in org { ... }`) into `Value::Concrete(ConcreteValue::String("org"))` — the
             // same slot a quoted literal uses. Reporting those as
             // `iterable is string "org"` is misleading: the user wrote an
             // identifier, not a literal, and the likely fault is a typo for
@@ -300,7 +312,7 @@ pub(crate) fn parse_for_expr(
             // module bindings are visible) can emit a proper
             // UndefinedIdentifier with the did-you-mean machinery from
             // #2038 / #2100. See #2101 / #2138.
-            if let Value::String(s) = &iterable
+            if let Value::Concrete(ConcreteValue::String(s)) = &iterable
                 && is_bare_identifier(s)
             {
                 let header = match &binding {
@@ -309,7 +321,8 @@ pub(crate) fn parse_for_expr(
                     ForBinding::Map(k, v) => format!("for {}, {} in {}", k, v, s),
                 };
                 let mut template_ctx = ctx.clone();
-                let placeholder = || Value::Unknown(UnknownReason::ForValue);
+                let placeholder =
+                    || Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue));
                 let bind = |c: &mut ParseContext, name: &str, v: Value| {
                     if name != "_" {
                         c.set_variable(name.to_string(), v);
@@ -323,12 +336,16 @@ pub(crate) fn parse_for_expr(
                         bind(
                             &mut template_ctx,
                             idx,
-                            Value::Unknown(UnknownReason::ForIndex),
+                            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex)),
                         );
                         bind(&mut template_ctx, val, placeholder());
                     }
                     ForBinding::Map(k, v) => {
-                        bind(&mut template_ctx, k, Value::Unknown(UnknownReason::ForKey));
+                        bind(
+                            &mut template_ctx,
+                            k,
+                            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)),
+                        );
                         bind(&mut template_ctx, v, placeholder());
                     }
                 }
@@ -362,18 +379,20 @@ pub(crate) fn parse_for_expr(
                 return Ok((resources, module_calls));
             }
             let iterable_type = match &iterable {
-                Value::String(s) => {
+                Value::Concrete(ConcreteValue::String(s)) => {
                     format!("string \"{}\"", if s.len() > 50 { &s[..50] } else { s })
                 }
-                Value::Int(i) => format!("int {}", i),
-                Value::Float(f) => format!("float {}", f),
-                Value::Bool(b) => format!("bool {}", b),
-                Value::Duration(d) => format!("duration {}", crate::value::render_duration(*d)),
-                Value::ResourceRef { path } => {
+                Value::Concrete(ConcreteValue::Int(i)) => format!("int {}", i),
+                Value::Concrete(ConcreteValue::Float(f)) => format!("float {}", f),
+                Value::Concrete(ConcreteValue::Bool(b)) => format!("bool {}", b),
+                Value::Concrete(ConcreteValue::Duration(d)) => {
+                    format!("duration {}", crate::value::render_duration(*d))
+                }
+                Value::Deferred(DeferredValue::ResourceRef { path }) => {
                     format!("unresolved reference {}", path.to_dot_string())
                 }
-                Value::List(_) => "list".to_string(),
-                Value::Map(_) => "map".to_string(),
+                Value::Concrete(ConcreteValue::List(_)) => "list".to_string(),
+                Value::Concrete(ConcreteValue::Map(_)) => "map".to_string(),
                 other => format!("{:?}", other),
             };
             let binding_type = match &binding {

--- a/carina-core/src/parser/expressions/if_expr.rs
+++ b/carina-core/src/parser/expressions/if_expr.rs
@@ -15,7 +15,7 @@ use crate::parser::{
     is_static_value, next_pair, parse_expression, parse_module_call, parse_read_resource_expr,
     parse_resource_expr,
 };
-use crate::resource::{Resource, Value};
+use crate::resource::{ConcreteValue, Resource, Value};
 
 /// Result of parsing an if expression body: a resource, a module call, or a value
 pub(crate) enum IfBodyResult {
@@ -55,7 +55,7 @@ pub(crate) fn parse_if_expr(
 
     // Condition must be a Bool
     let condition = match &condition_value {
-        Value::Bool(b) => *b,
+        Value::Concrete(ConcreteValue::Bool(b)) => *b,
         other => {
             return Err(ParseError::InvalidExpression {
                 line: 0,
@@ -79,7 +79,7 @@ pub(crate) fn parse_if_expr(
         parse_if_body_to_rhs(else_body, ctx, binding_name)
     } else {
         // No else clause and condition is false: produce nothing
-        let ref_value = Value::String(format!("${{if:{}}}", binding_name));
+        let ref_value = Value::Concrete(ConcreteValue::String(format!("${{if:{}}}", binding_name)));
         Ok((EvalValue::from_value(ref_value), vec![], vec![], None))
     }
 }
@@ -93,11 +93,15 @@ pub(crate) fn parse_if_body_to_rhs(
     let result = parse_if_body(pair, ctx, binding_name)?;
     match result {
         IfBodyResult::Resource(r) => {
-            let ref_value = Value::String(format!("${{{}}}", binding_name));
+            let ref_value =
+                Value::Concrete(ConcreteValue::String(format!("${{{}}}", binding_name)));
             Ok((EvalValue::from_value(ref_value), vec![*r], vec![], None))
         }
         IfBodyResult::ModuleCall(c) => {
-            let value = Value::String(format!("${{module:{}}}", c.module_name));
+            let value = Value::Concrete(ConcreteValue::String(format!(
+                "${{module:{}}}",
+                c.module_name
+            )));
             Ok((EvalValue::from_value(value), vec![], vec![c], None))
         }
         IfBodyResult::Value(v) => Ok((EvalValue::from_value(v), vec![], vec![], None)),
@@ -181,7 +185,7 @@ pub(crate) fn parse_if_value_expr(
 
     // Condition must be a Bool
     let condition = match &condition_value {
-        Value::Bool(b) => *b,
+        Value::Concrete(ConcreteValue::Bool(b)) => *b,
         other => {
             return Err(ParseError::InvalidExpression {
                 line: 0,

--- a/carina-core/src/parser/expressions/pipe.rs
+++ b/carina-core/src/parser/expressions/pipe.rs
@@ -12,7 +12,7 @@ use crate::parser::{
     ParseContext, ParseError, Rule, eval_type_name, evaluate_user_function, is_static_eval,
     is_static_value, next_pair, parse_expression,
 };
-use crate::resource::Value;
+use crate::resource::{DeferredValue, Value};
 
 pub(crate) fn parse_coalesce_expr(
     pair: pest::iterators::Pair<Rule>,
@@ -26,7 +26,7 @@ pub(crate) fn parse_coalesce_expr(
     if let Some(rhs_pair) = inner.next() {
         let default = parse_pipe_expr(rhs_pair, ctx)?;
         match &value {
-            EvalValue::User(Value::ResourceRef { .. }) => Ok(default),
+            EvalValue::User(Value::Deferred(DeferredValue::ResourceRef { .. })) => Ok(default),
             _ => Ok(value),
         }
     } else {
@@ -179,16 +179,16 @@ pub(crate) fn parse_pipe_expr(
                     message: format!("{}(): {}", func_name, e),
                 })?;
             } else {
-                value = EvalValue::from_value(Value::FunctionCall {
+                value = EvalValue::from_value(Value::Deferred(DeferredValue::FunctionCall {
                     name: func_name,
                     args,
-                });
+                }));
             }
         } else {
-            value = EvalValue::from_value(Value::FunctionCall {
+            value = EvalValue::from_value(Value::Deferred(DeferredValue::FunctionCall {
                 name: func_name,
                 args,
-            });
+            }));
         }
     }
 

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -12,7 +12,7 @@ use crate::parser::{
     ParseContext, ParseError, Rule, evaluate_user_function, extract_key_string, first_inner,
     is_static_value, next_pair, parse_block_contents, parse_expression, parse_expression_eval,
 };
-use crate::resource::{AccessPath, Subscript, Value};
+use crate::resource::{AccessPath, ConcreteValue, DeferredValue, Subscript, Value};
 use indexmap::IndexMap;
 
 /// Decode a duration literal (`75min`, `1h`, `30s`) into integer
@@ -59,7 +59,9 @@ pub(crate) fn parse_duration_secs(src: &str, line: usize) -> Result<u64, ParseEr
 
 pub(crate) fn parse_duration_literal(src: &str, line: usize) -> Result<Value, ParseError> {
     let secs = parse_duration_secs(src, line)?;
-    Ok(Value::Duration(std::time::Duration::from_secs(secs)))
+    Ok(Value::Concrete(ConcreteValue::Duration(
+        std::time::Duration::from_secs(secs),
+    )))
 }
 
 /// Convert an index-expression value into a `Subscript`. Only
@@ -70,12 +72,12 @@ pub(crate) fn parse_duration_literal(src: &str, line: usize) -> Result<Value, Pa
 /// resolver silently fall back to the unresolved ref.
 fn subscript_from_value(value: Value) -> Result<Subscript, ParseError> {
     match value {
-        Value::Int(n) if n < 0 => Err(ParseError::InvalidExpression {
+        Value::Concrete(ConcreteValue::Int(n)) if n < 0 => Err(ParseError::InvalidExpression {
             line: 0,
             message: format!("index access key must be non-negative, got {}", n),
         }),
-        Value::Int(n) => Ok(Subscript::Int { index: n }),
-        Value::String(s) => Ok(Subscript::Str { key: s }),
+        Value::Concrete(ConcreteValue::Int(n)) => Ok(Subscript::Int { index: n }),
+        Value::Concrete(ConcreteValue::String(s)) => Ok(Subscript::Str { key: s }),
         other => Err(ParseError::InvalidExpression {
             line: 0,
             message: format!(
@@ -113,7 +115,7 @@ fn parse_namespaced_id_value(
             parts[2..].iter().map(|s| s.to_string()).collect(),
             subscripts,
         );
-        EvalValue::from_value(Value::ResourceRef { path })
+        EvalValue::from_value(Value::Deferred(DeferredValue::ResourceRef { path }))
     };
 
     if ctx.is_resource_binding(parts[0]) {
@@ -131,7 +133,7 @@ fn parse_namespaced_id_value(
     // directly. This branch retained as a safety net for the truly-
     // undefined identifier path (typos, mid-edit references in the LSP
     // single-file fallback parses) — without it, an unknown subscripted
-    // ID would fall through to the enum-shorthand `Value::String`
+    // ID would fall through to the enum-shorthand `Value::Concrete(ConcreteValue::String)`
     // fallback below and silently mistype as a string. Originally added
     // for #2435.
     if !subscripts.is_empty() {
@@ -165,7 +167,9 @@ fn parse_namespaced_id_value(
         return Ok(as_resource_ref(Vec::new()));
     }
 
-    Ok(EvalValue::from_value(Value::String(full_str.to_string())))
+    Ok(EvalValue::from_value(Value::Concrete(
+        ConcreteValue::String(full_str.to_string()),
+    )))
 }
 
 pub(crate) fn parse_primary_eval(
@@ -192,7 +196,9 @@ pub(crate) fn parse_primary_eval(
                 .into_inner()
                 .map(|item| parse_expression(item, ctx))
                 .collect();
-            Ok(EvalValue::from_value(Value::List(items?)))
+            Ok(EvalValue::from_value(Value::Concrete(ConcreteValue::List(
+                items?,
+            ))))
         }
         Rule::map => {
             let mut map: IndexMap<String, Value> = IndexMap::new();
@@ -219,15 +225,17 @@ pub(crate) fn parse_primary_eval(
                         nested_blocks
                             .entry(block_name)
                             .or_default()
-                            .push(Value::Map(block_attrs));
+                            .push(Value::Concrete(ConcreteValue::Map(block_attrs)));
                     }
                     _ => {}
                 }
             }
             for (name, blocks) in nested_blocks {
-                map.insert(name, Value::List(blocks));
+                map.insert(name, Value::Concrete(ConcreteValue::List(blocks)));
             }
-            Ok(EvalValue::from_value(Value::Map(map)))
+            Ok(EvalValue::from_value(Value::Concrete(ConcreteValue::Map(
+                map,
+            ))))
         }
         Rule::namespaced_id => parse_namespaced_id_value(inner, ctx, Vec::new()),
         Rule::subscripted_id => {
@@ -251,7 +259,9 @@ pub(crate) fn parse_primary_eval(
         }
         Rule::boolean => {
             let b = inner.as_str() == "true";
-            Ok(EvalValue::from_value(Value::Bool(b)))
+            Ok(EvalValue::from_value(Value::Concrete(ConcreteValue::Bool(
+                b,
+            ))))
         }
         Rule::float => {
             let f: f64 = inner
@@ -261,7 +271,9 @@ pub(crate) fn parse_primary_eval(
                     line: inner.line_col().0,
                     message: format!("invalid float literal: {e}"),
                 })?;
-            Ok(EvalValue::from_value(Value::Float(f)))
+            Ok(EvalValue::from_value(Value::Concrete(
+                ConcreteValue::Float(f),
+            )))
         }
         Rule::number => {
             let n: i64 = inner
@@ -271,7 +283,9 @@ pub(crate) fn parse_primary_eval(
                     line: inner.line_col().0,
                     message: format!("integer literal out of range: {e}"),
                 })?;
-            Ok(EvalValue::from_value(Value::Int(n)))
+            Ok(EvalValue::from_value(Value::Concrete(ConcreteValue::Int(
+                n,
+            ))))
         }
         Rule::duration_literal => {
             let line = inner.line_col().0;
@@ -333,10 +347,12 @@ pub(crate) fn parse_primary_eval(
                 });
             }
 
-            Ok(EvalValue::from_value(Value::FunctionCall {
-                name: func_name,
-                args,
-            }))
+            Ok(EvalValue::from_value(Value::Deferred(
+                DeferredValue::FunctionCall {
+                    name: func_name,
+                    args,
+                },
+            )))
         }
         Rule::variable_ref => {
             // variable_ref = { identifier ~ (field_access | index_access)* }
@@ -352,8 +368,8 @@ pub(crate) fn parse_primary_eval(
                 // Simple variable reference (no access chain)
                 match ctx.get_variable(first_ident) {
                     Some(val) => Ok(val.clone()),
-                    None => Ok(EvalValue::from_value(Value::String(
-                        first_ident.to_string(),
+                    None => Ok(EvalValue::from_value(Value::Concrete(
+                        ConcreteValue::String(first_ident.to_string()),
                     ))),
                 }
             } else {
@@ -436,9 +452,11 @@ pub(crate) fn parse_primary_eval(
                     // unrepresentable.
                     match ctx.get_variable(&binding_name) {
                         Some(val) => Ok(val.clone()),
-                        None => Ok(EvalValue::from_value(Value::BindingRef {
-                            binding: binding_name,
-                        })),
+                        None => Ok(EvalValue::from_value(Value::Deferred(
+                            DeferredValue::BindingRef {
+                                binding: binding_name,
+                            },
+                        ))),
                     }
                 } else {
                     let attribute_name = field_names.remove(0);
@@ -448,14 +466,16 @@ pub(crate) fn parse_primary_eval(
                         field_names,
                         subscripts,
                     );
-                    Ok(EvalValue::from_value(Value::ResourceRef { path }))
+                    Ok(EvalValue::from_value(Value::Deferred(
+                        DeferredValue::ResourceRef { path },
+                    )))
                 }
             }
         }
         Rule::if_expr => parse_if_value_expr(inner, ctx).map(EvalValue::from_value),
         Rule::expression => parse_expression_eval(inner, ctx),
-        _ => Ok(EvalValue::from_value(Value::String(
-            inner.as_str().to_string(),
+        _ => Ok(EvalValue::from_value(Value::Concrete(
+            ConcreteValue::String(inner.as_str().to_string()),
         ))),
     }
 }

--- a/carina-core/src/parser/expressions/string_literal.rs
+++ b/carina-core/src/parser/expressions/string_literal.rs
@@ -4,7 +4,7 @@
 //! (interpolated) string forms, plus the related unescape routines.
 
 use crate::parser::{ParseContext, ParseError, Rule, first_inner, parse_expression};
-use crate::resource::{InterpolationPart, UnknownReason, Value};
+use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value};
 
 pub(crate) fn parse_string_literal(
     pair: pest::iterators::Pair<Rule>,
@@ -48,7 +48,7 @@ pub(crate) fn parse_string_value(
             .next()
             .map(|p| unescape_single_quoted(p.as_str()))
             .unwrap_or_default();
-        return Ok(Value::String(content));
+        return Ok(Value::Concrete(ConcreteValue::String(content)));
     }
 
     // Double-quoted string (original behavior)
@@ -67,12 +67,14 @@ pub(crate) fn parse_string_value(
                     has_interpolation = true;
                     // Grammar makes the inner expression optional so
                     // mid-edit `${}` doesn't poison the AST. An empty
-                    // interpolation lands as `Value::Unknown(EmptyInterpolation)`
+                    // interpolation lands as `Value::Deferred(DeferredValue::Unknown(EmptyInterpolation))`
                     // — the LSP surfaces it as a diagnostic; downstream
                     // resolvers carry it as an unresolved value. See #2480.
                     let value = match inner.into_inner().next() {
                         Some(expr_pair) => parse_expression(expr_pair, ctx)?,
-                        None => Value::Unknown(UnknownReason::EmptyInterpolation),
+                        None => Value::Deferred(DeferredValue::Unknown(
+                            UnknownReason::EmptyInterpolation,
+                        )),
                     };
                     parts.push(InterpolationPart::Expr(value));
                 }
@@ -85,11 +87,11 @@ pub(crate) fn parse_string_value(
         // Deliberately do *not* call `Value::canonicalize` here. The
         // deferred-for placeholder substitution in
         // `parser/ast.rs::substitute_placeholder` walks the `Expr`
-        // parts to replace `Value::Unknown(For*)` placeholders with the
+        // parts to replace `Value::Deferred(DeferredValue::Unknown(For*))` placeholders with the
         // resolved iterable element, so the parts must stay intact
         // through parse → for-expansion. Canonicalization runs later,
         // after resolution (see #2227).
-        Ok(Value::Interpolation(parts))
+        Ok(Value::Deferred(DeferredValue::Interpolation(parts)))
     } else {
         // No interpolation — collapse to a plain String
         let s = parts
@@ -99,7 +101,7 @@ pub(crate) fn parse_string_value(
                 _ => unreachable!(),
             })
             .collect::<String>();
-        Ok(Value::String(s))
+        Ok(Value::Concrete(ConcreteValue::String(s)))
     }
 }
 

--- a/carina-core/src/parser/expressions/wait_expr.rs
+++ b/carina-core/src/parser/expressions/wait_expr.rs
@@ -7,7 +7,7 @@ use super::primary::parse_duration_secs;
 use crate::parser::ast::{UntilPredicateAst, WaitBinding};
 use crate::parser::error::ParseError;
 use crate::parser::{Rule, first_inner};
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 use pest::iterators::Pair;
 
 /// Parse a `wait` expression into a [`WaitBinding`].
@@ -288,7 +288,9 @@ fn lower_until_rhs(pair: Pair<'_, Rule>, line: usize) -> Result<Value, ParseErro
                     message: "`until`: malformed string literal".to_string(),
                 });
             }
-            Ok(Value::String(raw[1..raw.len() - 1].to_string()))
+            Ok(Value::Concrete(ConcreteValue::String(
+                raw[1..raw.len() - 1].to_string(),
+            )))
         }
         Rule::number => {
             let n: i64 = primary
@@ -298,7 +300,7 @@ fn lower_until_rhs(pair: Pair<'_, Rule>, line: usize) -> Result<Value, ParseErro
                     line,
                     message: format!("`until`: invalid integer: {}", e),
                 })?;
-            Ok(Value::Int(n))
+            Ok(Value::Concrete(ConcreteValue::Int(n)))
         }
         Rule::float => {
             let f: f64 = primary
@@ -308,12 +310,16 @@ fn lower_until_rhs(pair: Pair<'_, Rule>, line: usize) -> Result<Value, ParseErro
                     line,
                     message: format!("`until`: invalid float: {}", e),
                 })?;
-            Ok(Value::Float(f))
+            Ok(Value::Concrete(ConcreteValue::Float(f)))
         }
-        Rule::boolean => Ok(Value::Bool(primary.as_str() == "true")),
+        Rule::boolean => Ok(Value::Concrete(ConcreteValue::Bool(
+            primary.as_str() == "true",
+        ))),
         Rule::duration_literal => {
             let secs = parse_duration_secs(primary.as_str(), line)?;
-            Ok(Value::Duration(std::time::Duration::from_secs(secs)))
+            Ok(Value::Concrete(ConcreteValue::Duration(
+                std::time::Duration::from_secs(secs),
+            )))
         }
         Rule::variable_ref => {
             // Treat dotted variable refs as namespaced enum identifiers
@@ -346,7 +352,7 @@ fn lower_until_rhs(pair: Pair<'_, Rule>, line: usize) -> Result<Value, ParseErro
             // wrote it; the differ's enum-resolution pass converts it to
             // the AWS canonical value when the target attribute is
             // declared as an enum.
-            Ok(Value::String(segments.join(".")))
+            Ok(Value::Concrete(ConcreteValue::String(segments.join("."))))
         }
         Rule::null_literal => Err(ParseError::InvalidExpression {
             line,
@@ -391,7 +397,9 @@ mod tests {
         assert_eq!(we.until_predicate.lhs_segments, vec!["cert", "status"]);
         assert_eq!(
             we.until_predicate.rhs,
-            Value::String("aws.acm.Certificate.Status.Issued".to_string())
+            Value::Concrete(ConcreteValue::String(
+                "aws.acm.Certificate.Status.Issued".to_string()
+            ))
         );
         assert!(we.timeout_secs.is_none());
         assert!(we.depends_on.is_empty());
@@ -400,19 +408,28 @@ mod tests {
     #[test]
     fn parses_string_rhs() {
         let we = parse_one("wait cert {\n    until = cert.status == \"ISSUED\"\n}");
-        assert_eq!(we.until_predicate.rhs, Value::String("ISSUED".to_string()));
+        assert_eq!(
+            we.until_predicate.rhs,
+            Value::Concrete(ConcreteValue::String("ISSUED".to_string()))
+        );
     }
 
     #[test]
     fn parses_int_rhs() {
         let we = parse_one("wait job {\n    until = job.completed_steps == 10\n}");
-        assert_eq!(we.until_predicate.rhs, Value::Int(10));
+        assert_eq!(
+            we.until_predicate.rhs,
+            Value::Concrete(ConcreteValue::Int(10))
+        );
     }
 
     #[test]
     fn parses_bool_rhs() {
         let we = parse_one("wait flag {\n    until = flag.enabled == true\n}");
-        assert_eq!(we.until_predicate.rhs, Value::Bool(true));
+        assert_eq!(
+            we.until_predicate.rhs,
+            Value::Concrete(ConcreteValue::Bool(true))
+        );
     }
 
     #[test]

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -9,7 +9,7 @@ use super::types::parse_type_expr;
 use super::util::{pascal_to_snake, value_type_name};
 use super::{ProviderContext, Rule, parse_expression};
 use crate::eval_value::EvalValue;
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 use crate::schema::{
     validate_ipv4_address, validate_ipv4_cidr, validate_ipv6_address, validate_ipv6_cidr,
 };
@@ -90,7 +90,7 @@ pub(super) fn parse_fn_def(
     for p in &params {
         body_ctx.set_variable(
             p.name.clone(),
-            Value::String(format!("__fn_param_{}", p.name)),
+            Value::Concrete(ConcreteValue::String(format!("__fn_param_{}", p.name))),
         );
     }
 
@@ -107,7 +107,7 @@ pub(super) fn parse_fn_def(
                 )?;
                 body_ctx.set_variable(
                     let_name.clone(),
-                    Value::String(format!("__fn_local_{let_name}")),
+                    Value::Concrete(ConcreteValue::String(format!("__fn_local_{let_name}"))),
                 );
                 local_lets.push((let_name, let_expr));
             }
@@ -220,15 +220,15 @@ pub fn validate_custom_type(
     config: &ProviderContext,
 ) -> Result<(), String> {
     match (type_name, value) {
-        ("ipv4_cidr", Value::String(s)) => validate_ipv4_cidr(s),
-        ("ipv4_address", Value::String(s)) => validate_ipv4_address(s),
-        ("ipv6_cidr", Value::String(s)) => validate_ipv6_cidr(s),
-        ("ipv6_address", Value::String(s)) => validate_ipv6_address(s),
-        (_, Value::ResourceRef { .. }) => Ok(()), // will be resolved later
-        (_, Value::FunctionCall { .. }) => Ok(()), // will be resolved later
-        (_, Value::Interpolation(_)) => Ok(()),   // will be resolved later
-        (_, Value::Unknown(_)) => Ok(()),         // resolved at upstream apply
-        (name, Value::String(s)) => {
+        ("ipv4_cidr", Value::Concrete(ConcreteValue::String(s))) => validate_ipv4_cidr(s),
+        ("ipv4_address", Value::Concrete(ConcreteValue::String(s))) => validate_ipv4_address(s),
+        ("ipv6_cidr", Value::Concrete(ConcreteValue::String(s))) => validate_ipv6_cidr(s),
+        ("ipv6_address", Value::Concrete(ConcreteValue::String(s))) => validate_ipv6_address(s),
+        (_, Value::Deferred(DeferredValue::ResourceRef { .. })) => Ok(()), // will be resolved later
+        (_, Value::Deferred(DeferredValue::FunctionCall { .. })) => Ok(()), // will be resolved later
+        (_, Value::Deferred(DeferredValue::Interpolation(_))) => Ok(()), // will be resolved later
+        (_, Value::Deferred(DeferredValue::Unknown(_))) => Ok(()), // resolved at upstream apply
+        (name, Value::Concrete(ConcreteValue::String(s))) => {
             // Check custom validators from config (schema-extracted)
             if let Some(validator) = config.validators.get(name) {
                 validator(s)?;
@@ -256,28 +256,32 @@ fn check_fn_arg_type(
     value: &Value,
     ctx: &ParseContext,
 ) -> Result<(), ParseError> {
-    // `Value::Unknown` resolves at upstream apply; the concrete type
+    // `Value::Deferred(DeferredValue::Unknown)` resolves at upstream apply; the concrete type
     // is unknowable at parse time. Skip the type check — same convention
     // the schema validator follows.
-    if matches!(value, Value::Unknown(_)) {
+    if matches!(value, Value::Deferred(DeferredValue::Unknown(_))) {
         return Ok(());
     }
     let type_matches = match type_expr {
         TypeExpr::String => matches!(
             value,
-            Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+            Value::Concrete(ConcreteValue::String(_))
+                | Value::Deferred(DeferredValue::Interpolation(_))
+                | Value::Deferred(DeferredValue::ResourceRef { .. })
         ),
-        TypeExpr::Int => matches!(value, Value::Int(_)),
-        TypeExpr::Float => matches!(value, Value::Float(_)),
-        TypeExpr::Bool => matches!(value, Value::Bool(_)),
-        TypeExpr::Duration => matches!(value, Value::Duration(_)),
-        TypeExpr::List(_) => matches!(value, Value::List(_)),
-        TypeExpr::Map(_) => matches!(value, Value::Map(_)),
+        TypeExpr::Int => matches!(value, Value::Concrete(ConcreteValue::Int(_))),
+        TypeExpr::Float => matches!(value, Value::Concrete(ConcreteValue::Float(_))),
+        TypeExpr::Bool => matches!(value, Value::Concrete(ConcreteValue::Bool(_))),
+        TypeExpr::Duration => matches!(value, Value::Concrete(ConcreteValue::Duration(_))),
+        TypeExpr::List(_) => matches!(value, Value::Concrete(ConcreteValue::List(_))),
+        TypeExpr::Map(_) => matches!(value, Value::Concrete(ConcreteValue::Map(_))),
         // Simple types (cidr, ipv4_address, arn, etc.) are string subtypes at runtime
         TypeExpr::Simple(name) => {
             if !matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ) {
                 false
             } else {
@@ -295,7 +299,7 @@ fn check_fn_arg_type(
             // The argument is passed as a ResourceRef-like string "${binding_name}"
             // or as a direct ResourceRef. Check if it corresponds to a resource binding
             // of the expected type.
-            if let Value::String(s) = value
+            if let Value::Concrete(ConcreteValue::String(s)) = value
                 && let Some(ref_name) = s.strip_prefix("${").and_then(|s| s.strip_suffix('}'))
                 && let Some(resource) = ctx.resource_bindings.get(ref_name)
             {
@@ -316,7 +320,9 @@ fn check_fn_arg_type(
         TypeExpr::SchemaType { type_name, .. } => {
             if !matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ) {
                 false
             } else {
@@ -330,13 +336,13 @@ fn check_fn_arg_type(
                 true
             }
         }
-        TypeExpr::Struct { .. } => matches!(value, Value::Map(_)),
+        TypeExpr::Struct { .. } => matches!(value, Value::Concrete(ConcreteValue::Map(_))),
         // Closed-set string literal: only the exact string matches.
         // Interpolations and ResourceRefs are rejected here because
         // their runtime expansion is not knowable at parse time.
         // See carina-rs/carina#2611.
         TypeExpr::StringLiteral(expected) => {
-            matches!(value, Value::String(s) if s == expected)
+            matches!(value, Value::Concrete(ConcreteValue::String(s)) if s == expected)
         }
         // Union: matches if at least one member's structural-shape
         // arm accepts the value. We only inspect literal/string-shape
@@ -346,11 +352,13 @@ fn check_fn_arg_type(
         // single point that needs updating then.
         TypeExpr::Union(members) => members.iter().any(|m| match m {
             TypeExpr::StringLiteral(expected) => {
-                matches!(value, Value::String(s) if s == expected)
+                matches!(value, Value::Concrete(ConcreteValue::String(s)) if s == expected)
             }
             TypeExpr::String => matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ),
             _ => false,
         }),
@@ -373,27 +381,31 @@ fn check_fn_return_type(
     value: &Value,
     config: &ProviderContext,
 ) -> Result<(), ParseError> {
-    // Same skip as `check_fn_arg_type`: a `Value::Unknown` propagated
+    // Same skip as `check_fn_arg_type`: a `Value::Deferred(DeferredValue::Unknown)` propagated
     // through a typed user fn carries no concrete type at parse time.
-    if matches!(value, Value::Unknown(_)) {
+    if matches!(value, Value::Deferred(DeferredValue::Unknown(_))) {
         return Ok(());
     }
     let type_matches = match type_expr {
         TypeExpr::String => matches!(
             value,
-            Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+            Value::Concrete(ConcreteValue::String(_))
+                | Value::Deferred(DeferredValue::Interpolation(_))
+                | Value::Deferred(DeferredValue::ResourceRef { .. })
         ),
-        TypeExpr::Int => matches!(value, Value::Int(_)),
-        TypeExpr::Float => matches!(value, Value::Float(_)),
-        TypeExpr::Bool => matches!(value, Value::Bool(_)),
-        TypeExpr::Duration => matches!(value, Value::Duration(_)),
-        TypeExpr::List(_) => matches!(value, Value::List(_)),
-        TypeExpr::Map(_) => matches!(value, Value::Map(_)),
+        TypeExpr::Int => matches!(value, Value::Concrete(ConcreteValue::Int(_))),
+        TypeExpr::Float => matches!(value, Value::Concrete(ConcreteValue::Float(_))),
+        TypeExpr::Bool => matches!(value, Value::Concrete(ConcreteValue::Bool(_))),
+        TypeExpr::Duration => matches!(value, Value::Concrete(ConcreteValue::Duration(_))),
+        TypeExpr::List(_) => matches!(value, Value::Concrete(ConcreteValue::List(_))),
+        TypeExpr::Map(_) => matches!(value, Value::Concrete(ConcreteValue::Map(_))),
         // Simple types (cidr, ipv4_address, arn, etc.) — validate the value
         TypeExpr::Simple(name) => {
             if !matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ) {
                 false
             } else {
@@ -411,7 +423,9 @@ fn check_fn_return_type(
         TypeExpr::SchemaType { type_name, .. } => {
             if !matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ) {
                 false
             } else {
@@ -424,22 +438,24 @@ fn check_fn_return_type(
                 true
             }
         }
-        TypeExpr::Struct { .. } => matches!(value, Value::Map(_)),
+        TypeExpr::Struct { .. } => matches!(value, Value::Concrete(ConcreteValue::Map(_))),
         // Closed-set string literal: only the exact string matches.
         // See carina-rs/carina#2611.
         TypeExpr::StringLiteral(expected) => {
-            matches!(value, Value::String(s) if s == expected)
+            matches!(value, Value::Concrete(ConcreteValue::String(s)) if s == expected)
         }
         // Union: matches if at least one member accepts the value.
         // Same shape as in `check_fn_arg_type` — only literal/string
         // members are inspected today.
         TypeExpr::Union(members) => members.iter().any(|m| match m {
             TypeExpr::StringLiteral(expected) => {
-                matches!(value, Value::String(s) if s == expected)
+                matches!(value, Value::Concrete(ConcreteValue::String(s)) if s == expected)
             }
             TypeExpr::String => matches!(
                 value,
-                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+                Value::Concrete(ConcreteValue::String(_))
+                    | Value::Deferred(DeferredValue::Interpolation(_))
+                    | Value::Deferred(DeferredValue::ResourceRef { .. })
             ),
             _ => false,
         }),
@@ -476,7 +492,7 @@ pub(crate) fn evaluate_user_function(
 /// Recursively substitute function parameter placeholders with actual values
 fn substitute_fn_params(value: &Value, substitutions: &HashMap<String, Value>) -> Value {
     match value {
-        Value::String(s) => {
+        Value::Concrete(ConcreteValue::String(s)) => {
             // Check if this is a parameter placeholder
             if let Some(param_name) = s.strip_prefix("__fn_param_")
                 && let Some(sub) = substitutions.get(param_name)
@@ -488,43 +504,49 @@ fn substitute_fn_params(value: &Value, substitutions: &HashMap<String, Value>) -
             {
                 return sub.clone();
             }
-            Value::String(s.clone())
+            Value::Concrete(ConcreteValue::String(s.clone()))
         }
-        Value::List(items) => Value::List(
+        Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
             items
                 .iter()
                 .map(|v| substitute_fn_params(v, substitutions))
                 .collect(),
-        ),
-        Value::Map(map) => Value::Map(
+        )),
+        Value::Concrete(ConcreteValue::Map(map)) => Value::Concrete(ConcreteValue::Map(
             map.iter()
                 .map(|(k, v)| (k.clone(), substitute_fn_params(v, substitutions)))
                 .collect(),
-        ),
-        Value::FunctionCall { name, args } => Value::FunctionCall {
-            name: name.clone(),
-            args: args
-                .iter()
-                .map(|a| substitute_fn_params(a, substitutions))
-                .collect(),
-        },
-        Value::Interpolation(parts) => Value::Interpolation(
-            parts
-                .iter()
-                .map(|p| match p {
-                    crate::resource::InterpolationPart::Expr(v) => {
-                        crate::resource::InterpolationPart::Expr(substitute_fn_params(
-                            v,
-                            substitutions,
-                        ))
-                    }
-                    other => other.clone(),
-                })
-                .collect(),
-        ),
-        Value::Secret(inner) => Value::Secret(Box::new(substitute_fn_params(inner, substitutions))),
-        // `Value::Unknown` is not a function-param placeholder. Pass through.
-        Value::Unknown(_) => value.clone(),
+        )),
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
+            Value::Deferred(DeferredValue::FunctionCall {
+                name: name.clone(),
+                args: args
+                    .iter()
+                    .map(|a| substitute_fn_params(a, substitutions))
+                    .collect(),
+            })
+        }
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
+            Value::Deferred(DeferredValue::Interpolation(
+                parts
+                    .iter()
+                    .map(|p| match p {
+                        crate::resource::InterpolationPart::Expr(v) => {
+                            crate::resource::InterpolationPart::Expr(substitute_fn_params(
+                                v,
+                                substitutions,
+                            ))
+                        }
+                        other => other.clone(),
+                    })
+                    .collect(),
+            ))
+        }
+        Value::Deferred(DeferredValue::Secret(inner)) => Value::Deferred(DeferredValue::Secret(
+            Box::new(substitute_fn_params(inner, substitutions)),
+        )),
+        // `Value::Deferred(DeferredValue::Unknown)` is not a function-param placeholder. Pass through.
+        Value::Deferred(DeferredValue::Unknown(_)) => value.clone(),
         other => other.clone(),
     }
 }
@@ -532,7 +554,7 @@ fn substitute_fn_params(value: &Value, substitutions: &HashMap<String, Value>) -
 /// Try to evaluate a value (resolve function calls including user-defined ones)
 fn try_evaluate_fn_value(value: Value, ctx: &ParseContext) -> Result<Value, ParseError> {
     match value {
-        Value::FunctionCall { ref name, ref args } => {
+        Value::Deferred(DeferredValue::FunctionCall { ref name, ref args }) => {
             // First, recursively evaluate arguments
             let evaluated_args: Result<Vec<Value>, ParseError> = args
                 .iter()
@@ -610,29 +632,29 @@ fn try_evaluate_fn_value(value: Value, ctx: &ParseContext) -> Result<Value, Pars
                         // `resource_bindings` are seeded — so this
                         // defer path remains the route by which a
                         // sibling-defined user fn becomes resolvable.
-                        Ok(Value::FunctionCall {
+                        Ok(Value::Deferred(DeferredValue::FunctionCall {
                             name: name.clone(),
                             args: evaluated_args,
-                        })
+                        }))
                     }
                 }
             }
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             let evaluated: Result<Vec<Value>, ParseError> = items
                 .into_iter()
                 .map(|v| try_evaluate_fn_value(v, ctx))
                 .collect();
-            Ok(Value::List(evaluated?))
+            Ok(Value::Concrete(ConcreteValue::List(evaluated?)))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let evaluated: Result<IndexMap<String, Value>, ParseError> = map
                 .into_iter()
                 .map(|(k, v)| try_evaluate_fn_value(v, ctx).map(|ev| (k, ev)))
                 .collect();
-            Ok(Value::Map(evaluated?))
+            Ok(Value::Concrete(ConcreteValue::Map(evaluated?)))
         }
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             let evaluated: Result<Vec<crate::resource::InterpolationPart>, ParseError> = parts
                 .into_iter()
                 .map(|p| match p {
@@ -642,7 +664,7 @@ fn try_evaluate_fn_value(value: Value, ctx: &ParseContext) -> Result<Value, Pars
                     other => Ok(other),
                 })
                 .collect();
-            Ok(Value::Interpolation(evaluated?))
+            Ok(Value::Deferred(DeferredValue::Interpolation(evaluated?)))
         }
         other => Ok(other),
     }

--- a/carina-core/src/parser/let_binding.rs
+++ b/carina-core/src/parser/let_binding.rs
@@ -21,7 +21,7 @@ use super::parse_expression;
 use super::static_eval::is_static_value;
 use super::util::eval_type_name;
 use crate::eval_value::EvalValue;
-use crate::resource::{Resource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
 
 /// Tuple returned by the let-binding parser. The RHS is `EvalValue`
 /// rather than `Value` so partial applications (closures) can survive
@@ -65,7 +65,7 @@ pub(super) fn parse_let_binding_extended(
     // else it is a parse error.
     if rhs_pair.as_rule() == Rule::use_expr {
         let use_stmt = parse_use_expr(rhs_pair, &name, ctx)?;
-        let value = Value::String(format!("${{use:{}}}", use_stmt.path));
+        let value = Value::Concrete(ConcreteValue::String(format!("${{use:{}}}", use_stmt.path)));
         return Ok((
             name,
             EvalValue::from_value(value),
@@ -283,10 +283,10 @@ fn parse_pipe_expr_with_resource_or_module(
             continue;
         }
 
-        value = EvalValue::from_value(Value::FunctionCall {
+        value = EvalValue::from_value(Value::Deferred(DeferredValue::FunctionCall {
             name: func_name,
             args,
-        });
+        }));
     }
 
     Ok((value, expanded_resources, module_calls, maybe_import))
@@ -302,7 +302,8 @@ fn parse_primary_with_resource_or_module(
     match inner.as_rule() {
         Rule::read_resource_expr => {
             let resource = parse_read_resource_expr(inner, ctx, binding_name)?;
-            let ref_value = Value::String(format!("${{{}}}", binding_name));
+            let ref_value =
+                Value::Concrete(ConcreteValue::String(format!("${{{}}}", binding_name)));
             Ok((
                 EvalValue::from_value(ref_value),
                 vec![resource],
@@ -320,7 +321,8 @@ fn parse_primary_with_resource_or_module(
                 });
             }
             ctx.upstream_states.insert(us.binding.clone(), us);
-            let ref_value = Value::String(format!("${{{}}}", binding_name));
+            let ref_value =
+                Value::Concrete(ConcreteValue::String(format!("${{{}}}", binding_name)));
             Ok((EvalValue::from_value(ref_value), vec![], vec![], None))
         }
         Rule::wait_expr => {
@@ -338,12 +340,14 @@ fn parse_primary_with_resource_or_module(
             // `<wait-binding>.<attr>` as passthrough of `<target>.<attr>`.
             // For now we mirror the upstream_state_expr pattern and emit
             // a placeholder `${binding}` reference.
-            let ref_value = Value::String(format!("${{{}}}", binding_name));
+            let ref_value =
+                Value::Concrete(ConcreteValue::String(format!("${{{}}}", binding_name)));
             Ok((EvalValue::from_value(ref_value), vec![], vec![], None))
         }
         Rule::resource_expr => {
             let resource = parse_resource_expr(inner, ctx, binding_name)?;
-            let ref_value = Value::String(format!("${{{}}}", binding_name));
+            let ref_value =
+                Value::Concrete(ConcreteValue::String(format!("${{{}}}", binding_name)));
             Ok((
                 EvalValue::from_value(ref_value),
                 vec![resource],
@@ -353,7 +357,8 @@ fn parse_primary_with_resource_or_module(
         }
         Rule::for_expr => {
             let (resources, module_calls) = parse_for_expr(inner, ctx, binding_name)?;
-            let ref_value = Value::String(format!("${{for:{}}}", binding_name));
+            let ref_value =
+                Value::Concrete(ConcreteValue::String(format!("${{for:{}}}", binding_name)));
             Ok((
                 EvalValue::from_value(ref_value),
                 resources,
@@ -367,7 +372,10 @@ fn parse_primary_with_resource_or_module(
         }
         Rule::module_call => {
             let call = parse_module_call(inner, ctx)?;
-            let value = Value::String(format!("${{module:{}}}", call.module_name));
+            let value = Value::Concrete(ConcreteValue::String(format!(
+                "${{module:{}}}",
+                call.module_name
+            )));
             Ok((EvalValue::from_value(value), vec![], vec![call], None))
         }
         Rule::function_call => {

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -7,7 +7,7 @@ use super::ast::{AttributeParameter, ExportParameter, ModuleCall, ParsedFile};
 use super::error::{ParseError, undefined_identifier_error};
 use super::static_eval::is_static_value;
 use crate::eval_value::EvalValue;
-use crate::resource::{Resource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
@@ -31,7 +31,7 @@ pub(super) fn resolve_forward_references(
         // round-trip. The placeholder is overwritten on the next line,
         // so its identity doesn't matter.
         for (_, attr) in resource.attributes.iter_mut() {
-            let placeholder = Value::Bool(false);
+            let placeholder = Value::Concrete(ConcreteValue::Bool(false));
             let value = std::mem::replace(attr, placeholder);
             *attr = resolve_forward_ref_in_value(value, resource_bindings);
         }
@@ -67,7 +67,7 @@ fn resolve_forward_ref_in_value(
     resource_bindings: &HashMap<String, Resource>,
 ) -> Value {
     match value {
-        Value::String(ref s) => {
+        Value::Concrete(ConcreteValue::String(ref s)) => {
             // A dotted string like "vpc.vpc_id" or "vpc.attr.nested" may be a
             // forward reference that was stored as a string during single-pass
             // parsing. Resolve it to ResourceRef if the first segment is a known
@@ -82,20 +82,20 @@ fn resolve_forward_ref_in_value(
             }
             value
         }
-        Value::List(items) => Value::List(
+        Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
             items
                 .into_iter()
                 .map(|v| resolve_forward_ref_in_value(v, resource_bindings))
                 .collect(),
-        ),
-        Value::Map(map) => Value::Map(
+        )),
+        Value::Concrete(ConcreteValue::Map(map)) => Value::Concrete(ConcreteValue::Map(
             map.into_iter()
                 .map(|(k, v)| (k, resolve_forward_ref_in_value(v, resource_bindings)))
                 .collect(),
-        ),
-        Value::Interpolation(parts) => {
+        )),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             use crate::resource::InterpolationPart;
-            Value::Interpolation(
+            Value::Deferred(DeferredValue::Interpolation(
                 parts
                     .into_iter()
                     .map(|p| match p {
@@ -105,16 +105,18 @@ fn resolve_forward_ref_in_value(
                         other => other,
                     })
                     .collect(),
-            )
+            ))
             .canonicalize()
         }
-        Value::FunctionCall { name, args } => Value::FunctionCall {
-            name,
-            args: args
-                .into_iter()
-                .map(|v| resolve_forward_ref_in_value(v, resource_bindings))
-                .collect(),
-        },
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
+            Value::Deferred(DeferredValue::FunctionCall {
+                name,
+                args: args
+                    .into_iter()
+                    .map(|v| resolve_forward_ref_in_value(v, resource_bindings))
+                    .collect(),
+            })
+        }
         other => other,
     }
 }
@@ -127,7 +129,7 @@ pub fn resolve_resource_refs(parsed: &mut ParsedFile) -> Result<(), ParseError> 
 
 /// Resolve resource references with the given parser configuration.
 ///
-/// `parsed.user_functions` is consulted when resolving `Value::FunctionCall`
+/// `parsed.user_functions` is consulted when resolving `Value::Deferred(DeferredValue::FunctionCall)`
 /// values — a name that isn't a builtin but is a user-defined function in
 /// the merged directory parse triggers user-fn evaluation here, even when
 /// the per-file parse couldn't evaluate it because the `fn` declaration
@@ -183,7 +185,7 @@ pub fn resolve_resource_refs_with_config(
     }
 
     // Build a `ParseContext` once, populated with the merged
-    // directory's user functions so a `Value::FunctionCall` whose name
+    // directory's user functions so a `Value::Deferred(DeferredValue::FunctionCall)` whose name
     // is a sibling-defined user-fn (visible only in the merged parse —
     // #2444) is evaluated here rather than rejected as "Unknown
     // built-in function". The HashMap is small (typically a handful of
@@ -208,11 +210,11 @@ pub fn resolve_resource_refs_with_config(
     }
 
     // Resolve top-level `let v = ...` bindings that contain
-    // `Value::FunctionCall` placeholders deferred by the per-file
+    // `Value::Deferred(DeferredValue::FunctionCall)` placeholders deferred by the per-file
     // parse — typically `fn X(...)` lives in a sibling `.crn` (#2444).
     // The variant below only mutates `FunctionCall` arms, leaving
-    // other shapes (`Value::String("${vpc}")` placeholder,
-    // `Value::ResourceRef`, etc.) untouched so earlier passes
+    // other shapes (`Value::Concrete(ConcreteValue::String("${vpc}"))` placeholder,
+    // `Value::Deferred(DeferredValue::ResourceRef)`, etc.) untouched so earlier passes
     // (`upstream_exports`, `BindingNameSet`) keep seeing the raw
     // unresolved forms they expect.
     let var_keys: Vec<String> = parsed.variables.keys().cloned().collect();
@@ -224,7 +226,7 @@ pub fn resolve_resource_refs_with_config(
 
     // Resolve cross-file forward references in export_params.
     // During per-file parsing, "binding.attribute" strings from sibling files
-    // remain as Value::String. Convert them to ResourceRef now that the full
+    // remain as Value::Concrete(ConcreteValue::String). Convert them to ResourceRef now that the full
     // binding map is available.
     let resource_bindings: HashMap<String, Resource> = parsed
         .resources
@@ -375,36 +377,38 @@ fn resolve_value_with_config(
     fn_ctx: &super::ParseContext<'_>,
 ) -> Result<Value, ParseError> {
     match value {
-        Value::ResourceRef { path } => match binding_map.get(path.binding()) {
-            Some(attributes) => match attributes.get(path.attribute()) {
-                Some(attr_value) => {
-                    // Recursively resolve in case the attribute itself is a reference
-                    resolve_value_with_config(attr_value, binding_map, fn_ctx)
-                }
-                None => {
-                    // Attribute not found, keep as reference (might be resolved at runtime)
-                    Ok(value.clone())
-                }
-            },
-            // Binding not found in *this* file's binding_map. The same
-            // resolver runs both per-file (config_loader.rs L93) and on
-            // the merged `ParsedFile` (L178); a per-file miss may be a
-            // legitimate cross-file ref (`upstream_state` declared in a
-            // sibling `.crn`, resource binding from another file).
-            // Keep the ref as-is and let the post-merge
-            // `check_identifier_scope` walk surface any genuine
-            // undefined identifiers — that walk has full directory
-            // context plus did-you-mean suggestions.
-            None => Ok(value.clone()),
-        },
-        Value::List(items) => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            match binding_map.get(path.binding()) {
+                Some(attributes) => match attributes.get(path.attribute()) {
+                    Some(attr_value) => {
+                        // Recursively resolve in case the attribute itself is a reference
+                        resolve_value_with_config(attr_value, binding_map, fn_ctx)
+                    }
+                    None => {
+                        // Attribute not found, keep as reference (might be resolved at runtime)
+                        Ok(value.clone())
+                    }
+                },
+                // Binding not found in *this* file's binding_map. The same
+                // resolver runs both per-file (config_loader.rs L93) and on
+                // the merged `ParsedFile` (L178); a per-file miss may be a
+                // legitimate cross-file ref (`upstream_state` declared in a
+                // sibling `.crn`, resource binding from another file).
+                // Keep the ref as-is and let the post-merge
+                // `check_identifier_scope` walk surface any genuine
+                // undefined identifiers — that walk has full directory
+                // context plus did-you-mean suggestions.
+                None => Ok(value.clone()),
+            }
+        }
+        Value::Concrete(ConcreteValue::List(items)) => {
             let resolved: Result<Vec<Value>, ParseError> = items
                 .iter()
                 .map(|item| resolve_value_with_config(item, binding_map, fn_ctx))
                 .collect();
-            Ok(Value::List(resolved?))
+            Ok(Value::Concrete(ConcreteValue::List(resolved?)))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut resolved: IndexMap<String, Value> = IndexMap::new();
             for (k, v) in map {
                 resolved.insert(
@@ -412,9 +416,9 @@ fn resolve_value_with_config(
                     resolve_value_with_config(v, binding_map, fn_ctx)?,
                 );
             }
-            Ok(Value::Map(resolved))
+            Ok(Value::Concrete(ConcreteValue::Map(resolved)))
         }
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             use crate::resource::InterpolationPart;
             let resolved: Result<Vec<InterpolationPart>, ParseError> = parts
                 .iter()
@@ -425,9 +429,9 @@ fn resolve_value_with_config(
                     other => Ok(other.clone()),
                 })
                 .collect();
-            Ok(Value::Interpolation(resolved?).canonicalize())
+            Ok(Value::Deferred(DeferredValue::Interpolation(resolved?)).canonicalize())
         }
-        Value::FunctionCall { name, args } => {
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
             let resolved_args: Result<Vec<Value>, ParseError> = args
                 .iter()
                 .map(|a| resolve_value_with_config(a, binding_map, fn_ctx))
@@ -474,10 +478,10 @@ fn resolve_value_with_config(
                         })
                     } else {
                         // Args contain unresolved refs — keep as FunctionCall for later resolution
-                        Ok(Value::FunctionCall {
+                        Ok(Value::Deferred(DeferredValue::FunctionCall {
                             name: name.clone(),
                             args: resolved_args,
-                        })
+                        }))
                     }
                 }
             }
@@ -486,7 +490,7 @@ fn resolve_value_with_config(
     }
 }
 
-/// Walk a value tree and finalize any `Value::FunctionCall` placeholder
+/// Walk a value tree and finalize any `Value::Deferred(DeferredValue::FunctionCall)` placeholder
 /// that the per-file parse deferred (typically because the user-fn
 /// lives in a sibling `.crn` — #2444). Recurses through `List` / `Map`
 /// / `Interpolation` containers so deferred calls inside them surface
@@ -500,15 +504,17 @@ fn resolve_function_calls_only(
 ) -> Result<Value, ParseError> {
     use crate::resource::InterpolationPart;
     match value {
-        Value::FunctionCall { .. } => resolve_value_with_config(value, binding_map, fn_ctx),
-        Value::List(items) => {
+        Value::Deferred(DeferredValue::FunctionCall { .. }) => {
+            resolve_value_with_config(value, binding_map, fn_ctx)
+        }
+        Value::Concrete(ConcreteValue::List(items)) => {
             let resolved: Result<Vec<Value>, ParseError> = items
                 .iter()
                 .map(|v| resolve_function_calls_only(v, binding_map, fn_ctx))
                 .collect();
-            Ok(Value::List(resolved?))
+            Ok(Value::Concrete(ConcreteValue::List(resolved?)))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut resolved: IndexMap<String, Value> = IndexMap::new();
             for (k, v) in map {
                 resolved.insert(
@@ -516,9 +522,9 @@ fn resolve_function_calls_only(
                     resolve_function_calls_only(v, binding_map, fn_ctx)?,
                 );
             }
-            Ok(Value::Map(resolved))
+            Ok(Value::Concrete(ConcreteValue::Map(resolved)))
         }
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             let resolved: Result<Vec<InterpolationPart>, ParseError> = parts
                 .iter()
                 .map(|p| match p {
@@ -528,7 +534,7 @@ fn resolve_function_calls_only(
                     other => Ok(other.clone()),
                 })
                 .collect();
-            Ok(Value::Interpolation(resolved?).canonicalize())
+            Ok(Value::Deferred(DeferredValue::Interpolation(resolved?)).canonicalize())
         }
         _ => Ok(value.clone()),
     }
@@ -601,7 +607,7 @@ pub fn finalize_provider_configs<E>(parsed: &mut super::File<E>) -> Result<(), P
     for provider in parsed.providers.iter_mut() {
         if let Some(value) = provider.unresolved_attributes.shift_remove("default_tags") {
             match value {
-                Value::Map(tags) => {
+                Value::Concrete(ConcreteValue::Map(tags)) => {
                     provider.default_tags = tags;
                 }
                 other => {

--- a/carina-core/src/parser/static_eval.rs
+++ b/carina-core/src/parser/static_eval.rs
@@ -7,25 +7,27 @@
 use super::ProviderContext;
 use super::error::ParseError;
 use crate::eval_value::EvalValue;
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 
 /// Check whether a Value is fully static (no runtime dependencies).
 pub(crate) fn is_static_value(value: &Value) -> bool {
     match value {
-        Value::String(_)
-        | Value::Int(_)
-        | Value::Float(_)
-        | Value::Bool(_)
-        | Value::Duration(_)
-        | Value::StringList(_) => true,
-        Value::List(items) => items.iter().all(is_static_value),
-        Value::Map(map) => map.values().all(is_static_value),
-        Value::FunctionCall { args, .. } => args.iter().all(is_static_value),
-        Value::ResourceRef { .. }
-        | Value::BindingRef { .. }
-        | Value::Interpolation(_)
-        | Value::Unknown(_) => false,
-        Value::Secret(inner) => is_static_value(inner),
+        Value::Concrete(ConcreteValue::String(_))
+        | Value::Concrete(ConcreteValue::Int(_))
+        | Value::Concrete(ConcreteValue::Float(_))
+        | Value::Concrete(ConcreteValue::Bool(_))
+        | Value::Concrete(ConcreteValue::Duration(_))
+        | Value::Concrete(ConcreteValue::StringList(_)) => true,
+        Value::Concrete(ConcreteValue::List(items)) => items.iter().all(is_static_value),
+        Value::Concrete(ConcreteValue::Map(map)) => map.values().all(is_static_value),
+        Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
+            args.iter().all(is_static_value)
+        }
+        Value::Deferred(DeferredValue::ResourceRef { .. })
+        | Value::Deferred(DeferredValue::BindingRef { .. })
+        | Value::Deferred(DeferredValue::Interpolation(_))
+        | Value::Deferred(DeferredValue::Unknown(_)) => false,
+        Value::Deferred(DeferredValue::Secret(inner)) => is_static_value(inner),
     }
 }
 
@@ -47,7 +49,7 @@ pub(crate) fn evaluate_static_value(
     config: &ProviderContext,
 ) -> Result<Value, ParseError> {
     match value {
-        Value::FunctionCall { ref name, ref args } => {
+        Value::Deferred(DeferredValue::FunctionCall { ref name, ref args }) => {
             if !is_static_value(&value) {
                 return Err(ParseError::InvalidExpression {
                     line: 0,

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::resource::{InterpolationPart, Resource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, Resource, Value};
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
@@ -27,7 +27,8 @@ fn parse_and_resolve_returns_value_only_no_closure() {
     // test is that the type contract holds: whatever shape this
     // is, downstream code does not have to consider closures.
     match joined {
-        Value::String(_) | Value::FunctionCall { .. } => {}
+        Value::Concrete(ConcreteValue::String(_))
+        | Value::Deferred(DeferredValue::FunctionCall { .. }) => {}
         other => panic!("unexpected variant for `joined`: {other:?}"),
     }
 }
@@ -72,7 +73,9 @@ fn iter_all_resources_yields_direct_then_deferred() {
     assert!(matches!(items[0].0, ResourceContext::Direct));
     assert_eq!(
         items[0].1.get_attr("name"),
-        Some(&Value::String("direct".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "direct".to_string()
+        )))
     );
 
     assert!(matches!(items[1].0, ResourceContext::Deferred(_)));
@@ -108,11 +111,15 @@ fn parse_resource_with_namespaced_type() {
     assert_eq!(resource.id.name_str(), "my_bucket"); // binding name becomes the resource ID
     assert_eq!(
         resource.get_attr("name"),
-        Some(&Value::String("my-bucket".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-bucket".to_string()
+        )))
     );
     assert_eq!(
         resource.get_attr("region"),
-        Some(&Value::String("aws.Region.ap_northeast_1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "aws.Region.ap_northeast_1".to_string()
+        )))
     );
 }
 
@@ -149,7 +156,9 @@ fn parse_variable_and_resource() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("region"),
-        Some(&Value::String("aws.Region.ap_northeast_1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "aws.Region.ap_northeast_1".to_string()
+        )))
     );
 }
 
@@ -183,11 +192,11 @@ fn parse_full_example() {
     assert_eq!(result.resources.len(), 2);
     assert_eq!(
         result.resources[0].get_attr("versioning"),
-        Some(&Value::Bool(true))
+        Some(&Value::Concrete(ConcreteValue::Bool(true)))
     );
     assert_eq!(
         result.resources[0].get_attr("expiration_days"),
-        Some(&Value::Int(90))
+        Some(&Value::Concrete(ConcreteValue::Int(90)))
     );
 }
 
@@ -203,10 +212,12 @@ fn function_call_is_parsed() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "env".to_string(),
-            args: vec![Value::String("SOME_VAR".to_string())],
-        })
+            args: vec![Value::Concrete(ConcreteValue::String(
+                "SOME_VAR".to_string()
+            ))],
+        }))
     );
 }
 
@@ -329,18 +340,22 @@ fn parse_and_resolve_resource_reference() {
     let policy = &result.resources[1];
     assert_eq!(
         policy.get_attr("bucket"),
-        Some(&Value::String("my-bucket".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-bucket".to_string()
+        )))
     );
     assert_eq!(
         policy.get_attr("bucket_region"),
-        Some(&Value::String("aws.Region.ap_northeast_1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "aws.Region.ap_northeast_1".to_string()
+        )))
     );
 }
 
 #[test]
 fn parse_undefined_two_part_identifier_becomes_resource_ref() {
     // A 2-part dotted identifier whose head is not a known binding in
-    // this file lowers to `Value::ResourceRef`, not a literal string.
+    // this file lowers to `Value::Deferred(DeferredValue::ResourceRef)`, not a literal string.
     // Two reasons:
     //   - the head may legitimately live in a sibling `.crn` (the
     //     directory-scoped, multi-file shape), and
@@ -359,7 +374,7 @@ fn parse_undefined_two_part_identifier_becomes_resource_ref() {
     assert!(result.is_ok());
     let parsed = result.unwrap();
     match parsed.resources[0].get_attr("bucket") {
-        Some(Value::ResourceRef { path }) => {
+        Some(Value::Deferred(DeferredValue::ResourceRef { path })) => {
             assert_eq!(path.binding(), "nonexistent");
             assert_eq!(path.attribute(), "name");
             assert!(path.field_path().is_empty());
@@ -395,7 +410,9 @@ fn parse_bare_identifier_becomes_string() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("instance_tenancy"),
-        Some(&Value::String("dedicated".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "dedicated".to_string()
+        )))
     );
 }
 
@@ -412,7 +429,9 @@ fn resource_reference_preserves_namespaced_id() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("region"),
-        Some(&Value::String("aws.Region.ap_northeast_1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "aws.Region.ap_northeast_1".to_string()
+        )))
     );
 }
 
@@ -429,9 +448,9 @@ fn namespaced_id_with_digit_segment() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("type"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "awscc.ec2.vpn_gateway.Type.ipsec.1".to_string()
-        ))
+        )))
     );
 }
 
@@ -475,16 +494,19 @@ fn parse_nested_blocks_terraform_style() {
 
     // Check ingress is a list with 2 items
     let ingress = sg.get_attr("ingress").unwrap();
-    if let Value::List(items) = ingress {
+    if let Value::Concrete(ConcreteValue::List(items)) = ingress {
         assert_eq!(items.len(), 2);
 
         // Check first ingress rule
-        if let Value::Map(rule) = &items[0] {
+        if let Value::Concrete(ConcreteValue::Map(rule)) = &items[0] {
             assert_eq!(
                 rule.get("protocol"),
-                Some(&Value::String("tcp".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String("tcp".to_string())))
             );
-            assert_eq!(rule.get("from_port"), Some(&Value::Int(80)));
+            assert_eq!(
+                rule.get("from_port"),
+                Some(&Value::Concrete(ConcreteValue::Int(80)))
+            );
         } else {
             panic!("Expected map for ingress rule");
         }
@@ -494,7 +516,7 @@ fn parse_nested_blocks_terraform_style() {
 
     // Check egress is a list with 1 item
     let egress = sg.get_attr("egress").unwrap();
-    if let Value::List(items) = egress {
+    if let Value::Concrete(ConcreteValue::List(items)) = egress {
         assert_eq!(items.len(), 1);
     } else {
         panic!("Expected list for egress");
@@ -520,17 +542,21 @@ fn parse_list_syntax() {
 
     let rt = &result.resources[0];
     let routes = rt.get_attr("routes").unwrap();
-    if let Value::List(items) = routes {
+    if let Value::Concrete(ConcreteValue::List(items)) = routes {
         assert_eq!(items.len(), 2);
 
-        if let Value::Map(route) = &items[0] {
+        if let Value::Concrete(ConcreteValue::Map(route)) = &items[0] {
             assert_eq!(
                 route.get("destination"),
-                Some(&Value::String("0.0.0.0/0".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "0.0.0.0/0".to_string()
+                )))
             );
             assert_eq!(
                 route.get("gateway"),
-                Some(&Value::String("my-igw".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "my-igw".to_string()
+                )))
             );
         } else {
             panic!("Expected map for route");
@@ -568,7 +594,10 @@ fn parse_directory_module() {
 
     assert_eq!(result.arguments[1].name, "enable_https");
     assert_eq!(result.arguments[1].type_expr, TypeExpr::Bool);
-    assert_eq!(result.arguments[1].default, Some(Value::Bool(true)));
+    assert_eq!(
+        result.arguments[1].default,
+        Some(Value::Concrete(ConcreteValue::Bool(true)))
+    );
 
     // Check attribute params
     assert_eq!(result.attribute_params.len(), 1);
@@ -580,9 +609,9 @@ fn parse_directory_module() {
     let sg = &result.resources[0];
     assert_eq!(
         sg.get_attr("vpc_id"),
-        Some(&Value::BindingRef {
+        Some(&Value::Deferred(DeferredValue::BindingRef {
             binding: "vpc_id".to_string(),
-        })
+        }))
     );
 }
 
@@ -1018,7 +1047,7 @@ fn parse_float_literal() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("weight"),
-        Some(&Value::Float(2.5))
+        Some(&Value::Concrete(ConcreteValue::Float(2.5)))
     );
 }
 
@@ -1034,7 +1063,7 @@ fn parse_negative_float_literal() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("offset"),
-        Some(&Value::Float(-0.5))
+        Some(&Value::Concrete(ConcreteValue::Float(-0.5)))
     );
 }
 
@@ -1083,20 +1112,29 @@ fn parse_backend_block() {
     assert_eq!(backend.backend_type, "s3");
     assert_eq!(
         backend.attributes.get("bucket"),
-        Some(&Value::String("my-carina-state".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-carina-state".to_string()
+        )))
     );
     assert_eq!(
         backend.attributes.get("key"),
-        Some(&Value::String("infra/prod/carina.crnstate".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "infra/prod/carina.crnstate".to_string()
+        )))
     );
     assert_eq!(
         backend.attributes.get("region"),
-        Some(&Value::String("aws.Region.ap_northeast_1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "aws.Region.ap_northeast_1".to_string()
+        )))
     );
-    assert_eq!(backend.attributes.get("encrypt"), Some(&Value::Bool(true)));
+    assert_eq!(
+        backend.attributes.get("encrypt"),
+        Some(&Value::Concrete(ConcreteValue::Bool(true)))
+    );
     assert_eq!(
         backend.attributes.get("auto_create"),
-        Some(&Value::Bool(true))
+        Some(&Value::Concrete(ConcreteValue::Bool(true)))
     );
 
     // Check provider
@@ -1135,7 +1173,9 @@ fn parse_backend_block_with_resources() {
     assert_eq!(backend.backend_type, "s3");
     assert_eq!(
         backend.attributes.get("bucket"),
-        Some(&Value::String("my-state".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-state".to_string()
+        )))
     );
 
     assert_eq!(result.providers.len(), 1);
@@ -1377,23 +1417,27 @@ fn parse_block_syntax_inside_map() {
 
     let role = &result.resources[0];
     let doc = role.get_attr("assume_role_policy_document").unwrap();
-    if let Value::Map(map) = doc {
+    if let Value::Concrete(ConcreteValue::Map(map)) = doc {
         assert_eq!(
             map.get("version"),
-            Some(&Value::String("2012-10-17".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "2012-10-17".to_string()
+            )))
         );
         // statement block becomes a list with one element
         let statement = map.get("statement").unwrap();
-        if let Value::List(stmts) = statement {
+        if let Value::Concrete(ConcreteValue::List(stmts)) = statement {
             assert_eq!(stmts.len(), 1);
-            if let Value::Map(stmt) = &stmts[0] {
+            if let Value::Concrete(ConcreteValue::Map(stmt)) = &stmts[0] {
                 assert_eq!(
                     stmt.get("effect"),
-                    Some(&Value::String("Allow".to_string()))
+                    Some(&Value::Concrete(ConcreteValue::String("Allow".to_string())))
                 );
                 assert_eq!(
                     stmt.get("action"),
-                    Some(&Value::String("sts:AssumeRole".to_string()))
+                    Some(&Value::Concrete(ConcreteValue::String(
+                        "sts:AssumeRole".to_string()
+                    )))
                 );
             } else {
                 panic!("Expected map for statement");
@@ -1427,9 +1471,9 @@ fn parse_multiple_blocks_inside_map() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     let role = &result.resources[0];
     let doc = role.get_attr("policy_document").unwrap();
-    if let Value::Map(map) = doc {
+    if let Value::Concrete(ConcreteValue::Map(map)) = doc {
         let statement = map.get("statement").unwrap();
-        if let Value::List(stmts) = statement {
+        if let Value::Concrete(ConcreteValue::List(stmts)) = statement {
             assert_eq!(stmts.len(), 2);
         } else {
             panic!("Expected list for statement");
@@ -1460,9 +1504,9 @@ fn parse_list_syntax_inside_map_still_works() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     let role = &result.resources[0];
     let doc = role.get_attr("assume_role_policy_document").unwrap();
-    if let Value::Map(map) = doc {
+    if let Value::Concrete(ConcreteValue::Map(map)) = doc {
         let statement = map.get("statement").unwrap();
-        if let Value::List(stmts) = statement {
+        if let Value::Concrete(ConcreteValue::List(stmts)) = statement {
             assert_eq!(stmts.len(), 1);
         } else {
             panic!("Expected list for statement");
@@ -1489,16 +1533,16 @@ fn parse_deeply_nested_blocks() {
     let r = &result.resources[0];
 
     let outer = r.get_attr("outer").unwrap();
-    if let Value::List(outer_items) = outer {
+    if let Value::Concrete(ConcreteValue::List(outer_items)) = outer {
         assert_eq!(outer_items.len(), 1);
-        if let Value::Map(outer_map) = &outer_items[0] {
+        if let Value::Concrete(ConcreteValue::Map(outer_map)) = &outer_items[0] {
             let inner = outer_map.get("inner").unwrap();
-            if let Value::List(inner_items) = inner {
+            if let Value::Concrete(ConcreteValue::List(inner_items)) = inner {
                 assert_eq!(inner_items.len(), 1);
-                if let Value::Map(inner_map) = &inner_items[0] {
+                if let Value::Concrete(ConcreteValue::Map(inner_map)) = &inner_items[0] {
                     assert_eq!(
                         inner_map.get("leaf"),
-                        Some(&Value::String("value".to_string()))
+                        Some(&Value::Concrete(ConcreteValue::String("value".to_string())))
                     );
                 } else {
                     panic!("Expected map for inner block");
@@ -1532,12 +1576,15 @@ fn parse_nested_block_in_map() {
     let role = &result.resources[0];
 
     let doc = role.get_attr("policy_document").unwrap();
-    if let Value::Map(map) = doc {
+    if let Value::Concrete(ConcreteValue::Map(map)) = doc {
         let statement = map.get("statement").unwrap();
-        if let Value::List(items) = statement {
+        if let Value::Concrete(ConcreteValue::List(items)) = statement {
             assert_eq!(items.len(), 1);
-            if let Value::Map(s) = &items[0] {
-                assert_eq!(s.get("effect"), Some(&Value::String("Allow".to_string())));
+            if let Value::Concrete(ConcreteValue::Map(s)) = &items[0] {
+                assert_eq!(
+                    s.get("effect"),
+                    Some(&Value::Concrete(ConcreteValue::String("Allow".to_string())))
+                );
             } else {
                 panic!("Expected map for statement");
             }
@@ -1614,10 +1661,10 @@ fn pipe_operator_desugars_to_function_call() {
     // "hello" |> upper() desugars to upper("hello")
     assert_eq!(
         result.variables.get("x"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "upper".to_string(),
-            args: vec![Value::String("hello".to_string())],
-        })
+            args: vec![Value::Concrete(ConcreteValue::String("hello".to_string()))],
+        }))
     );
 }
 
@@ -1632,10 +1679,10 @@ fn pipe_operator_in_attribute_desugars() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "lower".to_string(),
-            args: vec![Value::String("test".to_string())],
-        })
+            args: vec![Value::Concrete(ConcreteValue::String("test".to_string()))],
+        }))
     );
 }
 
@@ -1651,17 +1698,17 @@ fn join_function_call_parsed() {
     // At parse time, function calls remain as FunctionCall values
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
             args: vec![
-                Value::String("-".to_string()),
-                Value::List(vec![
-                    Value::String("a".to_string()),
-                    Value::String("b".to_string()),
-                    Value::String("c".to_string()),
-                ]),
+                Value::Concrete(ConcreteValue::String("-".to_string())),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::String("a".to_string())),
+                    Value::Concrete(ConcreteValue::String("b".to_string())),
+                    Value::Concrete(ConcreteValue::String("c".to_string())),
+                ])),
             ],
-        })
+        }))
     );
 }
 
@@ -1677,17 +1724,17 @@ fn pipe_with_join_parsed() {
     // ["a", "b", "c"] |> join("-") desugars to join("-", ["a", "b", "c"])
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
             args: vec![
-                Value::String("-".to_string()),
-                Value::List(vec![
-                    Value::String("a".to_string()),
-                    Value::String("b".to_string()),
-                    Value::String("c".to_string()),
-                ]),
+                Value::Concrete(ConcreteValue::String("-".to_string())),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::String("a".to_string())),
+                    Value::Concrete(ConcreteValue::String("b".to_string())),
+                    Value::Concrete(ConcreteValue::String("c".to_string())),
+                ])),
             ],
-        })
+        }))
     );
 }
 
@@ -1702,19 +1749,19 @@ fn join_with_multiple_pipes() {
     // => upper(join("-", ["a", "b"]))
     assert_eq!(
         result.variables.get("x"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "upper".to_string(),
-            args: vec![Value::FunctionCall {
+            args: vec![Value::Deferred(DeferredValue::FunctionCall {
                 name: "join".to_string(),
                 args: vec![
-                    Value::String("-".to_string()),
-                    Value::List(vec![
+                    Value::Concrete(ConcreteValue::String("-".to_string())),
+                    Value::Concrete(ConcreteValue::List(vec![
                         Value::String("a".to_string()),
                         Value::String("b".to_string()),
-                    ]),
+                    ])),
                 ],
-            }],
-        })
+            })],
+        }))
     );
 }
 
@@ -1726,10 +1773,10 @@ fn function_call_with_no_args() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("x"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "foo".to_string(),
             args: vec![],
-        })
+        }))
     );
 }
 
@@ -1744,7 +1791,9 @@ fn join_resolved_during_resource_ref_resolution() {
     resolve_resource_refs(&mut result).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("my-bucket-name".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-bucket-name".to_string()
+        )))
     );
 }
 
@@ -1759,7 +1808,9 @@ fn pipe_join_resolved_during_resource_ref_resolution() {
     resolve_resource_refs(&mut result).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("my-bucket".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-bucket".to_string()
+        )))
     );
 }
 
@@ -1792,7 +1843,7 @@ fn partial_application_join_with_pipe() {
     resolve_resource_refs(&mut result).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("a,b".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("a,b".to_string())))
     );
 }
 
@@ -1806,7 +1857,7 @@ fn partial_application_closure_direct_call() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("x"),
-        Some(&Value::String("a,b".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("a,b".to_string())))
     );
 }
 
@@ -1822,7 +1873,7 @@ fn partial_application_chained_pipes() {
     resolve_resource_refs(&mut result).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("A,B".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("A,B".to_string())))
     );
 }
 
@@ -1836,7 +1887,7 @@ fn partial_application_closure_pipe() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("x"),
-        Some(&Value::String("a,b".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("a,b".to_string())))
     );
 }
 
@@ -1861,7 +1912,9 @@ fn partial_application_replace() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("x"),
-        Some(&Value::String("hello_world".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "hello_world".to_string()
+        )))
     );
 }
 
@@ -1877,7 +1930,9 @@ fn partial_application_in_resource_attribute() {
     resolve_resource_refs(&mut parsed).unwrap();
     assert_eq!(
         parsed.resources[0].get_attr("name"),
-        Some(&Value::String("my-bucket".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-bucket".to_string()
+        )))
     );
 }
 
@@ -1894,7 +1949,9 @@ fn partial_application_closure_in_resource_attribute() {
     resolve_resource_refs(&mut parsed).unwrap();
     assert_eq!(
         parsed.resources[0].get_attr("name"),
-        Some(&Value::String("my-bucket".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-bucket".to_string()
+        )))
     );
 }
 
@@ -1911,7 +1968,9 @@ fn partial_application_closure_direct_call_in_resource_attribute() {
     resolve_resource_refs(&mut parsed).unwrap();
     assert_eq!(
         parsed.resources[0].get_attr("name"),
-        Some(&Value::String("my-bucket".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-bucket".to_string()
+        )))
     );
 }
 
@@ -2012,8 +2071,8 @@ fn forward_reference_in_nested_value() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     let subnet = &result.resources[0];
     // Check nested reference in list > map
-    if let Some(Value::List(items)) = subnet.get_attr("tags") {
-        if let Some(Value::Map(map)) = items.first() {
+    if let Some(Value::Concrete(ConcreteValue::List(items))) = subnet.get_attr("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(map))) = items.first() {
             assert_eq!(
                 map.get("vpc_ref"),
                 Some(&Value::resource_ref(
@@ -2219,7 +2278,9 @@ fn parse_slash_slash_comment_inline() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
 }
 
@@ -2238,7 +2299,9 @@ fn parse_mixed_comment_styles() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
 }
 
@@ -2302,7 +2365,9 @@ fn parse_block_comment_inline() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
 }
 
@@ -2360,7 +2425,7 @@ fn parse_provider_block_defers_non_literal_default_tags() {
 #[test]
 fn provider_block_undefined_let_reference_flagged() {
     // `nonexistent.tags` is a ResourceRef (bare identifiers without field
-    // access parse to Value::String per parser/expressions/primary.rs and
+    // access parse to Value::Concrete(ConcreteValue::String) per parser/expressions/primary.rs and
     // are intentionally not scope-checked). The `.tags` access is what
     // upgrades the value into a ResourceRef whose root must resolve.
     let input = r#"
@@ -2409,13 +2474,15 @@ fn finalize_provider_configs_promotes_resolved_default_tags() {
     );
     assert_eq!(
         pc.default_tags.get("region"),
-        Some(&Value::String("ap-northeast-1".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1".to_string()
+        ))),
         "resolved default_tags must contain the literal map's entries; got: {:?}",
         pc.default_tags
     );
     assert_eq!(
         pc.default_tags.get("env"),
-        Some(&Value::String("dev".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String("dev".to_string()))),
     );
 }
 
@@ -2448,13 +2515,15 @@ fn finalize_provider_configs_resolves_resource_ref_default_tags() {
     );
     assert_eq!(
         pc.default_tags.get("Project"),
-        Some(&Value::String("carina-rs".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "carina-rs".to_string()
+        ))),
         "ResourceRef default_tags must resolve to the referenced map; got: {:?}",
         pc.default_tags
     );
     assert_eq!(
         pc.default_tags.get("Env"),
-        Some(&Value::String("dev".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String("dev".to_string()))),
     );
 }
 
@@ -2518,15 +2587,21 @@ fn parse_provider_block_with_default_tags() {
     assert_eq!(result.providers[0].default_tags.len(), 3);
     assert_eq!(
         result.providers[0].default_tags.get("Environment"),
-        Some(&Value::String("production".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "production".to_string()
+        )))
     );
     assert_eq!(
         result.providers[0].default_tags.get("Team"),
-        Some(&Value::String("platform".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "platform".to_string()
+        )))
     );
     assert_eq!(
         result.providers[0].default_tags.get("ManagedBy"),
-        Some(&Value::String("carina".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "carina".to_string()
+        )))
     );
 }
 
@@ -2711,7 +2786,9 @@ fn parse_let_binding_module_call() {
     assert_eq!(call.binding_name, Some("web".to_string()));
     assert_eq!(
         call.arguments.get("vpc"),
-        Some(&Value::String("vpc-123".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-123".to_string()
+        )))
     );
 }
 
@@ -2757,7 +2834,9 @@ fn parse_string_interpolation_simple() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("vpc-prod".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-prod".to_string()
+        )))
     );
 }
 
@@ -2775,7 +2854,9 @@ fn parse_string_interpolation_multiple_exprs() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("vpc-prod-us-east-1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-prod-us-east-1".to_string()
+        )))
     );
 }
 
@@ -2794,20 +2875,20 @@ fn parse_string_interpolation_with_resource_ref() {
     let subnet = &result.resources[1];
     assert_eq!(
         subnet.get_attr("name"),
-        Some(&Value::Interpolation(vec![
+        Some(&Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("subnet-".to_string()),
             InterpolationPart::Expr(Value::resource_ref(
                 "vpc".to_string(),
                 "vpc_id".to_string(),
                 vec![]
             )),
-        ]))
+        ])))
     );
 }
 
 #[test]
 fn parse_string_no_interpolation() {
-    // Strings without ${} should remain as plain Value::String
+    // Strings without ${} should remain as plain Value::Concrete(ConcreteValue::String)
     let input = r#"
         let vpc = aws.ec2.Vpc {
             name = "my-vpc"
@@ -2818,7 +2899,9 @@ fn parse_string_no_interpolation() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("my-vpc".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-vpc".to_string()
+        )))
     );
 }
 
@@ -2835,7 +2918,9 @@ fn parse_string_dollar_without_brace() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("price$100".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "price$100".to_string()
+        )))
     );
 }
 
@@ -2852,14 +2937,16 @@ fn parse_string_escaped_interpolation() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("literal${expr}".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "literal${expr}".to_string()
+        )))
     );
 }
 
 #[test]
 fn parse_empty_interpolation_accepted_as_unknown() {
     // `${}` mid-edit must NOT abort parsing — instead it is stamped as
-    // `Value::Unknown(EmptyInterpolation)` so other diagnostics in the
+    // `Value::Deferred(DeferredValue::Unknown(EmptyInterpolation))` so other diagnostics in the
     // file (sibling let bindings, type mismatches, etc.) keep running.
     // See #2480 — pre-fix, this input rejected the entire AST with
     // `expected primary` and made every let binding appear undefined.
@@ -2874,20 +2961,23 @@ fn parse_empty_interpolation_accepted_as_unknown() {
     let bucket = &result.resources[0];
     let attr = bucket.get_attr("name").expect("name attr");
     let parts = match attr {
-        Value::Interpolation(parts) => parts,
-        other => panic!("expected Value::Interpolation, got {:?}", other),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => parts,
+        other => panic!(
+            "expected Value::Deferred(DeferredValue::Interpolation), got {:?}",
+            other
+        ),
     };
     let has_empty = parts.iter().any(|p| {
         matches!(
             p,
-            crate::resource::InterpolationPart::Expr(Value::Unknown(
+            crate::resource::InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
                 crate::resource::UnknownReason::EmptyInterpolation
-            ))
+            )))
         )
     });
     assert!(
         has_empty,
-        "expected an InterpolationPart::Expr(Value::Unknown(EmptyInterpolation)) in the parsed parts; got {:?}",
+        "expected an InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(EmptyInterpolation))) in the parsed parts; got {:?}",
         parts
     );
 }
@@ -2908,15 +2998,18 @@ fn parse_whitespace_only_interpolation_accepted_as_unknown() {
     let bucket = &result.resources[0];
     let attr = bucket.get_attr("name").expect("name attr");
     let parts = match attr {
-        Value::Interpolation(parts) => parts,
-        other => panic!("expected Value::Interpolation, got {:?}", other),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => parts,
+        other => panic!(
+            "expected Value::Deferred(DeferredValue::Interpolation), got {:?}",
+            other
+        ),
     };
     let has_empty = parts.iter().any(|p| {
         matches!(
             p,
-            crate::resource::InterpolationPart::Expr(Value::Unknown(
+            crate::resource::InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
                 crate::resource::UnknownReason::EmptyInterpolation
-            ))
+            )))
         )
     });
     assert!(
@@ -2966,7 +3059,9 @@ fn parse_string_interpolation_with_bool() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("enabled-true".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "enabled-true".to_string()
+        )))
     );
 }
 
@@ -2982,7 +3077,9 @@ fn parse_string_interpolation_with_number() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("port-8080".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "port-8080".to_string()
+        )))
     );
 }
 
@@ -3000,7 +3097,7 @@ fn parse_string_interpolation_only_expr() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("tag"),
-        Some(&Value::String("prod".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("prod".to_string())))
     );
 }
 
@@ -3023,11 +3120,15 @@ fn parse_local_let_binding_in_resource_block() {
     // The local binding value should be resolved in subsequent attributes
     assert_eq!(
         subnet.get_attr("tag_name"),
-        Some(&Value::String("my-subnet".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-subnet".to_string()
+        )))
     );
     assert_eq!(
         subnet.get_attr("cidr_block"),
-        Some(&Value::String("10.0.1.0/24".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.1.0/24".to_string()
+        )))
     );
 }
 
@@ -3048,7 +3149,9 @@ fn parse_local_let_binding_with_interpolation() {
     // Local binding should resolve outer scope variable in interpolation.
     assert_eq!(
         subnet.get_attr("tag_name"),
-        Some(&Value::String("app-prod".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "app-prod".to_string()
+        )))
     );
 }
 
@@ -3069,7 +3172,9 @@ fn parse_local_let_binding_chain() {
     // Chained local bindings should resolve correctly.
     assert_eq!(
         subnet.get_attr("tag_name"),
-        Some(&Value::String("app-subnet".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "app-subnet".to_string()
+        )))
     );
 
     // Local bindings should NOT appear in attributes
@@ -3093,10 +3198,12 @@ fn parse_local_let_binding_with_function_call() {
     // Local binding used inside function call
     assert_eq!(
         subnet.get_attr("tag_name"),
-        Some(&Value::FunctionCall {
+        Some(&Value::Deferred(DeferredValue::FunctionCall {
             name: "upper".to_string(),
-            args: vec![Value::String("my-subnet".to_string())],
-        })
+            args: vec![Value::Concrete(ConcreteValue::String(
+                "my-subnet".to_string()
+            ))],
+        }))
     );
 }
 
@@ -3117,7 +3224,9 @@ fn parse_local_let_binding_in_anonymous_resource() {
     assert!(!subnet.attributes.contains_key("name"));
     assert_eq!(
         subnet.get_attr("tag_name"),
-        Some(&Value::String("my-subnet".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-subnet".to_string()
+        )))
     );
 }
 
@@ -3137,9 +3246,12 @@ fn parse_local_let_binding_in_nested_block() {
     let subnet = &result.resources[0];
 
     // Local binding should be visible in nested blocks
-    if let Some(Value::List(tags_list)) = subnet.get_attr("tags") {
-        if let Some(Value::Map(tags)) = tags_list.first() {
-            assert_eq!(tags.get("Name"), Some(&Value::String("prod".to_string())));
+    if let Some(Value::Concrete(ConcreteValue::List(tags_list))) = subnet.get_attr("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(tags))) = tags_list.first() {
+            assert_eq!(
+                tags.get("Name"),
+                Some(&Value::Concrete(ConcreteValue::String("prod".to_string())))
+            );
         } else {
             panic!("Expected Map in tags list");
         }
@@ -3169,11 +3281,15 @@ fn parse_for_expression_over_list() {
     // Each resource should have the loop variable substituted
     assert_eq!(
         result.resources[0].get_attr("availability_zone"),
-        Some(&Value::String("ap-northeast-1a".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1a".to_string()
+        )))
     );
     assert_eq!(
         result.resources[1].get_attr("availability_zone"),
-        Some(&Value::String("ap-northeast-1c".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1c".to_string()
+        )))
     );
 }
 
@@ -3195,14 +3311,18 @@ fn parse_for_expression_with_index() {
     assert_eq!(result.resources[1].id.name_str(), "subnets[1]");
 
     // Check index variable is substituted
-    if let Some(Value::FunctionCall { args, .. }) = result.resources[0].get_attr("cidr_block") {
-        assert_eq!(args[2], Value::Int(0));
+    if let Some(Value::Deferred(DeferredValue::FunctionCall { args, .. })) =
+        result.resources[0].get_attr("cidr_block")
+    {
+        assert_eq!(args[2], Value::Concrete(ConcreteValue::Int(0)));
     } else {
         panic!("Expected FunctionCall for cidr_block");
     }
 
-    if let Some(Value::FunctionCall { args, .. }) = result.resources[1].get_attr("cidr_block") {
-        assert_eq!(args[2], Value::Int(1));
+    if let Some(Value::Deferred(DeferredValue::FunctionCall { args, .. })) =
+        result.resources[1].get_attr("cidr_block")
+    {
+        assert_eq!(args[2], Value::Concrete(ConcreteValue::Int(1)));
     } else {
         panic!("Expected FunctionCall for cidr_block");
     }
@@ -3253,9 +3373,11 @@ fn parse_for_expression_with_local_binding() {
     assert_eq!(result.resources.len(), 2);
 
     // Local binding should be resolved within each iteration
-    if let Some(Value::FunctionCall { name, args }) = result.resources[0].get_attr("cidr_block") {
+    if let Some(Value::Deferred(DeferredValue::FunctionCall { name, args })) =
+        result.resources[0].get_attr("cidr_block")
+    {
         assert_eq!(name, "cidr_subnet");
-        assert_eq!(args[2], Value::Int(0));
+        assert_eq!(args[2], Value::Concrete(ConcreteValue::Int(0)));
     } else {
         panic!("Expected FunctionCall for cidr_block");
     }
@@ -3305,7 +3427,9 @@ fn parse_for_expression_with_module_call() {
         .unwrap();
     assert_eq!(
         prod_call.arguments.get("vpc_cidr"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
 
     let staging_call = result
@@ -3315,7 +3439,9 @@ fn parse_for_expression_with_module_call() {
         .unwrap();
     assert_eq!(
         staging_call.arguments.get("vpc_cidr"),
-        Some(&Value::String("10.1.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.1.0.0/16".to_string()
+        )))
     );
 }
 
@@ -3346,11 +3472,15 @@ fn parse_for_expression_with_module_call_over_list() {
 
     assert_eq!(
         result.module_calls[0].arguments.get("vpc_cidr"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
     assert_eq!(
         result.module_calls[1].arguments.get("vpc_cidr"),
-        Some(&Value::String("10.1.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.1.0.0/16".to_string()
+        )))
     );
 }
 
@@ -3372,7 +3502,7 @@ fn test_chained_field_access_two_levels() {
     let subnet = &result.resources[1];
     let vpc_id = subnet.get_attr("vpc_id").expect("vpc_id attribute");
     match vpc_id {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let field_path = path.field_path();
@@ -3402,7 +3532,7 @@ fn test_chained_field_access_three_levels() {
     let subnet = &result.resources[1];
     let vpc_id = subnet.get_attr("vpc_id").expect("vpc_id attribute");
     match vpc_id {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let field_path = path.field_path();
@@ -3434,7 +3564,7 @@ fn parse_index_access_with_integer() {
     let rt = result.resources.last().expect("route_table resource");
     let subnet_id = rt.get_attr("subnet_id").expect("subnet_id attribute");
     match subnet_id {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let field_path = path.field_path();
@@ -3474,7 +3604,7 @@ fn parse_index_access_with_string_key() {
     let subnet = result.resources.last().expect("subnet resource");
     let vpc_id = subnet.get_attr("vpc_id").expect("vpc_id attribute");
     match vpc_id {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let field_path = path.field_path();
@@ -3511,7 +3641,7 @@ fn parse_index_access_with_chained_fields() {
     let subnet = result.resources.last().expect("subnet resource");
     let sg_id = subnet.get_attr("sg_id").expect("sg_id attribute");
     match sg_id {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let field_path = path.field_path();
@@ -3539,7 +3669,7 @@ fn parse_subscript_after_field_access_with_integer() {
     let subnet = result.resources.last().expect("subnet");
     let value = subnet.get_attr("cidr_block").expect("cidr_block");
     match value {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "accounts");
             assert!(path.field_path().is_empty());
@@ -3569,7 +3699,7 @@ fn parse_subscript_after_field_access_with_string_key() {
     let subnet = result.resources.last().expect("subnet");
     let value = subnet.get_attr("cidr_block").expect("cidr_block");
     match value {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "accounts");
             assert!(path.field_path().is_empty());
@@ -3602,7 +3732,7 @@ fn parse_chained_subscripts_after_field_access() {
     let subnet = result.resources.last().expect("subnet");
     let value = subnet.get_attr("cidr_block").expect("cidr_block");
     match value {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "matrix");
             assert!(path.field_path().is_empty());
@@ -3680,7 +3810,7 @@ fn parse_subscript_after_nested_field_access() {
     let subnet = result.resources.last().expect("subnet");
     let value = subnet.get_attr("cidr_block").expect("cidr_block");
     match value {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "account");
             assert_eq!(path.field_path(), vec!["accounts"]);
@@ -3877,11 +4007,11 @@ fn parse_for_expression_with_keys_function_call() {
     assert_eq!(result.resources[1].id.name_str(), "resources[1]");
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("Env".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("Env".to_string())))
     );
     assert_eq!(
         result.resources[1].get_attr("name"),
-        Some(&Value::String("Name".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("Name".to_string())))
     );
 }
 
@@ -3905,11 +4035,15 @@ fn parse_for_expression_with_values_function_call() {
     assert_eq!(result.resources.len(), 2);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
     assert_eq!(
         result.resources[1].get_attr("cidr_block"),
-        Some(&Value::String("10.1.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.1.0.0/16".to_string()
+        )))
     );
 }
 
@@ -3929,11 +4063,15 @@ fn parse_for_expression_with_concat_function_call() {
     // So concat(["10.0.0.0/16"], ["10.1.0.0/16"]) => ["10.1.0.0/16", "10.0.0.0/16"]
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("10.1.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.1.0.0/16".to_string()
+        )))
     );
     assert_eq!(
         result.resources[1].get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
 }
 
@@ -3979,7 +4117,9 @@ fn parse_if_true_condition_includes_resource() {
     assert_eq!(result.resources[0].id.name_str(), "alarm");
     assert_eq!(
         result.resources[0].get_attr("alarm_name"),
-        Some(&Value::String("cpu-high".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "cpu-high".to_string()
+        )))
     );
 }
 
@@ -4015,7 +4155,9 @@ fn parse_if_else_true_uses_if_branch() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
 }
 
@@ -4037,7 +4179,9 @@ fn parse_if_else_false_uses_else_branch() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("172.16.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "172.16.0.0/16".to_string()
+        )))
     );
 }
 
@@ -4070,7 +4214,9 @@ fn parse_if_else_value_expression() {
     let result2 = parse(input2, &ProviderContext::default()).unwrap();
     assert_eq!(
         result2.resources[0].get_attr("instance_type"),
-        Some(&Value::String("m5.xlarge".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "m5.xlarge".to_string()
+        )))
     );
 }
 
@@ -4091,7 +4237,9 @@ fn parse_if_else_value_expression_false_branch() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("instance_type"),
-        Some(&Value::String("t3.micro".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "t3.micro".to_string()
+        )))
     );
 }
 
@@ -4199,7 +4347,9 @@ fn parse_if_with_local_binding() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("alarm_name"),
-        Some(&Value::String("cpu-high".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "cpu-high".to_string()
+        )))
     );
 }
 
@@ -4217,7 +4367,9 @@ fn parse_if_else_value_expr_in_attribute_true() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
 }
 
@@ -4235,7 +4387,9 @@ fn parse_if_else_value_expr_in_attribute_false() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("172.16.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "172.16.0.0/16".to_string()
+        )))
     );
 }
 
@@ -4252,7 +4406,9 @@ fn parse_if_value_expr_no_else_true() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("cidr_block"),
-        Some(&Value::String("10.0.0.0/16".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
     );
 }
 
@@ -4291,11 +4447,15 @@ fn parse_top_level_for_expression() {
     // Each resource should have the loop variable substituted
     assert_eq!(
         result.resources[0].get_attr("availability_zone"),
-        Some(&Value::String("ap-northeast-1a".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1a".to_string()
+        )))
     );
     assert_eq!(
         result.resources[1].get_attr("availability_zone"),
-        Some(&Value::String("ap-northeast-1c".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1c".to_string()
+        )))
     );
 }
 
@@ -4314,7 +4474,9 @@ fn parse_top_level_if_expression() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("alarm_name"),
-        Some(&Value::String("cpu-high".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "cpu-high".to_string()
+        )))
     );
 }
 
@@ -4464,7 +4626,10 @@ fn parse_arguments_block_form_description_and_default() {
     assert_eq!(result.arguments.len(), 1);
     assert_eq!(result.arguments[0].name, "port");
     assert_eq!(result.arguments[0].type_expr, TypeExpr::Int);
-    assert_eq!(result.arguments[0].default, Some(Value::Int(8080)));
+    assert_eq!(
+        result.arguments[0].default,
+        Some(Value::Concrete(ConcreteValue::Int(8080)))
+    );
     assert_eq!(
         result.arguments[0].description.as_deref(),
         Some("Web server port")
@@ -4494,7 +4659,10 @@ fn parse_arguments_mixed_simple_and_block_form() {
     // Simple form (unchanged)
     assert_eq!(result.arguments[0].name, "enable_https");
     assert_eq!(result.arguments[0].type_expr, TypeExpr::Bool);
-    assert_eq!(result.arguments[0].default, Some(Value::Bool(true)));
+    assert_eq!(
+        result.arguments[0].default,
+        Some(Value::Concrete(ConcreteValue::Bool(true)))
+    );
     assert!(result.arguments[0].description.is_none());
 
     // Block form with description only
@@ -4512,7 +4680,10 @@ fn parse_arguments_mixed_simple_and_block_form() {
     // Block form with description and default
     assert_eq!(result.arguments[2].name, "port");
     assert_eq!(result.arguments[2].type_expr, TypeExpr::Int);
-    assert_eq!(result.arguments[2].default, Some(Value::Int(8080)));
+    assert_eq!(
+        result.arguments[2].default,
+        Some(Value::Concrete(ConcreteValue::Int(8080)))
+    );
     assert_eq!(
         result.arguments[2].description.as_deref(),
         Some("Web server port")
@@ -4700,7 +4871,10 @@ fn parse_arguments_block_form_default_only() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(result.arguments.len(), 1);
     assert_eq!(result.arguments[0].name, "port");
-    assert_eq!(result.arguments[0].default, Some(Value::Int(8080)));
+    assert_eq!(
+        result.arguments[0].default,
+        Some(Value::Concrete(ConcreteValue::Int(8080)))
+    );
     assert!(result.arguments[0].description.is_none());
 }
 
@@ -4740,7 +4914,9 @@ fn parse_arguments_block_form_string_default_not_confused_with_description() {
     );
     assert_eq!(
         result.arguments[0].default,
-        Some(Value::String("my-resource".to_string()))
+        Some(Value::Concrete(ConcreteValue::String(
+            "my-resource".to_string()
+        )))
     );
 }
 
@@ -4764,7 +4940,7 @@ fn parse_arguments_block_form_validation_block() {
     let arg = &result.arguments[0];
     assert_eq!(arg.name, "port");
     assert_eq!(arg.type_expr, TypeExpr::Int);
-    assert_eq!(arg.default, Some(Value::Int(8080)));
+    assert_eq!(arg.default, Some(Value::Concrete(ConcreteValue::Int(8080))));
     assert_eq!(arg.description.as_deref(), Some("Web server port"));
     assert_eq!(arg.validations.len(), 1);
     assert_eq!(
@@ -4947,7 +5123,7 @@ fn join_with_resolved_args_still_works() {
     let resource = &result.resources[0];
     assert_eq!(
         resource.get_attr("name"),
-        Some(&Value::String("a-b-c".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String("a-b-c".to_string()))),
     );
 }
 
@@ -4969,7 +5145,9 @@ fn user_fn_simple_call() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("hello world".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "hello world".to_string()
+        ))),
     );
 }
 
@@ -4992,11 +5170,15 @@ fn user_fn_with_default_param() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("prod-default".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "prod-default".to_string()
+        ))),
     );
     assert_eq!(
         result.resources[1].get_attr("name"),
-        Some(&Value::String("prod-web".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "prod-web".to_string()
+        ))),
     );
 }
 
@@ -5016,7 +5198,9 @@ fn user_fn_with_local_let() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("prod-subnet-a".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "prod-subnet-a".to_string()
+        ))),
     );
 }
 
@@ -5035,7 +5219,7 @@ fn user_fn_calling_builtin() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("HELLO".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String("HELLO".to_string()))),
     );
 }
 
@@ -5058,7 +5242,9 @@ fn user_fn_calling_another_fn() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("prod-app-web".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "prod-app-web".to_string()
+        ))),
     );
 }
 
@@ -5194,7 +5380,7 @@ fn user_fn_no_params() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("hello".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String("hello".to_string()))),
     );
 }
 
@@ -5255,7 +5441,9 @@ fn user_fn_with_pipe_operator() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("hello-world".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "hello-world".to_string()
+        ))),
     );
 }
 
@@ -5275,7 +5463,10 @@ fn user_fn_with_string_interpolation() {
     // the surrounding "-suffix" literal.
     let result = parse(input, &ProviderContext::default()).unwrap();
     let name = result.resources[0].get_attr("name").unwrap();
-    assert_eq!(name, &Value::String("hello world-suffix".to_string()));
+    assert_eq!(
+        name,
+        &Value::Concrete(ConcreteValue::String("hello world-suffix".to_string()))
+    );
 }
 
 #[test]
@@ -5294,7 +5485,9 @@ fn user_fn_typed_param_string() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("hello world".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "hello world".to_string()
+        ))),
     );
 }
 
@@ -5353,7 +5546,9 @@ fn user_fn_typed_param_with_default() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("prod-default".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "prod-default".to_string()
+        ))),
     );
 }
 
@@ -5372,7 +5567,9 @@ fn user_fn_mixed_typed_and_untyped() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("name"),
-        Some(&Value::String("prod-web".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "prod-web".to_string()
+        ))),
     );
 }
 
@@ -5399,7 +5596,7 @@ fn user_fn_typed_param_bool_mismatch() {
 #[test]
 fn typed_user_fn_accepts_value_unknown_in_deferred_for_body() {
     // RFC #2371 stage 3: a deferred for-expression binds the loop var
-    // to `Value::Unknown(ForValue)` during template parsing. If a typed
+    // to `Value::Deferred(DeferredValue::Unknown(ForValue))` during template parsing. If a typed
     // user function is invoked with that placeholder, `check_fn_arg_type`
     // must skip the type check (the concrete type resolves at upstream
     // apply). Without the skip, parsing fails with `expects type 'String'`.
@@ -5431,7 +5628,7 @@ fn typed_user_fn_accepts_value_unknown_in_deferred_for_body() {
 fn typed_return_user_fn_accepts_value_unknown_in_deferred_for_body() {
     // Same skip rule must apply to return-type checking. The user fn
     // here has both a typed param and a typed return; both must let
-    // `Value::Unknown` pass through.
+    // `Value::Deferred(DeferredValue::Unknown)` pass through.
     let input = r#"
         fn label(s: String): String {
             s
@@ -5931,7 +6128,10 @@ fn parse_decrypt_uses_config_decryptor() {
     resolve_resource_refs_with_config(&mut parsed, &config).unwrap();
     assert_eq!(parsed.resources.len(), 1); // allow: direct — fixture test inspection
     let secret_val = parsed.resources[0].get_attr("secret").unwrap();
-    assert_eq!(*secret_val, Value::String("decrypted:AQICAHh".to_string()));
+    assert_eq!(
+        *secret_val,
+        Value::Concrete(ConcreteValue::String("decrypted:AQICAHh".to_string()))
+    );
 }
 
 #[test]
@@ -5980,7 +6180,7 @@ fn parse_custom_validator_accepts_valid() {
 
     let result = validate_custom_type(
         "custom_type",
-        &Value::String("valid-data".to_string()),
+        &Value::Concrete(ConcreteValue::String("valid-data".to_string())),
         &config,
     );
     assert!(result.is_ok());
@@ -5988,7 +6188,7 @@ fn parse_custom_validator_accepts_valid() {
     // Unknown type with no custom validator should also pass (permissive)
     let result = validate_custom_type(
         "unknown_type",
-        &Value::String("anything".to_string()),
+        &Value::Concrete(ConcreteValue::String("anything".to_string())),
         &config,
     );
     assert!(result.is_ok());
@@ -6023,14 +6223,14 @@ fn parse_custom_validator_rejects_invalid() {
     // arbitrary type names. This verifies the custom validator is called.
     let valid_result = validate_custom_type(
         "custom_type",
-        &Value::String("valid-data".to_string()),
+        &Value::Concrete(ConcreteValue::String("valid-data".to_string())),
         &config,
     );
     assert!(valid_result.is_ok());
 
     let invalid_result = validate_custom_type(
         "custom_type",
-        &Value::String("invalid".to_string()),
+        &Value::Concrete(ConcreteValue::String("invalid".to_string())),
         &config,
     );
     assert!(invalid_result.is_err());
@@ -6172,7 +6372,7 @@ fn parse_upstream_state_registers_binding() {
     assert_eq!(result.resources.len(), 1);
     let vpc_id_attr = result.resources[0].get_attr("vpc_id").unwrap();
     match vpc_id_attr {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "network");
             assert_eq!(path.attribute(), "vpc");
             assert_eq!(path.field_path(), vec!["vpc_id"]);
@@ -6323,7 +6523,7 @@ fn test_compose_operator_followed_by_pipe_consumes_closure() {
 
     assert_eq!(
         result.variables.get("result").unwrap(),
-        &Value::String("a,b".to_string())
+        &Value::Concrete(ConcreteValue::String("a,b".to_string()))
     );
     // `f` is a closure-only binding and does not appear in the
     // user-facing variable map.
@@ -6340,7 +6540,7 @@ fn test_compose_operator_with_pipe() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("names").unwrap(),
-        &Value::String("alice, bob".to_string())
+        &Value::Concrete(ConcreteValue::String("alice, bob".to_string()))
     );
 }
 
@@ -6354,7 +6554,7 @@ fn test_compose_operator_two_step_chain() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("result").unwrap(),
-        &Value::String("a-b-c".to_string())
+        &Value::Concrete(ConcreteValue::String("a-b-c".to_string()))
     );
 }
 
@@ -6401,7 +6601,7 @@ fn test_compose_operator_precedence_with_pipe() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("result").unwrap(),
-        &Value::String("1-2".to_string())
+        &Value::Concrete(ConcreteValue::String("1-2".to_string()))
     );
 }
 
@@ -6433,7 +6633,9 @@ fn parse_single_quoted_string_literal() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("my-vpc".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-vpc".to_string()
+        )))
     );
 }
 
@@ -6452,7 +6654,9 @@ fn parse_single_quoted_string_no_interpolation() {
     // Should be a plain string, not interpolated
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("vpc-${env}".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "vpc-${env}".to_string()
+        )))
     );
 }
 
@@ -6468,7 +6672,9 @@ fn parse_single_quoted_string_escape_sequences() {
     let vpc = &result.resources[0];
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::String("it's a test".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "it's a test".to_string()
+        )))
     );
 }
 
@@ -6483,11 +6689,11 @@ fn test_compose_three_functions_execution() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("result").unwrap(),
-        &Value::List(vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
-            Value::String("c".to_string()),
-        ])
+        &Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
+            Value::Concrete(ConcreteValue::String("c".to_string())),
+        ]))
     );
 }
 
@@ -6507,9 +6713,9 @@ EOT
     let resource = &result.resources[0];
     assert_eq!(
         resource.get_attr("policy"),
-        Some(&Value::String(
+        Some(&Value::Concrete(ConcreteValue::String(
             "{\n  \"Version\": \"2012-10-17\"\n}".to_string()
-        ))
+        )))
     );
 }
 
@@ -6521,7 +6727,9 @@ fn parse_heredoc_indented() {
     let resource = &result.resources[0];
     assert_eq!(
         resource.get_attr("policy"),
-        Some(&Value::String("line1\nline2\nline3".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "line1\nline2\nline3".to_string()
+        )))
     );
 }
 
@@ -6532,7 +6740,7 @@ fn parse_heredoc_empty() {
     let resource = &result.resources[0];
     assert_eq!(
         resource.get_attr("policy"),
-        Some(&Value::String("".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("".to_string())))
     );
 }
 
@@ -6546,7 +6754,9 @@ EOF
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.variables.get("doc"),
-        Some(&Value::String("hello world".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "hello world".to_string()
+        )))
     );
 }
 
@@ -6559,14 +6769,18 @@ fn quoted_string_as_map_key() {
         }
     "#;
     let result = parse(input, &ProviderContext::default()).unwrap();
-    if let Some(Value::Map(map)) = result.variables.get("m") {
+    if let Some(Value::Concrete(ConcreteValue::Map(map))) = result.variables.get("m") {
         assert_eq!(
             map.get("token.actions.githubusercontent.com:aud"),
-            Some(&Value::String("sts.amazonaws.com".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "sts.amazonaws.com".to_string()
+            )))
         );
         assert_eq!(
             map.get("aws:SourceIp"),
-            Some(&Value::String("10.0.0.0/8".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "10.0.0.0/8".to_string()
+            )))
         );
     } else {
         panic!("Expected map, got {:?}", result.variables.get("m"));
@@ -6596,15 +6810,18 @@ fn quoted_string_as_attribute_key_in_block() {
     let resource = &result.resources[0];
     // Navigate: assume_role_policy_document -> statement[0] -> condition -> string_equals
     let doc = resource.get_attr("assume_role_policy_document").unwrap();
-    if let Value::Map(doc_map) = doc
-        && let Some(Value::List(statements)) = doc_map.get("statement")
-        && let Value::Map(stmt) = &statements[0]
-        && let Some(Value::Map(condition)) = stmt.get("condition")
-        && let Some(Value::Map(string_equals)) = condition.get("string_equals")
+    if let Value::Concrete(ConcreteValue::Map(doc_map)) = doc
+        && let Some(Value::Concrete(ConcreteValue::List(statements))) = doc_map.get("statement")
+        && let Value::Concrete(ConcreteValue::Map(stmt)) = &statements[0]
+        && let Some(Value::Concrete(ConcreteValue::Map(condition))) = stmt.get("condition")
+        && let Some(Value::Concrete(ConcreteValue::Map(string_equals))) =
+            condition.get("string_equals")
     {
         assert_eq!(
             string_equals.get("token.actions.githubusercontent.com:aud"),
-            Some(&Value::String("sts.amazonaws.com".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "sts.amazonaws.com".to_string()
+            )))
         );
     } else {
         panic!("Could not navigate to condition key");
@@ -6730,7 +6947,9 @@ awscc.ec2.Subnet {
     // Actually, resource refs remain as ResourceRef until resolution, so the left side IS a ResourceRef
     assert_eq!(
         cidr,
-        Some(&Value::String("10.0.1.0/24".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.0.1.0/24".to_string()
+        ))),
         "?? should return default when left is an unresolved ResourceRef"
     );
 }
@@ -6749,7 +6968,7 @@ exports {
     // Check if the value is a ResourceRef
     let value = exports_parsed.export_params[0].value.as_ref().unwrap();
     eprintln!("value: {:?}", value);
-    let is_ref = matches!(value, Value::ResourceRef { .. });
+    let is_ref = matches!(value, Value::Deferred(DeferredValue::ResourceRef { .. }));
     eprintln!("is_ref: {}", is_ref);
 
     // Now simulate merged ParsedFile with binding from main.crn
@@ -6791,7 +7010,9 @@ awscc.ec2.Vpc {
     let cidr = parsed.resources[0].get_attr("cidr_block");
     assert_eq!(
         cidr,
-        Some(&Value::String("10.1.0.0/16".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "10.1.0.0/16".to_string()
+        ))),
         "?? should return left when it's resolved"
     );
 }
@@ -6872,10 +7093,10 @@ fn expand_deferred_for_with_remote_bindings() {
     let mut orgs_attrs = HashMap::new();
     orgs_attrs.insert(
         "accounts".to_string(),
-        Value::List(vec![
-            Value::String("111111111111".to_string()),
-            Value::String("222222222222".to_string()),
-        ]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("111111111111".to_string())),
+            Value::Concrete(ConcreteValue::String("222222222222".to_string())),
+        ])),
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -6907,7 +7128,9 @@ fn expand_deferred_for_with_remote_bindings() {
     let target_id_0 = r0.get_attr("target_id");
     assert_eq!(
         target_id_0,
-        Some(&Value::String("111111111111".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "111111111111".to_string()
+        ))),
         "target_id should be substituted with actual account ID"
     );
 
@@ -6915,7 +7138,9 @@ fn expand_deferred_for_with_remote_bindings() {
     let target_id_1 = r1.get_attr("target_id");
     assert_eq!(
         target_id_1,
-        Some(&Value::String("222222222222".to_string())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "222222222222".to_string()
+        ))),
     );
 }
 
@@ -6973,11 +7198,17 @@ fn expand_deferred_for_map_binding_substitutes_key_and_value() {
     let mut accounts: IndexMap<String, Value> = IndexMap::new();
     accounts.insert(
         "prod".to_string(),
-        Value::String("111111111111".to_string()),
+        Value::Concrete(ConcreteValue::String("111111111111".to_string())),
     );
-    accounts.insert("dev".to_string(), Value::String("222222222222".to_string()));
+    accounts.insert(
+        "dev".to_string(),
+        Value::Concrete(ConcreteValue::String("222222222222".to_string())),
+    );
     let mut orgs_attrs = HashMap::new();
-    orgs_attrs.insert("accounts".to_string(), Value::Map(accounts));
+    orgs_attrs.insert(
+        "accounts".to_string(),
+        Value::Concrete(ConcreteValue::Map(accounts)),
+    );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
     parsed.expand_deferred_for_expressions(&remote_bindings);
@@ -6988,19 +7219,23 @@ fn expand_deferred_for_map_binding_substitutes_key_and_value() {
     // Verify both key and value are substituted.
     let mut by_name: HashMap<String, &Resource> = HashMap::new();
     for r in &parsed.resources {
-        if let Some(Value::String(s)) = r.get_attr("target_name") {
+        if let Some(Value::Concrete(ConcreteValue::String(s))) = r.get_attr("target_name") {
             by_name.insert(s.clone(), r);
         }
     }
     let prod = by_name.get("prod").expect("prod entry");
     assert_eq!(
         prod.get_attr("target_id"),
-        Some(&Value::String("111111111111".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "111111111111".to_string()
+        )))
     );
     let dev = by_name.get("dev").expect("dev entry");
     assert_eq!(
         dev.get_attr("target_id"),
-        Some(&Value::String("222222222222".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "222222222222".to_string()
+        )))
     );
 }
 
@@ -7029,10 +7264,10 @@ fn expand_deferred_for_indexed_binding_substitutes_index_and_value() {
     let mut orgs_attrs = HashMap::new();
     orgs_attrs.insert(
         "accounts".to_string(),
-        Value::List(vec![
-            Value::String("111111111111".to_string()),
-            Value::String("222222222222".to_string()),
-        ]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("111111111111".to_string())),
+            Value::Concrete(ConcreteValue::String("222222222222".to_string())),
+        ])),
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -7041,27 +7276,31 @@ fn expand_deferred_for_indexed_binding_substitutes_index_and_value() {
     assert_eq!(parsed.resources.len(), 2); // allow: direct — fixture test inspection
     assert_eq!(
         parsed.resources[0].get_attr("target_id"),
-        Some(&Value::String("111111111111".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "111111111111".to_string()
+        )))
     );
     assert_eq!(
         parsed.resources[0].get_attr("position"),
-        Some(&Value::Int(0)),
+        Some(&Value::Concrete(ConcreteValue::Int(0))),
         "index should be 0, not the item value"
     );
     assert_eq!(
         parsed.resources[1].get_attr("target_id"),
-        Some(&Value::String("222222222222".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "222222222222".to_string()
+        )))
     );
     assert_eq!(
         parsed.resources[1].get_attr("position"),
-        Some(&Value::Int(1))
+        Some(&Value::Concrete(ConcreteValue::Int(1)))
     );
 }
 
 #[test]
 fn expand_deferred_for_substitutes_placeholder_inside_interpolation() {
     // The loop var may appear inside a string interpolation like "acct-${id}".
-    // Placeholder substitution must recurse into Value::Interpolation parts,
+    // Placeholder substitution must recurse into Value::Deferred(DeferredValue::Interpolation) parts,
     // otherwise the rendered resource ships the raw placeholder string.
     let input = r#"
         let orgs = upstream_state {
@@ -7083,7 +7322,9 @@ fn expand_deferred_for_substitutes_placeholder_inside_interpolation() {
     let mut orgs_attrs = HashMap::new();
     orgs_attrs.insert(
         "accounts".to_string(),
-        Value::List(vec![Value::String("111111111111".to_string())]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("111111111111".to_string()),
+        )])),
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -7093,18 +7334,20 @@ fn expand_deferred_for_substitutes_placeholder_inside_interpolation() {
     // label must have the placeholder substituted in the interpolation.
     let label = parsed.resources[0].get_attr("label");
     let rendered = match label {
-        Some(Value::Interpolation(parts)) => {
+        Some(Value::Deferred(DeferredValue::Interpolation(parts))) => {
             let mut s = String::new();
             for p in parts {
                 match p {
                     crate::resource::InterpolationPart::Literal(lit) => s.push_str(lit),
-                    crate::resource::InterpolationPart::Expr(Value::String(v)) => s.push_str(v),
+                    crate::resource::InterpolationPart::Expr(Value::Concrete(
+                        ConcreteValue::String(v),
+                    )) => s.push_str(v),
                     _ => s.push_str("<expr>"),
                 }
             }
             s
         }
-        Some(Value::String(s)) => s.clone(),
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
         other => panic!("unexpected label shape: {:?}", other),
     };
     assert!(
@@ -7112,23 +7355,25 @@ fn expand_deferred_for_substitutes_placeholder_inside_interpolation() {
         "interpolation should contain substituted account id, got: {}",
         rendered
     );
-    // After expansion no `Value::Unknown(ForValue)` placeholder must
+    // After expansion no `Value::Deferred(DeferredValue::Unknown(ForValue))` placeholder must
     // remain in the resource tree — every for-binding occurrence is
     // replaced by the resolved iterable element. RFC #2371 stage 3.
     fn contains_for_unknown(v: &Value) -> bool {
         use crate::resource::{InterpolationPart, UnknownReason};
         match v {
-            Value::Unknown(UnknownReason::ForValue)
-            | Value::Unknown(UnknownReason::ForKey)
-            | Value::Unknown(UnknownReason::ForIndex) => true,
-            Value::List(items) => items.iter().any(contains_for_unknown),
-            Value::Map(m) => m.values().any(contains_for_unknown),
-            Value::Interpolation(parts) => parts.iter().any(|p| match p {
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue))
+            | Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey))
+            | Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex)) => true,
+            Value::Concrete(ConcreteValue::List(items)) => items.iter().any(contains_for_unknown),
+            Value::Concrete(ConcreteValue::Map(m)) => m.values().any(contains_for_unknown),
+            Value::Deferred(DeferredValue::Interpolation(parts)) => parts.iter().any(|p| match p {
                 InterpolationPart::Expr(inner) => contains_for_unknown(inner),
                 InterpolationPart::Literal(_) => false,
             }),
-            Value::FunctionCall { args, .. } => args.iter().any(contains_for_unknown),
-            Value::Secret(inner) => contains_for_unknown(inner),
+            Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
+                args.iter().any(contains_for_unknown)
+            }
+            Value::Deferred(DeferredValue::Secret(inner)) => contains_for_unknown(inner),
             _ => false,
         }
     }
@@ -7138,7 +7383,7 @@ fn expand_deferred_for_substitutes_placeholder_inside_interpolation() {
         .any(contains_for_unknown);
     assert!(
         !leaked,
-        "for-binding Value::Unknown placeholder must not leak into expanded resource"
+        "for-binding Value::Deferred(DeferredValue::Unknown) placeholder must not leak into expanded resource"
     );
 }
 
@@ -7164,10 +7409,13 @@ fn expand_deferred_for_simple_binding_with_map_iterable_warns() {
     let mut accounts: IndexMap<String, Value> = IndexMap::new();
     accounts.insert(
         "prod".to_string(),
-        Value::String("111111111111".to_string()),
+        Value::Concrete(ConcreteValue::String("111111111111".to_string())),
     );
     let mut orgs_attrs = HashMap::new();
-    orgs_attrs.insert("accounts".to_string(), Value::Map(accounts));
+    orgs_attrs.insert(
+        "accounts".to_string(),
+        Value::Concrete(ConcreteValue::Map(accounts)),
+    );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
     parsed.expand_deferred_for_expressions(&remote_bindings);
@@ -7210,10 +7458,10 @@ fn expand_deferred_for_map_binding_with_list_iterable_warns() {
     let mut orgs_attrs = HashMap::new();
     orgs_attrs.insert(
         "accounts".to_string(),
-        Value::List(vec![
-            Value::String("111111111111".to_string()),
-            Value::String("222222222222".to_string()),
-        ]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("111111111111".to_string())),
+            Value::Concrete(ConcreteValue::String("222222222222".to_string())),
+        ])),
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -7865,7 +8113,7 @@ fn quoted_string_attrs_skipped_for_interpolated_strings() {
         .iter()
         .find(|r| r.binding.as_deref() == Some("r"))
         .expect("r resource present");
-    // Interpolations parse to `Value::Interpolation`, not a plain
+    // Interpolations parse to `Value::Deferred(DeferredValue::Interpolation)`, not a plain
     // string, so they are never recorded in `quoted_string_attrs`.
     assert!(
         !r.quoted_string_attrs.contains("name"),
@@ -7874,7 +8122,7 @@ fn quoted_string_attrs_skipped_for_interpolated_strings() {
     );
 }
 
-/// The payload of `Value::Map` must preserve the source order of the
+/// The payload of `Value::Concrete(ConcreteValue::Map)` must preserve the source order of the
 /// keys the user wrote — top-level map literals included.
 #[test]
 fn value_map_preserves_insertion_order() {
@@ -7887,20 +8135,20 @@ fn value_map_preserves_insertion_order() {
         }
     "#;
     let parsed = parse(input, &ProviderContext::default()).unwrap();
-    let Some(Value::Map(map)) = parsed.variables.get("m") else {
-        panic!("expected variables['m'] to be a Value::Map");
+    let Some(Value::Concrete(ConcreteValue::Map(map))) = parsed.variables.get("m") else {
+        panic!("expected variables['m'] to be a Value::Concrete(ConcreteValue::Map)");
     };
     let keys: Vec<&str> = map.keys().map(String::as_str).collect();
     assert_eq!(
         keys,
         vec!["z_first", "a_second", "m_third", "b_fourth"],
-        "Value::Map must preserve source key order; got {keys:?}"
+        "Value::Concrete(ConcreteValue::Map) must preserve source key order; got {keys:?}"
     );
 }
 
 /// `ProviderConfig.default_tags` must preserve the source order in
 /// which the user wrote tag keys. The map is extracted from a
-/// `default_tags = { ... }` block, so the same `Value::Map`
+/// `default_tags = { ... }` block, so the same `Value::Concrete(ConcreteValue::Map)`
 /// guarantee applies.
 #[test]
 fn provider_config_default_tags_preserve_insertion_order() {
@@ -7981,7 +8229,7 @@ fn parsed_file_variables_preserve_insertion_order() {
 }
 
 /// A nested block's attributes must surface in source order on the
-/// `Value::Map` payload, end-to-end through the parser.
+/// `Value::Concrete(ConcreteValue::Map)` payload, end-to-end through the parser.
 #[test]
 fn nested_block_value_map_preserves_insertion_order() {
     let input = r#"
@@ -8008,18 +8256,18 @@ fn nested_block_value_map_preserves_insertion_order() {
         .get_attr("nested")
         .expect("expected `nested` attribute");
     // Nested blocks are wrapped in a List<Map> by the parser.
-    let Value::List(blocks) = nested else {
+    let Value::Concrete(ConcreteValue::List(blocks)) = nested else {
         panic!("expected nested blocks to be a List, got {nested:?}");
     };
     let block = blocks.first().expect("expected one nested block");
-    let Value::Map(map) = block else {
-        panic!("expected nested block to be a Value::Map, got {block:?}");
+    let Value::Concrete(ConcreteValue::Map(map)) = block else {
+        panic!("expected nested block to be a Value::Concrete(ConcreteValue::Map), got {block:?}");
     };
     let keys: Vec<&str> = map.keys().map(String::as_str).collect();
     assert_eq!(
         keys,
         vec!["z_first", "a_second", "m_third"],
-        "nested block Value::Map must preserve source key order; got {keys:?}"
+        "nested block Value::Concrete(ConcreteValue::Map) must preserve source key order; got {keys:?}"
     );
 }
 
@@ -8119,7 +8367,7 @@ fn parse_subscript_on_upstream_state_in_sibling_file() {
         .expect("resource present");
     let v = res.attributes.get("account_id").unwrap();
     match v {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "accounts");
             assert!(path.field_path().is_empty());
@@ -8175,12 +8423,15 @@ fn parse_subscript_on_upstream_state_inside_string_interpolation_sibling_file() 
         .expect("resource present");
     let v = res.attributes.get("arn").unwrap();
     match v {
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             // The middle Expr part should be the upstream ResourceRef
             // with a string subscript.
             let mut found_ref = false;
             for p in parts {
-                if let InterpolationPart::Expr(Value::ResourceRef { path }) = p {
+                if let InterpolationPart::Expr(Value::Deferred(DeferredValue::ResourceRef {
+                    path,
+                })) = p
+                {
                     assert_eq!(path.binding(), "orgs");
                     assert_eq!(path.attribute(), "accounts");
                     assert_eq!(
@@ -8197,7 +8448,7 @@ fn parse_subscript_on_upstream_state_inside_string_interpolation_sibling_file() 
                 "expected a ResourceRef expression part in the interpolation, got {parts:?}"
             );
         }
-        other => panic!("expected Value::Interpolation, got {other:?}"),
+        other => panic!("expected Value::Deferred(DeferredValue::Interpolation), got {other:?}"),
     }
 }
 
@@ -8205,9 +8456,9 @@ fn parse_subscript_on_upstream_state_inside_string_interpolation_sibling_file() 
 // #2447: dot-notation upstream_state field access across sibling files
 //
 // Symmetric with the #2435 subscript fixes above: `${orgs.accounts.k}` must
-// also lower to `Value::ResourceRef` when the `let orgs = upstream_state{...}`
+// also lower to `Value::Deferred(DeferredValue::ResourceRef)` when the `let orgs = upstream_state{...}`
 // declaration lives in a sibling .crn. Without this, the dotted form falls
-// through to a `Value::String("orgs.accounts.k")` literal and the literal
+// through to a `Value::Concrete(ConcreteValue::String("orgs.accounts.k"))` literal and the literal
 // flows through the resolver into the rendered plan.
 // ================================================================
 
@@ -8247,7 +8498,7 @@ fn parse_dot_notation_on_upstream_state_in_sibling_file() {
         .expect("resource present");
     let v = res.attributes.get("account_id").unwrap();
     match v {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "accounts");
             assert_eq!(path.field_path(), ["registry_dev".to_string()]);
@@ -8260,7 +8511,7 @@ fn parse_dot_notation_on_upstream_state_in_sibling_file() {
 #[test]
 fn parse_dot_notation_on_upstream_state_inside_string_interpolation_sibling_file() {
     // `"prefix${orgs.accounts.registry_dev}suffix"` must lower the field
-    // access into a `Value::ResourceRef` so the resolver can substitute
+    // access into a `Value::Deferred(DeferredValue::ResourceRef)` so the resolver can substitute
     // the actual map value at plan time. Without this fix the embedded
     // ${...} renders the literal substring `orgs.accounts.registry_dev`
     // into the output.
@@ -8298,10 +8549,13 @@ fn parse_dot_notation_on_upstream_state_inside_string_interpolation_sibling_file
         .expect("resource present");
     let v = res.attributes.get("arn").unwrap();
     match v {
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             let mut found_ref = false;
             for p in parts {
-                if let InterpolationPart::Expr(Value::ResourceRef { path }) = p {
+                if let InterpolationPart::Expr(Value::Deferred(DeferredValue::ResourceRef {
+                    path,
+                })) = p
+                {
                     assert_eq!(path.binding(), "orgs");
                     assert_eq!(path.attribute(), "accounts");
                     assert_eq!(path.field_path(), ["registry_dev".to_string()]);
@@ -8313,7 +8567,7 @@ fn parse_dot_notation_on_upstream_state_inside_string_interpolation_sibling_file
                 "expected a ResourceRef expression part in the interpolation, got {parts:?}"
             );
         }
-        other => panic!("expected Value::Interpolation, got {other:?}"),
+        other => panic!("expected Value::Deferred(DeferredValue::Interpolation), got {other:?}"),
     }
 }
 
@@ -8368,8 +8622,8 @@ fn parse_directory_resolves_sibling_user_fn_with_static_args() {
         .expect("resource present");
     let v = res.attributes.get("created_at").unwrap();
     match v {
-        Value::String(s) if s == "2026-05-05" => {}
-        Value::FunctionCall { name, .. } if name == "timestamp" => {}
+        Value::Concrete(ConcreteValue::String(s)) if s == "2026-05-05" => {}
+        Value::Deferred(DeferredValue::FunctionCall { name, .. }) if name == "timestamp" => {}
         other => panic!(
             "expected timestamp() to resolve to a String or be kept as FunctionCall, got {other:?}"
         ),
@@ -8422,7 +8676,7 @@ fn parse_directory_resolves_sibling_user_fn_in_top_level_let() {
         .get("v")
         .expect("variable `v` should be present");
     assert!(
-        matches!(v, Value::String(s) if s == "2026-05-05"),
+        matches!(v, Value::Concrete(ConcreteValue::String(s)) if s == "2026-05-05"),
         "expected `v` to resolve to the user-fn body, got: {v:?}"
     );
 }
@@ -8473,15 +8727,15 @@ fn parse_directory_resolves_sibling_user_fn_in_let_list() {
         .expect("List containing sibling user-fn must parse");
     let v = parsed.variables.get("xs").expect("xs present");
     match v {
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             assert_eq!(items.len(), 2);
             assert!(
-                matches!(&items[0], Value::String(s) if s == "2026"),
+                matches!(&items[0], Value::Concrete(ConcreteValue::String(s)) if s == "2026"),
                 "first item should resolve to user-fn body, got: {:?}",
                 items[0]
             );
         }
-        other => panic!("expected Value::List, got {other:?}"),
+        other => panic!("expected Value::Concrete(ConcreteValue::List), got {other:?}"),
     }
 }
 
@@ -8499,14 +8753,14 @@ fn parse_directory_resolves_sibling_user_fn_in_let_map() {
         .expect("Map containing sibling user-fn must parse");
     let v = parsed.variables.get("m").expect("m present");
     match v {
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let entry = map.get("created_at").expect("created_at key");
             assert!(
-                matches!(entry, Value::String(s) if s == "2026"),
+                matches!(entry, Value::Concrete(ConcreteValue::String(s)) if s == "2026"),
                 "map value should resolve to user-fn body, got: {entry:?}"
             );
         }
-        other => panic!("expected Value::Map, got {other:?}"),
+        other => panic!("expected Value::Concrete(ConcreteValue::Map), got {other:?}"),
     }
 }
 
@@ -8524,7 +8778,7 @@ fn parse_directory_resolves_sibling_user_fn_in_let_interpolation() {
         .expect("Interpolation containing sibling user-fn must parse");
     let v = parsed.variables.get("s").expect("s present");
     assert!(
-        matches!(v, Value::String(s) if s == "prefix-2026-suffix"),
+        matches!(v, Value::Concrete(ConcreteValue::String(s)) if s == "prefix-2026-suffix"),
         "interpolation should canonicalize to the joined string, got: {v:?}"
     );
 }
@@ -8614,7 +8868,7 @@ arguments {
     let arg = &parsed.arguments[0];
     assert_eq!(
         arg.default.as_ref().unwrap(),
-        &Value::String("prod".to_string())
+        &Value::Concrete(ConcreteValue::String("prod".to_string()))
     );
 }
 
@@ -8721,8 +8975,10 @@ fn parse_duration_literal_minutes() {
     let parsed = parse_and_resolve("let t = 75min").expect("parse should succeed");
     let v = parsed.variables.get("t").expect("t binding present");
     match v {
-        Value::Duration(d) => assert_eq!(*d, std::time::Duration::from_secs(75 * 60)),
-        other => panic!("expected Value::Duration, got {other:?}"),
+        Value::Concrete(ConcreteValue::Duration(d)) => {
+            assert_eq!(*d, std::time::Duration::from_secs(75 * 60))
+        }
+        other => panic!("expected Value::Concrete(ConcreteValue::Duration), got {other:?}"),
     }
 }
 
@@ -8749,8 +9005,10 @@ fn parse_duration_literal_all_units() {
             parse_and_resolve(&input).unwrap_or_else(|e| panic!("parse failed for {src}: {e}"));
         let v = parsed.variables.get("t").expect("t binding present");
         match v {
-            Value::Duration(d) => assert_eq!(d, expected, "case {src}"),
-            other => panic!("case {src}: expected Value::Duration, got {other:?}"),
+            Value::Concrete(ConcreteValue::Duration(d)) => assert_eq!(d, expected, "case {src}"),
+            other => panic!(
+                "case {src}: expected Value::Concrete(ConcreteValue::Duration), got {other:?}"
+            ),
         }
     }
 }
@@ -8758,12 +9016,12 @@ fn parse_duration_literal_all_units() {
 #[test]
 fn parse_bare_number_still_parses_as_int() {
     // Regression: an integer literal without a unit suffix must still
-    // be Value::Int, not interpreted as a malformed duration.
+    // be Value::Concrete(ConcreteValue::Int), not interpreted as a malformed duration.
     let parsed = parse_and_resolve("let n = 30").expect("parse should succeed");
     let v = parsed.variables.get("n").expect("n binding present");
     match v {
-        Value::Int(30) => {}
-        other => panic!("expected Value::Int(30), got {other:?}"),
+        Value::Concrete(ConcreteValue::Int(30)) => {}
+        other => panic!("expected Value::Concrete(ConcreteValue::Int(30)), got {other:?}"),
     }
 }
 
@@ -8781,11 +9039,11 @@ fn parse_duration_inside_list_and_map() {
     )
     .expect("list/map of Duration must parse");
     match parsed.variables.get("xs") {
-        Some(Value::List(items)) => {
+        Some(Value::Concrete(ConcreteValue::List(items))) => {
             let secs: Vec<u64> = items
                 .iter()
                 .map(|v| match v {
-                    Value::Duration(d) => d.as_secs(),
+                    Value::Concrete(ConcreteValue::Duration(d)) => d.as_secs(),
                     other => panic!("list element was not Duration: {other:?}"),
                 })
                 .collect();
@@ -8794,11 +9052,11 @@ fn parse_duration_inside_list_and_map() {
         other => panic!("expected list of Duration, got {other:?}"),
     }
     match parsed.variables.get("m") {
-        Some(Value::Map(map)) => {
+        Some(Value::Concrete(ConcreteValue::Map(map))) => {
             let a = map.get("a").expect("entry `a` present");
             let b = map.get("b").expect("entry `b` present");
-            assert!(matches!(a, Value::Duration(d) if d.as_secs() == 300));
-            assert!(matches!(b, Value::Duration(d) if d.as_secs() == 30));
+            assert!(matches!(a, Value::Concrete(ConcreteValue::Duration(d)) if d.as_secs() == 300));
+            assert!(matches!(b, Value::Concrete(ConcreteValue::Duration(d)) if d.as_secs() == 30));
         }
         other => panic!("expected map of Duration, got {other:?}"),
     }
@@ -8807,14 +9065,14 @@ fn parse_duration_inside_list_and_map() {
 #[test]
 fn parse_duration_rejects_internal_whitespace() {
     // `30 min` must NOT parse as a duration. Either the parse fails,
-    // or the value is something other than `Value::Duration` (most
-    // likely `Value::Int(30)` followed by a parse error from `min`).
+    // or the value is something other than `Value::Concrete(ConcreteValue::Duration)` (most
+    // likely `Value::Concrete(ConcreteValue::Int(30))` followed by a parse error from `min`).
     let result = parse_and_resolve("let t = 30 min");
     if let Ok(parsed) = result
         && let Some(v) = parsed.variables.get("t")
     {
         assert!(
-            !matches!(v, Value::Duration(_)),
+            !matches!(v, Value::Concrete(ConcreteValue::Duration(_))),
             "`30 min` must not parse as a Duration, got {v:?}"
         );
     }
@@ -8871,12 +9129,16 @@ fn parse_duration_in_directory_scoped_fixture() {
         .find(|r| r.attributes.contains_key("zero_time"))
         .expect("cert resource (with `zero_time`) present");
     match cert.attributes.get("wait_time") {
-        Some(Value::Duration(d)) => assert_eq!(*d, std::time::Duration::from_secs(4500)),
-        other => panic!("expected Value::Duration(4500), got {other:?}"),
+        Some(Value::Concrete(ConcreteValue::Duration(d))) => {
+            assert_eq!(*d, std::time::Duration::from_secs(4500))
+        }
+        other => panic!("expected Value::Concrete(ConcreteValue::Duration(4500)), got {other:?}"),
     }
     match cert.attributes.get("zero_time") {
-        Some(Value::Duration(d)) => assert_eq!(*d, std::time::Duration::ZERO),
-        other => panic!("expected Value::Duration(0), got {other:?}"),
+        Some(Value::Concrete(ConcreteValue::Duration(d))) => {
+            assert_eq!(*d, std::time::Duration::ZERO)
+        }
+        other => panic!("expected Value::Concrete(ConcreteValue::Duration(0)), got {other:?}"),
     }
     // The sibling file's resource is identifiable by lacking the
     // `zero_time` attribute that only `cert` carries.
@@ -8886,8 +9148,10 @@ fn parse_duration_in_directory_scoped_fixture() {
         .find(|r| r.attributes.contains_key("wait_time") && !r.attributes.contains_key("zero_time"))
         .expect("sibling-file resource present");
     match other.attributes.get("wait_time") {
-        Some(Value::Duration(d)) => assert_eq!(*d, std::time::Duration::from_secs(5 * 60)),
-        other => panic!("expected Value::Duration(300), got {other:?}"),
+        Some(Value::Concrete(ConcreteValue::Duration(d))) => {
+            assert_eq!(*d, std::time::Duration::from_secs(5 * 60))
+        }
+        other => panic!("expected Value::Concrete(ConcreteValue::Duration(300)), got {other:?}"),
     }
 }
 

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -7,7 +7,7 @@ use super::context::next_pair;
 use super::error::ParseError;
 use super::expressions::string_literal::{parse_string_literal, unescape_single_quoted};
 use crate::eval_value::EvalValue;
-use crate::resource::{ResourceId, Value};
+use crate::resource::{ConcreteValue, DeferredValue, ResourceId, Value};
 
 /// Convert PascalCase to snake_case (e.g., "VpcId" → "vpc_id", "AwsAccountId" → "aws_account_id").
 pub fn pascal_to_snake(s: &str) -> String {
@@ -49,20 +49,20 @@ pub fn snake_to_pascal(s: &str) -> String {
 /// Return a human-readable type name for a Value
 pub(crate) fn value_type_name(value: &Value) -> &'static str {
     match value {
-        Value::String(_) => "string",
-        Value::Int(_) => "int",
-        Value::Float(_) => "float",
-        Value::Bool(_) => "bool",
-        Value::Duration(_) => "duration",
-        Value::List(_) => "list",
-        Value::StringList(_) => "list",
-        Value::Map(_) => "map",
-        Value::ResourceRef { .. } => "resource reference",
-        Value::BindingRef { .. } => "binding reference",
-        Value::Interpolation(_) => "string",
-        Value::FunctionCall { .. } => "function call",
-        Value::Secret(_) => "secret",
-        Value::Unknown(_) => "unknown",
+        Value::Concrete(ConcreteValue::String(_)) => "string",
+        Value::Concrete(ConcreteValue::Int(_)) => "int",
+        Value::Concrete(ConcreteValue::Float(_)) => "float",
+        Value::Concrete(ConcreteValue::Bool(_)) => "bool",
+        Value::Concrete(ConcreteValue::Duration(_)) => "duration",
+        Value::Concrete(ConcreteValue::List(_)) => "list",
+        Value::Concrete(ConcreteValue::StringList(_)) => "list",
+        Value::Concrete(ConcreteValue::Map(_)) => "map",
+        Value::Deferred(DeferredValue::ResourceRef { .. }) => "resource reference",
+        Value::Deferred(DeferredValue::BindingRef { .. }) => "binding reference",
+        Value::Deferred(DeferredValue::Interpolation(_)) => "string",
+        Value::Deferred(DeferredValue::FunctionCall { .. }) => "function call",
+        Value::Deferred(DeferredValue::Secret(_)) => "secret",
+        Value::Deferred(DeferredValue::Unknown(_)) => "unknown",
     }
 }
 

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -420,7 +420,7 @@ mod tests {
 
     #[test]
     fn format_effect_brief_renders_wait() {
-        use crate::resource::{ResourceId, Value};
+        use crate::resource::{ConcreteValue, ResourceId, Value};
         use crate::wait::predicate::{AttrPath, WaitPredicate};
         use std::time::Duration;
 
@@ -430,7 +430,7 @@ mod tests {
             target_identifier: None,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
-                value: Value::String("ISSUED".to_string()),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
             },
             until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             timeout: Duration::from_secs(75 * 60),
@@ -445,7 +445,7 @@ mod tests {
 
     #[test]
     fn plan_summary_counts_wait() {
-        use crate::resource::{ResourceId, Value};
+        use crate::resource::{ConcreteValue, ResourceId, Value};
         use crate::wait::predicate::{AttrPath, WaitPredicate};
         use std::time::Duration;
 
@@ -457,7 +457,7 @@ mod tests {
             target_identifier: None,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
-                value: Value::String("ISSUED".to_string()),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
             },
             until_surface: "cert.status == ISSUED".to_string(),
             timeout: Duration::from_secs(60),

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use crate::deps::get_resource_dependencies;
 use crate::effect::Effect;
 use crate::plan::Plan;
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 use crate::utils::{convert_enum_value, is_dsl_enum_format};
 
 /// Intermediate data for tree-building: maps from effect indices to their
@@ -266,7 +266,7 @@ pub fn build_single_parent_tree(
 /// Extract a compact hint for anonymous resources.
 ///
 /// Collects the first distinguishing string attribute (like `service_name`) and ALL
-/// non-parent `Value::ResourceRef` attributes, then combines them into a comma-separated
+/// non-parent `Value::Deferred(DeferredValue::ResourceRef)` attributes, then combines them into a comma-separated
 /// hint. String hints appear first (most identifying), followed by ResourceRef hints.
 ///
 /// `parent_binding` is the binding name of the parent resource in the tree, used to
@@ -284,7 +284,7 @@ pub fn extract_compact_hint(
 
     // Priority 1: First distinguishing string attribute (most identifying)
     for key in &keys {
-        if let Some(Value::String(s)) = resource.get_attr(key)
+        if let Some(Value::Concrete(ConcreteValue::String(s))) = resource.get_attr(key)
             && !s.is_empty()
         {
             let short_key = shorten_attr_name(key);
@@ -302,16 +302,16 @@ pub fn extract_compact_hint(
     // Priority 2: First non-parent ResourceRef attribute (direct or inside a List)
     for key in &keys {
         match resource.get_attr(key) {
-            Some(Value::ResourceRef { path }) => {
+            Some(Value::Deferred(DeferredValue::ResourceRef { path })) => {
                 if parent_binding == Some(path.binding()) {
                     continue;
                 }
                 let short_key = shorten_attr_name(key);
                 return Some(format!("{}: {}", short_key, path.binding()));
             }
-            Some(Value::List(items)) => {
+            Some(Value::Concrete(ConcreteValue::List(items))) => {
                 for item in items {
-                    if let Value::ResourceRef { path } = item {
+                    if let Value::Deferred(DeferredValue::ResourceRef { path }) = item {
                         if parent_binding == Some(path.binding()) {
                             continue;
                         }

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::resource::{Directives, Resource, ResourceId, State, Value};
+use crate::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use crate::schema::SchemaRegistry;
 
 /// Contextual metadata attached to every [`ProviderError`] variant.
@@ -532,7 +532,7 @@ pub fn merge_default_tags_for_provider(
         // Merge default_tags into the resource's tags
         let mut default_tag_keys: Vec<String> = Vec::new();
         match resource.get_attr_mut("tags") {
-            Some(Value::Map(existing_tags)) => {
+            Some(Value::Concrete(ConcreteValue::Map(existing_tags))) => {
                 for (key, value) in default_tags {
                     if !existing_tags.contains_key(key) {
                         existing_tags.insert(key.clone(), value.clone());
@@ -542,7 +542,10 @@ pub fn merge_default_tags_for_provider(
             }
             None => {
                 default_tag_keys = default_tags.keys().cloned().collect();
-                resource.set_attr("tags".to_string(), Value::Map(default_tags.clone()));
+                resource.set_attr(
+                    "tags".to_string(),
+                    Value::Concrete(ConcreteValue::Map(default_tags.clone())),
+                );
             }
             _ => {
                 continue;
@@ -553,7 +556,9 @@ pub fn merge_default_tags_for_provider(
             default_tag_keys.sort();
             resource.set_attr(
                 "_default_tag_keys".to_string(),
-                Value::List(default_tag_keys.into_iter().map(Value::String).collect()),
+                Value::Concrete(ConcreteValue::List(
+                    default_tag_keys.into_iter().map(Value::String).collect(),
+                )),
             );
         }
     }
@@ -1157,22 +1162,26 @@ mod tests {
         let mut resource = Resource::new("identitystore.user", "mizzy");
         resource.set_attr(
             "identity_store_id".to_string(),
-            Value::String("d-9567916d09".to_string()),
+            Value::Concrete(ConcreteValue::String("d-9567916d09".to_string())),
         );
         resource.set_attr(
             "user_name".to_string(),
-            Value::String("gosukenator@gmail.com".to_string()),
+            Value::Concrete(ConcreteValue::String("gosukenator@gmail.com".to_string())),
         );
 
         let state = provider.read_data_source(&resource).await.unwrap();
         assert!(state.exists);
         assert_eq!(
             state.attributes.get("identity_store_id"),
-            Some(&Value::String("d-9567916d09".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "d-9567916d09".to_string()
+            )))
         );
         assert_eq!(
             state.attributes.get("user_name"),
-            Some(&Value::String("gosukenator@gmail.com".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "gosukenator@gmail.com".to_string()
+            )))
         );
     }
 
@@ -1183,12 +1192,15 @@ mod tests {
         // would use the trait's default impl and bypass the override.
         let provider: Box<dyn Provider> = Box::new(InputAwareProvider);
         let mut resource = Resource::new("identitystore.user", "mizzy");
-        resource.set_attr("user_name".to_string(), Value::String("x".to_string()));
+        resource.set_attr(
+            "user_name".to_string(),
+            Value::Concrete(ConcreteValue::String("x".to_string())),
+        );
         let state = provider.read_data_source(&resource).await.unwrap();
         assert!(state.exists);
         assert_eq!(
             state.attributes.get("user_name"),
-            Some(&Value::String("x".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("x".to_string())))
         );
     }
 
@@ -1200,12 +1212,15 @@ mod tests {
         router.add_provider("input-aware".to_string(), Box::new(InputAwareProvider));
 
         let mut resource = Resource::with_provider("input-aware", "identitystore.user", "mizzy");
-        resource.set_attr("user_name".to_string(), Value::String("x".to_string()));
+        resource.set_attr(
+            "user_name".to_string(),
+            Value::Concrete(ConcreteValue::String("x".to_string())),
+        );
         let state = router.read_data_source(&resource).await.unwrap();
         assert!(state.exists);
         assert_eq!(
             state.attributes.get("user_name"),
-            Some(&Value::String("x".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("x".to_string())))
         );
     }
 
@@ -1368,13 +1383,25 @@ mod tests {
     fn build_update_patch_classifies_ops() {
         let id = ResourceId::new("test", "example");
         let mut from_attrs = HashMap::new();
-        from_attrs.insert("a".to_string(), Value::String("old".into()));
-        from_attrs.insert("c".to_string(), Value::String("removed".into()));
+        from_attrs.insert(
+            "a".to_string(),
+            Value::Concrete(ConcreteValue::String("old".into())),
+        );
+        from_attrs.insert(
+            "c".to_string(),
+            Value::Concrete(ConcreteValue::String("removed".into())),
+        );
         let from = State::existing(id.clone(), from_attrs);
 
         let mut to = Resource::new("test", "example");
-        to.set_attr("a".to_string(), Value::String("new".into()));
-        to.set_attr("b".to_string(), Value::String("added".into()));
+        to.set_attr(
+            "a".to_string(),
+            Value::Concrete(ConcreteValue::String("new".into())),
+        );
+        to.set_attr(
+            "b".to_string(),
+            Value::Concrete(ConcreteValue::String("added".into())),
+        );
 
         let changed = vec!["a".to_string(), "b".to_string(), "c".to_string()];
         let patch = build_update_patch(&changed, &to, &from);
@@ -1384,10 +1411,16 @@ mod tests {
             patch.ops.iter().map(|op| (op.key.as_str(), op)).collect();
         let a = by_key["a"];
         assert_eq!(a.kind, PatchOpKind::Replace);
-        assert_eq!(a.value, Some(Value::String("new".into())));
+        assert_eq!(
+            a.value,
+            Some(Value::Concrete(ConcreteValue::String("new".into())))
+        );
         let b = by_key["b"];
         assert_eq!(b.kind, PatchOpKind::Add);
-        assert_eq!(b.value, Some(Value::String("added".into())));
+        assert_eq!(
+            b.value,
+            Some(Value::Concrete(ConcreteValue::String("added".into())))
+        );
         let c = by_key["c"];
         assert_eq!(c.kind, PatchOpKind::Remove);
         assert_eq!(c.value, None);
@@ -1513,7 +1546,7 @@ mod tests {
                 // Prefix all string attribute values with "normalized:"
                 for resource in resources.iter_mut() {
                     for value in resource.attributes.values_mut() {
-                        if let Value::String(s) = value {
+                        if let Value::Concrete(ConcreteValue::String(s)) = value {
                             *s = format!("normalized:{}", s);
                         }
                     }
@@ -1548,14 +1581,16 @@ mod tests {
 
         // Test normalize_desired
         let ext = SchemaOnlyProvider;
-        let mut resources = vec![
-            Resource::new("test", "example")
-                .with_attribute("key", Value::String("value".to_string())),
-        ];
+        let mut resources = vec![Resource::new("test", "example").with_attribute(
+            "key",
+            Value::Concrete(ConcreteValue::String("value".to_string())),
+        )];
         ext.normalize_desired(&mut resources);
         assert_eq!(
             resources[0].get_attr("key"),
-            Some(&Value::String("normalized:value".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "normalized:value".to_string()
+            )))
         );
 
         // Test hydrate_read_state
@@ -1565,12 +1600,15 @@ mod tests {
         let mut saved: SavedAttrs = HashMap::new();
         saved.insert(
             id.clone(),
-            HashMap::from([("restored".to_string(), Value::String("data".to_string()))]),
+            HashMap::from([(
+                "restored".to_string(),
+                Value::Concrete(ConcreteValue::String("data".to_string())),
+            )]),
         );
         ext.hydrate_read_state(&mut states, &saved);
         assert_eq!(
             states.get(&id).unwrap().attributes.get("restored"),
-            Some(&Value::String("data".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("data".to_string())))
         );
     }
 
@@ -1638,7 +1676,7 @@ mod tests {
                 for resource in resources.iter_mut() {
                     if resource.id.provider == "normalizing" {
                         for value in resource.attributes.values_mut() {
-                            if let Value::String(s) = value {
+                            if let Value::Concrete(ConcreteValue::String(s)) = value {
                                 *s = format!("norm:{}", s);
                             }
                         }
@@ -1660,13 +1698,17 @@ mod tests {
         router.add_normalizer(Box::new(TestNormalizer));
 
         let mut resources = vec![
-            Resource::with_provider("normalizing", "test", "example")
-                .with_attribute("key", Value::String("val".to_string())),
+            Resource::with_provider("normalizing", "test", "example").with_attribute(
+                "key",
+                Value::Concrete(ConcreteValue::String("val".to_string())),
+            ),
         ];
         router.normalize_desired(&mut resources);
         assert_eq!(
             resources[0].get_attr("key"),
-            Some(&Value::String("norm:val".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "norm:val".to_string()
+            )))
         );
     }
 }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -9,7 +9,8 @@ use indexmap::IndexMap;
 
 use crate::binding_index::ResolvedBindings;
 use crate::resource::{
-    InterpolationPart, Resource, ResourceId, State, Value, contains_resource_ref,
+    ConcreteValue, DeferredValue, InterpolationPart, Resource, ResourceId, State, Value,
+    contains_resource_ref,
 };
 
 /// Resolve all ResourceRef values in resources using current state.
@@ -111,50 +112,61 @@ fn stamp_unresolved_upstream(
     upstream_binding_names: &std::collections::HashSet<&str>,
 ) -> Value {
     match value {
-        Value::ResourceRef { path } if upstream_binding_names.contains(path.binding()) => {
-            Value::Unknown(crate::resource::UnknownReason::UpstreamRef { path })
+        Value::Deferred(DeferredValue::ResourceRef { path })
+            if upstream_binding_names.contains(path.binding()) =>
+        {
+            Value::Deferred(DeferredValue::Unknown(
+                crate::resource::UnknownReason::UpstreamRef { path },
+            ))
         }
-        Value::BindingRef { binding } if upstream_binding_names.contains(binding.as_str()) => {
-            Value::Unknown(crate::resource::UnknownReason::UpstreamBareRef { binding })
+        Value::Deferred(DeferredValue::BindingRef { binding })
+            if upstream_binding_names.contains(binding.as_str()) =>
+        {
+            Value::Deferred(DeferredValue::Unknown(
+                crate::resource::UnknownReason::UpstreamBareRef { binding },
+            ))
         }
-        Value::List(items) => Value::List(
+        Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
             items
                 .into_iter()
                 .map(|v| stamp_unresolved_upstream(v, upstream_binding_names))
                 .collect(),
-        ),
-        Value::Map(map) => {
+        )),
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut out: IndexMap<String, Value> = IndexMap::new();
             for (k, v) in map {
                 out.insert(k, stamp_unresolved_upstream(v, upstream_binding_names));
             }
-            Value::Map(out)
+            Value::Concrete(ConcreteValue::Map(out))
         }
-        Value::Interpolation(parts) => Value::Interpolation(
-            parts
-                .into_iter()
-                .map(|p| match p {
-                    InterpolationPart::Expr(v) => InterpolationPart::Expr(
-                        stamp_unresolved_upstream(v, upstream_binding_names),
-                    ),
-                    other => other,
-                })
-                .collect(),
-        ),
-        Value::FunctionCall { name, args } => Value::FunctionCall {
-            name,
-            args: args
-                .into_iter()
-                .map(|a| stamp_unresolved_upstream(a, upstream_binding_names))
-                .collect(),
-        },
-        Value::Secret(inner) => Value::Secret(Box::new(stamp_unresolved_upstream(
-            *inner,
-            upstream_binding_names,
-        ))),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
+            Value::Deferred(DeferredValue::Interpolation(
+                parts
+                    .into_iter()
+                    .map(|p| match p {
+                        InterpolationPart::Expr(v) => InterpolationPart::Expr(
+                            stamp_unresolved_upstream(v, upstream_binding_names),
+                        ),
+                        other => other,
+                    })
+                    .collect(),
+            ))
+        }
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
+            Value::Deferred(DeferredValue::FunctionCall {
+                name,
+                args: args
+                    .into_iter()
+                    .map(|a| stamp_unresolved_upstream(a, upstream_binding_names))
+                    .collect(),
+            })
+        }
+        Value::Deferred(DeferredValue::Secret(inner)) => Value::Deferred(DeferredValue::Secret(
+            Box::new(stamp_unresolved_upstream(*inner, upstream_binding_names)),
+        )),
         // An already-stamped `Value::Unknown` (from an earlier pass)
         // is passed through unchanged — it cannot be resolved further.
-        other @ Value::Unknown(_) => other,
+        other @ Value::Deferred(DeferredValue::Unknown(_)) => other,
         other => other,
     }
 }
@@ -165,7 +177,7 @@ fn stamp_unresolved_upstream(
 /// Returns an error if a builtin function fails with fully-resolved arguments.
 pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<Value, String> {
     match value {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let field_path = path.field_path();
@@ -193,7 +205,7 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                     // `Secret(Map)` ref silently.
                     let (peeled, secret_depth) = peel_secrets(resolved);
                     let next = match peeled {
-                        Value::Map(ref map) => match map.get(field) {
+                        Value::Concrete(ConcreteValue::Map(ref map)) => match map.get(field) {
                             Some(nested) => resolve_ref_value(nested, bindings)?,
                             None if is_upstream && secret_depth > 0 => {
                                 return Err(missing_map_key_error_redacted(path, map.len()));
@@ -215,23 +227,25 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                     // tag survives end-to-end. #2439.
                     let (peeled, secret_depth) = peel_secrets(resolved);
                     let next = match (peeled, sub) {
-                        (Value::List(items), Subscript::Int { index }) => {
+                        (Value::Concrete(ConcreteValue::List(items)), Subscript::Int { index }) => {
                             let idx = usize::try_from(*index).ok().filter(|i| *i < items.len());
                             match idx {
                                 Some(i) => resolve_ref_value(&items[i], bindings)?,
                                 None => return Ok(value.clone()),
                             }
                         }
-                        (Value::Map(map), Subscript::Str { key }) => match map.get(key) {
-                            Some(nested) => resolve_ref_value(nested, bindings)?,
-                            None if is_upstream && secret_depth > 0 => {
-                                return Err(missing_map_key_error_redacted(path, map.len()));
+                        (Value::Concrete(ConcreteValue::Map(map)), Subscript::Str { key }) => {
+                            match map.get(key) {
+                                Some(nested) => resolve_ref_value(nested, bindings)?,
+                                None if is_upstream && secret_depth > 0 => {
+                                    return Err(missing_map_key_error_redacted(path, map.len()));
+                                }
+                                None if is_upstream => {
+                                    return Err(missing_map_key_error(path, &map));
+                                }
+                                None => return Ok(value.clone()),
                             }
-                            None if is_upstream => {
-                                return Err(missing_map_key_error(path, &map));
-                            }
-                            None => return Ok(value.clone()),
-                        },
+                        }
                         _ => return Ok(value.clone()),
                     };
                     resolved = rewrap_secrets(next, secret_depth);
@@ -242,21 +256,21 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
             // Keep as-is if not found
             Ok(value.clone())
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             let resolved: Result<Vec<Value>, String> = items
                 .iter()
                 .map(|v| resolve_ref_value(v, bindings))
                 .collect();
-            Ok(Value::List(resolved?))
+            Ok(Value::Concrete(ConcreteValue::List(resolved?)))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut resolved: IndexMap<String, Value> = IndexMap::new();
             for (k, v) in map {
                 resolved.insert(k.clone(), resolve_ref_value(v, bindings)?);
             }
-            Ok(Value::Map(resolved))
+            Ok(Value::Concrete(ConcreteValue::Map(resolved)))
         }
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             let resolved_parts: Result<Vec<InterpolationPart>, String> = parts
                 .iter()
                 .map(|p| match p {
@@ -266,9 +280,9 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                     other => Ok(other.clone()),
                 })
                 .collect();
-            Ok(Value::Interpolation(resolved_parts?).canonicalize())
+            Ok(Value::Deferred(DeferredValue::Interpolation(resolved_parts?)).canonicalize())
         }
-        Value::FunctionCall { name, args } => {
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
             // First, resolve all arguments
             let resolved_args: Result<Vec<Value>, String> = args
                 .iter()
@@ -305,19 +319,21 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                 }
             } else {
                 // Keep as FunctionCall with partially resolved args
-                Ok(Value::FunctionCall {
+                Ok(Value::Deferred(DeferredValue::FunctionCall {
                     name: name.clone(),
                     args: resolved_args,
-                })
+                }))
             }
         }
-        Value::Secret(inner) => {
+        Value::Deferred(DeferredValue::Secret(inner)) => {
             let resolved_inner = resolve_ref_value(inner, bindings)?;
-            Ok(Value::Secret(Box::new(resolved_inner)))
+            Ok(Value::Deferred(DeferredValue::Secret(Box::new(
+                resolved_inner,
+            ))))
         }
         // `Value::Unknown` is the result of stamping a previously-
         // unresolved upstream ref; it cannot be resolved further.
-        Value::Unknown(_) => Ok(value.clone()),
+        Value::Deferred(DeferredValue::Unknown(_)) => Ok(value.clone()),
         _ => Ok(value.clone()),
     }
 }
@@ -329,7 +345,7 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
 /// the tag.
 fn peel_secrets(mut value: Value) -> (Value, usize) {
     let mut depth = 0;
-    while let Value::Secret(inner) = value {
+    while let Value::Deferred(DeferredValue::Secret(inner)) = value {
         value = *inner;
         depth += 1;
     }
@@ -339,7 +355,9 @@ fn peel_secrets(mut value: Value) -> (Value, usize) {
 /// Re-wrap `value` in `depth` layers of `Value::Secret`. Inverse of
 /// [`peel_secrets`].
 fn rewrap_secrets(value: Value, depth: usize) -> Value {
-    (0..depth).fold(value, |acc, _| Value::Secret(Box::new(acc)))
+    (0..depth).fold(value, |acc, _| {
+        Value::Deferred(DeferredValue::Secret(Box::new(acc)))
+    })
 }
 
 /// Format the "key not found; available keys: ..." error for a missing
@@ -403,10 +421,10 @@ mod tests {
             "orgs",
             vec![(
                 "accounts",
-                Value::List(vec![
-                    Value::String("alpha".to_string()),
-                    Value::String("beta".to_string()),
-                ]),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::String("alpha".to_string())),
+                    Value::Concrete(ConcreteValue::String("beta".to_string())),
+                ])),
             )],
         )]);
         let path = crate::resource::AccessPath::with_fields_and_subscripts(
@@ -415,9 +433,12 @@ mod tests {
             Vec::new(),
             vec![crate::resource::Subscript::Int { index: 0 }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
-        assert_eq!(resolved, Value::String("alpha".to_string()));
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("alpha".to_string()))
+        );
     }
 
     #[test]
@@ -425,12 +446,21 @@ mod tests {
         // `orgs.accounts["alpha"]` against `accounts: { alpha = "1", beta = "2" }`
         // resolves to `"1"`.
         let map: indexmap::IndexMap<String, Value> = vec![
-            ("alpha".to_string(), Value::String("1".to_string())),
-            ("beta".to_string(), Value::String("2".to_string())),
+            (
+                "alpha".to_string(),
+                Value::Concrete(ConcreteValue::String("1".to_string())),
+            ),
+            (
+                "beta".to_string(),
+                Value::Concrete(ConcreteValue::String("2".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
-        let bindings = bindings_from(vec![("orgs", vec![("accounts", Value::Map(map))])]);
+        let bindings = bindings_from(vec![(
+            "orgs",
+            vec![("accounts", Value::Concrete(ConcreteValue::Map(map)))],
+        )]);
         let path = crate::resource::AccessPath::with_fields_and_subscripts(
             "orgs",
             "accounts",
@@ -439,9 +469,12 @@ mod tests {
                 key: "alpha".to_string(),
             }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
-        assert_eq!(resolved, Value::String("1".to_string()));
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("1".to_string()))
+        );
     }
 
     #[test]
@@ -449,14 +482,25 @@ mod tests {
         // #2439: subscript on `Secret(Map)` must descend and re-wrap
         // so plan-display redaction survives end-to-end.
         let map: indexmap::IndexMap<String, Value> = vec![
-            ("db_pwd".to_string(), Value::String("hunter2".to_string())),
-            ("api_key".to_string(), Value::String("xyz".to_string())),
+            (
+                "db_pwd".to_string(),
+                Value::Concrete(ConcreteValue::String("hunter2".to_string())),
+            ),
+            (
+                "api_key".to_string(),
+                Value::Concrete(ConcreteValue::String("xyz".to_string())),
+            ),
         ]
         .into_iter()
         .collect();
         let bindings = bindings_from(vec![(
             "creds_binding",
-            vec![("creds", Value::Secret(Box::new(Value::Map(map))))],
+            vec![(
+                "creds",
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::Map(map),
+                )))),
+            )],
         )]);
         let path = crate::resource::AccessPath::with_fields_and_subscripts(
             "creds_binding",
@@ -466,11 +510,13 @@ mod tests {
                 key: "db_pwd".to_string(),
             }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
         assert_eq!(
             resolved,
-            Value::Secret(Box::new(Value::String("hunter2".to_string()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("hunter2".to_string())
+            )))),
             "subscript on Secret(Map) must project the entry and re-wrap as Secret(String)"
         );
     }
@@ -484,10 +530,12 @@ mod tests {
             "secret_holder",
             vec![(
                 "tokens",
-                Value::Secret(Box::new(Value::List(vec![
-                    Value::String("alpha".to_string()),
-                    Value::String("beta".to_string()),
-                ]))),
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::List(vec![
+                        Value::String("alpha".to_string()),
+                        Value::String("beta".to_string()),
+                    ]),
+                )))),
             )],
         )]);
         let path = crate::resource::AccessPath::with_fields_and_subscripts(
@@ -496,11 +544,13 @@ mod tests {
             Vec::new(),
             vec![crate::resource::Subscript::Int { index: 1 }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
         assert_eq!(
             resolved,
-            Value::Secret(Box::new(Value::String("beta".to_string()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("beta".to_string())
+            )))),
         );
     }
 
@@ -510,24 +560,33 @@ mod tests {
         // the same blind spot as the subscript path. Pin the symmetric
         // fix so a regression that drops the field_path peel doesn't
         // silently keep the ref.
-        let map: indexmap::IndexMap<String, Value> =
-            vec![("db_pwd".to_string(), Value::String("hunter2".to_string()))]
-                .into_iter()
-                .collect();
+        let map: indexmap::IndexMap<String, Value> = vec![(
+            "db_pwd".to_string(),
+            Value::Concrete(ConcreteValue::String("hunter2".to_string())),
+        )]
+        .into_iter()
+        .collect();
         let bindings = bindings_from(vec![(
             "creds_binding",
-            vec![("creds", Value::Secret(Box::new(Value::Map(map))))],
+            vec![(
+                "creds",
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::Map(map),
+                )))),
+            )],
         )]);
         let path = crate::resource::AccessPath::with_fields(
             "creds_binding",
             "creds",
             vec!["db_pwd".to_string()],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
         assert_eq!(
             resolved,
-            Value::Secret(Box::new(Value::String("hunter2".to_string()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("hunter2".to_string())
+            )))),
         );
     }
 
@@ -536,15 +595,19 @@ mod tests {
         // Defensive: stacked `Secret(Secret(Map))` (parser-rejected in
         // practice, but `peel_secrets` literally exists to handle it).
         // Re-wrap depth must match peel depth — pin the contract.
-        let map: indexmap::IndexMap<String, Value> =
-            vec![("k".to_string(), Value::String("v".to_string()))]
-                .into_iter()
-                .collect();
+        let map: indexmap::IndexMap<String, Value> = vec![(
+            "k".to_string(),
+            Value::Concrete(ConcreteValue::String("v".to_string())),
+        )]
+        .into_iter()
+        .collect();
         let bindings = bindings_from(vec![(
             "b",
             vec![(
                 "creds",
-                Value::Secret(Box::new(Value::Secret(Box::new(Value::Map(map))))),
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
+                    DeferredValue::Secret(Box::new(Value::Map(map))),
+                )))),
             )],
         )]);
         let path = crate::resource::AccessPath::with_fields_and_subscripts(
@@ -555,13 +618,13 @@ mod tests {
                 key: "k".to_string(),
             }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
         assert_eq!(
             resolved,
-            Value::Secret(Box::new(Value::Secret(Box::new(Value::String(
-                "v".to_string()
-            ))))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
+                DeferredValue::Secret(Box::new(Value::String("v".to_string())))
+            )))),
         );
     }
 
@@ -576,9 +639,9 @@ mod tests {
             "h",
             vec![(
                 "tokens",
-                Value::Secret(Box::new(Value::List(vec![Value::String(
-                    "only".to_string(),
-                )]))),
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::List(vec![Value::String("only".to_string())]),
+                )))),
             )],
         )]);
         let path = crate::resource::AccessPath::with_fields_and_subscripts(
@@ -587,7 +650,7 @@ mod tests {
             Vec::new(),
             vec![crate::resource::Subscript::Int { index: 5 }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
         assert_eq!(resolved, ref_value);
     }
@@ -598,13 +661,20 @@ mod tests {
         // a missing key keeps the ref unchanged because the value may
         // not be resolved yet. Mirrors the non-secret local-missing
         // path, just with the Secret peel.
-        let map: indexmap::IndexMap<String, Value> =
-            vec![("known".to_string(), Value::String("v".to_string()))]
-                .into_iter()
-                .collect();
+        let map: indexmap::IndexMap<String, Value> = vec![(
+            "known".to_string(),
+            Value::Concrete(ConcreteValue::String("v".to_string())),
+        )]
+        .into_iter()
+        .collect();
         let bindings = bindings_from(vec![(
             "h",
-            vec![("creds", Value::Secret(Box::new(Value::Map(map))))],
+            vec![(
+                "creds",
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::Map(map),
+                )))),
+            )],
         )]);
         let path = crate::resource::AccessPath::with_fields_and_subscripts(
             "h",
@@ -614,7 +684,7 @@ mod tests {
                 key: "missing".to_string(),
             }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
         assert_eq!(resolved, ref_value);
     }
@@ -633,15 +703,21 @@ mod tests {
         let map: indexmap::IndexMap<String, Value> = vec![
             (
                 "db_pwd".to_string(),
-                Value::Secret(Box::new(Value::String("v".to_string()))),
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::String("v".to_string()),
+                )))),
             ),
             (
                 "api_key".to_string(),
-                Value::Secret(Box::new(Value::String("v".to_string()))),
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::String("v".to_string()),
+                )))),
             ),
             (
                 "slack_token".to_string(),
-                Value::Secret(Box::new(Value::String("v".to_string()))),
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::String("v".to_string()),
+                )))),
             ),
         ]
         .into_iter()
@@ -649,7 +725,9 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "creds".to_string(),
-            Value::Secret(Box::new(Value::Map(map))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::Map(map),
+            )))),
         );
         let mut bindings = ResolvedBindings::default();
         bindings.set("h", attrs, BindingValueSource::Upstream);
@@ -661,7 +739,7 @@ mod tests {
                 key: "missing".to_string(),
             }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let result = resolve_ref_value(&ref_value, &bindings);
         let err = result.expect_err("missing key in concrete upstream Secret(Map) must error");
         assert!(
@@ -691,11 +769,15 @@ mod tests {
         let map: indexmap::IndexMap<String, Value> = vec![
             (
                 "db_pwd".to_string(),
-                Value::Secret(Box::new(Value::String("v".to_string()))),
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::String("v".to_string()),
+                )))),
             ),
             (
                 "api_key".to_string(),
-                Value::Secret(Box::new(Value::String("v".to_string()))),
+                Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                    ConcreteValue::String("v".to_string()),
+                )))),
             ),
         ]
         .into_iter()
@@ -703,7 +785,9 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "creds".to_string(),
-            Value::Secret(Box::new(Value::Map(map))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::Map(map),
+            )))),
         );
         let mut bindings = ResolvedBindings::default();
         bindings.set("h", attrs, BindingValueSource::Upstream);
@@ -713,7 +797,7 @@ mod tests {
             vec!["missing".to_string()],
             Vec::new(),
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let err = resolve_ref_value(&ref_value, &bindings)
             .expect_err("missing dot-form field in concrete upstream Secret(Map) must error");
         assert!(
@@ -739,7 +823,9 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "creds".to_string(),
-            Value::Secret(Box::new(Value::Map(indexmap::IndexMap::new()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::Map(indexmap::IndexMap::new()),
+            )))),
         );
         let mut bindings = ResolvedBindings::default();
         bindings.set("h", attrs, BindingValueSource::Upstream);
@@ -751,7 +837,7 @@ mod tests {
                 key: "missing".to_string(),
             }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let err = resolve_ref_value(&ref_value, &bindings)
             .expect_err("missing key in empty upstream Secret(Map) must error");
         assert!(
@@ -772,11 +858,11 @@ mod tests {
         let mut h_attrs: HashMap<String, Value> = HashMap::new();
         h_attrs.insert(
             "creds".to_string(),
-            Value::Secret(Box::new(Value::resource_ref(
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::resource_ref(
                 "missing".to_string(),
                 "x".to_string(),
                 vec![],
-            ))),
+            )))),
         );
         let mut bindings = crate::binding_index::ResolvedBindings::default();
         bindings.set(
@@ -792,7 +878,7 @@ mod tests {
                 key: "k".to_string(),
             }],
         );
-        let ref_value = Value::ResourceRef { path };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
         assert_eq!(
             resolved, ref_value,
@@ -808,7 +894,9 @@ mod tests {
             "orgs",
             vec![(
                 "accounts",
-                Value::List(vec![Value::String("a".to_string())]),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::String("a".to_string()),
+                )])),
             )],
         )]);
         let path = crate::resource::AccessPath::with_fields_and_subscripts(
@@ -817,7 +905,7 @@ mod tests {
             Vec::new(),
             vec![crate::resource::Subscript::Int { index: 5 }],
         );
-        let ref_value = Value::ResourceRef { path: path.clone() };
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path: path.clone() });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
         assert_eq!(resolved, ref_value);
     }
@@ -826,34 +914,43 @@ mod tests {
     fn test_resolve_simple_resource_ref() {
         let bindings = bindings_from(vec![(
             "my_vpc",
-            vec![("id", Value::String("vpc-123".to_string()))],
+            vec![(
+                "id",
+                Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+            )],
         )]);
 
         let ref_value = Value::resource_ref("my_vpc".to_string(), "id".to_string(), vec![]);
 
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
-        assert_eq!(resolved, Value::String("vpc-123".to_string()));
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string()))
+        );
     }
 
     #[test]
     fn test_resolve_nested_refs_in_list() {
         let bindings = bindings_from(vec![(
             "my_sg",
-            vec![("id", Value::String("sg-456".to_string()))],
+            vec![(
+                "id",
+                Value::Concrete(ConcreteValue::String("sg-456".to_string())),
+            )],
         )]);
 
-        let list = Value::List(vec![
-            Value::String("static".to_string()),
+        let list = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("static".to_string())),
             Value::resource_ref("my_sg".to_string(), "id".to_string(), vec![]),
-        ]);
+        ]));
 
         let resolved = resolve_ref_value(&list, &bindings).unwrap();
         assert_eq!(
             resolved,
-            Value::List(vec![
-                Value::String("static".to_string()),
-                Value::String("sg-456".to_string()),
-            ])
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("static".to_string())),
+                Value::Concrete(ConcreteValue::String("sg-456".to_string())),
+            ]))
         );
     }
 
@@ -861,23 +958,28 @@ mod tests {
     fn test_resolve_nested_refs_in_map() {
         let bindings = bindings_from(vec![(
             "my_subnet",
-            vec![("id", Value::String("subnet-789".to_string()))],
+            vec![(
+                "id",
+                Value::Concrete(ConcreteValue::String("subnet-789".to_string())),
+            )],
         )]);
 
-        let map = Value::Map(
+        let map = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "subnet_id".to_string(),
                 Value::resource_ref("my_subnet".to_string(), "id".to_string(), vec![]),
             )]
             .into_iter()
             .collect(),
-        );
+        ));
 
         let resolved = resolve_ref_value(&map, &bindings).unwrap();
-        if let Value::Map(m) = resolved {
+        if let Value::Concrete(ConcreteValue::Map(m)) = resolved {
             assert_eq!(
                 m.get("subnet_id"),
-                Some(&Value::String("subnet-789".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "subnet-789".to_string()
+                )))
             );
         } else {
             panic!("Expected Map");
@@ -898,55 +1000,64 @@ mod tests {
     fn test_resolve_interpolation_all_resolved() {
         let bindings = bindings_from(vec![(
             "my_vpc",
-            vec![("vpc_id", Value::String("vpc-123".to_string()))],
+            vec![(
+                "vpc_id",
+                Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+            )],
         )]);
 
-        let interp = Value::Interpolation(vec![
+        let interp = Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("subnet-".to_string()),
             InterpolationPart::Expr(Value::resource_ref(
                 "my_vpc".to_string(),
                 "vpc_id".to_string(),
                 vec![],
             )),
-        ]);
+        ]));
 
         let resolved = resolve_ref_value(&interp, &bindings).unwrap();
-        assert_eq!(resolved, Value::String("subnet-vpc-123".to_string()));
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("subnet-vpc-123".to_string()))
+        );
     }
 
     #[test]
     fn test_resolve_interpolation_partially_unresolved() {
         let bindings = ResolvedBindings::default();
 
-        let interp = Value::Interpolation(vec![
+        let interp = Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("subnet-".to_string()),
             InterpolationPart::Expr(Value::resource_ref(
                 "my_vpc".to_string(),
                 "vpc_id".to_string(),
                 vec![],
             )),
-        ]);
+        ]));
 
         let resolved = resolve_ref_value(&interp, &bindings).unwrap();
         // Should remain as Interpolation since the ref couldn't be resolved
-        assert!(matches!(resolved, Value::Interpolation(_)));
+        assert!(matches!(
+            resolved,
+            Value::Deferred(DeferredValue::Interpolation(_))
+        ));
     }
 
     #[test]
     fn test_resolve_interpolation_with_non_string_types() {
         let bindings = ResolvedBindings::default();
 
-        let interp = Value::Interpolation(vec![
+        let interp = Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("port-".to_string()),
-            InterpolationPart::Expr(Value::Int(8080)),
+            InterpolationPart::Expr(Value::Concrete(ConcreteValue::Int(8080))),
             InterpolationPart::Literal("-enabled-".to_string()),
-            InterpolationPart::Expr(Value::Bool(true)),
-        ]);
+            InterpolationPart::Expr(Value::Concrete(ConcreteValue::Bool(true))),
+        ]));
 
         let resolved = resolve_ref_value(&interp, &bindings).unwrap();
         assert_eq!(
             resolved,
-            Value::String("port-8080-enabled-true".to_string())
+            Value::Concrete(ConcreteValue::String("port-8080-enabled-true".to_string()))
         );
     }
 
@@ -957,7 +1068,10 @@ mod tests {
             make_resource(
                 "my-vpc",
                 Some("my_vpc"),
-                vec![("cidr_block", Value::String("10.0.0.0/16".to_string()))],
+                vec![(
+                    "cidr_block",
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+                )],
             ),
             make_resource(
                 "my-subnet",
@@ -976,9 +1090,12 @@ mod tests {
                 id: rid,
                 identifier: None,
                 exists: true,
-                attributes: vec![("vpc_id".to_string(), Value::String("vpc-abc".to_string()))]
-                    .into_iter()
-                    .collect(),
+                attributes: vec![(
+                    "vpc_id".to_string(),
+                    Value::Concrete(ConcreteValue::String("vpc-abc".to_string())),
+                )]
+                .into_iter()
+                .collect(),
                 dependency_bindings: std::collections::BTreeSet::new(),
             },
         );
@@ -988,7 +1105,9 @@ mod tests {
         // The subnet's vpc_id should be resolved from state
         assert_eq!(
             resources[1].get_attr("vpc_id"),
-            Some(&Value::String("vpc-abc".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "vpc-abc".to_string()
+            )))
         );
     }
 
@@ -996,43 +1115,52 @@ mod tests {
     fn test_resolve_function_call_join() {
         let bindings = ResolvedBindings::default();
 
-        let func = Value::FunctionCall {
+        let func = Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
             args: vec![
-                Value::String("-".to_string()),
-                Value::List(vec![
+                Value::Concrete(ConcreteValue::String("-".to_string())),
+                Value::Concrete(ConcreteValue::List(vec![
                     Value::String("a".to_string()),
                     Value::String("b".to_string()),
                     Value::String("c".to_string()),
-                ]),
+                ])),
             ],
-        };
+        });
 
         let resolved = resolve_ref_value(&func, &bindings).unwrap();
-        assert_eq!(resolved, Value::String("a-b-c".to_string()));
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("a-b-c".to_string()))
+        );
     }
 
     #[test]
     fn test_resolve_function_call_with_resource_ref() {
         let bindings = bindings_from(vec![(
             "vpc",
-            vec![("id", Value::String("vpc-123".to_string()))],
+            vec![(
+                "id",
+                Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+            )],
         )]);
 
         // join("-", ["prefix", vpc.id]) should resolve vpc.id first, then evaluate
-        let func = Value::FunctionCall {
+        let func = Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
             args: vec![
-                Value::String("-".to_string()),
-                Value::List(vec![
+                Value::Concrete(ConcreteValue::String("-".to_string())),
+                Value::Concrete(ConcreteValue::List(vec![
                     Value::String("prefix".to_string()),
                     Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
-                ]),
+                ])),
             ],
-        };
+        });
 
         let resolved = resolve_ref_value(&func, &bindings).unwrap();
-        assert_eq!(resolved, Value::String("prefix-vpc-123".to_string()));
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("prefix-vpc-123".to_string()))
+        );
     }
 
     #[test]
@@ -1040,28 +1168,37 @@ mod tests {
         let bindings = ResolvedBindings::default();
 
         // If a ResourceRef in the args can't be resolved, the FunctionCall is kept
-        let func = Value::FunctionCall {
+        let func = Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
             args: vec![
-                Value::String("-".to_string()),
-                Value::List(vec![Value::resource_ref(
+                Value::Concrete(ConcreteValue::String("-".to_string())),
+                Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
                     "unknown".to_string(),
                     "id".to_string(),
                     vec![],
-                )]),
+                )])),
             ],
-        };
+        });
 
         let resolved = resolve_ref_value(&func, &bindings).unwrap();
-        assert!(matches!(resolved, Value::FunctionCall { .. }));
+        assert!(matches!(
+            resolved,
+            Value::Deferred(DeferredValue::FunctionCall { .. })
+        ));
     }
 
     #[test]
     fn test_resolve_chained_field_access() {
         // web binding has a nested map: network = { vpc_id = "vpc-123" }
         let mut network_map = IndexMap::new();
-        network_map.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
-        let bindings = bindings_from(vec![("web", vec![("network", Value::Map(network_map))])]);
+        network_map.insert(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        );
+        let bindings = bindings_from(vec![(
+            "web",
+            vec![("network", Value::Concrete(ConcreteValue::Map(network_map)))],
+        )]);
 
         // web.network.vpc_id should resolve to "vpc-123"
         let ref_value = Value::resource_ref(
@@ -1071,17 +1208,29 @@ mod tests {
         );
 
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
-        assert_eq!(resolved, Value::String("vpc-123".to_string()));
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string()))
+        );
     }
 
     #[test]
     fn test_resolve_deeply_chained_field_access() {
         // web.output.network.vpc_id
         let mut inner_map = IndexMap::new();
-        inner_map.insert("vpc_id".to_string(), Value::String("vpc-456".to_string()));
+        inner_map.insert(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-456".to_string())),
+        );
         let mut output_map = IndexMap::new();
-        output_map.insert("network".to_string(), Value::Map(inner_map));
-        let bindings = bindings_from(vec![("web", vec![("output", Value::Map(output_map))])]);
+        output_map.insert(
+            "network".to_string(),
+            Value::Concrete(ConcreteValue::Map(inner_map)),
+        );
+        let bindings = bindings_from(vec![(
+            "web",
+            vec![("output", Value::Concrete(ConcreteValue::Map(output_map)))],
+        )]);
 
         let ref_value = Value::resource_ref(
             "web".to_string(),
@@ -1090,14 +1239,23 @@ mod tests {
         );
 
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
-        assert_eq!(resolved, Value::String("vpc-456".to_string()));
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("vpc-456".to_string()))
+        );
     }
 
     #[test]
     fn test_resolve_chained_field_missing_key_keeps_ref() {
         let mut network_map = IndexMap::new();
-        network_map.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
-        let bindings = bindings_from(vec![("web", vec![("network", Value::Map(network_map))])]);
+        network_map.insert(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        );
+        let bindings = bindings_from(vec![(
+            "web",
+            vec![("network", Value::Concrete(ConcreteValue::Map(network_map)))],
+        )]);
 
         // web.network.nonexistent should keep original ref
         let ref_value = Value::resource_ref(
@@ -1114,12 +1272,12 @@ mod tests {
     fn resolve_builtin_error_propagated_when_args_resolved() {
         // env() with a var name that is extremely unlikely to be set should propagate error
         let bindings = ResolvedBindings::default();
-        let value = Value::FunctionCall {
+        let value = Value::Deferred(DeferredValue::FunctionCall {
             name: "env".to_string(),
-            args: vec![Value::String(
+            args: vec![Value::Concrete(ConcreteValue::String(
                 "CARINA_RESOLVER_TEST_NONEXISTENT_VAR_12345".to_string(),
-            )],
-        };
+            ))],
+        });
 
         let result = resolve_ref_value(&value, &bindings);
         assert!(
@@ -1139,18 +1297,18 @@ mod tests {
     fn resolve_builtin_with_unresolved_ref_stays_as_function_call() {
         // join("-", vpc.tags) should stay as FunctionCall when vpc.tags is unresolved
         let bindings = ResolvedBindings::default();
-        let value = Value::FunctionCall {
+        let value = Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
             args: vec![
-                Value::String("-".to_string()),
+                Value::Concrete(ConcreteValue::String("-".to_string())),
                 Value::resource_ref("vpc".to_string(), "tags".to_string(), vec![]),
             ],
-        };
+        });
 
         let result = resolve_ref_value(&value, &bindings);
         assert!(result.is_ok(), "Unresolved ref should not cause error");
         match result.unwrap() {
-            Value::FunctionCall { name, .. } => assert_eq!(name, "join"),
+            Value::Deferred(DeferredValue::FunctionCall { name, .. }) => assert_eq!(name, "join"),
             other => panic!("Expected FunctionCall, got: {:?}", other),
         }
     }
@@ -1162,12 +1320,12 @@ mod tests {
             None,
             vec![(
                 "value",
-                Value::FunctionCall {
+                Value::Deferred(DeferredValue::FunctionCall {
                     name: "env".to_string(),
-                    args: vec![Value::String(
+                    args: vec![Value::Concrete(ConcreteValue::String(
                         "CARINA_RESOLVER_STATE_TEST_NONEXISTENT_VAR_12345".to_string(),
-                    )],
-                },
+                    ))],
+                }),
             )],
         )];
 
@@ -1208,13 +1366,19 @@ mod tests {
         // Build remote bindings: network -> { vpc -> Map { vpc_id -> "vpc-123" } }
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         let mut vpc_attrs = IndexMap::new();
-        vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+        vpc_attrs.insert(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        );
         vpc_attrs.insert(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         );
         let mut network_map = HashMap::new();
-        network_map.insert("vpc".to_string(), Value::Map(vpc_attrs));
+        network_map.insert(
+            "vpc".to_string(),
+            Value::Concrete(ConcreteValue::Map(vpc_attrs)),
+        );
         remote_bindings.insert("network".to_string(), network_map);
 
         resolve_refs_with_state_and_remote(&mut resources, &current_states, &remote_bindings)
@@ -1222,7 +1386,9 @@ mod tests {
 
         assert_eq!(
             resources[0].get_attr("vpc_id"),
-            Some(&Value::String("vpc-123".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "vpc-123".to_string()
+            )))
         );
     }
 
@@ -1238,7 +1404,7 @@ mod tests {
             vec![(
                 "principal_arn",
                 // orgs.accounts["registry_dev"]
-                Value::ResourceRef {
+                Value::Deferred(DeferredValue::ResourceRef {
                     path: crate::resource::AccessPath::with_fields_and_subscripts(
                         "orgs",
                         "accounts",
@@ -1247,21 +1413,24 @@ mod tests {
                             key: "registry_dev".to_string(),
                         }],
                     ),
-                },
+                }),
             )],
         )];
 
         let mut accounts_map: IndexMap<String, Value> = IndexMap::new();
         accounts_map.insert(
             "registry_prod".to_string(),
-            Value::String("111111111111".to_string()),
+            Value::Concrete(ConcreteValue::String("111111111111".to_string())),
         );
         accounts_map.insert(
             "registry_dev".to_string(),
-            Value::String("222222222222".to_string()),
+            Value::Concrete(ConcreteValue::String("222222222222".to_string())),
         );
         let mut orgs_attrs = HashMap::new();
-        orgs_attrs.insert("accounts".to_string(), Value::Map(accounts_map));
+        orgs_attrs.insert(
+            "accounts".to_string(),
+            Value::Concrete(ConcreteValue::Map(accounts_map)),
+        );
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -1270,7 +1439,9 @@ mod tests {
 
         assert_eq!(
             resources[0].get_attr("principal_arn"),
-            Some(&Value::String("222222222222".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "222222222222".to_string()
+            ))),
         );
     }
 
@@ -1286,7 +1457,7 @@ mod tests {
             None,
             vec![(
                 "principal_arn",
-                Value::ResourceRef {
+                Value::Deferred(DeferredValue::ResourceRef {
                     path: crate::resource::AccessPath::with_fields_and_subscripts(
                         "orgs",
                         "accounts",
@@ -1295,21 +1466,24 @@ mod tests {
                             key: "registry_qa".to_string(),
                         }],
                     ),
-                },
+                }),
             )],
         )];
 
         let mut accounts_map: IndexMap<String, Value> = IndexMap::new();
         accounts_map.insert(
             "registry_prod".to_string(),
-            Value::String("111111111111".to_string()),
+            Value::Concrete(ConcreteValue::String("111111111111".to_string())),
         );
         accounts_map.insert(
             "registry_dev".to_string(),
-            Value::String("222222222222".to_string()),
+            Value::Concrete(ConcreteValue::String("222222222222".to_string())),
         );
         let mut orgs_attrs = HashMap::new();
-        orgs_attrs.insert("accounts".to_string(), Value::Map(accounts_map));
+        orgs_attrs.insert(
+            "accounts".to_string(),
+            Value::Concrete(ConcreteValue::Map(accounts_map)),
+        );
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -1333,7 +1507,10 @@ mod tests {
         // still fire and the available-keys list must say so explicitly
         // ("<no keys>") rather than render an empty string.
         let mut orgs_attrs = HashMap::new();
-        orgs_attrs.insert("accounts".to_string(), Value::Map(IndexMap::new()));
+        orgs_attrs.insert(
+            "accounts".to_string(),
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+        );
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -1342,7 +1519,7 @@ mod tests {
             None,
             vec![(
                 "principal_arn",
-                Value::ResourceRef {
+                Value::Deferred(DeferredValue::ResourceRef {
                     path: crate::resource::AccessPath::with_fields_and_subscripts(
                         "orgs",
                         "accounts",
@@ -1351,7 +1528,7 @@ mod tests {
                             key: "registry_dev".to_string(),
                         }],
                     ),
-                },
+                }),
             )],
         )];
         let err =
@@ -1376,7 +1553,7 @@ mod tests {
             None,
             vec![(
                 "principal_arn",
-                Value::ResourceRef {
+                Value::Deferred(DeferredValue::ResourceRef {
                     path: crate::resource::AccessPath::with_fields_and_subscripts(
                         "orgs",
                         "accounts",
@@ -1385,7 +1562,7 @@ mod tests {
                             key: "anything".to_string(),
                         }],
                     ),
-                },
+                }),
             )],
         )];
 
@@ -1395,7 +1572,7 @@ mod tests {
         assert!(
             matches!(
                 resources[0].get_attr("principal_arn"),
-                Some(Value::ResourceRef { .. })
+                Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
             ),
             "ref must stay as ResourceRef when upstream is not loaded"
         );
@@ -1405,14 +1582,17 @@ mod tests {
     fn test_resolve_upstream_state_chained_subscripts() {
         // `orgs.regions['us'][0]` against a `map(list(String))` should
         // walk the map, then index into the list, returning the leaf.
-        let inner_list = Value::List(vec![
-            Value::String("aza".to_string()),
-            Value::String("azb".to_string()),
-        ]);
+        let inner_list = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("aza".to_string())),
+            Value::Concrete(ConcreteValue::String("azb".to_string())),
+        ]));
         let mut regions_map: IndexMap<String, Value> = IndexMap::new();
         regions_map.insert("us".to_string(), inner_list);
         let mut orgs_attrs = HashMap::new();
-        orgs_attrs.insert("regions".to_string(), Value::Map(regions_map));
+        orgs_attrs.insert(
+            "regions".to_string(),
+            Value::Concrete(ConcreteValue::Map(regions_map)),
+        );
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -1421,7 +1601,7 @@ mod tests {
             None,
             vec![(
                 "az",
-                Value::ResourceRef {
+                Value::Deferred(DeferredValue::ResourceRef {
                     path: crate::resource::AccessPath::with_fields_and_subscripts(
                         "orgs",
                         "regions",
@@ -1433,14 +1613,14 @@ mod tests {
                             crate::resource::Subscript::Int { index: 0 },
                         ],
                     ),
-                },
+                }),
             )],
         )];
         resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
             .unwrap();
         assert_eq!(
             resources[0].get_attr("az"),
-            Some(&Value::String("aza".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("aza".to_string())))
         );
     }
 
@@ -1452,10 +1632,15 @@ mod tests {
         let mut regions_map: IndexMap<String, Value> = IndexMap::new();
         regions_map.insert(
             "us".to_string(),
-            Value::List(vec![Value::String("aza".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("aza".to_string()),
+            )])),
         );
         let mut orgs_attrs = HashMap::new();
-        orgs_attrs.insert("regions".to_string(), Value::Map(regions_map));
+        orgs_attrs.insert(
+            "regions".to_string(),
+            Value::Concrete(ConcreteValue::Map(regions_map)),
+        );
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
@@ -1464,7 +1649,7 @@ mod tests {
             None,
             vec![(
                 "az",
-                Value::ResourceRef {
+                Value::Deferred(DeferredValue::ResourceRef {
                     path: crate::resource::AccessPath::with_fields_and_subscripts(
                         "orgs",
                         "regions",
@@ -1476,7 +1661,7 @@ mod tests {
                             crate::resource::Subscript::Int { index: 0 },
                         ],
                     ),
-                },
+                }),
             )],
         )];
         let err =
@@ -1514,7 +1699,7 @@ mod tests {
         // Should remain as ResourceRef since "nonexistent" binding is not found
         assert!(matches!(
             resources[0].get_attr("vpc_id"),
-            Some(Value::ResourceRef { .. })
+            Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
         ));
     }
 
@@ -1542,7 +1727,7 @@ mod tests {
         resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
 
         match resources[0].get_attr("vpc_id") {
-            Some(Value::Unknown(UnknownReason::UpstreamRef { path })) => {
+            Some(Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path }))) => {
                 assert_eq!(path.to_dot_string(), "network.vpc.vpc_id");
             }
             other => panic!("expected Value::Unknown(UpstreamRef), got {:?}", other),
@@ -1575,7 +1760,7 @@ mod tests {
 
         assert!(matches!(
             resources[0].get_attr("vpc_id"),
-            Some(Value::ResourceRef { .. })
+            Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
         ));
     }
 
@@ -1594,9 +1779,9 @@ mod tests {
             None,
             vec![(
                 "raw",
-                Value::BindingRef {
+                Value::Deferred(DeferredValue::BindingRef {
                     binding: "bootstrap".to_string(),
-                },
+                }),
             )],
         )];
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -1605,7 +1790,9 @@ mod tests {
         resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
 
         match resources[0].get_attr("raw") {
-            Some(Value::Unknown(UnknownReason::UpstreamBareRef { binding })) => {
+            Some(Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamBareRef {
+                binding,
+            }))) => {
                 assert_eq!(binding, "bootstrap");
             }
             other => panic!("expected Value::Unknown(UpstreamBareRef), got {:?}", other),
@@ -1624,14 +1811,14 @@ mod tests {
             None,
             vec![(
                 "raws",
-                Value::List(vec![
-                    Value::BindingRef {
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Deferred(DeferredValue::BindingRef {
                         binding: "bootstrap".to_string(),
-                    },
-                    Value::BindingRef {
+                    }),
+                    Value::Deferred(DeferredValue::BindingRef {
                         binding: "secondary".to_string(),
-                    },
-                ]),
+                    }),
+                ])),
             )],
         )];
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -1641,14 +1828,14 @@ mod tests {
         resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
 
         match resources[0].get_attr("raws") {
-            Some(Value::List(items)) => {
+            Some(Value::Concrete(ConcreteValue::List(items))) => {
                 assert_eq!(items.len(), 2);
                 let bindings: Vec<&str> = items
                     .iter()
                     .map(|v| match v {
-                        Value::Unknown(UnknownReason::UpstreamBareRef { binding }) => {
-                            binding.as_str()
-                        }
+                        Value::Deferred(DeferredValue::Unknown(
+                            UnknownReason::UpstreamBareRef { binding },
+                        )) => binding.as_str(),
                         other => panic!("expected UpstreamBareRef, got {:?}", other),
                     })
                     .collect();
@@ -1676,7 +1863,7 @@ mod tests {
 
         assert!(matches!(
             resources[0].get_attr("vpc_id"),
-            Some(Value::ResourceRef { .. })
+            Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
         ));
     }
 
@@ -1689,14 +1876,14 @@ mod tests {
             None,
             vec![(
                 "security_group_ids",
-                Value::List(vec![
+                Value::Concrete(ConcreteValue::List(vec![
                     Value::resource_ref("network".to_string(), "public_sg".to_string(), Vec::new()),
                     Value::resource_ref(
                         "network".to_string(),
                         "private_sg".to_string(),
                         Vec::new(),
                     ),
-                ]),
+                ])),
             )],
         )];
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -1705,11 +1892,11 @@ mod tests {
         resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
 
         match resources[0].get_attr("security_group_ids") {
-            Some(Value::List(items)) => {
+            Some(Value::Concrete(ConcreteValue::List(items))) => {
                 assert_eq!(items.len(), 2);
                 for (idx, item) in items.iter().enumerate() {
                     assert!(
-                        matches!(item, Value::Unknown(_)),
+                        matches!(item, Value::Deferred(DeferredValue::Unknown(_))),
                         "list[{}] should be Value::Unknown, got {:?}",
                         idx,
                         item
@@ -1764,7 +1951,7 @@ mod tests {
         let mut resources = vec![make_resource(
             "web-sg",
             None,
-            vec![("tags", Value::Map(tag_map))],
+            vec![("tags", Value::Concrete(ConcreteValue::Map(tag_map)))],
         )];
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
@@ -1772,8 +1959,8 @@ mod tests {
         resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
 
         match resources[0].get_attr("tags") {
-            Some(Value::Map(m)) => match m.get("VpcId") {
-                Some(Value::Unknown(_)) => {}
+            Some(Value::Concrete(ConcreteValue::Map(m))) => match m.get("VpcId") {
+                Some(Value::Deferred(DeferredValue::Unknown(_))) => {}
                 other => panic!("nested entry should be Value::Unknown, got {:?}", other),
             },
             other => panic!("expected Map, got {:?}", other),

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -401,9 +401,30 @@ pub(crate) mod duration_secs {
     }
 }
 
-/// Attribute value of a resource
+/// Attribute value of a resource.
+///
+/// Phase 5 of [RFC #2972](https://github.com/carina-rs/carina/issues/2972):
+/// physically split into the concrete / deferred axis. Every
+/// pattern site explicitly acknowledges which axis it handles, so
+/// "deferred Value leaked into concrete-only path" bugs are
+/// structurally unrepresentable workspace-wide (not just inside
+/// `validate_*`).
+///
+/// The serde representation uses `#[serde(untagged)]` so existing
+/// state files (in the pre-Phase-5 flat shape) round-trip via the
+/// inner enums' externally-tagged defaults — exactly the legacy
+/// JSON shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum Value {
+    Concrete(ConcreteValue),
+    Deferred(DeferredValue),
+}
+
+/// Concrete-axis variants: values that carry their own runtime type
+/// and are safe to type-check at validate time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ConcreteValue {
     String(String),
     Int(i64),
     Float(f64),
@@ -411,90 +432,89 @@ pub enum Value {
     /// Time duration carried as `std::time::Duration`.
     ///
     /// Constructed from a `<integer><unit>` literal in DSL source
-    /// (`75min`, `1h`, `30s`); the original unit is not preserved —
-    /// `Display` and `carina fmt` re-render via the canonical-form
-    /// rule documented in `notes/specs/2026-05-10-duration-design.md`.
-    /// Serialises to JSON as integer seconds at every value-tree
-    /// boundary (state file, plan file, WIT plugin contract).
+    /// `75min`, `1h`, `30s`. Serialises to JSON as integer seconds at
+    /// every value-tree boundary (state file, plan file, WIT plugin
+    /// contract).
     #[serde(with = "duration_secs")]
     Duration(std::time::Duration),
     List(Vec<Value>),
     /// Canonical form for fields whose schema type is
     /// `Union(vec![String, list(String)])` — the IAM-style
-    /// `string_or_list_of_strings` shape. AWS normalizes single-element
-    /// list condition values back to scalars, so a desired `["x"]` and
-    /// the actual `"x"` would otherwise diff forever. Carrying the
-    /// canonical shape in the type system makes the divergence
-    /// impossible at the differ boundary. See #2481, #2510.
-    ///
-    /// Producers must always go through
-    /// [`crate::value::canonicalize_with_type`] — never construct
-    /// `StringList` directly from user input or wire data without the
-    /// type, because the canonicalization decision depends on the
-    /// declared `AttributeType`.
+    /// `string_or_list_of_strings` shape. See #2481, #2510.
     StringList(Vec<String>),
     Map(IndexMap<String, Value>),
+}
+
+/// Deferred-axis variants: placeholders that resolve later
+/// (apply time, upstream load, function evaluation).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DeferredValue {
     /// Reference to another resource's attribute via an access path.
-    ///
-    /// The access path segments represent:
-    /// - segment 0: binding name (e.g., "vpc")
-    /// - segment 1: attribute name (e.g., "vpc_id")
-    /// - segments 2+: nested field path
-    ///
-    /// `AccessPath` carries a non-empty `attribute`; the type system
-    /// guarantees this — see [`AccessPath`]. A reference to a binding
-    /// without any attribute access (`bootstrap` standalone, the
-    /// directory-aware Pass-2 seed for sibling-defined names) is
-    /// represented as [`Value::BindingRef`] instead.
-    ResourceRef {
-        path: AccessPath,
-    },
+    ResourceRef { path: AccessPath },
     /// Reference to a binding without an attribute selector.
-    ///
-    /// Two producer sites:
-    /// - [`crate::parser::parse_with_seeded_bindings`] seeds every
-    ///   sibling-defined name (#2817) so in-file expressions resolve
-    ///   `name.attr` correctly; the seed itself carries no attribute.
-    /// - The parser's `variable_ref` rule emits `BindingRef` for a bare
-    ///   `let arn = bootstrap` (no `.attr` chain).
-    ///
-    /// `BindingRef` is invisible to attribute-walking code paths
-    /// (`visit_refs`, `check_upstream_state_field_references`, etc.) by
-    /// construction: there is no `attribute` slot for them to read. This
-    /// makes the empty-field diagnostic class (#2847) unrepresentable —
-    /// a sibling-only seed cannot synthesize a fake attribute reference
-    /// because the type carries none.
-    BindingRef {
-        binding: String,
-    },
+    BindingRef { binding: String },
     /// String interpolation: `"prefix-${expr}-suffix"`
-    /// Parts are evaluated and concatenated into a final String.
     Interpolation(Vec<InterpolationPart>),
-    /// Built-in function call: `join("-", ["a", "b"])` or via pipe `["a", "b"] |> join("-")`
-    /// Evaluated during reference resolution.
-    FunctionCall {
-        /// Function name (e.g., "join")
-        name: String,
-        /// Arguments to the function
-        args: Vec<Value>,
-    },
-    /// A secret value. The inner value is sent to the provider but stored as a
-    /// SHA256 hash in state. Plan output displays `(secret)` instead of the value.
+    /// Built-in function call: `join("-", ["a", "b"])` or via pipe
+    /// `["a", "b"] |> join("-")`. Evaluated during reference resolution.
+    FunctionCall { name: String, args: Vec<Value> },
+    /// A secret value. The inner value is sent to the provider but
+    /// stored as a SHA256 hash in state.
     Secret(Box<Value>),
-    /// A value not known at plan time. Plan-display only — must never
-    /// reach `apply`, state files, or provider plugins. See RFC #2371.
-    ///
-    /// `#[serde(skip)]` blocks both serialization (returns `Err`) and
-    /// deserialization (the variant is unreachable from any JSON input).
-    /// Together with the `Err(SerializationError::UnknownNotAllowed)`
-    /// arm at every serialization boundary (`value_to_json`,
-    /// `dsl_value_to_json`, `core_to_wit_value`, `redact_secrets_*`,
-    /// `backend_lock::value_to_json`), this enforces RFC constraints b
-    /// and c: a `Value::Unknown` cannot survive a state-file / plan-file
-    /// round trip, and any internal producer bug surfaces as a typed
-    /// error rather than corrupted output.
+    /// A value not known at plan time. RFC #2371.
     #[serde(skip)]
     Unknown(UnknownReason),
+}
+
+/// Backward-compatible variant constructors. Call sites can write
+/// `Value::String(s)` etc. exactly as in the pre-Phase-5 flat enum;
+/// pattern positions descend through `Value::Concrete(ConcreteValue::X(...))`.
+#[allow(non_snake_case)]
+impl Value {
+    #[inline]
+    pub fn String(s: String) -> Self {
+        Value::Concrete(ConcreteValue::String(s))
+    }
+    #[inline]
+    pub fn Int(n: i64) -> Self {
+        Value::Concrete(ConcreteValue::Int(n))
+    }
+    #[inline]
+    pub fn Float(f: f64) -> Self {
+        Value::Concrete(ConcreteValue::Float(f))
+    }
+    #[inline]
+    pub fn Bool(b: bool) -> Self {
+        Value::Concrete(ConcreteValue::Bool(b))
+    }
+    #[inline]
+    pub fn Duration(d: std::time::Duration) -> Self {
+        Value::Concrete(ConcreteValue::Duration(d))
+    }
+    #[inline]
+    pub fn List(items: Vec<Value>) -> Self {
+        Value::Concrete(ConcreteValue::List(items))
+    }
+    #[inline]
+    pub fn StringList(items: Vec<String>) -> Self {
+        Value::Concrete(ConcreteValue::StringList(items))
+    }
+    #[inline]
+    pub fn Map(map: IndexMap<String, Value>) -> Self {
+        Value::Concrete(ConcreteValue::Map(map))
+    }
+    #[inline]
+    pub fn Interpolation(parts: Vec<InterpolationPart>) -> Self {
+        Value::Deferred(DeferredValue::Interpolation(parts))
+    }
+    #[inline]
+    pub fn Secret(inner: Box<Value>) -> Self {
+        Value::Deferred(DeferredValue::Secret(inner))
+    }
+    #[inline]
+    pub fn Unknown(reason: UnknownReason) -> Self {
+        Value::Deferred(DeferredValue::Unknown(reason))
+    }
 }
 
 /// Borrowing projection of [`Value`] restricted to the **concrete** axis
@@ -561,20 +581,17 @@ impl Value {
     /// unrepresentable. See RFC #2972.
     pub fn as_concrete(&self) -> Option<ConcreteValueRef<'_>> {
         match self {
-            Value::String(s) => Some(ConcreteValueRef::String(s)),
-            Value::Int(n) => Some(ConcreteValueRef::Int(*n)),
-            Value::Float(f) => Some(ConcreteValueRef::Float(*f)),
-            Value::Bool(b) => Some(ConcreteValueRef::Bool(*b)),
-            Value::Duration(d) => Some(ConcreteValueRef::Duration(*d)),
-            Value::List(items) => Some(ConcreteValueRef::List(items)),
-            Value::StringList(items) => Some(ConcreteValueRef::StringList(items)),
-            Value::Map(map) => Some(ConcreteValueRef::Map(map)),
-            Value::ResourceRef { .. }
-            | Value::BindingRef { .. }
-            | Value::Interpolation(_)
-            | Value::FunctionCall { .. }
-            | Value::Secret(_)
-            | Value::Unknown(_) => None,
+            Value::Concrete(c) => Some(match c {
+                ConcreteValue::String(s) => ConcreteValueRef::String(s),
+                ConcreteValue::Int(n) => ConcreteValueRef::Int(*n),
+                ConcreteValue::Float(f) => ConcreteValueRef::Float(*f),
+                ConcreteValue::Bool(b) => ConcreteValueRef::Bool(*b),
+                ConcreteValue::Duration(d) => ConcreteValueRef::Duration(*d),
+                ConcreteValue::List(items) => ConcreteValueRef::List(items),
+                ConcreteValue::StringList(items) => ConcreteValueRef::StringList(items),
+                ConcreteValue::Map(map) => ConcreteValueRef::Map(map),
+            }),
+            Value::Deferred(_) => None,
         }
     }
 
@@ -583,22 +600,17 @@ impl Value {
     /// [`Self::as_concrete`].
     pub fn as_deferred(&self) -> Option<DeferredValueRef<'_>> {
         match self {
-            Value::ResourceRef { path } => Some(DeferredValueRef::ResourceRef { path }),
-            Value::BindingRef { binding } => Some(DeferredValueRef::BindingRef { binding }),
-            Value::Interpolation(parts) => Some(DeferredValueRef::Interpolation(parts)),
-            Value::FunctionCall { name, args } => {
-                Some(DeferredValueRef::FunctionCall { name, args })
-            }
-            Value::Secret(inner) => Some(DeferredValueRef::Secret(inner)),
-            Value::Unknown(reason) => Some(DeferredValueRef::Unknown(reason)),
-            Value::String(_)
-            | Value::Int(_)
-            | Value::Float(_)
-            | Value::Bool(_)
-            | Value::Duration(_)
-            | Value::List(_)
-            | Value::StringList(_)
-            | Value::Map(_) => None,
+            Value::Deferred(d) => Some(match d {
+                DeferredValue::ResourceRef { path } => DeferredValueRef::ResourceRef { path },
+                DeferredValue::BindingRef { binding } => DeferredValueRef::BindingRef { binding },
+                DeferredValue::Interpolation(parts) => DeferredValueRef::Interpolation(parts),
+                DeferredValue::FunctionCall { name, args } => {
+                    DeferredValueRef::FunctionCall { name, args }
+                }
+                DeferredValue::Secret(inner) => DeferredValueRef::Secret(inner),
+                DeferredValue::Unknown(reason) => DeferredValueRef::Unknown(reason),
+            }),
+            Value::Concrete(_) => None,
         }
     }
 }
@@ -661,23 +673,56 @@ impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             // Constraint: Unknown is never equal to anything.
-            (Value::Unknown(_), _) | (_, Value::Unknown(_)) => false,
-            (Value::String(a), Value::String(b)) => a == b,
-            (Value::Int(a), Value::Int(b)) => a == b,
-            (Value::Float(a), Value::Float(b)) => a == b,
-            (Value::Bool(a), Value::Bool(b)) => a == b,
-            (Value::Duration(a), Value::Duration(b)) => a == b,
-            (Value::List(a), Value::List(b)) => a == b,
-            (Value::StringList(a), Value::StringList(b)) => a == b,
-            (Value::Map(a), Value::Map(b)) => a == b,
-            (Value::ResourceRef { path: a }, Value::ResourceRef { path: b }) => a == b,
-            (Value::BindingRef { binding: a }, Value::BindingRef { binding: b }) => a == b,
-            (Value::Interpolation(a), Value::Interpolation(b)) => a == b,
+            (Value::Deferred(DeferredValue::Unknown(_)), _)
+            | (_, Value::Deferred(DeferredValue::Unknown(_))) => false,
             (
-                Value::FunctionCall { name: an, args: aa },
-                Value::FunctionCall { name: bn, args: ba },
+                Value::Concrete(ConcreteValue::String(a)),
+                Value::Concrete(ConcreteValue::String(b)),
+            ) => a == b,
+            (Value::Concrete(ConcreteValue::Int(a)), Value::Concrete(ConcreteValue::Int(b))) => {
+                a == b
+            }
+            (
+                Value::Concrete(ConcreteValue::Float(a)),
+                Value::Concrete(ConcreteValue::Float(b)),
+            ) => a == b,
+            (Value::Concrete(ConcreteValue::Bool(a)), Value::Concrete(ConcreteValue::Bool(b))) => {
+                a == b
+            }
+            (
+                Value::Concrete(ConcreteValue::Duration(a)),
+                Value::Concrete(ConcreteValue::Duration(b)),
+            ) => a == b,
+            (Value::Concrete(ConcreteValue::List(a)), Value::Concrete(ConcreteValue::List(b))) => {
+                a == b
+            }
+            (
+                Value::Concrete(ConcreteValue::StringList(a)),
+                Value::Concrete(ConcreteValue::StringList(b)),
+            ) => a == b,
+            (Value::Concrete(ConcreteValue::Map(a)), Value::Concrete(ConcreteValue::Map(b))) => {
+                a == b
+            }
+            (
+                Value::Deferred(DeferredValue::ResourceRef { path: a }),
+                Value::Deferred(DeferredValue::ResourceRef { path: b }),
+            ) => a == b,
+            (
+                Value::Deferred(DeferredValue::BindingRef { binding: a }),
+                Value::Deferred(DeferredValue::BindingRef { binding: b }),
+            ) => a == b,
+            (
+                Value::Deferred(DeferredValue::Interpolation(a)),
+                Value::Deferred(DeferredValue::Interpolation(b)),
+            ) => a == b,
+            (
+                Value::Deferred(DeferredValue::FunctionCall { name: an, args: aa }),
+                Value::Deferred(DeferredValue::FunctionCall { name: bn, args: ba }),
             ) => an == bn && aa == ba,
-            (Value::Secret(a), Value::Secret(b)) => a == b,
+            (
+                Value::Deferred(DeferredValue::Secret(a)),
+                Value::Deferred(DeferredValue::Secret(b)),
+            ) => a == b,
             _ => false,
         }
     }
@@ -708,18 +753,18 @@ fn canonicalize_interpolation(parts: Vec<InterpolationPart>) -> Value {
         }
     }
     if merged.is_empty() {
-        return Value::String(String::new());
+        return Value::Concrete(ConcreteValue::String(String::new()));
     }
     if merged.len() == 1 {
         // Pop the sole element. If it is a Literal, we collapse to
         // `Value::String`; otherwise it is a non-foldable Expr and we
         // rebuild the single-element Interpolation.
         match merged.pop().expect("len == 1") {
-            InterpolationPart::Literal(s) => return Value::String(s),
+            InterpolationPart::Literal(s) => return Value::Concrete(ConcreteValue::String(s)),
             expr @ InterpolationPart::Expr(_) => merged.push(expr),
         }
     }
-    Value::Interpolation(merged)
+    Value::Deferred(DeferredValue::Interpolation(merged))
 }
 
 /// If `v` is a string-shaped scalar, return its string form (consuming
@@ -732,10 +777,10 @@ fn canonicalize_interpolation(parts: Vec<InterpolationPart>) -> Value {
 /// stay as `Expr(Secret(...))`.
 fn value_into_literal(v: Value) -> Result<String, Value> {
     match v {
-        Value::String(s) => Ok(s),
-        Value::Int(n) => Ok(n.to_string()),
-        Value::Float(f) => Ok(f.to_string()),
-        Value::Bool(b) => Ok(b.to_string()),
+        Value::Concrete(ConcreteValue::String(s)) => Ok(s),
+        Value::Concrete(ConcreteValue::Int(n)) => Ok(n.to_string()),
+        Value::Concrete(ConcreteValue::Float(f)) => Ok(f.to_string()),
+        Value::Concrete(ConcreteValue::Bool(b)) => Ok(b.to_string()),
         other => Err(other),
     }
 }
@@ -769,26 +814,29 @@ impl Value {
     /// only has a `&mut Value` (e.g. inside `IndexMap::values_mut()`).
     pub fn canonicalize_in_place(&mut self) {
         match self {
-            Value::List(items) => {
+            Value::Concrete(ConcreteValue::List(items)) => {
                 for item in items {
                     item.canonicalize_in_place();
                 }
             }
-            Value::Map(map) => {
+            Value::Concrete(ConcreteValue::Map(map)) => {
                 for v in map.values_mut() {
                     v.canonicalize_in_place();
                 }
             }
-            Value::Secret(inner) => inner.canonicalize_in_place(),
-            Value::FunctionCall { args, .. } => {
+            Value::Deferred(DeferredValue::Secret(inner)) => inner.canonicalize_in_place(),
+            Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
                 for arg in args {
                     arg.canonicalize_in_place();
                 }
             }
-            Value::Interpolation(_) => {
+            Value::Deferred(DeferredValue::Interpolation(_)) => {
                 // Move the parts out so we can consume and rebuild them.
-                let parts = match std::mem::replace(self, Value::Interpolation(Vec::new())) {
-                    Value::Interpolation(parts) => parts,
+                let parts = match std::mem::replace(
+                    self,
+                    Value::Deferred(DeferredValue::Interpolation(Vec::new())),
+                ) {
+                    Value::Deferred(DeferredValue::Interpolation(parts)) => parts,
                     _ => unreachable!("matched Value::Interpolation"),
                 };
                 *self = canonicalize_interpolation(parts);
@@ -808,15 +856,15 @@ impl Value {
         attribute_name: impl Into<String>,
         field_path: Vec<String>,
     ) -> Self {
-        Value::ResourceRef {
+        Value::Deferred(DeferredValue::ResourceRef {
             path: AccessPath::with_fields(binding_name, attribute_name, field_path),
-        }
+        })
     }
 
     /// If this is a `ResourceRef`, returns the binding name.
     pub fn ref_binding(&self) -> Option<&str> {
         match self {
-            Value::ResourceRef { path } => Some(path.binding()),
+            Value::Deferred(DeferredValue::ResourceRef { path }) => Some(path.binding()),
             _ => None,
         }
     }
@@ -824,7 +872,7 @@ impl Value {
     /// If this is a `ResourceRef`, returns the attribute name.
     pub fn ref_attribute(&self) -> Option<&str> {
         match self {
-            Value::ResourceRef { path } => Some(path.attribute()),
+            Value::Deferred(DeferredValue::ResourceRef { path }) => Some(path.attribute()),
             _ => None,
         }
     }
@@ -832,7 +880,7 @@ impl Value {
     /// If this is a `ResourceRef`, returns the field path.
     pub fn ref_field_path(&self) -> Option<&[String]> {
         match self {
-            Value::ResourceRef { path } => Some(path.field_path()),
+            Value::Deferred(DeferredValue::ResourceRef { path }) => Some(path.field_path()),
             _ => None,
         }
     }
@@ -840,47 +888,47 @@ impl Value {
     /// Recursively walk this value, invoking `f` on each `ResourceRef`'s `AccessPath`.
     pub fn visit_refs(&self, f: &mut impl FnMut(&AccessPath)) {
         match self {
-            Value::ResourceRef { path } => f(path),
-            Value::List(items) => {
+            Value::Deferred(DeferredValue::ResourceRef { path }) => f(path),
+            Value::Concrete(ConcreteValue::List(items)) => {
                 for v in items {
                     v.visit_refs(f);
                 }
             }
-            Value::Map(map) => {
+            Value::Concrete(ConcreteValue::Map(map)) => {
                 for v in map.values() {
                     v.visit_refs(f);
                 }
             }
-            Value::Interpolation(parts) => {
+            Value::Deferred(DeferredValue::Interpolation(parts)) => {
                 for part in parts {
                     if let InterpolationPart::Expr(v) = part {
                         v.visit_refs(f);
                     }
                 }
             }
-            Value::FunctionCall { args, .. } => {
+            Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
                 for arg in args {
                     arg.visit_refs(f);
                 }
             }
-            Value::Secret(inner) => inner.visit_refs(f),
-            Value::String(_)
-            | Value::Int(_)
-            | Value::Float(_)
-            | Value::Bool(_)
-            | Value::Duration(_)
-            | Value::StringList(_) => {}
+            Value::Deferred(DeferredValue::Secret(inner)) => inner.visit_refs(f),
+            Value::Concrete(ConcreteValue::String(_))
+            | Value::Concrete(ConcreteValue::Int(_))
+            | Value::Concrete(ConcreteValue::Float(_))
+            | Value::Concrete(ConcreteValue::Bool(_))
+            | Value::Concrete(ConcreteValue::Duration(_))
+            | Value::Concrete(ConcreteValue::StringList(_)) => {}
             // `BindingRef` carries no attribute, so attribute-walking
             // visitors have nothing to do. Callers that *do* care about
             // bare-binding references walk them explicitly via
             // `visit_binding_refs`.
-            Value::BindingRef { .. } => {}
+            Value::Deferred(DeferredValue::BindingRef { .. }) => {}
             // `Value::Unknown` is what a previously-unresolved
             // `ResourceRef` was *replaced with* by `stamp_unresolved_upstream`.
             // It carries an `AccessPath` for display, but it is no longer
             // a live reference to walk — dependency analysis happens
             // upstream of the stamping pass.
-            Value::Unknown(_) => {}
+            Value::Deferred(DeferredValue::Unknown(_)) => {}
         }
     }
 }
@@ -917,8 +965,12 @@ impl Value {
     /// for all other variants, falls back to PartialEq.
     pub fn semantically_equal(&self, other: &Value) -> bool {
         match (self, other) {
-            (Value::List(a), Value::List(b)) => lists_equal(a, b),
-            (Value::Map(a), Value::Map(b)) => maps_semantically_equal(a, b),
+            (Value::Concrete(ConcreteValue::List(a)), Value::Concrete(ConcreteValue::List(b))) => {
+                lists_equal(a, b)
+            }
+            (Value::Concrete(ConcreteValue::Map(a)), Value::Concrete(ConcreteValue::Map(b))) => {
+                maps_semantically_equal(a, b)
+            }
             _ => self == other,
         }
     }
@@ -935,15 +987,15 @@ impl Value {
     fn hash_into(&self, hasher: &mut impl Hasher) {
         std::mem::discriminant(self).hash(hasher);
         match self {
-            Value::String(s) => s.hash(hasher),
-            Value::Int(i) => i.hash(hasher),
-            Value::Float(f) => {
+            Value::Concrete(ConcreteValue::String(s)) => s.hash(hasher),
+            Value::Concrete(ConcreteValue::Int(i)) => i.hash(hasher),
+            Value::Concrete(ConcreteValue::Float(f)) => {
                 // Use bits for deterministic hashing (NaN == NaN for our purposes)
                 f.to_bits().hash(hasher);
             }
-            Value::Bool(b) => b.hash(hasher),
-            Value::Duration(d) => d.as_secs().hash(hasher),
-            Value::List(items) => {
+            Value::Concrete(ConcreteValue::Bool(b)) => b.hash(hasher),
+            Value::Concrete(ConcreteValue::Duration(d)) => d.as_secs().hash(hasher),
+            Value::Concrete(ConcreteValue::List(items)) => {
                 // For list hashing, use an order-independent combination (wrapping sum)
                 // so that lists with same elements in different order hash the same.
                 // Wrapping sum is preferred over XOR because XOR causes all lists
@@ -955,7 +1007,7 @@ impl Value {
                 }
                 sum_hash.hash(hasher);
             }
-            Value::StringList(items) => {
+            Value::Concrete(ConcreteValue::StringList(items)) => {
                 // Hash with the same order-independent shape as
                 // `Value::List` so that a `List([String("x")])` and a
                 // `StringList(vec!["x"])` cannot collide on hash equality
@@ -970,7 +1022,7 @@ impl Value {
                 }
                 sum_hash.hash(hasher);
             }
-            Value::Map(map) => {
+            Value::Concrete(ConcreteValue::Map(map)) => {
                 map.len().hash(hasher);
                 // Sort keys for deterministic hashing
                 let mut keys: Vec<&String> = map.keys().collect();
@@ -980,13 +1032,13 @@ impl Value {
                     map[key].hash_into(hasher);
                 }
             }
-            Value::ResourceRef { path } => {
+            Value::Deferred(DeferredValue::ResourceRef { path }) => {
                 path.hash(hasher);
             }
-            Value::BindingRef { binding } => {
+            Value::Deferred(DeferredValue::BindingRef { binding }) => {
                 binding.hash(hasher);
             }
-            Value::Interpolation(parts) => {
+            Value::Deferred(DeferredValue::Interpolation(parts)) => {
                 parts.len().hash(hasher);
                 for part in parts {
                     match part {
@@ -1001,17 +1053,17 @@ impl Value {
                     }
                 }
             }
-            Value::FunctionCall { name, args } => {
+            Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
                 name.hash(hasher);
                 args.len().hash(hasher);
                 for arg in args {
                     arg.hash_into(hasher);
                 }
             }
-            Value::Secret(inner) => {
+            Value::Deferred(DeferredValue::Secret(inner)) => {
                 inner.hash_into(hasher);
             }
-            Value::Unknown(reason) => {
+            Value::Deferred(DeferredValue::Unknown(reason)) => {
                 // `Value::Unknown` reaches `merge_lists_hashed` → this
                 // function whenever a list element is unresolved. Hash
                 // deterministically: the outer `discriminant(self)`
@@ -1128,7 +1180,10 @@ fn lists_equal_hashed(a: &[Value], b: &[Value]) -> bool {
 /// For other types: return desired as-is.
 pub fn merge_with_saved(desired: &Value, saved: &Value) -> Value {
     match (desired, saved) {
-        (Value::Map(desired_map), Value::Map(saved_map)) => {
+        (
+            Value::Concrete(ConcreteValue::Map(desired_map)),
+            Value::Concrete(ConcreteValue::Map(saved_map)),
+        ) => {
             let mut merged = saved_map.clone();
             for (k, v) in desired_map {
                 let merged_v = if let Some(saved_v) = saved_map.get(k) {
@@ -1138,11 +1193,12 @@ pub fn merge_with_saved(desired: &Value, saved: &Value) -> Value {
                 };
                 merged.insert(k.clone(), merged_v);
             }
-            Value::Map(merged)
+            Value::Concrete(ConcreteValue::Map(merged))
         }
-        (Value::List(desired_list), Value::List(saved_list)) => {
-            Value::List(merge_lists(desired_list, saved_list))
-        }
+        (
+            Value::Concrete(ConcreteValue::List(desired_list)),
+            Value::Concrete(ConcreteValue::List(saved_list)),
+        ) => Value::Concrete(ConcreteValue::List(merge_lists(desired_list, saved_list))),
         _ => desired.clone(),
     }
 }
@@ -1230,12 +1286,12 @@ fn merge_lists_hashed(desired: &[Value], saved: &[Value]) -> Vec<Value> {
 
         // For Maps, also check other saved Maps for partial matches
         // (a Map may have extra fields from saved state, giving a different hash)
-        if matches!(d, Value::Map(_)) {
+        if matches!(d, Value::Concrete(ConcreteValue::Map(_))) {
             for (j, s) in saved.iter().enumerate() {
                 if used[j] || matches!(best_idx, Some(bi) if bi == j) {
                     continue;
                 }
-                if !matches!(s, Value::Map(_)) {
+                if !matches!(s, Value::Concrete(ConcreteValue::Map(_))) {
                     continue;
                 }
                 let score = similarity_score(d, s);
@@ -1263,7 +1319,7 @@ fn merge_lists_hashed(desired: &[Value], saved: &[Value]) -> Vec<Value> {
 /// Otherwise: return 0.
 fn similarity_score(a: &Value, b: &Value) -> usize {
     match (a, b) {
-        (Value::Map(am), Value::Map(bm)) => am
+        (Value::Concrete(ConcreteValue::Map(am)), Value::Concrete(ConcreteValue::Map(bm))) => am
             .iter()
             .filter(|(k, v)| {
                 bm.get(*k)

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -3,20 +3,28 @@ use super::*;
 #[test]
 fn value_serde_round_trip() {
     let values = vec![
-        Value::String("hello".to_string()),
-        Value::Int(42),
-        Value::Float(2.5),
-        Value::Float(-0.5),
-        Value::Bool(true),
-        Value::List(vec![Value::String("a".to_string()), Value::Int(1)]),
-        Value::Map(IndexMap::from([
-            ("key".to_string(), Value::String("val".to_string())),
-            ("num".to_string(), Value::Int(10)),
+        Value::Concrete(ConcreteValue::String("hello".to_string())),
+        Value::Concrete(ConcreteValue::Int(42)),
+        Value::Concrete(ConcreteValue::Float(2.5)),
+        Value::Concrete(ConcreteValue::Float(-0.5)),
+        Value::Concrete(ConcreteValue::Bool(true)),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::Int(1)),
         ])),
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            (
+                "key".to_string(),
+                Value::Concrete(ConcreteValue::String("val".to_string())),
+            ),
+            ("num".to_string(), Value::Concrete(ConcreteValue::Int(10))),
+        ]))),
         Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
-        Value::String("dedicated".to_string()),
-        Value::String("InstanceTenancy.dedicated".to_string()),
-        Value::Interpolation(vec![
+        Value::Concrete(ConcreteValue::String("dedicated".to_string())),
+        Value::Concrete(ConcreteValue::String(
+            "InstanceTenancy.dedicated".to_string(),
+        )),
+        Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("prefix-".to_string()),
             InterpolationPart::Expr(Value::resource_ref(
                 "vpc".to_string(),
@@ -24,18 +32,20 @@ fn value_serde_round_trip() {
                 vec![],
             )),
             InterpolationPart::Literal("-suffix".to_string()),
-        ]),
-        Value::FunctionCall {
+        ])),
+        Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
             args: vec![
-                Value::String("-".to_string()),
-                Value::List(vec![
-                    Value::String("a".to_string()),
-                    Value::String("b".to_string()),
-                ]),
+                Value::Concrete(ConcreteValue::String("-".to_string())),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::String("a".to_string())),
+                    Value::Concrete(ConcreteValue::String("b".to_string())),
+                ])),
             ],
-        },
-        Value::Secret(Box::new(Value::String("my-password".to_string()))),
+        }),
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        )))),
     ];
 
     for value in values {
@@ -124,8 +134,14 @@ fn resource_id_rename_pending_to_bound() {
 #[test]
 fn state_serde_round_trip() {
     let mut attrs = HashMap::new();
-    attrs.insert("name".to_string(), Value::String("my-bucket".to_string()));
-    attrs.insert("versioning".to_string(), Value::Bool(true));
+    attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+    );
+    attrs.insert(
+        "versioning".to_string(),
+        Value::Concrete(ConcreteValue::Bool(true)),
+    );
 
     let state = State::existing(
         ResourceId::with_provider("aws", "s3.Bucket", "my-bucket"),
@@ -214,88 +230,155 @@ fn directives_with_force_delete() {
 
 #[test]
 fn semantically_equal_lists_same_order() {
-    let a = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
-    let b = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+        Value::Concrete(ConcreteValue::Int(3)),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+        Value::Concrete(ConcreteValue::Int(3)),
+    ]));
     assert!(a.semantically_equal(&b));
 }
 
 #[test]
 fn semantically_equal_lists_different_order() {
-    let a = Value::List(vec![Value::Int(3), Value::Int(1), Value::Int(2)]);
-    let b = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(3)),
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+        Value::Concrete(ConcreteValue::Int(3)),
+    ]));
     assert!(a.semantically_equal(&b));
 }
 
 #[test]
 fn semantically_equal_lists_different_content() {
-    let a = Value::List(vec![Value::Int(1), Value::Int(2)]);
-    let b = Value::List(vec![Value::Int(1), Value::Int(3)]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(3)),
+    ]));
     assert!(!a.semantically_equal(&b));
 }
 
 #[test]
 fn semantically_equal_lists_different_lengths() {
-    let a = Value::List(vec![Value::Int(1), Value::Int(2)]);
-    let b = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+        Value::Concrete(ConcreteValue::Int(3)),
+    ]));
     assert!(!a.semantically_equal(&b));
 }
 
 #[test]
 fn semantically_equal_lists_with_duplicates() {
-    let a = Value::List(vec![Value::Int(1), Value::Int(1), Value::Int(2)]);
-    let b = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(1)]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+        Value::Concrete(ConcreteValue::Int(1)),
+    ]));
     assert!(a.semantically_equal(&b));
 
     // Different multiplicities should not be equal
-    let c = Value::List(vec![Value::Int(1), Value::Int(1), Value::Int(2)]);
-    let d = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(2)]);
+    let c = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+    ]));
+    let d = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+        Value::Concrete(ConcreteValue::Int(2)),
+    ]));
     assert!(!c.semantically_equal(&d));
 }
 
 #[test]
 fn semantically_equal_empty_lists() {
-    let a = Value::List(vec![]);
-    let b = Value::List(vec![]);
+    let a = Value::Concrete(ConcreteValue::List(vec![]));
+    let b = Value::Concrete(ConcreteValue::List(vec![]));
     assert!(a.semantically_equal(&b));
 }
 
 #[test]
 fn semantically_equal_lists_of_maps_different_order() {
     let mut map1 = IndexMap::new();
-    map1.insert("port".to_string(), Value::Int(80));
-    map1.insert("protocol".to_string(), Value::String("tcp".to_string()));
+    map1.insert("port".to_string(), Value::Concrete(ConcreteValue::Int(80)));
+    map1.insert(
+        "protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
 
     let mut map2 = IndexMap::new();
-    map2.insert("port".to_string(), Value::Int(443));
-    map2.insert("protocol".to_string(), Value::String("tcp".to_string()));
+    map2.insert("port".to_string(), Value::Concrete(ConcreteValue::Int(443)));
+    map2.insert(
+        "protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
 
-    let a = Value::List(vec![Value::Map(map1.clone()), Value::Map(map2.clone())]);
-    let b = Value::List(vec![Value::Map(map2), Value::Map(map1)]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Map(map1.clone())),
+        Value::Concrete(ConcreteValue::Map(map2.clone())),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Map(map2)),
+        Value::Concrete(ConcreteValue::Map(map1)),
+    ]));
     assert!(a.semantically_equal(&b));
 }
 
 #[test]
 fn semantically_equal_lists_of_strings() {
-    let a = Value::List(vec![
-        Value::String("b".to_string()),
-        Value::String("a".to_string()),
-    ]);
-    let b = Value::List(vec![
-        Value::String("a".to_string()),
-        Value::String("b".to_string()),
-    ]);
+    let a = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+        Value::Concrete(ConcreteValue::String("a".to_string())),
+    ]));
+    let b = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("a".to_string())),
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+    ]));
     assert!(a.semantically_equal(&b));
 }
 
 #[test]
 fn semantically_equal_non_list_values() {
     // Non-list values should use regular equality
-    assert!(Value::Int(42).semantically_equal(&Value::Int(42)));
-    assert!(!Value::Int(42).semantically_equal(&Value::Int(43)));
     assert!(
-        Value::String("hello".to_string()).semantically_equal(&Value::String("hello".to_string()))
+        Value::Concrete(ConcreteValue::Int(42))
+            .semantically_equal(&Value::Concrete(ConcreteValue::Int(42)))
     );
-    assert!(Value::Bool(true).semantically_equal(&Value::Bool(true)));
+    assert!(
+        !Value::Concrete(ConcreteValue::Int(42))
+            .semantically_equal(&Value::Concrete(ConcreteValue::Int(43)))
+    );
+    assert!(
+        Value::Concrete(ConcreteValue::String("hello".to_string()))
+            .semantically_equal(&Value::Concrete(ConcreteValue::String("hello".to_string())))
+    );
+    assert!(
+        Value::Concrete(ConcreteValue::Bool(true))
+            .semantically_equal(&Value::Concrete(ConcreteValue::Bool(true)))
+    );
 }
 
 #[test]
@@ -304,119 +387,164 @@ fn semantically_equal_nested_lists() {
     let mut map1 = IndexMap::new();
     map1.insert(
         "ports".to_string(),
-        Value::List(vec![Value::Int(80), Value::Int(443)]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(80)),
+            Value::Concrete(ConcreteValue::Int(443)),
+        ])),
     );
 
     let mut map2 = IndexMap::new();
     map2.insert(
         "ports".to_string(),
-        Value::List(vec![Value::Int(443), Value::Int(80)]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(443)),
+            Value::Concrete(ConcreteValue::Int(80)),
+        ])),
     );
 
-    let a = Value::Map(map1);
-    let b = Value::Map(map2);
+    let a = Value::Concrete(ConcreteValue::Map(map1));
+    let b = Value::Concrete(ConcreteValue::Map(map2));
     assert!(a.semantically_equal(&b));
 }
 
 #[test]
 fn semantically_equal_maps_different_keys() {
     let mut map1 = IndexMap::new();
-    map1.insert("a".to_string(), Value::Int(1));
+    map1.insert("a".to_string(), Value::Concrete(ConcreteValue::Int(1)));
 
     let mut map2 = IndexMap::new();
-    map2.insert("b".to_string(), Value::Int(1));
+    map2.insert("b".to_string(), Value::Concrete(ConcreteValue::Int(1)));
 
-    assert!(!Value::Map(map1).semantically_equal(&Value::Map(map2)));
+    assert!(
+        !Value::Concrete(ConcreteValue::Map(map1))
+            .semantically_equal(&Value::Concrete(ConcreteValue::Map(map2)))
+    );
 }
 
 #[test]
 fn semantically_equal_maps_different_sizes() {
     let mut map1 = IndexMap::new();
-    map1.insert("a".to_string(), Value::Int(1));
+    map1.insert("a".to_string(), Value::Concrete(ConcreteValue::Int(1)));
 
     let mut map2 = IndexMap::new();
-    map2.insert("a".to_string(), Value::Int(1));
-    map2.insert("b".to_string(), Value::Int(2));
+    map2.insert("a".to_string(), Value::Concrete(ConcreteValue::Int(1)));
+    map2.insert("b".to_string(), Value::Concrete(ConcreteValue::Int(2)));
 
-    assert!(!Value::Map(map1).semantically_equal(&Value::Map(map2)));
+    assert!(
+        !Value::Concrete(ConcreteValue::Map(map1))
+            .semantically_equal(&Value::Concrete(ConcreteValue::Map(map2)))
+    );
 }
 
 #[test]
 fn merge_with_saved_map_fills_extra_keys() {
-    let desired = Value::Map(IndexMap::from([
+    let desired = Value::Concrete(ConcreteValue::Map(IndexMap::from([
         (
             "hostname_type".to_string(),
-            Value::String("ip-name".to_string()),
+            Value::Concrete(ConcreteValue::String("ip-name".to_string())),
         ),
-        ("a_record".to_string(), Value::Bool(true)),
-    ]));
-    let saved = Value::Map(IndexMap::from([
+        (
+            "a_record".to_string(),
+            Value::Concrete(ConcreteValue::Bool(true)),
+        ),
+    ])));
+    let saved = Value::Concrete(ConcreteValue::Map(IndexMap::from([
         (
             "hostname_type".to_string(),
-            Value::String("ip-name".to_string()),
+            Value::Concrete(ConcreteValue::String("ip-name".to_string())),
         ),
-        ("a_record".to_string(), Value::Bool(true)),
-        ("aaaa_record".to_string(), Value::Bool(false)),
-    ]));
+        (
+            "a_record".to_string(),
+            Value::Concrete(ConcreteValue::Bool(true)),
+        ),
+        (
+            "aaaa_record".to_string(),
+            Value::Concrete(ConcreteValue::Bool(false)),
+        ),
+    ])));
 
     let merged = merge_with_saved(&desired, &saved);
-    let expected = Value::Map(IndexMap::from([
+    let expected = Value::Concrete(ConcreteValue::Map(IndexMap::from([
         (
             "hostname_type".to_string(),
-            Value::String("ip-name".to_string()),
+            Value::Concrete(ConcreteValue::String("ip-name".to_string())),
         ),
-        ("a_record".to_string(), Value::Bool(true)),
-        ("aaaa_record".to_string(), Value::Bool(false)),
-    ]));
+        (
+            "a_record".to_string(),
+            Value::Concrete(ConcreteValue::Bool(true)),
+        ),
+        (
+            "aaaa_record".to_string(),
+            Value::Concrete(ConcreteValue::Bool(false)),
+        ),
+    ])));
     assert!(merged.semantically_equal(&expected), "Merged: {:?}", merged);
 }
 
 #[test]
 fn merge_with_saved_desired_wins() {
-    let desired = Value::Map(IndexMap::from([("a".to_string(), Value::Int(10))]));
-    let saved = Value::Map(IndexMap::from([
-        ("a".to_string(), Value::Int(5)),
-        ("b".to_string(), Value::Int(20)),
-    ]));
+    let desired = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+        "a".to_string(),
+        Value::Concrete(ConcreteValue::Int(10)),
+    )])));
+    let saved = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        ("a".to_string(), Value::Concrete(ConcreteValue::Int(5))),
+        ("b".to_string(), Value::Concrete(ConcreteValue::Int(20))),
+    ])));
 
     let merged = merge_with_saved(&desired, &saved);
-    let expected = Value::Map(IndexMap::from([
-        ("a".to_string(), Value::Int(10)),
-        ("b".to_string(), Value::Int(20)),
-    ]));
+    let expected = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        ("a".to_string(), Value::Concrete(ConcreteValue::Int(10))),
+        ("b".to_string(), Value::Concrete(ConcreteValue::Int(20))),
+    ])));
     assert!(merged.semantically_equal(&expected), "Merged: {:?}", merged);
 }
 
 #[test]
 fn merge_with_saved_list_of_maps() {
-    let desired = Value::List(vec![Value::Map(IndexMap::from([(
-        "port".to_string(),
-        Value::Int(80),
-    )]))]);
-    let saved = Value::List(vec![Value::Map(IndexMap::from([
-        ("port".to_string(), Value::Int(80)),
-        ("protocol".to_string(), Value::String("tcp".to_string())),
-    ]))]);
+    let desired = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(IndexMap::from([(
+            "port".to_string(),
+            Value::Concrete(ConcreteValue::Int(80)),
+        )])),
+    )]));
+    let saved = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(IndexMap::from([
+            ("port".to_string(), Value::Concrete(ConcreteValue::Int(80))),
+            (
+                "protocol".to_string(),
+                Value::Concrete(ConcreteValue::String("tcp".to_string())),
+            ),
+        ])),
+    )]));
 
     let merged = merge_with_saved(&desired, &saved);
-    let expected = Value::List(vec![Value::Map(IndexMap::from([
-        ("port".to_string(), Value::Int(80)),
-        ("protocol".to_string(), Value::String("tcp".to_string())),
-    ]))]);
+    let expected = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(IndexMap::from([
+            ("port".to_string(), Value::Concrete(ConcreteValue::Int(80))),
+            (
+                "protocol".to_string(),
+                Value::Concrete(ConcreteValue::String("tcp".to_string())),
+            ),
+        ])),
+    )]));
     assert!(merged.semantically_equal(&expected), "Merged: {:?}", merged);
 }
 
 #[test]
 fn merge_with_saved_non_map() {
-    let desired = Value::String("hello".to_string());
-    let saved = Value::String("world".to_string());
+    let desired = Value::Concrete(ConcreteValue::String("hello".to_string()));
+    let saved = Value::Concrete(ConcreteValue::String("world".to_string()));
     let merged = merge_with_saved(&desired, &saved);
-    assert_eq!(merged, Value::String("hello".to_string()));
+    assert_eq!(
+        merged,
+        Value::Concrete(ConcreteValue::String("hello".to_string()))
+    );
 
-    let desired = Value::Int(42);
-    let saved = Value::Int(99);
+    let desired = Value::Concrete(ConcreteValue::Int(42));
+    let saved = Value::Concrete(ConcreteValue::Int(99));
     let merged = merge_with_saved(&desired, &saved);
-    assert_eq!(merged, Value::Int(42));
+    assert_eq!(merged, Value::Concrete(ConcreteValue::Int(42)));
 }
 
 #[test]
@@ -429,7 +557,7 @@ fn lists_equal_large_list_correctness() {
 
     // Different content
     let mut c: Vec<Value> = (0..n).map(Value::Int).collect();
-    c[n as usize - 1] = Value::Int(n); // change last element
+    c[n as usize - 1] = Value::Concrete(ConcreteValue::Int(n)); // change last element
     assert!(!lists_equal(&a, &c));
 }
 
@@ -437,17 +565,27 @@ fn lists_equal_large_list_correctness() {
 fn lists_equal_large_list_with_duplicates() {
     let n = 100;
     let a: Vec<Value> = (0..n)
-        .flat_map(|i| vec![Value::Int(i), Value::Int(i)])
+        .flat_map(|i| {
+            vec![
+                Value::Concrete(ConcreteValue::Int(i)),
+                Value::Concrete(ConcreteValue::Int(i)),
+            ]
+        })
         .collect();
     let b: Vec<Value> = (0..n)
         .rev()
-        .flat_map(|i| vec![Value::Int(i), Value::Int(i)])
+        .flat_map(|i| {
+            vec![
+                Value::Concrete(ConcreteValue::Int(i)),
+                Value::Concrete(ConcreteValue::Int(i)),
+            ]
+        })
         .collect();
     assert!(lists_equal(&a, &b));
 
     // Different multiplicities
     let mut c = a.clone();
-    c[0] = Value::Int(999);
+    c[0] = Value::Concrete(ConcreteValue::Int(999));
     assert!(!lists_equal(&a, &c));
 }
 
@@ -456,14 +594,17 @@ fn lists_equal_large_list_of_maps() {
     // Simulates security group rules (100+ maps)
     let n = 150;
     let make_rule = |i: i64| {
-        Value::Map(IndexMap::from([
-            ("port".to_string(), Value::Int(i)),
-            ("protocol".to_string(), Value::String("tcp".to_string())),
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([
+            ("port".to_string(), Value::Concrete(ConcreteValue::Int(i))),
+            (
+                "protocol".to_string(),
+                Value::Concrete(ConcreteValue::String("tcp".to_string())),
+            ),
             (
                 "cidr".to_string(),
-                Value::String(format!("10.0.{}.0/24", i)),
+                Value::Concrete(ConcreteValue::String(format!("10.0.{}.0/24", i))),
             ),
-        ]))
+        ])))
     };
 
     let a: Vec<Value> = (0..n).map(make_rule).collect();
@@ -497,15 +638,23 @@ fn merge_lists_large_list_correctness() {
     // Verify merge_lists works correctly with large lists
     let n = 50;
     let desired: Vec<Value> = (0..n)
-        .map(|i| Value::Map(IndexMap::from([("port".to_string(), Value::Int(i))])))
+        .map(|i| {
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+                "port".to_string(),
+                Value::Concrete(ConcreteValue::Int(i)),
+            )])))
+        })
         .collect();
     let saved: Vec<Value> = (0..n)
         .rev()
         .map(|i| {
-            Value::Map(IndexMap::from([
-                ("port".to_string(), Value::Int(i)),
-                ("protocol".to_string(), Value::String("tcp".to_string())),
-            ]))
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([
+                ("port".to_string(), Value::Concrete(ConcreteValue::Int(i))),
+                (
+                    "protocol".to_string(),
+                    Value::Concrete(ConcreteValue::String("tcp".to_string())),
+                ),
+            ])))
         })
         .collect();
 
@@ -514,7 +663,7 @@ fn merge_lists_large_list_correctness() {
 
     // Each merged element should have both port and protocol
     for item in &merged {
-        if let Value::Map(map) = item {
+        if let Value::Concrete(ConcreteValue::Map(map)) = item {
             assert!(map.contains_key("port"), "Missing port in merged item");
             assert!(
                 map.contains_key("protocol"),
@@ -529,23 +678,23 @@ fn merge_lists_large_list_correctness() {
 #[test]
 fn canonical_hash_consistency() {
     // Same value should produce same hash
-    let v1 = Value::Int(42);
-    let v2 = Value::Int(42);
+    let v1 = Value::Concrete(ConcreteValue::Int(42));
+    let v2 = Value::Concrete(ConcreteValue::Int(42));
     assert_eq!(v1.canonical_hash(), v2.canonical_hash());
 
     // Different values should (usually) produce different hashes
-    let v3 = Value::Int(43);
+    let v3 = Value::Concrete(ConcreteValue::Int(43));
     assert_ne!(v1.canonical_hash(), v3.canonical_hash());
 
     // Maps with same content should hash the same regardless of insertion order
-    let m1 = Value::Map(IndexMap::from([
-        ("a".to_string(), Value::Int(1)),
-        ("b".to_string(), Value::Int(2)),
-    ]));
-    let m2 = Value::Map(IndexMap::from([
-        ("b".to_string(), Value::Int(2)),
-        ("a".to_string(), Value::Int(1)),
-    ]));
+    let m1 = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
+        ("b".to_string(), Value::Concrete(ConcreteValue::Int(2))),
+    ])));
+    let m2 = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        ("b".to_string(), Value::Concrete(ConcreteValue::Int(2))),
+        ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
+    ])));
     assert_eq!(m1.canonical_hash(), m2.canonical_hash());
 }
 
@@ -663,29 +812,41 @@ fn resource_kind_enum_data_source() {
 #[test]
 fn resource_attributes_use_value_type() {
     let resource = Resource::new("s3.Bucket", "test")
-        .with_attribute("name", Value::String("my-bucket".to_string()))
+        .with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+        )
         .with_attribute(
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
         );
-    assert!(matches!(resource.get_attr("name"), Some(Value::String(_))));
+    assert!(matches!(
+        resource.get_attr("name"),
+        Some(Value::Concrete(ConcreteValue::String(_)))
+    ));
     assert!(matches!(
         resource.get_attr("vpc_id"),
-        Some(Value::ResourceRef { .. })
+        Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
     ));
 }
 
 #[test]
 fn attrs_to_hashmap_clones_values() {
     let mut attrs = IndexMap::new();
-    attrs.insert("name".to_string(), Value::String("test".to_string()));
-    attrs.insert("count".to_string(), Value::Int(5));
+    attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("test".to_string())),
+    );
+    attrs.insert("count".to_string(), Value::Concrete(ConcreteValue::Int(5)));
     let resolved = attrs_to_hashmap(&attrs);
     assert_eq!(
         resolved.get("name"),
-        Some(&Value::String("test".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String("test".to_string())))
     );
-    assert_eq!(resolved.get("count"), Some(&Value::Int(5)));
+    assert_eq!(
+        resolved.get("count"),
+        Some(&Value::Concrete(ConcreteValue::Int(5)))
+    );
 }
 
 #[test]
@@ -785,7 +946,7 @@ fn value_ref_helpers() {
         Some(["nested".to_string()].as_slice())
     );
 
-    let non_ref = Value::String("hello".to_string());
+    let non_ref = Value::Concrete(ConcreteValue::String("hello".to_string()));
     assert_eq!(non_ref.ref_binding(), None);
 }
 
@@ -795,23 +956,27 @@ fn value_ref_helpers() {
 
 #[test]
 fn visit_refs_collects_from_all_nested_variants() {
-    let value = Value::List(vec![
+    let value = Value::Concrete(ConcreteValue::List(vec![
         Value::resource_ref("a", "id", vec![]),
-        Value::Map(IndexMap::from([(
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
             "k".to_string(),
             Value::resource_ref("b", "id", vec![]),
-        )])),
-        Value::Interpolation(vec![
+        )]))),
+        Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("x".to_string()),
             InterpolationPart::Expr(Value::resource_ref("c", "id", vec![])),
-        ]),
-        Value::FunctionCall {
+        ])),
+        Value::Deferred(DeferredValue::FunctionCall {
             name: "join".to_string(),
             args: vec![Value::resource_ref("d", "id", vec![])],
-        },
-        Value::Secret(Box::new(Value::resource_ref("e", "id", vec![]))),
-        Value::String("plain".to_string()),
-    ]);
+        }),
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::resource_ref(
+            "e",
+            "id",
+            vec![],
+        )))),
+        Value::Concrete(ConcreteValue::String("plain".to_string())),
+    ]));
 
     let mut collected: Vec<String> = Vec::new();
     value.visit_refs(&mut |path| {
@@ -824,10 +989,10 @@ fn visit_refs_collects_from_all_nested_variants() {
 #[test]
 fn visit_refs_on_leaf_variants_calls_nothing() {
     for v in [
-        Value::String("s".into()),
-        Value::Int(1),
-        Value::Float(1.0),
-        Value::Bool(true),
+        Value::Concrete(ConcreteValue::String("s".into())),
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Float(1.0)),
+        Value::Concrete(ConcreteValue::Bool(true)),
     ] {
         let mut count = 0;
         v.visit_refs(&mut |_| count += 1);
@@ -840,10 +1005,10 @@ fn visit_refs_on_leaf_variants_calls_nothing() {
 #[test]
 fn canonicalize_leaves_simple_values_alone() {
     for v in [
-        Value::String("s".into()),
-        Value::Int(1),
-        Value::Float(1.5),
-        Value::Bool(true),
+        Value::Concrete(ConcreteValue::String("s".into())),
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Float(1.5)),
+        Value::Concrete(ConcreteValue::Bool(true)),
         Value::resource_ref("vpc", "id", vec![]),
     ] {
         assert_eq!(v.clone().canonicalize(), v);
@@ -852,36 +1017,46 @@ fn canonicalize_leaves_simple_values_alone() {
 
 #[test]
 fn canonicalize_collapses_all_literal_interpolation_to_string() {
-    let v = Value::Interpolation(vec![
+    let v = Value::Deferred(DeferredValue::Interpolation(vec![
         InterpolationPart::Literal("foo".into()),
         InterpolationPart::Literal("bar".into()),
-    ]);
-    assert_eq!(v.canonicalize(), Value::String("foobar".into()));
+    ]));
+    assert_eq!(
+        v.canonicalize(),
+        Value::Concrete(ConcreteValue::String("foobar".into()))
+    );
 }
 
 #[test]
 fn canonicalize_collapses_single_literal_interpolation_to_string() {
-    let v = Value::Interpolation(vec![InterpolationPart::Literal("foo".into())]);
-    assert_eq!(v.canonicalize(), Value::String("foo".into()));
+    let v = Value::Deferred(DeferredValue::Interpolation(vec![
+        InterpolationPart::Literal("foo".into()),
+    ]));
+    assert_eq!(
+        v.canonicalize(),
+        Value::Concrete(ConcreteValue::String("foo".into()))
+    );
 }
 
 #[test]
 fn canonicalize_unwraps_single_scalar_expr_interpolation() {
     // Every string-shaped scalar (String / Int / Float / Bool) is
-    // folded into a flat `Value::String` when wrapped in a
+    // folded into a flat `Value::Concrete(ConcreteValue::String)` when wrapped in a
     // single-element interpolation.
     let cases: Vec<(Value, &str)> = vec![
-        (Value::String("foo".into()), "foo"),
-        (Value::Int(42), "42"),
-        (Value::Float(1.5), "1.5"),
-        (Value::Bool(true), "true"),
+        (Value::Concrete(ConcreteValue::String("foo".into())), "foo"),
+        (Value::Concrete(ConcreteValue::Int(42)), "42"),
+        (Value::Concrete(ConcreteValue::Float(1.5)), "1.5"),
+        (Value::Concrete(ConcreteValue::Bool(true)), "true"),
     ];
     for (inner, expected) in cases {
         let label = format!("{:?}", inner);
-        let v = Value::Interpolation(vec![InterpolationPart::Expr(inner)]);
+        let v = Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+            inner,
+        )]));
         assert_eq!(
             v.canonicalize(),
-            Value::String(expected.into()),
+            Value::Concrete(ConcreteValue::String(expected.into())),
             "case {} failed",
             label
         );
@@ -890,32 +1065,35 @@ fn canonicalize_unwraps_single_scalar_expr_interpolation() {
 
 #[test]
 fn canonicalize_merges_adjacent_literals() {
-    let v = Value::Interpolation(vec![
+    let v = Value::Deferred(DeferredValue::Interpolation(vec![
         InterpolationPart::Literal("a".into()),
         InterpolationPart::Literal("b".into()),
         InterpolationPart::Expr(Value::resource_ref("vpc", "id", vec![])),
         InterpolationPart::Literal("c".into()),
         InterpolationPart::Literal("d".into()),
-    ]);
+    ]));
     assert_eq!(
         v.canonicalize(),
-        Value::Interpolation(vec![
+        Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("ab".into()),
             InterpolationPart::Expr(Value::resource_ref("vpc", "id", vec![])),
             InterpolationPart::Literal("cd".into()),
-        ])
+        ]))
     );
 }
 
 #[test]
 fn canonicalize_folds_simple_expr_into_literal_then_merges() {
     // ["prefix-", Expr(String("foo")), "-suffix"] -> "prefix-foo-suffix"
-    let v = Value::Interpolation(vec![
+    let v = Value::Deferred(DeferredValue::Interpolation(vec![
         InterpolationPart::Literal("prefix-".into()),
-        InterpolationPart::Expr(Value::String("foo".into())),
+        InterpolationPart::Expr(Value::Concrete(ConcreteValue::String("foo".into()))),
         InterpolationPart::Literal("-suffix".into()),
-    ]);
-    assert_eq!(v.canonicalize(), Value::String("prefix-foo-suffix".into()));
+    ]));
+    assert_eq!(
+        v.canonicalize(),
+        Value::Concrete(ConcreteValue::String("prefix-foo-suffix".into()))
+    );
 }
 
 #[test]
@@ -924,56 +1102,65 @@ fn canonicalize_keeps_resource_ref_expr_in_interpolation() {
         InterpolationPart::Literal("prefix-".into()),
         InterpolationPart::Expr(Value::resource_ref("vpc", "id", vec![])),
     ];
-    let v = Value::Interpolation(parts.clone());
-    assert_eq!(v.canonicalize(), Value::Interpolation(parts));
+    let v = Value::Deferred(DeferredValue::Interpolation(parts.clone()));
+    assert_eq!(
+        v.canonicalize(),
+        Value::Deferred(DeferredValue::Interpolation(parts))
+    );
 }
 
 #[test]
 fn canonicalize_recurses_into_list_and_map() {
-    let v = Value::List(vec![
-        Value::Interpolation(vec![InterpolationPart::Literal("foo".into())]),
-        Value::Map(IndexMap::from([(
+    let v = Value::Concrete(ConcreteValue::List(vec![
+        Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("foo".into()),
+        ])),
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
             "k".to_string(),
-            Value::Interpolation(vec![InterpolationPart::Literal("bar".into())]),
-        )])),
-    ]);
+            Value::Deferred(DeferredValue::Interpolation(vec![
+                InterpolationPart::Literal("bar".into()),
+            ])),
+        )]))),
+    ]));
     assert_eq!(
         v.canonicalize(),
-        Value::List(vec![
-            Value::String("foo".into()),
-            Value::Map(IndexMap::from([(
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("foo".into())),
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([(
                 "k".to_string(),
-                Value::String("bar".into()),
-            )])),
-        ])
+                Value::Concrete(ConcreteValue::String("bar".into())),
+            )]))),
+        ]))
     );
 }
 
 #[test]
 fn canonicalize_recurses_into_function_call_args() {
-    let v = Value::FunctionCall {
+    let v = Value::Deferred(DeferredValue::FunctionCall {
         name: "upper".into(),
-        args: vec![Value::Interpolation(vec![InterpolationPart::Literal(
-            "foo".into(),
-        )])],
-    };
+        args: vec![Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("foo".into()),
+        ]))],
+    });
     assert_eq!(
         v.canonicalize(),
-        Value::FunctionCall {
+        Value::Deferred(DeferredValue::FunctionCall {
             name: "upper".into(),
-            args: vec![Value::String("foo".into())],
-        }
+            args: vec![Value::Concrete(ConcreteValue::String("foo".into()))],
+        })
     );
 }
 
 #[test]
 fn canonicalize_recurses_into_secret() {
-    let v = Value::Secret(Box::new(Value::Interpolation(vec![
-        InterpolationPart::Literal("hidden".into()),
-    ])));
+    let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
+        DeferredValue::Interpolation(vec![InterpolationPart::Literal("hidden".into())]),
+    ))));
     assert_eq!(
         v.canonicalize(),
-        Value::Secret(Box::new(Value::String("hidden".into())))
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("hidden".into())
+        ))))
     );
 }
 
@@ -982,10 +1169,15 @@ fn canonicalize_collapses_nested_interpolation() {
     // Inner `Interpolation([Literal("foo")])` collapses to `String("foo")`,
     // its outer `Expr(String("foo"))` folds into a Literal, and the
     // single-literal Interpolation collapses to `String("foo")`.
-    let v = Value::Interpolation(vec![InterpolationPart::Expr(Value::Interpolation(vec![
-        InterpolationPart::Literal("foo".into()),
-    ]))]);
-    assert_eq!(v.canonicalize(), Value::String("foo".into()));
+    let v = Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+        Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("foo".into()),
+        ])),
+    )]));
+    assert_eq!(
+        v.canonicalize(),
+        Value::Concrete(ConcreteValue::String("foo".into()))
+    );
 }
 
 #[test]
@@ -993,19 +1185,28 @@ fn canonicalize_keeps_secret_expr_in_interpolation() {
     // A `Secret(_)` inside an `Expr` must NOT be folded into a Literal:
     // doing so would let the secret travel as plain text and bypass
     // redaction in plan display, state serialization, and logging.
-    let secret = Value::Secret(Box::new(Value::String("password".into())));
+    let secret = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("password".into()),
+    ))));
     let parts = vec![
         InterpolationPart::Literal("db-".into()),
         InterpolationPart::Expr(secret.clone()),
     ];
-    let v = Value::Interpolation(parts.clone());
-    assert_eq!(v.canonicalize(), Value::Interpolation(parts));
+    let v = Value::Deferred(DeferredValue::Interpolation(parts.clone()));
+    assert_eq!(
+        v.canonicalize(),
+        Value::Deferred(DeferredValue::Interpolation(parts))
+    );
 
     // Even when the Secret is the only Expr part, it must stay wrapped.
-    let only_secret = Value::Interpolation(vec![InterpolationPart::Expr(secret.clone())]);
+    let only_secret = Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+        secret.clone(),
+    )]));
     assert_eq!(
         only_secret.canonicalize(),
-        Value::Interpolation(vec![InterpolationPart::Expr(secret)]),
+        Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+            secret
+        )])),
     );
 }
 
@@ -1013,37 +1214,43 @@ fn canonicalize_keeps_secret_expr_in_interpolation() {
 fn canonicalize_is_idempotent() {
     let inputs = vec![
         // All-Literal Interpolation collapses to String on first call.
-        Value::Interpolation(vec![
+        Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("foo".into()),
             InterpolationPart::Literal("bar".into()),
-        ]),
+        ])),
         // ResourceRef-bearing Interpolation stays as Interpolation.
-        Value::Interpolation(vec![
+        Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("a".into()),
             InterpolationPart::Expr(Value::resource_ref("x", "y", vec![])),
             InterpolationPart::Literal("b".into()),
-        ]),
+        ])),
         // Nested Interpolation inside an Expr.
-        Value::Interpolation(vec![InterpolationPart::Expr(Value::Interpolation(vec![
-            InterpolationPart::Literal("nested".into()),
-        ]))]),
+        Value::Deferred(DeferredValue::Interpolation(vec![InterpolationPart::Expr(
+            Value::Deferred(DeferredValue::Interpolation(vec![
+                InterpolationPart::Literal("nested".into()),
+            ])),
+        )])),
         // Secret-wrapped Interpolation: canonicalize recurses through
         // Secret at the Value level but keeps Secret(Expr) wrapped.
-        Value::Secret(Box::new(Value::Interpolation(vec![
-            InterpolationPart::Literal("hidden".into()),
-        ]))),
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
+            DeferredValue::Interpolation(vec![InterpolationPart::Literal("hidden".into())]),
+        )))),
         // List, Map, FunctionCall — recursion shapes.
-        Value::List(vec![Value::String("x".into())]),
-        Value::Map(IndexMap::from([(
-            "k".to_string(),
-            Value::Interpolation(vec![InterpolationPart::Literal("v".into())]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("x".into()),
         )])),
-        Value::FunctionCall {
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+            "k".to_string(),
+            Value::Deferred(DeferredValue::Interpolation(vec![
+                InterpolationPart::Literal("v".into()),
+            ])),
+        )]))),
+        Value::Deferred(DeferredValue::FunctionCall {
             name: "upper".into(),
-            args: vec![Value::Interpolation(vec![InterpolationPart::Literal(
-                "x".into(),
-            )])],
-        },
+            args: vec![Value::Deferred(DeferredValue::Interpolation(vec![
+                InterpolationPart::Literal("x".into()),
+            ]))],
+        }),
     ];
     for v in inputs {
         let once = v.clone().canonicalize();
@@ -1052,25 +1259,30 @@ fn canonicalize_is_idempotent() {
     }
 }
 
-// ----- RFC #2371 stage 2 (#2377): Value::Unknown semantics -----
+// ----- RFC #2371 stage 2 (#2377): Value::Deferred(DeferredValue::Unknown) semantics -----
 
 #[test]
 fn unknown_never_equals_unknown() {
-    // Two Value::Unknown must compare unequal even when their reasons
+    // Two Value::Deferred(DeferredValue::Unknown) must compare unequal even when their reasons
     // are identical — an unknown value is, by definition, not equal to
     // anything (including itself). Without this, the differ would
     // suppress real diffs between two attributes that both happen to
     // be "unresolved upstream" of the same binding.
     let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-    let a = Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
-    let b = Value::Unknown(UnknownReason::UpstreamRef { path });
-    assert_ne!(a, b, "two `Value::Unknown`s must never compare equal");
+    let a = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+        path: path.clone(),
+    }));
+    let b = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path }));
+    assert_ne!(
+        a, b,
+        "two `Value::Deferred(DeferredValue::Unknown)`s must never compare equal"
+    );
 }
 
 #[test]
 fn unknown_never_equals_concrete() {
-    let a = Value::Unknown(UnknownReason::ForKey);
-    let b = Value::String("anything".into());
+    let a = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey));
+    let b = Value::Concrete(ConcreteValue::String("anything".into()));
     assert_ne!(a, b);
     assert_ne!(b, a);
 }
@@ -1078,12 +1290,12 @@ fn unknown_never_equals_concrete() {
 #[test]
 fn unknown_for_variants_never_equal() {
     assert_ne!(
-        Value::Unknown(UnknownReason::ForKey),
-        Value::Unknown(UnknownReason::ForKey)
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)),
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey))
     );
     assert_ne!(
-        Value::Unknown(UnknownReason::ForIndex),
-        Value::Unknown(UnknownReason::ForValue)
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex)),
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue))
     );
 }
 
@@ -1096,8 +1308,10 @@ fn unknown_hash_is_deterministic_per_path() {
         h.finish()
     }
     let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-    let a = Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
-    let b = Value::Unknown(UnknownReason::UpstreamRef { path });
+    let a = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+        path: path.clone(),
+    }));
+    let b = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path }));
     assert_eq!(
         hash_of(&a),
         hash_of(&b),
@@ -1115,8 +1329,12 @@ fn unknown_hash_differs_per_path() {
     }
     let p1 = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
     let p2 = AccessPath::with_fields("network", "vpc", vec!["cidr_block".into()]);
-    let a = Value::Unknown(UnknownReason::UpstreamRef { path: p1 });
-    let b = Value::Unknown(UnknownReason::UpstreamRef { path: p2 });
+    let a = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+        path: p1,
+    }));
+    let b = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+        path: p2,
+    }));
     assert_ne!(hash_of(&a), hash_of(&b));
 }
 
@@ -1124,26 +1342,26 @@ fn unknown_hash_differs_per_path() {
 fn unknown_hash_does_not_panic_for_for_variants() {
     use std::hash::Hasher;
     let mut h = std::collections::hash_map::DefaultHasher::new();
-    Value::Unknown(UnknownReason::ForKey).hash_into(&mut h);
-    Value::Unknown(UnknownReason::ForIndex).hash_into(&mut h);
-    Value::Unknown(UnknownReason::ForValue).hash_into(&mut h);
+    Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)).hash_into(&mut h);
+    Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex)).hash_into(&mut h);
+    Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)).hash_into(&mut h);
     let _ = h.finish();
 }
 
 #[test]
 fn unknown_cannot_round_trip_through_serde_json() {
-    // RFC #2371 constraint c: `Value::Unknown` must never reach state
+    // RFC #2371 constraint c: `Value::Deferred(DeferredValue::Unknown)` must never reach state
     // files / plan files / providers. The variant has `#[serde(skip)]`
     // so attempting to serialize it returns Err — even a hand-edited
     // JSON cannot resurrect the variant via deserialization.
     let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-    let v = Value::Unknown(UnknownReason::UpstreamRef { path });
+    let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path }));
 
     // Serialization must fail.
     let r = serde_json::to_string(&v);
     assert!(
         r.is_err(),
-        "serializing Value::Unknown must error, got Ok({:?})",
+        "serializing Value::Deferred(DeferredValue::Unknown) must error, got Ok({:?})",
         r
     );
 
@@ -1153,7 +1371,7 @@ fn unknown_cannot_round_trip_through_serde_json() {
     let r: Result<Value, _> = serde_json::from_str(payload);
     assert!(
         r.is_err(),
-        "deserializing Value::Unknown must error, got Ok({:?})",
+        "deserializing Value::Deferred(DeferredValue::Unknown) must error, got Ok({:?})",
         r
     );
 }
@@ -1207,17 +1425,20 @@ fn as_concrete_returns_projection_for_concrete_variants() {
     // is exhaustive so this is enough to catch a future variant added
     // to the wrong axis.
     let cases: Vec<(Value, &'static str)> = vec![
-        (Value::String("x".into()), "String"),
-        (Value::Int(1), "Int"),
-        (Value::Float(1.5), "Float"),
-        (Value::Bool(true), "Bool"),
+        (Value::Concrete(ConcreteValue::String("x".into())), "String"),
+        (Value::Concrete(ConcreteValue::Int(1)), "Int"),
+        (Value::Concrete(ConcreteValue::Float(1.5)), "Float"),
+        (Value::Concrete(ConcreteValue::Bool(true)), "Bool"),
         (
-            Value::Duration(std::time::Duration::from_secs(60)),
+            Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(60))),
             "Duration",
         ),
-        (Value::List(vec![]), "List"),
-        (Value::StringList(vec![]), "StringList"),
-        (Value::Map(IndexMap::new()), "Map"),
+        (Value::Concrete(ConcreteValue::List(vec![])), "List"),
+        (
+            Value::Concrete(ConcreteValue::StringList(vec![])),
+            "StringList",
+        ),
+        (Value::Concrete(ConcreteValue::Map(IndexMap::new())), "Map"),
     ];
     for (v, label) in cases {
         assert!(
@@ -1239,24 +1460,32 @@ fn as_deferred_returns_projection_for_deferred_variants() {
             "ResourceRef",
         ),
         (
-            Value::BindingRef {
+            Value::Deferred(DeferredValue::BindingRef {
                 binding: "bootstrap".to_string(),
-            },
+            }),
             "BindingRef",
         ),
-        (Value::Interpolation(vec![]), "Interpolation"),
         (
-            Value::FunctionCall {
+            Value::Deferred(DeferredValue::Interpolation(vec![])),
+            "Interpolation",
+        ),
+        (
+            Value::Deferred(DeferredValue::FunctionCall {
                 name: "join".to_string(),
                 args: vec![],
-            },
+            }),
             "FunctionCall",
         ),
         (
-            Value::Secret(Box::new(Value::String("inner".into()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("inner".into()),
+            )))),
             "Secret",
         ),
-        (Value::Unknown(UnknownReason::ForKey), "Unknown"),
+        (
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)),
+            "Unknown",
+        ),
     ];
     for (v, label) in cases {
         assert!(
@@ -1274,24 +1503,27 @@ fn as_deferred_returns_projection_for_deferred_variants() {
 fn as_concrete_borrows_inner_string_without_clone() {
     // The accessor must hand out a &str pointing into the original
     // value, not a copy. Easy proof: pointer equality on the bytes.
-    let v = Value::String("hello".into());
+    let v = Value::Concrete(ConcreteValue::String("hello".into()));
     let Some(ConcreteValueRef::String(borrowed)) = v.as_concrete() else {
         panic!("expected String projection");
     };
-    let Value::String(ref original) = v else {
-        unreachable!("v constructed as Value::String");
+    let Value::Concrete(ConcreteValue::String(ref original)) = v else {
+        unreachable!("v constructed as Value::Concrete(ConcreteValue::String)");
     };
     assert_eq!(borrowed.as_ptr(), original.as_str().as_ptr());
 }
 
 #[test]
 fn as_concrete_list_borrows_underlying_slice() {
-    let v = Value::List(vec![Value::Int(1), Value::Int(2)]);
+    let v = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Int(1)),
+        Value::Concrete(ConcreteValue::Int(2)),
+    ]));
     let Some(ConcreteValueRef::List(items)) = v.as_concrete() else {
         panic!("expected List projection");
     };
-    let Value::List(ref original) = v else {
-        unreachable!("v constructed as Value::List");
+    let Value::Concrete(ConcreteValue::List(ref original)) = v else {
+        unreachable!("v constructed as Value::Concrete(ConcreteValue::List)");
     };
     assert_eq!(items.as_ptr(), original.as_ptr());
     assert_eq!(items.len(), 2);

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 
-use crate::resource::{ConcreteValueRef, Resource, Value};
+use crate::resource::{ConcreteValue, ConcreteValueRef, DeferredValue, Resource, Value};
 use crate::utils::{extract_enum_value_with_values, validate_enum_namespace};
 use crate::value::format_value_with_key;
 
@@ -92,11 +92,11 @@ fn walk_custom_lookup(
     // which only resolve to a concrete string at apply time.
     if matches!(
         value,
-        Value::FunctionCall { .. }
-            | Value::Secret(_)
-            | Value::ResourceRef { .. }
-            | Value::Interpolation(_)
-            | Value::Unknown(_)
+        Value::Deferred(DeferredValue::FunctionCall { .. })
+            | Value::Deferred(DeferredValue::Secret(_))
+            | Value::Deferred(DeferredValue::ResourceRef { .. })
+            | Value::Deferred(DeferredValue::Interpolation(_))
+            | Value::Deferred(DeferredValue::Unknown(_))
     ) {
         return;
     }
@@ -121,21 +121,21 @@ fn walk_custom_lookup(
             }
         }
         AttributeType::List { inner, .. } => {
-            if let Value::List(items) = value {
+            if let Value::Concrete(ConcreteValue::List(items)) = value {
                 for item in items {
                     walk_custom_lookup(inner, item, attr_name, lookup, errors);
                 }
             }
         }
         AttributeType::Map { value: inner, .. } => {
-            if let Value::Map(map) = value {
+            if let Value::Concrete(ConcreteValue::Map(map)) = value {
                 for v in map.values() {
                     walk_custom_lookup(inner, v, attr_name, lookup, errors);
                 }
             }
         }
         AttributeType::Struct { fields, .. } => {
-            if let Value::Map(map) = value {
+            if let Value::Concrete(ConcreteValue::Map(map)) = value {
                 for f in fields {
                     if let Some(v) = map.get(&f.name) {
                         walk_custom_lookup(&f.field_type, v, attr_name, lookup, errors);
@@ -697,7 +697,7 @@ impl AttributeType {
         // the field value through `as_concrete()` again, so deferred
         // field values silently contribute no errors here. Phase 2 of
         // RFC #2972 makes this a single, type-aware filter point
-        // instead of the old per-site `matches!(v, Value::ResourceRef
+        // instead of the old per-site `matches!(v, Value::Deferred(DeferredValue::ResourceRef)
         // { .. })` skip.
         for (k, v) in map {
             match accepted.get(k.as_str()) {
@@ -753,8 +753,8 @@ impl AttributeType {
     /// Phase 2 of RFC #2972: takes [`ConcreteValueRef`], so deferred
     /// values (`ResourceRef`, `Interpolation`, ...) cannot reach this
     /// path — they were filtered at the dispatcher in [`Self::validate`].
-    /// The pre-Phase-2 `Value::String(_) | Value::ResourceRef { .. } |
-    /// Value::Interpolation(_)` arm is now structurally unrepresentable.
+    /// The pre-Phase-2 `Value::Concrete(ConcreteValue::String(_)) | Value::Deferred(DeferredValue::ResourceRef{ .. }) |
+    /// Value::Deferred(DeferredValue::Interpolation(_))` arm is now structurally unrepresentable.
     fn validate_primitive(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
         match (self, value) {
             (AttributeType::String, ConcreteValueRef::String(_)) => Ok(()),
@@ -781,7 +781,7 @@ impl AttributeType {
     /// top-level dispatcher.
     ///
     /// Phase 2 of RFC #2972: takes [`ConcreteValueRef`]. Pre-Phase-2
-    /// `Value::Interpolation` and `Value::ResourceRef` short-circuits
+    /// `Value::Deferred(DeferredValue::Interpolation)` and `Value::Deferred(DeferredValue::ResourceRef)` short-circuits
     /// are gone — the dispatcher filters deferred values.
     fn validate_string_enum(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
         let AttributeType::StringEnum {
@@ -797,7 +797,7 @@ impl AttributeType {
         let resolved_value = Self::resolve_enum_input(name, namespace.as_deref(), value);
         // Capture the user's original input for diagnostics. The parser
         // collapses both quoted literals (`"aaa"`) and bare identifiers
-        // (`dedicated`) into `Value::String`, and `resolve_enum_input`
+        // (`dedicated`) into `Value::Concrete(ConcreteValue::String)`, and `resolve_enum_input`
         // rewrites the non-dotted form into a synthesized namespaced
         // string for lookup. That synthesized form must stay internal:
         // error messages should quote what the user actually typed.
@@ -806,7 +806,7 @@ impl AttributeType {
             ConcreteValueRef::String(s) => Some(s),
             _ => None,
         };
-        if let Value::String(s) = &resolved_value {
+        if let Value::Concrete(ConcreteValue::String(s)) = &resolved_value {
             // Check if the raw string directly matches a valid enum value
             // before namespace validation. This handles values containing
             // dots (e.g., "ipsec.1") that would be misinterpreted as
@@ -886,7 +886,7 @@ impl AttributeType {
     /// closure after expanding any enum-shorthand identifier in `value`.
     ///
     /// Phase 2 of RFC #2972: takes [`ConcreteValueRef`]. The deferred-skip
-    /// guard for `Value::ResourceRef`/`Value::Interpolation` is gone —
+    /// guard for `Value::Deferred(DeferredValue::ResourceRef)`/`Value::Deferred(DeferredValue::Interpolation)` is gone —
     /// the dispatcher filters them out in [`Self::validate`].
     fn validate_custom(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
         let AttributeType::Custom {
@@ -925,12 +925,12 @@ impl AttributeType {
         // same way.
         if let ConcreteValueRef::StringList(items) = value {
             for (i, s) in items.iter().enumerate() {
-                inner.validate(&Value::String(s.clone())).map_err(|e| {
-                    TypeError::ListItemError {
+                inner
+                    .validate(&Value::Concrete(ConcreteValue::String(s.clone())))
+                    .map_err(|e| TypeError::ListItemError {
                         index: i,
                         inner: Box::new(e),
-                    }
-                })?;
+                    })?;
             }
             return Ok(());
         }
@@ -971,7 +971,7 @@ impl AttributeType {
         // Validate keys against key type
         for k in map.keys() {
             key_type
-                .validate(&Value::String(k.clone()))
+                .validate(&Value::Concrete(ConcreteValue::String(k.clone())))
                 .map_err(|e| TypeError::MapKeyError {
                     key: k.clone(),
                     inner: Box::new(e),
@@ -989,7 +989,7 @@ impl AttributeType {
     /// Validate a `Struct` variant: required fields, known field names, and
     /// recursively check each field's value.
     ///
-    /// Block syntax produces `Value::List([Value::Map(...)])`, but bare
+    /// Block syntax produces `Value::Concrete(ConcreteValue::List([Value::Map(...)]))`, but bare
     /// `Struct` requires map assignment syntax (`attr = { ... }`); a
     /// `List` is rejected explicitly with `BlockSyntaxNotAllowed`.
     ///
@@ -1423,7 +1423,7 @@ fn reshape_for_string_literal(
         namespace: Some(_),
         ..
     } = attr_type
-        && let Value::String(typed) = value
+        && let Value::Concrete(ConcreteValue::String(typed)) = value
         && let TypeError::ValidationFailed { message } = &tagged
     {
         return TypeError::StringLiteralExpectedEnum {
@@ -1740,22 +1740,26 @@ impl TypeError {
 impl Value {
     fn type_name(&self) -> String {
         match self {
-            Value::String(_) => "String".to_string(),
-            Value::Int(_) => "Int".to_string(),
-            Value::Float(_) => "Float".to_string(),
-            Value::Bool(_) => "Bool".to_string(),
-            Value::Duration(_) => "Duration".to_string(),
-            Value::List(_) => "List".to_string(),
-            Value::StringList(_) => "StringList".to_string(),
-            Value::Map(_) => "Map".to_string(),
-            Value::ResourceRef { path } => {
+            Value::Concrete(ConcreteValue::String(_)) => "String".to_string(),
+            Value::Concrete(ConcreteValue::Int(_)) => "Int".to_string(),
+            Value::Concrete(ConcreteValue::Float(_)) => "Float".to_string(),
+            Value::Concrete(ConcreteValue::Bool(_)) => "Bool".to_string(),
+            Value::Concrete(ConcreteValue::Duration(_)) => "Duration".to_string(),
+            Value::Concrete(ConcreteValue::List(_)) => "List".to_string(),
+            Value::Concrete(ConcreteValue::StringList(_)) => "StringList".to_string(),
+            Value::Concrete(ConcreteValue::Map(_)) => "Map".to_string(),
+            Value::Deferred(DeferredValue::ResourceRef { path }) => {
                 format!("ResourceRef({})", path.to_dot_string())
             }
-            Value::BindingRef { binding } => format!("BindingRef({})", binding),
-            Value::Interpolation(_) => "Interpolation".to_string(),
-            Value::FunctionCall { name, .. } => format!("FunctionCall({})", name),
-            Value::Secret(_) => "Secret".to_string(),
-            Value::Unknown(_) => "Unknown".to_string(),
+            Value::Deferred(DeferredValue::BindingRef { binding }) => {
+                format!("BindingRef({})", binding)
+            }
+            Value::Deferred(DeferredValue::Interpolation(_)) => "Interpolation".to_string(),
+            Value::Deferred(DeferredValue::FunctionCall { name, .. }) => {
+                format!("FunctionCall({})", name)
+            }
+            Value::Deferred(DeferredValue::Secret(_)) => "Secret".to_string(),
+            Value::Deferred(DeferredValue::Unknown(_)) => "Unknown".to_string(),
         }
     }
 }
@@ -1782,14 +1786,16 @@ impl ConcreteValueRef<'_> {
     /// be migrated to the projection without a wider API change.
     fn to_owned_value(self) -> Value {
         match self {
-            ConcreteValueRef::String(s) => Value::String(s.to_string()),
-            ConcreteValueRef::Int(n) => Value::Int(n),
-            ConcreteValueRef::Float(f) => Value::Float(f),
-            ConcreteValueRef::Bool(b) => Value::Bool(b),
-            ConcreteValueRef::Duration(d) => Value::Duration(d),
-            ConcreteValueRef::List(items) => Value::List(items.to_vec()),
-            ConcreteValueRef::StringList(items) => Value::StringList(items.to_vec()),
-            ConcreteValueRef::Map(map) => Value::Map(map.clone()),
+            ConcreteValueRef::String(s) => Value::Concrete(ConcreteValue::String(s.to_string())),
+            ConcreteValueRef::Int(n) => Value::Concrete(ConcreteValue::Int(n)),
+            ConcreteValueRef::Float(f) => Value::Concrete(ConcreteValue::Float(f)),
+            ConcreteValueRef::Bool(b) => Value::Concrete(ConcreteValue::Bool(b)),
+            ConcreteValueRef::Duration(d) => Value::Concrete(ConcreteValue::Duration(d)),
+            ConcreteValueRef::List(items) => Value::Concrete(ConcreteValue::List(items.to_vec())),
+            ConcreteValueRef::StringList(items) => {
+                Value::Concrete(ConcreteValue::StringList(items.to_vec()))
+            }
+            ConcreteValueRef::Map(map) => Value::Concrete(ConcreteValue::Map(map.clone())),
         }
     }
 }
@@ -1806,7 +1812,7 @@ pub mod validators {
     /// # Example
     /// ```
     /// use std::collections::HashMap;
-    /// use carina_core::resource::Value;
+    /// use carina_core::resource::{ConcreteValue, DeferredValue, Value};
     /// use carina_core::schema::{validators, TypeError};
     ///
     /// fn my_validator(attributes: &HashMap<String, Value>) -> Result<(), Vec<TypeError>> {
@@ -2422,14 +2428,14 @@ fn resolve_block_names_in_map(
         .collect();
 
     // Rename block name keys to canonical names, but only when the value
-    // is a List (from block syntax). Non-list values (e.g., Value::Map from
+    // is a List (from block syntax). Non-list values (e.g., Value::Concrete(ConcreteValue::Map) from
     // attribute assignment) target the actual field with that name.
     let renames: Vec<(String, String)> = map
         .keys()
         .filter_map(|key| {
             bn_map.get(key).and_then(|canon| {
                 // Only rename if the value is a List (block-originated)
-                if matches!(map.get(key), Some(Value::List(_))) {
+                if matches!(map.get(key), Some(Value::Concrete(ConcreteValue::List(_)))) {
                     Some((key.clone(), canon.clone()))
                 } else {
                     None
@@ -2462,16 +2468,16 @@ fn resolve_block_names_in_map(
         };
         match &field.field_type {
             AttributeType::Struct { fields: inner, .. } => {
-                if let Value::Map(inner_map) = value {
+                if let Value::Concrete(ConcreteValue::Map(inner_map)) = value {
                     resolve_block_names_in_map(inner_map, inner, resource_id, errors);
                 }
             }
             AttributeType::List { inner, .. } => {
                 if let AttributeType::Struct { fields: inner, .. } = inner.as_ref()
-                    && let Value::List(items) = value
+                    && let Value::Concrete(ConcreteValue::List(items)) = value
                 {
                     for item in items.iter_mut() {
-                        if let Value::Map(item_map) = item {
+                        if let Value::Concrete(ConcreteValue::Map(item_map)) = item {
                             resolve_block_names_in_map(item_map, inner, resource_id, errors);
                         }
                     }
@@ -2505,13 +2511,16 @@ pub fn resolve_block_names(
 
         // Collect keys to rename: (block_name_key, canonical_attr_name)
         // Only rename when the value is a List (from block syntax). Non-list values
-        // (e.g., Value::Map from attribute assignment) target the actual field with that name.
+        // (e.g., Value::Concrete(ConcreteValue::Map) from attribute assignment) target the actual field with that name.
         let renames: Vec<(String, String)> = resource
             .attributes
             .keys()
             .filter_map(|key| {
                 bn_map.get(key).and_then(|canon| {
-                    if matches!(resource.get_attr(key), Some(Value::List(_))) {
+                    if matches!(
+                        resource.get_attr(key),
+                        Some(Value::Concrete(ConcreteValue::List(_)))
+                    ) {
                         Some((key.clone(), canon.clone()))
                     } else {
                         None
@@ -2548,7 +2557,7 @@ pub fn resolve_block_names(
             };
             match &attr_schema.attr_type {
                 AttributeType::Struct { fields, .. } => {
-                    if let Value::Map(inner_map) = value {
+                    if let Value::Concrete(ConcreteValue::Map(inner_map)) = value {
                         resolve_block_names_in_map(
                             inner_map,
                             fields,
@@ -2559,10 +2568,10 @@ pub fn resolve_block_names(
                 }
                 AttributeType::List { inner, .. } => {
                     if let AttributeType::Struct { fields, .. } = inner.as_ref()
-                        && let Value::List(items) = value
+                        && let Value::Concrete(ConcreteValue::List(items)) = value
                     {
                         for item in items.iter_mut() {
-                            if let Value::Map(item_map) = item {
+                            if let Value::Concrete(ConcreteValue::Map(item_map)) = item {
                                 resolve_block_names_in_map(
                                     item_map,
                                     fields,
@@ -2599,7 +2608,7 @@ pub mod types {
             pattern: None,
             length: None,
             validate: legacy_validator(|value| {
-                if let Value::Int(n) = value {
+                if let Value::Concrete(ConcreteValue::Int(n)) = value {
                     if *n > 0 {
                         Ok(())
                     } else {
@@ -2622,7 +2631,7 @@ pub mod types {
             pattern: None,
             length: None,
             validate: legacy_validator(|value| {
-                if let Value::String(s) = value {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
                     validate_ipv4_cidr(s)
                 } else {
                     Err("Expected string".to_string())
@@ -2641,7 +2650,7 @@ pub mod types {
             pattern: None,
             length: None,
             validate: legacy_validator(|value| {
-                if let Value::String(s) = value {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
                     validate_ipv4_address(s)
                 } else {
                     Err("Expected string".to_string())
@@ -2660,7 +2669,7 @@ pub mod types {
             pattern: None,
             length: None,
             validate: legacy_validator(|value| {
-                if let Value::String(s) = value {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
                     validate_ipv6_address(s)
                 } else {
                     Err("Expected string".to_string())
@@ -2679,7 +2688,7 @@ pub mod types {
             pattern: None,
             length: None,
             validate: legacy_validator(|value| {
-                if let Value::String(s) = value {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
                     validate_ipv6_cidr(s)
                 } else {
                     Err("Expected string".to_string())
@@ -2707,7 +2716,7 @@ pub mod types {
             pattern: None,
             length: None,
             validate: legacy_validator(|value| {
-                if let Value::String(s) = value {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
                     validate_email(s)
                 } else {
                     Err("Expected string".to_string())

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -29,8 +29,14 @@ fn resource_schema_as_data_source_sets_kind() {
 #[test]
 fn validate_string_type() {
     let t = AttributeType::String;
-    assert!(t.validate(&Value::String("hello".to_string())).is_ok());
-    assert!(t.validate(&Value::Int(42)).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("hello".to_string())))
+            .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            .is_err()
+    );
 }
 
 #[test]
@@ -42,14 +48,23 @@ fn validate_string_enum_type() {
         dsl_aliases: vec![],
     };
     assert!(
-        t.validate(&Value::String(
+        t.validate(&Value::Concrete(ConcreteValue::String(
             "awscc.ec2.ipam_pool.AddressFamily.IPv4".to_string()
-        ))
+        )))
         .is_ok()
     );
-    assert!(t.validate(&Value::String("IPv6".to_string())).is_ok());
-    assert!(t.validate(&Value::String("ipv4".to_string())).is_ok());
-    assert!(t.validate(&Value::String("IPv5".to_string())).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("IPv6".to_string())))
+            .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("ipv4".to_string())))
+            .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("IPv5".to_string())))
+            .is_err()
+    );
 }
 
 #[test]
@@ -78,18 +93,29 @@ fn validate_string_enum_accepts_dsl_alias() {
         dsl_aliases: vec![("-1".to_string(), "all".to_string())],
     };
     // Canonical value "-1" should be accepted
-    assert!(t.validate(&Value::String("-1".to_string())).is_ok());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("-1".to_string())))
+            .is_ok()
+    );
     // DSL alias "all" should be accepted
     assert!(
-        t.validate(&Value::String(
+        t.validate(&Value::Concrete(ConcreteValue::String(
             "awscc.ec2.SecurityGroup.IpProtocol.all".to_string()
-        ))
+        )))
         .is_ok()
     );
     // Other canonical values should still work
-    assert!(t.validate(&Value::String("tcp".to_string())).is_ok());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("tcp".to_string())))
+            .is_ok()
+    );
     // Invalid values should still be rejected
-    assert!(t.validate(&Value::String("invalid".to_string())).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "invalid".to_string()
+        )))
+        .is_err()
+    );
 }
 
 #[test]
@@ -111,7 +137,7 @@ fn validate_string_enum_all_without_dsl_aliases_requires_explicit_variant() {
     // Without "all" in values and no dsl_aliases entry mapping to "all", it is rejected
     assert!(
         without_all
-            .validate(&Value::String("all".to_string()))
+            .validate(&Value::Concrete(ConcreteValue::String("all".to_string())))
             .is_err()
     );
 
@@ -129,7 +155,11 @@ fn validate_string_enum_all_without_dsl_aliases_requires_explicit_variant() {
         namespace: None,
         dsl_aliases: vec![],
     };
-    assert!(with_all.validate(&Value::String("all".to_string())).is_ok());
+    assert!(
+        with_all
+            .validate(&Value::Concrete(ConcreteValue::String("all".to_string())))
+            .is_ok()
+    );
 }
 
 #[test]
@@ -143,16 +173,26 @@ fn validate_string_enum_accepts_values_with_dots() {
         dsl_aliases: vec![],
     };
     // Quoted string with dot should match directly
-    assert!(t.validate(&Value::String("ipsec.1".to_string())).is_ok());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "ipsec.1".to_string()
+        )))
+        .is_ok()
+    );
     // Fully qualified form should also be accepted
     assert!(
-        t.validate(&Value::String(
+        t.validate(&Value::Concrete(ConcreteValue::String(
             "awscc.ec2.vpn_gateway.Type.ipsec.1".to_string()
-        ))
+        )))
         .is_ok()
     );
     // Invalid value should still be rejected
-    assert!(t.validate(&Value::String("ipsec.2".to_string())).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "ipsec.2".to_string()
+        )))
+        .is_err()
+    );
 }
 
 #[test]
@@ -166,7 +206,9 @@ fn invalid_enum_error_preserves_user_typed_string_literal() {
         namespace: Some("awscc.sso.Assignment".to_string()),
         dsl_aliases: vec![],
     };
-    let err = t.validate(&Value::String("aaa".to_string())).unwrap_err();
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String("aaa".to_string())))
+        .unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains("'aaa'"),
@@ -190,7 +232,9 @@ fn invalid_enum_error_names_the_enum_type_and_fully_qualified_variants() {
         namespace: Some("awscc.sso.Assignment".to_string()),
         dsl_aliases: vec![],
     };
-    let err = t.validate(&Value::String("aaa".to_string())).unwrap_err();
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String("aaa".to_string())))
+        .unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains("TargetType"),
@@ -214,7 +258,7 @@ fn with_attribute_adds_attribute_name_to_enum_error() {
         dsl_aliases: vec![],
     };
     let err = t
-        .validate(&Value::String("aaa".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String("aaa".to_string())))
         .unwrap_err()
         .with_attribute("target_id");
     let msg = err.to_string();
@@ -264,7 +308,10 @@ fn schema_validate_wraps_enum_error_with_attribute_name() {
         .required(),
     );
     let mut attrs = HashMap::new();
-    attrs.insert("target_type".to_string(), Value::String("aaa".to_string()));
+    attrs.insert(
+        "target_type".to_string(),
+        Value::Concrete(ConcreteValue::String("aaa".to_string())),
+    );
     let errs = schema.validate(&attrs).unwrap_err();
     let joined = errs
         .iter()
@@ -387,7 +434,10 @@ fn schema_validate_with_origins_emits_string_literal_diagnostic_for_quoted_enum(
         .required(),
     );
     let mut attrs = HashMap::new();
-    attrs.insert("target_type".to_string(), Value::String("aaa".to_string()));
+    attrs.insert(
+        "target_type".to_string(),
+        Value::Concrete(ConcreteValue::String("aaa".to_string())),
+    );
 
     // String-literal origin → reshaped diagnostic
     let errs = schema
@@ -431,7 +481,7 @@ fn schema_validate_with_origins_leaves_valid_values_alone() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "target_type".to_string(),
-        Value::String("AWS_ACCOUNT".to_string()),
+        Value::Concrete(ConcreteValue::String("AWS_ACCOUNT".to_string())),
     );
     assert!(
         schema.validate_with_origins(&attrs, &|_| true).is_ok(),
@@ -449,8 +499,10 @@ fn schema_validate_with_origins_reshapes_custom_namespaced_type() {
     // while marking the variant and type name correctly.
     fn validate_mode(v: &Value) -> Result<(), String> {
         match v {
-            Value::String(s) if s == "test.r.Mode.fast" => Ok(()),
-            Value::String(s) => Err(format!("invalid Mode '{}': expected fast", s)),
+            Value::Concrete(ConcreteValue::String(s)) if s == "test.r.Mode.fast" => Ok(()),
+            Value::Concrete(ConcreteValue::String(s)) => {
+                Err(format!("invalid Mode '{}': expected fast", s))
+            }
             _ => Err("expected String".to_string()),
         }
     }
@@ -473,7 +525,10 @@ fn schema_validate_with_origins_reshapes_custom_namespaced_type() {
     // Two-part form like "test.r.Mode.aaa" would skip the Custom
     // branch by passing validation; use a bare-shape literal that
     // resolve_enum_input can't save.
-    attrs.insert("mode".to_string(), Value::String("aaa".to_string()));
+    attrs.insert(
+        "mode".to_string(),
+        Value::Concrete(ConcreteValue::String("aaa".to_string())),
+    );
     let errs = schema
         .validate_with_origins(&attrs, &|n| n == "mode")
         .unwrap_err();
@@ -500,7 +555,9 @@ fn invalid_enum_error_without_namespace_uses_bare_variants() {
         namespace: None,
         dsl_aliases: vec![],
     };
-    let err = t.validate(&Value::String("zzz".to_string())).unwrap_err();
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains("fast") && msg.contains("slow"),
@@ -516,7 +573,7 @@ fn invalid_enum_error_without_namespace_uses_bare_variants() {
 #[test]
 fn invalid_enum_error_preserves_bare_identifier_form() {
     // When the user types the namespaced form directly (bare identifier
-    // path produces the same `Value::String(...)`), the error echoes the
+    // path produces the same `Value::Concrete(ConcreteValue::String(...))`), the error echoes the
     // full form back — still the "user-typed" form because that's what
     // was in the Value. This verifies the fix doesn't regress that case.
     let t = AttributeType::StringEnum {
@@ -526,7 +583,9 @@ fn invalid_enum_error_preserves_bare_identifier_form() {
         dsl_aliases: vec![],
     };
     let input = "awscc.sso.Assignment.TargetType.NOT_REAL".to_string();
-    let err = t.validate(&Value::String(input.clone())).unwrap_err();
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String(input.clone())))
+        .unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains(&input),
@@ -548,9 +607,9 @@ fn validate_string_enum_rejects_double_namespace() {
     };
     // Double-namespace must be rejected
     assert!(
-        t.validate(&Value::String(
+        t.validate(&Value::Concrete(ConcreteValue::String(
             "awscc.ec2.Vpc.InstanceTenancy.awscc.ec2.Vpc.InstanceTenancy.default".to_string()
-        ))
+        )))
         .is_err()
     );
 }
@@ -558,35 +617,65 @@ fn validate_string_enum_rejects_double_namespace() {
 #[test]
 fn validate_float_type() {
     let t = AttributeType::Float;
-    assert!(t.validate(&Value::Float(2.5)).is_ok());
-    assert!(t.validate(&Value::Float(-0.5)).is_ok());
-    assert!(t.validate(&Value::Int(42)).is_ok()); // integers are valid numbers
-    assert!(t.validate(&Value::String("3.14".to_string())).is_err());
-    assert!(t.validate(&Value::Bool(true)).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Float(2.5)))
+            .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Float(-0.5)))
+            .is_ok()
+    );
+    assert!(t.validate(&Value::Concrete(ConcreteValue::Int(42))).is_ok()); // integers are valid numbers
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("3.14".to_string())))
+            .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Bool(true)))
+            .is_err()
+    );
 }
 
 #[test]
 fn validate_float_rejects_non_finite() {
     let t = AttributeType::Float;
-    assert!(t.validate(&Value::Float(f64::NAN)).is_err());
-    assert!(t.validate(&Value::Float(f64::INFINITY)).is_err());
-    assert!(t.validate(&Value::Float(f64::NEG_INFINITY)).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Float(f64::NAN)))
+            .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Float(f64::INFINITY)))
+            .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Float(f64::NEG_INFINITY)))
+            .is_err()
+    );
 }
 
 #[test]
 fn validate_int_rejects_float() {
     let t = AttributeType::Int;
-    assert!(t.validate(&Value::Int(42)).is_ok());
-    assert!(t.validate(&Value::Float(2.5)).is_err()); // strict integer typing
+    assert!(t.validate(&Value::Concrete(ConcreteValue::Int(42))).is_ok());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Float(2.5)))
+            .is_err()
+    ); // strict integer typing
 }
 
 #[test]
 fn validate_positive_int() {
     let t = types::positive_int();
-    assert!(t.validate(&Value::Int(1)).is_ok());
-    assert!(t.validate(&Value::Int(100)).is_ok());
-    assert!(t.validate(&Value::Int(0)).is_err());
-    assert!(t.validate(&Value::Int(-1)).is_err());
+    assert!(t.validate(&Value::Concrete(ConcreteValue::Int(1))).is_ok());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(100)))
+            .is_ok()
+    );
+    assert!(t.validate(&Value::Concrete(ConcreteValue::Int(0))).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(-1)))
+            .is_err()
+    );
 }
 
 #[test]
@@ -597,9 +686,15 @@ fn validate_resource_schema() {
         .attribute(AttributeSchema::new("enabled", AttributeType::Bool));
 
     let mut attrs = HashMap::new();
-    attrs.insert("name".to_string(), Value::String("my-resource".to_string()));
-    attrs.insert("count".to_string(), Value::Int(5));
-    attrs.insert("enabled".to_string(), Value::Bool(true));
+    attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-resource".to_string())),
+    );
+    attrs.insert("count".to_string(), Value::Concrete(ConcreteValue::Int(5)));
+    attrs.insert(
+        "enabled".to_string(),
+        Value::Concrete(ConcreteValue::Bool(true)),
+    );
 
     assert!(schema.validate(&attrs).is_ok());
 }
@@ -620,32 +715,65 @@ fn validate_cidr_type() {
 
     // Valid CIDRs
     assert!(
-        t.validate(&Value::String("10.0.0.0/16".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
+        .is_ok()
     );
     assert!(
-        t.validate(&Value::String("192.168.1.0/24".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "192.168.1.0/24".to_string()
+        )))
+        .is_ok()
     );
-    assert!(t.validate(&Value::String("0.0.0.0/0".to_string())).is_ok());
     assert!(
-        t.validate(&Value::String("255.255.255.255/32".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "0.0.0.0/0".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "255.255.255.255/32".to_string()
+        )))
+        .is_ok()
     );
 
     // Invalid CIDRs
-    assert!(t.validate(&Value::String("10.0.0.0".to_string())).is_err()); // no prefix
     assert!(
-        t.validate(&Value::String("10.0.0.0/33".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0".to_string()
+        )))
+        .is_err()
+    ); // no prefix
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/33".to_string()
+        )))
+        .is_err()
     ); // prefix too large
     assert!(
-        t.validate(&Value::String("10.0.0.256/16".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.256/16".to_string()
+        )))
+        .is_err()
     ); // octet > 255
-    assert!(t.validate(&Value::String("10.0.0/16".to_string())).is_err()); // only 3 octets
-    assert!(t.validate(&Value::String("invalid".to_string())).is_err()); // not a CIDR
-    assert!(t.validate(&Value::Int(42)).is_err()); // wrong type
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0/16".to_string()
+        )))
+        .is_err()
+    ); // only 3 octets
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "invalid".to_string()
+        )))
+        .is_err()
+    ); // not a CIDR
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            .is_err()
+    ); // wrong type
 }
 
 #[test]
@@ -661,27 +789,47 @@ fn validate_struct_type() {
 
     // Valid: all required fields present
     let mut map = IndexMap::new();
-    map.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
-    map.insert("from_port".to_string(), Value::Int(80));
-    assert!(t.validate(&Value::Map(map)).is_ok());
+    map.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
+    map.insert(
+        "from_port".to_string(),
+        Value::Concrete(ConcreteValue::Int(80)),
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Map(map)))
+            .is_ok()
+    );
 
     // Invalid: missing required field
     let empty_map = IndexMap::new();
-    assert!(t.validate(&Value::Map(empty_map)).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Map(empty_map)))
+            .is_err()
+    );
 
     // Invalid: wrong type for field
     let mut bad_map = IndexMap::new();
-    bad_map.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
+    bad_map.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
     bad_map.insert(
         "from_port".to_string(),
-        Value::String("not_a_number".to_string()),
+        Value::Concrete(ConcreteValue::String("not_a_number".to_string())),
     );
-    assert!(t.validate(&Value::Map(bad_map)).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Map(bad_map)))
+            .is_err()
+    );
 
     // Invalid: not a Map
     assert!(
-        t.validate(&Value::String("not a struct".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "not a struct".to_string()
+        )))
+        .is_err()
     );
 }
 
@@ -699,12 +847,15 @@ fn struct_rejects_unknown_field() {
 
     // Unknown field should be rejected
     let mut map = IndexMap::new();
-    map.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
+    map.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
     map.insert(
         "unknown_field".to_string(),
-        Value::String("value".to_string()),
+        Value::Concrete(ConcreteValue::String("value".to_string())),
     );
-    let result = t.validate(&Value::Map(map));
+    let result = t.validate(&Value::Concrete(ConcreteValue::Map(map)));
     assert!(result.is_err());
     let err = result.unwrap_err();
     match &err {
@@ -735,8 +886,11 @@ fn struct_suggests_similar_field() {
 
     // Typo: "ip_protcol" -> should suggest "ip_protocol"
     let mut map = IndexMap::new();
-    map.insert("ip_protcol".to_string(), Value::String("tcp".to_string()));
-    let result = t.validate(&Value::Map(map));
+    map.insert(
+        "ip_protcol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
+    let result = t.validate(&Value::Concrete(ConcreteValue::Map(map)));
     assert!(result.is_err());
     let err = result.unwrap_err();
     match &err {
@@ -754,12 +908,15 @@ fn struct_suggests_similar_field() {
 
     // Typo: "cidr_iip" -> should suggest "cidr_ip"
     let mut map2 = IndexMap::new();
-    map2.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
+    map2.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
     map2.insert(
         "cidr_iip".to_string(),
-        Value::String("10.0.0.0/8".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
     );
-    let result2 = t.validate(&Value::Map(map2));
+    let result2 = t.validate(&Value::Concrete(ConcreteValue::Map(map2)));
     assert!(result2.is_err());
     let err2 = result2.unwrap_err();
     match &err2 {
@@ -785,8 +942,13 @@ fn struct_error_message_format() {
 
     // With suggestion
     let mut map = IndexMap::new();
-    map.insert("vpc_idd".to_string(), Value::String("vpc-123".to_string()));
-    let err = t.validate(&Value::Map(map)).unwrap_err();
+    map.insert(
+        "vpc_idd".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+    );
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::Map(map)))
+        .unwrap_err();
     assert_eq!(
         err.to_string(),
         "Unknown field 'vpc_idd' in SecurityGroupIngress, did you mean 'vpc_id'?"
@@ -796,9 +958,11 @@ fn struct_error_message_format() {
     let mut map2 = IndexMap::new();
     map2.insert(
         "completely_different".to_string(),
-        Value::String("x".to_string()),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
     );
-    let err2 = t.validate(&Value::Map(map2)).unwrap_err();
+    let err2 = t
+        .validate(&Value::Concrete(ConcreteValue::Map(map2)))
+        .unwrap_err();
     assert_eq!(
         err2.to_string(),
         "Unknown field 'completely_different' in SecurityGroupIngress"
@@ -847,18 +1011,25 @@ fn validate_list_of_struct() {
     let list_type = AttributeType::list(struct_type);
 
     let mut item = IndexMap::new();
-    item.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
-    let list = Value::List(vec![Value::Map(item)]);
+    item.insert(
+        "ip_protocol".to_string(),
+        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+    );
+    let list = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(item),
+    )]));
     assert!(list_type.validate(&list).is_ok());
 
     // Invalid item in list
-    let bad_list = Value::List(vec![Value::Map(IndexMap::new())]);
+    let bad_list = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(IndexMap::new()),
+    )]));
     assert!(list_type.validate(&bad_list).is_err());
 }
 
 #[test]
 fn struct_rejects_block_syntax_single_element() {
-    // Block syntax produces Value::List([Value::Map(...)]) which should be rejected
+    // Block syntax produces Value::Concrete(ConcreteValue::List([Value::Map(...)])) which should be rejected
     // for bare Struct attributes
     let struct_type = AttributeType::Struct {
         name: "VersioningConfiguration".to_string(),
@@ -866,8 +1037,13 @@ fn struct_rejects_block_syntax_single_element() {
     };
 
     let mut map = IndexMap::new();
-    map.insert("status".to_string(), Value::String("Enabled".to_string()));
-    let single_list = Value::List(vec![Value::Map(map)]);
+    map.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+    );
+    let single_list = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(map),
+    )]));
     let result = struct_type.validate(&single_list);
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -892,10 +1068,19 @@ fn struct_rejects_block_syntax_multiple_elements() {
     };
 
     let mut map1 = IndexMap::new();
-    map1.insert("status".to_string(), Value::String("Enabled".to_string()));
+    map1.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+    );
     let mut map2 = IndexMap::new();
-    map2.insert("status".to_string(), Value::String("Suspended".to_string()));
-    let multi_list = Value::List(vec![Value::Map(map1), Value::Map(map2)]);
+    map2.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("Suspended".to_string())),
+    );
+    let multi_list = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::Map(map1)),
+        Value::Concrete(ConcreteValue::Map(map2)),
+    ]));
     let result = struct_type.validate(&multi_list);
     assert!(result.is_err());
     match result.unwrap_err() {
@@ -912,22 +1097,41 @@ fn validate_ipv4_cidr_type() {
 
     // Valid IPv4 CIDRs
     assert!(
-        t.validate(&Value::String("10.0.0.0/16".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
+        .is_ok()
     );
-    assert!(t.validate(&Value::String("0.0.0.0/0".to_string())).is_ok());
     assert!(
-        t.validate(&Value::String("255.255.255.255/32".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "0.0.0.0/0".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "255.255.255.255/32".to_string()
+        )))
+        .is_ok()
     );
 
     // Invalid IPv4 CIDRs
     assert!(
-        t.validate(&Value::String("10.0.0.0/33".to_string()))
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/33".to_string()
+        )))
+        .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0".to_string()
+        )))
+        .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
             .is_err()
     );
-    assert!(t.validate(&Value::String("10.0.0.0".to_string())).is_err());
-    assert!(t.validate(&Value::Int(42)).is_err());
 }
 
 #[test]
@@ -935,43 +1139,76 @@ fn validate_ipv6_cidr_type() {
     let t = types::ipv6_cidr();
 
     // Valid IPv6 CIDRs
-    assert!(t.validate(&Value::String("::/0".to_string())).is_ok());
     assert!(
-        t.validate(&Value::String("2001:db8::/32".to_string()))
+        t.validate(&Value::Concrete(ConcreteValue::String("::/0".to_string())))
             .is_ok()
     );
-    assert!(t.validate(&Value::String("fe80::/10".to_string())).is_ok());
-    assert!(t.validate(&Value::String("::1/128".to_string())).is_ok());
     assert!(
-        t.validate(&Value::String(
-            "2001:0db8:85a3:0000:0000:8a2e:0370:7334/64".to_string()
-        ))
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:db8::/32".to_string()
+        )))
         .is_ok()
     );
-    assert!(t.validate(&Value::String("ff00::/8".to_string())).is_ok());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "fe80::/10".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "::1/128".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334/64".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "ff00::/8".to_string()
+        )))
+        .is_ok()
+    );
 
     // Invalid IPv6 CIDRs
     assert!(
-        t.validate(&Value::String("2001:db8::/129".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:db8::/129".to_string()
+        )))
+        .is_err()
     ); // prefix > 128
     assert!(
-        t.validate(&Value::String("2001:db8::".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:db8::".to_string()
+        )))
+        .is_err()
     ); // missing prefix
     assert!(
-        t.validate(&Value::String("2001:gggg::/32".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:gggg::/32".to_string()
+        )))
+        .is_err()
     ); // invalid hex
     assert!(
-        t.validate(&Value::String("2001:db8::1::2/64".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:db8::1::2/64".to_string()
+        )))
+        .is_err()
     ); // double ::
     assert!(
-        t.validate(&Value::String("10.0.0.0/16".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
+        .is_err()
     ); // IPv4, not IPv6
-    assert!(t.validate(&Value::Int(42)).is_err()); // wrong type
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            .is_err()
+    ); // wrong type
 }
 
 #[test]
@@ -996,25 +1233,47 @@ fn validate_cidr_accepts_both_ipv4_and_ipv6() {
 
     // Valid IPv4 CIDRs
     assert!(
-        t.validate(&Value::String("10.0.0.0/16".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
+        .is_ok()
     );
-    assert!(t.validate(&Value::String("0.0.0.0/0".to_string())).is_ok());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "0.0.0.0/0".to_string()
+        )))
+        .is_ok()
+    );
 
     // Valid IPv6 CIDRs
     assert!(
-        t.validate(&Value::String("2001:db8::/32".to_string()))
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:db8::/32".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("::/0".to_string())))
             .is_ok()
     );
-    assert!(t.validate(&Value::String("::/0".to_string())).is_ok());
 
     // Invalid
     assert!(
-        t.validate(&Value::String("not-a-cidr".to_string()))
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "not-a-cidr".to_string()
+        )))
+        .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0".to_string()
+        )))
+        .is_err()
+    ); // no prefix
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
             .is_err()
     );
-    assert!(t.validate(&Value::String("10.0.0.0".to_string())).is_err()); // no prefix
-    assert!(t.validate(&Value::Int(42)).is_err());
 }
 
 #[test]
@@ -1046,26 +1305,60 @@ fn validate_ipv4_address_type() {
     let t = types::ipv4_address();
 
     // Valid IPv4 addresses
-    assert!(t.validate(&Value::String("10.0.1.5".to_string())).is_ok());
     assert!(
-        t.validate(&Value::String("192.168.0.1".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.1.5".to_string()
+        )))
+        .is_ok()
     );
-    assert!(t.validate(&Value::String("0.0.0.0".to_string())).is_ok());
     assert!(
-        t.validate(&Value::String("255.255.255.255".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "192.168.0.1".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "0.0.0.0".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "255.255.255.255".to_string()
+        )))
+        .is_ok()
     );
 
     // Invalid IPv4 addresses
     assert!(
-        t.validate(&Value::String("10.0.0.0/16".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.0.0/16".to_string()
+        )))
+        .is_err()
     ); // CIDR, not address
-    assert!(t.validate(&Value::String("256.0.0.1".to_string())).is_err()); // octet > 255
-    assert!(t.validate(&Value::String("10.0.1".to_string())).is_err()); // only 3 octets
-    assert!(t.validate(&Value::String("not-an-ip".to_string())).is_err());
-    assert!(t.validate(&Value::Int(42)).is_err()); // wrong type
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "256.0.0.1".to_string()
+        )))
+        .is_err()
+    ); // octet > 255
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "10.0.1".to_string()
+        )))
+        .is_err()
+    ); // only 3 octets
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "not-an-ip".to_string()
+        )))
+        .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            .is_err()
+    ); // wrong type
 }
 
 #[test]
@@ -1073,27 +1366,50 @@ fn validate_ipv6_address_type() {
     let t = types::ipv6_address();
 
     // Valid IPv6 addresses
-    assert!(t.validate(&Value::String("::1".to_string())).is_ok());
     assert!(
-        t.validate(&Value::String("2001:db8::1".to_string()))
+        t.validate(&Value::Concrete(ConcreteValue::String("::1".to_string())))
             .is_ok()
     );
-    assert!(t.validate(&Value::String("fe80::1".to_string())).is_ok());
     assert!(
-        t.validate(&Value::String(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:db8::1".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "fe80::1".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
             "2001:0db8:85a3:0000:0000:8a2e:0370:7334".to_string()
-        ))
+        )))
         .is_ok()
     );
 
     // Invalid IPv6 addresses
     assert!(
-        t.validate(&Value::String("2001:db8::/32".to_string()))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "2001:db8::/32".to_string()
+        )))
+        .is_err()
     ); // CIDR, not address
-    assert!(t.validate(&Value::String("not-an-ip".to_string())).is_err());
-    assert!(t.validate(&Value::String("".to_string())).is_err());
-    assert!(t.validate(&Value::Int(42)).is_err()); // wrong type
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "not-an-ip".to_string()
+        )))
+        .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("".to_string())))
+            .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            .is_err()
+    ); // wrong type
 }
 
 #[test]
@@ -1142,12 +1458,18 @@ fn resource_validator_called() {
 
     // Valid: no forbidden attribute
     let mut attrs = HashMap::new();
-    attrs.insert("name".to_string(), Value::String("test".to_string()));
+    attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("test".to_string())),
+    );
     assert!(schema.validate(&attrs).is_ok());
 
     // Invalid: forbidden attribute present
     let mut bad_attrs = HashMap::new();
-    bad_attrs.insert("forbidden".to_string(), Value::String("bad".to_string()));
+    bad_attrs.insert(
+        "forbidden".to_string(),
+        Value::Concrete(ConcreteValue::String("bad".to_string())),
+    );
     let result = schema.validate(&bad_attrs);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().len(), 1);
@@ -1159,11 +1481,17 @@ fn validate_exclusive_required_helper() {
 
     // Valid: exactly one field present
     let mut attrs = HashMap::new();
-    attrs.insert("option_a".to_string(), Value::String("value".to_string()));
+    attrs.insert(
+        "option_a".to_string(),
+        Value::Concrete(ConcreteValue::String("value".to_string())),
+    );
     assert!(validate_exclusive_required(&attrs, &["option_a", "option_b"]).is_ok());
 
     let mut attrs2 = HashMap::new();
-    attrs2.insert("option_b".to_string(), Value::String("value".to_string()));
+    attrs2.insert(
+        "option_b".to_string(),
+        Value::Concrete(ConcreteValue::String("value".to_string())),
+    );
     assert!(validate_exclusive_required(&attrs2, &["option_a", "option_b"]).is_ok());
 
     // Invalid: neither field present
@@ -1180,8 +1508,14 @@ fn validate_exclusive_required_helper() {
 
     // Invalid: both fields present
     let mut both = HashMap::new();
-    both.insert("option_a".to_string(), Value::String("a".to_string()));
-    both.insert("option_b".to_string(), Value::String("b".to_string()));
+    both.insert(
+        "option_a".to_string(),
+        Value::Concrete(ConcreteValue::String("a".to_string())),
+    );
+    both.insert(
+        "option_b".to_string(),
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+    );
     let result = validate_exclusive_required(&both, &["option_a", "option_b"]);
     assert!(result.is_err());
     let errors = result.unwrap_err();
@@ -1211,38 +1545,50 @@ fn exclusive_required_with_resource_schema() {
 
     // Valid: has cidr_block only
     let mut attrs1 = HashMap::new();
-    attrs1.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+    attrs1.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+    );
     attrs1.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/24".to_string())),
     );
     assert!(schema.validate(&attrs1).is_ok());
 
     // Valid: has ipv4_ipam_pool_id only
     let mut attrs2 = HashMap::new();
-    attrs2.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+    attrs2.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+    );
     attrs2.insert(
         "ipv4_ipam_pool_id".to_string(),
-        Value::String("ipam-pool-123".to_string()),
+        Value::Concrete(ConcreteValue::String("ipam-pool-123".to_string())),
     );
     assert!(schema.validate(&attrs2).is_ok());
 
     // Invalid: has neither
     let mut attrs3 = HashMap::new();
-    attrs3.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+    attrs3.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+    );
     let result = schema.validate(&attrs3);
     assert!(result.is_err());
 
     // Invalid: has both
     let mut attrs4 = HashMap::new();
-    attrs4.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+    attrs4.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+    );
     attrs4.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/24".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/24".to_string())),
     );
     attrs4.insert(
         "ipv4_ipam_pool_id".to_string(),
-        Value::String("ipam-pool-123".to_string()),
+        Value::Concrete(ConcreteValue::String("ipam-pool-123".to_string())),
     );
     let result = schema.validate(&attrs4);
     assert!(result.is_err());
@@ -1264,7 +1610,7 @@ fn exclusive_required_declarative() {
     let mut one = HashMap::new();
     one.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     assert!(schema.validate(&one).is_ok());
 
@@ -1283,11 +1629,11 @@ fn exclusive_required_declarative() {
     let mut both = HashMap::new();
     both.insert(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     both.insert(
         "ipv4_ipam_pool_id".to_string(),
-        Value::String("pool-1".to_string()),
+        Value::Concrete(ConcreteValue::String("pool-1".to_string())),
     );
     let err = schema.validate(&both).unwrap_err();
     assert!(
@@ -1322,8 +1668,14 @@ fn exclusive_required_multiple_groups() {
 
     // Satisfy both groups
     let mut ok = HashMap::new();
-    ok.insert("a".to_string(), Value::String("1".to_string()));
-    ok.insert("x".to_string(), Value::String("1".to_string()));
+    ok.insert(
+        "a".to_string(),
+        Value::Concrete(ConcreteValue::String("1".to_string())),
+    );
+    ok.insert(
+        "x".to_string(),
+        Value::Concrete(ConcreteValue::String("1".to_string())),
+    );
     assert!(schema.validate(&ok).is_ok());
 }
 
@@ -1336,7 +1688,7 @@ fn validate_union_type() {
         pattern: None,
         length: None,
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 if s.starts_with("a-") {
                     Ok(())
                 } else {
@@ -1355,7 +1707,7 @@ fn validate_union_type() {
         pattern: None,
         length: None,
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 if s.starts_with("b-") {
                     Ok(())
                 } else {
@@ -1374,19 +1726,25 @@ fn validate_union_type() {
     // Valid: matches first member
     assert!(
         union_type
-            .validate(&Value::String("a-12345678".to_string()))
+            .validate(&Value::Concrete(ConcreteValue::String(
+                "a-12345678".to_string()
+            )))
             .is_ok()
     );
     // Valid: matches second member
     assert!(
         union_type
-            .validate(&Value::String("b-12345678".to_string()))
+            .validate(&Value::Concrete(ConcreteValue::String(
+                "b-12345678".to_string()
+            )))
             .is_ok()
     );
     // Invalid: matches neither
     assert!(
         union_type
-            .validate(&Value::String("c-12345678".to_string()))
+            .validate(&Value::Concrete(ConcreteValue::String(
+                "c-12345678".to_string()
+            )))
             .is_err()
     );
     // Valid: ResourceRef is accepted by Custom members
@@ -1417,11 +1775,16 @@ fn union_struct_unknown_field_shows_specific_error() {
     let mut map = IndexMap::new();
     map.insert(
         "federated".to_string(),
-        Value::String("arn:...".to_string()),
+        Value::Concrete(ConcreteValue::String("arn:...".to_string())),
     );
-    map.insert("aaa".to_string(), Value::String("bbb".to_string()));
+    map.insert(
+        "aaa".to_string(),
+        Value::Concrete(ConcreteValue::String("bbb".to_string())),
+    );
 
-    let err = principal_type.validate(&Value::Map(map)).unwrap_err();
+    let err = principal_type
+        .validate(&Value::Concrete(ConcreteValue::Map(map)))
+        .unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains("aaa"),
@@ -1530,17 +1893,19 @@ fn block_name_map_empty_when_no_block_names() {
 fn resolve_block_names_renames_key() {
     let mut resources = vec![{
         let mut r = Resource::new("ec2.ipam", "my-ipam");
-        // Block syntax produces Value::List
+        // Block syntax produces Value::Concrete(ConcreteValue::List)
         r.set_attr(
             "operating_region".to_string(),
-            Value::List(vec![Value::Map({
-                let mut m = IndexMap::new();
-                m.insert(
-                    "region_name".to_string(),
-                    Value::String("us-east-1".to_string()),
-                );
-                m
-            })]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map({
+                    let mut m = IndexMap::new();
+                    m.insert(
+                        "region_name".to_string(),
+                        Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+                    );
+                    m
+                }),
+            )])),
         );
         r
     }];
@@ -1564,7 +1929,10 @@ fn resolve_block_names_renames_key() {
 fn resolve_block_names_noop_when_no_match() {
     let mut resources = vec![{
         let mut r = Resource::new("ec2.ipam", "my-ipam");
-        r.set_attr("name".to_string(), Value::String("test".to_string()));
+        r.set_attr(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        );
         r
     }];
 
@@ -1584,29 +1952,33 @@ fn resolve_block_names_noop_when_no_match() {
 fn resolve_block_names_errors_on_mixed_syntax() {
     let mut resources = vec![{
         let mut r = Resource::new("ec2.ipam", "my-ipam");
-        // Block syntax produces Value::List
+        // Block syntax produces Value::Concrete(ConcreteValue::List)
         r.set_attr(
             "operating_region".to_string(),
-            Value::List(vec![Value::Map({
-                let mut m = IndexMap::new();
-                m.insert(
-                    "region_name".to_string(),
-                    Value::String("us-east-1".to_string()),
-                );
-                m
-            })]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map({
+                    let mut m = IndexMap::new();
+                    m.insert(
+                        "region_name".to_string(),
+                        Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+                    );
+                    m
+                }),
+            )])),
         );
         // User also explicitly set the canonical name
         r.set_attr(
             "operating_regions".to_string(),
-            Value::List(vec![Value::Map({
-                let mut m = IndexMap::new();
-                m.insert(
-                    "region_name".to_string(),
-                    Value::String("us-west-2".to_string()),
-                );
-                m
-            })]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map({
+                    let mut m = IndexMap::new();
+                    m.insert(
+                        "region_name".to_string(),
+                        Value::Concrete(ConcreteValue::String("us-west-2".to_string())),
+                    );
+                    m
+                }),
+            )])),
         );
         r
     }];
@@ -1633,7 +2005,7 @@ fn resolve_block_names_skips_unknown_schema() {
         let mut r = Resource::new("unknown.type", "test");
         r.set_attr(
             "operating_region".to_string(),
-            Value::String("us-east-1".to_string()),
+            Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
         );
         r
     }];
@@ -1667,19 +2039,24 @@ fn resolve_block_names_nested_struct() {
     let mut inner_map = IndexMap::new();
     inner_map.insert(
         "transition".to_string(),
-        Value::List(vec![Value::Map({
-            let mut m = IndexMap::new();
-            m.insert(
-                "storage_class".to_string(),
-                Value::String("GLACIER".to_string()),
-            );
-            m
-        })]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map({
+                let mut m = IndexMap::new();
+                m.insert(
+                    "storage_class".to_string(),
+                    Value::Concrete(ConcreteValue::String("GLACIER".to_string())),
+                );
+                m
+            }),
+        )])),
     );
 
     let mut resources = vec![{
         let mut r = Resource::new("s3.Bucket", "my-bucket");
-        r.set_attr("lifecycle_configuration".to_string(), Value::Map(inner_map));
+        r.set_attr(
+            "lifecycle_configuration".to_string(),
+            Value::Concrete(ConcreteValue::Map(inner_map)),
+        );
         r
     }];
 
@@ -1708,7 +2085,7 @@ fn resolve_block_names_nested_struct() {
 
     // The nested "transition" key should be renamed to "transitions"
     let lifecycle = match resources[0].get_attr("lifecycle_configuration") {
-        Some(Value::Map(m)) => m,
+        Some(Value::Concrete(ConcreteValue::Map(m))) => m,
         _ => panic!("expected Map"),
     };
     assert!(
@@ -1725,26 +2102,29 @@ fn resolve_block_names_nested_struct() {
 fn resolve_block_names_singular_field_not_renamed_when_assigned() {
     // When a struct has both `transition` (Struct) and `transitions` (List(Struct))
     // with block_name("transition") on the List field, an attribute assignment
-    // `transition = { ... }` (Value::Map) should NOT be renamed to `transitions`.
-    // Only block syntax `transition { ... }` (Value::List) should be renamed.
+    // `transition = { ... }` (Value::Concrete(ConcreteValue::Map)) should NOT be renamed to `transitions`.
+    // Only block syntax `transition { ... }` (Value::Concrete(ConcreteValue::List)) should be renamed.
     let mut inner_map = IndexMap::new();
     // This is an attribute assignment: transition = { storage_class = "GLACIER" }
-    // Parser produces Value::Map for attribute assignments
+    // Parser produces Value::Concrete(ConcreteValue::Map) for attribute assignments
     inner_map.insert(
         "transition".to_string(),
-        Value::Map({
+        Value::Concrete(ConcreteValue::Map({
             let mut m = IndexMap::new();
             m.insert(
                 "storage_class".to_string(),
-                Value::String("GLACIER".to_string()),
+                Value::Concrete(ConcreteValue::String("GLACIER".to_string())),
             );
             m
-        }),
+        })),
     );
 
     let mut resources = vec![{
         let mut r = Resource::new("s3.Bucket", "my-bucket");
-        r.set_attr("lifecycle_configuration".to_string(), Value::Map(inner_map));
+        r.set_attr(
+            "lifecycle_configuration".to_string(),
+            Value::Concrete(ConcreteValue::Map(inner_map)),
+        );
         r
     }];
 
@@ -1779,10 +2159,10 @@ fn resolve_block_names_singular_field_not_renamed_when_assigned() {
     resolve_block_names(&mut resources, &schemas).unwrap();
 
     let lifecycle = match resources[0].get_attr("lifecycle_configuration") {
-        Some(Value::Map(m)) => m,
+        Some(Value::Concrete(ConcreteValue::Map(m))) => m,
         _ => panic!("expected Map"),
     };
-    // The Value::Map should remain as "transition" (not renamed)
+    // The Value::Concrete(ConcreteValue::Map) should remain as "transition" (not renamed)
     assert!(
         lifecycle.contains_key("transition"),
         "expected 'transition' key to remain (attribute assignment)"
@@ -1798,22 +2178,27 @@ fn resolve_block_names_block_syntax_renamed_when_singular_field_exists() {
     // Block syntax `transition { ... }` should still be renamed to `transitions`
     // even when a singular `transition` field exists in the schema.
     let mut inner_map = IndexMap::new();
-    // Block syntax produces Value::List
+    // Block syntax produces Value::Concrete(ConcreteValue::List)
     inner_map.insert(
         "transition".to_string(),
-        Value::List(vec![Value::Map({
-            let mut m = IndexMap::new();
-            m.insert(
-                "storage_class".to_string(),
-                Value::String("GLACIER".to_string()),
-            );
-            m
-        })]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map({
+                let mut m = IndexMap::new();
+                m.insert(
+                    "storage_class".to_string(),
+                    Value::Concrete(ConcreteValue::String("GLACIER".to_string())),
+                );
+                m
+            }),
+        )])),
     );
 
     let mut resources = vec![{
         let mut r = Resource::new("s3.Bucket", "my-bucket");
-        r.set_attr("lifecycle_configuration".to_string(), Value::Map(inner_map));
+        r.set_attr(
+            "lifecycle_configuration".to_string(),
+            Value::Concrete(ConcreteValue::Map(inner_map)),
+        );
         r
     }];
 
@@ -1848,10 +2233,10 @@ fn resolve_block_names_block_syntax_renamed_when_singular_field_exists() {
     resolve_block_names(&mut resources, &schemas).unwrap();
 
     let lifecycle = match resources[0].get_attr("lifecycle_configuration") {
-        Some(Value::Map(m)) => m,
+        Some(Value::Concrete(ConcreteValue::Map(m))) => m,
         _ => panic!("expected Map"),
     };
-    // Block syntax (Value::List) should be renamed to "transitions"
+    // Block syntax (Value::Concrete(ConcreteValue::List)) should be renamed to "transitions"
     assert!(
         lifecycle.contains_key("transitions"),
         "expected 'transitions' key after resolve (block syntax)"
@@ -1869,14 +2254,19 @@ fn resolve_block_names_same_block_and_canonical_name() {
     // This regression was introduced in PR #913 and fixed in PR #917.
     let mut resources = vec![{
         let mut r = Resource::new("ec2.SecurityGroup", "my-sg");
-        // Block syntax produces Value::List
+        // Block syntax produces Value::Concrete(ConcreteValue::List)
         r.set_attr(
             "ingress".to_string(),
-            Value::List(vec![Value::Map({
-                let mut m = IndexMap::new();
-                m.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
-                m
-            })]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map({
+                    let mut m = IndexMap::new();
+                    m.insert(
+                        "ip_protocol".to_string(),
+                        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+                    );
+                    m
+                }),
+            )])),
         );
         r
     }];
@@ -1903,7 +2293,7 @@ fn resolve_block_names_same_block_and_canonical_name() {
     assert!(resources[0].attributes.contains_key("ingress"));
     // Value should be unchanged
     match resources[0].get_attr("ingress") {
-        Some(Value::List(items)) => assert_eq!(items.len(), 1),
+        Some(Value::Concrete(ConcreteValue::List(items))) => assert_eq!(items.len(), 1),
         other => panic!("expected List, got {:?}", other),
     }
 }
@@ -1911,25 +2301,31 @@ fn resolve_block_names_same_block_and_canonical_name() {
 #[test]
 fn resolve_block_names_same_block_and_canonical_name_multiple_items() {
     // When block_name == canonical name and the user provides multiple block
-    // items (Value::List with multiple entries), no conflict should occur.
+    // items (Value::Concrete(ConcreteValue::List) with multiple entries), no conflict should occur.
     // The key already exists (it IS the canonical key), so the `continue`
     // path handles it. This test verifies all items are preserved.
     let mut resources = vec![{
         let mut r = Resource::new("ec2.SecurityGroup", "my-sg");
         r.set_attr(
             "ingress".to_string(),
-            Value::List(vec![
-                Value::Map({
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Map({
                     let mut m = IndexMap::new();
-                    m.insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
+                    m.insert(
+                        "ip_protocol".to_string(),
+                        Value::Concrete(ConcreteValue::String("tcp".to_string())),
+                    );
                     m
-                }),
-                Value::Map({
+                })),
+                Value::Concrete(ConcreteValue::Map({
                     let mut m = IndexMap::new();
-                    m.insert("ip_protocol".to_string(), Value::String("udp".to_string()));
+                    m.insert(
+                        "ip_protocol".to_string(),
+                        Value::Concrete(ConcreteValue::String("udp".to_string())),
+                    );
                     m
-                }),
-            ]),
+                })),
+            ])),
         );
         r
     }];
@@ -1954,7 +2350,7 @@ fn resolve_block_names_same_block_and_canonical_name_multiple_items() {
 
     assert!(resources[0].attributes.contains_key("ingress"));
     match resources[0].get_attr("ingress") {
-        Some(Value::List(items)) => assert_eq!(items.len(), 2),
+        Some(Value::Concrete(ConcreteValue::List(items))) => assert_eq!(items.len(), 2),
         other => panic!("expected List with 2 items, got {:?}", other),
     }
 }
@@ -1966,17 +2362,28 @@ fn resolve_block_names_nested_same_block_and_canonical_name() {
     let mut inner_map = IndexMap::new();
     inner_map.insert(
         "tag".to_string(),
-        Value::List(vec![Value::Map({
-            let mut m = IndexMap::new();
-            m.insert("key".to_string(), Value::String("Name".to_string()));
-            m.insert("value".to_string(), Value::String("test".to_string()));
-            m
-        })]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map({
+                let mut m = IndexMap::new();
+                m.insert(
+                    "key".to_string(),
+                    Value::Concrete(ConcreteValue::String("Name".to_string())),
+                );
+                m.insert(
+                    "value".to_string(),
+                    Value::Concrete(ConcreteValue::String("test".to_string())),
+                );
+                m
+            }),
+        )])),
     );
 
     let mut resources = vec![{
         let mut r = Resource::new("test.resource", "my-resource");
-        r.set_attr("config".to_string(), Value::Map(inner_map));
+        r.set_attr(
+            "config".to_string(),
+            Value::Concrete(ConcreteValue::Map(inner_map)),
+        );
         r
     }];
 
@@ -2008,7 +2415,7 @@ fn resolve_block_names_nested_same_block_and_canonical_name() {
     resolve_block_names(&mut resources, &schemas).unwrap();
 
     let config = match resources[0].get_attr("config") {
-        Some(Value::Map(m)) => m,
+        Some(Value::Concrete(ConcreteValue::Map(m))) => m,
         _ => panic!("expected Map"),
     };
     // Key should remain as "tag" (no rename needed since block_name == canonical)
@@ -2017,7 +2424,7 @@ fn resolve_block_names_nested_same_block_and_canonical_name() {
         "expected 'tag' key to remain (block_name == canonical name)"
     );
     match config.get("tag") {
-        Some(Value::List(items)) => assert_eq!(items.len(), 1),
+        Some(Value::Concrete(ConcreteValue::List(items))) => assert_eq!(items.len(), 1),
         other => panic!("expected List, got {:?}", other),
     }
 }
@@ -2059,9 +2466,12 @@ fn validate_rejects_unknown_attribute() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "bucket_name".to_string(),
-        Value::String("my-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
-    attrs.insert("tags".to_string(), Value::Map(IndexMap::new()));
+    attrs.insert(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+    );
 
     let result = schema.validate(&attrs);
     assert!(result.is_err());
@@ -2082,9 +2492,12 @@ fn validate_allows_known_attributes_only() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "bucket_name".to_string(),
-        Value::String("my-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
-    attrs.insert("tags".to_string(), Value::Map(IndexMap::new()));
+    attrs.insert(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+    );
 
     assert!(schema.validate(&attrs).is_ok());
 }
@@ -2097,7 +2510,7 @@ fn validate_unknown_attribute_with_suggestion() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "bukcet_name".to_string(),
-        Value::String("my-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
 
     let result = schema.validate(&attrs);
@@ -2129,7 +2542,9 @@ fn validate_accepts_block_name_alias() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "ingress_rule".to_string(),
-        Value::List(vec![Value::String("rule1".to_string())]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("rule1".to_string()),
+        )])),
     );
 
     assert!(schema.validate(&attrs).is_ok());
@@ -2143,9 +2558,12 @@ fn validate_skips_internal_attributes() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "bucket_name".to_string(),
-        Value::String("my-bucket".to_string()),
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
-    attrs.insert("_binding".to_string(), Value::String("b".to_string()));
+    attrs.insert(
+        "_binding".to_string(),
+        Value::Concrete(ConcreteValue::String("b".to_string())),
+    );
 
     assert!(schema.validate(&attrs).is_ok());
 }
@@ -2556,34 +2974,51 @@ fn validate_email_type() {
 
     // Valid emails
     assert!(
-        t.validate(&Value::String("user@example.com".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "user@example.com".to_string()
+        )))
+        .is_ok()
     );
     assert!(
-        t.validate(&Value::String(
+        t.validate(&Value::Concrete(ConcreteValue::String(
             "user.name+tag@sub.example.co.jp".to_string()
-        ))
+        )))
         .is_ok()
     );
 
     // Invalid emails
     assert!(
-        t.validate(&Value::String("no-at-sign.com".to_string()))
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "no-at-sign.com".to_string()
+        )))
+        .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "noTLD@host".to_string()
+        )))
+        .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "@example.com".to_string()
+        )))
+        .is_err()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("user@".to_string())))
             .is_err()
     );
     assert!(
-        t.validate(&Value::String("noTLD@host".to_string()))
+        t.validate(&Value::Concrete(ConcreteValue::String("".to_string())))
             .is_err()
     );
-    assert!(
-        t.validate(&Value::String("@example.com".to_string()))
-            .is_err()
-    );
-    assert!(t.validate(&Value::String("user@".to_string())).is_err());
-    assert!(t.validate(&Value::String("".to_string())).is_err());
 
     // Wrong type
-    assert!(t.validate(&Value::Int(42)).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            .is_err()
+    );
 }
 
 #[cfg(test)]
@@ -2603,7 +3038,7 @@ mod validate_collect_tests {
         for (k, v) in entries {
             map.insert(k.to_string(), v);
         }
-        Value::Map(map)
+        Value::Concrete(ConcreteValue::Map(map))
     }
 
     #[test]
@@ -2616,8 +3051,11 @@ mod validate_collect_tests {
             ],
         );
         let v = map_value(vec![
-            ("status", Value::String("Enabled".to_string())),
-            ("mfa_delete", Value::Bool(false)),
+            (
+                "status",
+                Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+            ),
+            ("mfa_delete", Value::Concrete(ConcreteValue::Bool(false))),
         ]);
         let errors = ty.validate_collect(&v);
         assert!(
@@ -2636,8 +3074,11 @@ mod validate_collect_tests {
             vec![StructField::new("status", AttributeType::String)],
         );
         let v = map_value(vec![
-            ("statuus", Value::String("Enabled".to_string())),
-            ("mfa", Value::Bool(false)),
+            (
+                "statuus",
+                Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+            ),
+            ("mfa", Value::Concrete(ConcreteValue::Bool(false))),
         ]);
         let errors = ty.validate_collect(&v);
         assert_eq!(
@@ -2663,7 +3104,10 @@ mod validate_collect_tests {
         let outer = struct_type("Outer", vec![StructField::new("nested", inner).required()]);
         let v = map_value(vec![(
             "nested",
-            map_value(vec![("count", Value::String("not an int".to_string()))]),
+            map_value(vec![(
+                "count",
+                Value::Concrete(ConcreteValue::String("not an int".to_string())),
+            )]),
         )]);
         let errors = outer.validate_collect(&v);
         assert_eq!(errors.len(), 1, "got {errors:?}");
@@ -2686,10 +3130,13 @@ mod validate_collect_tests {
         };
 
         // Two list items, second one has wrong type for `name`
-        let v = Value::List(vec![
-            map_value(vec![("name", Value::String("ok".to_string()))]),
-            map_value(vec![("name", Value::Int(42))]),
-        ]);
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            map_value(vec![(
+                "name",
+                Value::Concrete(ConcreteValue::String("ok".to_string())),
+            )]),
+            map_value(vec![("name", Value::Concrete(ConcreteValue::Int(42)))]),
+        ]));
         let errors = outer_attr.validate_collect(&v);
         assert_eq!(errors.len(), 1, "got {errors:?}");
         let path = &errors[0].0;
@@ -2712,7 +3159,10 @@ mod validate_collect_tests {
                     .with_block_name("transition"),
             ],
         );
-        let v = map_value(vec![("transition", Value::String("ok".to_string()))]);
+        let v = map_value(vec![(
+            "transition",
+            Value::Concrete(ConcreteValue::String("ok".to_string())),
+        )]);
         let errors = ty.validate_collect(&v);
         assert!(
             errors.is_empty(),
@@ -2751,7 +3201,10 @@ mod validate_collect_tests {
             "Versioning",
             vec![StructField::new("status", AttributeType::String)],
         );
-        let v = map_value(vec![("statuus", Value::String("x".to_string()))]);
+        let v = map_value(vec![(
+            "statuus",
+            Value::Concrete(ConcreteValue::String("x".to_string())),
+        )]);
         let errors = ty.validate_collect(&v);
         assert_eq!(errors.len(), 1);
         match &errors[0].1 {
@@ -2828,7 +3281,9 @@ fn expected_includes_to_dsl_aliases_with_alias_flag() {
             ("Suspended".to_string(), "suspended".to_string()),
         ],
     };
-    let err = t.validate(&Value::String("zzz".to_string())).unwrap_err();
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .unwrap_err();
     let TypeError::InvalidEnumVariant { expected, .. } = err else {
         panic!("expected InvalidEnumVariant, got {err:?}");
     };
@@ -2864,8 +3319,10 @@ fn custom_namespaced_string_literal_routes_validator_text_to_extra_message() {
     // byte-identical.
     fn validate_mode(v: &Value) -> Result<(), String> {
         match v {
-            Value::String(s) if s == "test.r.Mode.fast" => Ok(()),
-            Value::String(s) => Err(format!("invalid Mode '{}': expected fast", s)),
+            Value::Concrete(ConcreteValue::String(s)) if s == "test.r.Mode.fast" => Ok(()),
+            Value::Concrete(ConcreteValue::String(s)) => {
+                Err(format!("invalid Mode '{}': expected fast", s))
+            }
             _ => Err("expected String".to_string()),
         }
     }
@@ -2885,7 +3342,10 @@ fn custom_namespaced_string_literal_routes_validator_text_to_extra_message() {
         .required(),
     );
     let mut attrs = HashMap::new();
-    attrs.insert("mode".to_string(), Value::String("aaa".to_string()));
+    attrs.insert(
+        "mode".to_string(),
+        Value::Concrete(ConcreteValue::String("aaa".to_string())),
+    );
     let errs = schema
         .validate_with_origins(&attrs, &|n| n == "mode")
         .unwrap_err();
@@ -2979,7 +3439,7 @@ fn union_string_vs_string_enum_picks_enum_error_for_string_input() {
         },
     ]);
     let err = union_type
-        .validate(&Value::String("zzz".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
         .unwrap_err();
     match err {
         TypeError::InvalidEnumVariant { ref expected, .. } => {
@@ -3007,9 +3467,17 @@ fn union_list_vs_list_struct_picks_inner_struct_error() {
         }),
     ]);
     let mut bad = IndexMap::new();
-    bad.insert("name".to_string(), Value::String("x".to_string()));
-    bad.insert("typo".to_string(), Value::String("y".to_string()));
-    let value = Value::List(vec![Value::Map(bad)]);
+    bad.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
+    );
+    bad.insert(
+        "typo".to_string(),
+        Value::Concrete(ConcreteValue::String("y".to_string())),
+    );
+    let value = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(bad),
+    )]));
     let err = union_type.validate(&value).unwrap_err();
     let msg = err.to_string();
     assert!(
@@ -3025,7 +3493,7 @@ fn union_string_vs_custom_picks_custom_error_for_string_input() {
     // the Custom validator's message, not a generic TypeMismatch.
     fn must_be_arn(v: &Value) -> Result<(), String> {
         match v {
-            Value::String(s) if s.starts_with("arn:") => Ok(()),
+            Value::Concrete(ConcreteValue::String(s)) if s.starts_with("arn:") => Ok(()),
             _ => Err("must start with 'arn:'".to_string()),
         }
     }
@@ -3042,7 +3510,9 @@ fn union_string_vs_custom_picks_custom_error_for_string_input() {
         },
     ]);
     let err = union_type
-        .validate(&Value::String("not-an-arn".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "not-an-arn".to_string(),
+        )))
         .unwrap_err();
     match err {
         TypeError::ValidationFailed { ref message } => {
@@ -3064,8 +3534,13 @@ fn union_falls_through_to_type_mismatch_when_no_member_matches_shape() {
     // "closer" candidate to surface.
     let union_type = AttributeType::Union(vec![AttributeType::Int, AttributeType::Bool]);
     let mut map = IndexMap::new();
-    map.insert("k".to_string(), Value::String("v".to_string()));
-    let err = union_type.validate(&Value::Map(map)).unwrap_err();
+    map.insert(
+        "k".to_string(),
+        Value::Concrete(ConcreteValue::String("v".to_string())),
+    );
+    let err = union_type
+        .validate(&Value::Concrete(ConcreteValue::Map(map)))
+        .unwrap_err();
     match err {
         TypeError::TypeMismatch { .. } => {}
         other => panic!("expected TypeMismatch, got: {other:?}"),
@@ -3082,13 +3557,13 @@ fn union_custom_with_int_base_picks_custom_error_for_int_input() {
     // `TypeMismatch` from the bare `Int` member's success path.
     fn must_be_positive(v: &Value) -> Result<(), String> {
         match v {
-            Value::Int(n) if *n > 0 => Ok(()),
+            Value::Concrete(ConcreteValue::Int(n)) if *n > 0 => Ok(()),
             _ => Err("must be positive".to_string()),
         }
     }
     // Flip the order so the bare `Int` arm doesn't accept the value
     // first — both members run validate(). Bare `Int::validate`
-    // accepts any `Value::Int`, so we have to keep it second; bind
+    // accepts any `Value::Concrete(ConcreteValue::Int)`, so we have to keep it second; bind
     // through a Custom on top so the actual reachable failure path
     // is the `Custom` one.
     let union_type = AttributeType::Union(vec![
@@ -3103,7 +3578,9 @@ fn union_custom_with_int_base_picks_custom_error_for_int_input() {
         },
         AttributeType::Bool,
     ]);
-    let err = union_type.validate(&Value::Int(-5)).unwrap_err();
+    let err = union_type
+        .validate(&Value::Concrete(ConcreteValue::Int(-5)))
+        .unwrap_err();
     match err {
         TypeError::ValidationFailed { ref message } => {
             assert!(
@@ -3132,9 +3609,17 @@ fn union_struct_member_still_wins_for_map_input_regression() {
         AttributeType::String,
     ]);
     let mut map = IndexMap::new();
-    map.insert("service".to_string(), Value::String("x".to_string()));
-    map.insert("typo".to_string(), Value::String("y".to_string()));
-    let err = union_type.validate(&Value::Map(map)).unwrap_err();
+    map.insert(
+        "service".to_string(),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
+    );
+    map.insert(
+        "typo".to_string(),
+        Value::Concrete(ConcreteValue::String("y".to_string())),
+    );
+    let err = union_type
+        .validate(&Value::Concrete(ConcreteValue::Map(map)))
+        .unwrap_err();
     let msg = err.to_string();
     assert!(
         msg.contains("typo") && msg.contains("Principal"),
@@ -3155,8 +3640,8 @@ fn custom_validator_can_capture_external_state() {
         pattern: None,
         length: None,
         validate: validator(move |v| match v {
-            Value::String(s) if s == &allowed_region => Ok(()),
-            Value::String(s) => Err(TypeError::ValidationFailed {
+            Value::Concrete(ConcreteValue::String(s)) if s == &allowed_region => Ok(()),
+            Value::Concrete(ConcreteValue::String(s)) => Err(TypeError::ValidationFailed {
                 message: format!("expected region {}, got {}", allowed_region, s),
             }),
             other => Err(TypeError::TypeMismatch {
@@ -3168,11 +3653,15 @@ fn custom_validator_can_capture_external_state() {
         to_dsl: None,
     };
     assert!(
-        attr.validate(&Value::String("ap-northeast-1".to_string()))
-            .is_ok()
+        attr.validate(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1".to_string()
+        )))
+        .is_ok()
     );
     let err = attr
-        .validate(&Value::String("us-east-1".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "us-east-1".to_string(),
+        )))
         .unwrap_err();
     match err {
         TypeError::ValidationFailed { message } => {
@@ -3194,8 +3683,8 @@ fn custom_validator_returns_structured_type_error_directly() {
         pattern: None,
         length: None,
         validate: validator(|v| match v {
-            Value::String(s) if s == "fast" || s == "slow" => Ok(()),
-            Value::String(s) => Err(TypeError::InvalidEnumVariant {
+            Value::Concrete(ConcreteValue::String(s)) if s == "fast" || s == "slow" => Ok(()),
+            Value::Concrete(ConcreteValue::String(s)) => Err(TypeError::InvalidEnumVariant {
                 value: s.clone(),
                 attribute: None,
                 type_name: Some("Mode".to_string()),
@@ -3213,7 +3702,9 @@ fn custom_validator_returns_structured_type_error_directly() {
         to_dsl: None,
     };
     let err = attr
-        .validate(&Value::String("medium".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "medium".to_string(),
+        )))
         .unwrap_err();
     match err {
         TypeError::InvalidEnumVariant {
@@ -3300,19 +3791,19 @@ fn schema_registry_has_managed_only_does_not_imply_data_source() {
 
 #[test]
 fn validate_skips_value_unknown_for_primitive_types() {
-    // `Value::Unknown` carries no concrete type at plan time, so it
+    // `Value::Deferred(DeferredValue::Unknown)` carries no concrete type at plan time, so it
     // takes the same skip path as `FunctionCall` and `Secret`. Without
     // this, a `for x in upstream.list { ... attr = x ... }` body fails
     // parse-time validation with `expected <type>, got unknown`.
     use crate::resource::{AccessPath, UnknownReason};
-    let unknown = Value::Unknown(UnknownReason::ForValue);
+    let unknown = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue));
     assert!(AttributeType::String.validate(&unknown).is_ok());
     assert!(AttributeType::Int.validate(&unknown).is_ok());
     assert!(AttributeType::Bool.validate(&unknown).is_ok());
 
-    let upstream = Value::Unknown(UnknownReason::UpstreamRef {
+    let upstream = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
         path: AccessPath::with_fields("net", "vpc", vec!["vpc_id".into()]),
-    });
+    }));
     assert!(AttributeType::String.validate(&upstream).is_ok());
     assert!(AttributeType::Int.validate(&upstream).is_ok());
 }
@@ -3321,14 +3812,15 @@ fn validate_skips_value_unknown_for_primitive_types() {
 fn walk_custom_lookup_skips_value_unknown() {
     // Custom-typed attributes (e.g. AWS resource-id types like `vpc_id`)
     // run through `walk_custom_lookup` instead of `validate`. Skip
-    // `Value::Unknown` here too, otherwise a custom-typed attribute
+    // `Value::Deferred(DeferredValue::Unknown)` here too, otherwise a custom-typed attribute
     // bound from a for-expression element fails plan with
     // `expected vpc_id, got unknown`.
     use crate::resource::UnknownReason;
 
     let always_fail = validator(|_v: &Value| {
         Err(TypeError::ValidationFailed {
-            message: "validator must not run for Value::Unknown".to_string(),
+            message: "validator must not run for Value::Deferred(DeferredValue::Unknown)"
+                .to_string(),
         })
     });
     let custom_type = AttributeType::Custom {
@@ -3344,7 +3836,7 @@ fn walk_custom_lookup_skips_value_unknown() {
     let mut errors = Vec::new();
     walk_custom_lookup(
         &custom_type,
-        &Value::Unknown(UnknownReason::ForValue),
+        &Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
         "vpc_id",
         &|_, _| {
             Err(TypeError::ValidationFailed {
@@ -3355,7 +3847,7 @@ fn walk_custom_lookup_skips_value_unknown() {
     );
     assert!(
         errors.is_empty(),
-        "Value::Unknown must not invoke the custom validator, got: {errors:?}"
+        "Value::Deferred(DeferredValue::Unknown) must not invoke the custom validator, got: {errors:?}"
     );
 }
 
@@ -3397,31 +3889,37 @@ fn dsl_aliases_validator_accepts_both_api_and_dsl_spellings() {
 
     // Bare API spelling: accepted (canonical).
     assert!(
-        t.validate(&Value::String("BucketOwnerEnforced".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "BucketOwnerEnforced".to_string()
+        )))
+        .is_ok()
     );
     // Bare DSL spelling: accepted (alias).
     assert!(
-        t.validate(&Value::String("bucket_owner_enforced".to_string()))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "bucket_owner_enforced".to_string()
+        )))
+        .is_ok()
     );
     // Fully-qualified API spelling: accepted.
     assert!(
-        t.validate(&Value::String(
+        t.validate(&Value::Concrete(ConcreteValue::String(
             "awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string()
-        ))
+        )))
         .is_ok()
     );
     // Fully-qualified DSL spelling: accepted (the awscc#199 case).
     assert!(
-        t.validate(&Value::String(
+        t.validate(&Value::Concrete(ConcreteValue::String(
             "awscc.s3.Bucket.ObjectOwnership.bucket_owner_enforced".to_string()
-        ))
+        )))
         .is_ok()
     );
     // An unrelated value: rejected, with both spellings listed.
     let err = t
-        .validate(&Value::String("garbage".to_string()))
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "garbage".to_string(),
+        )))
         .unwrap_err();
     let msg = err.to_string();
     assert!(
@@ -3448,7 +3946,9 @@ fn dsl_aliases_diagnostic_tags_alias_entries_distinct_from_canonical() {
             ("Suspended".to_string(), "suspended".to_string()),
         ],
     };
-    let err = t.validate(&Value::String("zzz".to_string())).unwrap_err();
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .unwrap_err();
     let TypeError::InvalidEnumVariant { expected, .. } = err else {
         panic!("expected InvalidEnumVariant");
     };
@@ -3478,6 +3978,14 @@ fn dsl_aliases_empty_keeps_api_only_validation() {
         namespace: Some("test.r".to_string()),
         dsl_aliases: vec![],
     };
-    assert!(t.validate(&Value::String("active".to_string())).is_ok());
-    assert!(t.validate(&Value::String("nope".to_string())).is_err());
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String(
+            "active".to_string()
+        )))
+        .is_ok()
+    );
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("nope".to_string())))
+            .is_err()
+    );
 }

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 
 use crate::config_loader::{find_crn_files_in_dir, parse_directory};
 use crate::parser::{ProviderContext, ResourceContext, TypeExpr, UpstreamState};
-use crate::resource::{Subscript, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Subscript, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
 /// One export's declared type and literal value, as carried through
@@ -382,7 +382,7 @@ enum NonResourceScope {
 /// Walk a parsed project and return an error for every reference whose root
 /// binding is in `exports` but whose field isn't in its declared key set.
 /// Also covers deferred for-iterables (e.g. `for _ in orgs.accounts`), which
-/// parse into `deferred_for_expressions` rather than `Value::ResourceRef`.
+/// parse into `deferred_for_expressions` rather than `Value::Deferred(DeferredValue::ResourceRef)`.
 ///
 /// Bindings absent from `exports` are skipped — the caller decides what to
 /// do about unresolved upstreams.
@@ -573,7 +573,7 @@ fn check_ref_against_type(
 }
 
 /// Positional walker: descend `value` and `expected` in lockstep,
-/// threading the inner expected type to each leaf `Value::ResourceRef`
+/// threading the inner expected type to each leaf `Value::Deferred(DeferredValue::ResourceRef)`
 /// so the comparison fires against the *position's* schema type rather
 /// than the outer attribute's. Without this, a ref deep inside a
 /// struct field or interpolation gets compared to the outer attr type
@@ -595,10 +595,10 @@ fn walk_value_against_type(
     errors: &mut Vec<UpstreamTypeError>,
 ) {
     match value {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             check_resource_ref_at_position(path, expected, exports, location, errors);
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             // Descend `list(T)` element-wise. For non-list receivers
             // the existing top-level shape check (run elsewhere)
             // already flags the kind mismatch, so we just walk each
@@ -612,7 +612,7 @@ fn walk_value_against_type(
                 walk_value_against_type(item, inner, exports, location, errors);
             }
         }
-        Value::Map(entries) => match expected {
+        Value::Concrete(ConcreteValue::Map(entries)) => match expected {
             AttributeType::Map { value: inner, .. } => {
                 for v in entries.values() {
                     walk_value_against_type(v, inner, exports, location, errors);
@@ -646,7 +646,7 @@ fn walk_value_against_type(
                 }
             }
         },
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             // The result of an interpolation is always a string, so
             // every embedded `Expr` part sits in a String position
             // regardless of where the interpolation itself appears.
@@ -656,10 +656,10 @@ fn walk_value_against_type(
                 }
             }
         }
-        Value::Secret(inner) => {
+        Value::Deferred(DeferredValue::Secret(inner)) => {
             walk_value_against_type(inner, expected, exports, location, errors);
         }
-        Value::FunctionCall { args, .. } => {
+        Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
             // Function arguments occupy function-internal positions
             // whose declared types live on the function definition
             // (out of reach here). Walk with `expected` as a
@@ -669,18 +669,18 @@ fn walk_value_against_type(
                 walk_value_against_type(arg, expected, exports, location, errors);
             }
         }
-        Value::String(_)
-        | Value::Int(_)
-        | Value::Float(_)
-        | Value::Bool(_)
-        | Value::Duration(_)
-        | Value::StringList(_)
-        | Value::Unknown(_) => {}
+        Value::Concrete(ConcreteValue::String(_))
+        | Value::Concrete(ConcreteValue::Int(_))
+        | Value::Concrete(ConcreteValue::Float(_))
+        | Value::Concrete(ConcreteValue::Bool(_))
+        | Value::Concrete(ConcreteValue::Duration(_))
+        | Value::Concrete(ConcreteValue::StringList(_))
+        | Value::Deferred(DeferredValue::Unknown(_)) => {}
         // `BindingRef` carries no attribute, so there is nothing to
         // type-check at a "field reference" position. The same applies
         // to all other walkers in this module: a bare-binding seed
         // cannot stand in for an attribute reference. (#2847)
-        Value::BindingRef { .. } => {}
+        Value::Deferred(DeferredValue::BindingRef { .. }) => {}
     }
 }
 
@@ -997,7 +997,7 @@ impl UpstreamRefDiagnostic for UpstreamAttributeAccessShapeError {
     }
 }
 
-/// Walk every `Value::ResourceRef` whose root is an `upstream_state`
+/// Walk every `Value::Deferred(DeferredValue::ResourceRef)` whose root is an `upstream_state`
 /// binding and whose `field_path` is non-empty, and emit an error
 /// whenever a path segment doesn't fit the declared upstream
 /// `TypeExpr`.
@@ -1161,7 +1161,7 @@ impl UpstreamRefDiagnostic for UpstreamSubscriptShapeError {
     }
 }
 
-/// Walk every `Value::ResourceRef` whose root is an `upstream_state`
+/// Walk every `Value::Deferred(DeferredValue::ResourceRef)` whose root is an `upstream_state`
 /// binding and whose `subscripts` chain is non-empty, and emit an error
 /// whenever a subscript's kind (integer vs string) doesn't fit the
 /// declared upstream `TypeExpr` at that depth.
@@ -1493,7 +1493,7 @@ mod tests {
         // `exports { }` block. Without the value, downstream consumers
         // (LSP map-literal-key completion, future doc-extracting tools)
         // have to re-parse the upstream directory a second time per call.
-        use crate::resource::Value;
+        use crate::resource::{ConcreteValue, Value};
 
         let tmp = tempfile::tempdir().unwrap();
         let upstream_dir = tmp.path().join("organizations");
@@ -1521,8 +1521,10 @@ mod tests {
             "type annotation must still be present"
         );
         let value = entry.value.as_ref().expect("export value must be carried");
-        let Value::Map(entries) = value else {
-            panic!("expected Value::Map for map literal export, got {value:?}");
+        let Value::Concrete(ConcreteValue::Map(entries)) = value else {
+            panic!(
+                "expected Value::Concrete(ConcreteValue::Map) for map literal export, got {value:?}"
+            );
         };
         let mut keys: Vec<&String> = entries.keys().collect();
         keys.sort();
@@ -1708,7 +1710,7 @@ mod tests {
         // surfaced as a `ResourceRef { attribute: "" }` and tripped the
         // walker into emitting `does not export ``.`. Type-split makes
         // the offending shape unrepresentable: a sibling-only seed is a
-        // `Value::BindingRef`, which has no attribute slot for the
+        // `Value::Deferred(DeferredValue::BindingRef)`, which has no attribute slot for the
         // walker to read, so the empty-field diagnostic class is
         // statically eliminated.
         let tmp = tempfile::tempdir().unwrap();
@@ -1732,7 +1734,10 @@ mod tests {
         // can no longer impersonate an attribute reference.
         let bootstrap_var = parsed.variables.get("bootstrap");
         assert!(
-            matches!(bootstrap_var, Some(Value::BindingRef { .. }) | None),
+            matches!(
+                bootstrap_var,
+                Some(Value::Deferred(DeferredValue::BindingRef { .. })) | None
+            ),
             "sibling-only `bootstrap` must be either absent or a \
              BindingRef, got: {bootstrap_var:?}"
         );

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -1,6 +1,6 @@
 //! Shared utility functions for value normalization and conversion
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 use crate::schema::NamespacedEnumParts;
 
 /// A namespaced DSL enum identifier, parsed once and reused.
@@ -218,11 +218,11 @@ fn is_intermediate_segment(s: &str) -> bool {
 /// pipeline so the two paths cannot drift.
 pub fn expand_enum_shorthand(value: &Value, name: &str, namespace: Option<&str>) -> Value {
     match value {
-        Value::String(s) if !s.contains('.') => match namespace {
-            Some(ns) => Value::String(format!("{}.{}.{}", ns, name, s)),
+        Value::Concrete(ConcreteValue::String(s)) if !s.contains('.') => match namespace {
+            Some(ns) => Value::Concrete(ConcreteValue::String(format!("{}.{}.{}", ns, name, s))),
             None => value.clone(),
         },
-        Value::String(s) => {
+        Value::Concrete(ConcreteValue::String(s)) => {
             if let Some(NamespacedId::TypeQualified {
                 type_name: ident,
                 value: member,
@@ -230,7 +230,10 @@ pub fn expand_enum_shorthand(value: &Value, name: &str, namespace: Option<&str>)
                 && let Some(ns) = namespace
                 && ident == name
             {
-                Value::String(format!("{}.{}.{}", ns, ident, member))
+                Value::Concrete(ConcreteValue::String(format!(
+                    "{}.{}.{}",
+                    ns, ident, member
+                )))
             } else {
                 value.clone()
             }
@@ -460,19 +463,25 @@ pub fn validate_enum_namespace(s: &str, type_name: &str, namespace: &str) -> Res
 pub fn resolve_enum_value(value: &Value, parts: &NamespacedEnumParts<'_>) -> Option<Value> {
     let (type_name, ns, dsl_map) = parts;
     match value {
-        Value::String(s) if !s.contains('.') => {
+        Value::Concrete(ConcreteValue::String(s)) if !s.contains('.') => {
             // bare identifier: "Enabled" -> ns.TypeName.Enabled
             let dsl_val = dsl_map.dsl_for(s);
-            Some(Value::String(format!("{}.{}.{}", ns, type_name, dsl_val)))
+            Some(Value::Concrete(ConcreteValue::String(format!(
+                "{}.{}.{}",
+                ns, type_name, dsl_val
+            ))))
         }
-        Value::String(s)
+        Value::Concrete(ConcreteValue::String(s))
             if s.split_once('.')
                 .is_some_and(|(ident, member)| ident == *type_name && !member.contains('.')) =>
         {
             // TypeName.value: "VersioningStatus.Enabled" -> ns.TypeName.Enabled
             let member = s.split_once('.').unwrap().1;
             let dsl_val = dsl_map.dsl_for(member);
-            Some(Value::String(format!("{}.{}.{}", ns, type_name, dsl_val)))
+            Some(Value::Concrete(ConcreteValue::String(format!(
+                "{}.{}.{}",
+                ns, type_name, dsl_val
+            ))))
         }
         _ => None,
     }
@@ -491,7 +500,7 @@ pub fn normalize_state_enum_value(
     string_enum_check: Option<&dyn Fn(&str) -> bool>,
 ) -> Option<Value> {
     let (type_name, ns, dsl_map) = parts;
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         // Skip values already in namespaced DSL format.
         // A value that contains '.' but is not already namespaced is a raw enum value
         // like "ipsec.1" -- check if it matches a known valid enum value.
@@ -499,7 +508,10 @@ pub fn normalize_state_enum_value(
             s.contains('.') && !string_enum_check.is_some_and(|check| check(s));
         if !already_namespaced {
             let dsl_val = dsl_map.dsl_for(s);
-            return Some(Value::String(format!("{}.{}.{}", ns, type_name, dsl_val)));
+            return Some(Value::Concrete(ConcreteValue::String(format!(
+                "{}.{}.{}",
+                ns, type_name, dsl_val
+            ))));
         }
     }
     None
@@ -1191,53 +1203,61 @@ mod tests {
         let cases: &[(Value, &str, Option<&str>, Value)] = &[
             // bare member + namespace → fully qualified
             (
-                Value::String("dedicated".into()),
+                Value::Concrete(ConcreteValue::String("dedicated".into())),
                 "InstanceTenancy",
                 Some("awscc.ec2.Vpc"),
-                Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.ec2.Vpc.InstanceTenancy.dedicated".into(),
+                )),
             ),
             // bare member, no namespace → passthrough
             (
-                Value::String("dedicated".into()),
+                Value::Concrete(ConcreteValue::String("dedicated".into())),
                 "InstanceTenancy",
                 None,
-                Value::String("dedicated".into()),
+                Value::Concrete(ConcreteValue::String("dedicated".into())),
             ),
             // TypeName.member matching `name` → fully qualified
             (
-                Value::String("InstanceTenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String("InstanceTenancy.dedicated".into())),
                 "InstanceTenancy",
                 Some("awscc.ec2.Vpc"),
-                Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.ec2.Vpc.InstanceTenancy.dedicated".into(),
+                )),
             ),
             // TypeName.member with foreign type name → passthrough
             (
-                Value::String("Tenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String("Tenancy.dedicated".into())),
                 "InstanceTenancy",
                 Some("awscc.ec2.Vpc"),
-                Value::String("Tenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String("Tenancy.dedicated".into())),
             ),
             // Already-fully-qualified → passthrough (parser returns
             // `FullyQualified`, helper only acts on `TypeQualified`)
             (
-                Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.ec2.Vpc.InstanceTenancy.dedicated".into(),
+                )),
                 "InstanceTenancy",
                 Some("awscc.ec2.Vpc"),
-                Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.ec2.Vpc.InstanceTenancy.dedicated".into(),
+                )),
             ),
             // Lowercase first segment → not a TypeName; passthrough
             (
-                Value::String("instanceTenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String("instanceTenancy.dedicated".into())),
                 "InstanceTenancy",
                 Some("awscc.ec2.Vpc"),
-                Value::String("instanceTenancy.dedicated".into()),
+                Value::Concrete(ConcreteValue::String("instanceTenancy.dedicated".into())),
             ),
             // Non-string → passthrough
             (
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
                 "Whatever",
                 Some("aws"),
-                Value::Bool(true),
+                Value::Concrete(ConcreteValue::Bool(true)),
             ),
         ];
         for (input, name, ns, expected) in cases {

--- a/carina-core/src/validation/depends_on.rs
+++ b/carina-core/src/validation/depends_on.rs
@@ -407,7 +407,7 @@ mod tests {
         // Ensures the redundant-edge check matches what `check_unused_bindings`
         // sees: dot-notation strings inside collections (e.g.
         // `principals = [role.arn]`) survive resolution as
-        // `Value::String("role.arn")`, not `Value::ResourceRef`. Without
+        // `Value::Concrete(ConcreteValue::String("role.arn"))`, not `Value::Deferred(DeferredValue::ResourceRef)`. Without
         // `collect_dot_notation_refs` here, the warning would silently
         // miss this shape.
         let src = r#"

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -12,19 +12,19 @@
 //!
 //! Inference rules:
 //!
-//! - `Value::String/Int/Bool/Float` → corresponding `TypeExpr` primitive.
-//! - `Value::List(items)` → `List(T)` where `T` is the unified element
+//! - `Value::Concrete(ConcreteValue::String)/Int/Bool/Float` → corresponding `TypeExpr` primitive.
+//! - `Value::Concrete(ConcreteValue::List(items))` → `List(T)` where `T` is the unified element
 //!   type. Heterogeneous lists fail inference.
-//! - `Value::Map(entries)` → `Map(T)` where `T` unifies value types.
-//! - `Value::ResourceRef { binding, attribute, field_path }` → walk
+//! - `Value::Concrete(ConcreteValue::Map(entries))` → `Map(T)` where `T` unifies value types.
+//! - `Value::Deferred(DeferredValue::ResourceRef{ binding, attribute, field_path })` → walk
 //!   the binding's resource schema, descend `field_path`, convert the
 //!   reached `AttributeType` into a `TypeExpr`.
-//! - `Value::Interpolation(_)` → `TypeExpr::String` (interpolation
+//! - `Value::Deferred(DeferredValue::Interpolation(_))` → `TypeExpr::String` (interpolation
 //!   results are always strings; users who need a specific Custom
 //!   identity must annotate to narrow).
-//! - `Value::Secret(_)` → `TypeExpr::String` (the secret's plaintext
+//! - `Value::Deferred(DeferredValue::Secret(_))` → `TypeExpr::String` (the secret's plaintext
 //!   shape; same reasoning as Interpolation).
-//! - `Value::FunctionCall { name, .. }` → consult `builtins`'s
+//! - `Value::Deferred(DeferredValue::FunctionCall{ name, .. })` → consult `builtins`'s
 //!   `BuiltinReturnType`. `String/Int/List/Map/Secret` map to the
 //!   corresponding `TypeExpr` primitive; `Any` (`lookup`, `min`,
 //!   `max`, `map`) is "depends on arguments" — counts as inference
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 
 use crate::builtins::{BuiltinReturnType, builtin_functions};
 use crate::parser::TypeExpr;
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 use crate::schema::{AttributeType, ResourceSchema, SchemaKind, SchemaRegistry};
 
 /// Why inference failed. Carries the rhs description so downstream
@@ -290,19 +290,23 @@ fn infer_type_from_value_with_visiting(
     visiting: &mut indexmap::IndexSet<String>,
 ) -> Result<TypeExpr, InferenceError> {
     match value {
-        Value::String(_) => Ok(TypeExpr::String),
-        Value::Int(_) => Ok(TypeExpr::Int),
-        Value::Float(_) => Ok(TypeExpr::Float),
-        Value::Bool(_) => Ok(TypeExpr::Bool),
-        Value::Duration(_) => Ok(TypeExpr::Duration),
-        Value::Interpolation(_) => Ok(TypeExpr::String),
-        Value::Secret(_) => Ok(TypeExpr::String),
-        Value::List(items) => infer_collection(items, bindings, schemas, visiting, TypeExpr::List),
-        Value::StringList(_) => Ok(TypeExpr::List(Box::new(TypeExpr::String))),
-        Value::Map(entries) => {
+        Value::Concrete(ConcreteValue::String(_)) => Ok(TypeExpr::String),
+        Value::Concrete(ConcreteValue::Int(_)) => Ok(TypeExpr::Int),
+        Value::Concrete(ConcreteValue::Float(_)) => Ok(TypeExpr::Float),
+        Value::Concrete(ConcreteValue::Bool(_)) => Ok(TypeExpr::Bool),
+        Value::Concrete(ConcreteValue::Duration(_)) => Ok(TypeExpr::Duration),
+        Value::Deferred(DeferredValue::Interpolation(_)) => Ok(TypeExpr::String),
+        Value::Deferred(DeferredValue::Secret(_)) => Ok(TypeExpr::String),
+        Value::Concrete(ConcreteValue::List(items)) => {
+            infer_collection(items, bindings, schemas, visiting, TypeExpr::List)
+        }
+        Value::Concrete(ConcreteValue::StringList(_)) => {
+            Ok(TypeExpr::List(Box::new(TypeExpr::String)))
+        }
+        Value::Concrete(ConcreteValue::Map(entries)) => {
             infer_collection(entries.values(), bindings, schemas, visiting, TypeExpr::Map)
         }
-        Value::ResourceRef { path } => infer_resource_ref_with_visiting(
+        Value::Deferred(DeferredValue::ResourceRef { path }) => infer_resource_ref_with_visiting(
             path.binding(),
             path.attribute(),
             path.field_path(),
@@ -314,11 +318,11 @@ fn infer_type_from_value_with_visiting(
         // `BindingRef` is a bare-binding placeholder with no attribute
         // and therefore no inferable position. Inference treats it as
         // "type unknown until accessed" — same shape as `Unknown(_)`.
-        Value::BindingRef { .. } => Err(InferenceError::UnknownType {
+        Value::Deferred(DeferredValue::BindingRef { .. }) => Err(InferenceError::UnknownType {
             reason: "bare binding reference has no attribute to infer".to_string(),
         }),
-        Value::FunctionCall { name, .. } => infer_function_call(name),
-        Value::Unknown(_) => Err(InferenceError::UnknownType {
+        Value::Deferred(DeferredValue::FunctionCall { name, .. }) => infer_function_call(name),
+        Value::Deferred(DeferredValue::Unknown(_)) => Err(InferenceError::UnknownType {
             reason: "value not yet known at plan time (unresolved upstream)".to_string(),
         }),
     }
@@ -740,7 +744,7 @@ mod tests {
     #[test]
     fn literal_string_inferred_as_string() {
         let r = infer_type_from_value(
-            &Value::String("hello".to_string()),
+            &Value::Concrete(ConcreteValue::String("hello".to_string())),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -750,7 +754,7 @@ mod tests {
     #[test]
     fn literal_int_inferred_as_int() {
         let r = infer_type_from_value(
-            &Value::Int(42),
+            &Value::Concrete(ConcreteValue::Int(42)),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -760,7 +764,7 @@ mod tests {
     #[test]
     fn literal_bool_inferred_as_bool() {
         let r = infer_type_from_value(
-            &Value::Bool(true),
+            &Value::Concrete(ConcreteValue::Bool(true)),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -773,7 +777,9 @@ mod tests {
         // result is always String. Use one literal part.
         use crate::resource::InterpolationPart;
         let r = infer_type_from_value(
-            &Value::Interpolation(vec![InterpolationPart::Literal("hello".to_string())]),
+            &Value::Deferred(DeferredValue::Interpolation(vec![
+                InterpolationPart::Literal("hello".to_string()),
+            ])),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -783,7 +789,9 @@ mod tests {
     #[test]
     fn secret_inferred_as_string() {
         let r = infer_type_from_value(
-            &Value::Secret(Box::new(Value::String("hidden".to_string()))),
+            &Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("hidden".to_string()),
+            )))),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -793,10 +801,10 @@ mod tests {
     #[test]
     fn list_of_strings_inferred_as_list_string() {
         let r = infer_type_from_value(
-            &Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-            ]),
+            &Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::String("b".to_string())),
+            ])),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -806,7 +814,10 @@ mod tests {
     #[test]
     fn list_with_mixed_types_fails() {
         let r = infer_type_from_value(
-            &Value::List(vec![Value::String("a".to_string()), Value::Int(1)]),
+            &Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("a".to_string())),
+                Value::Concrete(ConcreteValue::Int(1)),
+            ])),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -819,10 +830,16 @@ mod tests {
     #[test]
     fn map_of_strings_inferred_as_map_string() {
         let mut entries = indexmap::IndexMap::new();
-        entries.insert("a".to_string(), Value::String("x".to_string()));
-        entries.insert("b".to_string(), Value::String("y".to_string()));
+        entries.insert(
+            "a".to_string(),
+            Value::Concrete(ConcreteValue::String("x".to_string())),
+        );
+        entries.insert(
+            "b".to_string(),
+            Value::Concrete(ConcreteValue::String("y".to_string())),
+        );
         let r = infer_type_from_value(
-            &Value::Map(entries),
+            &Value::Concrete(ConcreteValue::Map(entries)),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -832,10 +849,13 @@ mod tests {
     #[test]
     fn map_with_mixed_value_types_fails() {
         let mut entries = indexmap::IndexMap::new();
-        entries.insert("a".to_string(), Value::String("x".to_string()));
-        entries.insert("b".to_string(), Value::Int(1));
+        entries.insert(
+            "a".to_string(),
+            Value::Concrete(ConcreteValue::String("x".to_string())),
+        );
+        entries.insert("b".to_string(), Value::Concrete(ConcreteValue::Int(1)));
         let r = infer_type_from_value(
-            &Value::Map(entries),
+            &Value::Concrete(ConcreteValue::Map(entries)),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -862,7 +882,7 @@ mod tests {
 
         let path = AccessPath::with_fields("vpc", "tags", vec!["environment".to_string()]);
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &binding_to_vpc("vpc"),
             &schemas,
         );
@@ -877,13 +897,13 @@ mod tests {
         // meant `lookup` to return `Int`) silently lock the export to
         // String. All-or-nothing is the safer default.
         let r = infer_type_from_value(
-            &Value::List(vec![
-                Value::FunctionCall {
+            &Value::Concrete(ConcreteValue::List(vec![
+                Value::Deferred(DeferredValue::FunctionCall {
                     name: "lookup".to_string(),
                     args: vec![],
-                },
-                Value::String("extra".to_string()),
-            ]),
+                }),
+                Value::Concrete(ConcreteValue::String("extra".to_string())),
+            ])),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -893,7 +913,7 @@ mod tests {
     #[test]
     fn empty_list_fails_inference() {
         let r = infer_type_from_value(
-            &Value::List(vec![]),
+            &Value::Concrete(ConcreteValue::List(vec![])),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -908,7 +928,7 @@ mod tests {
         // stores `: VpcId` annotations.
         let path = AccessPath::new("vpc", "vpc_id");
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &binding_to_vpc("vpc"),
             &schemas_with_vpc(),
         );
@@ -919,7 +939,7 @@ mod tests {
     fn resource_ref_to_string_attr_inferred_as_string() {
         let path = AccessPath::new("vpc", "cidr_block");
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &binding_to_vpc("vpc"),
             &schemas_with_vpc(),
         );
@@ -930,7 +950,7 @@ mod tests {
     fn resource_ref_unknown_binding_errors() {
         let path = AccessPath::new("missing", "vpc_id");
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &InferenceBindings::new(),
             &schemas_with_vpc(),
         );
@@ -941,7 +961,7 @@ mod tests {
     fn resource_ref_unknown_attribute_errors() {
         let path = AccessPath::new("vpc", "missing");
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &binding_to_vpc("vpc"),
             &schemas_with_vpc(),
         );
@@ -952,10 +972,10 @@ mod tests {
     fn function_call_join_inferred_as_string() {
         // `join` returns String per builtins metadata.
         let r = infer_type_from_value(
-            &Value::FunctionCall {
+            &Value::Deferred(DeferredValue::FunctionCall {
                 name: "join".to_string(),
                 args: vec![],
-            },
+            }),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -967,10 +987,10 @@ mod tests {
         // `lookup` returns Any — depends on arguments. Annotation
         // required.
         let r = infer_type_from_value(
-            &Value::FunctionCall {
+            &Value::Deferred(DeferredValue::FunctionCall {
                 name: "lookup".to_string(),
                 args: vec![],
-            },
+            }),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -999,7 +1019,7 @@ mod tests {
             vec![crate::resource::Subscript::Int { index: 0 }],
         );
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &binding_to_vpc("vpc"),
             &schemas,
         );
@@ -1012,7 +1032,7 @@ mod tests {
         // `UnknownBinding` rather than silently degrading to `None`.
         let path = AccessPath::new("mian", "vpc_id");
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &binding_to_vpc("main"),
             &schemas_with_vpc(),
         );
@@ -1030,7 +1050,7 @@ mod tests {
         bindings.insert("network".to_string(), InferenceBinding::UpstreamState);
         let path = AccessPath::new("network", "vpc_id");
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &bindings,
             &SchemaRegistry::new(),
         );
@@ -1047,9 +1067,9 @@ mod tests {
         let upstream_path = AccessPath::new("network", "vpc_id");
         let r = infer_type_expr(
             None,
-            Some(&Value::ResourceRef {
+            Some(&Value::Deferred(DeferredValue::ResourceRef {
                 path: upstream_path,
-            }),
+            })),
             &bindings,
             &SchemaRegistry::new(),
         );
@@ -1058,7 +1078,9 @@ mod tests {
         let typo_path = AccessPath::new("nonexistent", "vpc_id");
         let r = infer_type_expr(
             None,
-            Some(&Value::ResourceRef { path: typo_path }),
+            Some(&Value::Deferred(DeferredValue::ResourceRef {
+                path: typo_path,
+            })),
             &bindings,
             &SchemaRegistry::new(),
         );
@@ -1081,7 +1103,7 @@ mod tests {
 
         let path = AccessPath::new("vpc", "polymorphic");
         let r = infer_type_from_value(
-            &Value::ResourceRef { path },
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
             &binding_to_vpc("vpc"),
             &schemas,
         );
@@ -1162,7 +1184,11 @@ mod tests {
             },
         );
         let path = AccessPath::new("policy", "policy_document");
-        let r = infer_type_from_value(&Value::ResourceRef { path }, &bindings, &schemas);
+        let r = infer_type_from_value(
+            &Value::Deferred(DeferredValue::ResourceRef { path }),
+            &bindings,
+            &schemas,
+        );
         // Pin the inferred shape, not just `is_ok`: the outer Struct
         // is preserved with its `statement` field, and the buried
         // Union inside the inner Statement struct collapses to the
@@ -1198,10 +1224,10 @@ mod tests {
     #[test]
     fn function_call_unknown_name_fails_inference() {
         let r = infer_type_from_value(
-            &Value::FunctionCall {
+            &Value::Deferred(DeferredValue::FunctionCall {
                 name: "nonexistent".to_string(),
                 args: vec![],
-            },
+            }),
             &InferenceBindings::new(),
             &SchemaRegistry::new(),
         );
@@ -1240,10 +1266,10 @@ mod tests {
             name: "zone_id".to_string(),
             type_expr: None,
             // `lookup` returns Any: inference fails, sentinel produced.
-            value: Some(Value::FunctionCall {
+            value: Some(Value::Deferred(DeferredValue::FunctionCall {
                 name: "lookup".to_string(),
                 args: vec![],
-            }),
+            })),
         });
 
         let (inferred, errors) = apply_inference(parsed, &SchemaRegistry::new());
@@ -1260,7 +1286,9 @@ mod tests {
         parsed.export_params.push(crate::parser::ParsedExportParam {
             name: "vpc_id".to_string(),
             type_expr: Some(TypeExpr::Simple("vpc_id".to_string())),
-            value: Some(Value::String("vpc-abc".to_string())),
+            value: Some(Value::Concrete(ConcreteValue::String(
+                "vpc-abc".to_string(),
+            ))),
         });
 
         let (inferred, errors) = apply_inference(parsed, &SchemaRegistry::new());
@@ -1487,20 +1515,26 @@ mod tests {
         let mut bindings = InferenceBindings::new();
         bindings.insert(
             "a".to_string(),
-            virtual_binding(&[("x", Value::String("hi".to_string()))]),
+            virtual_binding(&[(
+                "x",
+                Value::Concrete(ConcreteValue::String("hi".to_string())),
+            )]),
         );
         bindings.insert(
             "b".to_string(),
-            virtual_binding(&[("y", Value::String("there".to_string()))]),
+            virtual_binding(&[(
+                "y",
+                Value::Concrete(ConcreteValue::String("there".to_string())),
+            )]),
         );
 
         // List of two refs to *different* Virtual bindings. After the
         // first ref returns, the visited-set must no longer contain `a`
         // when the second ref descends into `b`.
-        let entries = Value::List(vec![
+        let entries = Value::Concrete(ConcreteValue::List(vec![
             Value::resource_ref("a".to_string(), "x".to_string(), vec![]),
             Value::resource_ref("b".to_string(), "y".to_string(), vec![]),
-        ]);
+        ]));
         let r = infer_type_from_value(&entries, &bindings, &SchemaRegistry::new());
         assert_eq!(
             r,

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use crate::binding_index::BindingIndex;
 use crate::parser::{ModuleCall, ProviderContext, TypeExpr, validate_custom_type};
 use crate::provider::ProviderFactory;
-use crate::resource::{Resource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
 /// Validate resources against their schemas.
@@ -117,7 +117,7 @@ pub fn validate_resource_ref_types<E>(
             }
 
             let (ref_binding, ref_attr) = match attr_value {
-                Value::ResourceRef { path } => {
+                Value::Deferred(DeferredValue::ResourceRef { path }) => {
                     (path.binding().to_string(), path.attribute().to_string())
                 }
                 _ => continue,
@@ -220,7 +220,7 @@ pub fn validate_attribute_param_ref_types(
         };
 
         // Only check ResourceRef values
-        let Value::ResourceRef { path } = value else {
+        let Value::Deferred(DeferredValue::ResourceRef { path }) = value else {
             continue;
         };
         let ref_binding = path.binding().to_string();
@@ -322,7 +322,7 @@ fn collect_ref_type_errors(
     use crate::parser::TypeExpr;
 
     match (type_expr, value) {
-        (_, Value::ResourceRef { path }) => {
+        (_, Value::Deferred(DeferredValue::ResourceRef { path })) => {
             let ref_binding = path.binding();
             let ref_attr = path.attribute();
 
@@ -345,17 +345,17 @@ fn collect_ref_type_errors(
                 ));
             }
         }
-        (TypeExpr::List(inner), Value::List(items)) => {
+        (TypeExpr::List(inner), Value::Concrete(ConcreteValue::List(items))) => {
             for item in items {
                 collect_ref_type_errors(inner, item, param_name, binding_map, registry, errors);
             }
         }
-        (TypeExpr::Map(inner), Value::Map(map)) => {
+        (TypeExpr::Map(inner), Value::Concrete(ConcreteValue::Map(map))) => {
             for value in map.values() {
                 collect_ref_type_errors(inner, value, param_name, binding_map, registry, errors);
             }
         }
-        (TypeExpr::Struct { fields }, Value::Map(map)) => {
+        (TypeExpr::Struct { fields }, Value::Concrete(ConcreteValue::Map(map))) => {
             for (name, field_ty) in fields {
                 if let Some(value) = map.get(name) {
                     collect_ref_type_errors(
@@ -744,7 +744,7 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     // `collect_dot_notation_refs` also runs on resource attributes: when
     // a resource in file A references `binding.attr` where `binding` is
     // declared in sibling file B, per-file parse stores it as
-    // `Value::String("binding.attr")`. `resolve_resource_refs_with_config`
+    // `Value::Concrete(ConcreteValue::String("binding.attr"))`. `resolve_resource_refs_with_config`
     // lifts those to `ResourceRef` only when the value sits at the top
     // level of an attribute; inside a list / map / interpolation the
     // string form survives, so a reference nested in
@@ -813,15 +813,15 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
 /// Recursively collect all `ResourceRef` binding names from a value tree.
 pub(crate) fn collect_resource_refs(value: &Value, refs: &mut HashSet<String>) {
     match value {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             refs.insert(path.binding().to_string());
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             for item in items {
                 collect_resource_refs(item, refs);
             }
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             for v in map.values() {
                 collect_resource_refs(v, refs);
             }
@@ -837,7 +837,9 @@ pub(crate) fn collect_resource_refs(value: &Value, refs: &mut HashSet<String>) {
 /// the first component as a potential binding name.
 pub(crate) fn collect_dot_notation_refs(value: &Value, refs: &mut HashSet<String>) {
     match value {
-        Value::String(s) if s.contains('.') && !s.contains(' ') && !s.starts_with('/') => {
+        Value::Concrete(ConcreteValue::String(s))
+            if s.contains('.') && !s.contains(' ') && !s.starts_with('/') =>
+        {
             if let Some(binding) = s.split('.').next()
                 && !binding.is_empty()
                 && binding
@@ -847,12 +849,12 @@ pub(crate) fn collect_dot_notation_refs(value: &Value, refs: &mut HashSet<String
                 refs.insert(binding.to_string());
             }
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             for item in items {
                 collect_dot_notation_refs(item, refs);
             }
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             for v in map.values() {
                 collect_dot_notation_refs(v, refs);
             }
@@ -870,15 +872,15 @@ pub fn validate_type_expr_value(
     value: &Value,
     config: &ProviderContext,
 ) -> Option<String> {
-    // `Value::Unknown` resolves at upstream apply — the concrete type
+    // `Value::Deferred(DeferredValue::Unknown)` resolves at upstream apply — the concrete type
     // is unknowable here. Same skip rule the schema validator and
     // `check_fn_arg_type` follow.
-    if matches!(value, Value::Unknown(_)) {
+    if matches!(value, Value::Deferred(DeferredValue::Unknown(_))) {
         return None;
     }
     match (type_expr, value) {
         (TypeExpr::Simple(name), _) => validate_custom_type(name, value, config).err(),
-        (TypeExpr::List(inner), Value::List(items)) => {
+        (TypeExpr::List(inner), Value::Concrete(ConcreteValue::List(items))) => {
             for (i, item) in items.iter().enumerate() {
                 if let Some(e) = validate_type_expr_value(inner, item, config) {
                     return Some(format!("Element {}: {}", i, e));
@@ -886,7 +888,7 @@ pub fn validate_type_expr_value(
             }
             None
         }
-        (TypeExpr::Struct { fields }, Value::Map(entries)) => {
+        (TypeExpr::Struct { fields }, Value::Concrete(ConcreteValue::Map(entries))) => {
             validate_struct_fields(fields, entries, config)
         }
         (TypeExpr::Struct { .. }, _) => Some(format!(
@@ -894,40 +896,48 @@ pub fn validate_type_expr_value(
             type_expr,
             crate::parser::value_type_name(value)
         )),
-        (TypeExpr::Bool, Value::String(s)) => Some(format!(
+        (TypeExpr::Bool, Value::Concrete(ConcreteValue::String(s))) => Some(format!(
             "expected {type_expr}, got string \"{s}\". Use true or false."
         )),
-        (TypeExpr::Int, Value::String(s)) => {
+        (TypeExpr::Int, Value::Concrete(ConcreteValue::String(s))) => {
             Some(format!("expected {type_expr}, got string \"{s}\"."))
         }
-        (TypeExpr::Float, Value::String(s)) => {
+        (TypeExpr::Float, Value::Concrete(ConcreteValue::String(s))) => {
             Some(format!("expected {type_expr}, got string \"{s}\"."))
         }
-        (TypeExpr::String, Value::Bool(b)) => {
+        (TypeExpr::String, Value::Concrete(ConcreteValue::Bool(b))) => {
             Some(format!("expected {type_expr}, got bool ({b})."))
         }
-        (TypeExpr::String, Value::Int(n)) => Some(format!("expected {type_expr}, got int ({n}).")),
-        (TypeExpr::String, Value::Float(f)) => {
+        (TypeExpr::String, Value::Concrete(ConcreteValue::Int(n))) => {
+            Some(format!("expected {type_expr}, got int ({n})."))
+        }
+        (TypeExpr::String, Value::Concrete(ConcreteValue::Float(f))) => {
             Some(format!("expected {type_expr}, got float ({f})."))
         }
-        (TypeExpr::Bool, Value::Int(n)) => Some(format!("expected {type_expr}, got int ({n}).")),
-        (TypeExpr::Int, Value::Bool(b)) => Some(format!("expected {type_expr}, got bool ({b}).")),
-        (TypeExpr::Float, Value::Bool(b)) => Some(format!("expected {type_expr}, got bool ({b}).")),
+        (TypeExpr::Bool, Value::Concrete(ConcreteValue::Int(n))) => {
+            Some(format!("expected {type_expr}, got int ({n})."))
+        }
+        (TypeExpr::Int, Value::Concrete(ConcreteValue::Bool(b))) => {
+            Some(format!("expected {type_expr}, got bool ({b})."))
+        }
+        (TypeExpr::Float, Value::Concrete(ConcreteValue::Bool(b))) => {
+            Some(format!("expected {type_expr}, got bool ({b})."))
+        }
         // Schema types are string subtypes — reject non-string values
-        (TypeExpr::SchemaType { .. }, Value::Bool(b)) => {
+        (TypeExpr::SchemaType { .. }, Value::Concrete(ConcreteValue::Bool(b))) => {
             Some(format!("expected {}, got bool ({}).", type_expr, b))
         }
-        (TypeExpr::SchemaType { .. }, Value::Int(n)) => {
+        (TypeExpr::SchemaType { .. }, Value::Concrete(ConcreteValue::Int(n))) => {
             Some(format!("expected {}, got int ({}).", type_expr, n))
         }
-        (TypeExpr::SchemaType { .. }, Value::Float(f)) => {
+        (TypeExpr::SchemaType { .. }, Value::Concrete(ConcreteValue::Float(f))) => {
             Some(format!("expected {}, got float ({}).", type_expr, f))
         }
         _ => None,
     }
 }
 
-/// Check shape-level problems of a `Value::Map` against a struct field
+/// Check shape-level problems of a `Value::Concrete(ConcreteValue::Map)` against a struct field
 /// list: extra keys and missing keys. Returns `None` when the key sets
 /// match. Callers then walk each field with their own type-check pass.
 pub fn struct_field_shape_errors(

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -60,7 +60,10 @@ fn used_binding_no_warning() {
     // Resource with a binding
     let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+        );
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     // Resource that references the binding
@@ -79,7 +82,10 @@ fn unused_binding_warns() {
 
     let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+        );
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     let unused = check_unused_bindings(&parsed);
@@ -91,8 +97,10 @@ fn anonymous_resource_no_warning() {
     let mut parsed = empty_parsed();
 
     // Anonymous resource (no _binding attribute)
-    let bucket = Resource::with_provider("awscc", "s3.Bucket", "my-bucket")
-        .with_attribute("bucket_name", Value::String("my-bucket".to_string()));
+    let bucket = Resource::with_provider("awscc", "s3.Bucket", "my-bucket").with_attribute(
+        "bucket_name",
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+    );
     parsed.resources.push(bucket); // allow: direct — fixture test inspection
 
     assert!(check_unused_bindings(&parsed).is_empty());
@@ -111,8 +119,12 @@ fn binding_referenced_in_nested_value() {
         "vpc_id".to_string(),
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
-    let sg = Resource::with_provider("awscc", "ec2.SecurityGroup", "web-sg")
-        .with_attribute("tags", Value::List(vec![Value::Map(map)]));
+    let sg = Resource::with_provider("awscc", "ec2.SecurityGroup", "web-sg").with_attribute(
+        "tags",
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(map),
+        )])),
+    );
     parsed.resources.push(sg); // allow: direct — fixture test inspection
 
     assert!(check_unused_bindings(&parsed).is_empty());
@@ -244,7 +256,7 @@ let route = awscc.ec2.route {
         .unwrap();
     let gateway_id = route.get_attr("gateway_id").unwrap();
     match gateway_id {
-        Value::ResourceRef { path } => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "igw_attachment");
             assert_eq!(path.attribute(), "internet_gateway_id");
         }
@@ -456,7 +468,10 @@ fn unknown_attribute_reference_reports_error() {
     // VPC resource with binding
     let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc")
         .with_binding("vpc")
-        .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()));
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+        );
 
     // Subnet references vpc.nonexistent_attr which doesn't exist on the VPC schema
     let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet").with_attribute(
@@ -640,7 +655,7 @@ fn provider_in_module_with_attributes_errors() {
         .push(crate::parser::AttributeParameter {
             name: "vpc_id".to_string(),
             type_expr: Some(TypeExpr::String),
-            value: Some(Value::String("dummy".to_string())),
+            value: Some(Value::Concrete(ConcreteValue::String("dummy".to_string()))),
         });
 
     let result = validate_no_provider_in_module(&parsed);
@@ -754,7 +769,7 @@ fn empty_arguments_in_root_ok() {
 fn validate_type_expr_value_error_uses_pascal_case() {
     let msg = validate_type_expr_value(
         &TypeExpr::String,
-        &Value::Int(42),
+        &Value::Concrete(ConcreteValue::Int(42)),
         &ProviderContext::default(),
     )
     .expect("should error");
@@ -764,11 +779,14 @@ fn validate_type_expr_value_error_uses_pascal_case() {
 #[test]
 fn validate_type_expr_struct_error_uses_pascal_case_in_field_type() {
     let mut map = indexmap::IndexMap::new();
-    map.insert("count".to_string(), Value::String("x".into()));
+    map.insert(
+        "count".to_string(),
+        Value::Concrete(ConcreteValue::String("x".into())),
+    );
     let fields = vec![("count".to_string(), TypeExpr::Int)];
     let msg = validate_type_expr_value(
         &TypeExpr::Struct { fields },
-        &Value::Map(map),
+        &Value::Concrete(ConcreteValue::Map(map)),
         &ProviderContext::default(),
     )
     .expect("should error");
@@ -782,7 +800,7 @@ fn validate_type_expr_struct_error_uses_pascal_case_in_field_type() {
 fn validate_type_expr_value_ipv4_cidr_valid() {
     let result = validate_type_expr_value(
         &TypeExpr::Simple("ipv4_cidr".to_string()),
-        &Value::String("10.0.0.0/16".to_string()),
+        &Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_none());
@@ -792,7 +810,7 @@ fn validate_type_expr_value_ipv4_cidr_valid() {
 fn validate_type_expr_value_ipv4_cidr_invalid() {
     let result = validate_type_expr_value(
         &TypeExpr::Simple("ipv4_cidr".to_string()),
-        &Value::String("not-a-cidr".to_string()),
+        &Value::Concrete(ConcreteValue::String("not-a-cidr".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -802,7 +820,7 @@ fn validate_type_expr_value_ipv4_cidr_invalid() {
 fn validate_type_expr_value_ipv4_address_valid() {
     let result = validate_type_expr_value(
         &TypeExpr::Simple("ipv4_address".to_string()),
-        &Value::String("192.168.1.1".to_string()),
+        &Value::Concrete(ConcreteValue::String("192.168.1.1".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_none());
@@ -812,7 +830,7 @@ fn validate_type_expr_value_ipv4_address_valid() {
 fn validate_type_expr_value_ipv4_address_invalid() {
     let result = validate_type_expr_value(
         &TypeExpr::Simple("ipv4_address".to_string()),
-        &Value::String("999.999.999.999".to_string()),
+        &Value::Concrete(ConcreteValue::String("999.999.999.999".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -822,7 +840,7 @@ fn validate_type_expr_value_ipv4_address_invalid() {
 fn validate_type_expr_value_ipv6_cidr_valid() {
     let result = validate_type_expr_value(
         &TypeExpr::Simple("ipv6_cidr".to_string()),
-        &Value::String("2001:db8::/32".to_string()),
+        &Value::Concrete(ConcreteValue::String("2001:db8::/32".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_none());
@@ -832,7 +850,7 @@ fn validate_type_expr_value_ipv6_cidr_valid() {
 fn validate_type_expr_value_ipv6_cidr_invalid() {
     let result = validate_type_expr_value(
         &TypeExpr::Simple("ipv6_cidr".to_string()),
-        &Value::String("not-ipv6-cidr".to_string()),
+        &Value::Concrete(ConcreteValue::String("not-ipv6-cidr".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -842,7 +860,7 @@ fn validate_type_expr_value_ipv6_cidr_invalid() {
 fn validate_type_expr_value_ipv6_address_valid() {
     let result = validate_type_expr_value(
         &TypeExpr::Simple("ipv6_address".to_string()),
-        &Value::String("2001:db8::1".to_string()),
+        &Value::Concrete(ConcreteValue::String("2001:db8::1".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_none());
@@ -852,7 +870,7 @@ fn validate_type_expr_value_ipv6_address_valid() {
 fn validate_type_expr_value_ipv6_address_invalid() {
     let result = validate_type_expr_value(
         &TypeExpr::Simple("ipv6_address".to_string()),
-        &Value::String("zzz::zzz".to_string()),
+        &Value::Concrete(ConcreteValue::String("zzz::zzz".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -862,7 +880,7 @@ fn validate_type_expr_value_ipv6_address_invalid() {
 fn validate_type_expr_value_bool_mismatch() {
     let result = validate_type_expr_value(
         &TypeExpr::Bool,
-        &Value::String("yes".to_string()),
+        &Value::Concrete(ConcreteValue::String("yes".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -873,7 +891,7 @@ fn validate_type_expr_value_bool_mismatch() {
 fn validate_type_expr_value_int_mismatch() {
     let result = validate_type_expr_value(
         &TypeExpr::Int,
-        &Value::String("42".to_string()),
+        &Value::Concrete(ConcreteValue::String("42".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -884,7 +902,7 @@ fn validate_type_expr_value_int_mismatch() {
 fn validate_type_expr_value_float_mismatch() {
     let result = validate_type_expr_value(
         &TypeExpr::Float,
-        &Value::String("3.14".to_string()),
+        &Value::Concrete(ConcreteValue::String("3.14".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -894,12 +912,12 @@ fn validate_type_expr_value_float_mismatch() {
 #[test]
 fn validate_type_expr_value_list_of_ipv4_address() {
     let items = vec![
-        Value::String("192.168.1.1".to_string()),
-        Value::String("999.0.0.1".to_string()),
+        Value::Concrete(ConcreteValue::String("192.168.1.1".to_string())),
+        Value::Concrete(ConcreteValue::String("999.0.0.1".to_string())),
     ];
     let result = validate_type_expr_value(
         &TypeExpr::List(Box::new(TypeExpr::Simple("ipv4_address".to_string()))),
-        &Value::List(items),
+        &Value::Concrete(ConcreteValue::List(items)),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -910,7 +928,7 @@ fn validate_type_expr_value_list_of_ipv4_address() {
 fn validate_type_expr_value_string_type_accepts_string() {
     let result = validate_type_expr_value(
         &TypeExpr::String,
-        &Value::String("hello".to_string()),
+        &Value::Concrete(ConcreteValue::String("hello".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_none());
@@ -920,7 +938,7 @@ fn validate_type_expr_value_string_type_accepts_string() {
 fn validate_type_expr_value_string_got_bool() {
     let result = validate_type_expr_value(
         &TypeExpr::String,
-        &Value::Bool(true),
+        &Value::Concrete(ConcreteValue::Bool(true)),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -931,7 +949,7 @@ fn validate_type_expr_value_string_got_bool() {
 fn validate_type_expr_value_string_got_int() {
     let result = validate_type_expr_value(
         &TypeExpr::String,
-        &Value::Int(42),
+        &Value::Concrete(ConcreteValue::Int(42)),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -942,7 +960,7 @@ fn validate_type_expr_value_string_got_int() {
 fn validate_type_expr_value_string_got_float() {
     let result = validate_type_expr_value(
         &TypeExpr::String,
-        &Value::Float(1.5),
+        &Value::Concrete(ConcreteValue::Float(1.5)),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -951,8 +969,11 @@ fn validate_type_expr_value_string_got_float() {
 
 #[test]
 fn validate_type_expr_value_bool_got_int() {
-    let result =
-        validate_type_expr_value(&TypeExpr::Bool, &Value::Int(1), &ProviderContext::default());
+    let result = validate_type_expr_value(
+        &TypeExpr::Bool,
+        &Value::Concrete(ConcreteValue::Int(1)),
+        &ProviderContext::default(),
+    );
     assert!(result.is_some());
     assert!(result.unwrap().contains("expected Bool, got int"));
 }
@@ -961,7 +982,7 @@ fn validate_type_expr_value_bool_got_int() {
 fn validate_type_expr_value_int_got_bool() {
     let result = validate_type_expr_value(
         &TypeExpr::Int,
-        &Value::Bool(true),
+        &Value::Concrete(ConcreteValue::Bool(true)),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -972,7 +993,7 @@ fn validate_type_expr_value_int_got_bool() {
 fn validate_type_expr_value_float_got_bool() {
     let result = validate_type_expr_value(
         &TypeExpr::Float,
-        &Value::Bool(false),
+        &Value::Concrete(ConcreteValue::Bool(false)),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -988,7 +1009,7 @@ fn validate_type_expr_value_schema_type_accepts_string() {
     };
     let result = validate_type_expr_value(
         &schema_type,
-        &Value::String("vpc-12345678".to_string()),
+        &Value::Concrete(ConcreteValue::String("vpc-12345678".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_none());
@@ -1003,7 +1024,7 @@ fn validate_type_expr_value_schema_type_rejects_bool() {
     };
     let result = validate_type_expr_value(
         &schema_type,
-        &Value::Bool(true),
+        &Value::Concrete(ConcreteValue::Bool(true)),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -1017,8 +1038,11 @@ fn validate_type_expr_value_schema_type_rejects_int() {
         path: "ec2".to_string(),
         type_name: "VpcId".to_string(),
     };
-    let result =
-        validate_type_expr_value(&schema_type, &Value::Int(42), &ProviderContext::default());
+    let result = validate_type_expr_value(
+        &schema_type,
+        &Value::Concrete(ConcreteValue::Int(42)),
+        &ProviderContext::default(),
+    );
     assert!(result.is_some());
     assert!(result.unwrap().contains("expected awscc.ec2.VpcId"));
 }
@@ -1040,7 +1064,7 @@ fn validate_type_expr_custom_type_rejects_invalid() {
 
     let result = validate_type_expr_value(
         &TypeExpr::Simple("iam_policy_arn".to_string()),
-        &Value::String("aaaa".to_string()),
+        &Value::Concrete(ConcreteValue::String("aaaa".to_string())),
         &config,
     );
     assert!(result.is_some(), "Expected validation error for 'aaaa'");
@@ -1048,7 +1072,9 @@ fn validate_type_expr_custom_type_rejects_invalid() {
 
     let result = validate_type_expr_value(
         &TypeExpr::Simple("iam_policy_arn".to_string()),
-        &Value::String("arn:aws:iam::123456789012:policy/MyPolicy".to_string()),
+        &Value::Concrete(ConcreteValue::String(
+            "arn:aws:iam::123456789012:policy/MyPolicy".to_string(),
+        )),
         &config,
     );
     assert!(result.is_none(), "Expected no error for valid ARN");
@@ -1060,7 +1086,9 @@ fn validate_type_expr_list_custom_type_rejects_invalid() {
 
     let result = validate_type_expr_value(
         &TypeExpr::List(Box::new(TypeExpr::Simple("iam_policy_arn".to_string()))),
-        &Value::List(vec![Value::String("aaaa".to_string())]),
+        &Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("aaaa".to_string()),
+        )])),
         &config,
     );
     assert!(
@@ -1082,11 +1110,14 @@ fn struct_type_name_value() -> TypeExpr {
 #[test]
 fn validate_type_expr_struct_accepts_well_formed_map() {
     let mut map = IndexMap::new();
-    map.insert("name".to_string(), Value::String("x".to_string()));
-    map.insert("value".to_string(), Value::Int(1));
+    map.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
+    );
+    map.insert("value".to_string(), Value::Concrete(ConcreteValue::Int(1)));
     let result = validate_type_expr_value(
         &struct_type_name_value(),
-        &Value::Map(map),
+        &Value::Concrete(ConcreteValue::Map(map)),
         &ProviderContext::default(),
     );
     assert!(result.is_none(), "got error: {:?}", result);
@@ -1095,10 +1126,13 @@ fn validate_type_expr_struct_accepts_well_formed_map() {
 #[test]
 fn validate_type_expr_struct_rejects_missing_field() {
     let mut map = IndexMap::new();
-    map.insert("name".to_string(), Value::String("x".to_string()));
+    map.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
+    );
     let result = validate_type_expr_value(
         &struct_type_name_value(),
-        &Value::Map(map),
+        &Value::Concrete(ConcreteValue::Map(map)),
         &ProviderContext::default(),
     );
     assert_eq!(
@@ -1110,12 +1144,18 @@ fn validate_type_expr_struct_rejects_missing_field() {
 #[test]
 fn validate_type_expr_struct_rejects_unknown_field() {
     let mut map = IndexMap::new();
-    map.insert("name".to_string(), Value::String("x".to_string()));
-    map.insert("value".to_string(), Value::Int(1));
-    map.insert("extra".to_string(), Value::String("y".to_string()));
+    map.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
+    );
+    map.insert("value".to_string(), Value::Concrete(ConcreteValue::Int(1)));
+    map.insert(
+        "extra".to_string(),
+        Value::Concrete(ConcreteValue::String("y".to_string())),
+    );
     let result = validate_type_expr_value(
         &struct_type_name_value(),
-        &Value::Map(map),
+        &Value::Concrete(ConcreteValue::Map(map)),
         &ProviderContext::default(),
     );
     assert_eq!(
@@ -1127,11 +1167,17 @@ fn validate_type_expr_struct_rejects_unknown_field() {
 #[test]
 fn validate_type_expr_struct_rejects_wrong_field_type() {
     let mut map = IndexMap::new();
-    map.insert("name".to_string(), Value::String("x".to_string()));
-    map.insert("value".to_string(), Value::String("not-an-int".to_string()));
+    map.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
+    );
+    map.insert(
+        "value".to_string(),
+        Value::Concrete(ConcreteValue::String("not-an-int".to_string())),
+    );
     let result = validate_type_expr_value(
         &struct_type_name_value(),
-        &Value::Map(map),
+        &Value::Concrete(ConcreteValue::Map(map)),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -1143,7 +1189,7 @@ fn validate_type_expr_struct_rejects_wrong_field_type() {
 fn validate_type_expr_struct_rejects_non_map_value() {
     let result = validate_type_expr_value(
         &struct_type_name_value(),
-        &Value::String("oops".to_string()),
+        &Value::Concrete(ConcreteValue::String("oops".to_string())),
         &ProviderContext::default(),
     );
     assert!(result.is_some());
@@ -1157,10 +1203,22 @@ fn struct_field_shape_errors_is_deterministic_for_multiple_unknowns() {
     // hash seed.
     let fields: Vec<(String, TypeExpr)> = vec![("a".to_string(), TypeExpr::String)];
     let mut entries: IndexMap<String, Value> = IndexMap::new();
-    entries.insert("a".to_string(), Value::String("ok".into()));
-    entries.insert("z_extra".to_string(), Value::String("x".into()));
-    entries.insert("b_extra".to_string(), Value::String("y".into()));
-    entries.insert("m_extra".to_string(), Value::String("z".into()));
+    entries.insert(
+        "a".to_string(),
+        Value::Concrete(ConcreteValue::String("ok".into())),
+    );
+    entries.insert(
+        "z_extra".to_string(),
+        Value::Concrete(ConcreteValue::String("x".into())),
+    );
+    entries.insert(
+        "b_extra".to_string(),
+        Value::Concrete(ConcreteValue::String("y".into())),
+    );
+    entries.insert(
+        "m_extra".to_string(),
+        Value::Concrete(ConcreteValue::String("z".into())),
+    );
 
     let first = struct_field_shape_errors(&fields, &entries);
     for _ in 0..20 {
@@ -1438,7 +1496,9 @@ fn validate_module_calls_rejects_custom_type() {
     let mut args = HashMap::new();
     args.insert(
         "managed_policy_arns".to_string(),
-        Value::List(vec![Value::String("aaaa".to_string())]),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("aaaa".to_string()),
+        )])),
     );
 
     let module_calls = vec![ModuleCall {
@@ -1472,10 +1532,15 @@ fn attribute_param_ref_type_mismatch_detected() {
     // Build a resource with schema: role_name is String, arn is IamRoleArn (Custom)
     let role = Resource::with_provider("awscc", "iam.role", "github-role")
         .with_binding("role")
-        .with_attribute("role_name", Value::String("my-role".to_string()))
+        .with_attribute(
+            "role_name",
+            Value::Concrete(ConcreteValue::String("my-role".to_string())),
+        )
         .with_attribute(
             "arn",
-            Value::String("arn:aws:iam::123456789012:role/my-role".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "arn:aws:iam::123456789012:role/my-role".to_string(),
+            )),
         );
 
     let mut role_schema = ResourceSchema::new("iam.role");
@@ -1544,7 +1609,9 @@ fn validate_export_params_rejects_invalid_custom_type() {
     let exports = vec![InferredExportParam {
         name: "policy".to_string(),
         type_expr: TypeExpr::Simple("iam_policy_arn".to_string()),
-        value: Some(Value::String("not-an-arn".to_string())),
+        value: Some(Value::Concrete(ConcreteValue::String(
+            "not-an-arn".to_string(),
+        ))),
     }];
     let result = validate_export_params(&exports, &config);
     assert!(result.is_err());
@@ -1561,10 +1628,12 @@ fn validate_export_params_rejects_invalid_list_element() {
     let exports = vec![InferredExportParam {
         name: "policies".to_string(),
         type_expr: TypeExpr::List(Box::new(TypeExpr::Simple("iam_policy_arn".to_string()))),
-        value: Some(Value::List(vec![
-            Value::String("arn:aws:iam::123456789012:policy/valid".to_string()),
-            Value::String("garbage".to_string()),
-        ])),
+        value: Some(Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String(
+                "arn:aws:iam::123456789012:policy/valid".to_string(),
+            )),
+            Value::Concrete(ConcreteValue::String("garbage".to_string())),
+        ]))),
     }];
     let result = validate_export_params(&exports, &config);
     assert!(result.is_err());
@@ -1581,9 +1650,9 @@ fn validate_export_params_accepts_valid_values() {
     let exports = vec![InferredExportParam {
         name: "policy".to_string(),
         type_expr: TypeExpr::Simple("iam_policy_arn".to_string()),
-        value: Some(Value::String(
+        value: Some(Value::Concrete(ConcreteValue::String(
             "arn:aws:iam::123456789012:policy/admin".to_string(),
-        )),
+        ))),
     }];
     let result = validate_export_params(&exports, &config);
     assert!(result.is_ok());
@@ -1600,7 +1669,9 @@ fn validate_export_params_skips_unknown_sentinel() {
     let exports = vec![InferredExportParam {
         name: "raw".to_string(),
         type_expr: TypeExpr::Unknown,
-        value: Some(Value::String("anything".to_string())),
+        value: Some(Value::Concrete(ConcreteValue::String(
+            "anything".to_string(),
+        ))),
     }];
     let result = validate_export_params(&exports, &config);
     assert!(result.is_ok());
@@ -1614,7 +1685,9 @@ fn validate_export_params_rejects_type_mismatch() {
     let exports = vec![InferredExportParam {
         name: "flag".to_string(),
         type_expr: TypeExpr::Bool,
-        value: Some(Value::String("not-a-bool".to_string())),
+        value: Some(Value::Concrete(ConcreteValue::String(
+            "not-a-bool".to_string(),
+        ))),
     }];
     let result = validate_export_params(&exports, &config);
     assert!(result.is_err());
@@ -1907,7 +1980,10 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
 
     let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
         .with_binding("registry_prod")
-        .with_attribute("account_id", Value::String("111".to_string()));
+        .with_attribute(
+            "account_id",
+            Value::Concrete(ConcreteValue::String("111".to_string())),
+        );
 
     let mut map_value = IndexMap::new();
     map_value.insert(
@@ -1923,7 +1999,7 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
         name: "accounts".to_string(),
         // declared as map(string), and values are String-typed — should pass
         type_expr: TypeExpr::Map(Box::new(TypeExpr::String)),
-        value: Some(Value::Map(map_value)),
+        value: Some(Value::Concrete(ConcreteValue::Map(map_value))),
     }];
 
     let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
@@ -1949,7 +2025,10 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
 
     let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
         .with_binding("registry_prod")
-        .with_attribute("account_id", Value::String("111".to_string()));
+        .with_attribute(
+            "account_id",
+            Value::Concrete(ConcreteValue::String("111".to_string())),
+        );
 
     let mut map_value = IndexMap::new();
     map_value.insert(
@@ -1965,7 +2044,7 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
         name: "accounts".to_string(),
         // declared as map(bool) — values should be rejected as they are strings
         type_expr: TypeExpr::Map(Box::new(TypeExpr::Bool)),
-        value: Some(Value::Map(map_value)),
+        value: Some(Value::Concrete(ConcreteValue::Map(map_value))),
     }];
 
     let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
@@ -1990,7 +2069,9 @@ fn validate_export_param_ref_types_skips_unknown_sentinel() {
     let exports = vec![InferredExportParam {
         name: "zone_id".to_string(),
         type_expr: TypeExpr::Unknown,
-        value: Some(Value::String("ignored".to_string())),
+        value: Some(Value::Concrete(ConcreteValue::String(
+            "ignored".to_string(),
+        ))),
     }];
 
     let result = validate_export_param_ref_types(&exports, &[], &SchemaRegistry::new());
@@ -2010,7 +2091,10 @@ fn validate_export_param_ref_types_against_inferred_inputs() {
     // signature.
     let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
         .with_binding("registry_prod")
-        .with_attribute("account_id", Value::String("111".to_string()));
+        .with_attribute(
+            "account_id",
+            Value::Concrete(ConcreteValue::String("111".to_string())),
+        );
 
     let mut schemas = SchemaRegistry::new();
     schemas.insert(
@@ -2036,7 +2120,7 @@ fn validate_export_param_ref_types_against_inferred_inputs() {
     assert!(result.is_ok(), "got {:?}", result);
 }
 
-/// Issue #2954 acceptance. A `Value::ResourceRef` whose receiver is a
+/// Issue #2954 acceptance. A `Value::Deferred(DeferredValue::ResourceRef)` whose receiver is a
 /// `List<String>` attribute (e.g. `resource_records = registry_dev.nameservers`
 /// against `aws.route53.RecordSet.resource_records: List<String>`) must
 /// not be rejected by `validate_resources`. Pre-Phase-2 the schema-level
@@ -2085,7 +2169,7 @@ fn validate_resources_accepts_resource_ref_in_list_position() {
 
 /// Sibling of `..._in_list_position`: same invariant for a struct
 /// **field** position. `collect_struct` previously skipped
-/// `Value::ResourceRef` per-field with an explicit `matches!` guard;
+/// `Value::Deferred(DeferredValue::ResourceRef)` per-field with an explicit `matches!` guard;
 /// Phase 2 (RFC #2972) removed it because `collect_into` now projects
 /// each field through `as_concrete()` and short-circuits on `None`.
 /// This test pins the resulting behavior end-to-end.
@@ -2115,7 +2199,7 @@ fn validate_resources_accepts_resource_ref_in_struct_field_position() {
     );
 
     let holder = Resource::with_provider("aws", "test.StructHolder", "h")
-        .with_attribute("config", Value::Map(config));
+        .with_attribute("config", Value::Concrete(ConcreteValue::Map(config)));
 
     let mut known = HashSet::new();
     known.insert("aws".to_string());
@@ -2430,14 +2514,14 @@ fn read_against_managed_only_type_is_rejected() {
 
 #[test]
 fn validate_type_expr_value_skips_value_unknown() {
-    // RFC #2371 stage 3: a `Value::Unknown` reaching this validator
+    // RFC #2371 stage 3: a `Value::Deferred(DeferredValue::Unknown)` reaching this validator
     // (e.g. from a deferred-for body where a typed module-call argument
     // is bound to the loop var) must short-circuit rather than emit
     // `expected <type>, got unknown`.
-    use crate::resource::{UnknownReason, Value};
+    use crate::resource::{DeferredValue, UnknownReason, Value};
     use crate::validation::TypeExpr;
 
-    let unknown = Value::Unknown(UnknownReason::ForValue);
+    let unknown = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue));
     let cfg = ProviderContext::default();
 
     assert!(super::validate_type_expr_value(&TypeExpr::String, &unknown, &cfg).is_none());
@@ -2449,9 +2533,9 @@ fn validate_type_expr_value_skips_value_unknown() {
     };
     assert!(super::validate_type_expr_value(&struct_ty, &unknown, &cfg).is_none());
 
-    let upstream = Value::Unknown(UnknownReason::UpstreamRef {
+    let upstream = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
         path: crate::resource::AccessPath::with_fields("net", "vpc", vec!["vpc_id".into()]),
-    });
+    }));
     assert!(super::validate_type_expr_value(&TypeExpr::String, &upstream, &cfg).is_none());
     assert!(super::validate_type_expr_value(&struct_ty, &upstream, &cfg).is_none());
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -6,7 +6,7 @@ use argon2::Argon2;
 use indexmap::IndexMap;
 use thiserror::Error;
 
-use crate::resource::{InterpolationPart, UnknownReason, Value};
+use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value};
 use crate::schema::AttributeType;
 use crate::utils::{convert_enum_value, is_dsl_enum_format};
 
@@ -53,7 +53,7 @@ impl std::fmt::Display for SerializationContext {
 /// message string.
 #[derive(Debug, Error)]
 pub enum SerializationError {
-    /// A `Value::Unknown` reached a serialization boundary. Producers
+    /// A `Value::Deferred(DeferredValue::Unknown)` reached a serialization boundary. Producers
     /// must strip / resolve it before this point — see
     /// `PlanPreprocessor::strip_unknown_attributes` for the WASM
     /// boundary stripping pass.
@@ -69,7 +69,7 @@ pub enum SerializationError {
         value: f64,
         context: SerializationContext,
     },
-    /// A `Value::ResourceRef` reached a serialization boundary that
+    /// A `Value::Deferred(DeferredValue::ResourceRef)` reached a serialization boundary that
     /// expected a concrete value. Resolvers must substitute the
     /// reference before this point. Reaching this arm at apply-time
     /// state writeback or plan-file write is a resolver bug.
@@ -85,13 +85,13 @@ pub enum SerializationError {
         path: String,
         context: SerializationContext,
     },
-    /// A `Value::Interpolation` reached a serialization boundary. The
+    /// A `Value::Deferred(DeferredValue::Interpolation)` reached a serialization boundary. The
     /// canonicalize pass should collapse interpolations to a `String`
     /// once all parts resolve; reaching this arm means a part stayed
     /// unresolved through apply-time export resolution.
     #[error("cannot serialize at {context}: unresolved interpolation")]
     UnresolvedInterpolation { context: SerializationContext },
-    /// A `Value::FunctionCall` reached a serialization boundary. The
+    /// A `Value::Deferred(DeferredValue::FunctionCall)` reached a serialization boundary. The
     /// resolver should evaluate the function (built-in or user-defined)
     /// before this point; reaching this arm is a resolver bug.
     #[error("cannot serialize at {context}: unresolved function call {name}(...)")]
@@ -198,7 +198,7 @@ pub(crate) fn argon2id_hash(input: &[u8], context: Option<&SecretHashContext>) -
 /// Returns an error if `value` contains a non-finite float (NaN or infinity)
 /// because JSON cannot represent these values.
 ///
-/// For `Value::Secret`, uses the fallback salt. Use `value_to_json_with_context`
+/// For `Value::Deferred(DeferredValue::Secret)`, uses the fallback salt. Use `value_to_json_with_context`
 /// to provide resource context for deterministic context-specific salt.
 pub fn value_to_json(value: &Value) -> Result<serde_json::Value, SerializationError> {
     value_to_json_with_context(value, None)
@@ -206,7 +206,7 @@ pub fn value_to_json(value: &Value) -> Result<serde_json::Value, SerializationEr
 
 /// Convert `Value` to `serde_json::Value` with optional secret hash context.
 ///
-/// When `context` is provided and the value contains `Value::Secret`, the hash
+/// When `context` is provided and the value contains `Value::Deferred(DeferredValue::Secret)`, the hash
 /// uses a deterministic salt derived from the resource context. This ensures
 /// that the same password on different resources produces different hashes.
 pub fn value_to_json_with_context(
@@ -215,10 +215,12 @@ pub fn value_to_json_with_context(
 ) -> Result<serde_json::Value, SerializationError> {
     let ctx = SerializationContext::ValueToJson;
     match value {
-        Value::String(s) => Ok(serde_json::Value::String(s.clone())),
-        Value::Int(n) => Ok(serde_json::Value::Number((*n).into())),
-        Value::Duration(d) => Ok(serde_json::Value::Number((d.as_secs() as i64).into())),
-        Value::Float(f) => {
+        Value::Concrete(ConcreteValue::String(s)) => Ok(serde_json::Value::String(s.clone())),
+        Value::Concrete(ConcreteValue::Int(n)) => Ok(serde_json::Value::Number((*n).into())),
+        Value::Concrete(ConcreteValue::Duration(d)) => {
+            Ok(serde_json::Value::Number((d.as_secs() as i64).into()))
+        }
+        Value::Concrete(ConcreteValue::Float(f)) => {
             let num =
                 serde_json::Number::from_f64(*f).ok_or(SerializationError::NonFiniteFloat {
                     value: *f,
@@ -226,48 +228,54 @@ pub fn value_to_json_with_context(
                 })?;
             Ok(serde_json::Value::Number(num))
         }
-        Value::Bool(b) => Ok(serde_json::Value::Bool(*b)),
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::Bool(b)) => Ok(serde_json::Value::Bool(*b)),
+        Value::Concrete(ConcreteValue::List(items)) => {
             let arr: Result<Vec<_>, _> = items
                 .iter()
                 .map(|item| value_to_json_with_context(item, context))
                 .collect();
             Ok(serde_json::Value::Array(arr?))
         }
-        Value::StringList(items) => Ok(serde_json::Value::Array(
+        Value::Concrete(ConcreteValue::StringList(items)) => Ok(serde_json::Value::Array(
             items
                 .iter()
                 .map(|s| serde_json::Value::String(s.clone()))
                 .collect(),
         )),
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let obj: Result<serde_json::Map<_, _>, _> = map
                 .iter()
                 .map(|(k, v)| value_to_json_with_context(v, context).map(|jv| (k.clone(), jv)))
                 .collect();
             Ok(serde_json::Value::Object(obj?))
         }
-        Value::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
-            path: path.to_dot_string(),
-            context: ctx,
-        }),
-        Value::BindingRef { binding } => Err(SerializationError::UnresolvedResourceRef {
-            // A bare-binding reference is by construction never a
-            // resolved value — it must be substituted by the resolver
-            // pass before reaching any serialization boundary. Report
-            // through the same channel as `ResourceRef` so the same
-            // diagnostic path covers both producer kinds.
-            path: binding.clone(),
-            context: ctx,
-        }),
-        Value::Interpolation(_) => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            Err(SerializationError::UnresolvedResourceRef {
+                path: path.to_dot_string(),
+                context: ctx,
+            })
+        }
+        Value::Deferred(DeferredValue::BindingRef { binding }) => {
+            Err(SerializationError::UnresolvedResourceRef {
+                // A bare-binding reference is by construction never a
+                // resolved value — it must be substituted by the resolver
+                // pass before reaching any serialization boundary. Report
+                // through the same channel as `ResourceRef` so the same
+                // diagnostic path covers both producer kinds.
+                path: binding.clone(),
+                context: ctx,
+            })
+        }
+        Value::Deferred(DeferredValue::Interpolation(_)) => {
             Err(SerializationError::UnresolvedInterpolation { context: ctx })
         }
-        Value::FunctionCall { name, .. } => Err(SerializationError::UnresolvedFunctionCall {
-            name: name.clone(),
-            context: ctx,
-        }),
-        Value::Secret(inner) => {
+        Value::Deferred(DeferredValue::FunctionCall { name, .. }) => {
+            Err(SerializationError::UnresolvedFunctionCall {
+                name: name.clone(),
+                context: ctx,
+            })
+        }
+        Value::Deferred(DeferredValue::Secret(inner)) => {
             let inner_json = value_to_json_with_context(inner, context)?;
             // `serde_json::Value -> String` only fails on a custom
             // `Serialize` impl or invalid map keys, neither of which a
@@ -279,10 +287,12 @@ pub fn value_to_json_with_context(
                 "{SECRET_PREFIX}{hash_hex}",
             )))
         }
-        Value::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {
-            reason: reason.clone(),
-            context: ctx,
-        }),
+        Value::Deferred(DeferredValue::Unknown(reason)) => {
+            Err(SerializationError::UnknownNotAllowed {
+                reason: reason.clone(),
+                context: ctx,
+            })
+        }
     }
 }
 
@@ -293,24 +303,26 @@ pub fn value_to_json_with_context(
 /// entries when building attribute maps.
 pub fn json_to_dsl_value(json: &serde_json::Value) -> Option<Value> {
     match json {
-        serde_json::Value::String(s) => Some(Value::String(s.clone())),
+        serde_json::Value::String(s) => Some(Value::Concrete(ConcreteValue::String(s.clone()))),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Some(Value::Int(i))
+                Some(Value::Concrete(ConcreteValue::Int(i)))
             } else {
-                Some(Value::Float(n.as_f64().unwrap_or(0.0)))
+                Some(Value::Concrete(ConcreteValue::Float(
+                    n.as_f64().unwrap_or(0.0),
+                )))
             }
         }
-        serde_json::Value::Bool(b) => Some(Value::Bool(*b)),
-        serde_json::Value::Array(items) => Some(Value::List(
+        serde_json::Value::Bool(b) => Some(Value::Concrete(ConcreteValue::Bool(*b))),
+        serde_json::Value::Array(items) => Some(Value::Concrete(ConcreteValue::List(
             items.iter().filter_map(json_to_dsl_value).collect(),
-        )),
+        ))),
         serde_json::Value::Object(map) => {
             let m: IndexMap<_, _> = map
                 .iter()
                 .filter_map(|(k, v)| json_to_dsl_value(v).map(|val| (k.clone(), val)))
                 .collect();
-            Some(Value::Map(m))
+            Some(Value::Concrete(ConcreteValue::Map(m)))
         }
         serde_json::Value::Null => None,
     }
@@ -401,7 +413,7 @@ impl FormatSink for WidthCounter {
 ///
 /// Picks the largest unit that divides the duration cleanly:
 /// `3600s` → `1h`, `60s` → `1min`, anything else → `Ns`. The original
-/// authoring unit is not preserved (`Value::Duration` carries only a
+/// authoring unit is not preserved (`Value::Concrete(ConcreteValue::Duration)` carries only a
 /// `std::time::Duration`), so this is a deterministic re-rendering
 /// rule — not a faithful round-trip.
 ///
@@ -434,7 +446,7 @@ pub(crate) fn format_value_into<S: FormatSink>(
     sink: &mut S,
 ) -> Result<(), Overflow> {
     match value {
-        Value::String(s) => {
+        Value::Concrete(ConcreteValue::String(s)) => {
             // Secret hash strings should display as "(secret)" to avoid
             // leaking internal hash representation in plan output.
             if s.starts_with(SECRET_PREFIX) {
@@ -452,9 +464,9 @@ pub(crate) fn format_value_into<S: FormatSink>(
             sink.write_str(s)?;
             sink.write_str("\"")
         }
-        Value::Int(n) => sink.write_str(&n.to_string()),
-        Value::Duration(d) => sink.write_str(&render_duration(*d)),
-        Value::Float(f) => {
+        Value::Concrete(ConcreteValue::Int(n)) => sink.write_str(&n.to_string()),
+        Value::Concrete(ConcreteValue::Duration(d)) => sink.write_str(&render_duration(*d)),
+        Value::Concrete(ConcreteValue::Float(f)) => {
             let s = f.to_string();
             sink.write_str(&s)?;
             if !s.contains('.') {
@@ -462,8 +474,10 @@ pub(crate) fn format_value_into<S: FormatSink>(
             }
             Ok(())
         }
-        Value::Bool(b) => sink.write_str(if *b { "true" } else { "false" }),
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::Bool(b)) => {
+            sink.write_str(if *b { "true" } else { "false" })
+        }
+        Value::Concrete(ConcreteValue::List(items)) => {
             sink.write_str("[")?;
             for (i, item) in items.iter().enumerate() {
                 if i > 0 {
@@ -473,10 +487,10 @@ pub(crate) fn format_value_into<S: FormatSink>(
             }
             sink.write_str("]")
         }
-        Value::StringList(items) => {
+        Value::Concrete(ConcreteValue::StringList(items)) => {
             // Canonicalised string-or-list-of-strings shape (#2510).
-            // Renders with the same `[ "a", "b" ]` form as `Value::List`
-            // of `Value::String` so plan output stays uniform.
+            // Renders with the same `[ "a", "b" ]` form as `Value::Concrete(ConcreteValue::List)`
+            // of `Value::Concrete(ConcreteValue::String)` so plan output stays uniform.
             sink.write_str("[")?;
             for (i, item) in items.iter().enumerate() {
                 if i > 0 {
@@ -488,7 +502,7 @@ pub(crate) fn format_value_into<S: FormatSink>(
             }
             sink.write_str("]")
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut keys: Vec<_> = map.keys().collect();
             keys.sort();
             sink.write_str("{")?;
@@ -502,9 +516,11 @@ pub(crate) fn format_value_into<S: FormatSink>(
             }
             sink.write_str("}")
         }
-        Value::ResourceRef { path } => sink.write_str(&path.to_dot_string()),
-        Value::BindingRef { binding } => sink.write_str(binding),
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            sink.write_str(&path.to_dot_string())
+        }
+        Value::Deferred(DeferredValue::BindingRef { binding }) => sink.write_str(binding),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             sink.write_str("\"")?;
             for part in parts {
                 match part {
@@ -518,7 +534,7 @@ pub(crate) fn format_value_into<S: FormatSink>(
             }
             sink.write_str("\"")
         }
-        Value::FunctionCall { name, args } => {
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
             sink.write_str(name)?;
             sink.write_str("(")?;
             for (i, arg) in args.iter().enumerate() {
@@ -529,17 +545,17 @@ pub(crate) fn format_value_into<S: FormatSink>(
             }
             sink.write_str(")")
         }
-        Value::Secret(_) => sink.write_str("(secret)"),
-        Value::Unknown(reason) => sink.write_str(&render_unknown(reason)),
+        Value::Deferred(DeferredValue::Secret(_)) => sink.write_str("(secret)"),
+        Value::Deferred(DeferredValue::Unknown(reason)) => sink.write_str(&render_unknown(reason)),
     }
 }
 
 /// Check if a Value contains any Secret values at any nesting depth.
 pub fn contains_secret(value: &Value) -> bool {
     match value {
-        Value::Secret(_) => true,
-        Value::Map(map) => map.values().any(contains_secret),
-        Value::List(items) => items.iter().any(contains_secret),
+        Value::Deferred(DeferredValue::Secret(_)) => true,
+        Value::Concrete(ConcreteValue::Map(map)) => map.values().any(contains_secret),
+        Value::Concrete(ConcreteValue::List(items)) => items.iter().any(contains_secret),
         _ => false,
     }
 }
@@ -565,8 +581,8 @@ pub fn merge_secrets_into_provider_json(
     context: Option<&SecretHashContext>,
 ) -> Result<serde_json::Value, SerializationError> {
     match desired {
-        Value::Secret(_) => value_to_json_with_context(desired, context),
-        Value::Map(desired_map) => {
+        Value::Deferred(DeferredValue::Secret(_)) => value_to_json_with_context(desired, context),
+        Value::Concrete(ConcreteValue::Map(desired_map)) => {
             if let serde_json::Value::Object(provider_obj) = provider_json {
                 let mut merged = provider_obj.clone();
                 for (k, desired_val) in desired_map {
@@ -595,7 +611,7 @@ pub fn merge_secrets_into_provider_json(
                 value_to_json_with_context(desired, context)
             }
         }
-        Value::List(desired_items) => {
+        Value::Concrete(ConcreteValue::List(desired_items)) => {
             if let serde_json::Value::Array(provider_arr) = provider_json {
                 let mut merged = Vec::with_capacity(provider_arr.len());
                 for (i, provider_elem) in provider_arr.iter().enumerate() {
@@ -622,7 +638,7 @@ pub fn merge_secrets_into_provider_json(
     }
 }
 
-/// Recursively replace all `Value::Secret(inner)` with `Value::String(hash)`.
+/// Recursively replace all `Value::Deferred(DeferredValue::Secret(inner))` with `Value::Concrete(ConcreteValue::String(hash))`.
 ///
 /// This ensures that when a `Value` tree is serialized (e.g., via serde), no
 /// secret plaintext is ever written. The hash uses Argon2id with the fallback
@@ -630,28 +646,32 @@ pub fn merge_secrets_into_provider_json(
 /// the goal is redaction, not state comparison.
 pub fn redact_secrets_in_value(value: &Value) -> Result<Value, SerializationError> {
     match value {
-        Value::Secret(inner) => {
+        Value::Deferred(DeferredValue::Secret(inner)) => {
             let inner_json = value_to_json(inner)?;
             let json_str = serde_json::to_string(&inner_json)
                 .expect("serde_json::Value -> String is infallible");
             let hash_hex = argon2id_hash(json_str.as_bytes(), None);
-            Ok(Value::String(format!("{SECRET_PREFIX}{hash_hex}")))
+            Ok(Value::Concrete(ConcreteValue::String(format!(
+                "{SECRET_PREFIX}{hash_hex}"
+            ))))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let redacted: Result<IndexMap<String, Value>, _> = map
                 .iter()
                 .map(|(k, v)| redact_secrets_in_value(v).map(|rv| (k.clone(), rv)))
                 .collect();
-            Ok(Value::Map(redacted?))
+            Ok(Value::Concrete(ConcreteValue::Map(redacted?)))
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             let redacted: Result<Vec<_>, _> = items.iter().map(redact_secrets_in_value).collect();
-            Ok(Value::List(redacted?))
+            Ok(Value::Concrete(ConcreteValue::List(redacted?)))
         }
-        Value::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {
-            reason: reason.clone(),
-            context: SerializationContext::SecretRedaction,
-        }),
+        Value::Deferred(DeferredValue::Unknown(reason)) => {
+            Err(SerializationError::UnknownNotAllowed {
+                reason: reason.clone(),
+                context: SerializationContext::SecretRedaction,
+            })
+        }
         other => Ok(other.clone()),
     }
 }
@@ -816,7 +836,7 @@ impl<'a> PrettyLayout<'a> {
     /// Width of the prefix (`<indent>key: `) that the caller has already
     /// emitted, in columns. Used as the budget consumed before any value
     /// content can fit on the same line. Map keys can carry non-ASCII
-    /// characters (the `Value::Map` key type is `String` with no
+    /// characters (the `Value::Concrete(ConcreteValue::Map)` key type is `String` with no
     /// encoding constraint), so width is measured in Unicode scalar values.
     fn prefix_cols(&self) -> usize {
         self.parent_indent_cols + self.key.chars().count() + 2
@@ -837,20 +857,20 @@ impl<'a> PrettyLayout<'a> {
 ///
 /// Behavior:
 /// - Scalar variants are identical to `format_value_with_key(value, None)`.
-/// - `Value::List` of all `Value::Map` always renders vertically. Each
+/// - `Value::Concrete(ConcreteValue::List)` of all `Value::Concrete(ConcreteValue::Map)` always renders vertically. Each
 ///   element's first key is prefixed with `* ` at `parent_indent_cols + 2`;
 ///   continuation keys align at `parent_indent_cols + 4`. Map keys are
 ///   sorted alphabetically. Consecutive elements are also separated by
 ///   a blank line. The marker is `*` rather than `-` because `-`
 ///   collides with the destroy action marker at the resource-row level
 ///   (#2545 dropped the marker, #2552 brought it back as `*`).
-/// - `Value::List` of scalars renders inline `[a, b, c]` if the entire line
+/// - `Value::Concrete(ConcreteValue::List)` of scalars renders inline `[a, b, c]` if the entire line
 ///   (`<indent>key: <inline>`) fits within `PRETTY_LINE_LIMIT`; otherwise
 ///   expands to a bracketed multi-line form.
-/// - `Value::StringList` (the canonicalized `Union[String, list(String)]`
+/// - `Value::Concrete(ConcreteValue::StringList)` (the canonicalized `Union[String, list(String)]`
 ///   form, #2511) follows the same inline-vs-vertical rule as
-///   `Value::List` of `Value::String` (#2528).
-/// - `Value::Map` renders inline if it fits, otherwise expands vertically
+///   `Value::Concrete(ConcreteValue::List)` of `Value::Concrete(ConcreteValue::String)` (#2528).
+/// - `Value::Concrete(ConcreteValue::Map)` renders inline if it fits, otherwise expands vertically
 ///   with each key at `parent_indent_cols + 2`.
 ///
 /// When adding a new layout-bearing `Value` variant, add a new arm here
@@ -858,7 +878,7 @@ impl<'a> PrettyLayout<'a> {
 /// the line-budget check, which is wrong for any container variant.
 pub fn format_value_pretty(value: &Value, layout: PrettyLayout<'_>) -> String {
     match value {
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             if items.is_empty() {
                 return "[]".to_string();
             }
@@ -877,15 +897,15 @@ pub fn format_value_pretty(value: &Value, layout: PrettyLayout<'_>) -> String {
             }
             format_list_of_scalars_vertical(items, layout.child_indent_cols())
         }
-        Value::StringList(items) => {
-            // #2528: `Value::StringList` is the canonicalized form the
+        Value::Concrete(ConcreteValue::StringList(items)) => {
+            // #2528: `Value::Concrete(ConcreteValue::StringList)` is the canonicalized form the
             // `Union[String, list(String)]` shape collapses to (#2511).
-            // It behaves like `Value::List` of `Value::String` for
+            // It behaves like `Value::Concrete(ConcreteValue::List)` of `Value::Concrete(ConcreteValue::String)` for
             // layout purposes — apply the same inline-vs-vertical
             // decision so a long list under a dynamic-key Map (e.g. an
             // IAM `condition.string_like.<context-key>: [a, b]`) breaks
             // across lines instead of dumping inline. Lift items to
-            // `Value::String` for the vertical fallback so the per-item
+            // `Value::Concrete(ConcreteValue::String)` for the vertical fallback so the per-item
             // rendering (SECRET_PREFIX redaction, DSL-enum resolution)
             // stays byte-identical to `format_value_with_key`'s arm.
             if items.is_empty() {
@@ -898,7 +918,7 @@ pub fn format_value_pretty(value: &Value, layout: PrettyLayout<'_>) -> String {
             let lifted: Vec<Value> = items.iter().cloned().map(Value::String).collect();
             format_list_of_scalars_vertical(&lifted, layout.child_indent_cols())
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             if map.is_empty() {
                 return "{}".to_string();
             }
@@ -950,7 +970,7 @@ fn format_list_of_maps_vertical(items: &[Value], entry_indent_cols: usize) -> St
     let mut out = String::new();
     let mut first_element = true;
     for item in items {
-        if let Value::Map(map) = item {
+        if let Value::Concrete(ConcreteValue::Map(map)) = item {
             if !first_element {
                 out.push('\n');
             }
@@ -1034,26 +1054,29 @@ fn format_map_vertical(map: &IndexMap<String, Value>, key_indent_cols: usize) ->
 
 /// Check if a value is a list of maps (list-of-struct)
 pub fn is_list_of_maps(value: &Value) -> bool {
-    if let Value::List(items) = value {
-        !items.is_empty() && items.iter().all(|item| matches!(item, Value::Map(_)))
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
+        !items.is_empty()
+            && items
+                .iter()
+                .all(|item| matches!(item, Value::Concrete(ConcreteValue::Map(_))))
     } else {
         false
     }
 }
 
-/// Extract a `Vec<String>` from a `Value::StringList` or a `Value::List`
-/// whose every element is `Value::String`. Returns `None` for other
+/// Extract a `Vec<String>` from a `Value::Concrete(ConcreteValue::StringList)` or a `Value::Concrete(ConcreteValue::List)`
+/// whose every element is `Value::Concrete(ConcreteValue::String)`. Returns `None` for other
 /// shapes. Empty lists return `Some(vec![])` so callers can distinguish
 /// "empty string list" from "not a string list" — needed by #2943's
 /// diff path so a list shrinking to empty still routes through
 /// per-element `-` lines instead of the inline `[a, b] → []` form.
 pub fn as_string_list(value: &Value) -> Option<Vec<String>> {
     match value {
-        Value::StringList(items) => Some(items.clone()),
-        Value::List(items) => items
+        Value::Concrete(ConcreteValue::StringList(items)) => Some(items.clone()),
+        Value::Concrete(ConcreteValue::List(items)) => items
             .iter()
             .map(|v| match v {
-                Value::String(s) => Some(s.clone()),
+                Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                 _ => None,
             })
             .collect(),
@@ -1069,7 +1092,8 @@ pub fn as_string_list(value: &Value) -> Option<Vec<String>> {
 /// regular map under the parent key, and skipping the blank for it
 /// avoids noise around common single-statement policies. (#2555)
 pub fn needs_trailing_separator(value: &Value) -> bool {
-    is_list_of_maps(value) && matches!(value, Value::List(items) if items.len() >= 2)
+    is_list_of_maps(value)
+        && matches!(value, Value::Concrete(ConcreteValue::List(items)) if items.len() >= 2)
 }
 
 /// Count the number of shared key-value pairs between two map Values.
@@ -1077,7 +1101,7 @@ pub fn needs_trailing_separator(value: &Value) -> bool {
 /// Returns 0 if either value is not a Map.
 pub fn map_similarity(a: &Value, b: &Value) -> usize {
     match (a, b) {
-        (Value::Map(ma), Value::Map(mb)) => ma
+        (Value::Concrete(ConcreteValue::Map(ma)), Value::Concrete(ConcreteValue::Map(mb))) => ma
             .iter()
             .filter(|(k, v)| {
                 mb.get(*k)
@@ -1124,16 +1148,16 @@ fn peel_custom(t: &AttributeType) -> &AttributeType {
     cur
 }
 
-/// Convert `value` to the canonical `Value::StringList` form when
+/// Convert `value` to the canonical `Value::Concrete(ConcreteValue::StringList)` form when
 /// `attr_type` is the `string_or_list_of_strings` shape, recursing into
 /// containers (List, Map, Struct) so nested fields are also
 /// canonicalized.
 ///
 /// Conversion rules for `string_or_list_of_strings`:
-/// - `Value::String(s)` → `Value::StringList(vec![s])`
-/// - `Value::List([Value::String(_), ...])` (every element a String) →
-///   `Value::StringList(vec![..])`
-/// - `Value::StringList(_)` is returned unchanged
+/// - `Value::Concrete(ConcreteValue::String(s))` → `Value::Concrete(ConcreteValue::StringList(vec![s]))`
+/// - `Value::Concrete(ConcreteValue::List([Value::String(_), ...]))` (every element a String) →
+///   `Value::Concrete(ConcreteValue::StringList(vec![..]))`
+/// - `Value::Concrete(ConcreteValue::StringList(_))` is returned unchanged
 /// - any other shape (e.g. a list with non-string elements, a Map, a
 ///   ResourceRef, an unresolved Interpolation/FunctionCall) is returned
 ///   unchanged. Such shapes either fail validation downstream (wrong
@@ -1152,21 +1176,21 @@ pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value 
         return canonicalize_to_string_list(value);
     }
     match (value, unwrapped) {
-        (Value::List(items), AttributeType::List { inner, .. }) => {
+        (Value::Concrete(ConcreteValue::List(items)), AttributeType::List { inner, .. }) => {
             let canonicalized = items
                 .into_iter()
                 .map(|v| canonicalize_with_type(v, inner.as_ref()))
                 .collect();
-            Value::List(canonicalized)
+            Value::Concrete(ConcreteValue::List(canonicalized))
         }
-        (Value::Map(map), AttributeType::Map { value: vt, .. }) => {
+        (Value::Concrete(ConcreteValue::Map(map)), AttributeType::Map { value: vt, .. }) => {
             let canonicalized = map
                 .into_iter()
                 .map(|(k, v)| (k, canonicalize_with_type(v, vt.as_ref())))
                 .collect();
-            Value::Map(canonicalized)
+            Value::Concrete(ConcreteValue::Map(canonicalized))
         }
-        (Value::Map(map), AttributeType::Struct { fields, .. }) => {
+        (Value::Concrete(ConcreteValue::Map(map)), AttributeType::Struct { fields, .. }) => {
             let canonicalized = map
                 .into_iter()
                 .map(|(k, v)| {
@@ -1181,11 +1205,11 @@ pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value 
                     (k, canon)
                 })
                 .collect();
-            Value::Map(canonicalized)
+            Value::Concrete(ConcreteValue::Map(canonicalized))
         }
-        (Value::Secret(inner), _) => {
-            Value::Secret(Box::new(canonicalize_with_type(*inner, attr_type)))
-        }
+        (Value::Deferred(DeferredValue::Secret(inner)), _) => Value::Deferred(
+            DeferredValue::Secret(Box::new(canonicalize_with_type(*inner, attr_type))),
+        ),
         (v, _) => v,
     }
 }
@@ -1194,26 +1218,32 @@ pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value 
 /// `string_or_list_of_strings` case.
 fn canonicalize_to_string_list(value: Value) -> Value {
     match value {
-        Value::StringList(items) => Value::StringList(items),
-        Value::String(s) => Value::StringList(vec![s]),
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::StringList(items)) => {
+            Value::Concrete(ConcreteValue::StringList(items))
+        }
+        Value::Concrete(ConcreteValue::String(s)) => {
+            Value::Concrete(ConcreteValue::StringList(vec![s]))
+        }
+        Value::Concrete(ConcreteValue::List(items)) => {
             let mut strings = Vec::with_capacity(items.len());
             for item in &items {
                 match item {
-                    Value::String(s) => strings.push(s.clone()),
-                    _ => return Value::List(items),
+                    Value::Concrete(ConcreteValue::String(s)) => strings.push(s.clone()),
+                    _ => return Value::Concrete(ConcreteValue::List(items)),
                 }
             }
-            Value::StringList(strings)
+            Value::Concrete(ConcreteValue::StringList(strings))
         }
-        Value::Secret(inner) => Value::Secret(Box::new(canonicalize_to_string_list(*inner))),
+        Value::Deferred(DeferredValue::Secret(inner)) => Value::Deferred(DeferredValue::Secret(
+            Box::new(canonicalize_to_string_list(*inner)),
+        )),
         other => other,
     }
 }
 
 /// Walk every resource's attributes, canonicalizing values whose
 /// declared schema type is `Union[String, list(String)]` into
-/// `Value::StringList`. Resources whose schema is not in the registry
+/// `Value::Concrete(ConcreteValue::StringList)`. Resources whose schema is not in the registry
 /// (provider not loaded, unknown resource type) are skipped — schema
 /// validation surfaces the mismatch elsewhere.
 ///
@@ -1242,11 +1272,11 @@ pub fn canonicalize_resources_with_schemas(
 
 /// Walk every entry in a `current_states` map and canonicalize attribute
 /// values whose declared schema type is `Union[String, list(String)]`
-/// into `Value::StringList`.
+/// into `Value::Concrete(ConcreteValue::StringList)`.
 ///
 /// State files written before #2510 / #2511 (or by an apply path that
 /// somehow produced the legacy shape) come back through serde as the
-/// natural `Value::String` / `Value::List` form. Run this immediately
+/// natural `Value::Concrete(ConcreteValue::String)` / `Value::Concrete(ConcreteValue::List)` form. Run this immediately
 /// after `current_states` is built — typically right after
 /// `StateFile::build_state_for_resource` populates the map — so the
 /// differ never sees a non-canonical state value compared against a
@@ -1303,7 +1333,9 @@ mod tests {
 
     #[test]
     fn value_to_json_duration_emits_integer_seconds() {
-        let v = Value::Duration(std::time::Duration::from_secs(4500));
+        let v = Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(
+            4500,
+        )));
         let j = value_to_json_with_context(&v, None).unwrap();
         assert_eq!(j, serde_json::json!(4500));
     }
@@ -1311,14 +1343,18 @@ mod tests {
     #[test]
     fn value_duration_round_trips_serde() {
         // Confirms the `#[serde(with = "duration_secs")]` adapter on
-        // `Value::Duration` emits and reads back integer seconds, not
+        // `Value::Concrete(ConcreteValue::Duration)` emits and reads back integer seconds, not
         // the default `{secs, nanos}` shape.
-        let v = Value::Duration(std::time::Duration::from_secs(4500));
+        let v = Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(
+            4500,
+        )));
         let json = serde_json::to_string(&v).unwrap();
         let back: Value = serde_json::from_str(&json).unwrap();
         match back {
-            Value::Duration(d) => assert_eq!(d, std::time::Duration::from_secs(4500)),
-            other => panic!("expected Value::Duration, got {other:?}"),
+            Value::Concrete(ConcreteValue::Duration(d)) => {
+                assert_eq!(d, std::time::Duration::from_secs(4500))
+            }
+            other => panic!("expected Value::Concrete(ConcreteValue::Duration), got {other:?}"),
         }
     }
 
@@ -1419,25 +1455,25 @@ mod tests {
 
     #[test]
     fn test_value_to_json_string() {
-        let v = Value::String("hello".to_string());
+        let v = Value::Concrete(ConcreteValue::String("hello".to_string()));
         assert_eq!(value_to_json(&v).unwrap(), serde_json::json!("hello"));
     }
 
     #[test]
     fn test_value_to_json_int() {
-        let v = Value::Int(42);
+        let v = Value::Concrete(ConcreteValue::Int(42));
         assert_eq!(value_to_json(&v).unwrap(), serde_json::json!(42));
     }
 
     #[test]
     fn test_value_to_json_float() {
-        let v = Value::Float(1.5);
+        let v = Value::Concrete(ConcreteValue::Float(1.5));
         assert_eq!(value_to_json(&v).unwrap(), serde_json::json!(1.5));
     }
 
     #[test]
     fn test_value_to_json_nan_returns_error() {
-        let v = Value::Float(f64::NAN);
+        let v = Value::Concrete(ConcreteValue::Float(f64::NAN));
         let result = value_to_json(&v);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("NaN"));
@@ -1445,7 +1481,7 @@ mod tests {
 
     #[test]
     fn test_value_to_json_infinity_returns_error() {
-        let v = Value::Float(f64::INFINITY);
+        let v = Value::Concrete(ConcreteValue::Float(f64::INFINITY));
         let result = value_to_json(&v);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("inf"));
@@ -1453,7 +1489,7 @@ mod tests {
 
     #[test]
     fn test_value_to_json_neg_infinity_returns_error() {
-        let v = Value::Float(f64::NEG_INFINITY);
+        let v = Value::Concrete(ConcreteValue::Float(f64::NEG_INFINITY));
         let result = value_to_json(&v);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("-inf"));
@@ -1461,7 +1497,10 @@ mod tests {
 
     #[test]
     fn test_value_to_json_nan_in_list_returns_error() {
-        let v = Value::List(vec![Value::Int(1), Value::Float(f64::NAN)]);
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::Float(f64::NAN)),
+        ]));
         let result = value_to_json(&v);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("NaN"));
@@ -1470,8 +1509,11 @@ mod tests {
     #[test]
     fn test_value_to_json_nan_in_map_returns_error() {
         let mut map = IndexMap::new();
-        map.insert("key".to_string(), Value::Float(f64::INFINITY));
-        let v = Value::Map(map);
+        map.insert(
+            "key".to_string(),
+            Value::Concrete(ConcreteValue::Float(f64::INFINITY)),
+        );
+        let v = Value::Concrete(ConcreteValue::Map(map));
         let result = value_to_json(&v);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("inf"));
@@ -1479,21 +1521,27 @@ mod tests {
 
     #[test]
     fn test_value_to_json_bool() {
-        let v = Value::Bool(true);
+        let v = Value::Concrete(ConcreteValue::Bool(true));
         assert_eq!(value_to_json(&v).unwrap(), serde_json::json!(true));
     }
 
     #[test]
     fn test_value_to_json_list() {
-        let v = Value::List(vec![Value::Int(1), Value::Int(2)]);
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::Int(2)),
+        ]));
         assert_eq!(value_to_json(&v).unwrap(), serde_json::json!([1, 2]));
     }
 
     #[test]
     fn test_value_to_json_map() {
         let mut map = IndexMap::new();
-        map.insert("key".to_string(), Value::String("val".to_string()));
-        let v = Value::Map(map);
+        map.insert(
+            "key".to_string(),
+            Value::Concrete(ConcreteValue::String("val".to_string())),
+        );
+        let v = Value::Concrete(ConcreteValue::Map(map));
         assert_eq!(
             value_to_json(&v).unwrap(),
             serde_json::json!({"key": "val"})
@@ -1502,7 +1550,7 @@ mod tests {
 
     #[test]
     fn test_value_to_json_resource_ref_returns_err() {
-        // RFC #2371 #2385: `Value::ResourceRef` reaching JSON
+        // RFC #2371 #2385: `Value::Deferred(DeferredValue::ResourceRef)` reaching JSON
         // serialization is a resolver bug — surface as a structured
         // `UnresolvedResourceRef` Err instead of the legacy
         // `"${vpc.id}"` debug-string fallback.
@@ -1522,11 +1570,13 @@ mod tests {
 
     #[test]
     fn test_value_to_json_interpolation_returns_err() {
-        // RFC #2371 #2386: `Value::Interpolation` reaching JSON
+        // RFC #2371 #2386: `Value::Deferred(DeferredValue::Interpolation)` reaching JSON
         // serialization is a canonicalize / resolver bug — surface as
         // `UnresolvedInterpolation` instead of producing a partial
         // string with embedded debug formatting.
-        let v = Value::Interpolation(vec![InterpolationPart::Literal("hello".into())]);
+        let v = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("hello".into()),
+        ]));
         let err = value_to_json(&v).unwrap_err();
         assert!(
             matches!(
@@ -1541,13 +1591,13 @@ mod tests {
 
     #[test]
     fn test_value_to_json_function_call_returns_err() {
-        // RFC #2371 #2386: `Value::FunctionCall` reaching JSON
+        // RFC #2371 #2386: `Value::Deferred(DeferredValue::FunctionCall)` reaching JSON
         // serialization is a resolver bug — the function should have
         // been evaluated by this point.
-        let v = Value::FunctionCall {
+        let v = Value::Deferred(DeferredValue::FunctionCall {
             name: "join".into(),
             args: vec![],
-        };
+        });
         let err = value_to_json(&v).unwrap_err();
         assert!(
             matches!(
@@ -1566,26 +1616,35 @@ mod tests {
         let j = serde_json::json!("hello");
         assert_eq!(
             json_to_dsl_value(&j),
-            Some(Value::String("hello".to_string()))
+            Some(Value::Concrete(ConcreteValue::String("hello".to_string())))
         );
     }
 
     #[test]
     fn test_json_to_dsl_value_int() {
         let j = serde_json::json!(42);
-        assert_eq!(json_to_dsl_value(&j), Some(Value::Int(42)));
+        assert_eq!(
+            json_to_dsl_value(&j),
+            Some(Value::Concrete(ConcreteValue::Int(42)))
+        );
     }
 
     #[test]
     fn test_json_to_dsl_value_float() {
         let j = serde_json::json!(1.5);
-        assert_eq!(json_to_dsl_value(&j), Some(Value::Float(1.5)));
+        assert_eq!(
+            json_to_dsl_value(&j),
+            Some(Value::Concrete(ConcreteValue::Float(1.5)))
+        );
     }
 
     #[test]
     fn test_json_to_dsl_value_bool() {
         let j = serde_json::json!(true);
-        assert_eq!(json_to_dsl_value(&j), Some(Value::Bool(true)));
+        assert_eq!(
+            json_to_dsl_value(&j),
+            Some(Value::Concrete(ConcreteValue::Bool(true)))
+        );
     }
 
     #[test]
@@ -1593,7 +1652,10 @@ mod tests {
         let j = serde_json::json!([1, 2]);
         assert_eq!(
             json_to_dsl_value(&j),
-            Some(Value::List(vec![Value::Int(1), Value::Int(2)]))
+            Some(Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2))
+            ])))
         );
     }
 
@@ -1608,7 +1670,10 @@ mod tests {
         let j = serde_json::json!([1, null, 2]);
         assert_eq!(
             json_to_dsl_value(&j),
-            Some(Value::List(vec![Value::Int(1), Value::Int(2)]))
+            Some(Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Int(1)),
+                Value::Concrete(ConcreteValue::Int(2))
+            ])))
         );
     }
 
@@ -1616,11 +1681,14 @@ mod tests {
     fn test_json_to_dsl_value_null_in_object() {
         let j = serde_json::json!({"a": 1, "b": null, "c": "hello"});
         let result = json_to_dsl_value(&j).unwrap();
-        if let Value::Map(map) = result {
+        if let Value::Concrete(ConcreteValue::Map(map)) = result {
             assert_eq!(map.len(), 2);
-            assert_eq!(map.get("a"), Some(&Value::Int(1)));
+            assert_eq!(map.get("a"), Some(&Value::Concrete(ConcreteValue::Int(1))));
             assert_eq!(map.get("b"), None);
-            assert_eq!(map.get("c"), Some(&Value::String("hello".to_string())));
+            assert_eq!(
+                map.get("c"),
+                Some(&Value::Concrete(ConcreteValue::String("hello".to_string())))
+            );
         } else {
             panic!("Expected Map");
         }
@@ -1628,11 +1696,11 @@ mod tests {
 
     #[test]
     fn test_roundtrip_value_json() {
-        let original = Value::List(vec![
-            Value::String("hello".to_string()),
-            Value::Int(42),
-            Value::Bool(false),
-        ]);
+        let original = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("hello".to_string())),
+            Value::Concrete(ConcreteValue::Int(42)),
+            Value::Concrete(ConcreteValue::Bool(false)),
+        ]));
         let json = value_to_json(&original).unwrap();
         let back = json_to_dsl_value(&json).unwrap();
         assert_eq!(back, original);
@@ -1640,13 +1708,15 @@ mod tests {
 
     #[test]
     fn test_format_value_string() {
-        let v = Value::String("hello".to_string());
+        let v = Value::Concrete(ConcreteValue::String("hello".to_string()));
         assert_eq!(format_value(&v), "\"hello\"");
     }
 
     #[test]
     fn test_format_value_dsl_enum() {
-        let v = Value::String("aws.s3.VersioningStatus.Enabled".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "aws.s3.VersioningStatus.Enabled".to_string(),
+        ));
         assert_eq!(format_value(&v), "\"Enabled\"");
     }
 
@@ -1654,13 +1724,17 @@ mod tests {
     fn test_format_value_dsl_enum_region() {
         // Region displays in DSL form (underscored) until provider alias tables
         // are extended to include to_dsl reverse mappings (see issue #1675).
-        let v = Value::String("aws.Region.ap_northeast_1".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "aws.Region.ap_northeast_1".to_string(),
+        ));
         assert_eq!(format_value(&v), "\"ap_northeast_1\"");
     }
 
     #[test]
     fn test_format_value_dsl_enum_5_part() {
-        let v = Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string(),
+        ));
         assert_eq!(format_value(&v), "\"dedicated\"");
     }
 
@@ -1668,37 +1742,42 @@ mod tests {
     fn test_format_value_two_part_enum_string() {
         // Two-part enum strings like "InstanceTenancy.dedicated" are formatted
         // through convert_enum_value which extracts the value part
-        let v = Value::String("InstanceTenancy.dedicated".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "InstanceTenancy.dedicated".to_string(),
+        ));
         assert_eq!(format_value(&v), "\"dedicated\"");
     }
 
     #[test]
     fn test_format_value_bare_enum_string() {
-        let v = Value::String("dedicated".to_string());
+        let v = Value::Concrete(ConcreteValue::String("dedicated".to_string()));
         assert_eq!(format_value(&v), "\"dedicated\"");
     }
 
     #[test]
     fn test_format_value_int() {
-        let v = Value::Int(42);
+        let v = Value::Concrete(ConcreteValue::Int(42));
         assert_eq!(format_value(&v), "42");
     }
 
     #[test]
     fn test_format_value_float() {
-        let v = Value::Float(1.5);
+        let v = Value::Concrete(ConcreteValue::Float(1.5));
         assert_eq!(format_value(&v), "1.5");
     }
 
     #[test]
     fn test_format_value_bool() {
-        let v = Value::Bool(true);
+        let v = Value::Concrete(ConcreteValue::Bool(true));
         assert_eq!(format_value(&v), "true");
     }
 
     #[test]
     fn test_format_value_list() {
-        let v = Value::List(vec![Value::Int(1), Value::Int(2)]);
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::Int(2)),
+        ]));
         assert_eq!(format_value(&v), "[1, 2]");
     }
 
@@ -1708,15 +1787,15 @@ mod tests {
         assert_eq!(format_value(&v), "vpc.id");
     }
 
-    /// `Value::Unknown(UpstreamRef)` renders unquoted as
+    /// `Value::Deferred(DeferredValue::Unknown(UpstreamRef))` renders unquoted as
     /// `(known after upstream apply: <ref>)` via `format_value_with_key`.
     /// Stage 2 of RFC #2371 — the variant replaced the NUL-prefixed
-    /// `Value::String` sentinel from #2367.
+    /// `Value::Concrete(ConcreteValue::String)` sentinel from #2367.
     #[test]
     fn test_format_value_unresolved_upstream() {
         use crate::resource::{AccessPath, UnknownReason};
         let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".to_string()]);
-        let v = Value::Unknown(UnknownReason::UpstreamRef { path });
+        let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path }));
         assert_eq!(
             format_value(&v),
             "(known after upstream apply: network.vpc.vpc_id)"
@@ -1727,11 +1806,11 @@ mod tests {
     /// `Err(SerializationError::UnknownNotAllowed { reason })` rather
     /// than panicking. The `reason` field must round-trip the variant
     /// passed in so the caller can render an actionable diagnostic.
-    /// A silent fallback (e.g. `Ok(Value::String("Unknown(...)"))`)
+    /// A silent fallback (e.g. `Ok(Value::Concrete(ConcreteValue::String("Unknown(...)")))`)
     /// would re-introduce the v1 corruption bug (#2375).
     #[test]
     fn unknown_returns_err_in_value_to_json() {
-        let v = Value::Unknown(UnknownReason::ForKey);
+        let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey));
         let err = value_to_json(&v).unwrap_err();
         assert!(
             matches!(
@@ -1747,7 +1826,7 @@ mod tests {
 
     #[test]
     fn unknown_returns_err_in_redact_secrets_in_value() {
-        let v = Value::Unknown(UnknownReason::ForKey);
+        let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey));
         let err = redact_secrets_in_value(&v).unwrap_err();
         assert!(
             matches!(
@@ -1788,48 +1867,69 @@ mod tests {
     #[test]
     fn test_is_list_of_maps_true() {
         let mut map = IndexMap::new();
-        map.insert("key".to_string(), Value::String("val".to_string()));
-        let v = Value::List(vec![Value::Map(map)]);
+        map.insert(
+            "key".to_string(),
+            Value::Concrete(ConcreteValue::String("val".to_string())),
+        );
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(map),
+        )]));
         assert!(is_list_of_maps(&v));
     }
 
     #[test]
     fn test_is_list_of_maps_false_empty() {
-        let v = Value::List(vec![]);
+        let v = Value::Concrete(ConcreteValue::List(vec![]));
         assert!(!is_list_of_maps(&v));
     }
 
     #[test]
     fn test_is_list_of_maps_false_not_maps() {
-        let v = Value::List(vec![Value::Int(1)]);
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Int(1),
+        )]));
         assert!(!is_list_of_maps(&v));
     }
 
     #[test]
     fn test_is_list_of_maps_false_not_list() {
-        let v = Value::Int(1);
+        let v = Value::Concrete(ConcreteValue::Int(1));
         assert!(!is_list_of_maps(&v));
     }
 
     #[test]
     fn test_map_similarity_matching() {
         let mut m1 = IndexMap::new();
-        m1.insert("a".to_string(), Value::Int(1));
-        m1.insert("b".to_string(), Value::Int(2));
+        m1.insert("a".to_string(), Value::Concrete(ConcreteValue::Int(1)));
+        m1.insert("b".to_string(), Value::Concrete(ConcreteValue::Int(2)));
         let mut m2 = IndexMap::new();
-        m2.insert("a".to_string(), Value::Int(1));
-        m2.insert("b".to_string(), Value::Int(3));
-        assert_eq!(map_similarity(&Value::Map(m1), &Value::Map(m2)), 1);
+        m2.insert("a".to_string(), Value::Concrete(ConcreteValue::Int(1)));
+        m2.insert("b".to_string(), Value::Concrete(ConcreteValue::Int(3)));
+        assert_eq!(
+            map_similarity(
+                &Value::Concrete(ConcreteValue::Map(m1)),
+                &Value::Concrete(ConcreteValue::Map(m2))
+            ),
+            1
+        );
     }
 
     #[test]
     fn test_map_similarity_non_maps() {
-        assert_eq!(map_similarity(&Value::Int(1), &Value::Int(1)), 0);
+        assert_eq!(
+            map_similarity(
+                &Value::Concrete(ConcreteValue::Int(1)),
+                &Value::Concrete(ConcreteValue::Int(1))
+            ),
+            0
+        );
     }
 
     #[test]
     fn test_value_to_json_secret_produces_hash() {
-        let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         let json = value_to_json(&v).unwrap();
         let s = json.as_str().unwrap();
         assert!(
@@ -1844,8 +1944,12 @@ mod tests {
 
     #[test]
     fn test_value_to_json_secret_is_deterministic() {
-        let v1 = Value::Secret(Box::new(Value::String("my-password".to_string())));
-        let v2 = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v1 = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
+        let v2 = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         let json1 = value_to_json(&v1).unwrap();
         let json2 = value_to_json(&v2).unwrap();
         assert_eq!(json1, json2);
@@ -1853,8 +1957,12 @@ mod tests {
 
     #[test]
     fn test_value_to_json_secret_different_values_different_hashes() {
-        let v1 = Value::Secret(Box::new(Value::String("password-1".to_string())));
-        let v2 = Value::Secret(Box::new(Value::String("password-2".to_string())));
+        let v1 = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("password-1".to_string()),
+        ))));
+        let v2 = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("password-2".to_string()),
+        ))));
         let json1 = value_to_json(&v1).unwrap();
         let json2 = value_to_json(&v2).unwrap();
         assert_ne!(json1, json2);
@@ -1862,19 +1970,26 @@ mod tests {
 
     #[test]
     fn test_format_value_secret() {
-        let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         assert_eq!(format_value(&v), "(secret)");
     }
 
     #[test]
     fn test_format_value_secret_in_map() {
         let mut map = IndexMap::new();
-        map.insert("Name".to_string(), Value::String("test".to_string()));
+        map.insert(
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        );
         map.insert(
             "SecretTag".to_string(),
-            Value::Secret(Box::new(Value::String("my-password".to_string()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("my-password".to_string()),
+            )))),
         );
-        let v = Value::Map(map);
+        let v = Value::Concrete(ConcreteValue::Map(map));
         let formatted = format_value(&v);
         // Secret values inside maps should show as (secret), not the raw value
         assert!(
@@ -1892,12 +2007,17 @@ mod tests {
     #[test]
     fn test_value_to_json_secret_in_map() {
         let mut map = IndexMap::new();
-        map.insert("Name".to_string(), Value::String("test".to_string()));
+        map.insert(
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        );
         map.insert(
             "SecretTag".to_string(),
-            Value::Secret(Box::new(Value::String("my-password".to_string()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("my-password".to_string()),
+            )))),
         );
-        let v = Value::Map(map);
+        let v = Value::Concrete(ConcreteValue::Map(map));
         let json = value_to_json(&v).unwrap();
         let obj = json.as_object().unwrap();
         assert_eq!(obj.get("Name").unwrap().as_str().unwrap(), "test");
@@ -1916,13 +2036,15 @@ mod tests {
             "{}{}",
             SECRET_PREFIX, "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
         );
-        let v = Value::String(hash_str);
+        let v = Value::Concrete(ConcreteValue::String(hash_str));
         assert_eq!(format_value(&v), "(secret)");
     }
 
     #[test]
     fn test_value_to_json_with_context_different_resources_different_hashes() {
-        let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         let ctx1 = SecretHashContext::new("ec2.Vpc", "vpc-1", "password");
         let ctx2 = SecretHashContext::new("rds.db_instance", "my-db", "password");
         let json1 = value_to_json_with_context(&v, Some(&ctx1)).unwrap();
@@ -1935,7 +2057,9 @@ mod tests {
 
     #[test]
     fn test_value_to_json_with_context_different_attributes_different_hashes() {
-        let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         let ctx1 = SecretHashContext::new("rds.db_instance", "my-db", "master_password");
         let ctx2 = SecretHashContext::new("rds.db_instance", "my-db", "admin_password");
         let json1 = value_to_json_with_context(&v, Some(&ctx1)).unwrap();
@@ -1948,7 +2072,9 @@ mod tests {
 
     #[test]
     fn test_value_to_json_with_context_same_context_is_deterministic() {
-        let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         let ctx = SecretHashContext::new("rds.db_instance", "my-db", "master_password");
         let json1 = value_to_json_with_context(&v, Some(&ctx)).unwrap();
         let json2 = value_to_json_with_context(&v, Some(&ctx)).unwrap();
@@ -1960,7 +2086,9 @@ mod tests {
 
     #[test]
     fn test_value_to_json_with_context_differs_from_no_context() {
-        let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         let ctx = SecretHashContext::new("rds.db_instance", "my-db", "master_password");
         let json_with_ctx = value_to_json_with_context(&v, Some(&ctx)).unwrap();
         let json_no_ctx = value_to_json(&v).unwrap();
@@ -1972,11 +2100,13 @@ mod tests {
 
     #[test]
     fn test_redact_secrets_in_value_replaces_secret() {
-        let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         let redacted = redact_secrets_in_value(&v).unwrap();
         // Should be a String starting with the secret prefix, not a Secret variant
         match &redacted {
-            Value::String(s) => {
+            Value::Concrete(ConcreteValue::String(s)) => {
                 assert!(
                     s.starts_with(SECRET_PREFIX),
                     "Expected secret hash prefix, got: {}",
@@ -1984,7 +2114,7 @@ mod tests {
                 );
             }
             _ => panic!(
-                "Expected Value::String after redaction, got: {:?}",
+                "Expected Value::Concrete(ConcreteValue::String) after redaction, got: {:?}",
                 redacted
             ),
         }
@@ -1992,7 +2122,9 @@ mod tests {
 
     #[test]
     fn test_redact_secrets_in_value_no_plaintext_in_serialized_output() {
-        let v = Value::Secret(Box::new(Value::String("super-secret-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("super-secret-password".to_string()),
+        ))));
         let redacted = redact_secrets_in_value(&v).unwrap();
         let json = serde_json::to_string(&redacted).unwrap();
         assert!(
@@ -2005,12 +2137,17 @@ mod tests {
     #[test]
     fn test_redact_secrets_in_value_nested_in_map() {
         let mut map = IndexMap::new();
-        map.insert("name".to_string(), Value::String("test".to_string()));
+        map.insert(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        );
         map.insert(
             "password".to_string(),
-            Value::Secret(Box::new(Value::String("s3cret".to_string()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("s3cret".to_string()),
+            )))),
         );
-        let v = Value::Map(map);
+        let v = Value::Concrete(ConcreteValue::Map(map));
         let redacted = redact_secrets_in_value(&v).unwrap();
         let json = serde_json::to_string(&redacted).unwrap();
         assert!(
@@ -2027,10 +2164,12 @@ mod tests {
 
     #[test]
     fn test_redact_secrets_in_value_nested_in_list() {
-        let v = Value::List(vec![
-            Value::String("visible".to_string()),
-            Value::Secret(Box::new(Value::String("hidden".to_string()))),
-        ]);
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("visible".to_string())),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("hidden".to_string()),
+            )))),
+        ]));
         let redacted = redact_secrets_in_value(&v).unwrap();
         let json = serde_json::to_string(&redacted).unwrap();
         assert!(
@@ -2043,7 +2182,7 @@ mod tests {
 
     #[test]
     fn test_redact_secrets_in_value_preserves_non_secret() {
-        let v = Value::String("not-a-secret".to_string());
+        let v = Value::Concrete(ConcreteValue::String("not-a-secret".to_string()));
         let redacted = redact_secrets_in_value(&v).unwrap();
         assert_eq!(redacted, v);
     }
@@ -2051,10 +2190,15 @@ mod tests {
     #[test]
     fn test_redact_secrets_in_attributes() {
         let mut attrs = HashMap::new();
-        attrs.insert("name".to_string(), Value::String("my-bucket".to_string()));
+        attrs.insert(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+        );
         attrs.insert(
             "password".to_string(),
-            Value::Secret(Box::new(Value::String("hunter2".to_string()))),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("hunter2".to_string()),
+            )))),
         );
         let redacted = redact_secrets_in_attributes(&attrs).unwrap();
         let json = serde_json::to_string(&redacted).unwrap();
@@ -2083,49 +2227,68 @@ mod tests {
 
     #[test]
     fn format_value_pretty_string_matches_format_value() {
-        let v = Value::String("hello".to_string());
+        let v = Value::Concrete(ConcreteValue::String("hello".to_string()));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), format_value(&v));
     }
 
     #[test]
     fn format_value_pretty_int_renders_as_integer_literal() {
-        let v = Value::Int(42);
+        let v = Value::Concrete(ConcreteValue::Int(42));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), "42");
     }
 
     #[test]
     fn format_value_pretty_bool_renders_as_keyword() {
-        let v = Value::Bool(true);
+        let v = Value::Concrete(ConcreteValue::Bool(true));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), "true");
     }
 
     #[test]
     fn format_value_pretty_dsl_enum_resolves_to_provider_value() {
-        let v = Value::String("aws.s3.Bucket.VersioningStatus.enabled".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "aws.s3.Bucket.VersioningStatus.enabled".to_string(),
+        ));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), format_value(&v));
     }
 
     #[test]
     fn format_value_pretty_secret_masked() {
-        let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        ))));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), "(secret)");
     }
 
     #[test]
     fn format_value_pretty_unknown_renders_like_format_value() {
-        let v = Value::Unknown(UnknownReason::ForKey);
+        let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), format_value(&v));
     }
 
     #[test]
     fn format_value_pretty_list_of_maps_vertical() {
         let mut s1 = IndexMap::new();
-        s1.insert("sid".to_string(), Value::String("First".to_string()));
-        s1.insert("effect".to_string(), Value::String("Allow".to_string()));
+        s1.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String("First".to_string())),
+        );
+        s1.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
         let mut s2 = IndexMap::new();
-        s2.insert("sid".to_string(), Value::String("Second".to_string()));
-        s2.insert("effect".to_string(), Value::String("Deny".to_string()));
-        let v = Value::List(vec![Value::Map(s1), Value::Map(s2)]);
+        s2.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String("Second".to_string())),
+        );
+        s2.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Deny".to_string())),
+        );
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(s1)),
+            Value::Concrete(ConcreteValue::Map(s2)),
+        ]));
 
         // parent_indent_cols=6 → entry_indent_cols=8, where `* ` marker
         // sits; first key follows at col 10, continuation keys also at
@@ -2140,8 +2303,13 @@ mod tests {
     #[test]
     fn format_value_pretty_list_of_maps_single_entry() {
         let mut m = IndexMap::new();
-        m.insert("k".to_string(), Value::String("v".to_string()));
-        let v = Value::List(vec![Value::Map(m)]);
+        m.insert(
+            "k".to_string(),
+            Value::Concrete(ConcreteValue::String("v".to_string())),
+        );
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(m),
+        )]));
         // parent_indent_cols=4 → entry_indent_cols=6, `* ` at col 6, key
         // at col 8.
         let out = format_value_pretty(&v, layout(4, "items"));
@@ -2157,10 +2325,13 @@ mod tests {
     fn format_value_pretty_list_of_maps_three_entries_separated_by_blank_lines() {
         let make = |sid: &str| {
             let mut m = IndexMap::new();
-            m.insert("sid".to_string(), Value::String(sid.to_string()));
-            Value::Map(m)
+            m.insert(
+                "sid".to_string(),
+                Value::Concrete(ConcreteValue::String(sid.to_string())),
+            );
+            Value::Concrete(ConcreteValue::Map(m))
         };
-        let v = Value::List(vec![make("A"), make("B"), make("C")]);
+        let v = Value::Concrete(ConcreteValue::List(vec![make("A"), make("B"), make("C")]));
         let out = format_value_pretty(&v, layout(4, "items"));
         // Exactly N-1 = 2 blank-line separators between three elements.
         // The trailing blank before the next sibling key (#2555) is
@@ -2188,16 +2359,28 @@ mod tests {
     fn format_value_pretty_map_with_list_of_maps_then_sibling_separates() {
         let long = "x".repeat(40);
         let mut s1 = IndexMap::new();
-        s1.insert("sid_a".to_string(), Value::String(long.clone()));
+        s1.insert(
+            "sid_a".to_string(),
+            Value::Concrete(ConcreteValue::String(long.clone())),
+        );
         let mut s2 = IndexMap::new();
-        s2.insert("sid_b".to_string(), Value::String(long.clone()));
+        s2.insert(
+            "sid_b".to_string(),
+            Value::Concrete(ConcreteValue::String(long.clone())),
+        );
         let mut outer = IndexMap::new();
         outer.insert(
             "statement".to_string(),
-            Value::List(vec![Value::Map(s1), Value::Map(s2)]),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Map(s1)),
+                Value::Concrete(ConcreteValue::Map(s2)),
+            ])),
         );
-        outer.insert("version".to_string(), Value::String("2012".to_string()));
-        let v = Value::Map(outer);
+        outer.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::String("2012".to_string())),
+        );
+        let v = Value::Concrete(ConcreteValue::Map(outer));
         let out = format_value_pretty(&v, layout(2, "config"));
         // The blank-line MUST sit between the last element's last key
         // and the sibling `version:` key. Use unique key names so the
@@ -2216,16 +2399,28 @@ mod tests {
     fn format_value_pretty_map_with_trailing_list_of_maps_no_orphan_blank() {
         let long = "x".repeat(40);
         let mut s1 = IndexMap::new();
-        s1.insert("sid".to_string(), Value::String(long.clone()));
+        s1.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String(long.clone())),
+        );
         let mut s2 = IndexMap::new();
-        s2.insert("sid".to_string(), Value::String(long.clone()));
+        s2.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String(long.clone())),
+        );
         let mut outer = IndexMap::new();
-        outer.insert("version".to_string(), Value::String("2012".to_string()));
+        outer.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::String("2012".to_string())),
+        );
         outer.insert(
             "statement".to_string(),
-            Value::List(vec![Value::Map(s1), Value::Map(s2)]),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Map(s1)),
+                Value::Concrete(ConcreteValue::Map(s2)),
+            ])),
         );
-        let v = Value::Map(outer);
+        let v = Value::Concrete(ConcreteValue::Map(outer));
         let out = format_value_pretty(&v, layout(2, "config"));
         assert!(
             !out.ends_with("\n\n"),
@@ -2235,16 +2430,16 @@ mod tests {
 
     #[test]
     fn format_value_pretty_empty_list_inline() {
-        let v = Value::List(vec![]);
+        let v = Value::Concrete(ConcreteValue::List(vec![]));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), "[]");
     }
 
     #[test]
     fn format_value_pretty_list_of_strings_under_80_inline() {
-        let v = Value::List(vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
-        ]);
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
+        ]));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), "[\"a\", \"b\"]");
     }
 
@@ -2252,9 +2447,9 @@ mod tests {
     fn format_value_pretty_list_of_strings_over_80_vertical() {
         // 5 strings of ~20 chars each → inline ~110 chars
         let items: Vec<Value> = (0..5)
-            .map(|i| Value::String(format!("iam:LongActionName{}", i)))
+            .map(|i| Value::Concrete(ConcreteValue::String(format!("iam:LongActionName{}", i))))
             .collect();
-        let v = Value::List(items);
+        let v = Value::Concrete(ConcreteValue::List(items));
         // parent_indent_cols=4, key="action" → first item starts at parent_indent+2 = col 6.
         let out = format_value_pretty(&v, layout(4, "action"));
         assert!(
@@ -2276,7 +2471,9 @@ mod tests {
         // Inline form fits exactly within 80 cols at parent_indent=0, key="x" (1 char):
         // total = 0 + 1 + 2 + len(inline). For len(inline)=77, total=80 → stay inline.
         let item = "x".repeat(73); // inline = 1 + 1 + 73 + 1 + 1 = 77
-        let v = Value::List(vec![Value::String(item)]);
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String(item),
+        )]));
         let inline = format_value_with_key(&v, None);
         assert_eq!(inline.len(), 77, "fixture sanity: {} chars", inline.len());
         // total budget = 0 + 1 + 2 + 77 = 80, exactly at limit → inline.
@@ -2287,7 +2484,9 @@ mod tests {
     fn format_value_pretty_list_of_strings_threshold_boundary_81_expands() {
         // 1 char over threshold: 0 + 1 + 2 + 78 = 81 → expand.
         let item = "x".repeat(74); // inline = 78
-        let v = Value::List(vec![Value::String(item)]);
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String(item),
+        )]));
         let inline = format_value_with_key(&v, None);
         assert_eq!(inline.len(), 78, "fixture sanity: {} chars", inline.len());
         let out = format_value_pretty(&v, layout(0, "x"));
@@ -2303,7 +2502,9 @@ mod tests {
         // total = 10 + 2 + 2 + 75 = 89 → expand.
         let inline_target = 75;
         let item = "x".repeat(inline_target - 4);
-        let v = Value::List(vec![Value::String(item)]);
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String(item),
+        )]));
         let inline = format_value_with_key(&v, None);
         assert_eq!(inline.len(), inline_target);
         let out = format_value_pretty(&v, layout(10, "kk"));
@@ -2315,13 +2516,24 @@ mod tests {
         let mut inner = IndexMap::new();
         inner.insert("StringEquals".to_string(), {
             let mut m = IndexMap::new();
-            m.insert("aws:Tag".to_string(), Value::String("prod".to_string()));
-            Value::Map(m)
+            m.insert(
+                "aws:Tag".to_string(),
+                Value::Concrete(ConcreteValue::String("prod".to_string())),
+            );
+            Value::Concrete(ConcreteValue::Map(m))
         });
         let mut entry = IndexMap::new();
-        entry.insert("sid".to_string(), Value::String("X".to_string()));
-        entry.insert("condition".to_string(), Value::Map(inner));
-        let v = Value::List(vec![Value::Map(entry)]);
+        entry.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String("X".to_string())),
+        );
+        entry.insert(
+            "condition".to_string(),
+            Value::Concrete(ConcreteValue::Map(inner)),
+        );
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(entry),
+        )]));
         // parent_indent_cols=4 → entry_indent_cols=6; first sorted key
         // is preceded by `* ` at col 6 (#2552).
         let out = format_value_pretty(&v, layout(4, "statement"));
@@ -2335,12 +2547,20 @@ mod tests {
     #[test]
     fn format_value_pretty_list_of_maps_with_long_string_list_inside() {
         let actions: Vec<Value> = (0..6)
-            .map(|i| Value::String(format!("iam:Action{:03}", i)))
+            .map(|i| Value::Concrete(ConcreteValue::String(format!("iam:Action{:03}", i))))
             .collect();
         let mut entry = IndexMap::new();
-        entry.insert("sid".to_string(), Value::String("X".to_string()));
-        entry.insert("action".to_string(), Value::List(actions));
-        let v = Value::List(vec![Value::Map(entry)]);
+        entry.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String("X".to_string())),
+        );
+        entry.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::List(actions)),
+        );
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(entry),
+        )]));
         let out = format_value_pretty(&v, layout(4, "statement"));
         assert!(
             out.contains("action: ["),
@@ -2354,20 +2574,20 @@ mod tests {
 
     #[test]
     fn format_value_pretty_string_list_under_dynamic_key_breaks_vertically() {
-        // #2528 hypothesis: when the deepest value is `Value::StringList`
+        // #2528 hypothesis: when the deepest value is `Value::Concrete(ConcreteValue::StringList)`
         // (the canonical form #2511 folds `Union[String, list(String)]`
-        // into) rather than `Value::List`, `format_value_pretty` treats
+        // into) rather than `Value::Concrete(ConcreteValue::List)`, `format_value_pretty` treats
         // it as a scalar fallthrough and renders inline. This pins the
         // expected vertical break.
         let mut string_like = IndexMap::new();
         string_like.insert(
             "token.actions.githubusercontent.com:sub".to_string(),
-            Value::StringList(vec![
+            Value::Concrete(ConcreteValue::StringList(vec![
                 "repo:carina-rs/infra:ref:refs/heads/main".to_string(),
                 "repo:carina-rs/infra:pull_request".to_string(),
-            ]),
+            ])),
         );
-        let v = Value::Map(string_like);
+        let v = Value::Concrete(ConcreteValue::Map(string_like));
         // Mirror the layout under `condition.string_like:` (parent at
         // col 12 from the MapExpanded entry indentation). Inside a Map
         // the value text starts after `<key>: ` so the bracketed form
@@ -2388,10 +2608,13 @@ mod tests {
     #[test]
     fn format_value_pretty_top_level_string_list_breaks_vertically_when_oversize() {
         // The same fix applies when a top-level attribute value is
-        // already canonicalized to `Value::StringList`. Pre-fix the
+        // already canonicalized to `Value::Concrete(ConcreteValue::StringList)`. Pre-fix the
         // wildcard arm collapsed it to `["a", "b", ...]` even when the
         // line exceeded `PRETTY_LINE_LIMIT`.
-        let v = Value::StringList(vec!["a".repeat(40), "b".repeat(40)]);
+        let v = Value::Concrete(ConcreteValue::StringList(vec![
+            "a".repeat(40),
+            "b".repeat(40),
+        ]));
         let out = format_value_pretty(&v, layout(0, "k"));
         assert!(
             out.starts_with("[\n"),
@@ -2401,18 +2624,18 @@ mod tests {
 
     #[test]
     fn format_value_pretty_string_list_vertical_redacts_secret_prefix_strings() {
-        // Pin parity with `Value::List<Value::String>`: a string with
+        // Pin parity with `Value::Concrete(ConcreteValue::List)<Value::Concrete(ConcreteValue::String)>`: a string with
         // the SECRET_PREFIX must render as `(secret)` even when reached
         // through the StringList vertical path. Pre-fix attempt
         // (a dedicated `format_list_of_strings_vertical` that quoted the
         // raw &str) would have leaked the hash; the current shape lifts
-        // items to `Value::String` and reuses
+        // items to `Value::Concrete(ConcreteValue::String)` and reuses
         // `format_list_of_scalars_vertical`, so the SECRET_PREFIX arm
         // in `format_value_with_key` runs unchanged.
-        let v = Value::StringList(vec![
+        let v = Value::Concrete(ConcreteValue::StringList(vec![
             format!("{}deadbeef", SECRET_PREFIX),
             "x".repeat(80), // force vertical
-        ]);
+        ]));
         let out = format_value_pretty(&v, layout(0, "k"));
         assert!(
             out.contains("(secret),"),
@@ -2441,17 +2664,32 @@ mod tests {
         let mut string_like = IndexMap::new();
         string_like.insert(
             "token.actions.githubusercontent.com:sub".to_string(),
-            Value::List(vec![
-                Value::String("repo:carina-rs/infra:ref:refs/heads/main".to_string()),
-                Value::String("repo:carina-rs/infra:pull_request".to_string()),
-            ]),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String(
+                    "repo:carina-rs/infra:ref:refs/heads/main".to_string(),
+                )),
+                Value::Concrete(ConcreteValue::String(
+                    "repo:carina-rs/infra:pull_request".to_string(),
+                )),
+            ])),
         );
         let mut condition = IndexMap::new();
-        condition.insert("string_like".to_string(), Value::Map(string_like));
+        condition.insert(
+            "string_like".to_string(),
+            Value::Concrete(ConcreteValue::Map(string_like)),
+        );
         let mut entry = IndexMap::new();
-        entry.insert("sid".to_string(), Value::String("AssumeRole".to_string()));
-        entry.insert("condition".to_string(), Value::Map(condition));
-        let v = Value::List(vec![Value::Map(entry)]);
+        entry.insert(
+            "sid".to_string(),
+            Value::Concrete(ConcreteValue::String("AssumeRole".to_string())),
+        );
+        entry.insert(
+            "condition".to_string(),
+            Value::Concrete(ConcreteValue::Map(condition)),
+        );
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(entry),
+        )]));
         let out = format_value_pretty(&v, layout(4, "statement"));
         // The dynamic-key list value must break across lines (bracketed
         // form), not collapse to `<dynamic-key>: ["a", "b"]`.
@@ -2467,16 +2705,16 @@ mod tests {
 
     #[test]
     fn format_value_pretty_empty_map_inline() {
-        let v = Value::Map(IndexMap::new());
+        let v = Value::Concrete(ConcreteValue::Map(IndexMap::new()));
         assert_eq!(format_value_pretty(&v, layout(0, "k")), "{}");
     }
 
     #[test]
     fn format_value_pretty_small_map_inline_fits() {
         let mut m = IndexMap::new();
-        m.insert("a".to_string(), Value::Int(1));
-        m.insert("b".to_string(), Value::Int(2));
-        let v = Value::Map(m);
+        m.insert("a".to_string(), Value::Concrete(ConcreteValue::Int(1)));
+        m.insert("b".to_string(), Value::Concrete(ConcreteValue::Int(2)));
+        let v = Value::Concrete(ConcreteValue::Map(m));
         // {a: 1, b: 2} = 12 chars; total = 0 + 1 + 2 + 12 = 15 → inline.
         assert_eq!(format_value_pretty(&v, layout(0, "k")), "{a: 1, b: 2}");
     }
@@ -2484,9 +2722,15 @@ mod tests {
     #[test]
     fn format_value_pretty_top_level_map_expands_when_over_threshold() {
         let mut m = IndexMap::new();
-        m.insert("first_key".to_string(), Value::String("a".repeat(40)));
-        m.insert("second_key".to_string(), Value::String("b".repeat(40)));
-        let v = Value::Map(m);
+        m.insert(
+            "first_key".to_string(),
+            Value::Concrete(ConcreteValue::String("a".repeat(40))),
+        );
+        m.insert(
+            "second_key".to_string(),
+            Value::Concrete(ConcreteValue::String("b".repeat(40))),
+        );
+        let v = Value::Concrete(ConcreteValue::Map(m));
         let inline = format_value_with_key(&v, None);
         assert!(inline.len() > PRETTY_LINE_LIMIT, "fixture sanity");
 
@@ -2509,25 +2753,29 @@ mod tests {
 
         let path = AccessPath::new("vpc", "id");
         let cases = vec![
-            Value::String("hello".to_string()),
-            Value::Int(42),
-            Value::Float(2.5),
-            Value::Bool(false),
-            Value::Secret(Box::new(Value::String("pw".to_string()))),
-            Value::Unknown(UnknownReason::ForKey),
-            Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() }),
-            Value::ResourceRef { path: path.clone() },
-            Value::Interpolation(vec![
+            Value::Concrete(ConcreteValue::String("hello".to_string())),
+            Value::Concrete(ConcreteValue::Int(42)),
+            Value::Concrete(ConcreteValue::Float(2.5)),
+            Value::Concrete(ConcreteValue::Bool(false)),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("pw".to_string()),
+            )))),
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)),
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+                path: path.clone(),
+            })),
+            Value::Deferred(DeferredValue::ResourceRef { path: path.clone() }),
+            Value::Deferred(DeferredValue::Interpolation(vec![
                 InterpolationPart::Literal("prefix-".to_string()),
-                InterpolationPart::Expr(Value::ResourceRef { path }),
-            ]),
-            Value::FunctionCall {
+                InterpolationPart::Expr(Value::Deferred(DeferredValue::ResourceRef { path })),
+            ])),
+            Value::Deferred(DeferredValue::FunctionCall {
                 name: "concat".to_string(),
                 args: vec![
-                    Value::String("a".to_string()),
-                    Value::String("b".to_string()),
+                    Value::Concrete(ConcreteValue::String("a".to_string())),
+                    Value::Concrete(ConcreteValue::String("b".to_string())),
                 ],
-            },
+            }),
         ];
 
         for v in &cases {
@@ -2551,45 +2799,57 @@ mod tests {
     #[test]
     fn canonicalize_scalar_to_string_list() {
         let t = string_or_list_of_strings();
-        let v = Value::String("repo:foo:*".to_string());
+        let v = Value::Concrete(ConcreteValue::String("repo:foo:*".to_string()));
         let canon = canonicalize_with_type(v, &t);
-        assert_eq!(canon, Value::StringList(vec!["repo:foo:*".to_string()]));
+        assert_eq!(
+            canon,
+            Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]))
+        );
     }
 
     #[test]
     fn canonicalize_single_element_list_to_string_list() {
         let t = string_or_list_of_strings();
-        let v = Value::List(vec![Value::String("repo:foo:*".to_string())]);
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("repo:foo:*".to_string()),
+        )]));
         let canon = canonicalize_with_type(v, &t);
-        assert_eq!(canon, Value::StringList(vec!["repo:foo:*".to_string()]));
+        assert_eq!(
+            canon,
+            Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]))
+        );
     }
 
     #[test]
     fn canonicalize_multi_element_list_to_string_list() {
         let t = string_or_list_of_strings();
-        let v = Value::List(vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
-            Value::String("c".to_string()),
-        ]);
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
+            Value::Concrete(ConcreteValue::String("c".to_string())),
+        ]));
         let canon = canonicalize_with_type(v, &t);
         assert_eq!(
             canon,
-            Value::StringList(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+            Value::Concrete(ConcreteValue::StringList(vec![
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string()
+            ]))
         );
     }
 
     #[test]
     fn canonicalize_idempotent_on_string_list() {
         let t = string_or_list_of_strings();
-        let v = Value::StringList(vec!["a".to_string()]);
+        let v = Value::Concrete(ConcreteValue::StringList(vec!["a".to_string()]));
         let canon = canonicalize_with_type(v.clone(), &t);
         assert_eq!(canon, v);
     }
 
     #[test]
     fn canonicalize_passes_through_non_applicable_type() {
-        let v = Value::String("foo".to_string());
+        let v = Value::Concrete(ConcreteValue::String("foo".to_string()));
         let canon = canonicalize_with_type(v.clone(), &AttributeType::String);
         assert_eq!(canon, v);
     }
@@ -2599,7 +2859,9 @@ mod tests {
         let t = string_or_list_of_strings();
         // List with non-String elements stays as List — not the canonical
         // form. Schema validation will flag it elsewhere.
-        let v = Value::List(vec![Value::Int(1)]);
+        let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Int(1),
+        )]));
         let canon = canonicalize_with_type(v.clone(), &t);
         assert_eq!(canon, v);
     }
@@ -2616,15 +2878,17 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert(
             "action".to_string(),
-            Value::String("s3:GetObject".to_string()),
+            Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
         );
-        let v = Value::Map(map);
+        let v = Value::Concrete(ConcreteValue::Map(map));
         let canon = canonicalize_with_type(v, &t);
         match canon {
-            Value::Map(m) => {
+            Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
                     m.get("action"),
-                    Some(&Value::StringList(vec!["s3:GetObject".to_string()]))
+                    Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                        "s3:GetObject".to_string()
+                    ])))
                 );
             }
             _ => panic!("expected Map"),
@@ -2643,15 +2907,17 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert(
             "Action".to_string(),
-            Value::String("s3:GetObject".to_string()),
+            Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
         );
-        let v = Value::Map(map);
+        let v = Value::Concrete(ConcreteValue::Map(map));
         let canon = canonicalize_with_type(v, &t);
         match canon {
-            Value::Map(m) => {
+            Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
                     m.get("Action"),
-                    Some(&Value::StringList(vec!["s3:GetObject".to_string()]))
+                    Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                        "s3:GetObject".to_string()
+                    ])))
                 );
             }
             _ => panic!("expected Map"),
@@ -2667,15 +2933,17 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert(
             "token.actions.githubusercontent.com:sub".to_string(),
-            Value::String("repo:foo:*".to_string()),
+            Value::Concrete(ConcreteValue::String("repo:foo:*".to_string())),
         );
-        let v = Value::Map(map);
+        let v = Value::Concrete(ConcreteValue::Map(map));
         let canon = canonicalize_with_type(v, &t);
         match canon {
-            Value::Map(m) => {
+            Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
                     m.get("token.actions.githubusercontent.com:sub"),
-                    Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+                    Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                        "repo:foo:*".to_string()
+                    ])))
                 );
             }
             _ => panic!("expected Map"),
@@ -2694,19 +2962,27 @@ mod tests {
             namespace: None,
             to_dsl: None,
         };
-        let v = Value::String("x".to_string());
+        let v = Value::Concrete(ConcreteValue::String("x".to_string()));
         let canon = canonicalize_with_type(v, &t);
-        assert_eq!(canon, Value::StringList(vec!["x".to_string()]));
+        assert_eq!(
+            canon,
+            Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]))
+        );
     }
 
     #[test]
     fn canonicalize_secret_recurses_inner() {
         let t = string_or_list_of_strings();
-        let v = Value::Secret(Box::new(Value::String("s".to_string())));
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("s".to_string()),
+        ))));
         let canon = canonicalize_with_type(v, &t);
         match canon {
-            Value::Secret(inner) => {
-                assert_eq!(*inner, Value::StringList(vec!["s".to_string()]));
+            Value::Deferred(DeferredValue::Secret(inner)) => {
+                assert_eq!(
+                    *inner,
+                    Value::Concrete(ConcreteValue::StringList(vec!["s".to_string()]))
+                );
             }
             _ => panic!("expected Secret"),
         }
@@ -2714,7 +2990,10 @@ mod tests {
 
     #[test]
     fn canonicalize_value_to_json_string_list_serializes_as_array() {
-        let v = Value::StringList(vec!["a".to_string(), "b".to_string()]);
+        let v = Value::Concrete(ConcreteValue::StringList(vec![
+            "a".to_string(),
+            "b".to_string(),
+        ]));
         let json = value_to_json(&v).expect("StringList serializes cleanly");
         assert_eq!(
             json,
@@ -2746,15 +3025,17 @@ mod tests {
     #[test]
     fn inline_width_parity_for_scalars() {
         for v in [
-            Value::String("hello".to_string()),
-            Value::String("(empty)".to_string()),
-            Value::Int(42),
-            Value::Int(-7),
-            Value::Float(1.5),
-            Value::Float(2.0),
-            Value::Bool(true),
-            Value::Bool(false),
-            Value::Secret(Box::new(Value::String("hidden".to_string()))),
+            Value::Concrete(ConcreteValue::String("hello".to_string())),
+            Value::Concrete(ConcreteValue::String("(empty)".to_string())),
+            Value::Concrete(ConcreteValue::Int(42)),
+            Value::Concrete(ConcreteValue::Int(-7)),
+            Value::Concrete(ConcreteValue::Float(1.5)),
+            Value::Concrete(ConcreteValue::Float(2.0)),
+            Value::Concrete(ConcreteValue::Bool(true)),
+            Value::Concrete(ConcreteValue::Bool(false)),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("hidden".to_string()),
+            )))),
         ] {
             assert_inline_width_matches_build(&v);
         }
@@ -2762,27 +3043,33 @@ mod tests {
 
     #[test]
     fn inline_width_parity_for_lists_and_maps() {
-        let list = Value::List(vec![
-            Value::String("a".to_string()),
-            Value::Int(1),
-            Value::Bool(true),
-        ]);
+        let list = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::Bool(true)),
+        ]));
         assert_inline_width_matches_build(&list);
 
         let mut map = IndexMap::new();
-        map.insert("k1".to_string(), Value::String("v1".to_string()));
-        map.insert("k2".to_string(), Value::Int(99));
-        assert_inline_width_matches_build(&Value::Map(map));
+        map.insert(
+            "k1".to_string(),
+            Value::Concrete(ConcreteValue::String("v1".to_string())),
+        );
+        map.insert("k2".to_string(), Value::Concrete(ConcreteValue::Int(99)));
+        assert_inline_width_matches_build(&Value::Concrete(ConcreteValue::Map(map)));
 
         // Nested list/map.
         let mut inner = IndexMap::new();
-        inner.insert("x".to_string(), Value::Int(1));
-        let nested = Value::List(vec![Value::Map(inner), Value::String("end".to_string())]);
+        inner.insert("x".to_string(), Value::Concrete(ConcreteValue::Int(1)));
+        let nested = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Map(inner)),
+            Value::Concrete(ConcreteValue::String("end".to_string())),
+        ]));
         assert_inline_width_matches_build(&nested);
 
         // Empty collections.
-        assert_inline_width_matches_build(&Value::List(vec![]));
-        assert_inline_width_matches_build(&Value::Map(IndexMap::new()));
+        assert_inline_width_matches_build(&Value::Concrete(ConcreteValue::List(vec![])));
+        assert_inline_width_matches_build(&Value::Concrete(ConcreteValue::Map(IndexMap::new())));
     }
 
     #[test]
@@ -2791,7 +3078,9 @@ mod tests {
         // resolve to their provider value before being quoted in
         // `format_value_with_key`. inline_width must follow the same
         // resolution to match the rendered byte length.
-        let v = Value::String("aws.Region.ap_northeast_1".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "aws.Region.ap_northeast_1".to_string(),
+        ));
         assert_inline_width_matches_build(&v);
     }
 
@@ -2802,9 +3091,9 @@ mod tests {
         // every leaf. The cheapest observable proxy: a budget of 1 on a
         // value whose first byte already exceeds it returns None even
         // though the value itself is structurally complex.
-        let mut deep = Value::Int(1);
+        let mut deep = Value::Concrete(ConcreteValue::Int(1));
         for _ in 0..10 {
-            deep = Value::List(vec![deep]);
+            deep = Value::Concrete(ConcreteValue::List(vec![deep]));
         }
         assert_eq!(
             inline_width(&deep, 1),
@@ -2815,17 +3104,22 @@ mod tests {
 
     #[test]
     fn canonicalize_format_value_string_list() {
-        let v = Value::StringList(vec!["a".to_string(), "b".to_string()]);
+        let v = Value::Concrete(ConcreteValue::StringList(vec![
+            "a".to_string(),
+            "b".to_string(),
+        ]));
         assert_eq!(format_value(&v), "[\"a\", \"b\"]");
     }
 
     #[test]
     fn canonicalize_partial_eq_distinguishes_list_and_string_list() {
-        // `Value::List([String("x")])` and `Value::StringList(vec!["x"])`
+        // `Value::Concrete(ConcreteValue::List([String("x")]))` and `Value::Concrete(ConcreteValue::StringList(vec!["x"]))`
         // are *not* equal under PartialEq — the type system carries the
         // canonical-form invariant. Producers must canonicalize first.
-        let a = Value::List(vec![Value::String("x".to_string())]);
-        let b = Value::StringList(vec!["x".to_string()]);
+        let a = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("x".to_string()),
+        )]));
+        let b = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
         assert_ne!(a, b);
     }
 
@@ -2869,12 +3163,14 @@ mod tests {
         let registry = build_test_registry();
         let mut resources = vec![make_resource(vec![(
             "subject",
-            Value::String("repo:foo:*".to_string()),
+            Value::Concrete(ConcreteValue::String("repo:foo:*".to_string())),
         )])];
         canonicalize_resources_with_schemas(&mut resources, &registry);
         assert_eq!(
             resources[0].attributes.get("subject"),
-            Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "repo:foo:*".to_string()
+            ])))
         );
     }
 
@@ -2883,12 +3179,16 @@ mod tests {
         let registry = build_test_registry();
         let mut resources = vec![make_resource(vec![(
             "subject",
-            Value::List(vec![Value::String("repo:foo:*".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("repo:foo:*".to_string()),
+            )])),
         )])];
         canonicalize_resources_with_schemas(&mut resources, &registry);
         assert_eq!(
             resources[0].attributes.get("subject"),
-            Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "repo:foo:*".to_string()
+            ])))
         );
     }
 
@@ -2898,12 +3198,12 @@ mod tests {
         let registry = crate::schema::SchemaRegistry::new();
         let mut resources = vec![make_resource(vec![(
             "subject",
-            Value::String("x".to_string()),
+            Value::Concrete(ConcreteValue::String("x".to_string())),
         )])];
         canonicalize_resources_with_schemas(&mut resources, &registry);
         assert_eq!(
             resources[0].attributes.get("subject"),
-            Some(&Value::String("x".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("x".to_string())))
         );
     }
 
@@ -2913,13 +3213,19 @@ mod tests {
         // unknown attribute — leave it alone.
         let registry = build_test_registry();
         let mut resources = vec![make_resource(vec![
-            ("subject", Value::String("x".to_string())),
-            ("name", Value::String("p1".to_string())),
+            (
+                "subject",
+                Value::Concrete(ConcreteValue::String("x".to_string())),
+            ),
+            (
+                "name",
+                Value::Concrete(ConcreteValue::String("p1".to_string())),
+            ),
         ])];
         canonicalize_resources_with_schemas(&mut resources, &registry);
         assert_eq!(
             resources[0].attributes.get("name"),
-            Some(&Value::String("p1".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("p1".to_string())))
         );
     }
 
@@ -2931,11 +3237,13 @@ mod tests {
         let registry = build_test_registry();
         let mut a = vec![make_resource(vec![(
             "subject",
-            Value::String("repo:foo:*".to_string()),
+            Value::Concrete(ConcreteValue::String("repo:foo:*".to_string())),
         )])];
         let mut b = vec![make_resource(vec![(
             "subject",
-            Value::List(vec![Value::String("repo:foo:*".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("repo:foo:*".to_string()),
+            )])),
         )])];
         canonicalize_resources_with_schemas(&mut a, &registry);
         canonicalize_resources_with_schemas(&mut b, &registry);
@@ -2968,13 +3276,18 @@ mod tests {
     fn canonicalize_states_with_schemas_scalar_to_string_list() {
         let registry = build_test_registry();
         let mut states = std::collections::HashMap::new();
-        let s = make_state(vec![("subject", Value::String("repo:foo:*".to_string()))]);
+        let s = make_state(vec![(
+            "subject",
+            Value::Concrete(ConcreteValue::String("repo:foo:*".to_string())),
+        )]);
         states.insert(s.id.clone(), s);
         canonicalize_states_with_schemas(&mut states, &registry);
         let state = states.values().next().unwrap();
         assert_eq!(
             state.attributes.get("subject"),
-            Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "repo:foo:*".to_string()
+            ])))
         );
     }
 
@@ -2984,14 +3297,18 @@ mod tests {
         let mut states = std::collections::HashMap::new();
         let s = make_state(vec![(
             "subject",
-            Value::List(vec![Value::String("repo:foo:*".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("repo:foo:*".to_string()),
+            )])),
         )]);
         states.insert(s.id.clone(), s);
         canonicalize_states_with_schemas(&mut states, &registry);
         let state = states.values().next().unwrap();
         assert_eq!(
             state.attributes.get("subject"),
-            Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "repo:foo:*".to_string()
+            ])))
         );
     }
 
@@ -2999,13 +3316,16 @@ mod tests {
     fn canonicalize_states_with_schemas_skips_unknown_resource() {
         let registry = crate::schema::SchemaRegistry::new();
         let mut states = std::collections::HashMap::new();
-        let s = make_state(vec![("subject", Value::String("x".to_string()))]);
+        let s = make_state(vec![(
+            "subject",
+            Value::Concrete(ConcreteValue::String("x".to_string())),
+        )]);
         states.insert(s.id.clone(), s);
         canonicalize_states_with_schemas(&mut states, &registry);
         let state = states.values().next().unwrap();
         assert_eq!(
             state.attributes.get("subject"),
-            Some(&Value::String("x".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String("x".to_string())))
         );
     }
 
@@ -3013,18 +3333,23 @@ mod tests {
     fn canonicalize_states_diff_empty_after_both_sides_canonical() {
         // The acceptance criterion from #2513: a desired side written
         // as `["x"]` and a state side stored as `"x"` collapse to the
-        // same `Value::StringList(vec!["x"])` after both pass through
+        // same `Value::Concrete(ConcreteValue::StringList(vec!["x"]))` after both pass through
         // canonicalization.
         let registry = build_test_registry();
 
         let mut resources = vec![make_resource(vec![(
             "subject",
-            Value::List(vec![Value::String("repo:foo:*".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("repo:foo:*".to_string()),
+            )])),
         )])];
         canonicalize_resources_with_schemas(&mut resources, &registry);
 
         let mut states = std::collections::HashMap::new();
-        let s = make_state(vec![("subject", Value::String("repo:foo:*".to_string()))]);
+        let s = make_state(vec![(
+            "subject",
+            Value::Concrete(ConcreteValue::String("repo:foo:*".to_string())),
+        )]);
         states.insert(s.id.clone(), s);
         canonicalize_states_with_schemas(&mut states, &registry);
 
@@ -3039,29 +3364,35 @@ mod tests {
 
     #[test]
     fn validate_list_accepts_string_list() {
-        // The schema's `validate_list` must accept `Value::StringList`
-        // as the structural equivalent of `Value::List([String, ...])`,
+        // The schema's `validate_list` must accept `Value::Concrete(ConcreteValue::StringList)`
+        // as the structural equivalent of `Value::Concrete(ConcreteValue::List([String, ...]))`,
         // so a Union[String, list(String)] member's `list(String)`
         // branch validates the canonical form cleanly.
         use crate::schema::AttributeType;
         let list_of_string = AttributeType::list(AttributeType::String);
-        let v = Value::StringList(vec!["a".to_string(), "b".to_string()]);
+        let v = Value::Concrete(ConcreteValue::StringList(vec![
+            "a".to_string(),
+            "b".to_string(),
+        ]));
         assert!(list_of_string.validate(&v).is_ok());
     }
 
     #[test]
     fn validate_union_accepts_canonical_string_list() {
         let union = string_or_list_of_strings();
-        let v = Value::StringList(vec!["x".to_string()]);
+        let v = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
         assert!(union.validate(&v).is_ok());
     }
 
     #[test]
     fn format_value_string_list_renders_brackets() {
-        // `format_value` must render `Value::StringList` with bracket
+        // `format_value` must render `Value::Concrete(ConcreteValue::StringList)` with bracket
         // syntax — not a `_` wildcard fallback that would print debug
         // garbage in plan output.
-        let v = Value::StringList(vec!["a".to_string(), "b".to_string()]);
+        let v = Value::Concrete(ConcreteValue::StringList(vec![
+            "a".to_string(),
+            "b".to_string(),
+        ]));
         let formatted = format_value(&v);
         assert_eq!(formatted, "[\"a\", \"b\"]");
     }
@@ -3070,11 +3401,11 @@ mod tests {
     fn inline_width_returns_none_when_just_over_budget() {
         // List of three short strings: `["aa", "bb", "cc"]` = 18 bytes.
         // Budget 17 must return None; budget 18 must return Some(18).
-        let v = Value::List(vec![
-            Value::String("aa".to_string()),
-            Value::String("bb".to_string()),
-            Value::String("cc".to_string()),
-        ]);
+        let v = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("aa".to_string())),
+            Value::Concrete(ConcreteValue::String("bb".to_string())),
+            Value::Concrete(ConcreteValue::String("cc".to_string())),
+        ]));
         assert_eq!(
             format_value_with_key(&v, None).len(),
             18,
@@ -3093,10 +3424,10 @@ mod tests {
         // PRETTY_LINE_LIMIT (80) at the prefix boundary and confirm both
         // sides of the boundary still pick the same form.
         // Just under the limit (inline expected).
-        let small_list = Value::List(vec![
-            Value::String("aaaaaaaaaaaa".to_string()),
-            Value::String("bbbbbbbbbbbb".to_string()),
-        ]);
+        let small_list = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("aaaaaaaaaaaa".to_string())),
+            Value::Concrete(ConcreteValue::String("bbbbbbbbbbbb".to_string())),
+        ]));
         let small = format_value_pretty(&small_list, layout(0, "k"));
         assert!(
             !small.contains('\n'),
@@ -3104,11 +3435,11 @@ mod tests {
         );
 
         // Over the limit (vertical expected).
-        let big_list = Value::List(vec![
-            Value::String("a".repeat(40)),
-            Value::String("b".repeat(40)),
-            Value::String("c".repeat(40)),
-        ]);
+        let big_list = Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("a".repeat(40))),
+            Value::Concrete(ConcreteValue::String("b".repeat(40))),
+            Value::Concrete(ConcreteValue::String("c".repeat(40))),
+        ]));
         let big = format_value_pretty(&big_list, layout(0, "k"));
         assert!(
             big.contains('\n'),

--- a/carina-core/src/wait/predicate.rs
+++ b/carina-core/src/wait/predicate.rs
@@ -15,7 +15,7 @@ use crate::resource::Value;
 ///
 /// MVP only resolves a single top-level segment; nested-field traversal
 /// (`renewal_summary.renewal_status`) is reserved for a follow-up that
-/// teaches the evaluator to descend into `Value::Map`.
+/// teaches the evaluator to descend into `Value::Concrete(ConcreteValue::Map)`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttrPath {
     pub segments: Vec<String>,

--- a/carina-core/src/wait/tests.rs
+++ b/carina-core/src/wait/tests.rs
@@ -1,16 +1,19 @@
 use std::collections::HashMap;
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 use crate::wait::predicate::{AttrPath, WaitPredicate};
 
 #[test]
 fn equals_returns_true_when_attribute_matches() {
     let pred = WaitPredicate::Equals {
         attr: AttrPath::single("status"),
-        value: Value::String("ISSUED".to_string()),
+        value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
     };
     let mut attrs = HashMap::new();
-    attrs.insert("status".to_string(), Value::String("ISSUED".to_string()));
+    attrs.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+    );
     assert!(pred.evaluate(&attrs));
 }
 
@@ -18,12 +21,12 @@ fn equals_returns_true_when_attribute_matches() {
 fn equals_returns_false_when_attribute_differs() {
     let pred = WaitPredicate::Equals {
         attr: AttrPath::single("status"),
-        value: Value::String("ISSUED".to_string()),
+        value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
     };
     let mut attrs = HashMap::new();
     attrs.insert(
         "status".to_string(),
-        Value::String("PENDING_VALIDATION".to_string()),
+        Value::Concrete(ConcreteValue::String("PENDING_VALIDATION".to_string())),
     );
     assert!(!pred.evaluate(&attrs));
 }
@@ -32,7 +35,7 @@ fn equals_returns_false_when_attribute_differs() {
 fn equals_returns_false_when_attribute_absent() {
     let pred = WaitPredicate::Equals {
         attr: AttrPath::single("status"),
-        value: Value::String("ISSUED".to_string()),
+        value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
     };
     let attrs: HashMap<String, Value> = HashMap::new();
     assert!(!pred.evaluate(&attrs));

--- a/carina-core/tests/canonicalize_invariants.rs
+++ b/carina-core/tests/canonicalize_invariants.rs
@@ -1,10 +1,10 @@
 //! Invariants enforced by `Value::canonicalize` (#2227).
 //!
-//! After `parse + resolve`, every `Value::Interpolation` in the parsed
+//! After `parse + resolve`, every `Value::Deferred(DeferredValue::Interpolation)` in the parsed
 //! file must satisfy:
 //!
 //! 1. At least one part is an `Expr` (otherwise the value would be a
-//!    `Value::String`).
+//!    `Value::Concrete(ConcreteValue::String)`).
 //! 2. No two adjacent parts are both `Literal` (they would have been
 //!    merged).
 //! 3. The whole interpolation is not a single `Expr(scalar)` whose
@@ -15,11 +15,11 @@
 //! asserts the invariants hold for every interpolation found.
 
 use carina_core::parser::parse_and_resolve;
-use carina_core::resource::{InterpolationPart, Value};
+use carina_core::resource::{ConcreteValue, DeferredValue, InterpolationPart, Value};
 
 fn check_value(v: &Value, path: &str) {
     match v {
-        Value::Interpolation(parts) => {
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
             // (1) at least one Expr
             let has_expr = parts
                 .iter()
@@ -44,7 +44,10 @@ fn check_value(v: &Value, path: &str) {
             {
                 let scalar = matches!(
                     inner,
-                    Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_)
+                    Value::Concrete(ConcreteValue::String(_))
+                        | Value::Concrete(ConcreteValue::Int(_))
+                        | Value::Concrete(ConcreteValue::Float(_))
+                        | Value::Concrete(ConcreteValue::Bool(_))
                 );
                 assert!(
                     !scalar,
@@ -59,18 +62,20 @@ fn check_value(v: &Value, path: &str) {
                 }
             }
         }
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             for (i, item) in items.iter().enumerate() {
                 check_value(item, &format!("{}[{}]", path, i));
             }
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             for (k, vv) in map {
                 check_value(vv, &format!("{}.{}", path, k));
             }
         }
-        Value::Secret(inner) => check_value(inner, &format!("{}/<secret>", path)),
-        Value::FunctionCall { name, args } => {
+        Value::Deferred(DeferredValue::Secret(inner)) => {
+            check_value(inner, &format!("{}/<secret>", path))
+        }
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
             for (i, a) in args.iter().enumerate() {
                 check_value(a, &format!("{}/{}({})", path, name, i));
             }
@@ -135,8 +140,8 @@ fn parse_resolve_yields_canonical_interpolations() {
 #[test]
 fn double_quoted_literal_is_canonical_string() {
     // Pre-#2227 a double-quoted string with no `${...}` was
-    // `Value::Interpolation([Literal(...)])`; now it must be
-    // `Value::String(...)`.
+    // `Value::Deferred(DeferredValue::Interpolation([Literal(...)]))`; now it must be
+    // `Value::Concrete(ConcreteValue::String(...))`.
     let src = r#"
         mock.example.thing {
           name  = "no-interpolation-here"
@@ -146,7 +151,7 @@ fn double_quoted_literal_is_canonical_string() {
     let resource = &parsed.resources[0];
     let value = resource.attributes.get("name").expect("name attribute");
     assert!(
-        matches!(value, Value::String(_)),
+        matches!(value, Value::Concrete(ConcreteValue::String(_))),
         "literal-only double-quoted string must canonicalize to String, got {:?}",
         value
     );

--- a/carina-core/tests/wait_directory.rs
+++ b/carina-core/tests/wait_directory.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 use carina_core::config_loader::parse_directory;
 use carina_core::parser::ProviderContext;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 
 #[test]
 fn wait_resolves_target_and_depends_on_across_sibling_files() {
@@ -40,7 +40,9 @@ fn wait_resolves_target_and_depends_on_across_sibling_files() {
     assert_eq!(wait.until_predicate.lhs_segments, vec!["cert", "status"]);
     assert_eq!(
         wait.until_predicate.rhs,
-        Value::String("aws.acm.Certificate.Status.Issued".to_string())
+        Value::Concrete(ConcreteValue::String(
+            "aws.acm.Certificate.Status.Issued".to_string()
+        ))
     );
 
     // Sanity: the target binding really lives in a sibling file.

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -938,7 +938,9 @@ mod tests {
             cfg.attributes
                 .get("_installed_at")
                 .and_then(|v| match v {
-                    carina_core::resource::Value::String(s) => Some(s.as_str()),
+                    carina_core::resource::Value::Concrete(
+                        carina_core::resource::ConcreteValue::String(s),
+                    ) => Some(s.as_str()),
                     _ => None,
                 })
                 .map(|p| std::path::Path::new(p).exists())
@@ -955,7 +957,7 @@ mod tests {
     #[test]
     fn install_fingerprint_flips_when_local_wasm_is_deleted() {
         use carina_core::parser::ProviderConfig;
-        use carina_core::resource::Value;
+        use carina_core::resource::{ConcreteValue, Value};
 
         let tmp = tempfile::tempdir().unwrap();
         let installed = tmp.path().join("carina-provider-foo.wasm");
@@ -964,7 +966,7 @@ mod tests {
         let mut attributes = IndexMap::new();
         attributes.insert(
             "_installed_at".to_string(),
-            Value::String(installed.display().to_string()),
+            Value::Concrete(ConcreteValue::String(installed.display().to_string())),
         );
         let config = ProviderConfig {
             name: "foo".into(),
@@ -1022,7 +1024,7 @@ mod tests {
 mod reload_skip_tests {
     use super::*;
     use carina_core::parser::ProviderConfig;
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
     use indexmap::IndexMap;
 
     fn mk_config(name: &str, source: Option<&str>) -> ProviderConfig {
@@ -1090,13 +1092,15 @@ mod reload_skip_tests {
     fn configs_match_returns_false_when_attributes_change() {
         let dir = std::path::PathBuf::from("/tmp/x");
         let mut cfg_a = mk_config("awscc", Some("github.com/carina-rs/carina-provider-awscc"));
-        cfg_a
-            .attributes
-            .insert("region".into(), Value::String("us-east-1".into()));
+        cfg_a.attributes.insert(
+            "region".into(),
+            Value::Concrete(ConcreteValue::String("us-east-1".into())),
+        );
         let mut cfg_b = mk_config("awscc", Some("github.com/carina-rs/carina-provider-awscc"));
-        cfg_b
-            .attributes
-            .insert("region".into(), Value::String("ap-northeast-1".into()));
+        cfg_b.attributes.insert(
+            "region".into(),
+            Value::Concrete(ConcreteValue::String("ap-northeast-1".into())),
+        );
         let a = vec![(dir.clone(), cfg_a)];
         let b = vec![(dir, cfg_b)];
         assert!(!configs_match(&a, &b));
@@ -1108,19 +1112,23 @@ mod reload_skip_tests {
         // depend on the order in which attributes were inserted.
         let dir = std::path::PathBuf::from("/tmp/x");
         let mut cfg_a = mk_config("awscc", Some("github.com/carina-rs/carina-provider-awscc"));
-        cfg_a
-            .attributes
-            .insert("region".into(), Value::String("us-east-1".into()));
-        cfg_a
-            .attributes
-            .insert("profile".into(), Value::String("dev".into()));
+        cfg_a.attributes.insert(
+            "region".into(),
+            Value::Concrete(ConcreteValue::String("us-east-1".into())),
+        );
+        cfg_a.attributes.insert(
+            "profile".into(),
+            Value::Concrete(ConcreteValue::String("dev".into())),
+        );
         let mut cfg_b = mk_config("awscc", Some("github.com/carina-rs/carina-provider-awscc"));
-        cfg_b
-            .attributes
-            .insert("profile".into(), Value::String("dev".into()));
-        cfg_b
-            .attributes
-            .insert("region".into(), Value::String("us-east-1".into()));
+        cfg_b.attributes.insert(
+            "profile".into(),
+            Value::Concrete(ConcreteValue::String("dev".into())),
+        );
+        cfg_b.attributes.insert(
+            "region".into(),
+            Value::Concrete(ConcreteValue::String("us-east-1".into())),
+        );
         let a = vec![(dir.clone(), cfg_a)];
         let b = vec![(dir, cfg_b)];
         assert!(configs_match(&a, &b));

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -3370,7 +3370,7 @@ let main = awscc.ec2.Vpc {
 }
 
 /// Issue #2357 negative-acceptance. An export whose rhs is a
-/// `Value::FunctionCall` (e.g. `lookup`) cannot be statically typed —
+/// `Value::Deferred(DeferredValue::FunctionCall)` (e.g. `lookup`) cannot be statically typed —
 /// it must stay un-offered, matching the conservative behavior the
 /// stage-1 inference inherited.
 #[test]

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -1027,7 +1027,10 @@ impl CompletionProvider {
                 // mid-edit upstream where the body hasn't parsed yet)
                 // also yields no candidates — silently, so cross-file
                 // completion stays online while the user types (#2490).
-                let Some(carina_core::resource::Value::Map(entries)) = &entry.value else {
+                let Some(carina_core::resource::Value::Concrete(
+                    carina_core::resource::ConcreteValue::Map(entries),
+                )) = &entry.value
+                else {
                     return Vec::new();
                 };
                 let value_type = value_type.to_string();

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -8,7 +8,7 @@ use crate::document::Document;
 use crate::position;
 use carina_core::builtins;
 use carina_core::parser::{ArgumentParameter, ParsedFile, TypeExpr};
-use carina_core::resource::{Resource, Value};
+use carina_core::resource::{ConcreteValue, DeferredValue, Resource, Value};
 use carina_core::schema::{ResourceSchema, suggest_similar_name};
 use carina_core::upstream_exports::UpstreamRefDiagnostic;
 
@@ -1030,13 +1030,17 @@ impl DiagnosticEngine {
         for attr_param in &parsed.attribute_params {
             if let Some(value) = &attr_param.value {
                 // Check for undefined binding references — both shapes
-                // (`Value::ResourceRef` for `name.attr`, `Value::BindingRef`
+                // (`Value::Deferred(DeferredValue::ResourceRef)` for `name.attr`, `Value::Deferred(DeferredValue::BindingRef)`
                 // for bare `name`, since #2847).
                 let undefined_binding = match value {
-                    Value::ResourceRef { path } if !defined_bindings.contains(path.binding()) => {
+                    Value::Deferred(DeferredValue::ResourceRef { path })
+                        if !defined_bindings.contains(path.binding()) =>
+                    {
                         Some(path.binding().to_string())
                     }
-                    Value::BindingRef { binding } if !defined_bindings.contains(binding) => {
+                    Value::Deferred(DeferredValue::BindingRef { binding })
+                        if !defined_bindings.contains(binding) =>
+                    {
                         Some(binding.clone())
                     }
                     _ => None,
@@ -1076,7 +1080,7 @@ impl DiagnosticEngine {
                 // ResourceRef type validation: check that the referenced attribute's
                 // schema type is compatible with the declared TypeExpr
                 if let Some(ref type_expr) = attr_param.type_expr
-                    && let Value::ResourceRef { path } = value
+                    && let Value::Deferred(DeferredValue::ResourceRef { path }) = value
                     && let Some(ref_type_error) = self.check_attribute_ref_type(
                         type_expr,
                         path,
@@ -1199,9 +1203,9 @@ impl DiagnosticEngine {
             // not produced by the .crn parser — synthetic test inputs
             // and any caller that hands us a raw `"binding.attr"` —
             // since the parser itself now lowers dotted IDs to
-            // `Value::ResourceRef` (#2447). The ResourceRef arm below
+            // `Value::Deferred(DeferredValue::ResourceRef)` (#2447). The ResourceRef arm below
             // is the parser-produced path; both must agree.
-            (_, Value::String(s)) if is_dot_notation_ref(s) => {
+            (_, Value::Concrete(ConcreteValue::String(s))) if is_dot_notation_ref(s) => {
                 let parts: Vec<&str> = s.split('.').collect();
                 self.check_cross_file_ref_type(type_expr, parts[0], parts[1], sibling_bindings)
             }
@@ -1211,7 +1215,7 @@ impl DiagnosticEngine {
             // against the receiver precisely (#2475); skip the
             // comparison rather than false-flag against the head's
             // outer type.
-            (_, Value::ResourceRef { path })
+            (_, Value::Deferred(DeferredValue::ResourceRef { path }))
                 if path.field_path().is_empty() && path.subscripts().is_empty() =>
             {
                 self.check_cross_file_ref_type(
@@ -1221,14 +1225,14 @@ impl DiagnosticEngine {
                     sibling_bindings,
                 )
             }
-            (_, Value::ResourceRef { .. }) => None,
+            (_, Value::Deferred(DeferredValue::ResourceRef { .. })) => None,
             // Bare-binding ref (#2847): no attribute selector means we
             // cannot localize the type at this checkpoint without a
             // separate let/argument lookup. Skip rather than false-flag
             // — same policy as the `ResourceRef` fallthrough above.
-            (_, Value::BindingRef { .. }) => None,
+            (_, Value::Deferred(DeferredValue::BindingRef { .. })) => None,
             // List: recurse into elements
-            (TypeExpr::List(inner), Value::List(items)) => {
+            (TypeExpr::List(inner), Value::Concrete(ConcreteValue::List(items))) => {
                 for (i, item) in items.iter().enumerate() {
                     if let Some(e) =
                         self.validate_type_with_ref_awareness(inner, item, sibling_bindings)
@@ -1239,7 +1243,7 @@ impl DiagnosticEngine {
                 None
             }
             // Map: recurse into values
-            (TypeExpr::Map(inner), Value::Map(map)) => {
+            (TypeExpr::Map(inner), Value::Concrete(ConcreteValue::Map(map))) => {
                 for (key, val) in map {
                     if let Some(e) =
                         self.validate_type_with_ref_awareness(inner, val, sibling_bindings)
@@ -1251,7 +1255,7 @@ impl DiagnosticEngine {
             }
             // Recurse through this ref-aware walker — not `validate_type_expr_value` —
             // so cross-file refs inside struct fields still resolve against sibling bindings.
-            (TypeExpr::Struct { fields }, Value::Map(map)) => {
+            (TypeExpr::Struct { fields }, Value::Concrete(ConcreteValue::Map(map))) => {
                 if let Some(e) = carina_core::validation::struct_field_shape_errors(fields, map) {
                     return Some(e);
                 }
@@ -1683,7 +1687,7 @@ impl DiagnosticEngine {
         diagnostics: &mut Vec<Diagnostic>,
     ) {
         match value {
-            Value::FunctionCall { name, args } => {
+            Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
                 if !builtins::is_known_builtin(name)
                     && !user_fns.contains(name)
                     && let Some((line, col)) = self.find_function_call_position(doc, name)
@@ -1701,17 +1705,17 @@ impl DiagnosticEngine {
                     self.collect_unknown_function_diagnostics(doc, arg, user_fns, diagnostics);
                 }
             }
-            Value::List(items) => {
+            Value::Concrete(ConcreteValue::List(items)) => {
                 for item in items {
                     self.collect_unknown_function_diagnostics(doc, item, user_fns, diagnostics);
                 }
             }
-            Value::Map(map) => {
+            Value::Concrete(ConcreteValue::Map(map)) => {
                 for v in map.values() {
                     self.collect_unknown_function_diagnostics(doc, v, user_fns, diagnostics);
                 }
             }
-            Value::Interpolation(parts) => {
+            Value::Deferred(DeferredValue::Interpolation(parts)) => {
                 for part in parts {
                     if let carina_core::resource::InterpolationPart::Expr(expr) = part {
                         self.collect_unknown_function_diagnostics(doc, expr, user_fns, diagnostics);
@@ -1884,7 +1888,7 @@ impl DiagnosticEngine {
     /// hint that the placeholder is unfilled. See #2480.
     ///
     /// Text scan rather than AST walk: the parser stamps the empty case as
-    /// `Value::Unknown(UnknownReason::EmptyInterpolation)` but discards the
+    /// `Value::Deferred(DeferredValue::Unknown(UnknownReason::EmptyInterpolation))` but discards the
     /// source span, so the diagnostic range has to come from a source-level
     /// pass anyway.
     pub(super) fn check_empty_interpolations(&self, doc: &Document) -> Vec<Diagnostic> {

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -14,7 +14,7 @@ use crate::document::Document;
 use crate::position;
 use carina_core::parser::{ParseError, ParsedFile};
 use carina_core::provider::ProviderFactory;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, DeferredValue, Value};
 use carina_core::schema::{ResourceSchema, SchemaRegistry};
 
 /// Create a `Diagnostic` on a single line with the standard "carina" source.
@@ -409,12 +409,12 @@ impl DiagnosticEngine {
                         // Type validation
                         if let Some(attr_schema) = schema.attributes.get(canonical_name) {
                             // Check for block syntax on bare Struct attributes:
-                            // Block syntax produces Value::List, but bare Struct requires
+                            // Block syntax produces Value::Concrete(ConcreteValue::List), but bare Struct requires
                             // map assignment syntax: attr = { ... }
                             if matches!(
                                 &attr_schema.attr_type,
                                 carina_core::schema::AttributeType::Struct { .. }
-                            ) && matches!(attr_value, Value::List(_))
+                            ) && matches!(attr_value, Value::Concrete(ConcreteValue::List(_)))
                             {
                                 let search_name =
                                     attr_schema.block_name.as_deref().unwrap_or(attr_name);
@@ -459,32 +459,35 @@ impl DiagnosticEngine {
                             }
                             let type_error = match (&attr_schema.attr_type, attr_value) {
                                 // Bool type should not receive String
-                                (carina_core::schema::AttributeType::Bool, Value::String(s)) => {
-                                    Some(format!(
-                                        "Type mismatch: expected Bool, got String \"{}\". Use true or false.",
-                                        s
-                                    ))
-                                }
+                                (
+                                    carina_core::schema::AttributeType::Bool,
+                                    Value::Concrete(ConcreteValue::String(s)),
+                                ) => Some(format!(
+                                    "Type mismatch: expected Bool, got String \"{}\". Use true or false.",
+                                    s
+                                )),
                                 // Int type should not receive String
-                                (carina_core::schema::AttributeType::Int, Value::String(s)) => {
-                                    Some(format!(
-                                        "Type mismatch: expected Int, got String \"{}\".",
-                                        s
-                                    ))
-                                }
+                                (
+                                    carina_core::schema::AttributeType::Int,
+                                    Value::Concrete(ConcreteValue::String(s)),
+                                ) => Some(format!(
+                                    "Type mismatch: expected Int, got String \"{}\".",
+                                    s
+                                )),
                                 // Float type should not receive String
-                                (carina_core::schema::AttributeType::Float, Value::String(s)) => {
-                                    Some(format!(
-                                        "Type mismatch: expected Float, got String \"{}\".",
-                                        s
-                                    ))
-                                }
+                                (
+                                    carina_core::schema::AttributeType::Float,
+                                    Value::Concrete(ConcreteValue::String(s)),
+                                ) => Some(format!(
+                                    "Type mismatch: expected Float, got String \"{}\".",
+                                    s
+                                )),
                                 // ResourceRef type check for Union, StringEnum, and Custom types
                                 (
                                     carina_core::schema::AttributeType::Union(_)
                                     | carina_core::schema::AttributeType::StringEnum { .. }
                                     | carina_core::schema::AttributeType::Custom { .. },
-                                    Value::ResourceRef { path },
+                                    Value::Deferred(DeferredValue::ResourceRef { path }),
                                 ) => check_resource_ref_type_mismatch(
                                     &binding_schema_map,
                                     &attr_schema.attr_type,
@@ -522,9 +525,14 @@ impl DiagnosticEngine {
                                     },
                                     value,
                                 ) => {
-                                    // `Value::Unknown` resolves at upstream apply — skip,
+                                    // `Value::Deferred(DeferredValue::Unknown)` resolves at upstream apply — skip,
                                     // matching the CLI's `walk_custom_lookup` behavior.
-                                    if matches!(value, carina_core::resource::Value::Unknown(_)) {
+                                    if matches!(
+                                        value,
+                                        carina_core::resource::Value::Deferred(
+                                            carina_core::resource::DeferredValue::Unknown(_)
+                                        )
+                                    ) {
                                         None
                                     } else {
                                         let name = semantic_name.as_deref().unwrap_or("");
@@ -558,11 +566,11 @@ impl DiagnosticEngine {
                                         // string when wrapping for the LSP message. See #2094.
                                         let inner_msg = inner_err.to_string();
                                         if namespace.is_some()
-                                            && matches!(value, Value::String(s) if !s.contains('.'))
+                                            && matches!(value, Value::Concrete(ConcreteValue::String(s)) if !s.contains('.'))
                                             && resource.quoted_string_attrs.contains(attr_name)
                                         {
                                             let typed = match value {
-                                                Value::String(s) => s.as_str(),
+                                                Value::Concrete(ConcreteValue::String(s)) => s.as_str(),
                                                 _ => "",
                                             };
                                             format!(
@@ -576,7 +584,10 @@ impl DiagnosticEngine {
                                     }
                                 }
                                 // String type - check for bare resource binding
-                                (carina_core::schema::AttributeType::String, Value::String(s)) => {
+                                (
+                                    carina_core::schema::AttributeType::String,
+                                    Value::Concrete(ConcreteValue::String(s)),
+                                ) => {
                                     if let Some(binding) =
                                         s.strip_prefix("${").and_then(|s| s.strip_suffix("}"))
                                     {
@@ -597,7 +608,7 @@ impl DiagnosticEngine {
                                 // List<Struct> is handled by validate_struct_value below)
                                 (
                                     carina_core::schema::AttributeType::List { inner, .. },
-                                    Value::List(_),
+                                    Value::Concrete(ConcreteValue::List(_)),
                                 ) if !matches!(
                                     inner.as_ref(),
                                     carina_core::schema::AttributeType::Struct { .. }
@@ -610,13 +621,14 @@ impl DiagnosticEngine {
                                         .map(|e| e.with_attribute(attr_name).to_string())
                                 }
                                 // Validate Map value types
-                                (carina_core::schema::AttributeType::Map { .. }, Value::Map(_)) => {
-                                    attr_schema
-                                        .attr_type
-                                        .validate(attr_value)
-                                        .err()
-                                        .map(|e| e.with_attribute(attr_name).to_string())
-                                }
+                                (
+                                    carina_core::schema::AttributeType::Map { .. },
+                                    Value::Concrete(ConcreteValue::Map(_)),
+                                ) => attr_schema
+                                    .attr_type
+                                    .validate(attr_value)
+                                    .err()
+                                    .map(|e| e.with_attribute(attr_name).to_string()),
                                 // Validate Union static values (non-ResourceRef, non-BindingRef).
                                 // Ref-shaped values are unresolved at this
                                 // checkpoint and must not be type-checked
@@ -625,7 +637,8 @@ impl DiagnosticEngine {
                                 (carina_core::schema::AttributeType::Union(_), value)
                                     if !matches!(
                                         value,
-                                        Value::ResourceRef { .. } | Value::BindingRef { .. }
+                                        Value::Deferred(DeferredValue::ResourceRef { .. })
+                                            | Value::Deferred(DeferredValue::BindingRef { .. })
                                     ) =>
                                 {
                                     attr_schema

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1043,7 +1043,7 @@ let name = join("-", parts)
 fn validate_module_arg_type_ipv4_address_invalid() {
     let engine = test_engine();
     let type_expr = carina_core::parser::TypeExpr::Simple("ipv4_address".to_string());
-    let value = Value::String("not-an-ip".to_string());
+    let value = Value::Concrete(ConcreteValue::String("not-an-ip".to_string()));
     let result = engine.validate_module_arg_type(&type_expr, &value);
     assert!(
         result.is_some(),
@@ -1055,7 +1055,7 @@ fn validate_module_arg_type_ipv4_address_invalid() {
 fn validate_module_arg_type_ipv4_address_valid() {
     let engine = test_engine();
     let type_expr = carina_core::parser::TypeExpr::Simple("ipv4_address".to_string());
-    let value = Value::String("192.168.1.1".to_string());
+    let value = Value::Concrete(ConcreteValue::String("192.168.1.1".to_string()));
     let result = engine.validate_module_arg_type(&type_expr, &value);
     assert!(
         result.is_none(),
@@ -1068,7 +1068,7 @@ fn validate_module_arg_type_ipv4_address_valid() {
 fn validate_module_arg_type_ipv6_cidr_invalid() {
     let engine = test_engine();
     let type_expr = carina_core::parser::TypeExpr::Simple("ipv6_cidr".to_string());
-    let value = Value::String("not-a-cidr".to_string());
+    let value = Value::Concrete(ConcreteValue::String("not-a-cidr".to_string()));
     let result = engine.validate_module_arg_type(&type_expr, &value);
     assert!(
         result.is_some(),
@@ -1080,7 +1080,7 @@ fn validate_module_arg_type_ipv6_cidr_invalid() {
 fn validate_module_arg_type_ipv6_cidr_valid() {
     let engine = test_engine();
     let type_expr = carina_core::parser::TypeExpr::Simple("ipv6_cidr".to_string());
-    let value = Value::String("2001:db8::/32".to_string());
+    let value = Value::Concrete(ConcreteValue::String("2001:db8::/32".to_string()));
     let result = engine.validate_module_arg_type(&type_expr, &value);
     assert!(
         result.is_none(),
@@ -1093,7 +1093,7 @@ fn validate_module_arg_type_ipv6_cidr_valid() {
 fn validate_module_arg_type_ipv6_address_invalid() {
     let engine = test_engine();
     let type_expr = carina_core::parser::TypeExpr::Simple("ipv6_address".to_string());
-    let value = Value::String("not-an-ipv6".to_string());
+    let value = Value::Concrete(ConcreteValue::String("not-an-ipv6".to_string()));
     let result = engine.validate_module_arg_type(&type_expr, &value);
     assert!(
         result.is_some(),
@@ -1105,7 +1105,7 @@ fn validate_module_arg_type_ipv6_address_invalid() {
 fn validate_module_arg_type_ipv6_address_valid() {
     let engine = test_engine();
     let type_expr = carina_core::parser::TypeExpr::Simple("ipv6_address".to_string());
-    let value = Value::String("2001:db8::1".to_string());
+    let value = Value::Concrete(ConcreteValue::String("2001:db8::1".to_string()));
     let result = engine.validate_module_arg_type(&type_expr, &value);
     assert!(
         result.is_none(),
@@ -1120,10 +1120,10 @@ fn validate_module_arg_type_list_ipv4_address_invalid() {
     let type_expr = carina_core::parser::TypeExpr::List(Box::new(
         carina_core::parser::TypeExpr::Simple("ipv4_address".to_string()),
     ));
-    let value = Value::List(vec![
-        Value::String("192.168.1.1".to_string()),
-        Value::String("bad-ip".to_string()),
-    ]);
+    let value = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("192.168.1.1".to_string())),
+        Value::Concrete(ConcreteValue::String("bad-ip".to_string())),
+    ]));
     let result = engine.validate_module_arg_type(&type_expr, &value);
     assert!(
         result.is_some(),
@@ -1142,10 +1142,10 @@ fn validate_module_arg_type_list_ipv6_cidr_valid() {
     let type_expr = carina_core::parser::TypeExpr::List(Box::new(
         carina_core::parser::TypeExpr::Simple("ipv6_cidr".to_string()),
     ));
-    let value = Value::List(vec![
-        Value::String("2001:db8::/32".to_string()),
-        Value::String("::/0".to_string()),
-    ]);
+    let value = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("2001:db8::/32".to_string())),
+        Value::Concrete(ConcreteValue::String("::/0".to_string())),
+    ]));
     let result = engine.validate_module_arg_type(&type_expr, &value);
     assert!(
         result.is_none(),
@@ -1286,7 +1286,9 @@ fn resource_ref_type_check_helper_regression() {
 
     fn dummy_validate(v: &carina_core::resource::Value) -> Result<(), String> {
         match v {
-            carina_core::resource::Value::String(s) if s.starts_with("test.") => Ok(()),
+            carina_core::resource::Value::Concrete(
+                carina_core::resource::ConcreteValue::String(s),
+            ) if s.starts_with("test.") => Ok(()),
             _ => Err("invalid custom value".to_string()),
         }
     }
@@ -1457,7 +1459,10 @@ fn resource_validation_failed_with_attribute_points_to_attribute_line() {
             AttributeType::map(AttributeType::String),
         ))
         .with_validator(|attrs| {
-            if let Some(carina_core::resource::Value::Map(map)) = attrs.get("tags") {
+            if let Some(carina_core::resource::Value::Concrete(
+                carina_core::resource::ConcreteValue::Map(map),
+            )) = attrs.get("tags")
+            {
                 let has_key = map.keys().any(|k| k.eq_ignore_ascii_case("key"));
                 let has_value = map.keys().any(|k| k.eq_ignore_ascii_case("value"));
                 if has_key && has_value {
@@ -1741,14 +1746,18 @@ fn distinct_semantic_customs_are_rejected() {
 
     fn validate_account_id(v: &carina_core::resource::Value) -> Result<(), String> {
         match v {
-            carina_core::resource::Value::String(s) if s.len() == 12 => Ok(()),
+            carina_core::resource::Value::Concrete(
+                carina_core::resource::ConcreteValue::String(s),
+            ) if s.len() == 12 => Ok(()),
             _ => Err("expected 12-digit account ID".to_string()),
         }
     }
 
     fn validate_target_id(v: &carina_core::resource::Value) -> Result<(), String> {
         match v {
-            carina_core::resource::Value::String(_) => Ok(()),
+            carina_core::resource::Value::Concrete(
+                carina_core::resource::ConcreteValue::String(_),
+            ) => Ok(()),
             _ => Err("expected string".to_string()),
         }
     }
@@ -1809,10 +1818,10 @@ target_id = caller.account_id
 #[test]
 fn exports_cross_file_ref_no_false_positive() {
     // Regression: when exports.crn references a binding from a sibling file,
-    // single-file parsing leaves the reference as Value::String("binding.attr").
+    // single-file parsing leaves the reference as Value::Concrete(ConcreteValue::String("binding.attr")).
     // The custom type validator (e.g., aws_account_id: 12-digit check) must
     // skip these dot-notation strings to avoid false positives.
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
     let aws_account_id_type = AttributeType::Custom {
@@ -1821,8 +1830,12 @@ fn exports_cross_file_ref_no_false_positive() {
         pattern: None,
         length: None,
         validate: carina_core::schema::legacy_validator(|v| match v {
-            Value::String(s) if s.len() == 12 && s.chars().all(|c| c.is_ascii_digit()) => Ok(()),
-            Value::String(s) => Err(format!(
+            Value::Concrete(ConcreteValue::String(s))
+                if s.len() == 12 && s.chars().all(|c| c.is_ascii_digit()) =>
+            {
+                Ok(())
+            }
+            Value::Concrete(ConcreteValue::String(s)) => Err(format!(
                 "must be exactly 12 digits, got {} characters",
                 s.len()
             )),

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -128,14 +128,12 @@ pub(super) fn test_engine_with_custom_namespaced_attr() -> DiagnosticEngine {
 
     fn validate_mode(v: &carina_core::resource::Value) -> Result<(), String> {
         match v {
-            carina_core::resource::Value::String(s)
-                if s == "test.r.Mode.fast" || s == "test.r.Mode.slow" =>
-            {
-                Ok(())
-            }
-            carina_core::resource::Value::String(s) => {
-                Err(format!("invalid Mode '{}': expected fast or slow", s))
-            }
+            carina_core::resource::Value::Concrete(
+                carina_core::resource::ConcreteValue::String(s),
+            ) if s == "test.r.Mode.fast" || s == "test.r.Mode.slow" => Ok(()),
+            carina_core::resource::Value::Concrete(
+                carina_core::resource::ConcreteValue::String(s),
+            ) => Err(format!("invalid Mode '{}': expected fast or slow", s)),
             _ => Err("expected string".to_string()),
         }
     }

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -6,7 +6,7 @@ use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Posi
 use crate::document::Document;
 use carina_core::builtins;
 use carina_core::parser::ArgumentParameter;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{CompletionValue, ResourceSchema, SchemaRegistry};
 
 /// Find the `source` path of a `let <alias> = use {...}` declaration
@@ -50,13 +50,15 @@ fn find_use_import_path(
 /// Format a Value for hover display
 fn format_value_for_hover(value: &Value) -> String {
     match value {
-        Value::String(s) => format!("\"{}\"", s),
-        Value::Int(n) => n.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::Duration(d) => carina_core::value::render_duration(*d),
-        Value::List(_) | Value::StringList(_) => "[...]".to_string(),
-        Value::Map(_) => "{...}".to_string(),
+        Value::Concrete(ConcreteValue::String(s)) => format!("\"{}\"", s),
+        Value::Concrete(ConcreteValue::Int(n)) => n.to_string(),
+        Value::Concrete(ConcreteValue::Float(f)) => f.to_string(),
+        Value::Concrete(ConcreteValue::Bool(b)) => b.to_string(),
+        Value::Concrete(ConcreteValue::Duration(d)) => carina_core::value::render_duration(*d),
+        Value::Concrete(ConcreteValue::List(_)) | Value::Concrete(ConcreteValue::StringList(_)) => {
+            "[...]".to_string()
+        }
+        Value::Concrete(ConcreteValue::Map(_)) => "{...}".to_string(),
         _ => format!("{:?}", value),
     }
 }
@@ -805,14 +807,16 @@ mod tests {
 
     #[test]
     fn format_value_for_hover_renders_duration_as_canonical_form() {
-        // Regression: Round 1 added the Value::Duration arm so editor
+        // Regression: Round 1 added the Value::Concrete(ConcreteValue::Duration) arm so editor
         // hover doesn't show the {:?} fall-through
         // `Duration { secs: 60, nanos: 0 }`. Pin the canonical surface
         // form here.
-        use carina_core::resource::Value;
-        let v = Value::Duration(std::time::Duration::from_secs(60));
+        use carina_core::resource::{ConcreteValue, Value};
+        let v = Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(60)));
         assert_eq!(format_value_for_hover(&v), "1min");
-        let v = Value::Duration(std::time::Duration::from_secs(4500));
+        let v = Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(
+            4500,
+        )));
         assert_eq!(format_value_for_hover(&v), "75min");
     }
 
@@ -1259,7 +1263,7 @@ awscc.ec2.vpc_gateway_attachment {
         let arg = ArgumentParameter {
             name: "port".to_string(),
             type_expr: TypeExpr::Int,
-            default: Some(Value::Int(8080)),
+            default: Some(Value::Concrete(ConcreteValue::Int(8080))),
             description: Some("Web server port".to_string()),
             validations: vec![],
         };

--- a/carina-lsp/tests/e2e_typecheck.rs
+++ b/carina-lsp/tests/e2e_typecheck.rs
@@ -117,7 +117,10 @@ fn region_schemas() -> SchemaRegistry {
     // `carina-aws-types::types::aws_region` does.
     fn validate_region(v: &carina_core::resource::Value) -> Result<(), String> {
         const VALID: &[&str] = &["ap-northeast-1", "us-west-2"];
-        if let carina_core::resource::Value::String(s) = v {
+        if let carina_core::resource::Value::Concrete(
+            carina_core::resource::ConcreteValue::String(s),
+        ) = v
+        {
             // Same shape as `aws_region()`: strip any namespace prefix
             // (DSL form) and rewrite `_` → `-` to get the AWS form.
             let normalized = carina_core::utils::extract_enum_value(s).replace('_', "-");

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -9,8 +9,8 @@ use carina_core::provider::{
     UpdatePatch as CoreUpdatePatch, UpdateRequest as CoreUpdateRequest,
 };
 use carina_core::resource::{
-    Directives, Resource as CoreResource, ResourceId as CoreResourceId, State as CoreState,
-    Value as CoreValue,
+    ConcreteValue, DeferredValue, Directives, Resource as CoreResource,
+    ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
@@ -29,16 +29,16 @@ use crate::wasm_bindings::carina::provider::types as wit;
 /// List and Map values are serialized to JSON strings because WIT does
 /// not support recursive types.
 ///
-/// Returns `Err(SerializationError)` for `Value::Unknown`,
-/// `Value::ResourceRef`, `Value::Interpolation`, and
-/// `Value::FunctionCall`. The plan-time pipeline strips every attribute
+/// Returns `Err(SerializationError)` for `Value::Deferred(DeferredValue::Unknown)`,
+/// `Value::Deferred(DeferredValue::ResourceRef)`, `Value::Deferred(DeferredValue::Interpolation)`, and
+/// `Value::Deferred(DeferredValue::FunctionCall)`. The plan-time pipeline strips every attribute
 /// that recursively contains one of these via
 /// `PlanPreprocessor::prepare`'s strip-and-restore pass, so reaching
 /// any of these arms is a producer-side bug — the diagnostic identifies
 /// which variant leaked. See RFC #2371 stage 2 (#2378) for `Unknown`
 /// and #2387 for `ResourceRef` / `Interpolation` / `FunctionCall`.
 ///
-/// `Value::Secret(inner)` is encoded as the `secret-val` WIT variant
+/// `Value::Deferred(DeferredValue::Secret(inner))` is encoded as the `secret-val` WIT variant
 /// (#2390): the inner is JSON-encoded the same way `list-val` / `map-val`
 /// encode their contents, and a typed signal crosses the boundary so the
 /// WASM provider can distinguish a secret from a plain string. The
@@ -47,35 +47,37 @@ use crate::wasm_bindings::carina::provider::types as wit;
 /// equivalent to the pre-#2387 `ResourceRef` debug-string.
 pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError> {
     match v {
-        CoreValue::String(s) => Ok(wit::Value::StrVal(s.clone())),
-        CoreValue::Int(i) => Ok(wit::Value::IntVal(*i)),
-        CoreValue::Float(f) => Ok(wit::Value::FloatVal(*f)),
-        CoreValue::Bool(b) => Ok(wit::Value::BoolVal(*b)),
+        CoreValue::Concrete(ConcreteValue::String(s)) => Ok(wit::Value::StrVal(s.clone())),
+        CoreValue::Concrete(ConcreteValue::Int(i)) => Ok(wit::Value::IntVal(*i)),
+        CoreValue::Concrete(ConcreteValue::Float(f)) => Ok(wit::Value::FloatVal(*f)),
+        CoreValue::Concrete(ConcreteValue::Bool(b)) => Ok(wit::Value::BoolVal(*b)),
         // Duration crosses the WIT boundary as integer seconds — see
         // `notes/specs/2026-05-10-duration-design.md` for the rationale
         // (no `duration-val` variant; existing `aws`/`awscc` plugins
         // need no rebuild). The inbound `wit_to_core_value` path is
         // intentionally one-way for now: every `IntVal` reads back as
-        // `Value::Int`, regardless of whether the destination schema
+        // `Value::Concrete(ConcreteValue::Int)`, regardless of whether the destination schema
         // attribute is typed `Duration`. Re-typing on the inbound side
         // (so a Duration-typed schema attribute reconstructs as
-        // `Value::Duration`) is a deferred follow-up — without it, a
+        // `Value::Concrete(ConcreteValue::Duration)`) is a deferred follow-up — without it, a
         // post-apply state diff for a Duration attribute will surface
         // as `Duration(75min) → Int(4500)` until the schema-aware
         // re-typing lands. For MVP every consumer of Duration is
         // host-side (`wait { timeout = ... }`), so the asymmetry is
         // contained to the not-yet-existent provider-side use case.
-        CoreValue::Duration(d) => Ok(wit::Value::IntVal(d.as_secs() as i64)),
-        CoreValue::List(items) => {
+        CoreValue::Concrete(ConcreteValue::Duration(d)) => {
+            Ok(wit::Value::IntVal(d.as_secs() as i64))
+        }
+        CoreValue::Concrete(ConcreteValue::List(items)) => {
             let json_items: Result<Vec<serde_json::Value>, _> =
                 items.iter().map(core_value_to_json).collect();
             let json_str = serde_json::to_string(&json_items?)
                 .expect("serde_json::Value -> String is infallible");
             Ok(wit::Value::ListVal(json_str))
         }
-        CoreValue::StringList(items) => {
+        CoreValue::Concrete(ConcreteValue::StringList(items)) => {
             // Cross the WASM boundary as a plain JSON array of strings —
-            // the provider sees the same shape as `Value::List([String])`,
+            // the provider sees the same shape as `Value::Concrete(ConcreteValue::List([String]))`,
             // matching AWS's wire-format expectation for the
             // `string_or_list_of_strings` IAM shape.
             let json_arr: Vec<serde_json::Value> = items
@@ -86,7 +88,7 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
                 .expect("serde_json::Value -> String is infallible");
             Ok(wit::Value::ListVal(json_str))
         }
-        CoreValue::Map(map) => {
+        CoreValue::Concrete(ConcreteValue::Map(map)) => {
             let json_map: Result<serde_json::Map<String, serde_json::Value>, _> = map
                 .iter()
                 .map(|(k, v)| core_value_to_json(v).map(|jv| (k.clone(), jv)))
@@ -95,26 +97,36 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
                 .expect("serde_json::Value -> String is infallible");
             Ok(wit::Value::MapVal(json_str))
         }
-        CoreValue::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {
-            reason: reason.clone(),
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
-            path: path.to_dot_string(),
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::BindingRef { binding } => Err(SerializationError::UnresolvedResourceRef {
-            path: binding.clone(),
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::Interpolation(_) => Err(SerializationError::UnresolvedInterpolation {
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::FunctionCall { name, .. } => Err(SerializationError::UnresolvedFunctionCall {
-            name: name.clone(),
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::Secret(inner) => {
+        CoreValue::Deferred(DeferredValue::Unknown(reason)) => {
+            Err(SerializationError::UnknownNotAllowed {
+                reason: reason.clone(),
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::ResourceRef { path }) => {
+            Err(SerializationError::UnresolvedResourceRef {
+                path: path.to_dot_string(),
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::BindingRef { binding }) => {
+            Err(SerializationError::UnresolvedResourceRef {
+                path: binding.clone(),
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::Interpolation(_)) => {
+            Err(SerializationError::UnresolvedInterpolation {
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::FunctionCall { name, .. }) => {
+            Err(SerializationError::UnresolvedFunctionCall {
+                name: name.clone(),
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::Secret(inner)) => {
             let json = core_value_to_json(inner)?;
             let json_str =
                 serde_json::to_string(&json).expect("serde_json::Value -> String is infallible");
@@ -126,26 +138,28 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
 /// Convert a WIT Value to a core Value.
 pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
     match v {
-        wit::Value::StrVal(s) => CoreValue::String(s.clone()),
-        wit::Value::IntVal(i) => CoreValue::Int(*i),
-        wit::Value::FloatVal(f) => CoreValue::Float(*f),
-        wit::Value::BoolVal(b) => CoreValue::Bool(*b),
+        wit::Value::StrVal(s) => CoreValue::Concrete(ConcreteValue::String(s.clone())),
+        wit::Value::IntVal(i) => CoreValue::Concrete(ConcreteValue::Int(*i)),
+        wit::Value::FloatVal(f) => CoreValue::Concrete(ConcreteValue::Float(*f)),
+        wit::Value::BoolVal(b) => CoreValue::Concrete(ConcreteValue::Bool(*b)),
         wit::Value::ListVal(json) => {
             let items: Vec<serde_json::Value> = serde_json::from_str(json).unwrap_or_default();
-            CoreValue::List(items.iter().map(json_to_core_value).collect())
+            CoreValue::Concrete(ConcreteValue::List(
+                items.iter().map(json_to_core_value).collect(),
+            ))
         }
         wit::Value::MapVal(json) => {
             let map: serde_json::Map<String, serde_json::Value> =
                 serde_json::from_str(json).unwrap_or_default();
-            CoreValue::Map(
+            CoreValue::Concrete(ConcreteValue::Map(
                 map.iter()
                     .map(|(k, v)| (k.clone(), json_to_core_value(v)))
                     .collect(),
-            )
+            ))
         }
         wit::Value::SecretVal(json) => {
             // Decode the JSON-encoded inner value the same way `ListVal` /
-            // `MapVal` decode theirs, then re-wrap in `Value::Secret` so the
+            // `MapVal` decode theirs, then re-wrap in `Value::Deferred(DeferredValue::Secret)` so the
             // host's secret-tracking machinery (state hashing, plan
             // redaction) keeps working. A malformed encoding falls back to
             // an empty string secret rather than panicking — the WASM
@@ -153,7 +167,7 @@ pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
             let inner_json: serde_json::Value =
                 serde_json::from_str(json).unwrap_or(serde_json::Value::Null);
             let inner = json_to_core_value(&inner_json);
-            CoreValue::Secret(Box::new(inner))
+            CoreValue::Deferred(DeferredValue::Secret(Box::new(inner)))
         }
     }
 }
@@ -165,49 +179,61 @@ pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
 /// pass that keeps these arms unreachable in legitimate flows.
 fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationError> {
     match v {
-        CoreValue::String(s) => Ok(serde_json::Value::String(s.clone())),
-        CoreValue::Int(i) => Ok(serde_json::Value::Number((*i).into())),
-        CoreValue::Float(f) => Ok(serde_json::Number::from_f64(*f)
+        CoreValue::Concrete(ConcreteValue::String(s)) => Ok(serde_json::Value::String(s.clone())),
+        CoreValue::Concrete(ConcreteValue::Int(i)) => Ok(serde_json::Value::Number((*i).into())),
+        CoreValue::Concrete(ConcreteValue::Float(f)) => Ok(serde_json::Number::from_f64(*f)
             .map(serde_json::Value::Number)
             .unwrap_or(serde_json::Value::Null)),
-        CoreValue::Bool(b) => Ok(serde_json::Value::Bool(*b)),
-        CoreValue::Duration(d) => Ok(serde_json::Value::Number((d.as_secs() as i64).into())),
-        CoreValue::List(items) => {
+        CoreValue::Concrete(ConcreteValue::Bool(b)) => Ok(serde_json::Value::Bool(*b)),
+        CoreValue::Concrete(ConcreteValue::Duration(d)) => {
+            Ok(serde_json::Value::Number((d.as_secs() as i64).into()))
+        }
+        CoreValue::Concrete(ConcreteValue::List(items)) => {
             let arr: Result<Vec<_>, _> = items.iter().map(core_value_to_json).collect();
             Ok(serde_json::Value::Array(arr?))
         }
-        CoreValue::StringList(items) => Ok(serde_json::Value::Array(
+        CoreValue::Concrete(ConcreteValue::StringList(items)) => Ok(serde_json::Value::Array(
             items
                 .iter()
                 .map(|s| serde_json::Value::String(s.clone()))
                 .collect(),
         )),
-        CoreValue::Map(map) => {
+        CoreValue::Concrete(ConcreteValue::Map(map)) => {
             let obj: Result<serde_json::Map<String, serde_json::Value>, _> = map
                 .iter()
                 .map(|(k, v)| core_value_to_json(v).map(|jv| (k.clone(), jv)))
                 .collect();
             Ok(serde_json::Value::Object(obj?))
         }
-        CoreValue::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {
-            reason: reason.clone(),
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
-            path: path.to_dot_string(),
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::BindingRef { binding } => Err(SerializationError::UnresolvedResourceRef {
-            path: binding.clone(),
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::Interpolation(_) => Err(SerializationError::UnresolvedInterpolation {
-            context: SerializationContext::WasmBoundary,
-        }),
-        CoreValue::FunctionCall { name, .. } => Err(SerializationError::UnresolvedFunctionCall {
-            name: name.clone(),
-            context: SerializationContext::WasmBoundary,
-        }),
+        CoreValue::Deferred(DeferredValue::Unknown(reason)) => {
+            Err(SerializationError::UnknownNotAllowed {
+                reason: reason.clone(),
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::ResourceRef { path }) => {
+            Err(SerializationError::UnresolvedResourceRef {
+                path: path.to_dot_string(),
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::BindingRef { binding }) => {
+            Err(SerializationError::UnresolvedResourceRef {
+                path: binding.clone(),
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::Interpolation(_)) => {
+            Err(SerializationError::UnresolvedInterpolation {
+                context: SerializationContext::WasmBoundary,
+            })
+        }
+        CoreValue::Deferred(DeferredValue::FunctionCall { name, .. }) => {
+            Err(SerializationError::UnresolvedFunctionCall {
+                name: name.clone(),
+                context: SerializationContext::WasmBoundary,
+            })
+        }
         // Within this helper a `Secret` would only appear if the caller
         // wrapped one inside a `List` / `Map` payload going to a WIT
         // `list-val` / `map-val`. Render it as the JSON-encoded inner so
@@ -216,33 +242,33 @@ fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationE
         // that decode `list-val` / `map-val` see the inner JSON shape;
         // `secret-val` is the channel used to mark the *attribute* itself
         // as a secret.
-        CoreValue::Secret(inner) => core_value_to_json(inner),
+        CoreValue::Deferred(DeferredValue::Secret(inner)) => core_value_to_json(inner),
     }
 }
 
 /// Helper: convert a serde_json::Value to a core Value.
 fn json_to_core_value(v: &serde_json::Value) -> CoreValue {
     match v {
-        serde_json::Value::String(s) => CoreValue::String(s.clone()),
+        serde_json::Value::String(s) => CoreValue::Concrete(ConcreteValue::String(s.clone())),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                CoreValue::Int(i)
+                CoreValue::Concrete(ConcreteValue::Int(i))
             } else if let Some(f) = n.as_f64() {
-                CoreValue::Float(f)
+                CoreValue::Concrete(ConcreteValue::Float(f))
             } else {
-                CoreValue::String(n.to_string())
+                CoreValue::Concrete(ConcreteValue::String(n.to_string()))
             }
         }
-        serde_json::Value::Bool(b) => CoreValue::Bool(*b),
-        serde_json::Value::Array(items) => {
-            CoreValue::List(items.iter().map(json_to_core_value).collect())
-        }
-        serde_json::Value::Object(map) => CoreValue::Map(
+        serde_json::Value::Bool(b) => CoreValue::Concrete(ConcreteValue::Bool(*b)),
+        serde_json::Value::Array(items) => CoreValue::Concrete(ConcreteValue::List(
+            items.iter().map(json_to_core_value).collect(),
+        )),
+        serde_json::Value::Object(map) => CoreValue::Concrete(ConcreteValue::Map(
             map.iter()
                 .map(|(k, v)| (k.clone(), json_to_core_value(v)))
                 .collect(),
-        ),
-        serde_json::Value::Null => CoreValue::String(String::new()),
+        )),
+        serde_json::Value::Null => CoreValue::Concrete(ConcreteValue::String(String::new())),
     }
 }
 
@@ -581,7 +607,7 @@ fn build_validator_from_types(
 fn validate_tags_key_value(
     attrs: &HashMap<String, CoreValue>,
 ) -> Result<(), Vec<carina_core::schema::TypeError>> {
-    if let Some(CoreValue::Map(map)) = attrs.get("tags") {
+    if let Some(CoreValue::Concrete(ConcreteValue::Map(map))) = attrs.get("tags") {
         let (mut has_key, mut has_value) = (false, false);
         for k in map.keys() {
             if k.eq_ignore_ascii_case("key") {
@@ -685,7 +711,7 @@ fn proto_struct_field_to_core(f: &proto::StructField) -> CoreStructField {
 mod tests {
     use super::*;
 
-    /// RFC #2371 stage 4 contract pin: `Value::Unknown` reaching either
+    /// RFC #2371 stage 4 contract pin: `Value::Deferred(DeferredValue::Unknown)` reaching either
     /// WASM-boundary converter is a stage-2 invariant violation
     /// (`PlanPreprocessor::strip_unknown_attributes` must remove it
     /// first). The converters now return `Err(SerializationError::
@@ -696,7 +722,9 @@ mod tests {
     fn unknown_returns_err_in_core_to_wit_value() {
         use carina_core::resource::{AccessPath, UnknownReason};
         let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".to_string()]);
-        let v = CoreValue::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+        let v = CoreValue::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+            path: path.clone(),
+        }));
         let err = core_to_wit_value(&v).unwrap_err();
         match err {
             SerializationError::UnknownNotAllowed {
@@ -711,7 +739,9 @@ mod tests {
     fn unknown_returns_err_in_core_value_to_json() {
         use carina_core::resource::{AccessPath, UnknownReason};
         let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".to_string()]);
-        let v = CoreValue::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+        let v = CoreValue::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+            path: path.clone(),
+        }));
         let err = core_value_to_json(&v).unwrap_err();
         assert!(matches!(
             err,
@@ -726,7 +756,7 @@ mod tests {
 
     #[test]
     fn test_scalar_bool_roundtrip() {
-        let core = CoreValue::Bool(true);
+        let core = CoreValue::Concrete(ConcreteValue::Bool(true));
         let wit = core_to_wit_value(&core).unwrap();
         let back = wit_to_core_value(&wit);
         assert_eq!(core, back);
@@ -734,7 +764,7 @@ mod tests {
 
     #[test]
     fn test_scalar_int_roundtrip() {
-        let core = CoreValue::Int(42);
+        let core = CoreValue::Concrete(ConcreteValue::Int(42));
         let wit = core_to_wit_value(&core).unwrap();
         let back = wit_to_core_value(&wit);
         assert_eq!(core, back);
@@ -742,7 +772,7 @@ mod tests {
 
     #[test]
     fn test_scalar_float_roundtrip() {
-        let core = CoreValue::Float(2.78);
+        let core = CoreValue::Concrete(ConcreteValue::Float(2.78));
         let wit = core_to_wit_value(&core).unwrap();
         let back = wit_to_core_value(&wit);
         assert_eq!(core, back);
@@ -750,7 +780,7 @@ mod tests {
 
     #[test]
     fn test_scalar_string_roundtrip() {
-        let core = CoreValue::String("hello".into());
+        let core = CoreValue::Concrete(ConcreteValue::String("hello".into()));
         let wit = core_to_wit_value(&core).unwrap();
         let back = wit_to_core_value(&wit);
         assert_eq!(core, back);
@@ -758,11 +788,11 @@ mod tests {
 
     #[test]
     fn test_list_roundtrip() {
-        let core = CoreValue::List(vec![
-            CoreValue::String("a".into()),
-            CoreValue::Int(1),
-            CoreValue::Bool(false),
-        ]);
+        let core = CoreValue::Concrete(ConcreteValue::List(vec![
+            CoreValue::Concrete(ConcreteValue::String("a".into())),
+            CoreValue::Concrete(ConcreteValue::Int(1)),
+            CoreValue::Concrete(ConcreteValue::Bool(false)),
+        ]));
         let wit = core_to_wit_value(&core).unwrap();
         assert!(matches!(wit, wit::Value::ListVal(_)));
         let back = wit_to_core_value(&wit);
@@ -771,14 +801,20 @@ mod tests {
 
     #[test]
     fn test_map_roundtrip() {
-        let core = CoreValue::Map(
+        let core = CoreValue::Concrete(ConcreteValue::Map(
             vec![
-                ("key1".to_string(), CoreValue::String("val1".into())),
-                ("key2".to_string(), CoreValue::Int(99)),
+                (
+                    "key1".to_string(),
+                    CoreValue::Concrete(ConcreteValue::String("val1".into())),
+                ),
+                (
+                    "key2".to_string(),
+                    CoreValue::Concrete(ConcreteValue::Int(99)),
+                ),
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         let wit = core_to_wit_value(&core).unwrap();
         assert!(matches!(wit, wit::Value::MapVal(_)));
         let back = wit_to_core_value(&wit);
@@ -787,15 +823,21 @@ mod tests {
 
     #[test]
     fn test_nested_list_of_maps_roundtrip() {
-        let inner_map = CoreValue::Map(
+        let inner_map = CoreValue::Concrete(ConcreteValue::Map(
             vec![
-                ("name".to_string(), CoreValue::String("test".into())),
-                ("count".to_string(), CoreValue::Int(5)),
+                (
+                    "name".to_string(),
+                    CoreValue::Concrete(ConcreteValue::String("test".into())),
+                ),
+                (
+                    "count".to_string(),
+                    CoreValue::Concrete(ConcreteValue::Int(5)),
+                ),
             ]
             .into_iter()
             .collect(),
-        );
-        let core = CoreValue::List(vec![inner_map.clone(), inner_map]);
+        ));
+        let core = CoreValue::Concrete(ConcreteValue::List(vec![inner_map.clone(), inner_map]));
         let wit = core_to_wit_value(&core).unwrap();
         let back = wit_to_core_value(&wit);
         assert_eq!(core, back);
@@ -803,29 +845,32 @@ mod tests {
 
     #[test]
     fn test_nested_map_of_lists_roundtrip() {
-        let core = CoreValue::Map(
+        let core = CoreValue::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "tags".to_string(),
-                    CoreValue::List(vec![
+                    CoreValue::Concrete(ConcreteValue::List(vec![
                         CoreValue::String("a".into()),
                         CoreValue::String("b".into()),
-                    ]),
+                    ])),
                 ),
                 (
                     "counts".to_string(),
-                    CoreValue::List(vec![CoreValue::Int(1), CoreValue::Int(2)]),
+                    CoreValue::Concrete(ConcreteValue::List(vec![
+                        CoreValue::Int(1),
+                        CoreValue::Int(2),
+                    ])),
                 ),
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         let wit = core_to_wit_value(&core).unwrap();
         let back = wit_to_core_value(&wit);
         assert_eq!(core, back);
     }
 
-    /// #2387: `Value::ResourceRef` reaching `core_to_wit_value` is a
+    /// #2387: `Value::Deferred(DeferredValue::ResourceRef)` reaching `core_to_wit_value` is a
     /// stage-2 invariant violation now — the strip-and-restore pass in
     /// `PlanPreprocessor::prepare` removes any attribute that
     /// recursively contains a `ResourceRef` before this boundary. The
@@ -836,7 +881,7 @@ mod tests {
     fn resource_ref_returns_err_in_core_to_wit_value() {
         use carina_core::resource::AccessPath;
         let path = AccessPath::new("sso", "identity_store_id");
-        let v = CoreValue::ResourceRef { path: path.clone() };
+        let v = CoreValue::Deferred(DeferredValue::ResourceRef { path: path.clone() });
         let err = core_to_wit_value(&v).unwrap_err();
         match err {
             SerializationError::UnresolvedResourceRef {
@@ -850,12 +895,12 @@ mod tests {
     #[test]
     fn interpolation_returns_err_in_core_to_wit_value() {
         use carina_core::resource::{AccessPath, InterpolationPart};
-        let v = CoreValue::Interpolation(vec![
+        let v = CoreValue::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Literal("prefix-".into()),
-            InterpolationPart::Expr(CoreValue::ResourceRef {
+            InterpolationPart::Expr(CoreValue::Deferred(DeferredValue::ResourceRef {
                 path: AccessPath::new("vpc", "id"),
-            }),
-        ]);
+            })),
+        ]));
         let err = core_to_wit_value(&v).unwrap_err();
         assert!(matches!(
             err,
@@ -868,15 +913,15 @@ mod tests {
     #[test]
     fn function_call_returns_err_in_core_to_wit_value() {
         use carina_core::resource::AccessPath;
-        let v = CoreValue::FunctionCall {
+        let v = CoreValue::Deferred(DeferredValue::FunctionCall {
             name: "join".into(),
             args: vec![
-                CoreValue::String("-".into()),
-                CoreValue::ResourceRef {
+                CoreValue::Concrete(ConcreteValue::String("-".into())),
+                CoreValue::Deferred(DeferredValue::ResourceRef {
                     path: AccessPath::new("vpc", "id"),
-                },
+                }),
             ],
-        };
+        });
         let err = core_to_wit_value(&v).unwrap_err();
         match err {
             SerializationError::UnresolvedFunctionCall {
@@ -891,7 +936,7 @@ mod tests {
     fn resource_ref_returns_err_in_core_value_to_json() {
         use carina_core::resource::AccessPath;
         let path = AccessPath::new("sso", "identity_store_id");
-        let v = CoreValue::ResourceRef { path: path.clone() };
+        let v = CoreValue::Deferred(DeferredValue::ResourceRef { path: path.clone() });
         let err = core_value_to_json(&v).unwrap_err();
         assert!(matches!(
             err,
@@ -902,12 +947,14 @@ mod tests {
         ));
     }
 
-    /// #2390: `Value::Secret` crosses the boundary as the `secret-val`
+    /// #2390: `Value::Deferred(DeferredValue::Secret)` crosses the boundary as the `secret-val`
     /// WIT variant carrying the JSON-encoded inner — never as a
     /// `format!("{v:?}")` debug string.
     #[test]
     fn secret_string_emits_secret_val_variant() {
-        let v = CoreValue::Secret(Box::new(CoreValue::String("password".into())));
+        let v = CoreValue::Deferred(DeferredValue::Secret(Box::new(CoreValue::Concrete(
+            ConcreteValue::String("password".into()),
+        ))));
         let wit_v = core_to_wit_value(&v).unwrap();
         match wit_v {
             wit::Value::SecretVal(json) => assert_eq!(json, "\"password\""),
@@ -919,7 +966,9 @@ mod tests {
     fn secret_int_emits_secret_val_variant() {
         // Audit (carina#2390 step 12) confirmed `secret()` accepts any
         // scalar; pin the wire format for non-string inner values too.
-        let v = CoreValue::Secret(Box::new(CoreValue::Int(42)));
+        let v = CoreValue::Deferred(DeferredValue::Secret(Box::new(CoreValue::Concrete(
+            ConcreteValue::Int(42),
+        ))));
         let wit_v = core_to_wit_value(&v).unwrap();
         match wit_v {
             wit::Value::SecretVal(json) => assert_eq!(json, "42"),
@@ -932,12 +981,14 @@ mod tests {
         // Round-tripping through the WIT boundary preserves the
         // `Secret` wrapper so host-side machinery (state hashing, plan
         // redaction) keeps recognising it after a guest call returns.
-        let original = CoreValue::Secret(Box::new(CoreValue::String("hunter2".into())));
+        let original = CoreValue::Deferred(DeferredValue::Secret(Box::new(CoreValue::Concrete(
+            ConcreteValue::String("hunter2".into()),
+        ))));
         let wit_v = core_to_wit_value(&original).unwrap();
         let back = wit_to_core_value(&wit_v);
         match back {
-            CoreValue::Secret(inner) => match *inner {
-                CoreValue::String(s) => assert_eq!(s, "hunter2"),
+            CoreValue::Deferred(DeferredValue::Secret(inner)) => match *inner {
+                CoreValue::Concrete(ConcreteValue::String(s)) => assert_eq!(s, "hunter2"),
                 other => panic!("expected inner String, got: {other:?}"),
             },
             other => panic!("expected Secret, got: {other:?}"),
@@ -952,9 +1003,9 @@ mod tests {
         // decoding the list see the operational value. The
         // *attribute*-level secret signal goes through `secret-val` via
         // `core_to_wit_value`, not this path.
-        let v = CoreValue::List(vec![CoreValue::Secret(Box::new(CoreValue::String(
-            "p".into(),
-        )))]);
+        let v = CoreValue::Concrete(ConcreteValue::List(vec![CoreValue::Deferred(
+            DeferredValue::Secret(Box::new(CoreValue::String("p".into()))),
+        )]));
         let wit_v = core_to_wit_value(&v).unwrap();
         match wit_v {
             wit::Value::ListVal(json) => assert_eq!(json, "[\"p\"]"),
@@ -981,8 +1032,14 @@ mod tests {
     fn test_state_roundtrip() {
         let id = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket");
         let mut attrs = HashMap::new();
-        attrs.insert("name".into(), CoreValue::String("my-bucket".into()));
-        attrs.insert("region".into(), CoreValue::String("us-east-1".into()));
+        attrs.insert(
+            "name".into(),
+            CoreValue::Concrete(ConcreteValue::String("my-bucket".into())),
+        );
+        attrs.insert(
+            "region".into(),
+            CoreValue::Concrete(ConcreteValue::String("us-east-1".into())),
+        );
         let core = CoreState::existing(id.clone(), attrs);
 
         let wit = core_to_wit_state(&core).unwrap();
@@ -996,7 +1053,10 @@ mod tests {
     #[test]
     fn test_state_with_identifier_roundtrip() {
         let id = CoreResourceId::with_provider("aws", "ec2.Vpc", "main");
-        let attrs = HashMap::from([("cidr".into(), CoreValue::String("10.0.0.0/16".into()))]);
+        let attrs = HashMap::from([(
+            "cidr".into(),
+            CoreValue::Concrete(ConcreteValue::String("10.0.0.0/16".into())),
+        )]);
         let core = CoreState::existing(id.clone(), attrs).with_identifier("vpc-12345");
 
         let wit = core_to_wit_state(&core).unwrap();
@@ -1010,8 +1070,11 @@ mod tests {
     #[test]
     fn test_value_map_roundtrip() {
         let map: HashMap<String, CoreValue> = vec![
-            ("a".into(), CoreValue::String("hello".into())),
-            ("b".into(), CoreValue::Int(42)),
+            (
+                "a".into(),
+                CoreValue::Concrete(ConcreteValue::String("hello".into())),
+            ),
+            ("b".into(), CoreValue::Concrete(ConcreteValue::Int(42))),
         ]
         .into_iter()
         .collect();
@@ -1027,8 +1090,14 @@ mod tests {
     fn test_resource_roundtrip() {
         let mut resource = CoreResource::with_provider("aws", "s3.Bucket", "my-bucket");
         resource.attributes = indexmap::IndexMap::from([
-            ("name".into(), CoreValue::String("my-bucket".into())),
-            ("region".into(), CoreValue::String("us-east-1".into())),
+            (
+                "name".into(),
+                CoreValue::Concrete(ConcreteValue::String("my-bucket".into())),
+            ),
+            (
+                "region".into(),
+                CoreValue::Concrete(ConcreteValue::String("us-east-1".into())),
+            ),
         ]);
 
         let wit = core_to_wit_resource(&resource).unwrap();
@@ -1350,15 +1419,15 @@ mod tests {
 
     #[test]
     fn test_deeply_nested_list_map_roundtrip() {
-        let policy_document = CoreValue::Map(
+        let policy_document = CoreValue::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
-                    CoreValue::String("2012-10-17".into()),
+                    CoreValue::Concrete(ConcreteValue::String("2012-10-17".into())),
                 ),
                 (
                     "statement".to_string(),
-                    CoreValue::List(vec![CoreValue::Map(
+                    CoreValue::Concrete(ConcreteValue::List(vec![CoreValue::Map(
                         vec![
                             ("effect".to_string(), CoreValue::String("Allow".into())),
                             (
@@ -1369,23 +1438,25 @@ mod tests {
                         ]
                         .into_iter()
                         .collect(),
-                    )]),
+                    )])),
                 ),
             ]
             .into_iter()
             .collect(),
-        );
-        let policies = CoreValue::List(vec![CoreValue::Map(
-            vec![
-                (
-                    "policy_name".to_string(),
-                    CoreValue::String("test-policy".into()),
-                ),
-                ("policy_document".to_string(), policy_document),
-            ]
-            .into_iter()
-            .collect(),
-        )]);
+        ));
+        let policies = CoreValue::Concrete(ConcreteValue::List(vec![CoreValue::Concrete(
+            ConcreteValue::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        CoreValue::String("test-policy".into()),
+                    ),
+                    ("policy_document".to_string(), policy_document),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        )]));
 
         let wit = core_to_wit_value(&policies).unwrap();
         let back = wit_to_core_value(&wit);
@@ -1562,14 +1633,20 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "tags".to_string(),
-            CoreValue::Map(
+            CoreValue::Concrete(ConcreteValue::Map(
                 [
-                    ("key".to_string(), CoreValue::String("Project".into())),
-                    ("value".to_string(), CoreValue::String("carina".into())),
+                    (
+                        "key".to_string(),
+                        CoreValue::Concrete(ConcreteValue::String("Project".into())),
+                    ),
+                    (
+                        "value".to_string(),
+                        CoreValue::Concrete(ConcreteValue::String("carina".into())),
+                    ),
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
         );
         assert!(validator(&attrs).is_err());
 
@@ -1577,11 +1654,14 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "tags".to_string(),
-            CoreValue::Map(
-                [("Project".to_string(), CoreValue::String("carina".into()))]
-                    .into_iter()
-                    .collect(),
-            ),
+            CoreValue::Concrete(ConcreteValue::Map(
+                [(
+                    "Project".to_string(),
+                    CoreValue::Concrete(ConcreteValue::String("carina".into())),
+                )]
+                .into_iter()
+                .collect(),
+            )),
         );
         assert!(validator(&attrs).is_ok());
     }

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -24,7 +24,7 @@ use carina_core::provider::{
     BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderFactory,
     ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
 };
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::{CompletionValue, ResourceSchema};
 use carina_core::value::SerializationError;
 
@@ -1265,7 +1265,7 @@ impl ProviderFactory for WasmProviderFactory {
     }
 
     fn extract_region(&self, attributes: &IndexMap<String, Value>) -> String {
-        if let Some(Value::String(region)) = attributes.get("region") {
+        if let Some(Value::Concrete(ConcreteValue::String(region))) = attributes.get("region") {
             carina_core::utils::convert_region_value(region)
         } else {
             "ap-northeast-1".to_string()
@@ -1572,8 +1572,8 @@ impl ProviderNormalizer for WasmProviderNormalizer {
         match result {
             Ok(result) => {
                 // `PlanPreprocessor::prepare` strips every attribute that
-                // recursively contains `Value::ResourceRef` (alongside
-                // `Value::Unknown`) before this normalizer runs and
+                // recursively contains `Value::Deferred(DeferredValue::ResourceRef)` (alongside
+                // `Value::Deferred(DeferredValue::Unknown)`) before this normalizer runs and
                 // restores them afterwards (#2387), so we can blindly
                 // accept everything the WASM normalizer returns — the
                 // pre-#2387 `contains_resource_ref` overwrite-skip

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -7,7 +7,7 @@ use carina_core::provider::{
     CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, ProviderFactory, ReadRequest,
     UpdatePatch, UpdateRequest,
 };
-use carina_core::resource::{Resource, ResourceId, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, Value};
 use carina_plugin_host::WasmProviderFactory;
 
 fn wasm_path() -> Option<PathBuf> {
@@ -88,9 +88,15 @@ async fn test_wasm_mock_provider_create_and_read() {
     // Create a resource
     let mut resource = Resource::with_provider("mock", "test.resource", "my-resource");
     resource.attributes = indexmap::IndexMap::from([
-        ("name".into(), Value::String("my-resource".into())),
-        ("region".into(), Value::String("us-east-1".into())),
-        ("count".into(), Value::Int(42)),
+        (
+            "name".into(),
+            Value::Concrete(ConcreteValue::String("my-resource".into())),
+        ),
+        (
+            "region".into(),
+            Value::Concrete(ConcreteValue::String("us-east-1".into())),
+        ),
+        ("count".into(), Value::Concrete(ConcreteValue::Int(42))),
     ]);
 
     let created = provider
@@ -105,13 +111,18 @@ async fn test_wasm_mock_provider_create_and_read() {
     assert_eq!(created.identifier, Some("mock-id".into()));
     assert_eq!(
         created.attributes.get("name"),
-        Some(&Value::String("my-resource".into()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-resource".into()
+        )))
     );
     assert_eq!(
         created.attributes.get("region"),
-        Some(&Value::String("us-east-1".into()))
+        Some(&Value::Concrete(ConcreteValue::String("us-east-1".into())))
     );
-    assert_eq!(created.attributes.get("count"), Some(&Value::Int(42)));
+    assert_eq!(
+        created.attributes.get("count"),
+        Some(&Value::Concrete(ConcreteValue::Int(42)))
+    );
 
     // Read back - should return the created state
     let read_state = provider
@@ -121,13 +132,18 @@ async fn test_wasm_mock_provider_create_and_read() {
     assert_eq!(read_state.identifier, Some("mock-id".into()));
     assert_eq!(
         read_state.attributes.get("name"),
-        Some(&Value::String("my-resource".into()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my-resource".into()
+        )))
     );
     assert_eq!(
         read_state.attributes.get("region"),
-        Some(&Value::String("us-east-1".into()))
+        Some(&Value::Concrete(ConcreteValue::String("us-east-1".into())))
     );
-    assert_eq!(read_state.attributes.get("count"), Some(&Value::Int(42)));
+    assert_eq!(
+        read_state.attributes.get("count"),
+        Some(&Value::Concrete(ConcreteValue::Int(42)))
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -144,8 +160,11 @@ async fn test_wasm_mock_provider_update_and_delete() {
     // Create first
     let mut resource = Resource::with_provider("mock", "test.resource", "updatable");
     resource.attributes = indexmap::IndexMap::from([
-        ("color".into(), Value::String("red".into())),
-        ("size".into(), Value::Int(10)),
+        (
+            "color".into(),
+            Value::Concrete(ConcreteValue::String("red".into())),
+        ),
+        ("size".into(), Value::Concrete(ConcreteValue::Int(10))),
     ]);
 
     let created = provider
@@ -159,7 +178,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
         .expect("create should succeed");
     assert_eq!(
         created.attributes.get("color"),
-        Some(&Value::String("red".into()))
+        Some(&Value::Concrete(ConcreteValue::String("red".into())))
     );
 
     // Build an UpdatePatch describing the user's intended changes
@@ -170,12 +189,12 @@ async fn test_wasm_mock_provider_update_and_delete() {
             PatchOp {
                 kind: PatchOpKind::Replace,
                 key: "color".to_string(),
-                value: Some(Value::String("blue".into())),
+                value: Some(Value::Concrete(ConcreteValue::String("blue".into()))),
             },
             PatchOp {
                 kind: PatchOpKind::Replace,
                 key: "size".to_string(),
-                value: Some(Value::Int(20)),
+                value: Some(Value::Concrete(ConcreteValue::Int(20))),
             },
         ],
     };
@@ -193,9 +212,12 @@ async fn test_wasm_mock_provider_update_and_delete() {
         .expect("update should succeed");
     assert_eq!(
         updated.attributes.get("color"),
-        Some(&Value::String("blue".into()))
+        Some(&Value::Concrete(ConcreteValue::String("blue".into())))
     );
-    assert_eq!(updated.attributes.get("size"), Some(&Value::Int(20)));
+    assert_eq!(
+        updated.attributes.get("size"),
+        Some(&Value::Concrete(ConcreteValue::Int(20)))
+    );
     // The mock echoes the applied patch op kinds + keys as a sentinel
     // attribute so we can verify the patch round-tripped through the
     // WIT boundary in op order.
@@ -203,12 +225,18 @@ async fn test_wasm_mock_provider_update_and_delete() {
         .attributes
         .get("__mock_patch_ops__")
         .expect("mock should echo patch ops");
-    let Value::List(ops) = echoed else {
+    let Value::Concrete(ConcreteValue::List(ops)) = echoed else {
         panic!("__mock_patch_ops__ should be a list, got {echoed:?}");
     };
     assert_eq!(ops.len(), 2);
-    assert_eq!(ops[0], Value::String("replace:color".into()));
-    assert_eq!(ops[1], Value::String("replace:size".into()));
+    assert_eq!(
+        ops[0],
+        Value::Concrete(ConcreteValue::String("replace:color".into()))
+    );
+    assert_eq!(
+        ops[1],
+        Value::Concrete(ConcreteValue::String("replace:size".into()))
+    );
 
     // Read to verify update persisted in memory
     let read_state = provider
@@ -217,7 +245,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
         .expect("read should not error");
     assert_eq!(
         read_state.attributes.get("color"),
-        Some(&Value::String("blue".into()))
+        Some(&Value::Concrete(ConcreteValue::String("blue".into())))
     );
 
     // Delete
@@ -244,7 +272,10 @@ async fn test_wasm_mock_provider_normalizer() {
     // normalize_desired: mock provider returns resources unchanged
     let mut resources = vec![{
         let mut r = Resource::with_provider("mock", "test.resource", "norm-test");
-        r.attributes = indexmap::IndexMap::from([("key".into(), Value::String("value".into()))]);
+        r.attributes = indexmap::IndexMap::from([(
+            "key".into(),
+            Value::Concrete(ConcreteValue::String("value".into())),
+        )]);
         r
     }];
     let original_attrs = resources[0].resolved_attributes();
@@ -253,14 +284,17 @@ async fn test_wasm_mock_provider_normalizer() {
 
     // normalize_state: mock provider returns states unchanged
     let id = ResourceId::with_provider("mock", "test.resource", "norm-test");
-    let attrs = HashMap::from([("key".into(), Value::String("value".into()))]);
+    let attrs = HashMap::from([(
+        "key".into(),
+        Value::Concrete(ConcreteValue::String("value".into())),
+    )]);
     let state = carina_core::resource::State::existing(id.clone(), attrs.clone());
     let mut states = HashMap::from([(id.clone(), state)]);
     normalizer.normalize_state(&mut states);
     let result_state = states.values().next().unwrap();
     assert_eq!(
         result_state.attributes.get("key"),
-        Some(&Value::String("value".into()))
+        Some(&Value::Concrete(ConcreteValue::String("value".into())))
     );
 }
 
@@ -280,8 +314,14 @@ async fn test_wasm_mock_provider_merge_default_tags_dispatches_through_wit() {
     let registry = carina_core::schema::SchemaRegistry::new();
     let mut resources = vec![Resource::with_provider("mock", "test.resource", "tag-test")];
     let default_tags = indexmap::IndexMap::from([
-        ("Env".to_string(), Value::String("dev".to_string())),
-        ("Owner".to_string(), Value::String("platform".to_string())),
+        (
+            "Env".to_string(),
+            Value::Concrete(ConcreteValue::String("dev".to_string())),
+        ),
+        (
+            "Owner".to_string(),
+            Value::Concrete(ConcreteValue::String("platform".to_string())),
+        ),
     ]);
 
     normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
@@ -289,7 +329,7 @@ async fn test_wasm_mock_provider_merge_default_tags_dispatches_through_wit() {
     let echoed = resources[0]
         .get_attr("__mock_merged_default_tags__")
         .expect("guest's merge_default_tags must run via the WIT bridge");
-    let Value::List(items) = echoed else {
+    let Value::Concrete(ConcreteValue::List(items)) = echoed else {
         panic!("expected list, got {echoed:?}");
     };
     assert_eq!(items.len(), 2, "both default_tags should arrive at guest");
@@ -331,8 +371,10 @@ async fn test_wasm_mock_provider_merge_default_tags_preserves_order() {
         Resource::with_provider("mock", "test.resource", "beta"),
         Resource::with_provider("mock", "test.resource", "gamma"),
     ];
-    let default_tags =
-        indexmap::IndexMap::from([("Env".to_string(), Value::String("dev".to_string()))]);
+    let default_tags = indexmap::IndexMap::from([(
+        "Env".to_string(),
+        Value::Concrete(ConcreteValue::String("dev".to_string())),
+    )]);
 
     normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
 
@@ -367,11 +409,11 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     resource.attributes = indexmap::IndexMap::from([
         (
             "identity_store_id".into(),
-            Value::String("d-1234567890".into()),
+            Value::Concrete(ConcreteValue::String("d-1234567890".into())),
         ),
         (
             "user_name".into(),
-            Value::String("alice@example.com".into()),
+            Value::Concrete(ConcreteValue::String("alice@example.com".into())),
         ),
     ]);
 
@@ -383,16 +425,20 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     assert!(state.exists, "state should be marked as existing");
     assert_eq!(
         state.attributes.get("__mock_read_data_source__"),
-        Some(&Value::Bool(true)),
+        Some(&Value::Concrete(ConcreteValue::Bool(true))),
         "sentinel attribute must be present — proves the plugin override ran"
     );
     assert_eq!(
         state.attributes.get("identity_store_id"),
-        Some(&Value::String("d-1234567890".into())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "d-1234567890".into()
+        ))),
         "input attributes must cross the WASM boundary unchanged"
     );
     assert_eq!(
         state.attributes.get("user_name"),
-        Some(&Value::String("alice@example.com".into())),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "alice@example.com".into()
+        ))),
     );
 }

--- a/carina-state/src/backend.rs
+++ b/carina-state/src/backend.rs
@@ -264,7 +264,9 @@ impl BackendConfig {
     /// Get a string attribute value
     pub fn get_string(&self, key: &str) -> Option<&str> {
         match self.attributes.get(key) {
-            Some(carina_core::resource::Value::String(s)) => Some(s.as_str()),
+            Some(carina_core::resource::Value::Concrete(
+                carina_core::resource::ConcreteValue::String(s),
+            )) => Some(s.as_str()),
             _ => None,
         }
     }
@@ -272,7 +274,9 @@ impl BackendConfig {
     /// Get a boolean attribute value
     pub fn get_bool(&self, key: &str) -> Option<bool> {
         match self.attributes.get(key) {
-            Some(carina_core::resource::Value::Bool(b)) => Some(*b),
+            Some(carina_core::resource::Value::Concrete(
+                carina_core::resource::ConcreteValue::Bool(b),
+            )) => Some(*b),
             _ => None,
         }
     }
@@ -327,13 +331,19 @@ mod tests {
 
     #[test]
     fn test_backend_config_from_provider_context() {
-        use carina_core::resource::Value;
+        use carina_core::resource::{ConcreteValue, Value};
 
         let provider_context = carina_core::parser::BackendConfig {
             backend_type: "s3".to_string(),
             attributes: [
-                ("bucket".to_string(), Value::String("my-bucket".to_string())),
-                ("key".to_string(), Value::String("state.json".to_string())),
+                (
+                    "bucket".to_string(),
+                    Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+                ),
+                (
+                    "key".to_string(),
+                    Value::Concrete(ConcreteValue::String("state.json".to_string())),
+                ),
             ]
             .into_iter()
             .collect(),

--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -43,7 +43,7 @@ pub struct BackendLock {
 impl BackendLock {
     /// Build a lock snapshot from the current backend configuration.
     ///
-    /// Returns `Err` if any backend attribute holds a `Value::Unknown`
+    /// Returns `Err` if any backend attribute holds a `Value::Deferred(DeferredValue::Unknown)`
     /// — backend configurations cannot reference unresolved upstream
     /// values (RFC #2371 stage 4).
     pub fn from_config(
@@ -151,22 +151,26 @@ impl BackendLock {
 /// Convert a `carina_core::resource::Value` into a `serde_json::Value`
 /// for persistence in the lock file. Only scalar types are expected in
 /// backend configurations; complex types fall back to `null`. A
-/// `Value::Unknown` produces `Err` because backend configurations
+/// `Value::Deferred(DeferredValue::Unknown)` produces `Err` because backend configurations
 /// cannot reference unresolved upstream values.
 fn value_to_json(
     value: &carina_core::resource::Value,
 ) -> Result<serde_json::Value, carina_core::value::SerializationError> {
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, DeferredValue, Value};
     use carina_core::value::{SerializationContext, SerializationError};
     match value {
-        Value::String(s) => Ok(serde_json::Value::String(s.clone())),
-        Value::Bool(b) => Ok(serde_json::Value::Bool(*b)),
-        Value::Int(i) => Ok(serde_json::Value::Number((*i).into())),
-        Value::Duration(d) => Ok(serde_json::Value::Number((d.as_secs() as i64).into())),
-        Value::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {
-            reason: reason.clone(),
-            context: SerializationContext::BackendLock,
-        }),
+        Value::Concrete(ConcreteValue::String(s)) => Ok(serde_json::Value::String(s.clone())),
+        Value::Concrete(ConcreteValue::Bool(b)) => Ok(serde_json::Value::Bool(*b)),
+        Value::Concrete(ConcreteValue::Int(i)) => Ok(serde_json::Value::Number((*i).into())),
+        Value::Concrete(ConcreteValue::Duration(d)) => {
+            Ok(serde_json::Value::Number((d.as_secs() as i64).into()))
+        }
+        Value::Deferred(DeferredValue::Unknown(reason)) => {
+            Err(SerializationError::UnknownNotAllowed {
+                reason: reason.clone(),
+                context: SerializationContext::BackendLock,
+            })
+        }
         _ => Ok(serde_json::Value::Null),
     }
 }
@@ -174,13 +178,19 @@ fn value_to_json(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
     use std::collections::HashMap;
 
     fn make_config(bucket: &str, region: &str) -> BackendConfig {
         let mut attributes = HashMap::new();
-        attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
-        attributes.insert("region".to_string(), Value::String(region.to_string()));
+        attributes.insert(
+            "bucket".to_string(),
+            Value::Concrete(ConcreteValue::String(bucket.to_string())),
+        );
+        attributes.insert(
+            "region".to_string(),
+            Value::Concrete(ConcreteValue::String(region.to_string())),
+        );
         BackendConfig {
             backend_type: "s3".to_string(),
             attributes,
@@ -304,15 +314,17 @@ mod tests {
     }
 
     /// RFC #2371 stage 4 contract pin: `value_to_json` returns
-    /// `Err(SerializationError::UnknownNotAllowed)` for `Value::Unknown`.
+    /// `Err(SerializationError::UnknownNotAllowed)` for `Value::Deferred(DeferredValue::Unknown)`.
     /// Backend lock files must never carry the variant (constraint b);
     /// a silent fallback would re-introduce v1-style corruption.
     #[test]
     fn unknown_returns_err_in_value_to_json() {
-        use carina_core::resource::{AccessPath, UnknownReason, Value};
+        use carina_core::resource::{AccessPath, DeferredValue, UnknownReason, Value};
         use carina_core::value::{SerializationContext, SerializationError};
         let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
-        let v = Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+        let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef {
+            path: path.clone(),
+        }));
         let err = value_to_json(&v).unwrap_err();
         match err {
             SerializationError::UnknownNotAllowed {

--- a/carina-state/src/backends/local.rs
+++ b/carina-state/src/backends/local.rs
@@ -729,13 +729,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_local_backend_custom_path() {
-        use carina_core::resource::Value;
+        use carina_core::resource::{ConcreteValue, Value};
         use std::collections::HashMap;
 
         let mut attributes = HashMap::new();
         attributes.insert(
             "path".to_string(),
-            Value::String("custom.state.json".to_string()),
+            Value::Concrete(ConcreteValue::String("custom.state.json".to_string())),
         );
 
         let config = BackendConfig {

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -20,9 +20,9 @@
 //! let config = BackendConfig {
 //!     backend_type: "s3".to_string(),
 //!     attributes: [
-//!         ("bucket".to_string(), Value::String("my-state-bucket".to_string())),
-//!         ("key".to_string(), Value::String("infra/prod/carina.state".to_string())),
-//!         ("region".to_string(), Value::String("aws.Region.ap_northeast_1".to_string())),
+//!         ("bucket".to_string(), Value::Concrete(ConcreteValue::String("my-state-bucket".to_string()))),
+//!         ("key".to_string(), Value::Concrete(ConcreteValue::String("infra/prod/carina.state".to_string()))),
+//!         ("region".to_string(), Value::Concrete(ConcreteValue::String("aws.Region.ap_northeast_1".to_string()))),
 //!     ].into_iter().collect(),
 //! };
 //!

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -2,7 +2,7 @@
 
 use carina_core::deps::get_resource_dependencies;
 use carina_core::explicit::{self, ExplicitFields};
-use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::value::{
     SecretHashContext, contains_secret, json_to_dsl_value, merge_secrets_into_provider_json,
     value_to_json,
@@ -259,7 +259,10 @@ impl StateFile {
                     .collect();
                 // Inject _binding so orphan Delete effects can have tree structure
                 if let Some(ref binding) = rs.binding {
-                    attrs.insert("_binding".to_string(), Value::String(binding.clone()));
+                    attrs.insert(
+                        "_binding".to_string(),
+                        Value::Concrete(ConcreteValue::String(binding.clone())),
+                    );
                 }
                 let state = State {
                     id: id.clone(),
@@ -309,7 +312,7 @@ impl StateFile {
     /// Build a map of resource bindings for use as a remote state data source.
     ///
     /// Returns a map where each key is a resource binding name and the value is a
-    /// `Value::Map` containing that resource's attributes (converted from JSON to DSL values).
+    /// `Value::Concrete(ConcreteValue::Map)` containing that resource's attributes (converted from JSON to DSL values).
     /// Resources without a binding name are skipped.
     ///
     /// This is used by `remote_state` blocks to expose another project's state

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -189,7 +189,7 @@ fn test_build_directives() {
 
 #[test]
 fn test_build_saved_attrs() {
-    use carina_core::resource::{ResourceId, Value};
+    use carina_core::resource::{ConcreteValue, ResourceId, Value};
 
     let mut state = StateFile::new();
     let rs = ResourceState::new("s3.Bucket", "my-bucket", "awscc")
@@ -201,7 +201,9 @@ fn test_build_saved_attrs() {
     let attrs = saved.get(&id).unwrap();
     assert_eq!(
         attrs.get("region"),
-        Some(&Value::String("ap-northeast-1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1".to_string()
+        )))
     );
 }
 
@@ -252,7 +254,7 @@ fn test_resource_state_deserialization_without_v3_fields() {
 
 #[test]
 fn test_from_provider_state() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
     resource.directives.force_delete = true;
@@ -265,7 +267,7 @@ fn test_from_provider_state() {
         identifier: Some("my-bucket-abcd1234".to_string()),
         attributes: [(
             "region".to_string(),
-            Value::String("ap-northeast-1".to_string()),
+            Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -290,15 +292,18 @@ fn test_from_provider_state() {
 
 #[test]
 fn test_from_provider_state_without_existing() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     let resource = Resource::with_provider("aws", "s3.Bucket", "test");
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("test-id".to_string()),
-        attributes: [("name".to_string(), Value::String("test".to_string()))]
-            .into_iter()
-            .collect(),
+        attributes: [(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        )]
+        .into_iter()
+        .collect(),
         exists: true,
         dependency_bindings: BTreeSet::new(),
     };
@@ -399,7 +404,7 @@ fn test_build_directives_provider_scoped() {
 
 #[test]
 fn test_build_saved_attrs_provider_scoped() {
-    use carina_core::resource::{ResourceId, Value};
+    use carina_core::resource::{ConcreteValue, ResourceId, Value};
 
     let mut state = StateFile::new();
     let aws_rs = ResourceState::new("s3.Bucket", "main", "aws")
@@ -416,17 +421,21 @@ fn test_build_saved_attrs_provider_scoped() {
 
     assert_eq!(
         saved.get(&aws_id).unwrap().get("region"),
-        Some(&Value::String("us-east-1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "us-east-1".to_string()
+        )))
     );
     assert_eq!(
         saved.get(&awscc_id).unwrap().get("region"),
-        Some(&Value::String("ap-northeast-1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1".to_string()
+        )))
     );
 }
 
 #[test]
 fn test_build_state_for_resource_existing() {
-    use carina_core::resource::{Resource, Value};
+    use carina_core::resource::{ConcreteValue, Resource, Value};
 
     let mut state = StateFile::new();
     state.upsert_resource(
@@ -442,7 +451,9 @@ fn test_build_state_for_resource_existing() {
     assert_eq!(result.identifier, Some("my-bucket-id".to_string()));
     assert_eq!(
         result.attributes.get("region"),
-        Some(&Value::String("ap-northeast-1".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1".to_string()
+        )))
     );
 }
 
@@ -475,7 +486,7 @@ fn test_build_state_for_resource_without_identifier() {
 
 #[test]
 fn test_from_provider_state_stores_binding_and_dependencies() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     let mut resource = Resource::with_provider("awscc", "ec2.Subnet", "my-subnet");
     resource.binding = Some("my_subnet".to_string());
@@ -487,9 +498,12 @@ fn test_from_provider_state_stores_binding_and_dependencies() {
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("subnet-123".to_string()),
-        attributes: [("vpc_id".to_string(), Value::String("vpc-abc".to_string()))]
-            .into_iter()
-            .collect(),
+        attributes: [(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-abc".to_string())),
+        )]
+        .into_iter()
+        .collect(),
         exists: true,
         dependency_bindings: BTreeSet::new(),
     };
@@ -504,7 +518,7 @@ fn test_from_provider_state_stores_binding_and_dependencies() {
 
 #[test]
 fn test_build_orphan_states_injects_binding() {
-    use carina_core::resource::{ResourceId, Value};
+    use carina_core::resource::{ConcreteValue, ResourceId, Value};
 
     let mut state = StateFile::new();
     let mut rs =
@@ -521,7 +535,9 @@ fn test_build_orphan_states_injects_binding() {
     assert!(orphan_state.exists);
     assert_eq!(
         orphan_state.attributes.get("_binding"),
-        Some(&Value::String("my_subnet".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "my_subnet".to_string()
+        )))
     );
 }
 
@@ -665,15 +681,18 @@ fn test_check_and_migrate_bytes_invalid_utf8() {
 
 #[test]
 fn test_merge_write_only_attributes() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     // Simulate a VPC resource with a write-only attribute (ipv4_netmask_length)
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
     resource.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    resource.set_attr("ipv4_netmask_length".to_string(), Value::Int(16));
+    resource.set_attr(
+        "ipv4_netmask_length".to_string(),
+        Value::Concrete(ConcreteValue::Int(16)),
+    );
 
     // Provider returns state without write-only attributes (API doesn't return them)
     let provider_state = ProviderState {
@@ -681,7 +700,7 @@ fn test_merge_write_only_attributes() {
         identifier: Some("vpc-123".to_string()),
         attributes: [(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -711,13 +730,13 @@ fn test_merge_write_only_attributes() {
 
 #[test]
 fn test_merge_write_only_attributes_not_in_desired() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     // Resource without write-only attribute specified
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
     resource.set_attr(
         "cidr_block".to_string(),
-        Value::String("10.0.0.0/16".to_string()),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
     let provider_state = ProviderState {
@@ -725,7 +744,7 @@ fn test_merge_write_only_attributes_not_in_desired() {
         identifier: Some("vpc-123".to_string()),
         attributes: [(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -746,13 +765,13 @@ fn test_merge_write_only_attributes_not_in_desired() {
 
 #[test]
 fn test_merge_write_only_skips_if_already_in_provider_state() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     // Resource with a write-only attribute
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
     resource.set_attr(
         "some_attr".to_string(),
-        Value::String("desired".to_string()),
+        Value::Concrete(ConcreteValue::String("desired".to_string())),
     );
 
     // Provider happens to return this attribute (unusual for write-only but possible)
@@ -761,7 +780,7 @@ fn test_merge_write_only_skips_if_already_in_provider_state() {
         identifier: Some("vpc-123".to_string()),
         attributes: [(
             "some_attr".to_string(),
-            Value::String("from-api".to_string()),
+            Value::Concrete(ConcreteValue::String("from-api".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -818,13 +837,17 @@ fn test_write_only_attributes_omitted_when_empty() {
 
 #[test]
 fn test_from_provider_state_secret_stored_as_hash() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{
+        ConcreteValue, DeferredValue, Resource, State as ProviderState, Value,
+    };
     use carina_core::value::SECRET_PREFIX;
 
     let mut resource = Resource::with_provider("awscc", "rds.db_instance", "my-db");
     resource.set_attr(
         "master_password".to_string(),
-        Value::Secret(Box::new(Value::String("my-password".to_string()))),
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("my-password".to_string()),
+        )))),
     );
 
     let provider_state = ProviderState {
@@ -833,7 +856,7 @@ fn test_from_provider_state_secret_stored_as_hash() {
         // Provider returns the actual password (since secret was unwrapped before sending)
         attributes: [(
             "master_password".to_string(),
-            Value::String("my-password".to_string()),
+            Value::Concrete(ConcreteValue::String("my-password".to_string())),
         )]
         .into_iter()
         .collect(),
@@ -863,31 +886,47 @@ fn test_from_provider_state_secret_stored_as_hash() {
 
 #[test]
 fn test_from_provider_state_secret_in_map_stored_as_hash() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{
+        ConcreteValue, DeferredValue, Resource, State as ProviderState, Value,
+    };
     use carina_core::value::SECRET_PREFIX;
 
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
     let mut tags_map = IndexMap::new();
-    tags_map.insert("Name".to_string(), Value::String("test".to_string()));
+    tags_map.insert(
+        "Name".to_string(),
+        Value::Concrete(ConcreteValue::String("test".to_string())),
+    );
     tags_map.insert(
         "SecretTag".to_string(),
-        Value::Secret(Box::new(Value::String("super-secret-value".to_string()))),
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("super-secret-value".to_string()),
+        )))),
     );
-    resource.set_attr("tags".to_string(), Value::Map(tags_map));
+    resource.set_attr(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(tags_map)),
+    );
 
     let mut state_tags = IndexMap::new();
-    state_tags.insert("Name".to_string(), Value::String("test".to_string()));
+    state_tags.insert(
+        "Name".to_string(),
+        Value::Concrete(ConcreteValue::String("test".to_string())),
+    );
     state_tags.insert(
         "SecretTag".to_string(),
-        Value::String("super-secret-value".to_string()),
+        Value::Concrete(ConcreteValue::String("super-secret-value".to_string())),
     );
 
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("vpc-123".to_string()),
-        attributes: [("tags".to_string(), Value::Map(state_tags))]
-            .into_iter()
-            .collect(),
+        attributes: [(
+            "tags".to_string(),
+            Value::Concrete(ConcreteValue::Map(state_tags)),
+        )]
+        .into_iter()
+        .collect(),
         exists: true,
         dependency_bindings: BTreeSet::new(),
     };
@@ -916,7 +955,9 @@ fn test_from_provider_state_secret_in_map_stored_as_hash() {
 
 #[test]
 fn test_from_provider_state_secret_in_map_preserves_provider_extra_keys() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{
+        ConcreteValue, DeferredValue, Resource, State as ProviderState, Value,
+    };
     use carina_core::value::SECRET_PREFIX;
 
     // User specifies only SecretTag in tags
@@ -924,28 +965,39 @@ fn test_from_provider_state_secret_in_map_preserves_provider_extra_keys() {
     let mut tags_map = IndexMap::new();
     tags_map.insert(
         "SecretTag".to_string(),
-        Value::Secret(Box::new(Value::String("super-secret-value".to_string()))),
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+            ConcreteValue::String("super-secret-value".to_string()),
+        )))),
     );
-    resource.set_attr("tags".to_string(), Value::Map(tags_map));
+    resource.set_attr(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(tags_map)),
+    );
 
     // Provider returns extra keys (e.g., CloudControl adds Name automatically)
     let mut state_tags = IndexMap::new();
-    state_tags.insert("Name".to_string(), Value::String("test".to_string()));
+    state_tags.insert(
+        "Name".to_string(),
+        Value::Concrete(ConcreteValue::String("test".to_string())),
+    );
     state_tags.insert(
         "ExtraTag".to_string(),
-        Value::String("extra-value".to_string()),
+        Value::Concrete(ConcreteValue::String("extra-value".to_string())),
     );
     state_tags.insert(
         "SecretTag".to_string(),
-        Value::String("super-secret-value".to_string()),
+        Value::Concrete(ConcreteValue::String("super-secret-value".to_string())),
     );
 
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("vpc-123".to_string()),
-        attributes: [("tags".to_string(), Value::Map(state_tags))]
-            .into_iter()
-            .collect(),
+        attributes: [(
+            "tags".to_string(),
+            Value::Concrete(ConcreteValue::Map(state_tags)),
+        )]
+        .into_iter()
+        .collect(),
         exists: true,
         dependency_bindings: BTreeSet::new(),
     };
@@ -977,16 +1029,20 @@ fn test_from_provider_state_secret_in_map_preserves_provider_extra_keys() {
 
 #[test]
 fn test_from_provider_state_secret_in_list_stored_as_hash() {
-    use carina_core::resource::{Resource, State as ProviderState, Value};
+    use carina_core::resource::{
+        ConcreteValue, DeferredValue, Resource, State as ProviderState, Value,
+    };
     use carina_core::value::SECRET_PREFIX;
 
     let mut resource = Resource::with_provider("awscc", "test.resource", "my-res");
     resource.set_attr(
         "values".to_string(),
-        Value::List(vec![
-            Value::String("public".to_string()),
-            Value::Secret(Box::new(Value::String("secret-item".to_string()))),
-        ]),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("public".to_string())),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("secret-item".to_string()),
+            )))),
+        ])),
     );
 
     let provider_state = ProviderState {
@@ -994,10 +1050,10 @@ fn test_from_provider_state_secret_in_list_stored_as_hash() {
         identifier: Some("res-123".to_string()),
         attributes: [(
             "values".to_string(),
-            Value::List(vec![
-                Value::String("public".to_string()),
-                Value::String("secret-item".to_string()),
-            ]),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("public".to_string())),
+                Value::Concrete(ConcreteValue::String("secret-item".to_string())),
+            ])),
         )]
         .into_iter()
         .collect(),
@@ -1032,7 +1088,9 @@ fn build_remote_bindings_returns_exports() {
     let bindings = state.build_remote_bindings();
     assert_eq!(
         bindings.get("account_id"),
-        Some(&Value::String("123456789012".to_string()))
+        Some(&Value::Concrete(ConcreteValue::String(
+            "123456789012".to_string()
+        )))
     );
 }
 
@@ -1110,13 +1168,15 @@ fn check_and_migrate_canonicalizes_legacy_map_key_addresses() {
 }
 
 /// RFC #2371 #2385: state writeback rejects unresolved `Value` variants
-/// surfaced from a buggy provider that returns a `Value::ResourceRef`
+/// surfaced from a buggy provider that returns a `Value::Deferred(DeferredValue::ResourceRef)`
 /// in `state.attributes`. Provider-returned states must be concrete; a
 /// resolver / provider bug produces a typed `UnresolvedResourceRef`
 /// error rather than a debug-formatted string in state JSON.
 #[test]
 fn from_provider_state_rejects_resource_ref_in_provider_attributes() {
-    use carina_core::resource::{AccessPath, Resource, State as ProviderState, Value};
+    use carina_core::resource::{
+        AccessPath, DeferredValue, Resource, State as ProviderState, Value,
+    };
 
     let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
     let provider_state = ProviderState {
@@ -1124,9 +1184,9 @@ fn from_provider_state_rejects_resource_ref_in_provider_attributes() {
         identifier: Some("my-bucket".to_string()),
         attributes: [(
             "owner".to_string(),
-            Value::ResourceRef {
+            Value::Deferred(DeferredValue::ResourceRef {
                 path: AccessPath::with_fields("net", "vpc", vec!["vpc_id".into()]),
-            },
+            }),
         )]
         .into_iter()
         .collect(),

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::value::format_value;
 
 #[test]
@@ -71,13 +71,15 @@ fn update_effect_has_detail_rows() {
             ResourceId::new("s3.Bucket", "my-bucket"),
             [(
                 "versioning".to_string(),
-                Value::String("Disabled".to_string()),
+                Value::Concrete(ConcreteValue::String("Disabled".to_string())),
             )]
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("versioning", Value::String("Enabled".to_string())),
+        to: Resource::new("s3.Bucket", "my-bucket").with_attribute(
+            "versioning",
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        ),
         changed_attributes: vec!["versioning".to_string()],
     });
 
@@ -97,7 +99,10 @@ fn internal_attributes_filtered() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
         Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("name", Value::String("test".to_string()))
+            .with_attribute(
+                "name",
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            )
             .with_binding("my_bucket")
             .with_module_source(carina_core::resource::ModuleSource::module("web", "web")),
     ));
@@ -116,13 +121,19 @@ fn internal_attributes_filtered() {
 #[test]
 fn format_value_display() {
     assert_eq!(
-        format_value(&Value::String("hello".to_string())),
+        format_value(&Value::Concrete(ConcreteValue::String("hello".to_string()))),
         "\"hello\""
     );
-    assert_eq!(format_value(&Value::Int(42)), "42");
-    assert_eq!(format_value(&Value::Bool(true)), "true");
+    assert_eq!(format_value(&Value::Concrete(ConcreteValue::Int(42))), "42");
     assert_eq!(
-        format_value(&Value::List(vec![Value::Int(1), Value::Int(2)])),
+        format_value(&Value::Concrete(ConcreteValue::Bool(true))),
+        "true"
+    );
+    assert_eq!(
+        format_value(&Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::Int(1)),
+            Value::Concrete(ConcreteValue::Int(2))
+        ]))),
         "[1, 2]"
     );
 }
@@ -132,9 +143,12 @@ fn replace_effect_symbols() {
     let mut plan = Plan::new();
     let from = Box::new(State::existing(
         ResourceId::new("ec2.Vpc", "my-vpc"),
-        [("cidr".to_string(), Value::String("10.0.0.0/16".to_string()))]
-            .into_iter()
-            .collect(),
+        [(
+            "cidr".to_string(),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+        )]
+        .into_iter()
+        .collect(),
     ));
 
     // create_before_destroy = true -> "+/-"
@@ -176,7 +190,10 @@ fn tree_structure_with_dependencies() {
     plan.add(Effect::Create(
         Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
-            .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string())),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            ),
     ));
     plan.add(Effect::Create(
         Resource::new("ec2.Subnet", "my-subnet")
@@ -204,8 +221,10 @@ fn tree_structure_with_dependencies() {
 fn selected_node_returns_correct_node() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::new("s3.Bucket", "my-bucket")
-            .with_attribute("name", Value::String("test".to_string())),
+        Resource::new("s3.Bucket", "my-bucket").with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("test".to_string())),
+        ),
     ));
 
     let app = App::new(&plan, &SchemaRegistry::new());
@@ -344,7 +363,10 @@ fn make_tree_plan() -> Plan {
     plan.add(Effect::Create(
         Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
-            .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string())),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            ),
     ));
     plan.add(Effect::Create(
         Resource::new("ec2.Subnet", "my-subnet")
@@ -565,29 +587,33 @@ fn tab_complete_with_provider_prefix() {
 fn format_value_resolves_dsl_enum_identifiers() {
     // 5-part DSL enum: should resolve to quoted value
     assert_eq!(
-        format_value(&Value::String(
+        format_value(&Value::Concrete(ConcreteValue::String(
             "awscc.ec2.vpc_endpoint.VpcEndpointType.Interface".to_string()
-        )),
+        ))),
         "\"Interface\""
     );
 
     // 4-part DSL enum
     assert_eq!(
-        format_value(&Value::String(
+        format_value(&Value::Concrete(ConcreteValue::String(
             "aws.s3.VersioningStatus.Enabled".to_string()
-        )),
+        ))),
         "\"Enabled\""
     );
 
     // 3-part DSL enum: namespace stripped, value returned as-is
     assert_eq!(
-        format_value(&Value::String("aws.Region.ap_northeast_1".to_string())),
+        format_value(&Value::Concrete(ConcreteValue::String(
+            "aws.Region.ap_northeast_1".to_string()
+        ))),
         "\"ap_northeast_1\""
     );
 
     // Regular string should be quoted as-is
     assert_eq!(
-        format_value(&Value::String("my-bucket".to_string())),
+        format_value(&Value::Concrete(ConcreteValue::String(
+            "my-bucket".to_string()
+        ))),
         "\"my-bucket\""
     );
 
@@ -609,7 +635,9 @@ fn create_effect_attributes_resolve_enum_values() {
         Resource::new("ec2.vpc_endpoint", "my-endpoint")
             .with_attribute(
                 "vpc_endpoint_type",
-                Value::String("awscc.ec2.vpc_endpoint.VpcEndpointType.Interface".to_string()),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.ec2.vpc_endpoint.VpcEndpointType.Interface".to_string(),
+                )),
             )
             .with_attribute(
                 "vpc_id",
@@ -652,13 +680,15 @@ fn move_suppressed_when_update_exists_for_same_target() {
             ResourceId::new("s3.Bucket", "new-name"),
             [(
                 "versioning".to_string(),
-                Value::String("Disabled".to_string()),
+                Value::Concrete(ConcreteValue::String("Disabled".to_string())),
             )]
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("s3.Bucket", "new-name")
-            .with_attribute("versioning", Value::String("Enabled".to_string())),
+        to: Resource::new("s3.Bucket", "new-name").with_attribute(
+            "versioning",
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        ),
         changed_attributes: vec!["versioning".to_string()],
     });
 
@@ -679,9 +709,12 @@ fn move_suppressed_when_replace_exists_for_same_target() {
         id: ResourceId::new("ec2.Vpc", "new-vpc"),
         from: Box::new(State::existing(
             ResourceId::new("ec2.Vpc", "new-vpc"),
-            [("cidr".to_string(), Value::String("10.0.0.0/16".to_string()))]
-                .into_iter()
-                .collect(),
+            [(
+                "cidr".to_string(),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )]
+            .into_iter()
+            .collect(),
         )),
         to: Resource::new("ec2.Vpc", "new-vpc"),
         directives: Directives::default(),

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -10,7 +10,7 @@ use ratatui::backend::TestBackend;
 
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
-use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 
 use crate::app::App;
@@ -48,7 +48,10 @@ fn build_all_create_plan() -> Plan {
     plan.add(Effect::Create(
         Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
-            .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string())),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            ),
     ));
     plan.add(Effect::Create(
         Resource::new("ec2.RouteTable", "my-rt")
@@ -61,7 +64,10 @@ fn build_all_create_plan() -> Plan {
     plan.add(Effect::Create(
         Resource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
-            .with_attribute("cidr_block", Value::String("10.0.1.0/24".to_string()))
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+            )
             .with_attribute(
                 "vpc_id",
                 Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -80,17 +86,26 @@ fn build_mixed_operations_plan() -> Plan {
             [
                 (
                     "cidr_block".to_string(),
-                    Value::String("10.0.0.0/16".to_string()),
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
                 ),
-                ("_binding".to_string(), Value::String("vpc".to_string())),
+                (
+                    "_binding".to_string(),
+                    Value::Concrete(ConcreteValue::String("vpc".to_string())),
+                ),
             ]
             .into_iter()
             .collect(),
         )),
         to: Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
-            .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()))
-            .with_attribute("enable_dns_support", Value::Bool(true)),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )
+            .with_attribute(
+                "enable_dns_support",
+                Value::Concrete(ConcreteValue::Bool(true)),
+            ),
         changed_attributes: vec!["enable_dns_support".to_string()],
     });
     plan.add(Effect::Create(
@@ -98,7 +113,7 @@ fn build_mixed_operations_plan() -> Plan {
             .with_binding("sg")
             .with_attribute(
                 "group_description",
-                Value::String("Web security group".to_string()),
+                Value::Concrete(ConcreteValue::String("Web security group".to_string())),
             )
             .with_attribute(
                 "vpc_id",
@@ -121,23 +136,35 @@ fn build_map_key_diff_plan() -> Plan {
     let mut plan = Plan::new();
 
     let old_tags: indexmap::IndexMap<String, Value> = [
-        ("Name".to_string(), Value::String("my-vpc".to_string())),
+        (
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
+        ),
         (
             "Environment".to_string(),
-            Value::String("staging".to_string()),
+            Value::Concrete(ConcreteValue::String("staging".to_string())),
         ),
-        ("OldTag".to_string(), Value::String("to-remove".to_string())),
+        (
+            "OldTag".to_string(),
+            Value::Concrete(ConcreteValue::String("to-remove".to_string())),
+        ),
     ]
     .into_iter()
     .collect();
 
     let new_tags: indexmap::IndexMap<String, Value> = [
-        ("Name".to_string(), Value::String("my-vpc".to_string())),
+        (
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
+        ),
         (
             "Environment".to_string(),
-            Value::String("production".to_string()),
+            Value::Concrete(ConcreteValue::String("production".to_string())),
         ),
-        ("NewTag".to_string(), Value::String("added".to_string())),
+        (
+            "NewTag".to_string(),
+            Value::Concrete(ConcreteValue::String("added".to_string())),
+        ),
     ]
     .into_iter()
     .collect();
@@ -147,20 +174,29 @@ fn build_map_key_diff_plan() -> Plan {
         from: Box::new(State::existing(
             ResourceId::new("ec2.Vpc", "my-vpc"),
             [
-                ("_binding".to_string(), Value::String("vpc".to_string())),
+                (
+                    "_binding".to_string(),
+                    Value::Concrete(ConcreteValue::String("vpc".to_string())),
+                ),
                 (
                     "cidr_block".to_string(),
-                    Value::String("10.0.0.0/16".to_string()),
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
                 ),
-                ("tags".to_string(), Value::Map(old_tags)),
+                (
+                    "tags".to_string(),
+                    Value::Concrete(ConcreteValue::Map(old_tags)),
+                ),
             ]
             .into_iter()
             .collect(),
         )),
         to: Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
-            .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()))
-            .with_attribute("tags", Value::Map(new_tags)),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )
+            .with_attribute("tags", Value::Concrete(ConcreteValue::Map(new_tags))),
         changed_attributes: vec!["tags".to_string()],
     });
     plan
@@ -201,7 +237,10 @@ fn snapshot_create_with_schema() {
     plan.add(Effect::Create(
         Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
-            .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string())),
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            ),
     ));
 
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
@@ -210,11 +249,11 @@ fn snapshot_create_with_schema() {
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required())
         .attribute(
             AttributeSchema::new("enable_dns_support", AttributeType::Bool)
-                .with_default(Value::Bool(true)),
+                .with_default(Value::Concrete(ConcreteValue::Bool(true))),
         )
         .attribute(
             AttributeSchema::new("enable_dns_hostnames", AttributeType::Bool)
-                .with_default(Value::Bool(false)),
+                .with_default(Value::Concrete(ConcreteValue::Bool(false))),
         )
         .attribute(AttributeSchema::new("vpc_id", AttributeType::String).read_only())
         .attribute(
@@ -312,29 +351,41 @@ fn build_moved_with_changes_plan() -> Plan {
             [
                 (
                     "cidr_block".to_string(),
-                    Value::String("10.0.0.0/16".to_string()),
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
                 ),
-                ("_binding".to_string(), Value::String("new_vpc".to_string())),
+                (
+                    "_binding".to_string(),
+                    Value::Concrete(ConcreteValue::String("new_vpc".to_string())),
+                ),
             ]
             .into_iter()
             .collect(),
         )),
         to: Resource::new("ec2.Vpc", "new_vpc")
             .with_binding("new_vpc")
-            .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()))
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            )
             .with_attribute(
                 "tags",
-                Value::Map(
-                    [("Name".to_string(), Value::String("updated".to_string()))]
-                        .into_iter()
-                        .collect(),
-                ),
+                Value::Concrete(ConcreteValue::Map(
+                    [(
+                        "Name".to_string(),
+                        Value::Concrete(ConcreteValue::String("updated".to_string())),
+                    )]
+                    .into_iter()
+                    .collect(),
+                )),
             ),
         changed_attributes: vec!["tags".to_string()],
     });
     plan.add(Effect::Create(
         Resource::new("ec2.Subnet", "my-subnet")
-            .with_attribute("cidr_block", Value::String("10.0.1.0/24".to_string()))
+            .with_attribute(
+                "cidr_block",
+                Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+            )
             .with_attribute(
                 "vpc_id",
                 Value::resource_ref("new_vpc".to_string(), "vpc_id".to_string(), vec![]),

--- a/carina-tui/src/ui/detail.rs
+++ b/carina-tui/src/ui/detail.rs
@@ -388,7 +388,7 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
 mod tests {
     use super::*;
     use carina_core::detail_rows::MapExpandedEntry;
-    use carina_core::resource::Value;
+    use carina_core::resource::{ConcreteValue, Value};
     use indexmap::IndexMap;
 
     /// A multi-element list-of-maps entry inside a `MapExpanded` row
@@ -399,20 +399,23 @@ mod tests {
     fn map_expanded_inserts_blank_after_multi_element_list_of_maps() {
         let stmt = |sid: &str| {
             let mut m = IndexMap::new();
-            m.insert("sid".to_string(), Value::String(sid.to_string()));
-            Value::Map(m)
+            m.insert(
+                "sid".to_string(),
+                Value::Concrete(ConcreteValue::String(sid.to_string())),
+            );
+            Value::Concrete(ConcreteValue::Map(m))
         };
         let row = DetailRow::MapExpanded {
             key: "policy_document".to_string(),
             entries: vec![
                 MapExpandedEntry {
                     key: "statement".to_string(),
-                    value: Value::List(vec![stmt("A"), stmt("B")]),
+                    value: Value::Concrete(ConcreteValue::List(vec![stmt("A"), stmt("B")])),
                     annotation: None,
                 },
                 MapExpandedEntry {
                     key: "version".to_string(),
-                    value: Value::String("2012-10-17".to_string()),
+                    value: Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
                     annotation: None,
                 },
             ],
@@ -442,20 +445,23 @@ mod tests {
     fn map_expanded_no_orphan_blank_after_trailing_list_of_maps() {
         let stmt = |sid: &str| {
             let mut m = IndexMap::new();
-            m.insert("sid".to_string(), Value::String(sid.to_string()));
-            Value::Map(m)
+            m.insert(
+                "sid".to_string(),
+                Value::Concrete(ConcreteValue::String(sid.to_string())),
+            );
+            Value::Concrete(ConcreteValue::Map(m))
         };
         let row = DetailRow::MapExpanded {
             key: "policy_document".to_string(),
             entries: vec![
                 MapExpandedEntry {
                     key: "version".to_string(),
-                    value: Value::String("2012-10-17".to_string()),
+                    value: Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
                     annotation: None,
                 },
                 MapExpandedEntry {
                     key: "statement".to_string(),
-                    value: Value::List(vec![stmt("A"), stmt("B")]),
+                    value: Value::Concrete(ConcreteValue::List(vec![stmt("A"), stmt("B")])),
                     annotation: None,
                 },
             ],

--- a/carina-tui/src/ui/tree.rs
+++ b/carina-tui/src/ui/tree.rs
@@ -156,7 +156,7 @@ mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{Resource, Value};
+    use carina_core::resource::{ConcreteValue, Resource, Value};
     use carina_core::schema::SchemaRegistry;
 
     #[test]
@@ -173,7 +173,10 @@ mod tests {
         plan.add(Effect::Create(
             Resource::new("ec2.Vpc", "my-vpc")
                 .with_binding("vpc")
-                .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string())),
+                .with_attribute(
+                    "cidr_block",
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+                ),
         ));
         plan.add(Effect::Create(
             Resource::new("ec2.Subnet", "my-subnet")


### PR DESCRIPTION
## Summary

**Phase 5 of [RFC #2972](https://github.com/carina-rs/carina/issues/2972).** The genuine root-cause fix: physically restructures `Value` from a flat 14-variant enum into nested `enum Value { Concrete(ConcreteValue), Deferred(DeferredValue) }`.

After this lands, the *workspace-wide* invariant the RFC promised holds: "deferred Value leaked into concrete-only path" bugs are **structurally unrepresentable**, not just runtime-skipped. Every pattern site explicitly acknowledges which axis it handles. Future `validate_*`-style code paths anywhere in the workspace cannot accidentally re-introduce the bug class — the type system rejects it.

### Why Phase 5 (after Phase 2 already shipped)

Phase 2 (PR #2974) made `validate_*` type-prove "no deferred values reach me". That closed #2954. But Phase 2 only enforced the invariant **inside the validate sub-system**. A future contributor adding a new `differ_*`, `serializer_*`, or `plan_display_*` helper outside validate could re-introduce the same "axis B leaked into a concrete-only path" bug class. **Phase 5 makes the axis structurally explicit at the type level workspace-wide** — the type system itself enforces what was previously an unenforced invariant.

### Behavior preservation

- **Constructor ergonomics:** `Value::String(s)`, `Value::Int(n)`, `Value::Map(m)`, etc. continue to work via backward-compat `#[allow(non_snake_case)]` associated functions. Pattern positions descend through the new discriminator.
- **State file backcompat:** `#[serde(untagged)]` on `Value` preserves on-disk JSON shape. Pre-Phase-5 state files round-trip transparently. The Phase 1 fixture-based codec round-trip test (`carina-cli/tests/state_value_round_trip.rs`) exercises every `carina.state.json` in the tree and passes.
- **Phase 1 projection accessors** (`as_concrete()` / `as_deferred()`) remain as ergonomic helpers; they are now trivial outer-discriminator matches.
- **Phase 2 acceptance tests for #2954** (3 tests covering List, Map, Struct-field positions for `Value::ResourceRef`) all pass.

### Scope

120 files changed, ~5000 lines of mechanical pattern + constructor rewrite. Done via an axis-explicit Python script with comment-/string-aware bracket balancing. Hand-fixes for: closures passing constructors as function values (`.map(Value::String)`), `validate_string_enum` / `validate_custom` helpers, qualified `Value::` references in `carina-lsp`, the `carina-plugin-host::wasm_convert` WIT-host boundary, and a handful of test-module imports.

## Test plan

- [x] `cargo nextest run --workspace` — 3197 passed, 74 skipped
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] All 5 `bash scripts/check-*.sh` — green
- [x] Phase 1 fixture round-trip test — green
- [x] Phase 2 #2954 acceptance tests (List/Map/Struct-field) — green
- [x] 5 fresh review rounds — all GO
- [x] `cargo fmt --all --check` — clean

## Cross-repo follow-up

`carina-provider-aws` and `carina-provider-awscc` import `Value` via `carina-core` git dependency. After this lands, both providers will need a one-line import widening (`Value` → `{ConcreteValue, DeferredValue, Value}`) and pattern-site rewrite. Tracked as **Phase 4a / 4b** in RFC #2972; provider PRs land immediately after this merges. Until then, downstream provider pins to `main` will fail to build.

Refs #2972, #2954.

🤖 Generated with [Claude Code](https://claude.com/claude-code)