### PR TITLE
plugin-host: bump StoreLimits.table_elements 20000 → 65536 (#2993)

### DIFF
--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -598,12 +598,16 @@ impl WasmBindings {
 ///
 /// * 256 MB max linear memory – the AWSCC provider uses ~45 MB for
 ///   `validate`, so this gives plenty of headroom.
-/// * 20 000 table elements.
+/// * 65 536 table elements. The aws provider's WASM table grew past
+///   the previous 20 000 ceiling once `aws-sdk-sqs` was linked in
+///   (#2993); pick a wide value so similar additions don't hit the
+///   limit again. Cost is metadata-only — wasmtime allocates table
+///   slots lazily.
 /// * 10 component instances.
 fn build_store_limits() -> StoreLimits {
     StoreLimitsBuilder::new()
         .memory_size(256 * 1024 * 1024) // 256 MB
-        .table_elements(20_000)
+        .table_elements(65_536)
         .instances(10)
         .build()
 }
@@ -1817,11 +1821,11 @@ mod tests {
                 .unwrap()
         );
 
-        // table_growing: requesting up to 20_000 elements should succeed
-        assert!(limits.table_growing(0, 20_000, None).unwrap());
+        // table_growing: requesting up to 65_536 elements should succeed
+        assert!(limits.table_growing(0, 65_536, None).unwrap());
 
-        // table_growing: requesting beyond 20_000 should be denied
-        assert!(!limits.table_growing(0, 20_001, None).unwrap());
+        // table_growing: requesting beyond 65_536 should be denied
+        assert!(!limits.table_growing(0, 65_537, None).unwrap());
 
         // instances: should be capped at 10
         assert_eq!(limits.instances(), 10);


### PR DESCRIPTION
## Summary

Closes #2993.

`carina-plugin-host` hard-codes `StoreLimits::table_elements(20_000)` for every WASM plugin store. Adding `aws-sdk-sqs = "1"` to `carina-provider-aws` (for `carina-rs/carina-provider-aws#280`) pushes the aws provider WASM's table requirement to **21,160 elements**, exceeding the previous cap. Result: `carina apply` against any aws fixture in that branch fails to instantiate the provider:

```
table minimum size of 21160 elements exceeds table limits
```

This PR raises the cap to **65,536** (2^16, leaves ~3× headroom for future SDK growth). The wasmtime cost is metadata-only — `StoreLimitsBuilder::table_elements` is an upper bound enforced lazily at `table.grow` time via `ResourceLimiter::table_growing`, not a pre-allocation.

## Scope / blast radius

- `build_store_limits` is **private** (module-private `fn`, no `pub`). No public API change.
- Existing provider WASM ABI is identical (WIT contract untouched). Cached provider artifacts continue to load.
- aws#280 only needs a `Cargo.toml` carina rev bump after this merges — no call-site updates, no plugin-SDK rebuild.
- 256MB memory limit and 10-instance cap are untouched.

## Test plan

- [x] `cargo nextest run -p carina-plugin-host` — 79/79 pass (boundary test updated to match new threshold)
- [x] `cargo nextest run --workspace` — 3228 pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all green
- [x] Workspace-wide grep for stale `20_000` / `table_elements` references — only the modified lines

## Out of scope

- Tightening other `StoreLimits` knobs (memory_size, instances).
- Auditing whether 65,536 is "right" long-term — this is a one-shot raise to unblock #280. If the table grows again, raise again.
