### PR TITLE
resolver: validate directives.provider_instance bindings (#2191 Phase 3b-1)

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -157,7 +157,8 @@ pub fn load_configuration_with_config(
         // Identifier-scope checks are accumulated rather than short-
         // circuited so `carina validate` can keep going and report every
         // static error in one pass (#2102, #2126, #2138).
-        let identifier_scope_errors = parser::check_identifier_scope(&merged);
+        let mut identifier_scope_errors = parser::check_identifier_scope(&merged);
+        identifier_scope_errors.extend(parser::check_provider_instance_routing(&merged));
 
         // Phase transition: post-resolve, run rhs-driven inference over
         // every `exports { ... }` declaration so downstream consumers

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -31,8 +31,8 @@ pub use error::{ParseError, ParseWarning};
 pub(crate) use functions::evaluate_user_function;
 pub use functions::{provider_context_lookup, validate_custom_type};
 pub use resolve::{
-    check_identifier_scope, collect_known_bindings_merged, finalize_provider_configs,
-    resolve_provider_unresolved_attributes, resolve_resource_refs,
+    check_identifier_scope, check_provider_instance_routing, collect_known_bindings_merged,
+    finalize_provider_configs, resolve_provider_unresolved_attributes, resolve_resource_refs,
     resolve_resource_refs_with_config,
 };
 pub use types::parse_type_expr_str;

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -308,6 +308,101 @@ pub fn check_identifier_scope(parsed: &ParsedFile) -> Vec<ParseError> {
     errors
 }
 
+/// Validate every `directives { provider = <ident> }` reference and
+/// every implicit default-instance lookup against `parsed.providers`.
+///
+/// Emits an error for each:
+///
+/// - `provider = <binding>` whose binding is not a declared
+///   `ProviderInstance` (typo or undeclared name).
+/// - `provider = <binding>` whose binding's kind does not match the
+///   resource's kind (e.g. `aws.s3.Bucket { directives { provider =
+///   <awscc-binding> } }`).
+/// - Resource that omits `directives { provider = ... }` but whose
+///   kind has no default instance (the kind was registered via a
+///   top-level `provider <kind> { source = ..., version = ... }`
+///   block with no instance attributes, and every instance of that
+///   kind is named).
+///
+/// The check is a sibling of `check_identifier_scope` rather than
+/// folded into it: the errors are provider-specific, the inputs
+/// (`parsed.providers`) and outputs (kind-aware diagnostics) differ
+/// from the generic "is this identifier in scope" walk, and folding
+/// them together would force callers that only want one kind of
+/// validation to pay for both.
+pub fn check_provider_instance_routing(parsed: &ParsedFile) -> Vec<ParseError> {
+    let mut errors = Vec::new();
+    for resource in &parsed.resources {
+        match &resource.directives.provider_instance {
+            Some(binding) => {
+                let Some(instance) = parsed
+                    .providers
+                    .iter()
+                    .find(|p| p.binding.as_deref() == Some(binding.as_str()))
+                else {
+                    errors.push(ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "directives.provider: `{binding}` is not a known \
+                             provider instance. Declare it with `let {binding} \
+                             = provider <kind> {{ ... }}`."
+                        ),
+                    });
+                    continue;
+                };
+                if instance.name != resource.id.provider {
+                    errors.push(ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "directives.provider: instance `{binding}` has kind \
+                             `{}`, but resource `{}.{}` requires kind `{}`",
+                            instance.name,
+                            resource.id.provider,
+                            resource.id.resource_type,
+                            resource.id.provider,
+                        ),
+                    });
+                }
+            }
+            None => {
+                // Mock / synthetic resources (no provider prefix) have no
+                // kind to route by; skip them.
+                if resource.id.provider.is_empty() {
+                    continue;
+                }
+                let (kind_has_any, kind_has_default) =
+                    parsed
+                        .providers
+                        .iter()
+                        .fold((false, false), |(any, def), p| {
+                            let matches = p.name == resource.id.provider;
+                            (any || matches, def || (matches && p.is_default))
+                        });
+                if !kind_has_any {
+                    continue;
+                }
+                if !kind_has_default {
+                    errors.push(ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "resource `{}.{}` has no default provider \
+                             instance for kind `{}`: either add instance \
+                             attributes to the top-level `provider {}` \
+                             block, or set `directives {{ provider = \
+                             <instance> }}` explicitly.",
+                            resource.id.provider,
+                            resource.id.resource_type,
+                            resource.id.provider,
+                            resource.id.provider,
+                        ),
+                    });
+                }
+            }
+        }
+    }
+    errors
+}
+
 fn accumulate_undefined_reference_errors(
     parsed: &ParsedFile,
     known: &std::collections::HashSet<&str>,

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -9730,3 +9730,199 @@ fn extract_directives_reads_provider_in_anonymous_resource() {
         "anonymous-resource directives.provider must populate provider_instance"
     );
 }
+
+#[test]
+fn check_provider_instance_routing_accepts_named_instance() {
+    let src = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+            region = "ap-northeast-1"
+        }
+        let us = provider aws { region = "us-east-1" }
+        aws.s3.Bucket {
+            bucket_name = "x"
+            directives { provider = us }
+        }
+    "#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let errs = crate::parser::check_provider_instance_routing(&parsed);
+    assert!(
+        errs.is_empty(),
+        "valid named-instance routing must not produce errors, got: {errs:?}"
+    );
+}
+
+#[test]
+fn check_provider_instance_routing_accepts_default_when_none() {
+    let src = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+            region = "ap-northeast-1"
+        }
+        aws.s3.Bucket {
+            bucket_name = "x"
+        }
+    "#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let errs = crate::parser::check_provider_instance_routing(&parsed);
+    assert!(
+        errs.is_empty(),
+        "default-instance routing must not produce errors, got: {errs:?}"
+    );
+}
+
+#[test]
+fn check_provider_instance_routing_rejects_unknown_binding() {
+    let src = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+        aws.s3.Bucket {
+            bucket_name = "x"
+            directives { provider = nope }
+        }
+    "#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let errs = crate::parser::check_provider_instance_routing(&parsed);
+    assert_eq!(
+        errs.len(),
+        1,
+        "unknown binding must produce one error, got: {errs:?}"
+    );
+    let msg = format!("{}", errs[0]);
+    assert!(
+        msg.contains("nope") && msg.contains("provider instance"),
+        "error should name the unknown binding, got: {msg}"
+    );
+}
+
+#[test]
+fn check_provider_instance_routing_rejects_kind_mismatch() {
+    let src = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+        }
+        provider awscc {
+            source = "github.com/carina-rs/carina-provider-awscc"
+            version = "0.1.0"
+        }
+        let us = provider awscc { region = "us-east-1" }
+        aws.s3.Bucket {
+            bucket_name = "x"
+            directives { provider = us }
+        }
+    "#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let errs = crate::parser::check_provider_instance_routing(&parsed);
+    assert_eq!(
+        errs.len(),
+        1,
+        "kind mismatch must produce one error, got: {errs:?}"
+    );
+    let msg = format!("{}", errs[0]);
+    assert!(
+        msg.contains("us") && msg.contains("awscc") && msg.contains("aws"),
+        "error should name the binding and both kinds, got: {msg}"
+    );
+}
+
+#[test]
+fn check_provider_instance_routing_rejects_missing_default_instance() {
+    // No top-level `provider aws { ... }` block — only a named
+    // instance is declared. A resource that omits the directive
+    // resolves to "the kind's default", which does not exist here,
+    // so the resolver must point the user at either declaring a
+    // top-level block or setting `directives { provider = ... }`.
+    let src = r#"
+        let tokyo = provider aws { region = "ap-northeast-1" }
+        aws.s3.Bucket {
+            bucket_name = "x"
+        }
+    "#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let errs = crate::parser::check_provider_instance_routing(&parsed);
+    assert_eq!(
+        errs.len(),
+        1,
+        "missing default instance must produce one error, got: {errs:?}"
+    );
+    let msg = format!("{}", errs[0]);
+    assert!(
+        msg.contains("aws") && msg.contains("default"),
+        "error should mention the kind and default-instance absence, got: {msg}"
+    );
+}
+
+#[test]
+fn check_provider_instance_routing_multi_file_named_instance() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("providers.crn"),
+        r#"
+            provider aws {
+                source  = "github.com/carina-rs/carina-provider-aws"
+                version = "0.1.0"
+                region  = "ap-northeast-1"
+            }
+            let us = provider aws { region = "us-east-1" }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            aws.acm.Certificate {
+                domain_name = "registry.carina-rs.dev"
+                directives { provider = us }
+            }
+        "#,
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("multi-file directory parse must succeed");
+    let errs = crate::parser::check_provider_instance_routing(&parsed);
+    assert!(
+        errs.is_empty(),
+        "cross-file named-instance routing must validate cleanly, got: {errs:?}"
+    );
+}
+
+#[test]
+fn check_provider_instance_routing_rejects_non_provider_let_binding() {
+    // `provider = role` where `role` is a *resource* binding (not a
+    // provider instance) must be rejected. The parser already accepts
+    // any identifier here; the routing checker is the place that
+    // distinguishes provider-instance bindings from regular ones.
+    let src = r#"
+        provider aws {
+            source = "github.com/carina-rs/carina-provider-aws"
+            version = "0.1.0"
+            region = "ap-northeast-1"
+        }
+        let role = aws.iam.Role {
+            role_name = "r"
+            assume_role_policy_document = "{}"
+        }
+        aws.s3.Bucket {
+            bucket_name = "x"
+            directives { provider = role }
+        }
+    "#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let errs = crate::parser::check_provider_instance_routing(&parsed);
+    assert_eq!(
+        errs.len(),
+        1,
+        "non-provider let binding must produce one error, got: {errs:?}"
+    );
+    let msg = format!("{}", errs[0]);
+    assert!(
+        msg.contains("role") && msg.contains("provider instance"),
+        "error should clarify that `role` is not a provider instance, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 3b-1 of #2191: a new post-parse validator that checks every resource's `Directives.provider_instance` against the parsed `providers` set. Three error shapes surface (unknown binding, kind mismatch, missing default instance) — all routed through `ParseError::InvalidExpression`.

`ProviderRouter` re-keying, per-instance wiring, and the multi-instance fixture under `tests/fixtures/plan_display/` land in Phase 3b-2 (#2191).

## Resolution rules covered

| Resource shape | Effective instance |
| -------------- | ------------------ |
| `Resource { ... }` with no directive | The kind's default instance |
| `Resource { ..., directives { provider = us } }` | Instance bound to `us` (kinds must match) |
| Kind has no default + resource omits | ERROR with fix-it message |
| `directives { provider = <binding> }` where binding is not a provider instance | ERROR ("Declare it with `let X = provider <kind> { ... }`.") |
| `directives { provider = <binding> }` where binding's kind ≠ resource's kind | ERROR (names both kinds) |

## Why a sibling of `check_identifier_scope`, not folded into it

The inputs (`parsed.providers`) and outputs (kind-aware diagnostics) differ from the generic "is this identifier in scope" walk. Folding them would force callers that only want one kind of validation to pay for both.

## Out of scope (Phase 3b-2)

- `ProviderRouter` keyed on `(kind, binding)` instead of just `kind`
- Per-instance `factory.create_provider(...)` calls in `carina-cli/src/wiring/mod.rs`
- Multi-instance fixture under `tests/fixtures/plan_display/`
- State-loaded resources with stale provider bindings (flagged for the 3b-2 lookup error surface)

## Test plan

- [x] 7 parser tests (accepts named, accepts default, rejects unknown binding, rejects kind mismatch, rejects missing default, rejects non-provider let binding, multi-file directory routing)
- [x] `cargo nextest run --workspace` → 3267 passed
- [x] `cargo test --workspace --doc` → pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] All `scripts/check-*.sh` → OK
- [x] 5 rounds of self-review (1 comment added in Round 3; remaining findings out of scope)

Refs #2191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
