### PR TITLE
schema: accept bare-identifier map keys for Map<StringEnum, V>

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1155,10 +1155,21 @@ impl AttributeType {
                 got: value.type_name().to_string(),
             });
         };
-        // Validate keys against key type
+        // carina#2996: map-literal grammar is `(identifier | string) "="
+        // expression`, and both shapes lower to the same `String` key by
+        // the time we see them. For `StringEnum` keys, lift the key into
+        // `EnumIdentifier` form so the strict carina#2986 validator
+        // accepts it — there is no other syntax for writing an enum-
+        // shaped map key.
+        let key_is_enum = matches!(key_type.as_ref(), AttributeType::StringEnum { .. });
         for k in map.keys() {
+            let key_value = if key_is_enum {
+                Value::Concrete(ConcreteValue::EnumIdentifier(k.clone()))
+            } else {
+                Value::Concrete(ConcreteValue::String(k.clone()))
+            };
             key_type
-                .validate(&Value::Concrete(ConcreteValue::String(k.clone())))
+                .validate(&key_value)
                 .map_err(|e| TypeError::MapKeyError {
                     key: k.clone(),
                     inner: Box::new(e),

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -4502,3 +4502,81 @@ mod dsl_map_api_for {
         assert_eq!(map.api_for("bar"), "Foo");
     }
 }
+
+// carina#2996: `Map<StringEnum, V>` bare-identifier key acceptance.
+fn condition_operator_map(value: AttributeType) -> AttributeType {
+    AttributeType::Map {
+        key: Box::new(AttributeType::StringEnum {
+            name: "ConditionOperator".to_string(),
+            values: vec![
+                "string_equals".to_string(),
+                "string_not_equals".to_string(),
+                "arn_like".to_string(),
+            ],
+            namespace: Some("aws.iam.ConditionOperator".to_string()),
+            dsl_aliases: vec![],
+        }),
+        value: Box::new(value),
+    }
+}
+
+fn map_value_with_one_key(key: &str) -> Value {
+    let mut inner: IndexMap<String, Value> = IndexMap::new();
+    inner.insert(
+        key.to_string(),
+        Value::Concrete(ConcreteValue::String("v".to_string())),
+    );
+    Value::Concrete(ConcreteValue::Map(inner))
+}
+
+#[test]
+fn validate_map_with_string_enum_key_accepts_bare_identifier_spelling() {
+    let map_t = condition_operator_map(AttributeType::String);
+    let val = map_value_with_one_key("string_equals");
+    assert!(
+        map_t.validate(&val).is_ok(),
+        "bare-identifier map key for Map<StringEnum, V> must be accepted: {:?}",
+        map_t.validate(&val)
+    );
+}
+
+#[test]
+fn validate_map_with_string_enum_key_accepts_dsl_alias_spelling() {
+    // `IpProtocol` has a `("-1", "all")` alias: DSL must accept `all`
+    // both at attribute-value position (already covered) and at
+    // map-key position when used as `Map<StringEnum<IpProtocol>, V>`.
+    let map_t = AttributeType::Map {
+        key: Box::new(AttributeType::StringEnum {
+            name: "IpProtocol".to_string(),
+            values: vec!["tcp".to_string(), "-1".to_string()],
+            namespace: Some("awscc.ec2.SecurityGroup".to_string()),
+            dsl_aliases: vec![("-1".to_string(), "all".to_string())],
+        }),
+        value: Box::new(AttributeType::String),
+    };
+    let val = map_value_with_one_key("all");
+    assert!(
+        map_t.validate(&val).is_ok(),
+        "DSL-alias map key spelling must be accepted: {:?}",
+        map_t.validate(&val)
+    );
+}
+
+#[test]
+fn validate_map_with_string_enum_key_rejects_unknown_variant() {
+    let map_t = condition_operator_map(AttributeType::String);
+    let val = map_value_with_one_key("not_a_variant");
+    // The diagnostic must surface as `MapKeyError(InvalidEnumVariant)`,
+    // not the `StringLiteralExpectedEnum` shape that misled the user
+    // in carina#2996.
+    match map_t.validate(&val).unwrap_err() {
+        TypeError::MapKeyError { key, inner } => {
+            assert_eq!(key, "not_a_variant");
+            assert!(
+                matches!(*inner, TypeError::InvalidEnumVariant { .. }),
+                "expected InvalidEnumVariant inside MapKeyError, got: {inner:?}"
+            );
+        }
+        other => panic!("expected MapKeyError, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Lift map-literal keys to `ConcreteValue::EnumIdentifier` form when the schema's `key_type` is a `StringEnum`, so the strict carina#2986 validator accepts bare-identifier map keys.

Closes #2996

## Why

The map-literal grammar `(identifier | string) "=" expression` collapses both shapes into a `String` key by the time `validate_map` sees them. carina#2986 then rejects every `ConcreteValue::String` reaching `validate_string_enum`, with a `StringLiteralExpectedEnum` diagnostic that points the user at the exact spelling they already wrote:

```
ConditionOperator expects an enum identifier,
got a string literal "string_equals".
Use one of: string_equals, string_not_equals, ...
```

In real DSL this blocked every IAM policy `condition` block (`string_equals = { ... }`, `arn_like = { ... }`, etc.). The user's `carina-rs/infra/usecases/bootstrap/main.crn` could not validate.

## What

`carina-core/src/schema/mod.rs:1158-1177` — `validate_map` now checks `key_type` once before iterating keys and wraps each key as `EnumIdentifier` (for `StringEnum` keys) or `String` (otherwise). Six lines of comment record the WHY.

This matches Option 1 from issue #2995's discussion (the cleaner, strict-aligned path). Option 2 (relax the validator to accept enum-alias strings) was rejected because it would re-introduce the heuristic carina#2986 just removed.

## Tests

3 new unit tests in `carina-core/src/schema/tests.rs`:
- `validate_map_with_string_enum_key_accepts_bare_identifier_spelling`
- `validate_map_with_string_enum_key_accepts_dsl_alias_spelling` (IpProtocol `("-1", "all")` alias)
- `validate_map_with_string_enum_key_rejects_unknown_variant` — pins the error shape to `MapKeyError(InvalidEnumVariant)` so a future regression to `StringLiteralExpectedEnum` would be caught.

## Verification

- `cargo nextest run -p carina-core`: 1950 passed
- `cargo nextest run --workspace`: 3232 passed
- `cargo test --workspace --doc`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `bash scripts/check-*.sh` (all 5): pass
- Real-infra smoke: `carina validate carina-rs/infra/usecases/bootstrap` now succeeds (`✓ 5 resources validated successfully.`) where it previously failed on the IAM `condition` block.

## Follow-up

5-round review surfaced a parallel gap on the differ side: `differ::type_aware_maps_equal` compares `Map<StringEnum, V>` keys as raw strings without `dsl_aliases` canonicalization, mirroring what carina#2997/aws#271 just fixed for enum **values**. Filed as #2998 — out of scope here.
