### PR TITLE
validation: reject Float for Int and Bool TypeExpr

### DIFF
--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -917,12 +917,22 @@ pub fn validate_type_expr_value(
         (TypeExpr::Bool, Value::Concrete(ConcreteValue::Int(n))) => {
             Some(format!("expected {type_expr}, got int ({n})."))
         }
+        (TypeExpr::Bool, Value::Concrete(ConcreteValue::Float(f))) => {
+            Some(format!("expected {type_expr}, got float ({f})."))
+        }
         (TypeExpr::Int, Value::Concrete(ConcreteValue::Bool(b))) => {
             Some(format!("expected {type_expr}, got bool ({b})."))
+        }
+        (TypeExpr::Int, Value::Concrete(ConcreteValue::Float(f))) => {
+            Some(format!("expected {type_expr}, got float ({f})."))
         }
         (TypeExpr::Float, Value::Concrete(ConcreteValue::Bool(b))) => {
             Some(format!("expected {type_expr}, got bool ({b})."))
         }
+        // Intentional one-way widening: an Int may flow into a Float sink.
+        // The reverse (Float -> Int) is rejected above. Mirrors the schema
+        // validator's `(Float, Int) => Ok` rule in `schema/mod.rs`.
+        (TypeExpr::Float, Value::Concrete(ConcreteValue::Int(_))) => None,
         // Schema types are string subtypes — reject non-string values
         (TypeExpr::SchemaType { .. }, Value::Concrete(ConcreteValue::Bool(b))) => {
             Some(format!("expected {}, got bool ({}).", type_expr, b))

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1009,6 +1009,41 @@ fn validate_type_expr_value_float_got_bool() {
 }
 
 #[test]
+fn validate_type_expr_value_bool_got_float_is_rejected() {
+    // Regression for #2864: Float must not silently coerce into Bool.
+    let result = validate_type_expr_value(
+        &TypeExpr::Bool,
+        &Value::Concrete(ConcreteValue::Float(1.5)),
+        &ProviderContext::default(),
+    );
+    assert!(result.is_some());
+    assert!(result.unwrap().contains("expected Bool, got float"));
+}
+
+#[test]
+fn validate_type_expr_value_int_got_float_is_rejected() {
+    // Regression for #2864: Float must not silently coerce into Int.
+    let result = validate_type_expr_value(
+        &TypeExpr::Int,
+        &Value::Concrete(ConcreteValue::Float(1.5)),
+        &ProviderContext::default(),
+    );
+    assert!(result.is_some());
+    assert!(result.unwrap().contains("expected Int, got float"));
+}
+
+#[test]
+fn validate_type_expr_value_float_got_int_is_accepted() {
+    // Intentional one-way widening: Int flows into Float (see #2864).
+    let result = validate_type_expr_value(
+        &TypeExpr::Float,
+        &Value::Concrete(ConcreteValue::Int(42)),
+        &ProviderContext::default(),
+    );
+    assert!(result.is_none());
+}
+
+#[test]
 fn validate_type_expr_value_schema_type_accepts_string() {
     let schema_type = TypeExpr::SchemaType {
         provider: "awscc".to_string(),


### PR DESCRIPTION
## Summary

`validate_type_expr_value` was silently accepting `Value::Float` for `TypeExpr::Int` and `TypeExpr::Bool` via the catch-all `_ => None` fallthrough, contradicting the schema validator (which intentionally allows only the one-way `Int → Float` widening).

This change adds explicit reject branches for `(Bool, Float)` and `(Int, Float)`, plus an explicit `None` branch for `(Float, Int)` to document the intentional widening contract rather than relying on fallthrough.

## Test

Added three regression tests:
- `validate_type_expr_value_bool_got_float_is_rejected`
- `validate_type_expr_value_int_got_float_is_rejected`
- `validate_type_expr_value_float_got_int_is_accepted`

Closes #2864

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6HDAqh2SYjsRceSPe38aX)_