### PR TITLE
lsp: completion + diagnostics for directives.provider (#2191 Phase 5)

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -176,6 +176,9 @@ impl CompletionProvider {
                     position,
                     base_path,
                 ),
+            CompletionContext::InsideDirectivesProviderValue => {
+                self.directives_provider_completions(provider_ctx, base_path)
+            }
             CompletionContext::InsideProviderBlock { .. } => self.provider_block_completions(),
             CompletionContext::AfterProviderRegion { provider_name } => {
                 self.region_completions_for_provider(&provider_name)
@@ -471,6 +474,15 @@ impl CompletionProvider {
                     return CompletionContext::InsideDirectivesDependsOnList {
                         current_binding: current_binding.clone(),
                     };
+                }
+            }
+            // Cursor inside `directives { provider = | }` (#2191 Phase 5).
+            // The value position takes a bare binding identifier — the name
+            // of a `let <name> = provider <kind> { ... }` instance.
+            if prefix.contains('=') {
+                let attr_name = self.extract_attr_name(&prefix);
+                if attr_name == "provider" {
+                    return CompletionContext::InsideDirectivesProviderValue;
                 }
             }
             // Cursor at attribute-name position inside `directives { | }`.
@@ -892,6 +904,11 @@ enum CompletionContext {
     InsideDirectivesDependsOnList {
         current_binding: Option<String>,
     },
+    /// Cursor is inside `directives { provider = | }` (carina#2191
+    /// Phase 5). Suggests every named provider instance binding
+    /// (`let <name> = provider <kind> { ... }`) declared anywhere in
+    /// the directory.
+    InsideDirectivesProviderValue,
     InsideImportPath {
         partial_path: String,
     },

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -2395,7 +2395,7 @@ let rd = registry_deploy {
 }
 
 #[test]
-fn directives_block_completion_includes_all_four_keys() {
+fn directives_block_completion_includes_all_five_keys() {
     let provider = test_provider_single_attr();
     let doc = create_document("test.foo.bar {\n  attr = \"x\"\n  directives {\n    \n  }\n}\n");
     // Cursor inside directives block, line 3, char 4
@@ -2413,6 +2413,7 @@ fn directives_block_completion_includes_all_four_keys() {
         "create_before_destroy",
         "prevent_destroy",
         "depends_on",
+        "provider",
     ] {
         assert!(
             labels.contains(&key),
@@ -2471,5 +2472,78 @@ fn directives_depends_on_completion_excludes_already_listed_names() {
     assert!(
         labels.contains(&"kms"),
         "kms binding should still be suggested; got {labels:?}"
+    );
+}
+
+/// carina#2191 Phase 5: `directives { provider = | }` value-position
+/// completion must surface every named provider instance declared in
+/// the directory. Bindings in sibling `.crn` files count
+/// ([[feedback_directory_scoped_features]]) — the test puts the named
+/// instance in `providers.crn` while the cursor sits in `main.crn`.
+#[test]
+fn directives_provider_value_completion_lists_named_instances() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let provider = test_provider_single_attr();
+    let temp_dir = tempdir().expect("failed to create tempdir");
+    let base_path = temp_dir.path();
+
+    // Default instance + two named instances declared in a sibling
+    // file. The parser accepts arbitrary provider kinds at this stage;
+    // schema-level kind validation happens later in the pipeline.
+    let providers_crn = "provider test {\n  region = \"x\"\n}\n";
+    let named_instances_crn = "let us = provider test {\n  region = \"u\"\n}\nlet tokyo = provider test {\n  region = \"t\"\n}\n";
+    fs::write(base_path.join("providers.crn"), providers_crn).expect("write providers.crn");
+    fs::write(base_path.join("instances.crn"), named_instances_crn).expect("write instances.crn");
+
+    // main.crn on disk has a complete `directives` block so the
+    // directory parse succeeds; the buffer passed to the LSP layer
+    // (`main_content`, below) holds the in-progress edit with the
+    // cursor right after `provider = ` and no value yet.
+    fs::write(
+        base_path.join("main.crn"),
+        "test.foo.bar {\n  attr = \"r\"\n}\n",
+    )
+    .expect("write main.crn");
+
+    let main_content = "test.foo.bar {\n  attr = \"r\"\n  directives {\n    provider = \n  }\n}\n";
+
+    // Sanity: verify the directory parse sees both named instances.
+    // If this assertion ever fires the LSP completion can't possibly
+    // see them either — that's the path we're actually trying to test.
+    let parsed = carina_core::config_loader::parse_directory(
+        base_path,
+        &carina_core::parser::ProviderContext::default(),
+    )
+    .expect("parse_directory should accept the fixture");
+    let parsed_bindings: Vec<&str> = parsed
+        .providers
+        .iter()
+        .filter_map(|p| p.binding.as_deref())
+        .collect();
+    assert!(
+        parsed_bindings.contains(&"us") && parsed_bindings.contains(&"tokyo"),
+        "parser should see both named instances in sibling files; got {parsed_bindings:?}"
+    );
+
+    let doc = create_document(main_content);
+
+    // Cursor right after `provider = ` on line 3 (so `prefix.contains('=')`
+    // is true and `extract_attr_name` resolves to `provider`).
+    let position = Position {
+        line: 3,
+        character: 15,
+    };
+    let completions = provider.complete(&doc, position, Some(base_path));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"us"),
+        "named instance `us` must surface as a value candidate; got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"tokyo"),
+        "named instance `tokyo` must surface as a value candidate; got {labels:?}"
     );
 }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -656,9 +656,11 @@ impl CompletionProvider {
     }
 
     /// Attribute-name candidates for `directives { | }` (#2873). The
-    /// four directives — `force_delete`, `create_before_destroy`,
-    /// `prevent_destroy`, `depends_on` — exhaustively. Order is
-    /// alphabetical to match `KEYWORDS` ordering in `keywords.rs`.
+    /// five directives — `create_before_destroy`, `depends_on`,
+    /// `force_delete`, `prevent_destroy`, `provider` — exhaustively.
+    /// Order is alphabetical to match `KEYWORDS` ordering in
+    /// `keywords.rs`. `provider` was added in carina#2191 Phase 5 for
+    /// routing to named provider instances.
     pub(super) fn directives_block_completions(&self) -> Vec<CompletionItem> {
         let trigger_suggest = Command {
             title: "Trigger Suggest".to_string(),
@@ -698,10 +700,49 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::PROPERTY),
                 detail: Some("Block any plan that would destroy this resource".to_string()),
                 insert_text: Some("prevent_destroy = ".to_string()),
+                command: Some(trigger_suggest.clone()),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: "provider".to_string(),
+                kind: Some(CompletionItemKind::PROPERTY),
+                detail: Some(
+                    "Route this resource to a named provider instance \
+                     (`let <name> = provider <kind> { ... }`)"
+                        .to_string(),
+                ),
+                insert_text: Some("provider = ".to_string()),
                 command: Some(trigger_suggest),
                 ..Default::default()
             },
         ]
+    }
+
+    /// Value candidates for `directives { provider = | }` (carina#2191
+    /// Phase 5). Suggests every named provider instance binding
+    /// declared anywhere in the directory. The kind's default
+    /// instance (a top-level `provider <kind> { ... }` block without
+    /// a `let` prefix) carries no binding name and is intentionally
+    /// not surfaced — omitting `directives.provider` routes there.
+    pub(super) fn directives_provider_completions(
+        &self,
+        provider_ctx: &carina_core::parser::ProviderContext,
+        base_path: Option<&std::path::Path>,
+    ) -> Vec<CompletionItem> {
+        let bindings = collect_named_provider_instance_bindings(provider_ctx, base_path);
+        bindings
+            .into_iter()
+            .map(|binding| CompletionItem {
+                label: binding.clone(),
+                kind: Some(CompletionItemKind::VARIABLE),
+                detail: Some(format!(
+                    "Named provider instance `let {} = provider <kind> {{ ... }}`",
+                    binding
+                )),
+                insert_text: Some(binding),
+                ..Default::default()
+            })
+            .collect()
     }
 
     /// Element candidates for `directives { depends_on = [|] }`
@@ -2050,4 +2091,43 @@ fn join_relative(up_depth: usize, parts: &[&str]) -> String {
     }
     s.push_str(&parts.join("/"));
     s
+}
+
+/// Collect every named provider instance binding declared in the
+/// directory that `base_path` lives in. A *named* instance is one
+/// declared as `let <name> = provider <kind> { ... }`; the kind's
+/// default instance (a top-level `provider <kind> { ... }` without
+/// `let`) carries no binding name and is excluded.
+///
+/// The walk is directory-scoped: a binding declared in `providers.crn`
+/// must surface as a completion candidate while the user is editing
+/// `main.crn` in the same directory ([[feedback_directory_scoped_features]]).
+/// `parse_directory` is the right entry point because it merges every
+/// sibling `.crn` regardless of whether the directory is a module
+/// (input/output shape) or a root config — `load_module` returns
+/// `None` for root configs and would miss the bindings entirely.
+fn collect_named_provider_instance_bindings(
+    provider_ctx: &carina_core::parser::ProviderContext,
+    base_path: Option<&Path>,
+) -> Vec<String> {
+    let Some(base) = base_path else {
+        return Vec::new();
+    };
+    let dir = if base.is_file() {
+        base.parent().unwrap_or(base).to_path_buf()
+    } else {
+        base.to_path_buf()
+    };
+    let parsed = match carina_core::config_loader::parse_directory(&dir, provider_ctx) {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    let mut bindings: Vec<String> = parsed
+        .providers
+        .iter()
+        .filter_map(|p| p.binding.clone())
+        .collect();
+    bindings.sort();
+    bindings.dedup();
+    bindings
 }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -147,6 +147,18 @@ impl DiagnosticEngine {
             diagnostics.extend(self.check_for_iterable_bindings(doc, merged, current_file_name));
         }
 
+        // carina#2191 Phase 5: surface `check_provider_instance_routing`
+        // errors as editor diagnostics. The CLI's `load_configuration`
+        // accumulates them in `identifier_scope_errors`; LSP runs the
+        // same pass against the merged parse so users see the same
+        // "unknown provider instance" / "no default instance for kind"
+        // message before they run `carina validate`.
+        if let Some(merged) = merged.as_ref() {
+            for err in carina_core::parser::check_provider_instance_routing(merged) {
+                diagnostics.push(parse_error_to_diagnostic(&err));
+            }
+        }
+
         // Prefer the directory-merged parse so cross-file binding refs
         // resolve; fall back to the buffer-only parse otherwise.
         if let Some(parsed) = merged.as_ref() {


### PR DESCRIPTION
## Summary

Phase 5 of carina#2191 — editor support for the `directives.provider`
routing introduced in earlier phases.

- `directives { | }` attribute-name completion now lists a fifth key:
  `provider` (alongside `force_delete`, `create_before_destroy`,
  `prevent_destroy`, `depends_on`).
- Value-position completion: when the cursor sits at
  `directives { provider = | }`, every named provider instance
  binding declared in the directory (a `let <name> = provider <kind>
  { ... }` declaration in any sibling `.crn`) is offered as a
  candidate. The kind's default instance carries no binding name and
  is intentionally not surfaced — omitting the directive routes there.
- Diagnostic parity: the existing
  `check_provider_instance_routing` pass (which `carina validate`
  runs through `load_configuration`) now runs against the merged
  parse in the LSP too. Editors flag "unknown provider instance" /
  "no default instance for kind" before the user reaches the CLI.

Multi-file fixture test covers the directory-scoped walk — the named
instances live in `providers.crn`/`instances.crn` while the cursor
sits in `main.crn`.

Refs #2191. Follows #3018 (host multi-instance store). Phase 6 (state
docs + real-infra T6c) remains.

## Test plan

- [x] `cargo nextest run --workspace` — 3278 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — clean
- [x] New `directives_provider_value_completion_lists_named_instances`
  test exercises a multi-file fixture: bindings declared in
  `instances.crn` must surface while editing `main.crn`.
- [ ] Real-infra editor smoke — gated on Phase 6 + sibling repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
