### PR TITLE
provider: per-binding ProviderFactory + multi-instance host store (#2191 Phase 4)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -547,7 +547,9 @@ pub async fn run_apply(
                     .find(|p| p.name == backend_provider_name)
                     .map(|p| p.attributes.clone())
                     .unwrap_or_default();
-                let bucket_provider = factory.create_provider(&provider_config_attrs).await?;
+                let bucket_provider = factory
+                    .create_provider(None, &provider_config_attrs)
+                    .await?;
 
                 match bucket_provider
                     .create(

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -540,7 +540,9 @@ async fn run_state_bucket_delete(
         .find(|p| p.name == backend_provider_name)
         .map(|p| p.attributes.clone())
         .unwrap_or_default();
-    let bucket_provider = factory.create_provider(&provider_config_attrs).await?;
+    let bucket_provider = factory
+        .create_provider(None, &provider_config_attrs)
+        .await?;
 
     // First, try to empty the bucket (delete all objects and versions)
     println!();

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -156,7 +156,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         let mut router = ProviderRouter::new();
         for factory in wiring.factories() {
             let attrs = indexmap::IndexMap::new();
-            router.add_normalizer(rt.block_on(factory.create_normalizer(&attrs)));
+            router.add_normalizer(rt.block_on(factory.create_normalizer(None, &attrs)));
         }
         for provider_config in &parsed.providers {
             if !provider_config.default_tags.is_empty() {

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -713,7 +713,7 @@ pub fn normalize_desired_with_ctx(ctx: &WiringContext, resources: &mut [Resource
     let mut router = ProviderRouter::new();
     for factory in ctx.factories() {
         let attrs = indexmap::IndexMap::new();
-        router.add_normalizer(rt.block_on(factory.create_normalizer(&attrs)));
+        router.add_normalizer(rt.block_on(factory.create_normalizer(None, &attrs)));
     }
     router.normalize_desired(resources);
 }
@@ -734,7 +734,7 @@ pub fn normalize_state_with_ctx(
     let mut router = ProviderRouter::new();
     for factory in ctx.factories() {
         let attrs = indexmap::IndexMap::new();
-        router.add_normalizer(rt.block_on(factory.create_normalizer(&attrs)));
+        router.add_normalizer(rt.block_on(factory.create_normalizer(None, &attrs)));
     }
     router.normalize_state(current_states);
 }
@@ -985,11 +985,15 @@ async fn instantiate_provider_into_router(
             .cyan()
         );
         let provider = factory
-            .create_provider(&provider_config.attributes)
+            .create_provider(binding.as_deref(), &provider_config.attributes)
             .await
             .map_err(|e| e.for_provider(provider_config.name.clone()))?;
+        router.add_normalizer(
+            factory
+                .create_normalizer(binding.as_deref(), &provider_config.attributes)
+                .await,
+        );
         router.add_provider_instance(provider_config.name.clone(), binding, provider);
-        router.add_normalizer(factory.create_normalizer(&provider_config.attributes).await);
     } else if !provider_config.name.is_empty() {
         let message = match &binding {
             // Named instance whose kind's default did not register a
@@ -1024,7 +1028,7 @@ async fn try_add_source_provider(
                 format!("Using {} (region: {}, source: {})", name, region, source).cyan()
             );
             router.add_provider(name, provider);
-            router.add_normalizer(factory.create_normalizer(&config.attributes).await);
+            router.add_normalizer(factory.create_normalizer(None, &config.attributes).await);
             Ok(())
         }
         Err(LoadSourceError::Provider(e)) => {
@@ -1093,7 +1097,7 @@ async fn load_source_provider(
         .map_err(|e| LoadSourceError::Other(format!("Config validation failed: {e}")))?;
 
     let provider = factory
-        .create_provider(&config.attributes)
+        .create_provider(None, &config.attributes)
         .await
         .map_err(LoadSourceError::Provider)?;
     Ok((factory, provider, name))

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -321,7 +321,7 @@ fn test_merge_default_tags_prevents_false_diff() {
     let mut router = ProviderRouter::new();
     for factory in ctx.factories() {
         let attrs = IndexMap::new();
-        router.add_normalizer(rt.block_on(factory.create_normalizer(&attrs)));
+        router.add_normalizer(rt.block_on(factory.create_normalizer(None, &attrs)));
     }
     let mut resources_with = vec![resource];
     router.merge_default_tags(&mut resources_with, &default_tags, &schemas);

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -182,6 +182,7 @@ impl ProviderFactory for TestProviderFactory {
 
     fn create_provider(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<Box<dyn Provider>>> {
         Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
@@ -189,6 +190,7 @@ impl ProviderFactory for TestProviderFactory {
 
     fn create_normalizer(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
@@ -821,12 +823,14 @@ impl ProviderFactory for WasmStyleProviderFactory {
     }
     fn create_provider(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<Box<dyn Provider>>> {
         Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
     }
     fn create_normalizer(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })

--- a/carina-cli/tests/wait_validate_e2e.rs
+++ b/carina-cli/tests/wait_validate_e2e.rs
@@ -48,12 +48,14 @@ impl ProviderFactory for WaitTestFactory {
     }
     fn create_provider(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
         Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
     }
     fn create_normalizer(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -771,21 +771,32 @@ pub trait ProviderFactory: Send + Sync {
 
     /// Create a provider instance from configuration attributes.
     ///
+    /// `binding` is the `let <name> = provider <kind> { ... }` binding
+    /// name when this call instantiates a named instance, or `None`
+    /// when it instantiates the kind's default instance. The host
+    /// uses it as a cache key so multiple named instances of the same
+    /// kind do not collapse onto a single shared WASM instance.
+    /// Provider implementations are free to ignore it.
+    ///
     /// Returns `Err(ProviderError)` when the provider rejects the
     /// supplied configuration (e.g., an `allowed_account_ids` mismatch
     /// detected during `init`). Callers MUST surface the inner message
     /// verbatim — it is the user-facing error text.
     fn create_provider(
         &self,
+        binding: Option<&str>,
         attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>>;
 
     /// Create a normalizer instance from configuration attributes.
     ///
-    /// Returns a [`NoopNormalizer`] by default. Providers that need
-    /// plan-time normalization or state hydration should override this.
+    /// `binding` semantics match [`create_provider`]: `Some(name)` for
+    /// a named instance, `None` for the kind's default. Returns a
+    /// [`NoopNormalizer`] by default. Providers that need plan-time
+    /// normalization or state hydration should override this.
     fn create_normalizer(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
@@ -1630,6 +1641,7 @@ mod tests {
             }
             fn create_provider(
                 &self,
+                _binding: Option<&str>,
                 _attrs: &IndexMap<String, Value>,
             ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
                 Box::pin(async {
@@ -1646,7 +1658,7 @@ mod tests {
         }
 
         let factory = FailingFactory;
-        let result = factory.create_provider(&IndexMap::new()).await;
+        let result = factory.create_provider(None, &IndexMap::new()).await;
         let err = match result {
             Ok(_) => panic!("create_provider must surface the init error"),
             Err(e) => e,
@@ -1668,6 +1680,81 @@ mod tests {
         assert!(
             !msg.contains("panicked"),
             "must not surface panic framing: {msg}"
+        );
+    }
+
+    /// carina#2191 Phase 4: every `ProviderFactory::create_provider`
+    /// implementation must receive the `binding` argument and have the
+    /// opportunity to vary its returned provider per binding. The
+    /// `WasmProviderFactory` uses this as a cache key to keep one
+    /// `SharedWasmInstance` per named instance; this in-memory test
+    /// covers the trait-level contract.
+    #[tokio::test]
+    async fn provider_factory_create_provider_receives_binding() {
+        use std::sync::Arc;
+        use std::sync::Mutex as StdMutex;
+
+        use crate::schema::ResourceSchema;
+
+        #[derive(Default)]
+        struct BindingCapturingFactory {
+            calls: Arc<StdMutex<Vec<Option<String>>>>,
+        }
+
+        impl ProviderFactory for BindingCapturingFactory {
+            fn name(&self) -> &str {
+                "capture"
+            }
+            fn display_name(&self) -> &str {
+                "Capturing provider"
+            }
+            fn provider_config_attribute_types(
+                &self,
+            ) -> HashMap<String, crate::schema::AttributeType> {
+                HashMap::new()
+            }
+            fn validate_config(&self, _attrs: &IndexMap<String, Value>) -> Result<(), String> {
+                Ok(())
+            }
+            fn extract_region(&self, _attrs: &IndexMap<String, Value>) -> String {
+                "ap-northeast-1".to_string()
+            }
+            fn create_provider(
+                &self,
+                binding: Option<&str>,
+                _attrs: &IndexMap<String, Value>,
+            ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push(binding.map(|s| s.to_string()));
+                Box::pin(async { Ok(Box::new(MockProvider) as Box<dyn Provider>) })
+            }
+            fn schemas(&self) -> Vec<ResourceSchema> {
+                Vec::new()
+            }
+        }
+
+        let factory = BindingCapturingFactory::default();
+        let _ = factory
+            .create_provider(None, &IndexMap::new())
+            .await
+            .unwrap();
+        let _ = factory
+            .create_provider(Some("us"), &IndexMap::new())
+            .await
+            .unwrap();
+        let _ = factory
+            .create_provider(Some("tokyo"), &IndexMap::new())
+            .await
+            .unwrap();
+
+        let calls = factory.calls.lock().unwrap().clone();
+        assert_eq!(
+            calls,
+            vec![None, Some("us".to_string()), Some("tokyo".to_string())],
+            "factory must observe each binding distinctly so it can key per-instance state \
+             (cache the WASM instance / hand back independent providers)"
         );
     }
 

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -822,10 +822,16 @@ pub struct WasmProviderFactory {
     /// Reusable WASM instance from factory initialization.
     /// Used by `validate_config()` to avoid creating a throwaway instance.
     init_instance: Mutex<(Store<HostState>, WasmBindings)>,
-    /// Lazily created shared instance for provider + normalizer.
-    /// The first call to `create_provider` or `create_normalizer` creates
-    /// the instance; the second reuses it via `Arc`.
-    shared_instance: Mutex<Option<Arc<SharedWasmInstance>>>,
+    /// Lazily created shared instances for provider + normalizer, keyed
+    /// by binding name. `None` is the kind's default instance;
+    /// `Some(name)` is a named instance (`let <name> = provider <kind>
+    /// { ... }`). The first call for a given key creates the instance;
+    /// subsequent calls reuse it via `Arc`. Keeping a per-binding entry
+    /// is what makes carina#2191 routing work end-to-end — collapsing
+    /// every binding onto a single shared instance would pin each kind
+    /// to the first instance's attributes (e.g. region) regardless of
+    /// what later instances configure.
+    shared_instances: Mutex<HashMap<Option<String>, Arc<SharedWasmInstance>>>,
     /// Background thread that ticks the epoch counter for timeout enforcement.
     /// Kept alive for the lifetime of the factory; dropped automatically.
     _epoch_ticker: EpochTicker,
@@ -1017,7 +1023,7 @@ impl WasmProviderFactory {
             cached_provider_config_types,
             enable_http,
             init_instance: Mutex::new((store, bindings)),
-            shared_instance: Mutex::new(None),
+            shared_instances: Mutex::new(HashMap::new()),
             _epoch_ticker: epoch_ticker,
         })
     }
@@ -1125,7 +1131,7 @@ impl WasmProviderFactory {
             cached_provider_config_types,
             enable_http,
             init_instance: Mutex::new((store, bindings)),
-            shared_instance: Mutex::new(None),
+            shared_instances: Mutex::new(HashMap::new()),
             _epoch_ticker: epoch_ticker,
         })
     }
@@ -1164,17 +1170,23 @@ impl WasmProviderFactory {
         Ok((store, bindings))
     }
 
-    /// Get or create the shared WASM instance for provider + normalizer.
+    /// Get or create the shared WASM instance for the given binding's
+    /// provider + normalizer pair.
     ///
-    /// The first call creates and initializes a new instance; subsequent calls
-    /// return an `Arc` to the same instance. This avoids creating two separate
-    /// WASM instances for the provider and normalizer.
+    /// The first call for a `binding` key creates and initializes a new
+    /// instance; subsequent calls for the same key return an `Arc` to
+    /// the same instance. Different bindings (e.g. `None` for the kind
+    /// default and `Some("us")` for a named instance) deliberately get
+    /// distinct instances — that is what makes per-instance config
+    /// (region, credentials, etc.) survive into runtime calls.
     async fn get_or_create_shared_instance(
         &self,
+        binding: Option<&str>,
         attributes: &IndexMap<String, Value>,
     ) -> Result<Arc<SharedWasmInstance>, String> {
-        let mut guard = self.shared_instance.lock().await;
-        if let Some(ref instance) = *guard {
+        let key: Option<String> = binding.map(|s| s.to_string());
+        let mut guard = self.shared_instances.lock().await;
+        if let Some(instance) = guard.get(&key) {
             return Ok(Arc::clone(instance));
         }
         let (store, bindings) = self.create_initialized_instance(attributes).await?;
@@ -1182,7 +1194,7 @@ impl WasmProviderFactory {
             store: Mutex::new(store),
             bindings,
         });
-        *guard = Some(Arc::clone(&instance));
+        guard.insert(key, Arc::clone(&instance));
         Ok(instance)
     }
 }
@@ -1302,9 +1314,11 @@ impl ProviderFactory for WasmProviderFactory {
 
     fn create_provider(
         &self,
+        binding: Option<&str>,
         attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
         let attrs = attributes.clone();
+        let binding = binding.map(|s| s.to_string());
         Box::pin(async move {
             // Surface the inner error string verbatim — it carries the
             // user-actionable message (e.g. allowed_account_ids
@@ -1312,7 +1326,7 @@ impl ProviderFactory for WasmProviderFactory {
             // wrapper prefix here would leak the WASM hosting detail
             // into the user-facing error (see #2407).
             let instance = self
-                .get_or_create_shared_instance(&attrs)
+                .get_or_create_shared_instance(binding.as_deref(), &attrs)
                 .await
                 .map_err(ProviderError::invalid_input)?;
             Ok(Box::new(WasmProvider {
@@ -1324,11 +1338,16 @@ impl ProviderFactory for WasmProviderFactory {
 
     fn create_normalizer(
         &self,
+        binding: Option<&str>,
         attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         let attrs = attributes.clone();
+        let binding = binding.map(|s| s.to_string());
         Box::pin(async move {
-            match self.get_or_create_shared_instance(&attrs).await {
+            match self
+                .get_or_create_shared_instance(binding.as_deref(), &attrs)
+                .await
+            {
                 Ok(instance) => {
                     Box::new(WasmProviderNormalizer { instance }) as Box<dyn ProviderNormalizer>
                 }

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -70,7 +70,7 @@ async fn test_wasm_mock_provider_create_and_read() {
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
     let provider = factory
-        .create_provider(&indexmap::IndexMap::new())
+        .create_provider(None, &indexmap::IndexMap::new())
         .await
         .expect("provider should init");
 
@@ -151,7 +151,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
     let provider = factory
-        .create_provider(&indexmap::IndexMap::new())
+        .create_provider(None, &indexmap::IndexMap::new())
         .await
         .expect("provider should init");
 
@@ -267,7 +267,9 @@ async fn test_wasm_mock_provider_update_and_delete() {
 async fn test_wasm_mock_provider_normalizer() {
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
-    let normalizer = factory.create_normalizer(&indexmap::IndexMap::new()).await;
+    let normalizer = factory
+        .create_normalizer(None, &indexmap::IndexMap::new())
+        .await;
 
     // normalize_desired: mock provider returns resources unchanged
     let mut resources = vec![{
@@ -309,7 +311,9 @@ async fn test_wasm_mock_provider_merge_default_tags_dispatches_through_wit() {
     // its presence proves the WIT bridge round-tripped.
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
-    let normalizer = factory.create_normalizer(&indexmap::IndexMap::new()).await;
+    let normalizer = factory
+        .create_normalizer(None, &indexmap::IndexMap::new())
+        .await;
 
     let registry = carina_core::schema::SchemaRegistry::new();
     let mut resources = vec![Resource::with_provider("mock", "test.resource", "tag-test")];
@@ -341,7 +345,9 @@ async fn test_wasm_mock_provider_merge_default_tags_empty_short_circuits() {
     // didn't, the mock guest would still write its sentinel attribute.
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
-    let normalizer = factory.create_normalizer(&indexmap::IndexMap::new()).await;
+    let normalizer = factory
+        .create_normalizer(None, &indexmap::IndexMap::new())
+        .await;
 
     let registry = carina_core::schema::SchemaRegistry::new();
     let mut resources = vec![Resource::with_provider("mock", "test.resource", "no-tags")];
@@ -363,7 +369,9 @@ async fn test_wasm_mock_provider_merge_default_tags_preserves_order() {
     // index, so the guest must return resources in input order.
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
-    let normalizer = factory.create_normalizer(&indexmap::IndexMap::new()).await;
+    let normalizer = factory
+        .create_normalizer(None, &indexmap::IndexMap::new())
+        .await;
 
     let registry = carina_core::schema::SchemaRegistry::new();
     let mut resources = vec![
@@ -401,7 +409,7 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
     let provider = factory
-        .create_provider(&indexmap::IndexMap::new())
+        .create_provider(None, &indexmap::IndexMap::new())
         .await
         .expect("provider should init");
 

--- a/carina-plugin-host/tests/wasm_precompile_test.rs
+++ b/carina-plugin-host/tests/wasm_precompile_test.rs
@@ -147,7 +147,7 @@ async fn test_precompiled_factory_creates_provider() {
 
     // Verify the factory can actually create a working provider
     let provider = factory
-        .create_provider(&indexmap::IndexMap::new())
+        .create_provider(None, &indexmap::IndexMap::new())
         .await
         .expect("provider should init");
     assert_eq!(provider.name(), "mock");


### PR DESCRIPTION
## Summary

Phase 4 of carina#2191 (named provider instances). Closes the runtime
side: `WasmProviderFactory` now keeps one WASM instance per binding,
and the trait surface gives every factory the binding identity it
needs to do the same.

- `ProviderFactory::create_provider` / `create_normalizer` now take
  `binding: Option<&str>` — `None` for the kind's default instance,
  `Some(name)` for a named one (`let <name> = provider <kind> { ... }`).
- `WasmProviderFactory.shared_instances` is keyed by `Option<String>`.
  Previously a single `shared_instance` collapsed every call onto the
  first instance's WASM store regardless of attributes — broken for
  multi-region routing once Phase 3b-2b started dispatching by binding.
- Wiring threads the binding through both call sites in
  `instantiate_provider_into_router`.
- A trait-level test (`provider_factory_create_provider_receives_binding`)
  pins that each call surfaces its binding distinctly.

In-process factories (aws / awscc, in sibling repos) can ignore the
binding because they construct a fresh provider per call; follow-up
PRs in those repos will update their signatures and bump the
`carina-core` rev together.

Refs #2191. Follows #3017 (router routing). Phase 5 (LSP / display
polish) and Phase 6 (state docs + real-infra T6c) remain.

## Test plan

- [x] `cargo nextest run --workspace` — 3277 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — clean
- [x] New `provider_factory_create_provider_receives_binding`
  trait-level test asserts `(None, Some("us"), Some("tokyo"))` calls
  are observed distinctly.
- [ ] Real-infra T6c — still gated on Phase 6 + the aws/awscc
  follow-up PRs that bump rev to this PR's merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
