### PR TITLE
executor: fail-fast on unresolved refs at apply seam (refs #3032)

### DIFF
--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -108,22 +108,37 @@ pub(super) async fn refresh_pending_states(
 
 /// Resolve a resource's attributes using the current bindings.
 /// Secret values are unwrapped so the provider receives the plain inner value.
+///
+/// Any attribute that still contains a `Value::Deferred(ResourceRef|
+/// BindingRef|Interpolation|FunctionCall)` after resolution is rejected
+/// here — pre-#3032 the executor passed such values straight through
+/// to the provider, where the WASM serializer surfaced them as a
+/// generic "cannot serialize at WASM provider boundary" error with no
+/// hint about *why* the reference was unresolved.
+///
+/// The fail-fast happens at the executor seam rather than at the WASM
+/// boundary so the error names the attribute and points the user at
+/// `wait` as the synchronization mechanism for upstream attributes
+/// that populate asynchronously (ACM `domain_validation_options`,
+/// CloudFront `domain_name`, etc.).
 pub(super) fn resolve_resource(
     resource: &Resource,
     bindings: &ResolvedBindings,
 ) -> Result<Resource, String> {
     let mut resolved = resource.clone();
     for (key, expr) in &resource.attributes {
-        let resolved_value = resolve_ref_value(expr, bindings)?;
-        resolved
-            .attributes
-            .insert(key.clone(), unwrap_secret(resolved_value));
+        let resolved_value = unwrap_secret(resolve_ref_value(expr, bindings)?);
+        assert_fully_resolved(&resolved_value, key)?;
+        resolved.attributes.insert(key.clone(), resolved_value);
     }
     Ok(resolved)
 }
 
 /// Resolve a resource, preferring unresolved source for re-resolution.
 /// Secret values are unwrapped so the provider receives the plain inner value.
+///
+/// See [`resolve_resource`] for the fail-fast contract on
+/// still-deferred values.
 pub(super) fn resolve_resource_with_source(
     target: &Resource,
     source: &Resource,
@@ -131,12 +146,63 @@ pub(super) fn resolve_resource_with_source(
 ) -> Result<Resource, String> {
     let mut resolved = target.clone();
     for (key, expr) in &source.attributes {
-        let resolved_value = resolve_ref_value(expr, bindings)?;
-        resolved
-            .attributes
-            .insert(key.clone(), unwrap_secret(resolved_value));
+        let resolved_value = unwrap_secret(resolve_ref_value(expr, bindings)?);
+        assert_fully_resolved(&resolved_value, key)?;
+        resolved.attributes.insert(key.clone(), resolved_value);
     }
     Ok(resolved)
+}
+
+/// Reject a resolved attribute value that still carries an unresolved
+/// `Deferred` payload (carina#3032).
+///
+/// Walks `List` / `Map` containers so a chained `[idx].field` ref
+/// hidden inside `resource_records = [cert.dvo[0].rrv]` is caught.
+/// `Secret` is peeled and recursed — secret-tagged refs still need to
+/// be resolved before reaching the provider (the executor unwraps
+/// secrets just downstream of this check).
+///
+/// `Unknown` is *not* rejected: it is the deliberately-modeled
+/// "known after upstream apply" placeholder used by plan rendering
+/// (`UnknownReason::UpstreamRef`) and never reaches the apply path
+/// for local refs. Treating it as unresolved here would regress
+/// `resolve_refs_for_plan`'s contract.
+fn assert_fully_resolved(value: &Value, attribute_key: &str) -> Result<(), String> {
+    match value {
+        Value::Concrete(ConcreteValue::List(items)) => {
+            for item in items {
+                assert_fully_resolved(item, attribute_key)?;
+            }
+            Ok(())
+        }
+        Value::Concrete(ConcreteValue::Map(map)) => {
+            for v in map.values() {
+                assert_fully_resolved(v, attribute_key)?;
+            }
+            Ok(())
+        }
+        Value::Deferred(DeferredValue::Secret(inner)) => {
+            assert_fully_resolved(inner, attribute_key)
+        }
+        Value::Deferred(DeferredValue::ResourceRef { path }) => Err(format!(
+            "attribute `{attribute_key}` references `{}` which has not been published yet by the upstream resource. \
+                 Add a `wait` block on the upstream binding to synchronize on this attribute before downstream resources read it.",
+            path.to_dot_string(),
+        )),
+        Value::Deferred(DeferredValue::BindingRef { binding }) => Err(format!(
+            "attribute `{attribute_key}` references binding `{binding}` which has not been resolved at apply time. \
+                 Add a `wait` block on the upstream binding to synchronize before downstream resources read it.",
+        )),
+        Value::Deferred(DeferredValue::Interpolation(_)) => Err(format!(
+            "attribute `{attribute_key}` contains an interpolation that did not fully resolve at apply time. \
+                 At least one referenced binding has not been published yet; add a `wait` block on the upstream attribute.",
+        )),
+        Value::Deferred(DeferredValue::FunctionCall { name, .. }) => Err(format!(
+            "attribute `{attribute_key}` calls function `{name}()` whose arguments did not fully resolve at apply time. \
+                 At least one referenced binding has not been published yet; add a `wait` block on the upstream attribute.",
+        )),
+        _ => Ok(()),
+    }
 }
 
 /// Recursively unwrap `Value::Deferred(DeferredValue::Secret(inner))` to just the inner value.
@@ -400,5 +466,130 @@ pub(super) async fn execute_basic_effect<'a>(
             }
         },
         _ => unreachable!("execute_basic_effect called with non-basic effect"),
+    }
+}
+
+#[cfg(test)]
+mod assert_fully_resolved_tests {
+    //! Unit-level coverage of the apply-time fail-fast contract added
+    //! for carina#3032. The end-to-end executor variant lives at
+    //! `executor::tests::test_chained_index_then_field_unresolved_at_apply_fails_with_clear_error`;
+    //! these tests cover the deferred-variant matrix without going
+    //! through the executor + mock provider scaffolding.
+    use super::*;
+    use crate::resource::{
+        AccessPath, ConcreteValue, DeferredValue, InterpolationPart, PathSegment, Subscript,
+        UnknownReason, Value,
+    };
+
+    fn dvo_chained_ref() -> Value {
+        let path = AccessPath::with_segments(
+            "cert",
+            "domain_validation_options",
+            vec![
+                PathSegment::Subscript {
+                    index: Subscript::Int { index: 0 },
+                },
+                PathSegment::Field {
+                    name: "resource_record_value".to_string(),
+                },
+            ],
+        );
+        Value::Deferred(DeferredValue::ResourceRef { path })
+    }
+
+    #[test]
+    fn concrete_value_is_fully_resolved() {
+        assert!(
+            assert_fully_resolved(&Value::Concrete(ConcreteValue::String("ok".into())), "name",)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn unknown_is_intentionally_allowed() {
+        // `Unknown` is the plan-rendering placeholder for upstream
+        // refs (#2371). It legitimately reaches the apply path during
+        // re-resolution sweeps and must not be rejected by the local
+        // fail-fast.
+        let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue));
+        assert!(assert_fully_resolved(&v, "name").is_ok());
+    }
+
+    #[test]
+    fn direct_chained_resource_ref_is_rejected_with_path_and_wait_hint() {
+        let err = assert_fully_resolved(&dvo_chained_ref(), "name")
+            .expect_err("direct ResourceRef must be rejected at apply seam");
+        assert!(
+            err.contains("cert.domain_validation_options[0].resource_record_value"),
+            "error must name the unresolved path; got: {err}",
+        );
+        assert!(
+            err.contains("wait"),
+            "error must point at `wait` as the workaround; got: {err}",
+        );
+    }
+
+    #[test]
+    fn list_wrapped_chained_ref_is_rejected() {
+        // The exact carina#3032 failing form: `resource_records =
+        // [cert.dvo[0].rrv]`. The list literal must be walked.
+        let v = Value::Concrete(ConcreteValue::List(vec![dvo_chained_ref()]));
+        let err = assert_fully_resolved(&v, "resource_records")
+            .expect_err("list-wrapped ResourceRef must be rejected");
+        assert!(err.contains("resource_record_value"), "got: {err}");
+    }
+
+    #[test]
+    fn map_wrapped_chained_ref_is_rejected() {
+        let mut m: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
+        m.insert("nested".to_string(), dvo_chained_ref());
+        let err = assert_fully_resolved(&Value::Concrete(ConcreteValue::Map(m)), "tags")
+            .expect_err("map-wrapped ResourceRef must be rejected");
+        assert!(err.contains("resource_record_value"), "got: {err}");
+    }
+
+    #[test]
+    fn secret_wrapped_ref_is_peeled_and_rejected() {
+        // `Secret(ResourceRef)` would otherwise sneak past — the
+        // secret tag would survive but the ref would still be
+        // unresolved at the WASM boundary.
+        let v = Value::Deferred(DeferredValue::Secret(Box::new(dvo_chained_ref())));
+        let err = assert_fully_resolved(&v, "password")
+            .expect_err("Secret wrapping does not exempt unresolved refs");
+        assert!(err.contains("resource_record_value"), "got: {err}");
+    }
+
+    #[test]
+    fn binding_ref_is_rejected() {
+        let v = Value::Deferred(DeferredValue::BindingRef {
+            binding: "vpc".to_string(),
+        });
+        let err =
+            assert_fully_resolved(&v, "vpc_id").expect_err("bare BindingRef must be rejected");
+        assert!(err.contains("vpc"), "got: {err}");
+        assert!(err.contains("wait"), "got: {err}");
+    }
+
+    #[test]
+    fn interpolation_with_unresolved_part_is_rejected() {
+        let v = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("prefix-".to_string()),
+            InterpolationPart::Expr(dvo_chained_ref()),
+        ]));
+        let err = assert_fully_resolved(&v, "name")
+            .expect_err("Interpolation that did not collapse must be rejected");
+        assert!(err.contains("interpolation"), "got: {err}");
+    }
+
+    #[test]
+    fn function_call_with_unresolved_args_is_rejected() {
+        let v = Value::Deferred(DeferredValue::FunctionCall {
+            name: "concat".to_string(),
+            args: vec![dvo_chained_ref()],
+        });
+        let err = assert_fully_resolved(&v, "name")
+            .expect_err("FunctionCall that did not evaluate must be rejected");
+        assert!(err.contains("concat"), "got: {err}");
     }
 }

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -4,7 +4,7 @@ use crate::provider::{
     BoxFuture, CreateRequest, DeleteRequest, ProviderError, ProviderResult, ReadRequest,
     UpdateRequest,
 };
-use crate::resource::{ConcreteValue, Directives, Resource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Directives, Resource, Value};
 use parallel::{build_dependency_levels, build_dependency_map};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -20,6 +20,10 @@ struct MockProvider {
     read_results: Mutex<Vec<ProviderResult<State>>>,
     /// Records calls in order: ("create"|"delete"|"update"|"read", resource_id_string)
     call_log: Arc<Mutex<Vec<(String, String)>>>,
+    /// Resources passed in to `create()` in call order — lets a test
+    /// assert that the executor handed the provider a fully-resolved
+    /// resource (no remaining `Value::Deferred(ResourceRef)` etc.).
+    create_resources: Arc<Mutex<Vec<Resource>>>,
 }
 
 impl MockProvider {
@@ -30,6 +34,7 @@ impl MockProvider {
             update_results: Mutex::new(Vec::new()),
             read_results: Mutex::new(Vec::new()),
             call_log: Arc::new(Mutex::new(Vec::new())),
+            create_resources: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -53,6 +58,10 @@ impl MockProvider {
 
     fn calls(&self) -> Vec<(String, String)> {
         self.call_log.lock().unwrap().clone()
+    }
+
+    fn captured_create_resources(&self) -> Vec<Resource> {
+        self.create_resources.lock().unwrap().clone()
     }
 }
 
@@ -83,13 +92,14 @@ impl Provider for MockProvider {
     fn create(
         &self,
         id: &ResourceId,
-        _request: CreateRequest,
+        request: CreateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id_str = id.to_string();
         self.call_log
             .lock()
             .unwrap()
             .push(("create".to_string(), id_str));
+        self.create_resources.lock().unwrap().push(request.resource);
         let result = self.create_results.lock().unwrap().remove(0);
         Box::pin(async move { result })
     }
@@ -215,7 +225,17 @@ fn make_resource(binding: &str, deps: &[&str]) -> Resource {
 }
 
 fn ok_state(id: &ResourceId) -> State {
-    State::existing(id.clone(), HashMap::new()).with_identifier("id-123")
+    // The `id` attribute mirrors what a real provider's read-back
+    // publishes after Create — without it, dependents created via
+    // `make_resource(name, &["dep"])` (which writes `ref_dep =
+    // ResourceRef(dep, "id")`) cannot resolve their references and
+    // post-#3032 the executor rejects them at the apply seam.
+    let mut attrs = HashMap::new();
+    attrs.insert(
+        "id".to_string(),
+        Value::Concrete(ConcreteValue::String("id-123".to_string())),
+    );
+    State::existing(id.clone(), attrs).with_identifier("id-123")
 }
 
 // -----------------------------------------------------------------------
@@ -889,7 +909,16 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
                 log.lock()
                     .unwrap()
                     .push(("create".to_string(), name, Instant::now()));
-                Ok(State::existing(id_clone, HashMap::new()).with_identifier("id-123"))
+                // Publish `id` so dependents created via
+                // `make_resource(name, &["dep"])` resolve their
+                // `ResourceRef(parent, "id")` (post-#3032 the executor
+                // rejects unresolved refs at the apply seam).
+                let mut attrs = HashMap::new();
+                attrs.insert(
+                    "id".to_string(),
+                    Value::Concrete(ConcreteValue::String("id-123".to_string())),
+                );
+                Ok(State::existing(id_clone, attrs).with_identifier("id-123"))
             })
         }
 
@@ -983,11 +1012,22 @@ async fn test_waiting_events_emitted_for_dependent_effects() {
     // Push create results for both resources
     let a_id = ResourceId::new("test", "a");
     let c_id = ResourceId::new("test", "c");
+    // Publish `id` in state.attributes so dependents resolve their
+    // `ResourceRef(parent, "id")` refs (post-#3032 the executor
+    // rejects unresolved refs at the apply seam).
+    let id_attr = |val: &str| -> HashMap<String, Value> {
+        let mut m = HashMap::new();
+        m.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String(val.to_string())),
+        );
+        m
+    };
     provider.push_create(Ok(
-        State::existing(a_id, HashMap::new()).with_identifier("id-a")
+        State::existing(a_id, id_attr("id-a")).with_identifier("id-a")
     ));
     provider.push_create(Ok(
-        State::existing(c_id, HashMap::new()).with_identifier("id-c")
+        State::existing(c_id, id_attr("id-c")).with_identifier("id-c")
     ));
     let result = execute_plan(&provider, input, &observer).await;
 
@@ -1680,5 +1720,148 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     assert!(
         result.applied_states.contains_key(&synthetic),
         "wait should register its captured State under the __wait synthetic id"
+    );
+}
+
+/// carina#3032 — when a chained `[idx].field` access cannot be
+/// resolved at apply time (because the upstream resource has not
+/// published the referenced attribute yet — e.g. ACM
+/// `domain_validation_options` is populated asynchronously after
+/// RequestCertificate), the executor must fail with an actionable
+/// error that names the unresolved reference, **not** silently pass
+/// the literal `ResourceRef` to the provider where it surfaces as
+/// a generic "cannot serialize at WASM provider boundary" error.
+///
+/// Pre-fix: `resolve_ref_value` bails out on the missing
+/// `domain_validation_options` key (resolver.rs:254 catch-all),
+/// returns the original `ResourceRef` unchanged, the dependent's
+/// `resource_records` reaches `Provider::create()` as
+/// `Value::Concrete(List([Value::Deferred(ResourceRef { … })]))`,
+/// and the WASM serializer's `core_to_wit_value` rejects it with
+/// the unhelpful contract message.
+///
+/// Post-fix: the executor's `resolve_resource` rejects any value
+/// still containing a `ResourceRef` / `BindingRef` after resolution,
+/// with an error that points at the unresolved attribute path and
+/// suggests using `wait` to synchronize on the upstream attribute.
+#[tokio::test]
+async fn test_chained_index_then_field_unresolved_at_apply_fails_with_clear_error() {
+    use crate::resource::{AccessPath, ConcreteValue, PathSegment, Subscript};
+
+    let provider = MockProvider::new();
+
+    // The cert resource — no DSL attrs that reference DVO; the
+    // attribute would be populated only by the create's read-back
+    // state. Mirror the real ACM Certificate's user-facing shape.
+    let cert = {
+        let mut r = Resource::new("test", "cert");
+        r.binding = Some("cert".to_string());
+        r.set_attr(
+            "domain_name",
+            Value::Concrete(ConcreteValue::String("example.com".to_string())),
+        );
+        r
+    };
+    let cert_id = cert.id.clone();
+
+    // The dependent resource mirrors the failing route53 RecordSet
+    // attributes from the issue:
+    //   resource_records = [cert.domain_validation_options[0].resource_record_value]
+    let record = {
+        let mut r = Resource::new("test", "record");
+        r.binding = Some("record".to_string());
+        r.dependency_bindings = ["cert".to_string()].into_iter().collect();
+        let value_path = AccessPath::with_segments(
+            "cert",
+            "domain_validation_options",
+            vec![
+                PathSegment::Subscript {
+                    index: Subscript::Int { index: 0 },
+                },
+                PathSegment::Field {
+                    name: "resource_record_value".to_string(),
+                },
+            ],
+        );
+        r.set_attr(
+            "resource_records",
+            Value::Concrete(ConcreteValue::List(vec![Value::Deferred(
+                DeferredValue::ResourceRef { path: value_path },
+            )])),
+        );
+        r
+    };
+    let record_id = record.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::Create(record));
+
+    // Mirror the AWS RequestCertificate read-back race: the DVO list
+    // is populated asynchronously by ACM after RequestCertificate
+    // returns, so the create read-back surfaces zero DVO entries
+    // and the AWS provider's `read_acm_certificate` *omits* the
+    // `domain_validation_options` key entirely
+    // (carina-provider-aws::services::acm::certificate.rs:210
+    // `if !dvs.is_empty()`).
+    provider.push_create(Ok(
+        State::existing(cert_id.clone(), HashMap::new()).with_identifier("acm-cert-id")
+    ));
+    // Reserve a create slot for the record in case the executor
+    // attempts it before failing — pre-fix it would have, and the
+    // mock would otherwise panic-on-empty-queue masking the actual
+    // bug.
+    provider.push_create(Ok(
+        State::existing(record_id.clone(), HashMap::new()).with_identifier("rrset-id")
+    ));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+
+    // Cert succeeds; the record fails at apply-time resolution
+    // *before* reaching the provider — no `create` call for the
+    // record should be recorded.
+    assert_eq!(result.success_count, 1, "events: {:?}", observer.events());
+    assert_eq!(result.failure_count, 1, "events: {:?}", observer.events());
+
+    let captured = provider.captured_create_resources();
+    assert!(
+        captured.iter().all(|r| r.id != record_id),
+        "record resource must NOT be passed to create (resolution \
+         should fail upstream); captured: {:?}",
+        captured.iter().map(|r| r.id.clone()).collect::<Vec<_>>(),
+    );
+
+    // The error message must name the unresolved reference path so
+    // the user can fix it (typically by adding a `wait` block on the
+    // upstream attribute).
+    let failed_event = observer
+        .events()
+        .iter()
+        .find(|e| e.starts_with("failed:") && e.contains("record"))
+        .cloned()
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a `failed:` event for the record resource; \
+                 got events: {:?}",
+                observer.events()
+            )
+        });
+    assert!(
+        failed_event.contains("cert.domain_validation_options"),
+        "error must name the unresolved attribute path so the user \
+         knows what to wait on; got: {failed_event}",
+    );
+    assert!(
+        failed_event.contains("wait"),
+        "error must suggest `wait` as the synchronization mechanism; \
+         got: {failed_event}",
     );
 }


### PR DESCRIPTION
## Summary

Closes the apply-time half of carina#3032: an unresolved `Value::Deferred(ResourceRef|BindingRef|Interpolation|FunctionCall)` no longer escapes `resolve_resource` / `resolve_resource_with_source` and silently reaches the WASM provider boundary. The executor rejects such values immediately with an error that names the unresolved attribute path and points the user at `wait` as the synchronization mechanism for upstream attributes that publish asynchronously (ACM `domain_validation_options`, CloudFront `domain_name`, etc.).

The trigger in #3032 is the chained `cert.domain_validation_options[0].resource_record_value` ref inside a `route53.RecordSet`'s `resource_records` list literal: AWS's `RequestCertificate` returns before ACM populates the validation records, so the post-Create binding lacks `domain_validation_options`, the resolver correctly preserves the ref (so the differ keeps it as a dependency edge), but pre-fix the executor accepted the still-deferred value and shipped it to the WASM serializer where it surfaced as the generic "cannot serialize at WASM provider boundary: unresolved reference …" message — leaving the user no hint about why the ref didn't resolve.

This is the staging fix in #3032's planned work (refs, not closes — the `resource_record_value` would still time out today; closing waits on the schema-level `DeferredPopulate<T>` annotation tracked in a follow-up issue).

## What changed

- `resolve_resource` / `resolve_resource_with_source` (carina-core/src/executor/basic.rs:124, 142) now call `assert_fully_resolved` after `unwrap_secret` and propagate any deferred-value error.
- New `assert_fully_resolved` walks `List` / `Map` / `Secret` containers so refs hidden inside list literals are caught. `Unknown` is intentionally allowed (it is the upstream-ref placeholder used by plan rendering — rejecting it would regress `resolve_refs_for_plan`'s contract).
- 9 unit tests at `executor::basic::assert_fully_resolved_tests` cover the deferred-variant matrix; one end-to-end test at `executor::tests::test_chained_index_then_field_unresolved_at_apply_fails_with_clear_error` reproduces the original failure path through the full executor.

## Latent test bugs surfaced

Two pre-existing executor scheduling tests built dependents via `make_resource(name, &["dep"])` (which writes `ResourceRef(dep, "id")`) but the mock provider's `ok_state` returned `State::existing(id, HashMap::new())` — no `id` attribute. Pre-fix this silently passed; post-fix it correctly errors. The mock helpers now publish `id` in `state.attributes`, mirroring what real providers do after Create. No production code change drove these test edits.

## Test plan

- [x] `cargo nextest run --workspace` — 3304/3304 pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — clean
- [ ] Real-infra smoke (user-driven): re-run `carina apply registry/dev/registry` and confirm the failure now surfaces as the new attribute-named error (mentioning `cert.domain_validation_options[0].resource_record_value` and suggesting `wait`) instead of "cannot serialize at WASM provider boundary".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
