### PR TITLE
core/schema: reject API spelling when dsl_aliases registers a DSL rewrite

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -974,7 +974,24 @@ impl AttributeType {
             let matches_alias = dsl_aliases
                 .iter()
                 .any(|(_api, dsl)| string_enum_value_matches(variant, dsl));
-            if matches_canonical || matches_alias {
+            // DSL surface convention is snake_case (see
+            // `feedback_dsl_enum_snake_case_convention.md`). When an
+            // enum has a `dsl_aliases` entry that rewrites its API
+            // spelling (e.g. `("-1", "all")`, `("VPC", "vpc")`,
+            // `("BucketOwnerEnforced", "bucket_owner_enforced")`),
+            // the validator must reject the API form on DSL input —
+            // the user is supposed to write the DSL spelling. An
+            // enum whose `dsl_aliases` table is empty (or whose
+            // matched value has no rewrite registered) keeps the
+            // canonical fall-through enabled, so the change is a
+            // no-op until codegen populates the table per enum.
+            //
+            // See carina#2980 for the full sweep plan.
+            let rewritten_by_alias = dsl_aliases
+                .iter()
+                .any(|(api, dsl)| api != dsl && string_enum_value_matches(variant, api));
+            let canonical_ok = matches_canonical && !rewritten_by_alias;
+            if matches_alias || canonical_ok {
                 Ok(())
             } else {
                 // Aliases from `dsl_aliases` are tagged `is_alias = true`

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -92,10 +92,12 @@ fn validate_string_enum_accepts_dsl_alias() {
         namespace: Some("awscc.ec2.SecurityGroup".to_string()),
         dsl_aliases: vec![("-1".to_string(), "all".to_string())],
     };
-    // Canonical value "-1" should be accepted
+    // Canonical "-1" is rewritten to DSL "all" — the DSL surface must
+    // not accept the API form when an alias is registered. Users
+    // write `all`. Updated for carina#2980.
     assert!(
         t.validate(&Value::Concrete(ConcreteValue::String("-1".to_string())))
-            .is_ok()
+            .is_err()
     );
     // DSL alias "all" should be accepted
     assert!(
@@ -104,7 +106,9 @@ fn validate_string_enum_accepts_dsl_alias() {
         )))
         .is_ok()
     );
-    // Other canonical values should still work
+    // Other canonical values without an alias rewrite (e.g. `tcp`,
+    // which is already snake_case) keep working — the API spelling
+    // *is* the DSL spelling for them.
     assert!(
         t.validate(&Value::Concrete(ConcreteValue::String("tcp".to_string())))
             .is_ok()
@@ -3990,11 +3994,18 @@ fn union_walk_custom_lookup_cidr_accepts_ipv4_when_lookup_routes_correctly() {
 // =====================================================================
 
 #[test]
-fn dsl_aliases_validator_accepts_both_api_and_dsl_spellings() {
-    // Pinned to the awscc#199 / aws#247 reproducer:
-    // `object_ownership = bucket_owner_enforced` was rejected because
-    // the WASM-loaded schema lost the alias map. With the data form the
-    // host validator sees both spellings.
+fn dsl_aliases_validator_accepts_dsl_spellings_only() {
+    // Updated for carina#2980: once `dsl_aliases` is non-empty for an
+    // enum, the validator is strict — only the DSL (snake_case) side
+    // of an `(api, dsl)` pair is accepted on input. Pre-#2980 the
+    // bare API spelling (`BucketOwnerEnforced`) was also accepted;
+    // that path is gone so users cannot ship fixtures using the AWS
+    // canonical spelling and have CI pass anyway.
+    //
+    // Original awscc#199 / aws#247 case still works: the fully- and
+    // bare-DSL forms (`bucket_owner_enforced`,
+    // `awscc.s3.Bucket.ObjectOwnership.bucket_owner_enforced`) are
+    // accepted.
     let t = AttributeType::StringEnum {
         name: "ObjectOwnership".to_string(),
         values: vec![
@@ -4016,13 +4027,18 @@ fn dsl_aliases_validator_accepts_both_api_and_dsl_spellings() {
         ],
     };
 
-    // Bare API spelling: accepted (canonical).
-    assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
-            "BucketOwnerEnforced".to_string()
+    // Bare API spelling: REJECTED under strict mode.
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "BucketOwnerEnforced".to_string(),
         )))
-        .is_ok()
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("bucket_owner_enforced"),
+        "diagnostic must point users at the DSL spelling, got: {msg}"
     );
+
     // Bare DSL spelling: accepted (alias).
     assert!(
         t.validate(&Value::Concrete(ConcreteValue::String(
@@ -4030,12 +4046,12 @@ fn dsl_aliases_validator_accepts_both_api_and_dsl_spellings() {
         )))
         .is_ok()
     );
-    // Fully-qualified API spelling: accepted.
+    // Fully-qualified API spelling: REJECTED under strict mode.
     assert!(
         t.validate(&Value::Concrete(ConcreteValue::String(
             "awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string()
         )))
-        .is_ok()
+        .is_err()
     );
     // Fully-qualified DSL spelling: accepted (the awscc#199 case).
     assert!(
@@ -4044,7 +4060,10 @@ fn dsl_aliases_validator_accepts_both_api_and_dsl_spellings() {
         )))
         .is_ok()
     );
-    // An unrelated value: rejected, with both spellings listed.
+
+    // An unrelated value: rejected, with both spellings still
+    // listed for context (the API spelling is what the AWS docs show,
+    // the DSL spelling is what `validate` accepts).
     let err = t
         .validate(&Value::Concrete(ConcreteValue::String(
             "garbage".to_string(),
@@ -4058,6 +4077,31 @@ fn dsl_aliases_validator_accepts_both_api_and_dsl_spellings() {
     assert!(
         msg.contains("bucket_owner_enforced"),
         "diagnostic must list the DSL spelling, got: {msg}"
+    );
+}
+
+#[test]
+fn enum_without_dsl_aliases_accepts_api_spelling_as_before() {
+    // An enum where codegen has not yet populated `dsl_aliases`
+    // (e.g. a newly added resource pending the carina#2980 sweep)
+    // keeps the pre-#2980 behavior: API canonical spellings are
+    // accepted via the `values` list. This is the staged-migration
+    // hook — strictness flips on per enum as codegen populates the
+    // table, so a partial sweep never breaks compilation.
+    let t = AttributeType::StringEnum {
+        name: "TrafficType".to_string(),
+        values: vec![
+            "ACCEPT".to_string(),
+            "REJECT".to_string(),
+            "ALL".to_string(),
+        ],
+        namespace: Some("aws.ec2.FlowLog".to_string()),
+        dsl_aliases: vec![],
+    };
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::String("ALL".to_string())))
+            .is_ok(),
+        "lax mode (empty dsl_aliases) accepts API canonical"
     );
 }
 


### PR DESCRIPTION
Refs #2980. Phase 1 of 3.

## Summary

`validate_string_enum` accepted both the API canonical spelling and the DSL alias. Once an enum has a `dsl_aliases` entry that rewrites its API spelling — `("-1", "all")`, `("VPC", "vpc")`, `("BucketOwnerEnforced", "bucket_owner_enforced")` — that pair tells codegen and the validator alike that the DSL surface is the *dsl* side. Accepting the API form in DSL position lets convention violations (the recurring stream of "PascalCase fixtures slipped through CI") ship without `validate` ever raising a flag.

Change the rule:

> A value is accepted iff
> - it matches the dsl side of any `(api, dsl)` pair, OR
> - it matches a `values` entry whose api spelling is NOT rewritten by any alias (identity: the API spelling *is* the DSL spelling for this variant).

## Behavior matrix

| Enum | `dsl_aliases` | Input | Old | New |
|------|---------------|-------|-----|-----|
| `ObjectOwnership` | rewrites incl. `("BucketOwnerEnforced", "bucket_owner_enforced")` | `BucketOwnerEnforced` | accept | **reject** |
| `ObjectOwnership` | (same) | `bucket_owner_enforced` | accept | accept |
| `IpProtocol` | `[("-1", "all")]` | `-1` | accept | **reject** |
| `IpProtocol` | (same) | `tcp` (identity in `values`) | accept | accept |
| `TrafficType` | `[]` (no rewrites) | `ALL` | accept | accept (lax stays on) |

The empty / identity-only `dsl_aliases` case stays lax so this PR is a no-op for every enum the codegen sweep hasn't reached yet. Strictness flips on per-enum as each provider codegen populates the table.

## State read path

Unchanged. State JSON arrives as API canonical (`"Enabled"`); the differ / `normalize_state_enum_value` keeps its existing behavior because state values flow through the legacy `extract_enum_value_with_values` route, not `validate_string_enum`. No false drift.

## Followups

- `carina-rs/carina-provider-aws#268` — codegen must emit `dsl_aliases` exhaustively (identity rows included); acceptance fixtures sweep.
- `carina-rs/carina-provider-awscc#222` — same for awscc.

Once those land, every enum is strict and `validate` rejects every PascalCase / SCREAMING_SNAKE / hyphenated / dotted spelling in DSL position.

## Test plan

- [x] `cargo nextest run -p carina-core` — 1944 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/check-*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
