### PR TITLE
carina#2986 Phase 1+2: add ConcreteValue::EnumIdentifier variant

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -161,7 +161,10 @@ pub(crate) fn dsl_value_to_json(
     use carina_core::value::{SerializationContext, SerializationError};
     let ctx = SerializationContext::StateWriteback;
     match value {
-        Value::Concrete(ConcreteValue::String(s)) => Ok(Some(serde_json::Value::String(s.clone()))),
+        Value::Concrete(ConcreteValue::String(s))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            Ok(Some(serde_json::Value::String(s.clone())))
+        }
         Value::Concrete(ConcreteValue::Bool(b)) => Ok(Some(serde_json::Value::Bool(*b))),
         Value::Concrete(ConcreteValue::Int(i)) => Ok(Some(serde_json::Value::Number((*i).into()))),
         Value::Concrete(ConcreteValue::Float(f)) => {

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -413,6 +413,7 @@ pub(crate) fn evaluate_builtin_with_config_to_value(
 fn value_type_name(value: &Value) -> &'static str {
     match value {
         Value::Concrete(ConcreteValue::String(_)) => "String",
+        Value::Concrete(ConcreteValue::EnumIdentifier(_)) => "EnumIdentifier",
         Value::Concrete(ConcreteValue::Int(_)) => "Int",
         Value::Concrete(ConcreteValue::Float(_)) => "Float",
         Value::Concrete(ConcreteValue::Bool(_)) => "Bool",

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -66,6 +66,7 @@ fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
             }
             Value::Deferred(DeferredValue::Secret(inner)) => walk(inner, deps),
             Value::Concrete(ConcreteValue::String(_))
+            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
             | Value::Concrete(ConcreteValue::Int(_))
             | Value::Concrete(ConcreteValue::Float(_))
             | Value::Concrete(ConcreteValue::Bool(_))

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -162,6 +162,7 @@ pub fn reconcile_prefixed_names(
 fn deterministic_value_string(value: &Value) -> String {
     match value {
         Value::Concrete(ConcreteValue::String(s)) => format!("String({:?})", s),
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => format!("EnumIdentifier({:?})", s),
         Value::Concrete(ConcreteValue::Int(i)) => format!("Int({})", i),
         Value::Concrete(ConcreteValue::Float(f)) => format!("Float({})", f),
         Value::Concrete(ConcreteValue::Bool(b)) => format!("Bool({})", b),

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -125,6 +125,15 @@ fn format_value(value: &Value) -> String {
                 format!("\"{}\"", s)
             }
         }
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            // Enum identifiers render unquoted to match how the user
+            // typed them.
+            if s.len() > 50 {
+                format!("{}...", &s[..47])
+            } else {
+                s.clone()
+            }
+        }
         Value::Concrete(ConcreteValue::Int(n)) => n.to_string(),
         Value::Concrete(ConcreteValue::Float(f)) => {
             let s = f.to_string();

--- a/carina-core/src/parser/static_eval.rs
+++ b/carina-core/src/parser/static_eval.rs
@@ -13,6 +13,7 @@ use crate::resource::{ConcreteValue, DeferredValue, Value};
 pub(crate) fn is_static_value(value: &Value) -> bool {
     match value {
         Value::Concrete(ConcreteValue::String(_))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(_))
         | Value::Concrete(ConcreteValue::Int(_))
         | Value::Concrete(ConcreteValue::Float(_))
         | Value::Concrete(ConcreteValue::Bool(_))

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -50,6 +50,7 @@ pub fn snake_to_pascal(s: &str) -> String {
 pub(crate) fn value_type_name(value: &Value) -> &'static str {
     match value {
         Value::Concrete(ConcreteValue::String(_)) => "string",
+        Value::Concrete(ConcreteValue::EnumIdentifier(_)) => "enum identifier",
         Value::Concrete(ConcreteValue::Int(_)) => "int",
         Value::Concrete(ConcreteValue::Float(_)) => "float",
         Value::Concrete(ConcreteValue::Bool(_)) => "bool",

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -426,6 +426,15 @@ pub enum Value {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ConcreteValue {
     String(String),
+    /// An enum identifier — a value written in the DSL as a bare
+    /// identifier (`tcp`) or namespaced identifier
+    /// (`awscc.ec2.SecurityGroup.IpProtocol.tcp`), not as a quoted
+    /// string literal. The parser routes `namespaced_id` and bare
+    /// `variable_ref`s in `StringEnum` attribute positions into this
+    /// variant so the validator can distinguish "identifier value"
+    /// from "string value" without re-deriving the question from
+    /// string content. See carina#2986.
+    EnumIdentifier(String),
     Int(i64),
     Float(f64),
     Bool(bool),
@@ -487,6 +496,8 @@ pub enum DeferredValue {
 #[derive(Debug, Clone, Copy)]
 pub enum ConcreteValueRef<'a> {
     String(&'a str),
+    /// See `ConcreteValue::EnumIdentifier`.
+    EnumIdentifier(&'a str),
     Int(i64),
     Float(f64),
     Bool(bool),
@@ -494,6 +505,20 @@ pub enum ConcreteValueRef<'a> {
     List(&'a [Value]),
     StringList(&'a [String]),
     Map(&'a IndexMap<String, Value>),
+}
+
+impl<'a> ConcreteValueRef<'a> {
+    /// Return the inner `&str` for both `String` and `EnumIdentifier`
+    /// variants. The vast majority of consumers (formatter, plan
+    /// display, differ, state writer) treat the two identically —
+    /// only the validator cares about the distinction.
+    pub fn as_string_like(&self) -> Option<&'a str> {
+        match self {
+            ConcreteValueRef::String(s) => Some(s),
+            ConcreteValueRef::EnumIdentifier(s) => Some(s),
+            _ => None,
+        }
+    }
 }
 
 /// Borrowing projection of [`Value`] restricted to the **deferred** axis
@@ -532,6 +557,7 @@ impl Value {
         match self {
             Value::Concrete(c) => Some(match c {
                 ConcreteValue::String(s) => ConcreteValueRef::String(s),
+                ConcreteValue::EnumIdentifier(s) => ConcreteValueRef::EnumIdentifier(s),
                 ConcreteValue::Int(n) => ConcreteValueRef::Int(*n),
                 ConcreteValue::Float(f) => ConcreteValueRef::Float(*f),
                 ConcreteValue::Bool(b) => ConcreteValueRef::Bool(*b),
@@ -862,6 +888,7 @@ impl Value {
             }
             Value::Deferred(DeferredValue::Secret(inner)) => inner.visit_refs(f),
             Value::Concrete(ConcreteValue::String(_))
+            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
             | Value::Concrete(ConcreteValue::Int(_))
             | Value::Concrete(ConcreteValue::Float(_))
             | Value::Concrete(ConcreteValue::Bool(_))
@@ -936,7 +963,8 @@ impl Value {
     fn hash_into(&self, hasher: &mut impl Hasher) {
         std::mem::discriminant(self).hash(hasher);
         match self {
-            Value::Concrete(ConcreteValue::String(s)) => s.hash(hasher),
+            Value::Concrete(ConcreteValue::String(s))
+            | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => s.hash(hasher),
             Value::Concrete(ConcreteValue::Int(i)) => i.hash(hasher),
             Value::Concrete(ConcreteValue::Float(f)) => {
                 // Use bits for deterministic hashing (NaN == NaN for our purposes)

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1890,6 +1890,7 @@ impl Value {
     fn type_name(&self) -> String {
         match self {
             Value::Concrete(ConcreteValue::String(_)) => "String".to_string(),
+            Value::Concrete(ConcreteValue::EnumIdentifier(_)) => "EnumIdentifier".to_string(),
             Value::Concrete(ConcreteValue::Int(_)) => "Int".to_string(),
             Value::Concrete(ConcreteValue::Float(_)) => "Float".to_string(),
             Value::Concrete(ConcreteValue::Bool(_)) => "Bool".to_string(),
@@ -1919,6 +1920,7 @@ impl ConcreteValueRef<'_> {
     fn type_name(&self) -> &'static str {
         match self {
             ConcreteValueRef::String(_) => "String",
+            ConcreteValueRef::EnumIdentifier(_) => "EnumIdentifier",
             ConcreteValueRef::Int(_) => "Int",
             ConcreteValueRef::Float(_) => "Float",
             ConcreteValueRef::Bool(_) => "Bool",
@@ -1936,6 +1938,9 @@ impl ConcreteValueRef<'_> {
     fn to_owned_value(self) -> Value {
         match self {
             ConcreteValueRef::String(s) => Value::Concrete(ConcreteValue::String(s.to_string())),
+            ConcreteValueRef::EnumIdentifier(s) => {
+                Value::Concrete(ConcreteValue::EnumIdentifier(s.to_string()))
+            }
             ConcreteValueRef::Int(n) => Value::Concrete(ConcreteValue::Int(n)),
             ConcreteValueRef::Float(f) => Value::Concrete(ConcreteValue::Float(f)),
             ConcreteValueRef::Bool(b) => Value::Concrete(ConcreteValue::Bool(b)),

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -670,6 +670,7 @@ fn walk_value_against_type(
             }
         }
         Value::Concrete(ConcreteValue::String(_))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(_))
         | Value::Concrete(ConcreteValue::Int(_))
         | Value::Concrete(ConcreteValue::Float(_))
         | Value::Concrete(ConcreteValue::Bool(_))

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -291,6 +291,10 @@ fn infer_type_from_value_with_visiting(
 ) -> Result<TypeExpr, InferenceError> {
     match value {
         Value::Concrete(ConcreteValue::String(_)) => Ok(TypeExpr::String),
+        // Enum identifiers infer as `String` for the type-expression
+        // layer — the value-layer distinction matters only inside the
+        // `StringEnum` validator. See carina#2986.
+        Value::Concrete(ConcreteValue::EnumIdentifier(_)) => Ok(TypeExpr::String),
         Value::Concrete(ConcreteValue::Int(_)) => Ok(TypeExpr::Int),
         Value::Concrete(ConcreteValue::Float(_)) => Ok(TypeExpr::Float),
         Value::Concrete(ConcreteValue::Bool(_)) => Ok(TypeExpr::Bool),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -215,7 +215,14 @@ pub fn value_to_json_with_context(
 ) -> Result<serde_json::Value, SerializationError> {
     let ctx = SerializationContext::ValueToJson;
     match value {
-        Value::Concrete(ConcreteValue::String(s)) => Ok(serde_json::Value::String(s.clone())),
+        Value::Concrete(ConcreteValue::String(s))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            // Both serialize as a flat JSON string. The schema-aware
+            // state loader re-classifies `EnumIdentifier` from the
+            // attribute's declared type, so the on-disk JSON stays
+            // unchanged. See carina#2986 design doc §5.
+            Ok(serde_json::Value::String(s.clone()))
+        }
         Value::Concrete(ConcreteValue::Int(n)) => Ok(serde_json::Value::Number((*n).into())),
         Value::Concrete(ConcreteValue::Duration(d)) => {
             Ok(serde_json::Value::Number((d.as_secs() as i64).into()))
@@ -463,6 +470,13 @@ pub(crate) fn format_value_into<S: FormatSink>(
             sink.write_str("\"")?;
             sink.write_str(s)?;
             sink.write_str("\"")
+        }
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            // Enum identifiers render unquoted in plan/diff output to
+            // match how the user typed them. The resolver has already
+            // canonicalized any namespaced form, so `s` is the bare
+            // identifier ready for direct display.
+            sink.write_str(s)
         }
         Value::Concrete(ConcreteValue::Int(n)) => sink.write_str(&n.to_string()),
         Value::Concrete(ConcreteValue::Duration(d)) => sink.write_str(&render_duration(*d)),

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -47,7 +47,13 @@ use crate::wasm_bindings::carina::provider::types as wit;
 /// equivalent to the pre-#2387 `ResourceRef` debug-string.
 pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError> {
     match v {
-        CoreValue::Concrete(ConcreteValue::String(s)) => Ok(wit::Value::StrVal(s.clone())),
+        CoreValue::Concrete(ConcreteValue::String(s))
+        | CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            // Enum identifiers lower to the WIT boundary as plain
+            // strings — the WASM plugin sees the same wire shape as
+            // any other string value. See carina#2986.
+            Ok(wit::Value::StrVal(s.clone()))
+        }
         CoreValue::Concrete(ConcreteValue::Int(i)) => Ok(wit::Value::IntVal(*i)),
         CoreValue::Concrete(ConcreteValue::Float(f)) => Ok(wit::Value::FloatVal(*f)),
         CoreValue::Concrete(ConcreteValue::Bool(b)) => Ok(wit::Value::BoolVal(*b)),
@@ -179,7 +185,10 @@ pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
 /// pass that keeps these arms unreachable in legitimate flows.
 fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationError> {
     match v {
-        CoreValue::Concrete(ConcreteValue::String(s)) => Ok(serde_json::Value::String(s.clone())),
+        CoreValue::Concrete(ConcreteValue::String(s))
+        | CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            Ok(serde_json::Value::String(s.clone()))
+        }
         CoreValue::Concrete(ConcreteValue::Int(i)) => Ok(serde_json::Value::Number((*i).into())),
         CoreValue::Concrete(ConcreteValue::Float(f)) => Ok(serde_json::Number::from_f64(*f)
             .map(serde_json::Value::Number)


### PR DESCRIPTION
## Summary

Phase 1+2 of the strict-enum-identifier validator (design: `notes/specs/2026-05-12-strict-enum-identifier-design.md`, merged via #2988). Adds the value-layer variant that distinguishes "enum identifier" from "string literal" at the type level, and threads it through every existing match arm so the workspace compiles.

**No semantic change in this PR.** The parser still emits `ConcreteValue::String` for everything; the validator still accepts strings on `StringEnum` attributes. Behavior change ships in Phase 3+ (parser routing + validator strict mode) in a follow-up PR.

## What's in this PR

- `ConcreteValue::EnumIdentifier(String)` (owned) and `ConcreteValueRef::EnumIdentifier(&str)` (borrowed)
- `ConcreteValueRef::as_string_like()` — `Option<&str>` for both `String` and `EnumIdentifier`, so the many "I just need the text" sites (formatter, plan display, state writer, WIT lowering) do not need to enumerate two arms
- 14 workspace-wide match-arm additions: every site that switches on `ConcreteValue` / `ConcreteValueRef` now has an `EnumIdentifier` arm. Default treatment matches `String` (same text content, same serialization, same hash).

## Why structural, not heuristic

PR #2985 enforced the same convention via string-content heuristics on `dsl_aliases` and shipped a regression (`values:` entries with hyphen/colon API spellings got rejected even when listed by the schema). The parser already distinguishes `namespaced_id` / `variable_ref` / `string` grammar rules — route that distinction through `Value` and let the validator match on it.

## Test plan

- [x] `cargo nextest run --workspace` — 3226 passed / 74 skipped
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] All `scripts/check-*.sh` — pass

Refs #2986.