### PR TITLE
core/schema: error on bare-binding × StringEnum DSL alias collision (closes #2978)

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -73,6 +73,59 @@ pub fn no_lookup() -> CustomTypeLookup<'static> {
     &|_name, _value| Ok(())
 }
 
+/// If `value` is a bare reference to a `let` binding (no access path,
+/// no attribute selector), return the binding name. Otherwise return
+/// `None`. Used by `AttributeType::validate` to detect the collision
+/// case from #2978: a StringEnum attribute receives a bare identifier
+/// that the parser already resolved as a binding reference rather than
+/// as the enum's DSL alias of the same spelling.
+fn bare_binding_name(value: &Value) -> Option<&str> {
+    match value {
+        Value::Deferred(DeferredValue::BindingRef { binding }) => Some(binding.as_str()),
+        _ => None,
+    }
+}
+
+/// True when `binding` matches a canonical enum value or a DSL alias
+/// of `(values, dsl_aliases)`. Drives the #2978 collision check.
+fn enum_alias_collides_with(
+    binding: &str,
+    values: &[String],
+    dsl_aliases: &[(String, String)],
+) -> bool {
+    if values.iter().any(|v| v == binding) {
+        return true;
+    }
+    dsl_aliases.iter().any(|(_api, dsl)| dsl == binding)
+}
+
+/// Build the user-facing error message for the #2978 collision case.
+fn enum_binding_collision_message(
+    binding: &str,
+    type_name: &str,
+    namespace: Option<&str>,
+    values: &[String],
+    dsl_aliases: &[(String, String)],
+) -> String {
+    // Prefer the DSL spelling if one exists for the colliding API value;
+    // that is the form the user almost certainly meant to write.
+    let dsl_spelling = dsl_aliases
+        .iter()
+        .find(|(_api, dsl)| dsl == binding)
+        .map(|(_api, dsl)| dsl.as_str())
+        .or_else(|| values.iter().find(|v| *v == binding).map(String::as_str))
+        .unwrap_or(binding);
+    let type_qualified = format!("{}.{}", type_name, dsl_spelling);
+    let fully_qualified = match namespace {
+        Some(ns) => format!("{}.{}.{}", ns, type_name, dsl_spelling),
+        None => type_qualified.clone(),
+    };
+    format!(
+        "bare identifier `{binding}` is shadowed by a `let` binding of the same name; \
+         to use the enum value, write `{type_qualified}`, `{fully_qualified}`, or `'{dsl_spelling}'`"
+    )
+}
+
 /// Walk an [`AttributeType`] and apply `lookup` to every `Custom` node
 /// reached. Pushes any returned error into `errors`, tagged with
 /// `attr_name` so it points back at the user-visible attribute. Used
@@ -571,6 +624,33 @@ impl AttributeType {
     /// independently re-projected. Lists may legitimately mix concrete
     /// and deferred elements (e.g. `[vpc.id, "literal"]`).
     pub fn validate(&self, value: &Value) -> Result<(), TypeError> {
+        // StringEnum attributes assigned a bare `BindingRef` are the
+        // shadowing collision case described in #2978: the user wrote a
+        // bare identifier that happens to be a `let` binding *and* is
+        // also a DSL alias for one of this enum's variants. Surface a
+        // pointed error so they can disambiguate (use `TypeName.value`,
+        // fully-qualified, or quoted string). Without this check the
+        // deferred value flows through validation unchecked and only
+        // surfaces later as a `${vpc}`-style error from the resolver.
+        if let AttributeType::StringEnum {
+            name,
+            values,
+            namespace,
+            dsl_aliases,
+        } = self
+            && let Some(binding) = bare_binding_name(value)
+            && enum_alias_collides_with(binding, values, dsl_aliases)
+        {
+            return Err(TypeError::ValidationFailed {
+                message: enum_binding_collision_message(
+                    binding,
+                    name,
+                    namespace.as_deref(),
+                    values,
+                    dsl_aliases,
+                ),
+            });
+        }
         let Some(concrete) = value.as_concrete() else {
             return Ok(());
         };

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -3989,3 +3989,135 @@ fn dsl_aliases_empty_keeps_api_only_validation() {
             .is_err()
     );
 }
+
+// #2978 — collision between a `let` binding name and a `StringEnum`
+// DSL alias. The parser resolves a bare identifier to the binding
+// first (see parser/expressions/primary.rs:367-374), producing a
+// `Value::Deferred(DeferredValue::BindingRef { binding: "vpc" })` for
+// the attribute value. Without the dedicated check, the deferred value
+// flows past `validate` and only surfaces later as a `${vpc}`-style
+// error from the resolver, which is hard to diagnose. Pin the
+// behavior here so a regression on the `validate` side is visible
+// without round-tripping through plan execution.
+mod string_enum_binding_collision {
+    use super::*;
+    use crate::resource::DeferredValue;
+
+    fn flow_log_resource_type() -> AttributeType {
+        // Mirrors the awscc.ec2.FlowLog.ResourceType enum that
+        // surfaced the issue. The `"vpc"` alias is what collides with
+        // a `let vpc = ...` binding name in real fixtures.
+        AttributeType::StringEnum {
+            name: "ResourceType".to_string(),
+            values: vec![
+                "NetworkInterface".to_string(),
+                "Subnet".to_string(),
+                "VPC".to_string(),
+            ],
+            namespace: Some("awscc.ec2.FlowLog".to_string()),
+            dsl_aliases: vec![
+                (
+                    "NetworkInterface".to_string(),
+                    "network_interface".to_string(),
+                ),
+                ("Subnet".to_string(), "subnet".to_string()),
+                ("VPC".to_string(), "vpc".to_string()),
+            ],
+        }
+    }
+
+    #[test]
+    fn bare_binding_matching_dsl_alias_is_rejected() {
+        let t = flow_log_resource_type();
+        // `let vpc = ...` in scope → parser hands the validator a
+        // `BindingRef("vpc")` for `resource_type = vpc`.
+        let value = Value::Deferred(DeferredValue::BindingRef {
+            binding: "vpc".to_string(),
+        });
+        let err = t.validate(&value).unwrap_err();
+        let TypeError::ValidationFailed { message } = err else {
+            panic!("expected ValidationFailed, got {:?}", err);
+        };
+        assert!(
+            message.contains("shadowed by a `let` binding"),
+            "message did not mention the shadowing rule: {message}"
+        );
+        // Suggest the type-qualified form using the DSL spelling.
+        assert!(
+            message.contains("ResourceType.vpc"),
+            "missing type-qualified suggestion: {message}"
+        );
+        // And the fully qualified form.
+        assert!(
+            message.contains("awscc.ec2.FlowLog.ResourceType.vpc"),
+            "missing fully-qualified suggestion: {message}"
+        );
+        // And the quoted-string escape hatch.
+        assert!(
+            message.contains("'vpc'"),
+            "missing quoted-string suggestion: {message}"
+        );
+    }
+
+    #[test]
+    fn bare_binding_matching_canonical_value_is_rejected() {
+        // Same trap, hit through the canonical spelling rather than
+        // the alias: `let VPC = ...` would collide with the `"VPC"`
+        // value directly.
+        let t = flow_log_resource_type();
+        let value = Value::Deferred(DeferredValue::BindingRef {
+            binding: "VPC".to_string(),
+        });
+        let err = t.validate(&value).unwrap_err();
+        let TypeError::ValidationFailed { message } = err else {
+            panic!("expected ValidationFailed, got {:?}", err);
+        };
+        assert!(message.contains("shadowed by a `let` binding"), "{message}");
+    }
+
+    #[test]
+    fn bare_binding_not_matching_alias_passes_through_validate() {
+        // `let some_other_name = ...` does not match any DSL alias for
+        // ResourceType, so it is not the collision case. `validate`
+        // must stay quiet at this layer; the deferred-aware resolver
+        // can still surface other errors downstream.
+        let t = flow_log_resource_type();
+        let value = Value::Deferred(DeferredValue::BindingRef {
+            binding: "some_other_name".to_string(),
+        });
+        assert!(t.validate(&value).is_ok());
+    }
+
+    #[test]
+    fn collision_check_only_fires_on_string_enum() {
+        // Other AttributeType kinds (e.g., String) must not be
+        // affected by the collision check — many of them legitimately
+        // accept a `BindingRef`.
+        let t = AttributeType::String;
+        let value = Value::Deferred(DeferredValue::BindingRef {
+            binding: "vpc".to_string(),
+        });
+        assert!(t.validate(&value).is_ok());
+    }
+
+    #[test]
+    fn explicit_quoted_string_still_passes() {
+        // `attribute = 'vpc'` reaches the validator as a plain
+        // concrete string, unrelated to the binding-collision branch.
+        // Must validate as a normal DSL alias.
+        let t = flow_log_resource_type();
+        let value = Value::Concrete(ConcreteValue::String("vpc".to_string()));
+        assert!(t.validate(&value).is_ok());
+    }
+
+    #[test]
+    fn fully_qualified_form_still_passes() {
+        // `attribute = awscc.ec2.FlowLog.ResourceType.vpc` reaches the
+        // validator as a concrete string in fully-qualified form.
+        let t = flow_log_resource_type();
+        let value = Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.FlowLog.ResourceType.vpc".to_string(),
+        ));
+        assert!(t.validate(&value).is_ok());
+    }
+}


### PR DESCRIPTION
Closes #2978.

## Summary

When the DSL has `let vpc = ...` and an attribute of type `StringEnum` is then assigned `vpc` (bare identifier), the parser resolves the right-hand side to a binding reference rather than the enum alias of the same spelling. Without a dedicated check the deferred value passes through `AttributeType::validate` (which short-circuits on the `as_concrete()` projection) and surfaces only later as a `${vpc}` error from the resolver — a confusing message that hides the actual mistake.

Add a collision check at the top of `AttributeType::validate`:

- only fires on `StringEnum` schemas
- only fires on `Value::Deferred(DeferredValue::BindingRef { binding })`
- only fires when `binding` matches one of the enum's canonical `values` or DSL `aliases`

When all three match, return a `TypeError::ValidationFailed` that names the binding, points at the shadowing, and suggests the three unambiguous forms: `TypeName.value`, fully qualified (`namespace.TypeName.value`), and the quoted-string escape hatch (`'value'`).

The LSP path inherits the new behavior automatically because `diagnostics/mod.rs` already routes the StringEnum branch through `attr_type.validate(value)` and renders the resulting error as a WARNING. The LSP completion path already proposes only the fully-qualified form for namespaced enums, so users will never see a colliding bare alias as a completion suggestion.

## Tests

Six new tests in `carina-core/src/schema/tests::string_enum_binding_collision` cover:
- bare binding matching a DSL alias → rejected with helpful message
- bare binding matching the canonical value → also rejected
- bare binding *not* matching any enum value → passes through
- non-StringEnum types are unaffected
- the explicit quoted-string form and the fully-qualified form continue to validate

## Test plan

- [x] `cargo nextest run --workspace` → 3203/3203 pass
- [x] `cargo test --workspace --doc` → pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `scripts/check-*.sh` all pass
- [ ] CI green

## Concrete acceptance

The `ec2_flow_log` fixtures at carina-provider-awscc#216 currently shipped with `resource_type = vpc` (alias-spelled) under a `let vpc = ...` binding, fail at apply with a `${vpc}` resolver error. After this change the failure surfaces at validate time with a precise message that names the three working forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
