### PR TITLE
core/schema: walk_custom_lookup honors Union "any member accepts"

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -197,8 +197,32 @@ fn walk_custom_lookup(
             }
         }
         AttributeType::Union(members) => {
+            // Union semantics: a value is valid if *any* member accepts
+            // it. The previous loop walked every member and pushed
+            // every error, so a value that legitimately matched one arm
+            // (e.g. an IPv4 CIDR like `"10.0.0.0/8"` matching
+            // `ipv4_cidr()` inside `types::cidr()`) still surfaced the
+            // failure from the sibling IPv6 arm's validator. See
+            // awscc#217.
+            //
+            // Walk every member into a local buffer; if any member
+            // emits no errors the Union succeeds and the sibling
+            // failures are discarded. If every member fails, keep the
+            // smallest error set so the user-facing diagnostic stays
+            // pointed at the closest near-match.
+            let mut best: Option<Vec<TypeError>> = None;
             for member in members {
-                walk_custom_lookup(member, value, attr_name, lookup, errors);
+                let mut local = Vec::new();
+                walk_custom_lookup(member, value, attr_name, lookup, &mut local);
+                if local.is_empty() {
+                    return;
+                }
+                if best.as_ref().is_none_or(|b| local.len() < b.len()) {
+                    best = Some(local);
+                }
+            }
+            if let Some(b) = best {
+                errors.extend(b);
             }
         }
         AttributeType::String

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -3852,6 +3852,135 @@ fn walk_custom_lookup_skips_value_unknown() {
 }
 
 // =====================================================================
+// awscc#217: `walk_custom_lookup` walked every Union member and pushed
+// every member's failure into the shared errors vec. A value that
+// validly matched one arm (an IPv4 CIDR like `10.0.0.0/8` matching the
+// `ipv4_cidr()` arm of `types::cidr()`) still surfaced the sibling
+// IPv6 arm's failure (`expected 8 groups, got 1`). Union semantics is
+// "any member accepts" — if one member emits no errors, the union
+// succeeds and sibling failures are discarded.
+// =====================================================================
+
+#[test]
+fn union_walk_custom_lookup_succeeds_when_any_member_accepts() {
+    // Custom-typed Union members: the host-side lookup approves one
+    // arm by name and rejects the other. The Union must succeed
+    // because the approving arm matches; the sibling's failure is
+    // discarded.
+    let custom = |name: &str| AttributeType::Custom {
+        base: Box::new(AttributeType::String),
+        validate: validator(|_v: &Value| Ok(())),
+        semantic_name: Some(name.to_string()),
+        namespace: None,
+        pattern: None,
+        length: None,
+        to_dsl: None,
+    };
+    let union = AttributeType::Union(vec![custom("ok_arm"), custom("fail_arm")]);
+
+    let lookup = |name: &str, _v: &Value| -> Result<(), TypeError> {
+        if name == "ok_arm" {
+            Ok(())
+        } else {
+            Err(TypeError::ValidationFailed {
+                message: format!("{name} rejects"),
+            })
+        }
+    };
+
+    let mut errors = Vec::new();
+    walk_custom_lookup(
+        &union,
+        &Value::Concrete(ConcreteValue::String("anything".to_string())),
+        "attr",
+        &lookup,
+        &mut errors,
+    );
+    assert!(
+        errors.is_empty(),
+        "Union must succeed when any member accepts; got errors: {errors:?}"
+    );
+}
+
+#[test]
+fn union_walk_custom_lookup_emits_smallest_error_set_when_all_fail() {
+    // Both arms fail. The Union must surface only one of the
+    // sibling failure sets (the smaller one if they differ), not the
+    // sum. Both arms emit a single error here, so the Union's error
+    // count must be 1, not 2.
+    let custom = |name: &str| AttributeType::Custom {
+        base: Box::new(AttributeType::String),
+        validate: validator(|_v: &Value| Ok(())),
+        semantic_name: Some(name.to_string()),
+        namespace: None,
+        pattern: None,
+        length: None,
+        to_dsl: None,
+    };
+    let union = AttributeType::Union(vec![custom("a"), custom("b")]);
+
+    let lookup = |name: &str, _v: &Value| -> Result<(), TypeError> {
+        Err(TypeError::ValidationFailed {
+            message: format!("{name} rejects"),
+        })
+    };
+
+    let mut errors = Vec::new();
+    walk_custom_lookup(
+        &union,
+        &Value::Concrete(ConcreteValue::String("anything".to_string())),
+        "attr",
+        &lookup,
+        &mut errors,
+    );
+    assert_eq!(
+        errors.len(),
+        1,
+        "Union must surface only the closest near-match, not the sum of all members"
+    );
+}
+
+#[test]
+fn union_walk_custom_lookup_cidr_accepts_ipv4_when_lookup_routes_correctly() {
+    // Regression for awscc#217. WASM-plugin schemas arrive with the
+    // schema-attached `Custom.validate` closure stripped (replaced by
+    // `noop_validator`); host-side validation runs through `lookup`
+    // by semantic_name. Models that: lookup approves `Ipv4Cidr` for
+    // `"10.0.0.0/8"` and rejects `Ipv6Cidr`. The Union must surface
+    // no errors — the previous loop would have pushed the IPv6
+    // rejection through anyway. This is the awscc#217 reproduction.
+    let cidr = AttributeType::Union(vec![types::ipv4_cidr(), types::ipv6_cidr()]);
+
+    let lookup = |name: &str, value: &Value| -> Result<(), TypeError> {
+        let Value::Concrete(ConcreteValue::String(s)) = value else {
+            return Ok(());
+        };
+        match name {
+            "Ipv4Cidr" => {
+                validate_ipv4_cidr(s).map_err(|message| TypeError::ValidationFailed { message })
+            }
+            "Ipv6Cidr" => {
+                validate_ipv6_cidr(s).map_err(|message| TypeError::ValidationFailed { message })
+            }
+            _ => Ok(()),
+        }
+    };
+
+    let mut errors = Vec::new();
+    walk_custom_lookup(
+        &cidr,
+        &Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
+        "cidr",
+        &lookup,
+        &mut errors,
+    );
+    assert!(
+        errors.is_empty(),
+        "Union<ipv4_cidr, ipv6_cidr> must accept `10.0.0.0/8`; got: {errors:?}"
+    );
+}
+
+// =====================================================================
 // carina#2831: `StringEnum.dsl_aliases` is the data form that survives
 // the WASM-component boundary, replacing the closure-based `to_dsl`
 // pointer that could not. The validator must accept both the API


### PR DESCRIPTION
Fixes `carina-rs/carina-provider-awscc#217`.

## Summary

`walk_custom_lookup` walked every Union member and pushed every member's failure into the shared errors vec. A value that legitimately matched one arm (an IPv4 CIDR like `"10.0.0.0/8"` matching the `ipv4_cidr()` arm of `types::cidr()`) still surfaced the sibling IPv6 arm's failure (`Invalid IPv6 address '10.0.0.0': expected 8 groups, got 1`) — surfacing as a confusing apply-time validation failure for the IPAM Pool fixture.

Union semantics is "any member accepts". Walk each member into a local buffer; if any member emits no errors, the Union succeeds and sibling failures are discarded. If every member fails, surface the smallest error set so the user-facing diagnostic stays pointed at the closest near-match.

The schema-attached `validate_union` path already had this behavior. `walk_custom_lookup` — the host-side lookup path used by WASM-plugin schemas where the schema's `Custom.validate` closure is `noop_validator` and validation is routed through `ProviderContext.validators` — was missing it.

## Followup

awscc#217 closes once the awscc provider's `carina-core` rev is bumped past this PR. No code change required in the provider — the bug is entirely in the host-side validation traversal.

## Test plan

- [x] 3 new unit tests:
  - one member accepts → Union succeeds, errors empty
  - all members fail → only the smallest error set is surfaced
  - the awscc#217 reproduction: `Union<ipv4_cidr, ipv6_cidr>` with `"10.0.0.0/8"` and a lookup that routes by `semantic_name` succeeds
- [x] `cargo nextest run -p carina-core` — 1943 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/check-*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
