### PR TITLE
provider: route to named instances via ProviderRouter (#2191 Phase 3b-2b)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,9 @@ plan-fixtures:
 	@echo ""
 	@echo "=== module_anonymous_resource ==="
 	@$(MAKE) plan-module-anonymous-resource
+	@echo ""
+	@echo "=== multi_instance_create ==="
+	@$(MAKE) plan-multi-instance-create
 
 plan-upstream-state:
 	$(PLAN_FIXTURE) upstream_state
@@ -215,6 +218,8 @@ plan-module-anonymous-resource:
 	$(PLAN_FIXTURE) module_anonymous_resource
 plan-server-default-struct-leaf:
 	$(PLAN_FIXTURE) server_default_struct_leaf
+plan-multi-instance-create:
+	$(PLAN_FIXTURE) multi_instance_create
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
         plan-list-diff-modified-with-unchanged \
@@ -228,6 +233,7 @@ plan-server-default-struct-leaf:
         plan-policy-pretty-nested plan-policy-pretty-dynamic-key-list \
         plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
         plan-module-anonymous-resource plan-server-default-struct-leaf \
+        plan-multi-instance-create \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -106,6 +106,59 @@ fn snapshot_all_create() {
     insta::assert_snapshot!(output);
 }
 
+/// carina#2191 Phase 3b-2b acceptance: a directory with one default
+/// instance (`provider awscc { ... }`) and one named instance
+/// (`let us = provider awscc { ... }`), plus two resources where only
+/// the second carries `directives { provider = us }`. The snapshot
+/// pins the rendered plan output for the two-resource shape; the
+/// companion `multi_instance_create_propagates_provider_instance`
+/// test asserts the binding is carried on `ResourceId.provider_instance`
+/// so apply-time routing has it available (plan display is intentionally
+/// silent about the instance — that surface is owned by a later phase).
+#[test]
+fn snapshot_multi_instance_create() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("multi_instance_create");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+    ));
+    insta::assert_snapshot!(output);
+}
+
+/// Acceptance for the parse → plan flow on the multi-instance fixture:
+/// the `us_bucket` resource — the only one carrying
+/// `directives { provider = us }` — must reach the plan with
+/// `ResourceId.provider_instance == Some("us")`. The other bucket and
+/// the kind's default instance must remain `None`. This is what
+/// `ProviderRouter::get_provider_or_error` keys on at apply time.
+#[test]
+fn multi_instance_create_propagates_provider_instance() {
+    let (plan, _schemas, _moved) = build_plan_from_fixture("multi_instance_create");
+
+    let mut by_name: HashMap<String, Option<String>> = HashMap::new();
+    for effect in plan.effects() {
+        let id = effect.resource_id();
+        by_name.insert(id.name_str().to_string(), id.provider_instance.clone());
+    }
+
+    assert_eq!(
+        by_name.get("tokyo_bucket"),
+        Some(&None),
+        "tokyo_bucket has no directives — must route to the kind default (provider_instance = None)"
+    );
+    assert_eq!(
+        by_name.get("us_bucket"),
+        Some(&Some("us".to_string())),
+        "us_bucket has directives {{ provider = us }} — must carry the binding through to the plan"
+    );
+}
+
 /// Locks in the no-trailing-dot regression from #2516. The hash-with-
 /// instance-prefix path is covered by the unit tests in
 /// `carina-core/src/identifier/tests.rs`; fixture mode skips the hash

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_multi_instance_create.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_multi_instance_create.snap
@@ -1,0 +1,12 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.s3.Bucket tokyo_bucket
+      bucket_name: "multi-instance-tokyo"
+  + awscc.s3.Bucket us_bucket
+      bucket_name: "multi-instance-us"
+
+Plan: 2 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -907,46 +907,107 @@ pub async fn get_provider_with_ctx<E>(
 ) -> Result<ProviderRouter, AppError> {
     let mut router = ProviderRouter::new();
 
-    for provider_config in &parsed.providers {
-        // If the provider has a source, load it as a WASM plugin
-        if let Some(ref source) = provider_config.source {
-            try_add_source_provider(&mut router, source, provider_config, base_dir).await?;
-            continue;
-        }
+    // Two-pass build so named instances can reuse the kind's factory.
+    // Pass 1 handles every default instance (top-level `provider <kind>`
+    // blocks) — these are the entries that carry `source`/`version` and
+    // may need a WASM plugin to be loaded. Pass 2 handles each named
+    // instance (`let <name> = provider <kind> { ... }`), reusing the
+    // factory the default instance already brought in.
+    for provider_config in parsed.providers.iter().filter(|p| p.is_default) {
+        instantiate_provider_into_router(ctx, &mut router, provider_config, base_dir, None).await?;
+    }
 
-        // Otherwise, look up from the dynamic factories passed to WiringContext
-        if let Some(factory) = provider_mod::find_factory(ctx.factories(), &provider_config.name) {
-            let region = factory.extract_region(&provider_config.attributes);
-            println!(
-                "{}",
-                format!("Using {} (region: {})", factory.display_name(), region).cyan()
-            );
-            let provider = factory
-                .create_provider(&provider_config.attributes)
-                .await
-                .map_err(|e| e.for_provider(provider_config.name.clone()))?;
-            router.add_provider(provider_config.name.clone(), provider);
-            router.add_normalizer(factory.create_normalizer(&provider_config.attributes).await);
-        } else if !provider_config.name.is_empty() {
-            eprintln!(
-                "{}",
-                format!(
-                    "Provider '{}' requires 'source' and 'version' attributes.",
-                    provider_config.name
-                )
-                .red()
-            );
-        }
+    for provider_config in parsed.providers.iter().filter(|p| !p.is_default) {
+        let binding = provider_config
+            .binding
+            .clone()
+            .expect("named instance must carry its binding name (parser invariant)");
+        instantiate_provider_into_router(
+            ctx,
+            &mut router,
+            provider_config,
+            base_dir,
+            Some(binding),
+        )
+        .await?;
     }
 
     if router.is_empty() {
         // Use mock provider for other cases.
-        // Register with empty key to match resources without a provider prefix.
+        // Register the kind's default instance with empty kind to match
+        // resources without a provider prefix.
         println!("{}", "Using mock provider".cyan());
         router.add_provider(String::new(), Box::new(MockProvider::new()));
     }
 
     Ok(router)
+}
+
+/// Register a single provider instance into `router`. `binding = None`
+/// is the kind's default instance; `binding = Some(name)` is a named
+/// instance and routes resources tagged `directives { provider = name }`.
+///
+/// Source-loading (`provider <kind> { source = ... }`) is only invoked
+/// when this is the kind's default instance — named instances reuse the
+/// factory the default instance already loaded.
+async fn instantiate_provider_into_router(
+    ctx: &WiringContext,
+    router: &mut ProviderRouter,
+    provider_config: &ProviderConfig,
+    base_dir: &Path,
+    binding: Option<String>,
+) -> Result<(), AppError> {
+    // Named instances inherit `source`/`version`/`revision` from the
+    // kind's default — these fields are rejected by the parser when set
+    // on `let <name> = provider <kind> { ... }`. Only the default
+    // instance can trigger the source-loading path.
+    if binding.is_none()
+        && let Some(ref source) = provider_config.source
+    {
+        try_add_source_provider(router, source, provider_config, base_dir).await?;
+        return Ok(());
+    }
+
+    if let Some(factory) = provider_mod::find_factory(ctx.factories(), &provider_config.name) {
+        let region = factory.extract_region(&provider_config.attributes);
+        let instance_label = match &binding {
+            Some(name) => format!(" instance={}", name),
+            None => String::new(),
+        };
+        println!(
+            "{}",
+            format!(
+                "Using {} (region: {}{})",
+                factory.display_name(),
+                region,
+                instance_label
+            )
+            .cyan()
+        );
+        let provider = factory
+            .create_provider(&provider_config.attributes)
+            .await
+            .map_err(|e| e.for_provider(provider_config.name.clone()))?;
+        router.add_provider_instance(provider_config.name.clone(), binding, provider);
+        router.add_normalizer(factory.create_normalizer(&provider_config.attributes).await);
+    } else if !provider_config.name.is_empty() {
+        let message = match &binding {
+            // Named instance whose kind's default did not register a
+            // factory — usually the default instance failed to load
+            // (a separate error has already been printed for it).
+            Some(name) => format!(
+                "Named provider instance '{}' (kind '{}') cannot be loaded \
+                 because the kind's default instance is unavailable.",
+                name, provider_config.name
+            ),
+            None => format!(
+                "Provider '{}' requires 'source' and 'version' attributes.",
+                provider_config.name
+            ),
+        };
+        eprintln!("{}", message.red());
+    }
+    Ok(())
 }
 
 async fn try_add_source_provider(
@@ -1046,26 +1107,19 @@ pub async fn create_providers_from_configs(
     let ctx = WiringContext::new(factories);
     let mut router = ProviderRouter::new();
 
-    for config in configs {
-        // If the provider has a source, load it as a WASM plugin
-        if let Some(ref source) = config.source {
-            try_add_source_provider(&mut router, source, config, base_dir).await?;
-            continue;
-        }
-
-        if let Some(factory) = provider_mod::find_factory(ctx.factories(), &config.name) {
-            let region = factory.extract_region(&config.attributes);
-            println!(
-                "{}",
-                format!("Using {} (region: {})", factory.display_name(), region).cyan()
-            );
-            let provider = factory
-                .create_provider(&config.attributes)
-                .await
-                .map_err(|e| e.for_provider(config.name.clone()))?;
-            router.add_provider(config.name.clone(), provider);
-            router.add_normalizer(factory.create_normalizer(&config.attributes).await);
-        }
+    // Same two-pass shape as `get_provider_with_ctx`: default instances
+    // first (they may load the WASM plugin), then named instances reuse
+    // the factory that was just loaded.
+    for config in configs.iter().filter(|p| p.is_default) {
+        instantiate_provider_into_router(&ctx, &mut router, config, base_dir, None).await?;
+    }
+    for config in configs.iter().filter(|p| !p.is_default) {
+        let binding = config
+            .binding
+            .clone()
+            .expect("named instance must carry its binding name (parser invariant)");
+        instantiate_provider_into_router(&ctx, &mut router, config, base_dir, Some(binding))
+            .await?;
     }
 
     if router.is_empty() {

--- a/carina-cli/tests/fixtures/plan_display/multi_instance_create/exports.crn
+++ b/carina-cli/tests/fixtures/plan_display/multi_instance_create/exports.crn
@@ -1,0 +1,4 @@
+exports {
+  tokyo_bucket_name = tokyo_bucket.bucket_name
+  us_bucket_name = us_bucket.bucket_name
+}

--- a/carina-cli/tests/fixtures/plan_display/multi_instance_create/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/multi_instance_create/main.crn
@@ -1,0 +1,16 @@
+# Two buckets routed to different provider instances. The
+# `directives { provider = us }` block on the second resource is the
+# only difference — exercises ResourceId.provider_instance plumbing
+# through parse -> plan rendering. Both bindings are referenced from
+# `exports.crn` so the unused-let-binding fixture check passes.
+let tokyo_bucket = awscc.s3.Bucket {
+  bucket_name = 'multi-instance-tokyo'
+}
+
+let us_bucket = awscc.s3.Bucket {
+  bucket_name = 'multi-instance-us'
+
+  directives {
+    provider = us
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/multi_instance_create/providers.crn
+++ b/carina-cli/tests/fixtures/plan_display/multi_instance_create/providers.crn
@@ -1,0 +1,10 @@
+# Default instance of the `awscc` provider kind.
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+# Named instance targeting a different region. Resources tagged
+# `directives { provider = us }` route to this instance, not the default.
+let us = provider awscc {
+  region = awscc.Region.us_east_1
+}

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -568,9 +568,16 @@ pub fn merge_default_tags_for_provider(
 }
 
 /// A provider that routes operations to the correct sub-provider
-/// based on the resource's provider name (`ResourceId.provider`).
+/// based on the resource's `(provider, provider_instance)` pair.
+///
+/// Each entry is keyed by `(kind, binding)`:
+/// - `binding = None` is the kind's default instance, used by resources
+///   that omit `directives { provider = ... }`.
+/// - `binding = Some(name)` is a named instance declared as
+///   `let <name> = provider <kind> { ... }` and selected via
+///   `directives { provider = <name> }`.
 pub struct ProviderRouter {
-    providers: HashMap<String, Box<dyn Provider>>,
+    providers: HashMap<(String, Option<String>), Box<dyn Provider>>,
     normalizers: Vec<Box<dyn ProviderNormalizer>>,
 }
 
@@ -588,8 +595,22 @@ impl ProviderRouter {
         }
     }
 
-    pub fn add_provider(&mut self, name: String, provider: Box<dyn Provider>) {
-        self.providers.insert(name, provider);
+    /// Register the kind's default instance (resources with
+    /// `provider_instance = None` route here).
+    pub fn add_provider(&mut self, kind: String, provider: Box<dyn Provider>) {
+        self.providers.insert((kind, None), provider);
+    }
+
+    /// Register a provider instance. `binding = None` registers the
+    /// kind's default instance; `binding = Some(name)` registers a
+    /// named instance.
+    pub fn add_provider_instance(
+        &mut self,
+        kind: String,
+        binding: Option<String>,
+        provider: Box<dyn Provider>,
+    ) {
+        self.providers.insert((kind, binding), provider);
     }
 
     pub fn add_normalizer(&mut self, ext: Box<dyn ProviderNormalizer>) {
@@ -600,11 +621,17 @@ impl ProviderRouter {
         self.providers.is_empty()
     }
 
-    fn get_provider_or_error(&self, provider_name: &str) -> ProviderResult<&dyn Provider> {
-        self.providers
-            .get(provider_name)
-            .map(|p| p.as_ref())
-            .ok_or_else(|| ProviderError::internal(format!("Unknown provider: {}", provider_name)))
+    fn get_provider_or_error(&self, id: &ResourceId) -> ProviderResult<&dyn Provider> {
+        let key = (id.provider.clone(), id.provider_instance.clone());
+        self.providers.get(&key).map(|p| p.as_ref()).ok_or_else(|| {
+            ProviderError::internal(match &id.provider_instance {
+                Some(binding) => format!(
+                    "Unknown provider instance: {} (kind={})",
+                    binding, id.provider
+                ),
+                None => format!("Unknown provider: {}", id.provider),
+            })
+        })
     }
 }
 
@@ -619,14 +646,14 @@ impl Provider for ProviderRouter {
         identifier: Option<&str>,
         request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        match self.get_provider_or_error(&id.provider) {
+        match self.get_provider_or_error(id) {
             Ok(provider) => provider.read(id, identifier, request),
             Err(e) => Box::pin(async move { Err(e) }),
         }
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        match self.get_provider_or_error(&resource.id.provider) {
+        match self.get_provider_or_error(&resource.id) {
             Ok(provider) => provider.read_data_source(resource),
             Err(e) => Box::pin(async move { Err(e) }),
         }
@@ -637,7 +664,7 @@ impl Provider for ProviderRouter {
         id: &ResourceId,
         request: CreateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        match self.get_provider_or_error(&id.provider) {
+        match self.get_provider_or_error(id) {
             Ok(provider) => provider.create(id, request),
             Err(e) => Box::pin(async move { Err(e) }),
         }
@@ -649,7 +676,7 @@ impl Provider for ProviderRouter {
         identifier: &str,
         request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        match self.get_provider_or_error(&id.provider) {
+        match self.get_provider_or_error(id) {
             Ok(provider) => provider.update(id, identifier, request),
             Err(e) => Box::pin(async move { Err(e) }),
         }
@@ -661,7 +688,7 @@ impl Provider for ProviderRouter {
         identifier: &str,
         request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
-        match self.get_provider_or_error(&id.provider) {
+        match self.get_provider_or_error(id) {
             Ok(provider) => provider.delete(id, identifier, request),
             Err(e) => Box::pin(async move { Err(e) }),
         }
@@ -1466,6 +1493,111 @@ mod tests {
         let err = result.unwrap_err();
         assert!(matches!(err, ProviderError::Internal(_)));
         assert!(err.message().contains("Unknown provider: nonexistent"));
+    }
+
+    /// A provider that records its identity in the returned state
+    /// so a routing test can tell which instance handled a call.
+    struct TaggedProvider {
+        tag: &'static str,
+    }
+    impl Provider for TaggedProvider {
+        fn name(&self) -> &str {
+            "tagged"
+        }
+        fn read(
+            &self,
+            id: &ResourceId,
+            _identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let mut attrs = HashMap::new();
+            attrs.insert(
+                "tag".to_string(),
+                Value::Concrete(ConcreteValue::String(self.tag.to_string())),
+            );
+            let state = State::existing(id.clone(), attrs);
+            Box::pin(async move { Ok(state) })
+        }
+        fn read_data_source(&self, _resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("not supported")) })
+        }
+        fn create(
+            &self,
+            _id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("not supported")) })
+        }
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("not supported")) })
+        }
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_router_dispatches_to_named_instance() {
+        // Two instances of the same kind ("mock") routed by binding.
+        let mut router = ProviderRouter::new();
+        router.add_provider_instance(
+            "mock".to_string(),
+            None,
+            Box::new(TaggedProvider { tag: "default" }),
+        );
+        router.add_provider_instance(
+            "mock".to_string(),
+            Some("us".to_string()),
+            Box::new(TaggedProvider { tag: "us" }),
+        );
+
+        let default_id = ResourceId::with_provider("mock", "test", "a");
+        let state = router.read(&default_id, None, ReadRequest).await.unwrap();
+        assert_eq!(
+            state.attributes.get("tag"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "default".to_string()
+            ))),
+            "resources without provider_instance must route to the kind's default instance"
+        );
+
+        let us_id =
+            ResourceId::with_provider_and_instance("mock", "test", "b", Some("us".to_string()));
+        let state = router.read(&us_id, None, ReadRequest).await.unwrap();
+        assert_eq!(
+            state.attributes.get("tag"),
+            Some(&Value::Concrete(ConcreteValue::String("us".to_string()))),
+            "resources tagged with binding=Some('us') must route to that named instance"
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_router_unknown_named_instance_errors_with_binding() {
+        let mut router = ProviderRouter::new();
+        router.add_provider("mock".to_string(), Box::new(MockProvider));
+
+        let id = ResourceId::with_provider_and_instance(
+            "mock",
+            "test",
+            "x",
+            Some("missing".to_string()),
+        );
+        let err = router.read(&id, None, ReadRequest).await.unwrap_err();
+        let msg = err.message();
+        assert!(
+            msg.contains("missing") && msg.contains("mock"),
+            "error must name both the binding and the kind, got: {msg}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Phase 3b-2b of carina#2191 (named provider instances). Wires up the
runtime routing layer that Phase 3b-2a left dangling: a resource with
`directives { provider = <binding> }` now reaches the matching named
provider instance instead of the kind's default.

- `ProviderRouter.providers` is re-keyed to `(kind, Option<binding>)`.
  The lookup uses both `id.provider` and `id.provider_instance`.
  `add_provider` still registers the kind's default;
  `add_provider_instance` is the explicit form.
- Wiring (`get_provider_with_ctx` / `create_providers_from_configs`)
  is now two-pass: default instances first (they own
  `source`/`version`/`revision` and may load a WASM plugin), then
  named instances reuse the factory the default already brought in.
- New fixture `multi_instance_create/` (multi-file: `providers.crn`,
  `main.crn`, `exports.crn`) exercises the full parse → plan flow.
  Companion test pins that the binding reaches
  `ResourceId.provider_instance`; plan display is intentionally
  silent about the instance — that surface is owned by Phase 5.

Refs #2191. Follows #3014 (resolver) and #3016 (ResourceId field).
Phase 4 (plugin host multi-instance store) and Phase 5 (LSP /
display polish) remain.

## Test plan

- [x] `cargo nextest run --workspace` — 3276 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — clean (incl. plan-fixtures Makefile parity)
- [x] New `provider_router_dispatches_to_named_instance` /
  `provider_router_unknown_named_instance_errors_with_binding` unit
  tests
- [x] `multi_instance_create_propagates_provider_instance` end-to-end
  through the fixture pipeline
- [ ] Real-infra T6c (registry usecase CloudFront viewer cert in
  us-east-1) — deferred to user run; this PR is the prerequisite
  routing layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)