### PR TITLE
differ: apply dsl_aliases when comparing StringEnum values (refs aws#271)

### DIFF
--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -142,14 +142,21 @@ pub(super) fn type_aware_equal(
             // enum-typed attribute whose value flowed through a provider
             // `read`. Comparison is text-based and case-insensitive on
             // the enum value, matching the existing String × String arm.
-            (a, b, AttributeType::StringEnum { values, .. })
-                if matches!(
-                    a,
-                    Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
-                ) && matches!(
-                    b,
-                    Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
-                ) =>
+            (
+                a,
+                b,
+                AttributeType::StringEnum {
+                    values,
+                    dsl_aliases,
+                    ..
+                },
+            ) if matches!(
+                a,
+                Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
+            ) && matches!(
+                b,
+                Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
+            ) =>
             {
                 let text = |v: &Value| -> Option<String> {
                     match v {
@@ -167,7 +174,25 @@ pub(super) fn type_aware_equal(
                 let valid_values: Vec<&str> = values.iter().map(String::as_str).collect();
                 let va = crate::utils::extract_enum_value_with_values(&sa, &valid_values);
                 let vb = crate::utils::extract_enum_value_with_values(&sb, &valid_values);
-                va.eq_ignore_ascii_case(vb)
+                // Map both sides through the DSL alias table to a common
+                // (API-canonical) form before comparing. `eq_ignore_ascii_case`
+                // alone suffices when the DSL alias differs only in case
+                // from the API canonical (`enabled` vs `Enabled`), but it
+                // fails on compound-word aliases like
+                // `bucket_owner_enforced` vs `BucketOwnerEnforced` — same
+                // enum value, different spelling. Aligning both sides to
+                // the API spelling closes that gap (aws#271).
+                let canonical = |trailing: &str| -> String {
+                    // dsl_aliases is `[(api, dsl)]`; if `trailing` matches
+                    // the DSL spelling, swap it for the API spelling.
+                    for (api, dsl) in dsl_aliases {
+                        if dsl.eq_ignore_ascii_case(trailing) {
+                            return api.clone();
+                        }
+                    }
+                    trailing.to_string()
+                };
+                canonical(va).eq_ignore_ascii_case(&canonical(vb))
             }
 
             // Custom types with base type: delegate to base

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -1323,3 +1323,72 @@ fn diff_false_positive_when_ordered_true_for_struct_list() {
         result
     );
 }
+
+/// Regression for aws#271: enum DSL alias (snake_case) and API canonical
+/// (PascalCase compound) must compare equal under StringEnum even when
+/// `eq_ignore_ascii_case` alone is not enough.
+///
+/// Scenario: BucketOwnershipControls.object_ownership — state stores
+/// `aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced`
+/// (after normalize_state_enums applies the snake_case dsl_alias) and
+/// desired arrives as `BucketOwnerEnforced` (the API-canonical form
+/// after resolve_enum_identifiers' pass-2 api-canonicalize). The two
+/// name the same enum value, so the differ must see NoChange.
+#[test]
+fn diff_no_change_for_compound_word_dsl_alias() {
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let schema =
+        ResourceSchema::new("aws.s3.BucketOwnershipControls").attribute(AttributeSchema::new(
+            "object_ownership",
+            AttributeType::StringEnum {
+                name: "ObjectOwnership".to_string(),
+                values: vec![
+                    "BucketOwnerEnforced".to_string(),
+                    "BucketOwnerPreferred".to_string(),
+                    "ObjectWriter".to_string(),
+                ],
+                namespace: Some("aws.s3.BucketOwnershipControls".to_string()),
+                dsl_aliases: vec![
+                    (
+                        "BucketOwnerEnforced".to_string(),
+                        "bucket_owner_enforced".to_string(),
+                    ),
+                    (
+                        "BucketOwnerPreferred".to_string(),
+                        "bucket_owner_preferred".to_string(),
+                    ),
+                    ("ObjectWriter".to_string(), "object_writer".to_string()),
+                ],
+            },
+        ));
+
+    // Desired: API-canonical bare spelling (output of pass-2 in
+    // AwsNormalizer::resolve_enum_identifiers).
+    let desired = Resource::with_provider("aws", "s3.BucketOwnershipControls", "test")
+        .with_attribute(
+            "object_ownership",
+            Value::Concrete(ConcreteValue::String("BucketOwnerEnforced".to_string())),
+        );
+
+    // Current state: fully-qualified namespaced DSL form with snake_case
+    // alias (output of normalize_state_enums).
+    let mut attrs = HashMap::new();
+    attrs.insert(
+        "object_ownership".to_string(),
+        Value::Concrete(ConcreteValue::String(
+            "aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced".to_string(),
+        )),
+    );
+    let current = State::existing(
+        ResourceId::with_provider("aws", "s3.BucketOwnershipControls", "test"),
+        attrs,
+    );
+
+    let result = diff(&desired, &current, None, None, Some(&schema));
+    assert!(
+        matches!(result, Diff::NoChange(_)),
+        "Expected NoChange (DSL alias must equal API canonical), got: {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary

The `StringEnum` equality path in `type_aware_equal` extracted the trailing enum segment and compared with `eq_ignore_ascii_case`. That suffices for case-only differences (`enabled` vs `Enabled`), but fails on compound-word aliases where the *spelling itself* differs:

```
state    aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced
desired  BucketOwnerEnforced
```

After trailing-segment extraction:
```
"bucket_owner_enforced".eq_ignore_ascii_case("BucketOwnerEnforced") = false
```

— same enum value, different spelling, false negative.

This PR applies the `StringEnum`'s own `dsl_aliases` table to both sides before the case-insensitive compare, mapping DSL spellings back to the API spelling. Resources with no aliases (or where both sides are already API-canonical) are unaffected.

## Why this surfaces now

`aws.s3.BucketOwnershipControls` and `aws.s3.BucketAcl` exhibit the failure as `plan-verify` diffs after `apply` — the state stores the snake_case-aliased namespaced DSL form (via `normalize_state_enums`), while `desired` arrives as the API-canonical bare spelling (via `AwsNormalizer::resolve_enum_identifiers`). These two flows have always produced different strings for compound-word aliases; the case-insensitive comparator just happened to paper over the simpler cases.

## Tests

Added `diff_no_change_for_compound_word_dsl_alias` reproducing the exact aws#271 scenario:
- state: `aws.s3.BucketOwnershipControls.ObjectOwnership.bucket_owner_enforced`
- desired: `BucketOwnerEnforced`

Expected: `Diff::NoChange`. The new test fails on `main` and passes on this branch.

Workspace test sweep: 3229/3229 pass; doctests pass; clippy clean; all `scripts/check-*.sh` pass.

## Refs

- Refs carina-rs/carina-provider-aws#271 — BucketOwnershipControls / BucketAcl post-apply idempotency. The provider side still needs a separate fix for BucketAcl's grant-list reverse lookup (state has `(none)` because the read path skips writing `acl` entirely); this PR fixes the comparator gap that affects every StringEnum with compound-word aliases.

## Test plan

- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] New regression test asserts the previously-broken case
