### PR TITLE
core/resource: remove Value::X helper-method shims (RFC #2972 Phase 5b)

### DIFF
--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1040,8 +1040,8 @@ fn test_format_cascading_update_diff_includes_list_with_ref() {
             ResourceId::new("ec2.Instance", "instance"),
             HashMap::from([(
                 "security_group_ids".to_string(),
-                Value::Concrete(ConcreteValue::List(vec![Value::String(
-                    "sg-old123".to_string(),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::String("sg-old123".to_string()),
                 )])),
             )]),
         )),

--- a/carina-core/src/builtins/env.rs
+++ b/carina-core/src/builtins/env.rs
@@ -34,7 +34,7 @@ pub(crate) fn builtin_env(args: &[Value]) -> Result<Value, String> {
     };
 
     std::env::var(name)
-        .map(Value::String)
+        .map(|s| Value::Concrete(ConcreteValue::String(s)))
         .map_err(|_| format!("environment variable '{}' is not set", name))
 }
 

--- a/carina-core/src/builtins/flatten.rs
+++ b/carina-core/src/builtins/flatten.rs
@@ -150,7 +150,10 @@ mod tests {
         let args = vec![Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
             ConcreteValue::List(vec![
                 Value::Concrete(ConcreteValue::Int(1)),
-                Value::Concrete(ConcreteValue::List(vec![Value::Int(2), Value::Int(3)])),
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::Int(2)),
+                    Value::Concrete(ConcreteValue::Int(3)),
+                ])),
             ]),
         )]))];
         let result = evaluate_builtin("flatten", &args).unwrap();

--- a/carina-core/src/builtins/keys_values.rs
+++ b/carina-core/src/builtins/keys_values.rs
@@ -24,7 +24,9 @@ pub(crate) fn builtin_keys(args: &[Value]) -> Result<Value, String> {
             let mut keys: Vec<String> = map.keys().cloned().collect();
             keys.sort();
             Ok(Value::Concrete(ConcreteValue::List(
-                keys.into_iter().map(Value::String).collect(),
+                keys.into_iter()
+                    .map(|s| Value::Concrete(ConcreteValue::String(s)))
+                    .collect(),
             )))
         }
         other => Err(format!(

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -1756,8 +1756,8 @@ fn join_with_multiple_pipes() {
                 args: vec![
                     Value::Concrete(ConcreteValue::String("-".to_string())),
                     Value::Concrete(ConcreteValue::List(vec![
-                        Value::String("a".to_string()),
-                        Value::String("b".to_string()),
+                        Value::Concrete(ConcreteValue::String("a".to_string())),
+                        Value::Concrete(ConcreteValue::String("b".to_string())),
                     ])),
                 ],
             })],

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -557,7 +557,10 @@ pub fn merge_default_tags_for_provider(
             resource.set_attr(
                 "_default_tag_keys".to_string(),
                 Value::Concrete(ConcreteValue::List(
-                    default_tag_keys.into_iter().map(Value::String).collect(),
+                    default_tag_keys
+                        .into_iter()
+                        .map(|s| Value::Concrete(ConcreteValue::String(s)))
+                        .collect(),
                 )),
             );
         }
@@ -875,8 +878,10 @@ fn collect_validators_from_type(
             validators.entry(snake_name).or_insert_with(|| {
                 let validate_fn = validate.clone();
                 Box::new(move |s: &str| {
-                    validate_fn(&crate::resource::Value::String(s.to_string()))
-                        .map_err(|e| e.to_string())
+                    validate_fn(&crate::resource::Value::Concrete(
+                        crate::resource::ConcreteValue::String(s.to_string()),
+                    ))
+                    .map_err(|e| e.to_string())
                 })
             });
         }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -524,7 +524,7 @@ mod tests {
     #[test]
     fn test_resolve_subscript_descends_into_secret_wrapped_list() {
         // Symmetric with the map test: `Value::Secret(Box::new(
-        // Value::List(...)))` + integer subscript projects the element
+        // Value::Concrete(ConcreteValue::List(...))))` + integer subscript projects the element
         // and re-wraps the leaf as `Value::Secret`.
         let bindings = bindings_from(vec![(
             "secret_holder",
@@ -532,8 +532,8 @@ mod tests {
                 "tokens",
                 Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
                     ConcreteValue::List(vec![
-                        Value::String("alpha".to_string()),
-                        Value::String("beta".to_string()),
+                        Value::Concrete(ConcreteValue::String("alpha".to_string())),
+                        Value::Concrete(ConcreteValue::String("beta".to_string())),
                     ]),
                 )))),
             )],
@@ -606,7 +606,7 @@ mod tests {
             vec![(
                 "creds",
                 Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
-                    DeferredValue::Secret(Box::new(Value::Map(map))),
+                    DeferredValue::Secret(Box::new(Value::Concrete(ConcreteValue::Map(map)))),
                 )))),
             )],
         )]);
@@ -623,7 +623,9 @@ mod tests {
         assert_eq!(
             resolved,
             Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
-                DeferredValue::Secret(Box::new(Value::String("v".to_string())))
+                DeferredValue::Secret(Box::new(Value::Concrete(ConcreteValue::String(
+                    "v".to_string()
+                ))))
             )))),
         );
     }
@@ -640,7 +642,9 @@ mod tests {
             vec![(
                 "tokens",
                 Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
-                    ConcreteValue::List(vec![Value::String("only".to_string())]),
+                    ConcreteValue::List(vec![Value::Concrete(ConcreteValue::String(
+                        "only".to_string(),
+                    ))]),
                 )))),
             )],
         )]);
@@ -1120,9 +1124,9 @@ mod tests {
             args: vec![
                 Value::Concrete(ConcreteValue::String("-".to_string())),
                 Value::Concrete(ConcreteValue::List(vec![
-                    Value::String("a".to_string()),
-                    Value::String("b".to_string()),
-                    Value::String("c".to_string()),
+                    Value::Concrete(ConcreteValue::String("a".to_string())),
+                    Value::Concrete(ConcreteValue::String("b".to_string())),
+                    Value::Concrete(ConcreteValue::String("c".to_string())),
                 ])),
             ],
         });
@@ -1150,7 +1154,7 @@ mod tests {
             args: vec![
                 Value::Concrete(ConcreteValue::String("-".to_string())),
                 Value::Concrete(ConcreteValue::List(vec![
-                    Value::String("prefix".to_string()),
+                    Value::Concrete(ConcreteValue::String("prefix".to_string())),
                     Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
                 ])),
             ],

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -466,57 +466,6 @@ pub enum DeferredValue {
     Unknown(UnknownReason),
 }
 
-/// Backward-compatible variant constructors. Call sites can write
-/// `Value::String(s)` etc. exactly as in the pre-Phase-5 flat enum;
-/// pattern positions descend through `Value::Concrete(ConcreteValue::X(...))`.
-#[allow(non_snake_case)]
-impl Value {
-    #[inline]
-    pub fn String(s: String) -> Self {
-        Value::Concrete(ConcreteValue::String(s))
-    }
-    #[inline]
-    pub fn Int(n: i64) -> Self {
-        Value::Concrete(ConcreteValue::Int(n))
-    }
-    #[inline]
-    pub fn Float(f: f64) -> Self {
-        Value::Concrete(ConcreteValue::Float(f))
-    }
-    #[inline]
-    pub fn Bool(b: bool) -> Self {
-        Value::Concrete(ConcreteValue::Bool(b))
-    }
-    #[inline]
-    pub fn Duration(d: std::time::Duration) -> Self {
-        Value::Concrete(ConcreteValue::Duration(d))
-    }
-    #[inline]
-    pub fn List(items: Vec<Value>) -> Self {
-        Value::Concrete(ConcreteValue::List(items))
-    }
-    #[inline]
-    pub fn StringList(items: Vec<String>) -> Self {
-        Value::Concrete(ConcreteValue::StringList(items))
-    }
-    #[inline]
-    pub fn Map(map: IndexMap<String, Value>) -> Self {
-        Value::Concrete(ConcreteValue::Map(map))
-    }
-    #[inline]
-    pub fn Interpolation(parts: Vec<InterpolationPart>) -> Self {
-        Value::Deferred(DeferredValue::Interpolation(parts))
-    }
-    #[inline]
-    pub fn Secret(inner: Box<Value>) -> Self {
-        Value::Deferred(DeferredValue::Secret(inner))
-    }
-    #[inline]
-    pub fn Unknown(reason: UnknownReason) -> Self {
-        Value::Deferred(DeferredValue::Unknown(reason))
-    }
-}
-
 /// Borrowing projection of [`Value`] restricted to the **concrete** axis
 /// — variants that carry their own runtime type and are safe to type-check
 /// at validate time.

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -551,12 +551,19 @@ fn merge_with_saved_non_map() {
 fn lists_equal_large_list_correctness() {
     // Verify correctness with a list larger than HASH_THRESHOLD
     let n = 200;
-    let a: Vec<Value> = (0..n).map(Value::Int).collect();
-    let b: Vec<Value> = (0..n).rev().map(Value::Int).collect();
+    let a: Vec<Value> = (0..n)
+        .map(|i| Value::Concrete(ConcreteValue::Int(i)))
+        .collect();
+    let b: Vec<Value> = (0..n)
+        .rev()
+        .map(|i| Value::Concrete(ConcreteValue::Int(i)))
+        .collect();
     assert!(lists_equal(&a, &b));
 
     // Different content
-    let mut c: Vec<Value> = (0..n).map(Value::Int).collect();
+    let mut c: Vec<Value> = (0..n)
+        .map(|i| Value::Concrete(ConcreteValue::Int(i)))
+        .collect();
     c[n as usize - 1] = Value::Concrete(ConcreteValue::Int(n)); // change last element
     assert!(!lists_equal(&a, &c));
 }
@@ -617,8 +624,13 @@ fn lists_equal_performance_large_list() {
     // Benchmark: 1000-element list comparison should complete quickly
     // With O(n^2), 1000 elements = 1M comparisons; with hashing, ~1000.
     let n = 1000;
-    let a: Vec<Value> = (0..n).map(Value::Int).collect();
-    let b: Vec<Value> = (0..n).rev().map(Value::Int).collect();
+    let a: Vec<Value> = (0..n)
+        .map(|i| Value::Concrete(ConcreteValue::Int(i)))
+        .collect();
+    let b: Vec<Value> = (0..n)
+        .rev()
+        .map(|i| Value::Concrete(ConcreteValue::Int(i)))
+        .collect();
 
     let start = std::time::Instant::now();
     for _ in 0..100 {

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -915,7 +915,11 @@ pub fn format_value_pretty(value: &Value, layout: PrettyLayout<'_>) -> String {
             if inline_width(value, budget).is_some() {
                 return format_value_with_key(value, None);
             }
-            let lifted: Vec<Value> = items.iter().cloned().map(Value::String).collect();
+            let lifted: Vec<Value> = items
+                .iter()
+                .cloned()
+                .map(|s| Value::Concrete(ConcreteValue::String(s)))
+                .collect();
             format_list_of_scalars_vertical(&lifted, layout.child_indent_cols())
         }
         Value::Concrete(ConcreteValue::Map(map)) => {

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -850,15 +850,15 @@ mod tests {
                 (
                     "tags".to_string(),
                     CoreValue::Concrete(ConcreteValue::List(vec![
-                        CoreValue::String("a".into()),
-                        CoreValue::String("b".into()),
+                        CoreValue::Concrete(ConcreteValue::String("a".into())),
+                        CoreValue::Concrete(ConcreteValue::String("b".into())),
                     ])),
                 ),
                 (
                     "counts".to_string(),
                     CoreValue::Concrete(ConcreteValue::List(vec![
-                        CoreValue::Int(1),
-                        CoreValue::Int(2),
+                        CoreValue::Concrete(ConcreteValue::Int(1)),
+                        CoreValue::Concrete(ConcreteValue::Int(2)),
                     ])),
                 ),
             ]
@@ -1004,7 +1004,9 @@ mod tests {
         // *attribute*-level secret signal goes through `secret-val` via
         // `core_to_wit_value`, not this path.
         let v = CoreValue::Concrete(ConcreteValue::List(vec![CoreValue::Deferred(
-            DeferredValue::Secret(Box::new(CoreValue::String("p".into()))),
+            DeferredValue::Secret(Box::new(CoreValue::Concrete(ConcreteValue::String(
+                "p".into(),
+            )))),
         )]));
         let wit_v = core_to_wit_value(&v).unwrap();
         match wit_v {
@@ -1200,12 +1202,12 @@ mod tests {
                 CorePatchOp {
                     kind: CorePatchOpKind::Add,
                     key: "a".to_string(),
-                    value: Some(CV::String("alpha".into())),
+                    value: Some(CV::Concrete(ConcreteValue::String("alpha".into()))),
                 },
                 CorePatchOp {
                     kind: CorePatchOpKind::Replace,
                     key: "b".to_string(),
-                    value: Some(CV::Int(42)),
+                    value: Some(CV::Concrete(ConcreteValue::Int(42))),
                 },
                 CorePatchOp {
                     kind: CorePatchOpKind::Remove,
@@ -1427,17 +1429,27 @@ mod tests {
                 ),
                 (
                     "statement".to_string(),
-                    CoreValue::Concrete(ConcreteValue::List(vec![CoreValue::Map(
-                        vec![
-                            ("effect".to_string(), CoreValue::String("Allow".into())),
-                            (
-                                "action".to_string(),
-                                CoreValue::String("logs:CreateLogGroup".into()),
-                            ),
-                            ("resource".to_string(), CoreValue::String("*".into())),
-                        ]
-                        .into_iter()
-                        .collect(),
+                    CoreValue::Concrete(ConcreteValue::List(vec![CoreValue::Concrete(
+                        ConcreteValue::Map(
+                            vec![
+                                (
+                                    "effect".to_string(),
+                                    CoreValue::Concrete(ConcreteValue::String("Allow".into())),
+                                ),
+                                (
+                                    "action".to_string(),
+                                    CoreValue::Concrete(ConcreteValue::String(
+                                        "logs:CreateLogGroup".into(),
+                                    )),
+                                ),
+                                (
+                                    "resource".to_string(),
+                                    CoreValue::Concrete(ConcreteValue::String("*".into())),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        ),
                     )])),
                 ),
             ]
@@ -1449,7 +1461,7 @@ mod tests {
                 vec![
                     (
                         "policy_name".to_string(),
-                        CoreValue::String("test-policy".into()),
+                        CoreValue::Concrete(ConcreteValue::String("test-policy".into())),
                     ),
                     ("policy_document".to_string(), policy_document),
                 ]


### PR DESCRIPTION
## Summary

RFC #2972 Phase 5b — finishes the Concrete/Deferred axis split.

With every emitter in carina-provider-aws (#256) and carina-provider-awscc (#214) migrated to the nested `Value::Concrete(ConcreteValue::X(...))` form, the `#[allow(non_snake_case)] impl Value { fn String(s) -> Self, ... }` backward-compat shims (14 methods) have no live callers and can be removed.

Result: there is now exactly one way to construct a concrete `Value`, and pattern position vs expression position no longer requires consulting two different shapes.

### Removed

- `impl Value::{String, Int, Float, Bool, Duration, List, StringList, Map, Interpolation, Secret, Unknown}` — the 14 helper-method shims in `carina-core/src/resource/mod.rs`.

### In-tree fixes (same reason)

A handful of carina-core / carina-cli / carina-plugin-host test fixtures and one `.map(Value::String)` method-reference in:
- `builtins/env.rs`, `builtins/keys_values.rs`, `builtins/flatten.rs`
- `provider.rs`, `value.rs`
- `resolver.rs`, `parser/tests.rs`, `resource/tests.rs`
- `display/tests.rs`, `wasm_convert.rs`

switched to the nested form. Closures replace the method-reference pattern (Rust does not allow tuple-variant references like `ConcreteValue::Int` to flow through an outer `Value::Concrete(...)` wrapper).

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo nextest run --workspace` → 3197/3197 pass
- [x] `cargo test --workspace --doc` → pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `scripts/check-*.sh` all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
