### PR TITLE
parser: accept let <name> = provider <kind> { ... } (#2191 Phase 2)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -595,8 +595,9 @@ mod tests {
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
         });
-
         let base_dir = std::path::Path::new("/tmp/nonexistent-carina-test");
         let result = validate_and_resolve_with_config(&mut parsed, base_dir, false);
 
@@ -628,8 +629,9 @@ mod tests {
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
         });
-
         let base_dir = std::path::Path::new("/tmp/nonexistent-carina-test");
         let result = validate_and_resolve_with_config(&mut parsed, base_dir, false);
 

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -316,6 +316,8 @@ fn plan_file_serde_round_trip() {
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
         }],
         backend_config: Some(BackendConfig {
             backend_type: "s3".to_string(),
@@ -601,6 +603,8 @@ fn make_awscc_provider(region_dsl: &str) -> ProviderConfig {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }
 }
 

--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -270,6 +270,12 @@ upstream_state_expr = {
     kw_upstream_state ~ trivia* ~ open_brace ~ block_content* ~ close_brace
 }
 
+// Provider expression: provider <kind> { ... }
+// Used as the RHS of a `let` binding to declare a named provider instance.
+provider_expr = {
+    kw_provider ~ trivia+ ~ identifier ~ trivia* ~ open_brace ~ block_content* ~ close_brace
+}
+
 // Wait expression: wait <target> { until = ..., depends_on = [...], timeout = ... }
 // Mirrors carina.pest:wait_expr. The body is a sequence of `wait_attr`
 // terms; the formatter walks them with the same one-attribute-per-line
@@ -300,6 +306,7 @@ primary = {
     read_resource_expr
   | wait_expr
   | upstream_state_expr
+  | provider_expr        // must precede module_call-like fallbacks
   | resource_expr
   | for_expr
   | if_expr

--- a/carina-core/src/formatter/cst.rs
+++ b/carina-core/src/formatter/cst.rs
@@ -77,6 +77,7 @@ pub enum NodeKind {
     ResourceExpr,
     ReadResourceExpr,
     UpstreamStateExpr,
+    ProviderExpr,
     WaitExpr,
     WaitAttr,
     WaitUntilAttr,

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -169,6 +169,9 @@ impl<'a> CstBuilder<'a> {
             Rule::upstream_state_expr => Some(CstChild::Node(
                 self.build_node(NodeKind::UpstreamStateExpr, pair),
             )),
+            Rule::provider_expr => Some(CstChild::Node(
+                self.build_node(NodeKind::ProviderExpr, pair),
+            )),
             Rule::wait_expr => Some(CstChild::Node(self.build_node(NodeKind::WaitExpr, pair))),
             Rule::wait_attr => Some(CstChild::Node(self.build_node(NodeKind::WaitAttr, pair))),
             Rule::wait_until_attr => Some(CstChild::Node(

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -196,6 +196,7 @@ impl Formatter {
             NodeKind::ResourceExpr => self.format_resource_expr(node),
             NodeKind::ReadResourceExpr => self.format_read_resource_expr(node),
             NodeKind::UpstreamStateExpr => self.format_upstream_state_expr(node),
+            NodeKind::ProviderExpr => self.format_provider_expr(node),
             NodeKind::FnDef => self.format_fn_def(node),
             NodeKind::FnParam => self.format_default(node),
             NodeKind::ForExpr => self.format_for_expr(node),
@@ -1687,6 +1688,29 @@ require   port >= 1 && port <= 65535  , "port must be valid"
             "discard pattern `_` must survive formatting. Got:\n{}",
             result
         );
+    }
+
+    /// `let <name> = provider <kind> { ... }` round-trips through the
+    /// formatter without losing the keyword, kind, or body, and is
+    /// idempotent on a second pass.
+    #[test]
+    fn test_format_provider_expr_named_instance() {
+        let input = "let us = provider aws {\n    region = 'us-east-1'\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert!(
+            result.contains("let us = provider aws"),
+            "named provider instance header must be preserved. Got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("region = 'us-east-1'"),
+            "body attribute must be preserved. Got:\n{}",
+            result
+        );
+        // Idempotent.
+        let second = format(&result, &config).unwrap();
+        assert_eq!(result, second, "format must be idempotent");
     }
 
     /// Idempotence for both constructs above.

--- a/carina-core/src/formatter/rules/provider.rs
+++ b/carina-core/src/formatter/rules/provider.rs
@@ -57,4 +57,22 @@ impl Formatter {
         self.write("}");
         self.write_newline();
     }
+
+    /// Format `provider <kind> { ... }` when it appears as the RHS of a
+    /// `let` binding. The surrounding `let` formatter has already emitted
+    /// the indent and `let name = ` prefix, so this only emits the
+    /// keyword, kind identifier, and block body.
+    pub(in crate::formatter) fn format_provider_expr(&mut self, node: &CstNode) {
+        self.write("provider ");
+        for child in &node.children {
+            if let CstChild::Token(token) = child
+                && self.is_identifier(&token.text)
+                && token.text != "provider"
+            {
+                self.write_token(&token.text);
+                break;
+            }
+        }
+        self.format_block_body_tail(node);
+    }
 }

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -213,6 +213,8 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -405,6 +407,8 @@ fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -458,6 +462,8 @@ fn test_anonymous_resource_no_create_only_properties() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -495,6 +501,8 @@ fn test_anonymous_resource_no_create_only_deterministic() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -530,6 +538,8 @@ fn test_anonymous_resource_no_create_only_collision() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -577,6 +587,8 @@ fn test_identity_attribute_prevents_collision() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -706,6 +718,8 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -815,6 +829,8 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1000,6 +1016,8 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1108,6 +1126,8 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1171,6 +1191,8 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1232,6 +1254,8 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1330,6 +1354,8 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1373,6 +1399,8 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1561,6 +1589,8 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -2212,6 +2242,8 @@ fn anonymous_identifier_includes_provider_prefix() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -2248,6 +2280,8 @@ fn anonymous_identifier_provider_prefix_for_aws_provider() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -2280,6 +2314,8 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -430,6 +430,25 @@ pub struct ProviderConfig {
     /// empty after finalization. In-memory transit only — never serialized.
     #[serde(skip)]
     pub unresolved_attributes: IndexMap<String, Value>,
+    /// `let` binding name when this entry was declared as a named instance
+    /// via `let <name> = provider <kind> { ... }`. `None` for the default
+    /// instance produced by a top-level `provider <kind> { ... }` block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding: Option<String>,
+    /// True when this entry is the kind's default instance (sourced from a
+    /// top-level `provider <kind> { ... }` block). False for named instances.
+    /// Resources without an explicit provider directive resolve to the
+    /// kind's default instance.
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    pub is_default: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn is_true(b: &bool) -> bool {
+    *b
 }
 
 /// Backend configuration for state storage

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -338,6 +338,7 @@ pub(in crate::parser) fn extract_directives(
                 create_before_destroy,
                 prevent_destroy,
                 depends_on,
+                ..Directives::default()
             });
         }
     }

--- a/carina-core/src/parser/blocks/provider.rs
+++ b/carina-core/src/parser/blocks/provider.rs
@@ -105,7 +105,51 @@ pub(in crate::parser) fn parse_provider_block(
         version,
         revision,
         unresolved_attributes,
+        binding: None,
+        is_default: true,
     })
+}
+
+/// Parse a `provider <kind> { ... }` expression used as the RHS of a
+/// `let` binding. `source` / `version` / `revision` describe **how to
+/// load** the provider plugin and are properties of the kind, not of
+/// an individual instance — declaring them on a named instance would
+/// invite divergent plugin versions per instance, so they are rejected
+/// here in favour of the single top-level `provider <kind>` block.
+pub(in crate::parser) fn parse_provider_expr(
+    pair: pest::iterators::Pair<Rule>,
+    ctx: &ParseContext,
+    binding_name: &str,
+) -> Result<ProviderConfig, ParseError> {
+    let mut config = parse_provider_block(pair, ctx)?;
+
+    let kind_level_present: &[(&str, bool)] = &[
+        ("source", config.source.is_some()),
+        ("version", config.version.is_some()),
+        ("revision", config.revision.is_some()),
+    ];
+    for (field, present) in kind_level_present {
+        if *present {
+            return Err(reject_kind_level_attr(field, binding_name, &config.name));
+        }
+    }
+
+    config.binding = Some(binding_name.to_string());
+    config.is_default = false;
+    Ok(config)
+}
+
+fn reject_kind_level_attr(field: &str, binding: &str, kind: &str) -> ParseError {
+    ParseError::Syntax(pest::error::Error::new_from_pos(
+        pest::error::ErrorVariant::CustomError {
+            message: format!(
+                "'{field}' is a kind-level attribute and cannot be set on \
+                 a named provider instance '{binding}'. Move it to the \
+                 top-level `provider {kind}` block."
+            ),
+        },
+        pest::Position::from_start(""),
+    ))
 }
 
 /// Parse a require statement: `require <validate_expr>, "error message"`

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -187,6 +187,13 @@ provider_block = {
     "provider" ~ identifier ~ "{" ~ attribute* ~ "}"
 }
 
+// Provider expression: `let <name> = provider <kind> { ... }`. Must be
+// listed in `primary` before `module_call`, otherwise `provider aws { ... }`
+// would silently parse as a module call whose name is `provider`.
+provider_expr = {
+    "provider" ~ identifier ~ "{" ~ attribute* ~ "}"
+}
+
 // Variable/resource definition: let name = value
 // discard_pattern allows `let _ = expr` to suppress unused binding warnings
 // `use_expr` is allowed only here (not in `expression`/`primary`) because it is
@@ -247,6 +254,7 @@ primary = {
     read_resource_expr   // Must come before resource_expr for "read aws..." parsing
   | wait_expr            // Must come before module_call so "wait <target> { ... }" is not parsed as a module call
   | upstream_state_expr  // Must come before module_call so "upstream_state { ... }" is not parsed as a module call
+  | provider_expr        // Must come before module_call so "provider <kind> { ... }" is not parsed as a module call
   | resource_expr
   | for_expr             // Must come before module_call so "for" is not parsed as module name
   | if_expr              // Must come before module_call so "if" is not parsed as module name

--- a/carina-core/src/parser/context.rs
+++ b/carina-core/src/parser/context.rs
@@ -4,7 +4,7 @@
 //!
 //! Extracted from `parser/mod.rs` per #2263 (part 2/2).
 
-use super::ast::{DeferredForExpression, UpstreamState, UserFunction, WaitBinding};
+use super::ast::{DeferredForExpression, ProviderConfig, UpstreamState, UserFunction, WaitBinding};
 use super::error::{ParseError, ParseWarning};
 use super::{ProviderContext, Rule};
 use crate::eval_value::EvalValue;
@@ -39,6 +39,10 @@ pub(crate) struct ParseContext<'cfg> {
     /// `wait` bindings declared via `let <name> = wait <target> { ... }`
     /// (binding_name -> WaitBinding).
     pub(super) wait_bindings: HashMap<String, WaitBinding>,
+    /// Named provider instances declared via
+    /// `let <name> = provider <kind> { ... }`. Drained into
+    /// `ParsedFile.providers` by the top-level parse loop.
+    pub(super) named_provider_instances: Vec<ProviderConfig>,
     /// Non-fatal warnings collected during parsing
     pub(super) warnings: Vec<ParseWarning>,
     /// Deferred for-expressions collected during parsing
@@ -63,6 +67,7 @@ impl<'cfg> ParseContext<'cfg> {
             structural_bindings: HashSet::new(),
             upstream_states: HashMap::new(),
             wait_bindings: HashMap::new(),
+            named_provider_instances: Vec::new(),
             warnings: Vec::new(),
             deferred_for_expressions: Vec::new(),
             seeded_bindings: HashSet::new(),

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -221,6 +221,10 @@ pub fn parse_with_seeded_bindings(
                                 let is_discard = name == "_";
                                 let is_upstream_state = ctx.upstream_states.contains_key(&name);
                                 let is_wait_binding = ctx.wait_bindings.contains_key(&name);
+                                let is_provider_instance = ctx
+                                    .named_provider_instances
+                                    .iter()
+                                    .any(|p| p.binding.as_deref() == Some(&name));
                                 if !is_discard {
                                     // A seeded placeholder (from a sibling-file
                                     // declaration during the directory-aware
@@ -239,15 +243,18 @@ pub fn parse_with_seeded_bindings(
                                     if shadows_seed {
                                         ctx.unmark_seeded(&name);
                                     }
-                                    if is_upstream_state || is_wait_binding {
-                                        // upstream_state and wait lets do not bind a
-                                        // user-facing value; the binding name
-                                        // resolves through `resource_bindings`
-                                        // as a forward reference. When a seed
-                                        // pre-installed a placeholder under
-                                        // this name, drop it so the ParsedFile
-                                        // we hand back doesn't leak the seeded
-                                        // `ResourceRef` into downstream walkers
+                                    if is_upstream_state || is_wait_binding || is_provider_instance
+                                    {
+                                        // upstream_state, wait, and named provider
+                                        // instance lets do not bind a user-facing
+                                        // value; the binding name is consumed by a
+                                        // dedicated side-channel (`upstream_states`,
+                                        // `wait_bindings`, `providers`) and would
+                                        // collide downstream if also stored as a
+                                        // regular variable. When a seed pre-installed
+                                        // a placeholder under this name, drop it so
+                                        // the ParsedFile we hand back doesn't leak the
+                                        // seeded `ResourceRef` into downstream walkers
                                         // (#2817).
                                         if shadows_seed {
                                             ctx.variables.shift_remove(&name);
@@ -317,6 +324,8 @@ pub fn parse_with_seeded_bindings(
             }
         }
     }
+
+    providers.extend(std::mem::take(&mut ctx.named_provider_instances));
 
     // Second pass: resolve forward references.
     // During parsing, unknown 2-part identifiers (e.g., vpc.vpc_id where vpc is

--- a/carina-core/src/parser/let_binding.rs
+++ b/carina-core/src/parser/let_binding.rs
@@ -9,6 +9,7 @@ use super::Rule;
 use super::ast::{ModuleCall, UseStatement};
 use super::blocks::backend::parse_upstream_state_expr;
 use super::blocks::module_call::parse_module_call;
+use super::blocks::provider::parse_provider_expr;
 use super::blocks::resource::{parse_read_resource_expr, parse_resource_expr};
 use super::blocks::use_stmt::parse_use_expr;
 use super::context::{ParseContext, first_inner, next_pair};
@@ -321,6 +322,24 @@ fn parse_primary_with_resource_or_module(
                 });
             }
             ctx.upstream_states.insert(us.binding.clone(), us);
+            let ref_value =
+                Value::Concrete(ConcreteValue::String(format!("${{{}}}", binding_name)));
+            Ok((EvalValue::from_value(ref_value), vec![], vec![], None))
+        }
+        Rule::provider_expr => {
+            let (line, _) = inner.as_span().start_pos().line_col();
+            let config = parse_provider_expr(inner, ctx, binding_name)?;
+            if ctx
+                .named_provider_instances
+                .iter()
+                .any(|p| p.binding.as_deref() == Some(binding_name))
+            {
+                return Err(ParseError::DuplicateBinding {
+                    name: binding_name.to_string(),
+                    line,
+                });
+            }
+            ctx.named_provider_instances.push(config);
             let ref_value =
                 Value::Concrete(ConcreteValue::String(format!("${{{}}}", binding_name)));
             Ok((EvalValue::from_value(ref_value), vec![], vec![], None))

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2567,6 +2567,8 @@ fn provider_config_carries_unresolved_attributes_field() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     };
     assert!(pc.unresolved_attributes.is_empty());
 }
@@ -9241,4 +9243,335 @@ fn extract_directives_rejects_string_literal_in_anonymous_resource_depends_on() 
         "error should mention binding identifiers, got: {}",
         err
     );
+}
+
+#[test]
+fn parse_provider_expr_named_instance_in_let_binding() {
+    let input = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+
+        let us = provider aws {
+            region = "us-east-1"
+        }
+    "#;
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+
+    // Two entries: the default kind+instance from the top-level block,
+    // plus the `let us = ...` named instance.
+    assert_eq!(
+        parsed.providers.len(),
+        2,
+        "expected default + named instance"
+    );
+
+    let default = parsed
+        .providers
+        .iter()
+        .find(|p| p.is_default)
+        .expect("default instance from top-level block");
+    assert_eq!(default.name, "aws");
+    assert!(default.binding.is_none());
+    assert_eq!(
+        default.source.as_deref(),
+        Some("github.com/carina-rs/carina-provider-aws")
+    );
+
+    let named = parsed
+        .providers
+        .iter()
+        .find(|p| !p.is_default)
+        .expect("named instance from let binding");
+    assert_eq!(named.name, "aws", "named instance carries the kind");
+    assert_eq!(named.binding.as_deref(), Some("us"));
+    // Named instances do NOT carry source/version/revision; those are kind-level.
+    assert!(named.source.is_none());
+    assert!(named.version.is_none());
+    assert!(named.revision.is_none());
+    // Instance attributes are present.
+    match named.attributes.get("region") {
+        Some(Value::Concrete(ConcreteValue::String(s))) => assert_eq!(s, "us-east-1"),
+        other => panic!("expected region string attribute, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_provider_expr_rejects_source_on_named_instance() {
+    // `source` is a kind-level attribute; declaring it on a named
+    // instance is an error.
+    let input = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+
+        let us = provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            region = "us-east-1"
+        }
+    "#;
+    let err = parse(input, &ProviderContext::default())
+        .expect_err("source on named instance must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("source"),
+        "error must mention the offending field, got: {msg}"
+    );
+}
+
+#[test]
+fn parse_provider_expr_rejects_version_on_named_instance() {
+    let input = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+
+        let us = provider aws {
+            version = "0.2.0"
+        }
+    "#;
+    let err = parse(input, &ProviderContext::default())
+        .expect_err("version on named instance must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("version"),
+        "error must mention the offending field, got: {msg}"
+    );
+}
+
+#[test]
+fn parse_provider_expr_rejects_revision_on_named_instance() {
+    let input = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+
+        let us = provider aws {
+            revision = "main"
+        }
+    "#;
+    let err = parse(input, &ProviderContext::default())
+        .expect_err("revision on named instance must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("revision"),
+        "error must mention the offending field, got: {msg}"
+    );
+}
+
+#[test]
+fn parse_top_level_provider_block_keeps_default_instance_flags() {
+    // The existing top-level `provider <kind> { ... }` shape continues to
+    // parse and now carries the default-instance metadata.
+    let input = r#"
+        provider mock {
+            source = "github.com/carina-rs/carina-provider-mock"
+            version = "0.1.0"
+        }
+    "#;
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(parsed.providers.len(), 1);
+    let p = &parsed.providers[0];
+    assert_eq!(p.name, "mock");
+    assert!(
+        p.is_default,
+        "top-level provider block is the kind's default instance"
+    );
+    assert!(p.binding.is_none(), "default instance has no binding name");
+}
+
+#[test]
+fn parse_provider_expr_multiple_named_instances() {
+    let input = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+            region = "ap-northeast-1"
+        }
+
+        let tokyo = provider aws {
+            region = "ap-northeast-1"
+        }
+
+        let virginia = provider aws {
+            region = "us-east-1"
+        }
+    "#;
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(parsed.providers.len(), 3);
+    let mut bindings: Vec<Option<&str>> = parsed
+        .providers
+        .iter()
+        .map(|p| p.binding.as_deref())
+        .collect();
+    bindings.sort();
+    assert_eq!(bindings, vec![None, Some("tokyo"), Some("virginia")]);
+}
+
+/// Directory-scoped: a named instance in one file must be visible
+/// alongside the default instance in a sibling file (mirrors the
+/// `carina-rs/infra` T6c layout where `providers.crn` registers the
+/// kind and a separate file declares a per-region named instance).
+#[test]
+fn parse_provider_expr_named_instance_visible_across_files() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("providers.crn"),
+        r#"
+            provider aws {
+                source  = "github.com/carina-rs/carina-provider-aws"
+                version = "0.1.0"
+                region  = "ap-northeast-1"
+            }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            let us = provider aws {
+                region = "us-east-1"
+            }
+        "#,
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("multi-file directory parse must succeed");
+
+    assert_eq!(
+        parsed.providers.len(),
+        2,
+        "expected default + named instance across sibling files"
+    );
+    let has_default = parsed
+        .providers
+        .iter()
+        .any(|p| p.name == "aws" && p.is_default && p.binding.is_none());
+    let has_named = parsed
+        .providers
+        .iter()
+        .any(|p| p.name == "aws" && !p.is_default && p.binding.as_deref() == Some("us"));
+    assert!(has_default, "default instance from providers.crn missing");
+    assert!(has_named, "named instance from main.crn missing");
+}
+
+#[test]
+fn parse_provider_expr_empty_body() {
+    let input = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+        let us = provider aws {}
+    "#;
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+    let named = parsed
+        .providers
+        .iter()
+        .find(|p| p.binding.as_deref() == Some("us"))
+        .expect("named instance with empty body must parse");
+    assert!(
+        named.attributes.is_empty(),
+        "empty body yields no attributes"
+    );
+}
+
+#[test]
+fn parse_provider_expr_rejects_duplicate_binding() {
+    let input = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+        let us = provider aws { region = "us-east-1" }
+        let us = provider aws { region = "eu-west-1" }
+    "#;
+    let err = parse(input, &ProviderContext::default())
+        .expect_err("duplicate let binding for a provider instance must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.to_lowercase().contains("duplicate"),
+        "error should flag duplicate binding, got: {msg}"
+    );
+}
+
+#[test]
+fn parse_provider_expr_with_discard_pattern() {
+    // `let _ = provider aws { ... }` parses successfully — the discard
+    // pattern is grammar-legal and the named instance is collected, but
+    // it is unreferenceable from `directives { provider = ... }` because
+    // `_` is not a valid binding name to refer to. Documents the current
+    // behaviour; Phase 3 will surface the unused-instance warning.
+    let input = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+        let _ = provider aws { region = "us-east-1" }
+    "#;
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(parsed.providers.len(), 2);
+}
+
+#[test]
+fn provider_config_named_instance_serde_round_trip() {
+    use crate::parser::ast::ProviderConfig;
+    let original = ProviderConfig {
+        name: "aws".to_string(),
+        attributes: {
+            let mut m = IndexMap::new();
+            m.insert(
+                "region".to_string(),
+                Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+            );
+            m
+        },
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+        unresolved_attributes: IndexMap::new(),
+        binding: Some("us".to_string()),
+        is_default: false,
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    let decoded: ProviderConfig = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(decoded.name, "aws");
+    assert_eq!(decoded.binding.as_deref(), Some("us"));
+    assert!(!decoded.is_default);
+}
+
+#[test]
+fn provider_config_default_instance_serde_round_trip() {
+    use crate::parser::ast::ProviderConfig;
+    let original = ProviderConfig {
+        name: "aws".to_string(),
+        attributes: IndexMap::new(),
+        default_tags: IndexMap::new(),
+        source: Some("github.com/x/y".to_string()),
+        version: None,
+        revision: None,
+        unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    // Defaults skipped from the JSON to keep state files small.
+    assert!(
+        !json.contains("\"binding\""),
+        "binding: None should be skipped, got: {json}"
+    );
+    assert!(
+        !json.contains("\"is_default\""),
+        "is_default: true should be skipped, got: {json}"
+    );
+    // Deserialising omitted fields must still produce the default-instance shape.
+    let decoded: ProviderConfig = serde_json::from_str(&json).expect("deserialize");
+    assert!(decoded.binding.is_none());
+    assert!(decoded.is_default);
 }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1359,6 +1359,12 @@ pub struct Directives {
     /// Vec to preserve source order for `carina fmt` round-tripping.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub depends_on: Vec<String>,
+    /// Binding name of the provider instance to use for this resource.
+    /// `None` resolves to the kind's default instance. Phase 2 only
+    /// holds the slot; `directives { provider = ... }` reading and
+    /// routing land in Phase 3.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_instance: Option<String>,
 }
 
 /// Source of a resource (root or from a module)

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -621,6 +621,8 @@ fn provider_in_module_with_arguments_errors() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     });
     parsed.arguments.push(crate::parser::ArgumentParameter {
         name: "vpc_cidr".to_string(),
@@ -649,6 +651,8 @@ fn provider_in_module_with_attributes_errors() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     });
     parsed
         .attribute_params
@@ -673,6 +677,8 @@ fn provider_without_module_markers_ok() {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     });
 
     let result = validate_no_provider_in_module(&parsed);
@@ -715,6 +721,8 @@ fn provider(name: &str) -> crate::parser::ProviderConfig {
         version: None,
         revision: None,
         unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
     }
 }
 

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -974,6 +974,8 @@ mod tests {
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
             attributes,
             default_tags: IndexMap::new(),
         };
@@ -1007,6 +1009,8 @@ mod tests {
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         };
@@ -1036,6 +1040,8 @@ mod reload_skip_tests {
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
         }
     }
 

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -1131,6 +1131,7 @@ mod tests {
             create_before_destroy: false,
             prevent_destroy: false,
             depends_on: Vec::new(),
+            ..Directives::default()
         };
         let json = directives_to_json(&directives);
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/carina-provider-resolver/src/provider_resolver.rs
+++ b/carina-provider-resolver/src/provider_resolver.rs
@@ -1035,6 +1035,8 @@ mod tests {
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
         }
     }
 
@@ -1383,6 +1385,8 @@ sha256 = "abc"
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         }];
@@ -1409,6 +1413,8 @@ sha256 = "abc"
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         }];
@@ -1507,6 +1513,8 @@ sha256 = "abc"
             ),
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         }
@@ -1679,6 +1687,8 @@ sha256 = "abc"
             version: None,
             revision: None,
             unresolved_attributes: IndexMap::new(),
+            binding: None,
+            is_default: true,
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         };


### PR DESCRIPTION
## Summary

Phase 2 of #2191: parser + grammar support for `let <name> = provider <kind> { ... }`.

The named instance lands in `File.providers` alongside the default instance produced by the top-level `provider <kind> { ... }` block. Resource-side routing (`directives { provider = us }` resolution), plugin-host multi-instance store, state schema, and LSP support land in later phases.

```crn
provider aws {
  source  = 'github.com/carina-rs/carina-provider-aws'
  version = '~0.1.0'
  region  = aws.Region.ap_northeast_1
}

let us = provider aws {
  region = aws.Region.us_east_1
}
```

### Changes

- New grammar rule `provider_expr` (parser + formatter), added to `primary` before `module_call`.
- `ProviderConfig` gains `binding: Option<String>` and `is_default: bool` to distinguish kind-default from named instances. Phase 3 replaces this with the full `ProviderKind` / `ProviderInstance` split.
- `Directives.provider_instance: Option<String>` slot added (carina-internal; WIT contract unchanged). Phase 3 wires `directives { provider = us }` into it.
- Kind-level attributes (`source` / `version` / `revision`) are rejected on named instances with a clear error.
- Duplicate `let us = provider ...` declarations are rejected via the same side-channel pattern used by `upstream_state_expr` / `wait_expr`.
- Formatter parity: `provider_expr` rule + `NodeKind::ProviderExpr` + `format_provider_expr` (mirrors `format_upstream_state_expr`).

### Phasing note

Per the design PR #3005, the original Phase 1 (full AST split into `ProviderKind` / `ProviderInstance`) is folded into Phase 3. The split's invariants are load-bearing only once Phase 3 lands, so doing it earlier would add zip/re-merge boilerplate across 17 files without paying off. Phase 2 instead adds two narrow fields that Phase 3 will replace by the full split in one move.

### Test plan

- [x] 9 parser tests (happy path, source/version/revision rejection, default-instance flags, multiple named instances, empty body, discard pattern, duplicate-binding rejection)
- [x] 1 multi-file directory test mirroring the `carina-rs/infra` T6c layout (`providers.crn` + `main.crn`)
- [x] 2 serde round-trip tests (default + named instance shapes)
- [x] 1 formatter test (round-trip + idempotence)
- [x] `cargo nextest run --workspace` → 3245 pass
- [x] `cargo test --workspace --doc` → pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] All `scripts/check-*.sh` → OK
- [x] 5 rounds of self-review

Refs #2191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
