### PR TITLE
fmt: chained index-then-field access in subscripted_id (closes #3030)

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -238,11 +238,12 @@ identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 // Namespaced identifier: aws.s3_bucket, aws.Region.ap_northeast_1, Type.ipsec.1
 namespaced_id = @{ identifier ~ ("." ~ (identifier | ASCII_DIGIT+))+ }
 
-// Namespaced identifier with trailing `[index]` subscripts:
-// `orgs.accounts[0]`, `orgs.account.children["alpha"]`. Mirrors the
-// canonical parser's `subscripted_id` so post-field index access
-// formats round-trip.
-subscripted_id = { namespaced_id ~ (trivia* ~ index_access)+ }
+// Namespaced identifier with a trailing chain of `[index]` /
+// `.field` continuations: `orgs.accounts[0]`,
+// `orgs.account.children["alpha"]`, `cert.domain_validation_options[0].resource_record_name`
+// (carina#3030). Mirrors the canonical parser's `subscripted_id` so
+// every shape the main parser accepts round-trips through `carina fmt`.
+subscripted_id = { namespaced_id ~ (trivia* ~ (index_access | field_access))+ }
 
 // Expression
 expression = { pipe_expr }

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -1029,6 +1029,29 @@ mod tests {
     }
 
     #[test]
+    fn test_format_chained_index_then_field_after_namespaced_id() {
+        // carina#3030: chained `[idx].field` continuation after a
+        // dotted resource ref must round-trip through `carina fmt`.
+        // Pre-fix the formatter parser rejected this with
+        // "expected ... close_brace, open_bracket, ..." at the `.`
+        // that introduced the second field segment.
+        let input = "aws.route53.RecordSet {\n  name = cert.domain_validation_options[0].resource_record_name\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert!(
+            result.contains("cert.domain_validation_options[0].resource_record_name"),
+            "Chained access surface form must survive formatting, got:\n{}",
+            result
+        );
+        // Idempotency: a second pass must produce the same output.
+        let second = format(&result, &config).unwrap();
+        assert_eq!(
+            result, second,
+            "format must be idempotent for chained access"
+        );
+    }
+
+    #[test]
     fn test_format_for_expression() {
         let input = "let subnets = for subnet in subnets {\n  awscc.ec2.Subnet {\n    cidr_block = subnet.cidr\n  }\n}\n";
         let config = FormatConfig::default();

--- a/carina-core/src/formatter/parser.rs
+++ b/carina-core/src/formatter/parser.rs
@@ -304,6 +304,40 @@ mod tests {
     }
 
     #[test]
+    fn issue_3030_chained_index_then_field_after_namespaced_id() {
+        // The formatter's grammar used to accept `binding.attr[idx]` but
+        // reject `binding.attr[idx].field` — the same chained
+        // index-then-field shape that #3026/#3027 enabled in the main
+        // parser. Without this fix the pre-commit `carina fmt` hook
+        // blocks anyone using the now-legal form (carina#3030).
+        let input = r#"aws.route53.RecordSet {
+  name = cert.domain_validation_options[0].resource_record_name
+}
+"#;
+        let result = parse(input);
+        assert!(
+            result.is_ok(),
+            "Chained index-then-field after namespaced_id should parse (carina#3030), got: {}",
+            result.unwrap_err()
+        );
+    }
+
+    #[test]
+    fn issue_3030_multi_step_index_field_chain_after_namespaced_id() {
+        // `binding.attr[i].sub[j].leaf` — multi-step chain after a
+        // namespaced_id. Lock the shape down so future grammar tweaks
+        // don't silently regress.
+        let input = r#"let x = orgs.accounts[0].subnets[1].id
+"#;
+        let result = parse(input);
+        assert!(
+            result.is_ok(),
+            "Multi-step chained access after namespaced_id should parse, got: {}",
+            result.unwrap_err()
+        );
+    }
+
+    #[test]
     fn issue_2504_let_binding_with_module_call_rhs() {
         // `let X = module_call { ... }` is accepted by the main parser
         // but rejected by the formatter parser. See carina-rs/carina#2504.

--- a/carina-core/src/formatter/rules/expressions.rs
+++ b/carina-core/src/formatter/rules/expressions.rs
@@ -264,9 +264,11 @@ impl Formatter {
     }
 
     pub(in crate::formatter) fn format_subscripted_id(&mut self, node: &CstNode) {
-        // `binding.field[idx]…` — the namespaced_id portion is a single
-        // token (the `@{ }` rule produces no inner pairs), and each
-        // `index_access` child carries its own `[` / expression / `]`.
+        // `binding.field[idx]…`, `binding.field[idx].subfield`,
+        // `binding.field.sub[i].leaf` — the namespaced_id portion is a
+        // single token (the `@{ }` rule produces no inner pairs), and
+        // each `index_access` / `field_access` child carries its own
+        // surface form (`[idx]` / `.field`). carina#3030.
         for child in &node.children {
             match child {
                 CstChild::Token(token) => {
@@ -274,6 +276,9 @@ impl Formatter {
                 }
                 CstChild::Node(n) if n.kind == NodeKind::IndexAccess => {
                     self.format_index_access(n);
+                }
+                CstChild::Node(n) if n.kind == NodeKind::FieldAccess => {
+                    self.format_field_access(n);
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary

`carina-core/src/formatter/carina_fmt.pest` carries a separate grammar from the canonical `carina.pest`. The chained-access work in #3026/#3027 only updated the main grammar, so `carina validate` accepts `cert.list[0].field` while `carina fmt` rejects it — anyone with a pre-commit hook running `carina fmt` is blocked on the now-legal syntax with no path forward short of `--no-verify`.

Bring the formatter back into parity:

- `subscripted_id` now matches `namespaced_id ~ (trivia* ~ (index_access | field_access))+`, mirroring the main parser's `(index_access | field_access)+`.
- `format_subscripted_id` walks both `IndexAccess` and `FieldAccess` CST children so the formatted output preserves source order.

## Tests

- `issue_3030_chained_index_then_field_after_namespaced_id` — exact reproduction from the issue
- `issue_3030_multi_step_index_field_chain_after_namespaced_id` — `orgs.accounts[0].subnets[1].id`
- `test_format_chained_index_then_field_after_namespaced_id` — round-trip: chained surface form survives formatting and a second pass is idempotent

## Test plan

- [x] `cargo nextest run --workspace` — 3294 passed
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all green

Closes #3030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)