### PR TITLE
plan: render multi-key Map removal one key per line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ plan-map-diff:
 	$(PLAN_FIXTURE) map_key_diff
 plan-map-added-from-none:
 	$(PLAN_FIXTURE) map_added_from_none
+plan-map-attribute-removed:
+	$(PLAN_FIXTURE) map_attribute_removed
 plan-nested-map-diff:
 	$(PLAN_FIXTURE) nested_map_diff
 plan-list-diff-added-struct:
@@ -92,6 +94,8 @@ plan-fixtures:
 	@$(MAKE) plan-map-diff
 	@echo "---"
 	@$(MAKE) plan-map-added-from-none
+	@echo "---"
+	@$(MAKE) plan-map-attribute-removed
 	@echo ""
 	@echo "=== nested_map_diff ==="
 	@$(MAKE) plan-nested-map-diff

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -328,6 +328,27 @@ fn snapshot_map_added_from_none() {
     insta::assert_snapshot!(output);
 }
 
+/// #2939: a Map<String, String> attribute that goes from a multi-key
+/// value in state to absent in desired must render as per-key
+/// `- key: "value"` lines, not as a single inline
+/// `tags: {...} → (removed)` line. Mirrors `snapshot_map_added_from_none`
+/// for the removal direction.
+#[test]
+fn snapshot_map_attribute_removed() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("map_attribute_removed");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+    ));
+    insta::assert_snapshot!(output);
+}
+
 #[test]
 fn snapshot_enum_display() {
     let (plan, schemas, _moved) = build_plan_from_fixture("enum_display");

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_map_attribute_removed.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_map_attribute_removed.snap
@@ -1,0 +1,16 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.ec2.Vpc vpc
+      tags:
+        - Component: "registry"
+        - Environment: "dev"
+        - ManagedBy: "carina"
+        - Project: "carina-rs"
+        - Repository: "carina-rs/infra"
+      # (1 unchanged attribute hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/map_attribute_removed/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_attribute_removed/carina.state.json
@@ -1,0 +1,42 @@
+{
+  "version": 6,
+  "serial": 1,
+  "lineage": "test-lineage-map-attribute-removed",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.Vpc",
+      "name": "vpc",
+      "provider": "awscc",
+      "identifier": "vpc-0123456789abcdef0",
+      "attributes": {
+        "cidr_block": "10.0.0.0/16",
+        "vpc_id": "vpc-0123456789abcdef0",
+        "tags": {
+          "Component": "registry",
+          "Environment": "dev",
+          "ManagedBy": "carina",
+          "Project": "carina-rs",
+          "Repository": "carina-rs/infra"
+        }
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "vpc",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/map_attribute_removed/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/map_attribute_removed/main.crn
@@ -1,0 +1,16 @@
+# Update plan: Map<String, String> attribute (tags) removed to `(none)`
+# (issue #2939). State has a multi-key `tags` map; desired drops it
+# entirely. Expected rendering: per-key `- key: "value"` lines, not a
+# single overflowing inline `tags: {...} → (removed)` line.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+exports {
+  cidr_block = vpc.cidr_block
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -605,6 +605,15 @@ fn build_update_rows(
     removed_keys.sort();
     for key in removed_keys {
         if let Some(old_value) = from_attrs_projected.get(key.as_str()) {
+            // Mirror the addition direction (#2936): when a Map
+            // attribute is dropped entirely, route through `MapDiff`
+            // so each key renders on its own line as `- key: "value"`
+            // instead of overflowing on a single inline `{...} → (removed)`
+            // row (#2939).
+            if let Some(row) = build_map_removed_row(key, old_value) {
+                rows.push(row);
+                continue;
+            }
             rows.push(DetailRow::Removed {
                 key: key.to_string(),
                 old: format_value_with_key(old_value, Some(key)),
@@ -814,6 +823,39 @@ fn build_delete_rows(
     }
 
     rows
+}
+
+/// Build a `DetailRow::MapDiff` whose entries are all `Removed`,
+/// mirroring the addition-direction path that emits all-`Added`
+/// entries when an attribute appears for the first time (#2936).
+///
+/// Returns `None` when `old_value` is not a `Map`, or when the map
+/// is empty (single inline `tags: {} → (removed)` rendering is fine
+/// at that size). The caller falls through to the inline
+/// `DetailRow::Removed` form in both cases. Used by `build_update_rows`
+/// to fix #2939, where a multi-key map dropped from a resource used
+/// to render inline on one overflowing line.
+fn build_map_removed_row(key: &str, old_value: &Value) -> Option<DetailRow> {
+    let Value::Concrete(ConcreteValue::Map(old_map)) = old_value else {
+        return None;
+    };
+    if old_map.is_empty() {
+        return None;
+    }
+    let mut sorted_keys: Vec<&String> = old_map.keys().collect();
+    sorted_keys.sort();
+    let entries: Vec<MapDiffEntryIR> = sorted_keys
+        .into_iter()
+        .map(|k| MapDiffEntryIR::Removed {
+            key: k.clone(),
+            value: format_value_with_key(&old_map[k], Some(k)),
+        })
+        .collect();
+    let entries = NonEmptyVec::from_vec(entries)?;
+    Some(DetailRow::MapDiff {
+        key: key.to_string(),
+        entries,
+    })
 }
 
 /// Returns `None` when `compute_map_diff_entries` filters every entry


### PR DESCRIPTION
## Summary

Mirror of the addition-direction fix from #2936 for the removal direction. When a `Map` attribute (e.g. `tags`) was dropped from a resource, `build_update_rows` always emitted a single inline `DetailRow::Removed`, so a 5-key map collapsed onto one overflowing line.

This change routes multi-key Map removals through `DetailRow::MapDiff` with all-`MapDiffEntryIR::Removed` entries, so each key renders as `- key: "value"` on its own line. Non-Map or empty-Map values keep the existing inline `Removed` form.

## Test

- New fixture `carina-cli/tests/fixtures/plan_display/map_attribute_removed/` (state has a 5-key `tags` map; desired drops it).
- New snapshot test `snapshot_map_attribute_removed` matching the issue's expected output.
- Added `plan-map-attribute-removed` Makefile target and wired it into `plan-fixtures`.

Closes #2939

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6HDAqh2SYjsRceSPe38aX)_