### PR TITLE
core/schema: add DslMap::api_for(dsl) reverse lookup

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -248,6 +248,34 @@ impl<'a> DslMap<'a> {
         }
     }
 
+    /// Translate a DSL spelling back to its API-canonical spelling.
+    /// Returns the input unchanged when no mapping applies.
+    ///
+    /// Mirror of [`dsl_for`]. Used by providers that have a DSL-spelled
+    /// enum value in hand and need the API-canonical form to feed into
+    /// an SDK builder. Without this, hand-written provider code that
+    /// extracts the trailing segment of a namespaced identifier passes
+    /// the DSL alias (e.g. `"enabled"`) straight to the SDK and the API
+    /// rejects it (e.g. S3 `MalformedXML`).
+    ///
+    /// The [`DslMap::Closure`] variant carries an API→DSL function only;
+    /// the inverse direction is not representable, so this method returns
+    /// the input as-is for that variant. Callers whose value space goes
+    /// through a `Closure` must reverse the mapping themselves.
+    ///
+    /// When two `(api, dsl)` entries share the same `dsl` spelling, the
+    /// first match wins. Codegen is expected to ensure DSL spellings are
+    /// unique within a single enum's alias table.
+    pub fn api_for(&self, dsl: &str) -> String {
+        match self {
+            DslMap::Aliases(map) => map
+                .iter()
+                .find_map(|(a, d)| (d == dsl).then(|| a.clone()))
+                .unwrap_or_else(|| dsl.to_string()),
+            DslMap::Closure(_) => dsl.to_string(),
+        }
+    }
+
     /// True when the mapping carries no DSL-side rewrites.
     pub fn is_empty(&self) -> bool {
         match self {

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -4121,3 +4121,86 @@ mod string_enum_binding_collision {
         assert!(t.validate(&value).is_ok());
     }
 }
+
+mod dsl_map_api_for {
+    use super::*;
+
+    fn alias_table() -> Vec<(String, String)> {
+        vec![
+            ("Enabled".to_string(), "enabled".to_string()),
+            ("Suspended".to_string(), "suspended".to_string()),
+            ("VPC".to_string(), "vpc".to_string()),
+        ]
+    }
+
+    #[test]
+    fn aliases_resolves_dsl_to_api_canonical() {
+        let aliases = alias_table();
+        let map = DslMap::Aliases(&aliases);
+        assert_eq!(map.api_for("enabled"), "Enabled");
+        assert_eq!(map.api_for("suspended"), "Suspended");
+        assert_eq!(map.api_for("vpc"), "VPC");
+    }
+
+    #[test]
+    fn aliases_returns_input_when_no_match() {
+        // No alias entry for `unknown`; passthrough so callers can hand
+        // off identity-mapped values (where API spelling == DSL spelling)
+        // straight to the SDK.
+        let aliases = alias_table();
+        let map = DslMap::Aliases(&aliases);
+        assert_eq!(map.api_for("unknown"), "unknown");
+    }
+
+    #[test]
+    fn aliases_returns_input_when_given_api_canonical() {
+        // If the caller already has the API spelling, `api_for` is a
+        // no-op: the alias table is `(api, dsl)`, so an API value
+        // doesn't match any `dsl` side and falls through.
+        let aliases = alias_table();
+        let map = DslMap::Aliases(&aliases);
+        assert_eq!(map.api_for("Enabled"), "Enabled");
+    }
+
+    #[test]
+    fn aliases_empty_table_is_identity() {
+        let aliases: Vec<(String, String)> = vec![];
+        let map = DslMap::Aliases(&aliases);
+        assert_eq!(map.api_for("anything"), "anything");
+    }
+
+    #[test]
+    fn closure_some_returns_input_unchanged() {
+        // The closure is one-way (api -> dsl); reversing it is not
+        // representable, so `api_for` is documented to return the input
+        // as-is for the Closure variant. Callers that go through a
+        // `Closure` (currently only Region with hyphen↔underscore) must
+        // reverse the mapping themselves.
+        fn to_dsl(api: &str) -> String {
+            api.replace('-', "_")
+        }
+        let map = DslMap::Closure(Some(to_dsl));
+        assert_eq!(map.api_for("ap_northeast_1"), "ap_northeast_1");
+    }
+
+    #[test]
+    fn closure_none_returns_input_unchanged() {
+        let map = DslMap::Closure(None);
+        assert_eq!(map.api_for("anything"), "anything");
+    }
+
+    #[test]
+    fn aliases_duplicate_dsl_spelling_returns_first_match() {
+        // Pins the deterministic behavior when two entries share a DSL
+        // spelling: `find_map` returns the first match. Such duplicates
+        // should not exist in real codegen output, but the inverse map
+        // is intrinsically lossy and the documented contract is "first
+        // wins" rather than "panic" or "undefined".
+        let aliases = vec![
+            ("Foo".to_string(), "bar".to_string()),
+            ("Baz".to_string(), "bar".to_string()),
+        ];
+        let map = DslMap::Aliases(&aliases);
+        assert_eq!(map.api_for("bar"), "Foo");
+    }
+}


### PR DESCRIPTION
Closes #2977.

## Summary

Adds `DslMap::api_for(&self, dsl: &str) -> String`, the inverse of the existing `dsl_for(api)`. Translates a DSL-spelled enum value (e.g. `"enabled"`) back to its API-canonical spelling (`"Enabled"`).

Hand-written provider code today extracts the trailing segment of a namespaced identifier via `extract_enum_value` and feeds the result straight to AWS SDK builders. When the DSL alias spelling is used, the SDK silently wraps it in `Unknown(...)` and the API rejects the request (e.g. S3 `MalformedXML`). `api_for` gives providers a first-class primitive to canonicalize the value through the same `(api, dsl)` table that codegen already populates.

## Behavior

| Variant | Behavior |
|---------|----------|
| `Aliases(map)` | Inverse lookup on the `(api, dsl)` table. Returns `api` when `dsl` is found, otherwise returns the input as-is (identity-mapped values flow through unchanged). |
| `Closure(_)` | One-way function (API→DSL); the inverse is not representable, so this method returns the input as-is. Callers whose value space goes through a `Closure` must reverse it themselves. |

Duplicate DSL spellings within the alias table: first match wins. Documented in the doc comment and pinned by a test; codegen is expected to keep DSL spellings unique within a single enum.

## Followups

- aws#258 will use `api_for` from the s3 hand-written code to fix `MalformedXML` regressions.
- awscc#220 will collapse the existing `get_enum_alias_reverse` dispatch table onto `DslMap::api_for` once carina#2980 makes the alias table exhaustive.

## Test plan

- [x] `cargo nextest run -p carina-core` — 1928 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/check-*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)