### PR TITLE
carina#2986 Phase 3+4+5: strict enum identifier validator

### DIFF
--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_enum_display.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_enum_display.snap
@@ -6,6 +6,6 @@ Execution Plan:
 
   + awscc.ec2.Vpc 
       cidr_block: "10.0.0.0/16"
-      instance_tenancy: "dedicated"
+      instance_tenancy: awscc.ec2.Vpc.InstanceTenancy.dedicated
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -52,10 +52,15 @@ fn invalid_enum_variant_namespaced_display() {
         )
         .required(),
     );
+    // Phase 4 of carina#2986: the test exercises the wrong-variant
+    // path (`InvalidEnumVariant`), which is reached only by the
+    // identifier shape. A `ConcreteValue::String` here would route to
+    // `StringLiteralExpectedEnum` instead — covered separately by
+    // `string_literal_expected_enum_string_enum_display`.
     let mut attrs = HashMap::new();
     attrs.insert(
         "versioning".to_string(),
-        Value::Concrete(ConcreteValue::String(
+        Value::Concrete(ConcreteValue::EnumIdentifier(
             "aws.s3.Bucket.VersioningStatus.NotReal".to_string(),
         )),
     );
@@ -64,6 +69,9 @@ fn invalid_enum_variant_namespaced_display() {
 
 #[test]
 fn invalid_enum_variant_bare_display() {
+    // Phase 4 of carina#2986: identifier-shape input reaches the
+    // wrong-variant matcher; a string literal goes to
+    // `StringLiteralExpectedEnum`.
     let t = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
@@ -71,13 +79,16 @@ fn invalid_enum_variant_bare_display() {
         dsl_aliases: vec![],
     };
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "zzz".to_string(),
+        )))
         .unwrap_err();
     insta::assert_snapshot!(err.to_string());
 }
 
 #[test]
 fn invalid_enum_variant_with_dsl_aliases_display() {
+    // Phase 4 of carina#2986: identifier-shape input.
     let t = AttributeType::StringEnum {
         name: "VersioningStatus".to_string(),
         values: vec!["Enabled".to_string(), "Suspended".to_string()],
@@ -88,7 +99,9 @@ fn invalid_enum_variant_with_dsl_aliases_display() {
         ],
     };
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "zzz".to_string(),
+        )))
         .unwrap_err();
     insta::assert_snapshot!(err.to_string());
 }

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -134,15 +134,39 @@ pub(super) fn type_aware_equal(
                 }
             }
 
-            // StringEnum: extract enum values from namespaced identifiers and compare
-            (
-                Value::Concrete(ConcreteValue::String(sa)),
-                Value::Concrete(ConcreteValue::String(sb)),
-                AttributeType::StringEnum { values, .. },
-            ) if sa != sb => {
+            // StringEnum: extract enum values from namespaced identifiers
+            // and compare. Phase 5 of carina#2986: accept the cross-shape
+            // `String × EnumIdentifier` pair so the differ is stable
+            // across "state file stores plain string, desired-side parsed
+            // as identifier short form" — the steady-state shape for any
+            // enum-typed attribute whose value flowed through a provider
+            // `read`. Comparison is text-based and case-insensitive on
+            // the enum value, matching the existing String × String arm.
+            (a, b, AttributeType::StringEnum { values, .. })
+                if matches!(
+                    a,
+                    Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
+                ) && matches!(
+                    b,
+                    Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
+                ) =>
+            {
+                let text = |v: &Value| -> Option<String> {
+                    match v {
+                        Value::Concrete(ConcreteValue::String(s))
+                        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.clone()),
+                        _ => None,
+                    }
+                };
+                let (Some(sa), Some(sb)) = (text(a), text(b)) else {
+                    return a.semantically_equal(b);
+                };
+                if sa == sb {
+                    return true;
+                }
                 let valid_values: Vec<&str> = values.iter().map(String::as_str).collect();
-                let va = crate::utils::extract_enum_value_with_values(sa, &valid_values);
-                let vb = crate::utils::extract_enum_value_with_values(sb, &valid_values);
+                let va = crate::utils::extract_enum_value_with_values(&sa, &valid_values);
+                let vb = crate::utils::extract_enum_value_with_values(&sb, &valid_values);
                 va.eq_ignore_ascii_case(vb)
             }
 
@@ -288,11 +312,10 @@ fn is_type_default(value: &Value, attr_type: Option<&AttributeType>) -> bool {
         {
             true
         }
-        (Value::Concrete(ConcreteValue::String(s)), Some(AttributeType::StringEnum { .. }))
-            if s.is_empty() =>
-        {
-            true
-        }
+        (
+            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
+            Some(AttributeType::StringEnum { .. }),
+        ) if s.is_empty() => true,
         (Value::Concrete(ConcreteValue::List(l)), Some(AttributeType::List { .. }))
             if l.is_empty() =>
         {

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -296,6 +296,18 @@ pub(in crate::parser) fn extract_directives(
                                     .unwrap_or(name.as_str());
                                 names.push(bare.to_string());
                             }
+                            Value::Concrete(ConcreteValue::EnumIdentifier(name)) => {
+                                // Bare identifier reached the directives
+                                // parser before `is_resource_binding` could
+                                // catch it (e.g. forward reference in a
+                                // cycle test, or a typo flagged later by
+                                // `check_identifier_scope`). Phase 3 of
+                                // carina#2986 routes such identifiers into
+                                // `ConcreteValue::EnumIdentifier`; from the
+                                // depends_on perspective the text is still
+                                // the user's intended binding name.
+                                names.push(name.clone());
+                            }
                             other => {
                                 return Err(ParseError::InvalidExpression {
                                     line: 0,

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -301,20 +301,27 @@ pub(crate) fn parse_for_expr(
             // Return empty — the for body produces zero concrete resources
         }
         _ => {
-            // Special case: the parser collapses bare unresolved identifiers
-            // (e.g. `for _ in org { ... }`) into `Value::Concrete(ConcreteValue::String("org"))` — the
-            // same slot a quoted literal uses. Reporting those as
-            // `iterable is string "org"` is misleading: the user wrote an
-            // identifier, not a literal, and the likely fault is a typo for
-            // a known binding. Record them as deferred for-expressions so
-            // `check_identifier_scope` (which runs on the merged
-            // directory-wide ParsedFile, so cross-file upstream_state /
-            // module bindings are visible) can emit a proper
-            // UndefinedIdentifier with the did-you-mean machinery from
-            // #2038 / #2100. See #2101 / #2138.
-            if let Value::Concrete(ConcreteValue::String(s)) = &iterable
-                && is_bare_identifier(s)
-            {
+            // Special case: the parser lowers bare unresolved identifiers
+            // (e.g. `for _ in org { ... }`) into
+            // `Value::Concrete(ConcreteValue::EnumIdentifier("org"))`
+            // (carina#2986 Phase 3 routing). Pre-Phase-3 they landed as
+            // `ConcreteValue::String`; we still accept both shapes here
+            // because a quoted literal `for _ in "org" { ... }` should
+            // also drop into this branch — reporting either as
+            // `iterable is string "org"` is misleading. Record them as
+            // deferred for-expressions so `check_identifier_scope` (which
+            // runs on the merged directory-wide ParsedFile, so cross-file
+            // upstream_state / module bindings are visible) can emit a
+            // proper UndefinedIdentifier with the did-you-mean machinery
+            // from #2038 / #2100. See #2101 / #2138.
+            let bare_ident_text: Option<String> = match &iterable {
+                Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.clone()),
+                Value::Concrete(ConcreteValue::String(s)) if is_bare_identifier(s) => {
+                    Some(s.clone())
+                }
+                _ => None,
+            };
+            if let Some(s) = bare_ident_text.as_ref() {
                 let header = match &binding {
                     ForBinding::Simple(var) => format!("for {} in {}", var, s),
                     ForBinding::Indexed(idx, val) => format!("for ({}, {}) in {}", idx, val, s),
@@ -381,6 +388,9 @@ pub(crate) fn parse_for_expr(
             let iterable_type = match &iterable {
                 Value::Concrete(ConcreteValue::String(s)) => {
                     format!("string \"{}\"", if s.len() > 50 { &s[..50] } else { s })
+                }
+                Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+                    format!("identifier `{}`", if s.len() > 50 { &s[..50] } else { s })
                 }
                 Value::Concrete(ConcreteValue::Int(i)) => format!("int {}", i),
                 Value::Concrete(ConcreteValue::Float(f)) => format!("float {}", f),

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -168,7 +168,7 @@ fn parse_namespaced_id_value(
     }
 
     Ok(EvalValue::from_value(Value::Concrete(
-        ConcreteValue::String(full_str.to_string()),
+        ConcreteValue::EnumIdentifier(full_str.to_string()),
     )))
 }
 
@@ -366,10 +366,20 @@ pub(crate) fn parse_primary_eval(
 
             if access_steps.is_empty() {
                 // Simple variable reference (no access chain)
+                //
+                // Bare identifiers (`dedicated`, `enabled`) are emitted as
+                // `ConcreteValue::EnumIdentifier` short form. The validator
+                // performs schema-aware namespace expansion against the
+                // enclosing attribute's `StringEnum` definition; if the
+                // attribute isn't an enum, the validator surfaces a clear
+                // type mismatch with the user-typed text intact. Binding
+                // precedence is already honored by the `get_variable` arm
+                // above — we only reach the `None` branch when the parser
+                // has no in-scope variable / let-binding for this name.
                 match ctx.get_variable(first_ident) {
                     Some(val) => Ok(val.clone()),
                     None => Ok(EvalValue::from_value(Value::Concrete(
-                        ConcreteValue::String(first_ident.to_string()),
+                        ConcreteValue::EnumIdentifier(first_ident.to_string()),
                     ))),
                 }
             } else {

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -220,15 +220,35 @@ pub fn validate_custom_type(
     config: &ProviderContext,
 ) -> Result<(), String> {
     match (type_name, value) {
-        ("ipv4_cidr", Value::Concrete(ConcreteValue::String(s))) => validate_ipv4_cidr(s),
-        ("ipv4_address", Value::Concrete(ConcreteValue::String(s))) => validate_ipv4_address(s),
-        ("ipv6_cidr", Value::Concrete(ConcreteValue::String(s))) => validate_ipv6_cidr(s),
-        ("ipv6_address", Value::Concrete(ConcreteValue::String(s))) => validate_ipv6_address(s),
+        (
+            "ipv4_cidr",
+            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
+        ) => validate_ipv4_cidr(s),
+        (
+            "ipv4_address",
+            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
+        ) => validate_ipv4_address(s),
+        (
+            "ipv6_cidr",
+            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
+        ) => validate_ipv6_cidr(s),
+        (
+            "ipv6_address",
+            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
+        ) => validate_ipv6_address(s),
         (_, Value::Deferred(DeferredValue::ResourceRef { .. })) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::FunctionCall { .. })) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::Interpolation(_))) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::Unknown(_))) => Ok(()), // resolved at upstream apply
-        (name, Value::Concrete(ConcreteValue::String(s))) => {
+        (name, Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s))) => {
+            // Both `String` (quoted-literal source) and `EnumIdentifier`
+            // (bare or namespaced identifier source) are accepted: this
+            // lookup runs from `walk_custom_lookup`, which is reached
+            // *after* `expand_enum_shorthand` has normalized the value
+            // for `validate_custom`. The strict-shape rejection for
+            // quoted literals on namespaced Custom types happens in the
+            // LSP / CLI surface code (carina#2986 Phase 4), not here —
+            // this fallback validator just needs the textual payload.
             // Check custom validators from config (schema-extracted)
             if let Some(validator) = config.validators.get(name) {
                 validator(s)?;

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -117,7 +117,7 @@ fn parse_resource_with_namespaced_type() {
     );
     assert_eq!(
         resource.get_attr("region"),
-        Some(&Value::Concrete(ConcreteValue::String(
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );
@@ -156,7 +156,7 @@ fn parse_variable_and_resource() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("region"),
-        Some(&Value::Concrete(ConcreteValue::String(
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );
@@ -346,7 +346,7 @@ fn parse_and_resolve_resource_reference() {
     );
     assert_eq!(
         policy.get_attr("bucket_region"),
-        Some(&Value::Concrete(ConcreteValue::String(
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );
@@ -398,9 +398,14 @@ fn parse_undefined_two_part_identifier_becomes_resource_ref() {
 }
 
 #[test]
-fn parse_bare_identifier_becomes_string() {
-    // When a bare identifier is not a known variable or binding,
-    // it becomes a String for later schema validation (enum resolution)
+fn parse_bare_identifier_becomes_enum_identifier() {
+    // Phase 3 of carina#2986: a bare identifier that is not a known
+    // variable or binding lowers to `ConcreteValue::EnumIdentifier`, the
+    // strict short-form variant. The validator performs schema-aware
+    // namespace expansion against the enclosing `StringEnum`; this is the
+    // mechanism that turns `dedicated` into
+    // `awscc.ec2.Vpc.InstanceTenancy.dedicated` at validation time without
+    // requiring schema context in the parser.
     let input = r#"
         let vpc = awscc.ec2.Vpc {
             instance_tenancy = dedicated
@@ -410,7 +415,7 @@ fn parse_bare_identifier_becomes_string() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("instance_tenancy"),
-        Some(&Value::Concrete(ConcreteValue::String(
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "dedicated".to_string()
         )))
     );
@@ -429,7 +434,7 @@ fn resource_reference_preserves_namespaced_id() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("region"),
-        Some(&Value::Concrete(ConcreteValue::String(
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );
@@ -448,7 +453,7 @@ fn namespaced_id_with_digit_segment() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("type"),
-        Some(&Value::Concrete(ConcreteValue::String(
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.ec2.vpn_gateway.Type.ipsec.1".to_string()
         )))
     );
@@ -1124,7 +1129,7 @@ fn parse_backend_block() {
     );
     assert_eq!(
         backend.attributes.get("region"),
-        Some(&Value::Concrete(ConcreteValue::String(
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -654,6 +654,29 @@ impl PartialEq for Value {
                 Value::Concrete(ConcreteValue::String(a)),
                 Value::Concrete(ConcreteValue::String(b)),
             ) => a == b,
+            // `EnumIdentifier` is structurally equal to `String` (and to
+            // itself) when the carried text matches. The source-shape
+            // distinction lives on the variant tag — validator and other
+            // pattern-matching sites stay strict because they `match` on
+            // the variant directly, not through `PartialEq`. Value-tree
+            // comparison (differ, state round-trip checks, diff_tests)
+            // treats the two as the same textual payload; otherwise every
+            // provider `read` (which round-trips through plain JSON
+            // strings on the WIT boundary) would produce a phantom diff
+            // against a desired-side identifier form. See carina#2986
+            // Phase 5.
+            (
+                Value::Concrete(ConcreteValue::EnumIdentifier(a)),
+                Value::Concrete(ConcreteValue::EnumIdentifier(b)),
+            )
+            | (
+                Value::Concrete(ConcreteValue::EnumIdentifier(a)),
+                Value::Concrete(ConcreteValue::String(b)),
+            )
+            | (
+                Value::Concrete(ConcreteValue::String(a)),
+                Value::Concrete(ConcreteValue::EnumIdentifier(b)),
+            ) => a == b,
             (Value::Concrete(ConcreteValue::Int(a)), Value::Concrete(ConcreteValue::Int(b))) => {
                 a == b
             }

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -926,16 +926,54 @@ impl AttributeType {
             unreachable!("validate_string_enum called on non-StringEnum");
         };
 
+        // Phase 4 of carina#2986: enum attributes accept only DSL
+        // identifiers (`ConcreteValue::EnumIdentifier`), never quoted
+        // string literals. A `ConcreteValueRef::String` reaching this
+        // function means the user wrote `attr = "value"` on an enum
+        // attribute — reshape into `StringLiteralExpectedEnum` with the
+        // full expected variant list so the LSP code action can offer
+        // "drop quotes / use identifier form" without re-deriving
+        // candidates.
+        if let ConcreteValueRef::String(s) = value {
+            let mut expected: Vec<ExpectedEnumVariant> = Vec::new();
+            let mut push = |variant_value: &str, is_alias: bool| {
+                let entry = ExpectedEnumVariant::from_namespaced(
+                    namespace.as_deref(),
+                    name,
+                    variant_value,
+                    is_alias,
+                );
+                if !expected.contains(&entry) {
+                    expected.push(entry);
+                }
+            };
+            for v in values {
+                push(v, false);
+            }
+            for (api, dsl) in dsl_aliases {
+                if dsl != api {
+                    push(dsl, true);
+                }
+            }
+            return Err(TypeError::StringLiteralExpectedEnum {
+                user_typed: s.to_string(),
+                attribute: None,
+                type_name: name.clone(),
+                expected,
+                extra_message: None,
+            });
+        }
+
         let resolved_value = Self::resolve_enum_input(name, namespace.as_deref(), value);
         // Capture the user's original input for diagnostics. The parser
-        // collapses both quoted literals (`"aaa"`) and bare identifiers
-        // (`dedicated`) into `Value::Concrete(ConcreteValue::String)`, and `resolve_enum_input`
-        // rewrites the non-dotted form into a synthesized namespaced
-        // string for lookup. That synthesized form must stay internal:
-        // error messages should quote what the user actually typed.
-        // See #2077.
+        // emits `ConcreteValue::EnumIdentifier` for bare identifier short
+        // forms (`dedicated`) and dotted forms (`aws.s3.Bucket.VersioningStatus.Enabled`).
+        // `resolve_enum_input` rewrites the non-dotted form into a
+        // synthesized namespaced string for lookup. That synthesized form
+        // must stay internal: error messages should quote what the user
+        // actually typed. See #2077.
         let user_input = match value {
-            ConcreteValueRef::String(s) => Some(s),
+            ConcreteValueRef::EnumIdentifier(s) => Some(s),
             _ => None,
         };
         if let Value::Concrete(ConcreteValue::String(s)) = &resolved_value {
@@ -1405,12 +1443,20 @@ fn union_member_score(member: &AttributeType, value: ConcreteValueRef<'_>) -> u3
         // generic `TypeMismatch`.
         (AT::Struct { .. }, ConcreteValueRef::Map(_)) => 100,
         // Same-constructor match — second tier.
+        //
+        // `StringEnum` matches both `String` (quoted literal form) and
+        // `EnumIdentifier` (identifier form, carina#2986). The strict
+        // validator rejects the `String` shape inside `validate_string_enum`
+        // and surfaces `StringLiteralExpectedEnum`; the union picker
+        // still routes through this member so that error reaches the
+        // caller instead of a generic `TypeMismatch`.
         (AT::Map { .. }, ConcreteValueRef::Map(_))
         | (AT::String, ConcreteValueRef::String(_))
         | (AT::Int, ConcreteValueRef::Int(_))
         | (AT::Float, ConcreteValueRef::Float(_))
         | (AT::Bool, ConcreteValueRef::Bool(_))
-        | (AT::StringEnum { .. }, ConcreteValueRef::String(_)) => 80,
+        | (AT::StringEnum { .. }, ConcreteValueRef::String(_))
+        | (AT::StringEnum { .. }, ConcreteValueRef::EnumIdentifier(_)) => 80,
         // List↔List: peek at the first element's structural match
         // against the member's inner type so `List<Struct>` outranks
         // `List<String>` for an input like `[{...}]`. The inner

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -41,6 +41,10 @@ fn validate_string_type() {
 
 #[test]
 fn validate_string_enum_type() {
+    // Phase 4 of carina#2986: enum attributes accept only
+    // `ConcreteValue::EnumIdentifier`. Constructed-by-hand strings are
+    // rejected as `StringLiteralExpectedEnum` — see
+    // `validate_string_enum_rejects_quoted_string_literal` for that path.
     let t = AttributeType::StringEnum {
         name: "AddressFamily".to_string(),
         values: vec!["IPv4".to_string(), "IPv6".to_string()],
@@ -48,22 +52,50 @@ fn validate_string_enum_type() {
         dsl_aliases: vec![],
     };
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.ec2.ipam_pool.AddressFamily.IPv4".to_string()
         )))
         .is_ok()
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String("IPv6".to_string())))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "IPv6".to_string()
+        )))
+        .is_ok()
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String("ipv4".to_string())))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "ipv4".to_string()
+        )))
+        .is_ok()
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String("IPv5".to_string())))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "IPv5".to_string()
+        )))
+        .is_err()
+    );
+}
+
+#[test]
+fn validate_string_enum_rejects_quoted_string_literal() {
+    // Phase 4 of carina#2986: a `String`-shaped value on a `StringEnum`
+    // attribute means the user wrote `attr = "value"`. The validator
+    // emits `StringLiteralExpectedEnum` with the full expected variant
+    // list so the LSP code action can offer "drop quotes / use
+    // identifier form" without re-deriving candidates.
+    let t = AttributeType::StringEnum {
+        name: "AddressFamily".to_string(),
+        values: vec!["IPv4".to_string(), "IPv6".to_string()],
+        namespace: Some("awscc.ec2.ipam_pool".to_string()),
+        dsl_aliases: vec![],
+    };
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::String("IPv4".to_string())))
+        .unwrap_err();
+    assert!(
+        matches!(err, TypeError::StringLiteralExpectedEnum { ref user_typed, .. } if user_typed == "IPv4"),
+        "expected StringLiteralExpectedEnum, got: {err:?}"
     );
 }
 
@@ -94,14 +126,16 @@ fn validate_string_enum_accepts_dsl_alias() {
     };
     // Canonical "-1" is rewritten to DSL "all" — the DSL surface must
     // not accept the API form when an alias is registered. Users
-    // write `all`. Updated for carina#2980.
+    // write `all`. Updated for carina#2980 / carina#2986.
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String("-1".to_string())))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "-1".to_string()
+        )))
+        .is_err()
     );
     // DSL alias "all" should be accepted
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.ec2.SecurityGroup.IpProtocol.all".to_string()
         )))
         .is_ok()
@@ -110,12 +144,14 @@ fn validate_string_enum_accepts_dsl_alias() {
     // which is already snake_case) keep working — the API spelling
     // *is* the DSL spelling for them.
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String("tcp".to_string())))
-            .is_ok()
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "tcp".to_string()
+        )))
+        .is_ok()
     );
     // Invalid values should still be rejected
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "invalid".to_string()
         )))
         .is_err()
@@ -141,7 +177,9 @@ fn validate_string_enum_all_without_dsl_aliases_requires_explicit_variant() {
     // Without "all" in values and no dsl_aliases entry mapping to "all", it is rejected
     assert!(
         without_all
-            .validate(&Value::Concrete(ConcreteValue::String("all".to_string())))
+            .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+                "all".to_string()
+            )))
             .is_err()
     );
 
@@ -161,7 +199,9 @@ fn validate_string_enum_all_without_dsl_aliases_requires_explicit_variant() {
     };
     assert!(
         with_all
-            .validate(&Value::Concrete(ConcreteValue::String("all".to_string())))
+            .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+                "all".to_string()
+            )))
             .is_ok()
     );
 }
@@ -176,23 +216,26 @@ fn validate_string_enum_accepts_values_with_dots() {
         namespace: Some("awscc.ec2.vpn_gateway".to_string()),
         dsl_aliases: vec![],
     };
-    // Quoted string with dot should match directly
+    // Bare identifier with dot should match directly (carried as
+    // `EnumIdentifier` under strict mode — the test name still says
+    // "Quoted string" for historical reasons but values are written
+    // unquoted in real DSL).
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "ipsec.1".to_string()
         )))
         .is_ok()
     );
     // Fully qualified form should also be accepted
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.ec2.vpn_gateway.Type.ipsec.1".to_string()
         )))
         .is_ok()
     );
     // Invalid value should still be rejected
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "ipsec.2".to_string()
         )))
         .is_err()
@@ -201,9 +244,13 @@ fn validate_string_enum_accepts_values_with_dots() {
 
 #[test]
 fn invalid_enum_error_preserves_user_typed_string_literal() {
-    // Regression for #2077. A quoted string literal like `target_type = "aaa"`
-    // should surface in the error as the typed value, not as the synthesized
-    // namespaced form `awscc.sso.Assignment.TargetType.aaa`.
+    // Regression for #2077, updated for carina#2986: a quoted string
+    // literal `target_type = "aaa"` now reaches the validator as
+    // `ConcreteValue::String("aaa")` and is rejected as
+    // `StringLiteralExpectedEnum`. The user-typed value must surface in
+    // the error verbatim (echoed inside double quotes per the
+    // `format_string_literal_expected_enum` shape) without leaking the
+    // synthesized namespaced form.
     let t = AttributeType::StringEnum {
         name: "TargetType".to_string(),
         values: vec!["AWS_ACCOUNT".to_string()],
@@ -215,8 +262,8 @@ fn invalid_enum_error_preserves_user_typed_string_literal() {
         .unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("'aaa'"),
-        "error should quote the user's typed value, got: {msg}"
+        msg.contains("\"aaa\""),
+        "error should echo the user's typed value, got: {msg}"
     );
     assert!(
         !msg.contains("awscc.sso.Assignment.TargetType.aaa"),
@@ -252,15 +299,20 @@ fn invalid_enum_error_names_the_enum_type_and_fully_qualified_variants() {
 
 #[test]
 fn with_attribute_adds_attribute_name_to_enum_error() {
-    // Regression for #2098. When a caller knows which attribute produced
-    // the error, wrapping it with `with_attribute` must surface the name
-    // in the rendered message so the reader can locate it in their .crn.
+    // Regression for #2098, updated for carina#2986. The
+    // `with_attribute` plumbing routes the attribute name onto both
+    // `InvalidEnumVariant` (for genuine wrong-variant inputs) and
+    // `StringLiteralExpectedEnum` (the strict-mode quoted-string
+    // rejection). Pin both behaviors:
     let t = AttributeType::StringEnum {
         name: "TargetType".to_string(),
         values: vec!["AWS_ACCOUNT".to_string()],
         namespace: Some("awscc.sso.Assignment".to_string()),
         dsl_aliases: vec![],
     };
+    // String-literal path (strict-mode rejection): rendered as
+    // `'target_id' (TargetType) expects an enum identifier, got a
+    // string literal "aaa"...`.
     let err = t
         .validate(&Value::Concrete(ConcreteValue::String("aaa".to_string())))
         .unwrap_err()
@@ -275,8 +327,26 @@ fn with_attribute_adds_attribute_name_to_enum_error() {
         "error should still name the enum type, got: {msg}"
     );
     assert!(
+        msg.contains("\"aaa\""),
+        "error should still echo the user value, got: {msg}"
+    );
+
+    // Identifier path (`InvalidEnumVariant`): the message keeps the
+    // single-quoted form for the bare value.
+    let err = t
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "aaa".to_string(),
+        )))
+        .unwrap_err()
+        .with_attribute("target_id");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("'target_id'"),
+        "identifier-path error should quote attribute name, got: {msg}"
+    );
+    assert!(
         msg.contains("'aaa'"),
-        "error should still quote the user value, got: {msg}"
+        "identifier-path error should single-quote the bare value, got: {msg}"
     );
 }
 
@@ -423,8 +493,12 @@ fn into_string_literal_diagnostic_without_type_name_passes_through() {
 fn schema_validate_with_origins_emits_string_literal_diagnostic_for_quoted_enum() {
     // `validate_with_origins` is the entry point the CLI/LSP wiring
     // calls once it knows which attributes were written as quoted
-    // string literals. A quoted-literal assignment to a StringEnum
-    // must reshape into `StringLiteralExpectedEnum`.
+    // string literals. Under carina#2986 strict mode the `Value`
+    // variant alone already encodes that distinction
+    // (`ConcreteValue::String` = quoted literal,
+    // `ConcreteValue::EnumIdentifier` = bare/namespaced identifier),
+    // so the diagnostic shape follows from the value's variant
+    // independently of the origin tag.
     let schema = ResourceSchema::new("test.assignment").attribute(
         AttributeSchema::new(
             "target_type",
@@ -437,13 +511,13 @@ fn schema_validate_with_origins_emits_string_literal_diagnostic_for_quoted_enum(
         )
         .required(),
     );
+
+    // Quoted literal → reshaped diagnostic, regardless of origin tag.
     let mut attrs = HashMap::new();
     attrs.insert(
         "target_type".to_string(),
         Value::Concrete(ConcreteValue::String("aaa".to_string())),
     );
-
-    // String-literal origin → reshaped diagnostic
     let errs = schema
         .validate_with_origins(&attrs, &|name| name == "target_type")
         .unwrap_err();
@@ -453,15 +527,19 @@ fn schema_validate_with_origins_emits_string_literal_diagnostic_for_quoted_enum(
         "expected StringLiteralExpectedEnum variant, got: {errs:?}"
     );
 
-    // No string-literal origin → classic InvalidEnumVariant (unchanged
-    // behaviour for bare-identifier / namespaced inputs)
+    // Bare-identifier wrong-variant → classic InvalidEnumVariant.
+    let mut attrs = HashMap::new();
+    attrs.insert(
+        "target_type".to_string(),
+        Value::Concrete(ConcreteValue::EnumIdentifier("aaa".to_string())),
+    );
     let errs = schema
         .validate_with_origins(&attrs, &|_| false)
         .unwrap_err();
     assert!(
         errs.iter()
             .any(|e| matches!(e, TypeError::InvalidEnumVariant { .. })),
-        "expected InvalidEnumVariant variant when origin is not a literal, got: {errs:?}"
+        "expected InvalidEnumVariant variant for bare identifier, got: {errs:?}"
     );
 }
 
@@ -485,7 +563,7 @@ fn schema_validate_with_origins_leaves_valid_values_alone() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "target_type".to_string(),
-        Value::Concrete(ConcreteValue::String("AWS_ACCOUNT".to_string())),
+        Value::Concrete(ConcreteValue::EnumIdentifier("AWS_ACCOUNT".to_string())),
     );
     assert!(
         schema.validate_with_origins(&attrs, &|_| true).is_ok(),
@@ -3285,8 +3363,14 @@ fn expected_includes_to_dsl_aliases_with_alias_flag() {
             ("Suspended".to_string(), "suspended".to_string()),
         ],
     };
+    // Use `EnumIdentifier` so the strict-mode validator reaches the
+    // wrong-variant branch (`InvalidEnumVariant`). A `String` here would
+    // be rejected earlier as `StringLiteralExpectedEnum` — that path is
+    // covered by `validate_string_enum_rejects_quoted_string_literal`.
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "zzz".to_string(),
+        )))
         .unwrap_err();
     let TypeError::InvalidEnumVariant { expected, .. } = err else {
         panic!("expected InvalidEnumVariant, got {err:?}");
@@ -3429,10 +3513,17 @@ fn expected_enum_variant_serde_round_trip() {
 
 #[test]
 fn union_string_vs_string_enum_picks_enum_error_for_string_input() {
-    // Acceptance #2 from #2219: `Int | StringEnum` with a string input
-    // that doesn't match any enum variant must surface the
-    // `InvalidEnumVariant` error (so the user sees `expected one of:
-    // fast, slow`), not a generic `TypeMismatch`.
+    // Acceptance #2 from #2219: `Int | StringEnum` with an identifier
+    // input that doesn't match any enum variant must surface the
+    // `InvalidEnumVariant` error from the StringEnum member (so the
+    // user sees `expected one of: fast, slow`), not a generic
+    // `TypeMismatch` from the Int member.
+    //
+    // Updated for carina#2986 strict mode: the test input is an
+    // `EnumIdentifier`, which is the legitimate identifier-shaped path
+    // that lands in the enum-variant matcher. A `String` here would
+    // short-circuit to `StringLiteralExpectedEnum`, which is a
+    // different concern covered separately.
     let union_type = AttributeType::Union(vec![
         AttributeType::Int,
         AttributeType::StringEnum {
@@ -3443,7 +3534,9 @@ fn union_string_vs_string_enum_picks_enum_error_for_string_input() {
         },
     ]);
     let err = union_type
-        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "zzz".to_string(),
+        )))
         .unwrap_err();
     match err {
         TypeError::InvalidEnumVariant { ref expected, .. } => {
@@ -4027,9 +4120,13 @@ fn dsl_aliases_validator_accepts_dsl_spellings_only() {
         ],
     };
 
-    // Bare API spelling: REJECTED under strict mode.
+    // Bare API spelling: REJECTED under strict mode (the DSL alias
+    // rewrite invalidates the API spelling — users must type the DSL
+    // form `bucket_owner_enforced`). Phase 4 of carina#2986 carries the
+    // input as `EnumIdentifier` because the user wrote it as a bare
+    // identifier, not a quoted string.
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::String(
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "BucketOwnerEnforced".to_string(),
         )))
         .unwrap_err();
@@ -4041,21 +4138,21 @@ fn dsl_aliases_validator_accepts_dsl_spellings_only() {
 
     // Bare DSL spelling: accepted (alias).
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "bucket_owner_enforced".to_string()
         )))
         .is_ok()
     );
     // Fully-qualified API spelling: REJECTED under strict mode.
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string()
         )))
         .is_err()
     );
     // Fully-qualified DSL spelling: accepted (the awscc#199 case).
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.s3.Bucket.ObjectOwnership.bucket_owner_enforced".to_string()
         )))
         .is_ok()
@@ -4065,7 +4162,7 @@ fn dsl_aliases_validator_accepts_dsl_spellings_only() {
     // listed for context (the API spelling is what the AWS docs show,
     // the DSL spelling is what `validate` accepts).
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::String(
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "garbage".to_string(),
         )))
         .unwrap_err();
@@ -4099,8 +4196,10 @@ fn enum_without_dsl_aliases_accepts_api_spelling_as_before() {
         dsl_aliases: vec![],
     };
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String("ALL".to_string())))
-            .is_ok(),
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "ALL".to_string()
+        )))
+        .is_ok(),
         "lax mode (empty dsl_aliases) accepts API canonical"
     );
 }
@@ -4119,8 +4218,14 @@ fn dsl_aliases_diagnostic_tags_alias_entries_distinct_from_canonical() {
             ("Suspended".to_string(), "suspended".to_string()),
         ],
     };
+    // Use `EnumIdentifier` so the strict-mode validator reaches the
+    // unknown-variant branch (the alias-tagging behavior we want to
+    // pin). A `String` here would take the `StringLiteralExpectedEnum`
+    // path which is covered by sibling tests.
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::String("zzz".to_string())))
+        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "zzz".to_string(),
+        )))
         .unwrap_err();
     let TypeError::InvalidEnumVariant { expected, .. } = err else {
         panic!("expected InvalidEnumVariant");
@@ -4152,14 +4257,16 @@ fn dsl_aliases_empty_keeps_api_only_validation() {
         dsl_aliases: vec![],
     };
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String(
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "active".to_string()
         )))
         .is_ok()
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::String("nope".to_string())))
-            .is_err()
+        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "nope".to_string()
+        )))
+        .is_err()
     );
 }
 
@@ -4274,21 +4381,39 @@ mod string_enum_binding_collision {
     }
 
     #[test]
-    fn explicit_quoted_string_still_passes() {
-        // `attribute = 'vpc'` reaches the validator as a plain
-        // concrete string, unrelated to the binding-collision branch.
-        // Must validate as a normal DSL alias.
+    fn explicit_quoted_string_is_rejected() {
+        // Phase 4 of carina#2986: `attribute = "vpc"` reaches the
+        // validator as a `ConcreteValue::String` (the user wrote a
+        // quoted literal). Strict mode rejects it with
+        // `StringLiteralExpectedEnum` — the message must point users
+        // at the DSL identifier form.
         let t = flow_log_resource_type();
         let value = Value::Concrete(ConcreteValue::String("vpc".to_string()));
+        let err = t.validate(&value).unwrap_err();
+        assert!(
+            matches!(err, TypeError::StringLiteralExpectedEnum { ref user_typed, .. } if user_typed == "vpc"),
+            "expected StringLiteralExpectedEnum, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn bare_identifier_form_passes() {
+        // `attribute = vpc` (bare identifier; no binding in scope)
+        // reaches the validator as `ConcreteValue::EnumIdentifier("vpc")`
+        // — the validator resolves it against the `dsl_aliases` table
+        // for `ResourceType` and accepts.
+        let t = flow_log_resource_type();
+        let value = Value::Concrete(ConcreteValue::EnumIdentifier("vpc".to_string()));
         assert!(t.validate(&value).is_ok());
     }
 
     #[test]
     fn fully_qualified_form_still_passes() {
         // `attribute = awscc.ec2.FlowLog.ResourceType.vpc` reaches the
-        // validator as a concrete string in fully-qualified form.
+        // validator as `ConcreteValue::EnumIdentifier` (carina#2986
+        // Phase 3 parser routing).
         let t = flow_log_resource_type();
-        let value = Value::Concrete(ConcreteValue::String(
+        let value = Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.ec2.FlowLog.ResourceType.vpc".to_string(),
         ));
         assert!(t.validate(&value).is_ok());

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -217,12 +217,26 @@ fn is_intermediate_segment(s: &str) -> bool {
 /// Used by both `AttributeType::resolve_value` and the LSP diagnostic
 /// pipeline so the two paths cannot drift.
 pub fn expand_enum_shorthand(value: &Value, name: &str, namespace: Option<&str>) -> Value {
-    match value {
-        Value::Concrete(ConcreteValue::String(s)) if !s.contains('.') => match namespace {
+    // Phase 4 of carina#2986: `EnumIdentifier` carries the same textual
+    // payload as `String` (only the source-shape tag differs) and goes
+    // through the same namespace expansion. The result is materialized as
+    // `String` because every downstream consumer
+    // (`validate_string_enum`, the LSP completion helpers, the
+    // builtin-result coercion in `convert_enum_value`) reads through the
+    // `Value::Concrete(ConcreteValue::String)` arm. The `EnumIdentifier`
+    // distinction is a parser-level signal used for strict shape
+    // enforcement at the validator entry, not a wire-level form.
+    let text_form: Option<&str> = match value {
+        Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.as_str()),
+        _ => None,
+    };
+    match text_form {
+        Some(s) if !s.contains('.') => match namespace {
             Some(ns) => Value::Concrete(ConcreteValue::String(format!("{}.{}.{}", ns, name, s))),
-            None => value.clone(),
+            None => Value::Concrete(ConcreteValue::String(s.to_string())),
         },
-        Value::Concrete(ConcreteValue::String(s)) => {
+        Some(s) => {
             if let Some(NamespacedId::TypeQualified {
                 type_name: ident,
                 value: member,
@@ -235,10 +249,10 @@ pub fn expand_enum_shorthand(value: &Value, name: &str, namespace: Option<&str>)
                     ns, ident, member
                 )))
             } else {
-                value.clone()
+                Value::Concrete(ConcreteValue::String(s.to_string()))
             }
         }
-        other => other.clone(),
+        None => value.clone(),
     }
 }
 

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -283,9 +283,14 @@ fn list_item_type_validation() {
         Arc::new(vec![]),
     );
 
+    // Use bare identifiers (`tcp`, `invalid_protocol`) rather than
+    // quoted strings — under carina#2986 strict mode, an enum attribute
+    // requires the identifier shape. The list is otherwise valid and
+    // the `invalid_protocol` item should surface as
+    // `InvalidEnumVariant`.
     let doc = create_document(
         r#"let r = test.list.resource {
-protocols = ["tcp", "invalid_protocol"]
+protocols = [tcp, invalid_protocol]
 }"#,
     );
 


### PR DESCRIPTION
## Summary

Builds on Phase 1+2 (#2989) to turn the `ConcreteValue::EnumIdentifier` variant into a load-bearing distinction between **enum identifier** and **string literal** across the parser, validator, and differ. Design: `notes/specs/2026-05-12-strict-enum-identifier-design.md` (#2988).

This is the behavior change: `attr = "value"` (quoted string) is now rejected on every `StringEnum`-typed attribute, and the rejection emits the `StringLiteralExpectedEnum` diagnostic with a structured `expected` payload the LSP code action can consume.

## What lands in this PR

### Phase 3 — parser routing
- `parse_namespaced_id_value` emits `EnumIdentifier(full_str)` for dotted shorthands (`aws.Region.ap_northeast_1`, `awscc.ec2.vpn_gateway.Type.ipsec.1`)
- `variable_ref` arm emits `EnumIdentifier(name)` for bare identifiers that are neither known variables nor known resource bindings. Binding precedence is preserved by the earlier `get_variable` arm.
- `for_expr` accepts `EnumIdentifier` as the bare-iterable shape alongside the historical `String`, so the post-#2101 deferred-for path still reaches `check_identifier_scope`'s did-you-mean machinery
- `directives.depends_on` accepts `EnumIdentifier` list elements as bare binding identifiers, matching the existing `BindingRef` / `${name}` arms

### Phase 4 — validator strict mode
- `validate_string_enum` rejects `ConcreteValueRef::String` with `TypeError::StringLiteralExpectedEnum`, populating the structured `expected` slot directly so LSP code actions get the same payload they used to get via post-hoc reshape
- `expand_enum_shorthand` accepts both `String` and `EnumIdentifier` inputs and always materializes to `String` so every downstream consumer keeps a single shape to match on
- `union_member_score` recognizes `EnumIdentifier` as a same-tier match for `StringEnum` so the closest-member error from #2219 still surfaces under strict mode
- `validate_custom_type` / `provider_context_lookup` accept `EnumIdentifier` alongside `String`, since shape-strictness for namespaced Custom types is enforced at the surface (CLI / LSP) layer

### Phase 5 — round-trip equality
- `PartialEq for Value` treats `String(s) == EnumIdentifier(s)` when the carried text matches. The variant tag is preserved for pattern-matching sites, but value-tree comparison cannot diverge — otherwise every provider `read` (which always emits plain JSON strings on the WIT boundary) would produce a phantom diff against the desired-side identifier form.
- `type_aware_equal` in the differ accepts the cross-shape pair on `StringEnum` attributes
- `is_type_default` accepts the empty `EnumIdentifier` the same as empty `String` for `StringEnum`

## Follow-ups (separate issues / PRs)
- **Phase 6 — provider fixture sweep**: `carina-provider-aws/acceptance-tests/**/*.crn` and `carina-provider-awscc/acceptance-tests/**/*.crn` still contain quoted-string forms for enum attributes. With this PR merged, those start failing validation and need rewriting to identifier form. To be filed as aws / awscc tracker issues after merge.
- **Phase 7 — LSP code action UX**: the diagnostic data shape carried by `StringLiteralExpectedEnum` is already structured; the corresponding "drop quotes" code action UX can be tightened in a follow-up. Not blocking.

## Test plan

- [x] `cargo nextest run --workspace --no-fail-fast` — 3228 passed, 74 skipped, 1 leaky
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] All `scripts/check-*.sh` — pass
- New regression tests:
  - `validate_string_enum_rejects_quoted_string_literal`
  - `explicit_quoted_string_is_rejected`
  - `bare_identifier_form_passes`
  - `parse_bare_identifier_becomes_enum_identifier`

Refs #2986.