### PR TITLE
parser/resolver: chained index-then-field access (closes #3025)

### DIFF
--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -364,11 +364,10 @@ pub(super) fn rewrite_intra_module_refs(
             if intra_module_bindings.contains(path.binding()) =>
         {
             Value::Deferred(DeferredValue::ResourceRef {
-                path: crate::resource::AccessPath::with_fields_and_subscripts(
+                path: crate::resource::AccessPath::with_segments(
                     format!("{}.{}", instance_prefix, path.binding()),
                     path.attribute().to_string(),
-                    path.field_path().to_vec(),
-                    path.subscripts().to_vec(),
+                    path.segments().to_vec(),
                 ),
             })
         }
@@ -627,11 +626,10 @@ fn rewrite_ref_prefixes(
             {
                 let new_binding = format!("{}_{:016x}.{}", module, target, rest);
                 return Value::Deferred(DeferredValue::ResourceRef {
-                    path: crate::resource::AccessPath::with_fields_and_subscripts(
+                    path: crate::resource::AccessPath::with_segments(
                         new_binding,
                         path.attribute().to_string(),
-                        path.field_path().to_vec(),
-                        path.subscripts().to_vec(),
+                        path.segments().to_vec(),
                     ),
                 });
             }

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -223,12 +223,15 @@ identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 // Segments after the first dot can also be digit-only (e.g., "Type.ipsec.1")
 namespaced_id = @{ identifier ~ ("." ~ (identifier | ASCII_DIGIT+))+ }
 
-// Namespaced identifier followed by one or more `[index]` subscripts:
-// `orgs.accounts[0]`, `orgs.account.children["alpha"]`. Captured as a
-// distinct rule so the namespaced_id arm doesn't have to introspect for
-// trailing subscripts and so the grammar matches the issue-#2318
-// surface (post-field index access) explicitly.
-subscripted_id = { namespaced_id ~ index_access+ }
+// Namespaced identifier followed by one or more `[index]` subscripts
+// and/or `.field` continuations: `orgs.accounts[0]`,
+// `orgs.account.children["alpha"]`,
+// `cert.domain_validation_options[0].resource_record_name` (carina#3025).
+// Captured as a distinct rule from `variable_ref` so the namespaced_id
+// head ambiguity (`a.b` could be a binding+field or a 2-part enum)
+// stays resolved by the trailing-access shape, and so the grammar
+// matches the post-field index/field access surface explicitly.
+subscripted_id = { namespaced_id ~ (index_access | field_access)+ }
 
 // Expression
 expression = { coalesce_expr }

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -12,7 +12,7 @@ use crate::parser::{
     ParseContext, ParseError, Rule, evaluate_user_function, extract_key_string, first_inner,
     is_static_value, next_pair, parse_block_contents, parse_expression, parse_expression_eval,
 };
-use crate::resource::{AccessPath, ConcreteValue, DeferredValue, Subscript, Value};
+use crate::resource::{AccessPath, ConcreteValue, DeferredValue, PathSegment, Subscript, Value};
 use indexmap::IndexMap;
 
 /// Decode a duration literal (`75min`, `1h`, `30s`) into integer
@@ -89,13 +89,14 @@ fn subscript_from_value(value: Value) -> Result<Subscript, ParseError> {
 }
 
 /// Lower a `namespaced_id` pair to its `EvalValue`, attaching any
-/// trailing subscripts collected by the caller (the `subscripted_id`
-/// arm). String-form enum shorthands like `aws.Region.ap_northeast_1`
-/// have no `AccessPath` to host subscripts — those reject outright.
+/// trailing path segments collected by the caller (the `subscripted_id`
+/// arm — a mix of `.field` and `[index]` continuations). String-form
+/// enum shorthands like `aws.Region.ap_northeast_1` have no
+/// `AccessPath` to host segments — those reject outright.
 fn parse_namespaced_id_value(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
-    subscripts: Vec<Subscript>,
+    trailing_segments: Vec<PathSegment>,
 ) -> Result<EvalValue, ParseError> {
     let full_str = pair.as_str();
     let parts: Vec<&str> = full_str.split('.').collect();
@@ -108,24 +109,28 @@ fn parse_namespaced_id_value(
         full_str
     );
 
-    let as_resource_ref = |subscripts: Vec<Subscript>| {
-        let path = AccessPath::with_fields_and_subscripts(
-            parts[0].to_string(),
-            parts[1].to_string(),
-            parts[2..].iter().map(|s| s.to_string()).collect(),
-            subscripts,
-        );
+    let as_resource_ref = |trailing_segments: Vec<PathSegment>| {
+        let mut segments: Vec<PathSegment> = parts[2..]
+            .iter()
+            .map(|s| PathSegment::Field {
+                name: (*s).to_string(),
+            })
+            .collect();
+        segments.extend(trailing_segments);
+        let path = AccessPath::with_segments(parts[0].to_string(), parts[1].to_string(), segments);
         EvalValue::from_value(Value::Deferred(DeferredValue::ResourceRef { path }))
     };
 
     if ctx.is_resource_binding(parts[0]) {
-        return Ok(as_resource_ref(subscripts));
+        return Ok(as_resource_ref(trailing_segments));
     }
 
-    // Subscripts (`a.b['k']`, `a.b[0]`) unambiguously mean binding
-    // access — no enum shorthand uses `[...]`. When the head is not a
-    // resource binding in this file, emit a structured `ResourceRef`
-    // and let `check_identifier_scope` flag genuine typos post-merge.
+    // Trailing segments (`a.b['k']`, `a.b[0]`, `a.b.c[0].d`)
+    // unambiguously mean binding access — no enum shorthand uses
+    // `[...]` and the parser only generates trailing path segments for
+    // `subscripted_id`. When the head is not a resource binding in this
+    // file, emit a structured `ResourceRef` and let
+    // `check_identifier_scope` flag genuine typos post-merge.
     //
     // Under the directory-aware parse pipeline (#2817), sibling-defined
     // bindings are seeded into `ctx.resource_bindings` so the early
@@ -136,8 +141,8 @@ fn parse_namespaced_id_value(
     // ID would fall through to the enum-shorthand `Value::Concrete(ConcreteValue::String)`
     // fallback below and silently mistype as a string. Originally added
     // for #2435.
-    if !subscripts.is_empty() {
-        return Ok(as_resource_ref(subscripts));
+    if !trailing_segments.is_empty() {
+        return Ok(as_resource_ref(trailing_segments));
     }
 
     if parts.len() == 2
@@ -239,23 +244,36 @@ pub(crate) fn parse_primary_eval(
         }
         Rule::namespaced_id => parse_namespaced_id_value(inner, ctx, Vec::new()),
         Rule::subscripted_id => {
-            // `binding.field[idx]` / `binding.field.subfield[idx]…` —
-            // the namespaced_id portion behaves like a plain
-            // namespaced_id (identifier shorthand or resource ref), and
-            // any trailing `[idx]` subscripts are folded onto the
-            // resulting `AccessPath`.
+            // `binding.field[idx]`, `binding.field.subfield[idx]…`,
+            // `binding.field[idx].subfield…` — the namespaced_id portion
+            // behaves like a plain namespaced_id (identifier shorthand
+            // or resource ref), and any trailing chain of `.field` /
+            // `[idx]` continuations is folded onto the resulting
+            // `AccessPath` as an ordered `Vec<PathSegment>` so source
+            // order is preserved (carina#3025).
             let mut parts = inner.into_inner();
             let head = next_pair(&mut parts, "namespaced_id", "subscripted_id")?;
-            let mut subscripts: Vec<Subscript> = Vec::new();
-            for index_pair in parts {
-                if !matches!(index_pair.as_rule(), Rule::index_access) {
-                    continue;
+            let mut segments: Vec<PathSegment> = Vec::new();
+            for pair in parts {
+                match pair.as_rule() {
+                    Rule::index_access => {
+                        let index_expr_pair =
+                            first_inner(pair, "index expression", "index access")?;
+                        let index_value = parse_expression(index_expr_pair, ctx)?;
+                        segments.push(PathSegment::Subscript {
+                            index: subscript_from_value(index_value)?,
+                        });
+                    }
+                    Rule::field_access => {
+                        let ident = first_inner(pair, "identifier", "field access")?;
+                        segments.push(PathSegment::Field {
+                            name: ident.as_str().to_string(),
+                        });
+                    }
+                    _ => continue,
                 }
-                let index_expr_pair = first_inner(index_pair, "index expression", "index access")?;
-                let index_value = parse_expression(index_expr_pair, ctx)?;
-                subscripts.push(subscript_from_value(index_value)?);
             }
-            parse_namespaced_id_value(head, ctx, subscripts)
+            parse_namespaced_id_value(head, ctx, segments)
         }
         Rule::boolean => {
             let b = inner.as_str() == "true";

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -10145,3 +10145,36 @@ fn resource_id_provider_instance_makes_distinct_ids() {
     map.insert(us.clone(), ());
     assert_eq!(map.len(), 2);
 }
+
+/// carina#3025: `<binding>.<field>[<idx>].<field>` must parse and reach
+/// the AST. Prior to the fix, the grammar's `subscripted_id` rule
+/// accepted only trailing `[idx]+` after the namespaced head and
+/// refused any `.field` continuation; the parser produced a syntax
+/// error at the first `.` after `[<idx>]`. The bug affects every
+/// list-of-structs read pattern (e.g. ACM cert
+/// `domain_validation_options[0].resource_record_name`) where the
+/// user has to fall back to a `for` loop over a length-1 list.
+#[test]
+fn parse_chained_index_then_field_access() {
+    let src = r#"
+        let cert = aws.acm.Certificate {
+            domain_name = "x"
+        }
+        aws.route53.RecordSet {
+            name = cert.domain_validation_options[0].resource_record_name
+        }
+    "#;
+    let parsed = parse(src, &ProviderContext::default())
+        .expect("`<binding>.<field>[<idx>].<field>` must parse — carina#3025");
+
+    // Sanity: the resource exists and its `name` attribute is on the parse tree.
+    let rs = parsed
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "route53.RecordSet")
+        .expect("RecordSet must be in parsed.resources");
+    assert!(
+        rs.attributes.contains_key("name"),
+        "RecordSet.name attribute must be present in parsed AST"
+    );
+}

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -377,8 +377,8 @@ fn parse_undefined_two_part_identifier_becomes_resource_ref() {
         Some(Value::Deferred(DeferredValue::ResourceRef { path })) => {
             assert_eq!(path.binding(), "nonexistent");
             assert_eq!(path.attribute(), "name");
-            assert!(path.field_path().is_empty());
-            assert!(path.subscripts().is_empty());
+            assert!(path.leading_field_path().is_empty());
+            assert!(path.trailing_subscripts().is_empty());
         }
         other => panic!("expected ResourceRef, got {other:?}"),
     }
@@ -3512,7 +3512,7 @@ fn test_chained_field_access_two_levels() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
-            let field_path = path.field_path();
+            let field_path = path.leading_field_path();
             assert_eq!(binding_name, "vpc");
             assert_eq!(attribute_name, "network");
             assert_eq!(field_path, vec!["vpc_id"]);
@@ -3542,7 +3542,7 @@ fn test_chained_field_access_three_levels() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
-            let field_path = path.field_path();
+            let field_path = path.leading_field_path();
             assert_eq!(binding_name, "web");
             assert_eq!(attribute_name, "output");
             assert_eq!(field_path, vec!["network", "vpc_id"]);
@@ -3574,7 +3574,7 @@ fn parse_index_access_with_integer() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
-            let field_path = path.field_path();
+            let field_path = path.leading_field_path();
             assert_eq!(binding_name, "subnets[0]");
             assert_eq!(attribute_name, "subnet_id");
             assert!(field_path.is_empty());
@@ -3614,7 +3614,7 @@ fn parse_index_access_with_string_key() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
-            let field_path = path.field_path();
+            let field_path = path.leading_field_path();
             assert_eq!(binding_name, "networks.prod");
             assert_eq!(attribute_name, "vpc_id");
             assert!(field_path.is_empty());
@@ -3651,7 +3651,7 @@ fn parse_index_access_with_chained_fields() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
-            let field_path = path.field_path();
+            let field_path = path.leading_field_path();
             assert_eq!(binding_name, "webs.prod");
             assert_eq!(attribute_name, "security_group");
             assert_eq!(field_path, vec!["id"]);
@@ -3679,9 +3679,9 @@ fn parse_subscript_after_field_access_with_integer() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "accounts");
-            assert!(path.field_path().is_empty());
+            assert!(path.leading_field_path().is_empty());
             assert_eq!(
-                path.subscripts(),
+                path.trailing_subscripts(),
                 [crate::resource::Subscript::Int { index: 0 }]
             );
             assert_eq!(path.to_dot_string(), "orgs.accounts[0]");
@@ -3709,9 +3709,9 @@ fn parse_subscript_after_field_access_with_string_key() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "accounts");
-            assert!(path.field_path().is_empty());
+            assert!(path.leading_field_path().is_empty());
             assert_eq!(
-                path.subscripts(),
+                path.trailing_subscripts(),
                 [crate::resource::Subscript::Str {
                     key: "alpha".to_string()
                 }]
@@ -3742,9 +3742,9 @@ fn parse_chained_subscripts_after_field_access() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "matrix");
-            assert!(path.field_path().is_empty());
+            assert!(path.leading_field_path().is_empty());
             assert_eq!(
-                path.subscripts(),
+                path.trailing_subscripts(),
                 [
                     crate::resource::Subscript::Int { index: 0 },
                     crate::resource::Subscript::Int { index: 1 },
@@ -3777,10 +3777,11 @@ fn parse_negative_subscript_is_rejected() {
 }
 
 #[test]
-fn parse_field_after_subscript_after_field_is_rejected() {
-    // `a.b[0].c` — once a subscript appears after a field, no more
-    // fields are allowed. Runtime list-indexing of arbitrary structs
-    // isn't representable today.
+fn parse_field_after_subscript_after_field_is_accepted() {
+    // `a.b[0].c` — chained index-then-field access (carina#3025).
+    // The grammar accepts any mix of `.field` / `[idx]` continuations
+    // and the AST stores them as an ordered `Vec<PathSegment>`, so
+    // source order survives end-to-end.
     let input = r#"
         let orgs = upstream_state { source = "../organizations" }
 
@@ -3789,15 +3790,28 @@ fn parse_field_after_subscript_after_field_is_rejected() {
             cidr_block = orgs.accounts[0].id
         }
     "#;
-    let err = parse(input, &ProviderContext::default()).unwrap_err();
-    let msg = format!("{:?}", err);
-    assert!(
-        msg.contains("field access after index access")
-            || msg.contains("field_access after index_access")
-            || msg.contains("InvalidExpression")
-            || msg.contains("Syntax"),
-        "expected rejection of `a.b[0].c`, got: {msg}"
-    );
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    let subnet = result.resources.last().expect("subnet");
+    let value = subnet.get_attr("cidr_block").expect("cidr_block");
+    match value {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            use crate::resource::{PathSegment, Subscript};
+            assert_eq!(path.binding(), "orgs");
+            assert_eq!(path.attribute(), "accounts");
+            assert_eq!(
+                path.segments(),
+                &[
+                    PathSegment::Subscript {
+                        index: Subscript::Int { index: 0 }
+                    },
+                    PathSegment::Field {
+                        name: "id".to_string()
+                    },
+                ]
+            );
+        }
+        other => panic!("expected ResourceRef, got: {other:?}"),
+    }
 }
 
 #[test]
@@ -3820,9 +3834,9 @@ fn parse_subscript_after_nested_field_access() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "account");
-            assert_eq!(path.field_path(), vec!["accounts"]);
+            assert_eq!(path.leading_field_path(), vec!["accounts"]);
             assert_eq!(
-                path.subscripts(),
+                path.trailing_subscripts(),
                 [crate::resource::Subscript::Int { index: 0 }]
             );
         }
@@ -6382,7 +6396,7 @@ fn parse_upstream_state_registers_binding() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "network");
             assert_eq!(path.attribute(), "vpc");
-            assert_eq!(path.field_path(), vec!["vpc_id"]);
+            assert_eq!(path.leading_field_path(), vec!["vpc_id"]);
         }
         other => panic!("Expected ResourceRef, got: {:?}", other),
     }
@@ -8377,9 +8391,9 @@ fn parse_subscript_on_upstream_state_in_sibling_file() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "accounts");
-            assert!(path.field_path().is_empty());
+            assert!(path.leading_field_path().is_empty());
             assert_eq!(
-                path.subscripts(),
+                path.trailing_subscripts(),
                 [crate::resource::Subscript::Str {
                     key: "registry_dev".to_string()
                 }]
@@ -8442,7 +8456,7 @@ fn parse_subscript_on_upstream_state_inside_string_interpolation_sibling_file() 
                     assert_eq!(path.binding(), "orgs");
                     assert_eq!(path.attribute(), "accounts");
                     assert_eq!(
-                        path.subscripts(),
+                        path.trailing_subscripts(),
                         [crate::resource::Subscript::Str {
                             key: "registry_dev".to_string()
                         }]
@@ -8508,8 +8522,8 @@ fn parse_dot_notation_on_upstream_state_in_sibling_file() {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             assert_eq!(path.binding(), "orgs");
             assert_eq!(path.attribute(), "accounts");
-            assert_eq!(path.field_path(), ["registry_dev".to_string()]);
-            assert!(path.subscripts().is_empty());
+            assert_eq!(path.leading_field_path(), ["registry_dev".to_string()]);
+            assert!(path.trailing_subscripts().is_empty());
         }
         other => panic!("expected ResourceRef with field_path, got {other:?}"),
     }
@@ -8565,7 +8579,7 @@ fn parse_dot_notation_on_upstream_state_inside_string_interpolation_sibling_file
                 {
                     assert_eq!(path.binding(), "orgs");
                     assert_eq!(path.attribute(), "accounts");
-                    assert_eq!(path.field_path(), ["registry_dev".to_string()]);
+                    assert_eq!(path.leading_field_path(), ["registry_dev".to_string()]);
                     found_ref = true;
                 }
             }
@@ -10167,14 +10181,102 @@ fn parse_chained_index_then_field_access() {
     let parsed = parse(src, &ProviderContext::default())
         .expect("`<binding>.<field>[<idx>].<field>` must parse — carina#3025");
 
-    // Sanity: the resource exists and its `name` attribute is on the parse tree.
+    // The resource exists and its `name` attribute carries the
+    // expected ordered segment chain.
     let rs = parsed
         .resources
         .iter()
         .find(|r| r.id.resource_type == "route53.RecordSet")
         .expect("RecordSet must be in parsed.resources");
-    assert!(
-        rs.attributes.contains_key("name"),
-        "RecordSet.name attribute must be present in parsed AST"
+    let name_value = rs.get_attr("name").expect("RecordSet.name");
+    match name_value {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            use crate::resource::{PathSegment, Subscript};
+            assert_eq!(path.binding(), "cert");
+            assert_eq!(path.attribute(), "domain_validation_options");
+            assert_eq!(
+                path.segments(),
+                &[
+                    PathSegment::Subscript {
+                        index: Subscript::Int { index: 0 }
+                    },
+                    PathSegment::Field {
+                        name: "resource_record_name".to_string()
+                    },
+                ]
+            );
+        }
+        other => panic!("expected ResourceRef, got: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_multi_step_index_then_field_chain() {
+    // `a.b[0].c[1].d` — out-of-scope per the spec but the segment
+    // representation already supports it. Lock the shape down so future
+    // grammar tweaks don't silently drop a leg.
+    let src = r#"
+        let orgs = upstream_state { source = "../organizations" }
+
+        awscc.ec2.Subnet {
+            name = "test"
+            cidr_block = orgs.accounts[0].subnets[1].id
+        }
+    "#;
+    let result = parse(src, &ProviderContext::default()).unwrap();
+    let subnet = result.resources.last().expect("subnet");
+    let value = subnet.get_attr("cidr_block").expect("cidr_block");
+    match value {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            use crate::resource::{PathSegment, Subscript};
+            assert_eq!(path.binding(), "orgs");
+            assert_eq!(path.attribute(), "accounts");
+            assert_eq!(
+                path.segments(),
+                &[
+                    PathSegment::Subscript {
+                        index: Subscript::Int { index: 0 }
+                    },
+                    PathSegment::Field {
+                        name: "subnets".to_string()
+                    },
+                    PathSegment::Subscript {
+                        index: Subscript::Int { index: 1 }
+                    },
+                    PathSegment::Field {
+                        name: "id".to_string()
+                    },
+                ]
+            );
+        }
+        other => panic!("expected ResourceRef, got: {other:?}"),
+    }
+}
+
+#[test]
+fn access_path_serde_round_trips_mixed_segments() {
+    // State files persist `AccessPath` as JSON. A path with mixed
+    // segments (the chained-access shape) must round-trip structurally
+    // so reloaded state preserves source-order semantics.
+    use crate::resource::{AccessPath, PathSegment, Subscript};
+    let original = AccessPath::with_segments(
+        "cert",
+        "domain_validation_options",
+        vec![
+            PathSegment::Subscript {
+                index: Subscript::Int { index: 0 },
+            },
+            PathSegment::Field {
+                name: "resource_record_name".to_string(),
+            },
+            PathSegment::Subscript {
+                index: Subscript::Str {
+                    key: "primary".to_string(),
+                },
+            },
+        ],
     );
+    let json = serde_json::to_string(&original).unwrap();
+    let reloaded: AccessPath = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, reloaded);
 }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -180,7 +180,6 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
-            let field_path = path.field_path();
             if let Some(attrs) = bindings.get(binding_name)
                 && let Some(attr_value) = attrs.get(attribute_name)
             {
@@ -196,16 +195,18 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                     bindings.source(binding_name),
                     Some(crate::binding_index::BindingValueSource::Upstream)
                 );
-                for field in field_path {
-                    // Peel `Secret` wrappers so dot-form key access
-                    // (`creds.db_pwd` against a `Secret(Map)` upstream)
-                    // descends into the inner map and re-wraps the
-                    // leaf — symmetric with the subscript walk below
-                    // (#2439). Pre-fix the wildcard arm dropped any
-                    // `Secret(Map)` ref silently.
+                use crate::resource::{PathSegment, Subscript};
+                for segment in path.segments() {
+                    // Peel `Secret` wrappers so dot-form / subscript
+                    // access descends into the inner container, then
+                    // re-wraps the leaf so the secret tag survives
+                    // end-to-end. #2439.
                     let (peeled, secret_depth) = peel_secrets(resolved);
-                    let next = match peeled {
-                        Value::Concrete(ConcreteValue::Map(ref map)) => match map.get(field) {
+                    let next = match (peeled, segment) {
+                        (
+                            Value::Concrete(ConcreteValue::Map(ref map)),
+                            PathSegment::Field { name: field },
+                        ) => match map.get(field) {
                             Some(nested) => resolve_ref_value(nested, bindings)?,
                             None if is_upstream && secret_depth > 0 => {
                                 return Err(missing_map_key_error_redacted(path, map.len()));
@@ -215,37 +216,33 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                             }
                             None => return Ok(value.clone()),
                         },
-                        _ => return Ok(value.clone()),
-                    };
-                    resolved = rewrap_secrets(next, secret_depth);
-                }
-
-                use crate::resource::Subscript;
-                for sub in path.subscripts() {
-                    // Peel `Secret` wrappers so the subscript addresses
-                    // the inner container, then re-wrap so the secret
-                    // tag survives end-to-end. #2439.
-                    let (peeled, secret_depth) = peel_secrets(resolved);
-                    let next = match (peeled, sub) {
-                        (Value::Concrete(ConcreteValue::List(items)), Subscript::Int { index }) => {
+                        (
+                            Value::Concrete(ConcreteValue::List(items)),
+                            PathSegment::Subscript {
+                                index: Subscript::Int { index },
+                            },
+                        ) => {
                             let idx = usize::try_from(*index).ok().filter(|i| *i < items.len());
                             match idx {
                                 Some(i) => resolve_ref_value(&items[i], bindings)?,
                                 None => return Ok(value.clone()),
                             }
                         }
-                        (Value::Concrete(ConcreteValue::Map(map)), Subscript::Str { key }) => {
-                            match map.get(key) {
-                                Some(nested) => resolve_ref_value(nested, bindings)?,
-                                None if is_upstream && secret_depth > 0 => {
-                                    return Err(missing_map_key_error_redacted(path, map.len()));
-                                }
-                                None if is_upstream => {
-                                    return Err(missing_map_key_error(path, &map));
-                                }
-                                None => return Ok(value.clone()),
+                        (
+                            Value::Concrete(ConcreteValue::Map(map)),
+                            PathSegment::Subscript {
+                                index: Subscript::Str { key },
+                            },
+                        ) => match map.get(key) {
+                            Some(nested) => resolve_ref_value(nested, bindings)?,
+                            None if is_upstream && secret_depth > 0 => {
+                                return Err(missing_map_key_error_redacted(path, map.len()));
                             }
-                        }
+                            None if is_upstream => {
+                                return Err(missing_map_key_error(path, &map));
+                            }
+                            None => return Ok(value.clone()),
+                        },
                         _ => return Ok(value.clone()),
                     };
                     resolved = rewrap_secrets(next, secret_depth);
@@ -432,6 +429,56 @@ mod tests {
             "accounts",
             Vec::new(),
             vec![crate::resource::Subscript::Int { index: 0 }],
+        );
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
+        let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String("alpha".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_chained_subscript_then_field_descends_into_struct() {
+        // carina#3025 reproduction: `cert.list[0].name` against
+        // `list: [ { name = "alpha" }, { name = "beta" } ]` resolves
+        // to `"alpha"`. The resolver walks segments in source order
+        // (Subscript then Field), so the post-subscript field access
+        // descends into the inner map.
+        use crate::resource::{AccessPath, PathSegment, Subscript};
+        let inner_alpha: indexmap::IndexMap<String, Value> = vec![(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("alpha".to_string())),
+        )]
+        .into_iter()
+        .collect();
+        let inner_beta: indexmap::IndexMap<String, Value> = vec![(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("beta".to_string())),
+        )]
+        .into_iter()
+        .collect();
+        let bindings = bindings_from(vec![(
+            "cert",
+            vec![(
+                "list",
+                Value::Concrete(ConcreteValue::List(vec![
+                    Value::Concrete(ConcreteValue::Map(inner_alpha)),
+                    Value::Concrete(ConcreteValue::Map(inner_beta)),
+                ])),
+            )],
+        )]);
+        let path = AccessPath::with_segments(
+            "cert",
+            "list",
+            vec![
+                PathSegment::Subscript {
+                    index: Subscript::Int { index: 0 },
+                },
+                PathSegment::Field {
+                    name: "name".to_string(),
+                },
+            ],
         );
         let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -229,7 +229,10 @@ impl std::fmt::Display for ResourceId {
 /// reject `[0]` against a `map(_)` export and `["k"]` against a
 /// `list(_)` export with type-aware diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+// `index_kind` (not `kind`) so the tag cannot collide with the
+// `PathSegment` discriminator when a `Subscript` is `#[serde(flatten)]`-ed
+// into a `PathSegment::Subscript` (carina#3025).
+#[serde(tag = "index_kind", rename_all = "snake_case")]
 pub enum Subscript {
     /// Integer subscript: `[0]`. Valid against `list(_)` exports.
     Int { index: i64 },
@@ -330,8 +333,13 @@ impl AccessPath {
         field_path: Vec<String>,
         subscripts: Vec<Subscript>,
     ) -> Self {
-        let mut segments: Vec<PathSegment> = Vec::with_capacity(field_path.len() + subscripts.len());
-        segments.extend(field_path.into_iter().map(|name| PathSegment::Field { name }));
+        let mut segments: Vec<PathSegment> =
+            Vec::with_capacity(field_path.len() + subscripts.len());
+        segments.extend(
+            field_path
+                .into_iter()
+                .map(|name| PathSegment::Field { name }),
+        );
         segments.extend(
             subscripts
                 .into_iter()
@@ -380,6 +388,67 @@ impl AccessPath {
     /// for a top-level attribute reference. carina#3025.
     pub fn segments(&self) -> &[PathSegment] {
         &self.segments
+    }
+
+    /// Returns the leading run of `.field` segments before the first
+    /// `[idx]` subscript. For `cert.foo.bar[0].baz` this yields
+    /// `["foo", "bar"]`; for `cert.foo[0].bar` it yields `["foo"]`;
+    /// for `cert.foo[0]` it yields `["foo"]`; for `cert.foo` it yields
+    /// `["foo"]`. Used by cross-directory shape checkers that walk
+    /// dot-form access against an `UpstreamExports` type expression.
+    pub fn leading_field_path(&self) -> Vec<String> {
+        self.segments
+            .iter()
+            .map_while(|seg| match seg {
+                PathSegment::Field { name } => Some(name.clone()),
+                PathSegment::Subscript { .. } => None,
+            })
+            .collect()
+    }
+
+    /// Returns the trailing run of `[idx]` subscripts after the leading
+    /// `.field` prefix. For `cert.foo.bar[0]["k"]` this yields the two
+    /// subscripts; for `cert.foo[0].bar` it yields *empty* (the
+    /// chained-access case where a `.field` follows a subscript — the
+    /// trailing run terminates because subscripts aren't contiguous at
+    /// the end). carina#3025.
+    pub fn trailing_subscripts(&self) -> Vec<Subscript> {
+        // Walk from the end; stop at the first Field encountered (going
+        // backwards). The resulting slice is reversed to restore order.
+        let mut out: Vec<Subscript> = Vec::new();
+        for seg in self.segments.iter().rev() {
+            match seg {
+                PathSegment::Subscript { index } => out.push(index.clone()),
+                PathSegment::Field { .. } => break,
+            }
+        }
+        out.reverse();
+        out
+    }
+
+    /// Returns `true` when the path's segment chain is the
+    /// "leading fields then trailing subscripts" shape — the
+    /// pre-carina#3025 grammar. Chained access (`cert.foo[0].bar`) is
+    /// the only shape that fails this check; cross-directory shape
+    /// checkers that don't yet understand chained walks can skip those
+    /// paths and let resolver-time errors surface instead.
+    pub fn is_simple_shape(&self) -> bool {
+        // Equivalent to: there is at most one transition from Field
+        // to Subscript in the chain.
+        let mut seen_subscript = false;
+        for seg in &self.segments {
+            match seg {
+                PathSegment::Field { .. } => {
+                    if seen_subscript {
+                        return false;
+                    }
+                }
+                PathSegment::Subscript { .. } => {
+                    seen_subscript = true;
+                }
+            }
+        }
+        true
     }
 
     /// Returns the path in source-form: `binding.attribute` followed by
@@ -916,10 +985,11 @@ impl Value {
         }
     }
 
-    /// If this is a `ResourceRef`, returns the field path.
-    pub fn ref_field_path(&self) -> Option<&[String]> {
+    /// If this is a `ResourceRef`, returns the ordered path segments
+    /// past `binding.attribute`. carina#3025.
+    pub fn ref_segments(&self) -> Option<&[PathSegment]> {
         match self {
-            Value::Deferred(DeferredValue::ResourceRef { path }) => Some(path.field_path()),
+            Value::Deferred(DeferredValue::ResourceRef { path }) => Some(path.segments()),
             _ => None,
         }
     }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -255,14 +255,31 @@ impl Subscript {
     }
 }
 
+/// One step along an [`AccessPath`] past its `binding.attribute` head.
+///
+/// A path is an ordered sequence of `PathSegment`s; the grammar can
+/// produce any mix of `.field` and `[index]` continuations at any
+/// depth (e.g. `cert.foo[0].bar[1].baz`). carina#3025.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PathSegment {
+    /// A `.field` continuation.
+    Field { name: String },
+    /// A `[index]` / `["key"]` subscript.
+    Subscript {
+        #[serde(flatten)]
+        index: Subscript,
+    },
+}
+
 /// A typed access path representing a `ResourceRef` target.
 ///
-/// The path always carries a binding name and an attribute name; nested
-/// field access (e.g., `web.network.vpc_id`) is captured in
-/// `field_path`, and any trailing `[index]` subscripts in `subscripts`.
-/// The grammar accepts only `binding.field[…]…`, never `binding[…].field`,
-/// so the two chains never interleave — pre-field index access is folded
-/// into the binding name string by the parser as before.
+/// The path always carries a binding name and an attribute name; the
+/// remainder of the chain is an ordered `Vec<PathSegment>` that
+/// captures the source-form mix of `.field` and `[index]`
+/// continuations at any depth (carina#3025). Pre-attribute index
+/// access (e.g. `binding[0].x`) is still folded into the binding name
+/// string by the parser as before.
 ///
 /// The "binding + attribute is mandatory" invariant is enforced by the
 /// type system — there is no way to construct an `AccessPath` without
@@ -272,9 +289,7 @@ pub struct AccessPath {
     binding: String,
     attribute: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    field_path: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    subscripts: Vec<Subscript>,
+    segments: Vec<PathSegment>,
 }
 
 impl AccessPath {
@@ -284,23 +299,12 @@ impl AccessPath {
     /// `.attr`) is represented by [`Value::BindingRef`], not by an
     /// `AccessPath` with an empty attribute.
     pub fn new(binding: impl Into<String>, attribute: impl Into<String>) -> Self {
-        let binding = binding.into();
-        let attribute = attribute.into();
-        assert!(
-            !attribute.is_empty(),
-            "AccessPath::new with empty attribute for binding {:?}; \
-             use Value::BindingRef instead (#2847)",
-            binding
-        );
-        Self {
-            binding,
-            attribute,
-            field_path: Vec::new(),
-            subscripts: Vec::new(),
-        }
+        Self::with_segments(binding, attribute, Vec::new())
     }
 
-    /// Create an `AccessPath` with a nested field path (e.g., `web.network.vpc_id`).
+    /// Create an `AccessPath` with a nested field path (e.g.,
+    /// `web.network.vpc_id`). Equivalent to a path whose every segment
+    /// after `attribute` is a `Field`.
     ///
     /// `attribute` must be non-empty. See [`AccessPath::new`].
     pub fn with_fields(
@@ -308,20 +312,11 @@ impl AccessPath {
         attribute: impl Into<String>,
         field_path: Vec<String>,
     ) -> Self {
-        let binding = binding.into();
-        let attribute = attribute.into();
-        assert!(
-            !attribute.is_empty(),
-            "AccessPath::with_fields with empty attribute for binding {:?}; \
-             use Value::BindingRef instead (#2847)",
-            binding
-        );
-        Self {
-            binding,
-            attribute,
-            field_path,
-            subscripts: Vec::new(),
-        }
+        let segments = field_path
+            .into_iter()
+            .map(|name| PathSegment::Field { name })
+            .collect();
+        Self::with_segments(binding, attribute, segments)
     }
 
     /// Create an `AccessPath` with both a field chain and trailing
@@ -335,19 +330,39 @@ impl AccessPath {
         field_path: Vec<String>,
         subscripts: Vec<Subscript>,
     ) -> Self {
+        let mut segments: Vec<PathSegment> = Vec::with_capacity(field_path.len() + subscripts.len());
+        segments.extend(field_path.into_iter().map(|name| PathSegment::Field { name }));
+        segments.extend(
+            subscripts
+                .into_iter()
+                .map(|index| PathSegment::Subscript { index }),
+        );
+        Self::with_segments(binding, attribute, segments)
+    }
+
+    /// Create an `AccessPath` from an explicit segment list — the
+    /// canonical form. Used by the parser when source contains any
+    /// mix of `.field` and `[index]` continuations
+    /// (`cert.foo[0].bar`, `a.b.c[0]["k"].d`, …). carina#3025.
+    ///
+    /// `attribute` must be non-empty. See [`AccessPath::new`].
+    pub fn with_segments(
+        binding: impl Into<String>,
+        attribute: impl Into<String>,
+        segments: Vec<PathSegment>,
+    ) -> Self {
         let binding = binding.into();
         let attribute = attribute.into();
         assert!(
             !attribute.is_empty(),
-            "AccessPath::with_fields_and_subscripts with empty attribute for binding {:?}; \
+            "AccessPath::with_segments with empty attribute for binding {:?}; \
              use Value::BindingRef instead (#2847)",
             binding
         );
         Self {
             binding,
             attribute,
-            field_path,
-            subscripts,
+            segments,
         }
     }
 
@@ -361,36 +376,38 @@ impl AccessPath {
         &self.attribute
     }
 
-    /// Returns the nested field path (empty if the reference targets a
-    /// top-level attribute).
-    pub fn field_path(&self) -> &[String] {
-        &self.field_path
-    }
-
-    /// Returns the trailing `[index]` subscripts (empty if the
-    /// reference doesn't subscript past the field chain).
-    pub fn subscripts(&self) -> &[Subscript] {
-        &self.subscripts
+    /// Returns the ordered segments past `binding.attribute`. Empty
+    /// for a top-level attribute reference. carina#3025.
+    pub fn segments(&self) -> &[PathSegment] {
+        &self.segments
     }
 
     /// Returns the path in source-form: `binding.attribute` followed by
     /// `.field…[idx]…` segments as written.
     pub fn to_dot_string(&self) -> String {
-        let mut out = String::with_capacity(
-            self.binding.len()
-                + self.attribute.len()
-                + 1
-                + self.field_path.iter().map(|s| s.len() + 1).sum::<usize>(),
-        );
+        let segment_len: usize = self
+            .segments
+            .iter()
+            .map(|s| match s {
+                PathSegment::Field { name } => name.len() + 1,
+                PathSegment::Subscript { .. } => 4, // rough: `[xx]`
+            })
+            .sum();
+        let mut out =
+            String::with_capacity(self.binding.len() + self.attribute.len() + 1 + segment_len);
         out.push_str(&self.binding);
         out.push('.');
         out.push_str(&self.attribute);
-        for field in &self.field_path {
-            out.push('.');
-            out.push_str(field);
-        }
-        for sub in &self.subscripts {
-            sub.append_to_dot_string(&mut out);
+        for segment in &self.segments {
+            match segment {
+                PathSegment::Field { name } => {
+                    out.push('.');
+                    out.push_str(name);
+                }
+                PathSegment::Subscript { index } => {
+                    index.append_to_dot_string(&mut out);
+                }
+            }
         }
         out
     }

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -921,7 +921,7 @@ fn access_path_new() {
     let path = AccessPath::new("vpc", "id");
     assert_eq!(path.binding(), "vpc");
     assert_eq!(path.attribute(), "id");
-    assert!(path.field_path().is_empty());
+    assert!(path.leading_field_path().is_empty());
     assert_eq!(path.to_dot_string(), "vpc.id");
 }
 
@@ -930,7 +930,7 @@ fn access_path_with_fields() {
     let path = AccessPath::with_fields("web", "network", vec!["vpc_id".to_string()]);
     assert_eq!(path.binding(), "web");
     assert_eq!(path.attribute(), "network");
-    assert_eq!(path.field_path(), ["vpc_id".to_string()]);
+    assert_eq!(path.leading_field_path(), ["vpc_id".to_string()]);
     assert_eq!(path.to_dot_string(), "web.network.vpc_id");
 }
 
@@ -956,8 +956,13 @@ fn value_ref_helpers() {
     assert_eq!(value.ref_binding(), Some("vpc"));
     assert_eq!(value.ref_attribute(), Some("vpc_id"));
     assert_eq!(
-        value.ref_field_path(),
-        Some(["nested".to_string()].as_slice())
+        value.ref_segments(),
+        Some(
+            [PathSegment::Field {
+                name: "nested".to_string()
+            }]
+            .as_slice()
+        )
     );
 
     let non_ref = Value::Concrete(ConcreteValue::String("hello".to_string()));

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -709,7 +709,7 @@ fn check_resource_ref_at_position(
     else {
         return;
     };
-    let Some(narrowed) = narrow_type_expr(export_type, path.field_path(), path.subscripts()) else {
+    let Some(narrowed) = narrow_type_expr(export_type, path.segments()) else {
         // Kind mismatch through the access path — already reported by
         // `check_upstream_state_attribute_access_shapes` /
         // `check_upstream_state_subscript_shapes`. Skip to avoid
@@ -741,7 +741,7 @@ fn check_resource_ref_at_position(
     });
 }
 
-use crate::validation::{narrow_type_expr, walk_type_expr_path};
+use crate::validation::{narrow_type_expr, walk_type_expr_fields};
 
 /// A `for` expression iterates an `upstream_state` field whose declared
 /// export type doesn't match the binding pattern's expected shape:
@@ -1059,8 +1059,8 @@ fn visit_attribute_access(
     errors: &mut Vec<UpstreamAttributeAccessShapeError>,
 ) {
     value.visit_refs(&mut |path| {
-        let field_path = path.field_path();
-        if field_path.is_empty() {
+        let leading: Vec<String> = path.leading_field_path();
+        if leading.is_empty() {
             return;
         }
         let binding = path.binding();
@@ -1075,14 +1075,17 @@ fn visit_attribute_access(
         else {
             return;
         };
-        if let Err((mismatched_at, bad_segment)) = walk_type_expr_path(export_type, field_path) {
+        let walk_result = walk_type_expr_fields(export_type, &leading);
+        if let Err((mismatched_at, bad_segment)) = walk_result {
+            let mismatched_at = mismatched_at.clone();
+            let bad_segment = bad_segment.to_string();
             errors.push(UpstreamAttributeAccessShapeError {
                 location: location.to_string(),
                 binding: binding.to_string(),
                 field: attribute.to_string(),
-                field_path: field_path.to_vec(),
-                mismatched_at: mismatched_at.clone(),
-                bad_segment: bad_segment.to_string(),
+                field_path: leading,
+                mismatched_at,
+                bad_segment,
             });
         }
     });
@@ -1216,7 +1219,15 @@ fn visit_subscript_access(
     errors: &mut Vec<UpstreamSubscriptShapeError>,
 ) {
     value.visit_refs(&mut |path| {
-        let subscripts = path.subscripts();
+        // Chained access (`cert.foo[0].bar`) is not yet exercised by
+        // this checker — see #3025 for the planned segments-driven
+        // walker. Skip the path here; the resolver still surfaces
+        // typos at apply time and the simple-shape paths remain
+        // covered.
+        if !path.is_simple_shape() {
+            return;
+        }
+        let subscripts = path.trailing_subscripts();
         if subscripts.is_empty() {
             return;
         }
@@ -1235,14 +1246,14 @@ fn visit_subscript_access(
         // If the field path itself doesn't resolve, the
         // attribute-access check will already report it. Skip here so
         // we don't double-fire.
-        let field_path = path.field_path();
-        let Ok(at_field_end) = walk_type_expr_path(export_type, field_path) else {
+        let field_path: Vec<String> = path.leading_field_path();
+        let Ok(at_field_end) = walk_type_expr_fields(export_type, &field_path) else {
             return;
         };
         // Step through each subscript, descending into the element
         // type when it fits and emitting at the first kind mismatch.
         let mut current = at_field_end;
-        for sub in subscripts {
+        for sub in &subscripts {
             match (current, sub) {
                 (TypeExpr::List(inner), Subscript::Int { .. }) => {
                     current = inner.as_ref();
@@ -1255,7 +1266,7 @@ fn visit_subscript_access(
                         location: location.to_string(),
                         binding: binding.to_string(),
                         field: attribute.to_string(),
-                        field_path: field_path.to_vec(),
+                        field_path: field_path.clone(),
                         mismatched_at: mismatched_at.clone(),
                         bad_subscript: bad.clone(),
                     });

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -313,8 +313,7 @@ fn infer_type_from_value_with_visiting(
         Value::Deferred(DeferredValue::ResourceRef { path }) => infer_resource_ref_with_visiting(
             path.binding(),
             path.attribute(),
-            path.field_path(),
-            path.subscripts(),
+            path.segments(),
             bindings,
             schemas,
             visiting,
@@ -377,8 +376,7 @@ where
 fn infer_resource_ref_with_visiting(
     binding: &str,
     attribute: &str,
-    field_path: &[String],
-    subscripts: &[crate::resource::Subscript],
+    segments: &[crate::resource::PathSegment],
     bindings: &InferenceBindings,
     schemas: &SchemaRegistry,
     visiting: &mut indexmap::IndexSet<String>,
@@ -426,7 +424,7 @@ fn infer_resource_ref_with_visiting(
                 infer_type_from_value_with_visiting(inner, bindings, schemas, visiting);
             visiting.shift_remove(binding);
             let inner_type = inner_type_result?;
-            return super::narrow_type_expr(&inner_type, field_path, subscripts).ok_or_else(|| {
+            return super::narrow_type_expr(&inner_type, segments).ok_or_else(|| {
                 InferenceError::UnknownAttribute {
                     binding: binding.to_string(),
                     attribute: attribute.to_string(),
@@ -450,32 +448,40 @@ fn infer_resource_ref_with_visiting(
             attribute: attribute.to_string(),
         });
     };
+    // Walk the path's ordered segments — a free mix of `.field` and
+    // `[idx]` continuations (carina#3025). A `.field` descends into the
+    // current struct; an `[idx]` peels one collection layer (`list(T)
+    // → T`, `map(_, V) → V`). Any mismatch surfaces a typed error
+    // rather than silently dropping the path.
+    use crate::resource::{PathSegment, Subscript};
     let mut current = &attr_schema.attr_type;
-    for segment in field_path {
-        current = match descend_struct_field(current, segment) {
-            Some(t) => t,
-            None => {
-                return Err(InferenceError::UnknownAttribute {
-                    binding: binding.to_string(),
-                    attribute: format!("{}.{}", attribute, segment),
-                });
-            }
-        };
-    }
-    // Peel one collection layer per trailing subscript: `[0]` against a
-    // `List<T>` projects to `T`; `["k"]` against a `Map<_, V>` projects
-    // to `V`. The grammar already enforces matching subscript shapes,
-    // but inference still has to descend so the resulting `TypeExpr`
-    // reflects the post-projection element type rather than the
-    // collection itself.
-    for sub in subscripts {
-        current = match (sub, current) {
-            (crate::resource::Subscript::Int { .. }, AttributeType::List { inner, .. }) => inner,
-            (crate::resource::Subscript::Str { .. }, AttributeType::Map { value, .. }) => value,
+    for seg in segments {
+        current = match (seg, current) {
+            (PathSegment::Field { name }, attr) => match descend_struct_field(attr, name) {
+                Some(t) => t,
+                None => {
+                    return Err(InferenceError::UnknownAttribute {
+                        binding: binding.to_string(),
+                        attribute: format!("{}.{}", attribute, name),
+                    });
+                }
+            },
+            (
+                PathSegment::Subscript {
+                    index: Subscript::Int { .. },
+                },
+                AttributeType::List { inner, .. },
+            ) => inner,
+            (
+                PathSegment::Subscript {
+                    index: Subscript::Str { .. },
+                },
+                AttributeType::Map { value, .. },
+            ) => value,
             _ => {
                 return Err(InferenceError::UnknownType {
                     reason: format!(
-                        "subscript on `{}.{}` does not match the attribute's collection shape",
+                        "access path on `{}.{}` does not match the attribute's shape",
                         binding, attribute
                     ),
                 });

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -997,6 +997,13 @@ fn validate_struct_fields(
 /// for the diagnostic builder's "use iteration / subscript / nothing"
 /// suggestion.
 ///
+/// Walk `start` through a chain of `.field` segments (the leading
+/// `PathSegment::Field` prefix of an [`AccessPath`]). Stops at the first
+/// non-`Field` segment and returns the type at that position together
+/// with the index of the segment that stopped descent — callers that
+/// need to continue with subscripts use [`narrow_type_expr`], callers
+/// that only care about the field-path leg use [`walk_type_expr_fields`].
+///
 /// Walks by reference so deep struct paths don't pay an O(depth) clone
 /// chain — the caller clones once at the return site if it needs an
 /// owned copy.
@@ -1004,7 +1011,7 @@ fn validate_struct_fields(
 /// `Map` segments unwrap to the value type so dot-form key access
 /// (`accounts.k → T`) is symmetric with the subscript form
 /// (`accounts['k']`). #2447.
-pub(crate) fn walk_type_expr_path<'a, 'b>(
+pub(crate) fn walk_type_expr_fields<'a, 'b>(
     start: &'a TypeExpr,
     field_path: &'b [String],
 ) -> Result<&'a TypeExpr, (&'a TypeExpr, &'b str)> {
@@ -1022,26 +1029,39 @@ pub(crate) fn walk_type_expr_path<'a, 'b>(
     Ok(current)
 }
 
-/// Narrow `start` through a chain of `field_path` segments and trailing
-/// `subscripts`. Returns `None` when a step doesn't fit the container
+/// Narrow `start` through an `AccessPath`'s ordered segments — a free
+/// mix of `.field` and `[index]` continuations at any depth
+/// (carina#3025). Returns `None` when a step doesn't fit the container
 /// kind; those mismatches are reported by the dedicated shape checkers
 /// and a duplicate here would be noise.
 ///
-/// The field-path leg delegates to [`walk_type_expr_path`] to keep the
-/// dot-form descent rules in one place. Used by both upstream-export
-/// type-checking and module-call attribute-export inference.
+/// Used by both upstream-export type-checking and module-call
+/// attribute-export inference.
 pub(crate) fn narrow_type_expr(
     start: &TypeExpr,
-    field_path: &[String],
-    subscripts: &[crate::resource::Subscript],
+    segments: &[crate::resource::PathSegment],
 ) -> Option<TypeExpr> {
-    let after_fields = walk_type_expr_path(start, field_path).ok()?;
-    let mut current = after_fields.clone();
-    use crate::resource::Subscript;
-    for sub in subscripts {
-        current = match (current, sub) {
-            (TypeExpr::List(inner), Subscript::Int { .. }) => *inner,
-            (TypeExpr::Map(inner), Subscript::Str { .. }) => *inner,
+    use crate::resource::{PathSegment, Subscript};
+    let mut current = start.clone();
+    for seg in segments {
+        current = match (current, seg) {
+            (TypeExpr::Struct { fields }, PathSegment::Field { name }) => {
+                let (_, ty) = fields.into_iter().find(|(n, _)| n == name)?;
+                ty
+            }
+            (TypeExpr::Map(inner), PathSegment::Field { .. }) => *inner,
+            (
+                TypeExpr::List(inner),
+                PathSegment::Subscript {
+                    index: Subscript::Int { .. },
+                },
+            ) => *inner,
+            (
+                TypeExpr::Map(inner),
+                PathSegment::Subscript {
+                    index: Subscript::Str { .. },
+                },
+            ) => *inner,
             _ => return None,
         };
     }

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1216,7 +1216,7 @@ impl DiagnosticEngine {
             // comparison rather than false-flag against the head's
             // outer type.
             (_, Value::Deferred(DeferredValue::ResourceRef { path }))
-                if path.field_path().is_empty() && path.subscripts().is_empty() =>
+                if path.segments().is_empty() =>
             {
                 self.check_cross_file_ref_type(
                     type_expr,


### PR DESCRIPTION
## Summary

- Migrates every `AccessPath` caller to the unified segments representation introduced in the WIP commit / design PR #3026, so `cert.domain_validation_options[0].resource_record_name` — and any free mix of `.field` / `[idx]` continuations at arbitrary depth — parses, type-checks, and resolves end-to-end.
- Parser AST builder (`Rule::subscripted_id`) walks both `index_access` and `field_access` pairs in source order; resolver and validation walkers evaluate the segment chain uniformly.
- `Subscript` serde tag renamed `kind` → `index_kind` to avoid colliding with the `PathSegment` discriminator when flattened. Per project policy (experimental, no backward-compat), legacy state files in the old `{kind: "int"}` shape no longer deserialise.

## Why

Pre-fix grammar accepted at most one transition from `.field` to `[idx]`, modelled in the AST as `field_path: Vec<String>` + `subscripts: Vec<Subscript>`. That representation cannot express `binding.field[0].subfield` — the T6c reproduction case — and worked around it by lowering chained access to a single-element `for` loop. Closes the structural gap; the WIP commit on this branch set up the data type, this commit migrates the ~16 callers (plus ~24 tests) and adds the segments-driven walkers.

## Out of scope (filed as follow-ups in spirit, not in this PR)

- Upstream shape checkers do not yet walk the segment chain across an intervening subscript (e.g. `cert.list[0].field` against a declared `list(struct{field: T})`). Those paths are skipped via `is_simple_shape()` for now — the resolver still evaluates them correctly; the type check is silent. The shape checker rewrite is a follow-up.
- LSP completion at `cert.foo[0].|` — separate UX issue.

## Tests

- `parse_field_after_subscript_after_field_is_accepted` (was `_rejected`)
- `parse_chained_index_then_field_access` (carina#3025 reproduction; asserts segment shape)
- `parse_multi_step_index_then_field_chain` (`a.b[0].c[1].d`)
- `access_path_serde_round_trips_mixed_segments`
- `test_resolve_chained_subscript_then_field_descends_into_struct`

All 3289 workspace tests pass, doctests pass, clippy clean, `scripts/check-*.sh` all green.

## Test plan

- [x] `cargo nextest run --workspace` — 3289 passed
- [x] `cargo test --workspace --doc` — all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all green
- [ ] Real-infra smoke test (T6c ACM DNS validation use case in `carina-rs/infra`) — deferred to user, per handoff policy

Closes #3025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)