### PR TITLE
cli/lsp: skip source check for named provider instances (closes #3023)

### DIFF
--- a/carina-cli/src/commands/init.rs
+++ b/carina-cli/src/commands/init.rs
@@ -30,11 +30,17 @@ pub fn run_init(path: &Path, upgrade: bool, locked: bool) -> Result<(), String> 
     )
     .map_err(|e| format!("Failed to load configuration: {e}"))?;
 
+    // `source` is a kind-level property — only the kind's default
+    // instance carries it. Named instances declared as
+    // `let <name> = provider <kind> { ... }` cannot set it (the
+    // parser rejects them). Restrict the pre-resolution check to
+    // default instances so a named instance's deliberate absence
+    // of `source` does not surface as a user error (carina#3023).
     let missing_source: Vec<String> = loaded
         .parsed
         .providers
         .iter()
-        .filter(|p| p.source.is_none())
+        .filter(|p| p.is_default && p.source.is_none())
         .map(|p| crate::commands::missing_provider_source_message(&p.name))
         .collect();
     if !missing_source.is_empty() {

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -235,6 +235,12 @@ pub fn validate_and_resolve_errors_with_factories(
     }
 
     // Check for declared providers whose plugins failed to load.
+    // Named instances (`!is_default`) deliberately omit `source` —
+    // the parser enforces that `source` is a kind-level property
+    // (carina#3023). They inherit the kind default's plugin, so
+    // they only matter to this check when the *kind default* could
+    // not be loaded, which is already reported via the
+    // `factories().iter().any(...)` lookup on the kind's name.
     if !skip_resource_validation {
         for provider in &parsed.providers {
             let loaded = ctx.factories().iter().any(|f| f.name() == provider.name);
@@ -243,7 +249,7 @@ pub fn validate_and_resolve_errors_with_factories(
             }
             if let Some(reason) = load_errors.get(&provider.name) {
                 errors.push(AppError::Validation(reason.clone()));
-            } else if provider.source.is_none() {
+            } else if provider.is_default && provider.source.is_none() {
                 errors.push(AppError::Validation(missing_provider_source_message(
                     &provider.name,
                 )));

--- a/carina-cli/tests/init_validation.rs
+++ b/carina-cli/tests/init_validation.rs
@@ -62,3 +62,73 @@ awscc.s3.Bucket {
         "carina-providers.lock should not be created on failure",
     );
 }
+
+/// carina#3023: `carina init` must not require `source` on a named
+/// provider instance. The parser already rejects `source` /
+/// `version` / `revision` on `let <name> = provider <kind> { ... }`
+/// (those are kind-level properties), so the init source-existence
+/// check needs to look at the kind default only.
+///
+/// Pre-fix behaviour: init walked every `ProviderConfig` and
+/// reported "Provider 'aws' has no source configured" for the named
+/// instance. The reported message named the *kind*, leaving users
+/// with no way to act on it: their default block already had
+/// `source` set.
+///
+/// We assert on the *stderr text* rather than overall exit code:
+/// downstream of the pre-check, `carina init` tries to resolve the
+/// `file://` plugin we point at (which doesn't exist on the test
+/// runner), so init will still fail — but it should fail with a
+/// different error (a fetch / find error from
+/// `carina_provider_resolver`), not the pre-check string.
+#[test]
+fn init_does_not_require_source_on_named_provider_instance() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+
+    // Multi-file fixture mirroring the carina-rs/infra shape from the
+    // bug report: default `provider aws` carries `source` on its own
+    // (`file://` to a fake path — init will still fail downstream
+    // because the plugin doesn't actually resolve, but that's a
+    // different error than the pre-check we're testing for), and a
+    // `let us = provider aws { region = ... }` named instance sits
+    // beside it without `source`.
+    fs::write(
+        project.join("providers.crn"),
+        "provider aws {\n  \
+         source = 'file:///nonexistent/fake-provider.wasm'\n  \
+         region = aws.Region.ap_northeast_1\n\
+         }\n\
+         \n\
+         let us = provider aws {\n  \
+         region = aws.Region.us_east_1\n\
+         }\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("main.crn"),
+        "aws.s3.Bucket {\n  \
+         bucket_name = 'test'\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = carina_init(project);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Match the exact wording `missing_provider_source_message`
+    // produces, not just a loose substring, so a future
+    // unrelated error from `carina_provider_resolver` that
+    // happens to share words doesn't masquerade as a pass.
+    let pre_check_msg = "Provider 'aws' has no source configured. Add `source = 'github.com/...'` to the provider block.";
+    assert!(
+        !stderr.contains(pre_check_msg) && !stdout.contains(pre_check_msg),
+        "init must not surface the kind-level 'no source configured' \
+         error when the only entry lacking `source` is the named \
+         instance — that's a parser-enforced invariant, not a user \
+         mistake. carina#3023.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        stdout,
+        stderr,
+    );
+}

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -47,11 +47,23 @@ fn build_factories(providers: &[(PathBuf, ProviderConfig)]) -> FactoryBuildResul
         let source = match &config.source {
             Some(s) => s,
             None => {
-                errors.insert(
-                    config.name.clone(),
-                    "no source configured. Add `source = 'github.com/...'` to the provider block."
-                        .to_string(),
-                );
+                // Named provider instances (`let <name> = provider <kind>
+                // { ... }`) inherit `source` from the kind's default;
+                // the parser forbids them from setting it themselves.
+                // Only the kind default's deliberate absence of
+                // `source` is a real user error (carina#3023). The
+                // `fingerprint` push stays outside this gate so
+                // every config in `providers` produces exactly one
+                // entry — `probe_install_fingerprint` iterates the
+                // same slice unconditionally, and the LSP's
+                // drift-poll compares the two fingerprint vectors
+                // for equality.
+                if config.is_default {
+                    errors.insert(
+                        config.name.clone(),
+                        "no source configured. Add `source = 'github.com/...'` to the provider block.".to_string(),
+                    );
+                }
                 fingerprint.push((config.name.clone(), false));
                 continue;
             }
@@ -153,4 +165,69 @@ async fn main() {
         )
     });
     Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_core::parser::ProviderConfig;
+    use indexmap::IndexMap;
+    use std::path::PathBuf;
+
+    fn cfg(
+        name: &str,
+        source: Option<&str>,
+        is_default: bool,
+        binding: Option<&str>,
+    ) -> (PathBuf, ProviderConfig) {
+        (
+            PathBuf::from("/tmp"),
+            ProviderConfig {
+                name: name.to_string(),
+                attributes: IndexMap::new(),
+                default_tags: IndexMap::new(),
+                source: source.map(String::from),
+                version: None,
+                revision: None,
+                unresolved_attributes: IndexMap::new(),
+                binding: binding.map(String::from),
+                is_default,
+            },
+        )
+    }
+
+    /// carina#3023: when a named provider instance sits beside the
+    /// kind default, `build_factories` must produce a fingerprint
+    /// entry for *every* config — same length as the input — so the
+    /// LSP's drift-poll comparison against `probe_install_fingerprint`
+    /// (which iterates every config unconditionally) keeps agreeing
+    /// when nothing changed. Previously the fingerprint push was
+    /// gated behind the missing-source error path; when we silenced
+    /// that error for named instances, the push got silenced with
+    /// it and the poll detected fake drift every tick.
+    #[test]
+    fn build_factories_fingerprint_length_matches_configs_length() {
+        let providers = vec![
+            cfg("aws", Some("file:///nonexistent/fake.wasm"), true, None),
+            cfg("aws", None, false, Some("us")),
+        ];
+        let (_factories, errors, fingerprint) = build_factories(&providers);
+        assert_eq!(
+            fingerprint.len(),
+            providers.len(),
+            "fingerprint must emit one entry per config (including named instances); \
+             otherwise the drift-poll mismatch causes a perpetual rebuild loop. carina#3023."
+        );
+        // Sanity: named instance does not surface the kind-level
+        // "no source configured" error, since the parser forbids it
+        // from setting `source` in the first place.
+        assert!(
+            !errors
+                .get("aws")
+                .is_some_and(|m| m.contains("no source configured")),
+            "named instance must not trigger the kind-level missing-source diagnostic. \
+             carina#3023. errors: {:?}",
+            errors
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #3023.

`carina init` failed with `Provider 'aws' has no source configured`
whenever a named provider instance (`let us = provider aws { ... }`)
sat beside the kind default — even though the parser forbids named
instances from setting `source` / `version` / `revision` in the
first place. The init pre-check walked every `ProviderConfig`
indiscriminately, so the named instance with its parser-enforced
`source: None` looked like a user mistake.

Four sites carried the same pattern; all four are now gated on
`provider.is_default`:

1. `carina-cli/src/commands/init.rs` — init pre-check
2. `carina-cli/src/commands/mod.rs` — `validate_and_resolve` post-load check
3. `carina-lsp/src/main.rs` — LSP `build_factories` error path
4. `carina-lsp/src/main.rs` — fingerprint push (deliberately *outside*
   the gate, see below)

The LSP `fingerprint` push stays unconditional because
`probe_install_fingerprint` walks every config and the drift-poll
compares the two vectors for equality. If the push had been moved
inside the `is_default` gate, the LSP would have re-built factories
every 2-second poll tick on any project with a named instance. The
unit test pins this invariant.

Follows carina#3021 (also a Phase 4 cleanup, separate bug class —
that one was about runtime region extraction).

## Test plan

- [x] `cargo nextest run -p carina-cli` — 411 passed
- [x] `cargo nextest run -p carina-lsp` — passed (includes new unit test)
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — clean
- [x] New integration test
  `init_does_not_require_source_on_named_provider_instance`
  reproduces the exact issue-body shape (multi-file fixture with
  default `provider aws` + `let us = provider aws { ... }`) and
  asserts the exact pre-check message stays absent.
- [x] New LSP unit test
  `build_factories_fingerprint_length_matches_configs_length`
  guards both the silenced kind-level diagnostic and the
  fingerprint-length invariant.
- [ ] Real-infra T6c smoke (`carina-rs/infra/.../registry`) — gated
  on the aws sibling-repo PR that re-points `extract_region` at the
  shared helper (carina#3021's follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
