### PR TITLE
validation: narrow schema type through AccessPath segments (closes #3028)

### DIFF
--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -116,10 +116,12 @@ pub fn validate_resource_ref_types<E>(
                 continue;
             }
 
-            let (ref_binding, ref_attr) = match attr_value {
-                Value::Deferred(DeferredValue::ResourceRef { path }) => {
-                    (path.binding().to_string(), path.attribute().to_string())
-                }
+            let (ref_binding, ref_attr, ref_path) = match attr_value {
+                Value::Deferred(DeferredValue::ResourceRef { path }) => (
+                    path.binding().to_string(),
+                    path.attribute().to_string(),
+                    path,
+                ),
                 _ => continue,
             };
 
@@ -161,14 +163,26 @@ pub fn validate_resource_ref_types<E>(
                 ));
                 continue;
             };
-            let ref_type_name = ref_attr_schema.attr_type.type_name();
 
-            // Directional check: source (the referenced attribute) must be
-            // assignable to the sink (the current resource's attribute).
-            if ref_attr_schema
-                .attr_type
-                .is_assignable_to(&attr_schema.attr_type)
-            {
+            // Narrow through the path's segments — `[idx]` peels one
+            // `List<T>` / `Map<_,V>` layer, `.field` descends a
+            // `Struct`. carina#3028. When a segment doesn't fit the
+            // shape (e.g. `.x` against a scalar), skip the type check
+            // rather than emit a noisy mismatch: schema-level
+            // attribute validation already reports unknown fields and
+            // resolver-time evaluation catches the shape error with
+            // location context.
+            let Some(narrowed) =
+                narrow_attribute_type(&ref_attr_schema.attr_type, ref_path.segments())
+            else {
+                continue;
+            };
+            let ref_type_name = narrowed.type_name();
+
+            // Directional check: source (the referenced attribute, post
+            // path narrowing) must be assignable to the sink (the
+            // current resource's attribute).
+            if narrowed.is_assignable_to(&attr_schema.attr_type) {
                 continue;
             }
 
@@ -1062,6 +1076,54 @@ pub(crate) fn narrow_type_expr(
                     index: Subscript::Str { .. },
                 },
             ) => *inner,
+            _ => return None,
+        };
+    }
+    Some(current)
+}
+
+/// Narrow `start` (a schema [`AttributeType`]) through an
+/// [`AccessPath`](crate::resource::AccessPath)'s ordered segments — a
+/// free mix of `.field` (descend into a `Struct`) and `[idx]` (peel one
+/// `List<T>` / `Map<_, V>` layer) continuations (carina#3025).
+///
+/// Returns `None` when any segment doesn't fit the container shape at
+/// its position (`.x` against a scalar, `[0]` against a `Struct`, …).
+/// The caller decides whether that's a hard error or — when the path
+/// is "permissive" (chained access into a shape the checker doesn't
+/// yet narrow precisely) — silent.
+///
+/// Borrows so deep paths don't pay an O(depth) clone chain. Used by
+/// `validate_resource_ref_types` to honour the carina#3025 segments
+/// representation when type-checking cross-resource references
+/// (carina#3028).
+pub(crate) fn narrow_attribute_type<'a>(
+    start: &'a AttributeType,
+    segments: &[crate::resource::PathSegment],
+) -> Option<&'a AttributeType> {
+    use crate::resource::{PathSegment, Subscript};
+    let mut current = start;
+    for seg in segments {
+        current = match (seg, current) {
+            (PathSegment::Field { name }, AttributeType::Struct { fields, .. }) => fields
+                .iter()
+                .find(|f| f.name == *name)
+                .map(|f| &f.field_type)?,
+            // Dot-form key access against a `map(_, V)` projects to
+            // `V`, mirroring the resolver's behaviour (carina#2447).
+            (PathSegment::Field { .. }, AttributeType::Map { value, .. }) => value.as_ref(),
+            (
+                PathSegment::Subscript {
+                    index: Subscript::Int { .. },
+                },
+                AttributeType::List { inner, .. },
+            ) => inner.as_ref(),
+            (
+                PathSegment::Subscript {
+                    index: Subscript::Str { .. },
+                },
+                AttributeType::Map { value, .. },
+            ) => value.as_ref(),
             _ => return None,
         };
     }

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -2582,3 +2582,133 @@ fn validate_type_expr_value_skips_value_unknown() {
     assert!(super::validate_type_expr_value(&TypeExpr::String, &upstream, &cfg).is_none());
     assert!(super::validate_type_expr_value(&struct_ty, &upstream, &cfg).is_none());
 }
+
+/// carina#3028: when a `ResourceRef` chains `[idx]` followed by
+/// `.field`, the type checker must narrow the schema type through
+/// each subscript (`List<T> → T`, `Map<_,V> → V`) before walking the
+/// following field segments. Pre-fix the checker compared the whole
+/// `List<Struct>` against the receiver `String`, ignoring the path
+/// entirely past `binding.attribute`.
+#[test]
+fn ref_with_chained_subscript_then_field_narrows_through_list() {
+    use crate::resource::{AccessPath, PathSegment, Subscript, Value};
+    use crate::schema::StructField;
+
+    let mut schemas = SchemaRegistry::new();
+    // `aws.acm.Certificate` exposes `domain_validation_options:
+    // List<Struct{resource_record_name: String, ...}>`.
+    schemas.insert(
+        "aws",
+        make_schema(
+            "acm.Certificate",
+            vec![(
+                "domain_validation_options",
+                AttributeType::List {
+                    inner: Box::new(AttributeType::Struct {
+                        name: "DomainValidationOption".to_string(),
+                        fields: vec![
+                            StructField::new("resource_record_name", AttributeType::String),
+                            StructField::new("resource_record_value", AttributeType::String),
+                        ],
+                    }),
+                    ordered: true,
+                },
+            )],
+        ),
+    );
+    // `aws.route53.RecordSet.name` is a plain String.
+    schemas.insert(
+        "aws",
+        make_schema("route53.RecordSet", vec![("name", AttributeType::String)]),
+    );
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "main").with_binding("cert");
+
+    // `cert.domain_validation_options[0].resource_record_name`
+    let path = AccessPath::with_segments(
+        "cert",
+        "domain_validation_options",
+        vec![
+            PathSegment::Subscript {
+                index: Subscript::Int { index: 0 },
+            },
+            PathSegment::Field {
+                name: "resource_record_name".to_string(),
+            },
+        ],
+    );
+    let record = Resource::with_provider("aws", "route53.RecordSet", "validation").with_attribute(
+        "name",
+        Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
+    );
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.resources.push(record); // allow: direct — fixture test inspection
+    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
+    assert!(
+        result.is_ok(),
+        "chained subscript-then-field should narrow List<Struct> → Struct → String, got: {:?}",
+        result.err(),
+    );
+}
+
+/// Sibling check for carina#3028: when the narrowed leaf is itself
+/// incompatible with the receiver, the checker must still flag it —
+/// narrowing is "honest" about the path, not a silent acceptance.
+#[test]
+fn ref_with_chained_subscript_then_field_rejects_real_mismatch() {
+    use crate::resource::{AccessPath, PathSegment, Subscript, Value};
+    use crate::schema::StructField;
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "aws",
+        make_schema(
+            "acm.Certificate",
+            vec![(
+                "domain_validation_options",
+                AttributeType::List {
+                    inner: Box::new(AttributeType::Struct {
+                        name: "DomainValidationOption".to_string(),
+                        fields: vec![StructField::new("rotation_count", AttributeType::Int)],
+                    }),
+                    ordered: true,
+                },
+            )],
+        ),
+    );
+    // Receiver `name` is String — the chained access yields Int.
+    schemas.insert(
+        "aws",
+        make_schema("route53.RecordSet", vec![("name", AttributeType::String)]),
+    );
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "main").with_binding("cert");
+
+    let path = AccessPath::with_segments(
+        "cert",
+        "domain_validation_options",
+        vec![
+            PathSegment::Subscript {
+                index: Subscript::Int { index: 0 },
+            },
+            PathSegment::Field {
+                name: "rotation_count".to_string(),
+            },
+        ],
+    );
+    let record = Resource::with_provider("aws", "route53.RecordSet", "validation").with_attribute(
+        "name",
+        Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
+    );
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.resources.push(record); // allow: direct — fixture test inspection
+    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    assert!(
+        err.contains("expected String"),
+        "expected real Int→String mismatch to be flagged, got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

`validate_resource_ref_types` was comparing the *root* attribute type of a `ResourceRef` against the receiver, ignoring everything past `binding.attribute` in the access path. Post-#3025 the AST carries the full `[idx]` / `.field` chain as ordered segments, but the type checker hadn't been taught to walk it — so the carina#3028 reproduction `cert.domain_validation_options[0].resource_record_name` (a `String` leaf inside `List<Struct{resource_record_name: String, ...}>`) was rejected as \"expected String, got List<Struct(...)>\".

Add `validation::narrow_attribute_type`, a borrowing walker over the schema `AttributeType` mirroring the existing `narrow_type_expr` on the declaration side: `.field` descends a `Struct`, `[idx]` peels one `List<T>` → `T` or `Map<_, V>` → `V` layer, and dot-form key access against `Map<_, V>` projects to `V` (symmetric with the resolver — carina#2447). On a shape mismatch the walker returns `None`; the caller skips the type check there since schema-level attribute validation already flags unknown fields and resolver-time evaluation catches shape errors with location context.

## Tests

- `ref_with_chained_subscript_then_field_narrows_through_list` — the carina#3028 reproduction, exact `List<Struct{name: String}>` → `String` path. Pre-fix this asserts the issue's exact error message; post-fix it validates cleanly.
- `ref_with_chained_subscript_then_field_rejects_real_mismatch` — regression guard so narrowing doesn't *silently* accept a genuinely incompatible leaf.

## Test plan

- [x] `cargo nextest run --workspace` — 3291 passed
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all green

Closes #3028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)