### PR TITLE
core: DeferredPopulate validation rule + LSP diagnostic (refs #3034)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -26,10 +26,10 @@ use crate::error::AppError;
 use crate::wiring::{
     WiringContext, build_factories_from_providers, compute_anonymous_identifiers_with_ctx,
     resolve_names_with_ctx, validate_attribute_param_ref_types_with_ctx,
-    validate_depends_on_with_ctx, validate_module_attribute_param_types, validate_module_calls,
-    validate_no_empty_interpolations, validate_provider_region_with_ctx,
-    validate_resource_ref_types_with_ctx, validate_resources_with_ctx,
-    validate_wait_bindings_with_ctx,
+    validate_deferred_populate_refs_with_ctx, validate_depends_on_with_ctx,
+    validate_module_attribute_param_types, validate_module_calls, validate_no_empty_interpolations,
+    validate_provider_region_with_ctx, validate_resource_ref_types_with_ctx,
+    validate_resources_with_ctx, validate_wait_bindings_with_ctx,
 };
 
 /// Detect whether the `backend` block in the current configuration has
@@ -325,6 +325,7 @@ pub fn validate_and_resolve_errors_with_factories(
         errors.extend(validate_resources_with_ctx(&ctx, parsed, &enriched_context));
         errors.extend(validate_depends_on_with_ctx(parsed));
         errors.extend(validate_wait_bindings_with_ctx(&ctx, parsed));
+        errors.extend(validate_deferred_populate_refs_with_ctx(&ctx, parsed));
         let mut argument_names: HashSet<String> =
             parsed.arguments.iter().map(|a| a.name.clone()).collect();
         // Upstream state bindings are resolved at plan time, skip type validation

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -233,6 +233,24 @@ pub fn validate_wait_bindings_with_ctx<E>(
         .collect()
 }
 
+/// Surface deferred-populate-bound chained references that lack a
+/// synchronizing `wait` block as `AppError::Validation`. Shared with
+/// the LSP via the underlying
+/// `carina_core::validation::deferred_populate::validate_deferred_populate_refs`
+/// pass. carina#3034.
+pub fn validate_deferred_populate_refs_with_ctx<E>(
+    ctx: &WiringContext,
+    parsed: &carina_core::parser::File<E>,
+) -> Vec<AppError> {
+    carina_core::validation::deferred_populate::validate_deferred_populate_refs(
+        parsed,
+        ctx.schemas(),
+    )
+    .into_iter()
+    .map(|d| AppError::Validation(d.message))
+    .collect()
+}
+
 pub fn validate_resource_ref_types_with_ctx<E>(
     ctx: &WiringContext,
     parsed: &carina_core::parser::File<E>,

--- a/carina-cli/tests/deferred_populate_validate_e2e.rs
+++ b/carina-cli/tests/deferred_populate_validate_e2e.rs
@@ -1,0 +1,287 @@
+//! End-to-end validation tests for the `deferred_populate` annotation
+//! (carina#3034). Mirrors the directory-scoped pattern of
+//! `wait_validate_e2e.rs`.
+//!
+//! Per CLAUDE.md "directory-scoped, never single-file": every fixture
+//! is a multi-file `tempfile::tempdir()` layout — the cert lives in
+//! `acm.crn`, the dependent route53 RecordSet in `route53.crn`, and
+//! the optional `wait` block in `wait.crn`, so the merged-parse path
+//! that LSP and CLI share is exercised.
+
+use carina_core::provider::{
+    BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
+};
+use carina_core::resource::{Resource, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Test factory exposing aws.acm.Certificate (with a deferred-populate
+// inner field on `domain_validation_options`) and aws.route53.RecordSet.
+// ---------------------------------------------------------------------------
+
+struct DeferredPopulateTestFactory;
+
+impl ProviderFactory for DeferredPopulateTestFactory {
+    fn name(&self) -> &str {
+        "aws"
+    }
+    fn display_name(&self) -> &str {
+        "AWS (deferred-populate test stub)"
+    }
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+        Ok(())
+    }
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "us-east-1".to_string()
+    }
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
+    }
+    fn create_normalizer(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+        Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+    }
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![cert_schema(), rrset_schema()]
+    }
+}
+
+fn cert_schema() -> ResourceSchema {
+    ResourceSchema::new("acm.Certificate")
+        .attribute(AttributeSchema::new("domain_name", AttributeType::String))
+        .attribute(AttributeSchema::new(
+            "validation_method",
+            AttributeType::String,
+        ))
+        .attribute(AttributeSchema::new("status", AttributeType::String).deferred_populate())
+        .attribute(AttributeSchema::new(
+            "domain_validation_options",
+            AttributeType::list(AttributeType::Struct {
+                name: "DomainValidationOption".to_string(),
+                fields: vec![
+                    StructField::new("domain_name", AttributeType::String),
+                    StructField::new("resource_record_name", AttributeType::String)
+                        .deferred_populate(),
+                    StructField::new("resource_record_type", AttributeType::String)
+                        .deferred_populate(),
+                    StructField::new("resource_record_value", AttributeType::String)
+                        .deferred_populate(),
+                ],
+            }),
+        ))
+}
+
+fn rrset_schema() -> ResourceSchema {
+    ResourceSchema::new("route53.RecordSet")
+        .attribute(AttributeSchema::new(
+            "hosted_zone_id",
+            AttributeType::String,
+        ))
+        .attribute(AttributeSchema::new("name", AttributeType::String))
+        .attribute(AttributeSchema::new("type", AttributeType::String))
+        .attribute(AttributeSchema::new("ttl", AttributeType::Int))
+        .attribute(AttributeSchema::new(
+            "resource_records",
+            AttributeType::list(AttributeType::String),
+        ))
+}
+
+struct NoopProvider;
+
+impl Provider for NoopProvider {
+    fn name(&self) -> &str {
+        "aws"
+    }
+    fn read(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: Option<&str>,
+        _request: carina_core::provider::ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::not_found(id)) })
+    }
+    fn read_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn create(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn update(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn delete(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn factories() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(DeferredPopulateTestFactory) as Box<dyn ProviderFactory>]
+}
+
+fn write_fixture(files: &[(&str, &str)]) -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (name, content) in files {
+        std::fs::write(dir.path().join(name), content).expect("write fixture");
+    }
+    dir
+}
+
+fn cli_validate(fixture: &TempDir) -> Vec<String> {
+    carina_cli::commands::validate::validate_with_factories(fixture.path(), factories())
+}
+
+const PROVIDERS_CRN: &str = r#"provider aws {
+    region = "us-east-1"
+}
+"#;
+
+const ACM_CRN: &str = r#"let cert = aws.acm.Certificate {
+    domain_name       = "registry.example.com"
+    validation_method = "DNS"
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The carina#3032 reproduction shape, decomposed into a multi-file
+/// fixture. The cert is in `acm.crn`, the route53 RecordSet that
+/// reads the cert's deferred-populate inner field is in
+/// `route53.crn`, and there is *no* `wait` block — validate must
+/// flag the chained reference and name `cert` as the wait target.
+#[test]
+fn validate_flags_chained_ref_to_deferred_inner_field_without_wait() {
+    let fixture = write_fixture(&[
+        ("providers.crn", PROVIDERS_CRN),
+        ("acm.crn", ACM_CRN),
+        (
+            "route53.crn",
+            r#"aws.route53.RecordSet {
+    hosted_zone_id   = "Z1"
+    name             = cert.domain_validation_options[0].resource_record_name
+    type             = "CNAME"
+    ttl              = 300
+    resource_records = [cert.domain_validation_options[0].resource_record_value]
+}
+"#,
+        ),
+    ]);
+
+    let diags = cli_validate(&fixture);
+    assert!(
+        diags.iter().any(
+            |d| d.contains("cert.domain_validation_options[0].resource_record_value")
+                && d.contains("wait cert")
+        ),
+        "expected a deferred-populate diagnostic naming the unresolved \
+         path and `wait cert` as the workaround; got: {diags:?}",
+    );
+}
+
+/// Adding `wait cert { ... }` in a sibling `.crn` file satisfies the
+/// rule for *any* chained access on `cert` — the LSP and CLI both
+/// merge the directory before validating, so a wait declared in
+/// `wait.crn` is visible to references in `route53.crn`. This is
+/// the load-bearing directory-scoped assertion for the feature.
+#[test]
+fn validate_accepts_chained_ref_when_wait_is_declared_in_sibling_file() {
+    let fixture = write_fixture(&[
+        ("providers.crn", PROVIDERS_CRN),
+        ("acm.crn", ACM_CRN),
+        (
+            "route53.crn",
+            r#"aws.route53.RecordSet {
+    hosted_zone_id   = "Z1"
+    name             = cert.domain_validation_options[0].resource_record_name
+    type             = "CNAME"
+    ttl              = 300
+    resource_records = [cert.domain_validation_options[0].resource_record_value]
+}
+"#,
+        ),
+        (
+            "wait.crn",
+            r#"let cert_issued = wait cert {
+    until   = cert.status == "ISSUED"
+    timeout = 75min
+}
+"#,
+        ),
+    ]);
+
+    let diags = cli_validate(&fixture);
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.contains("domain_validation_options")),
+        "wait `cert` declared in a sibling file must satisfy the \
+         deferred-populate rule for chained refs on the same binding; \
+         got: {diags:?}",
+    );
+}
+
+/// Reference to a non-deferred attribute (`cert.domain_name`) must
+/// not trip the diagnostic, even without a `wait`. Sanity check that
+/// the rule only fires for schema-flagged paths.
+#[test]
+fn validate_does_not_flag_non_deferred_attribute_access() {
+    let fixture = write_fixture(&[
+        ("providers.crn", PROVIDERS_CRN),
+        ("acm.crn", ACM_CRN),
+        (
+            "consumer.crn",
+            r#"aws.route53.RecordSet {
+    hosted_zone_id   = "Z1"
+    name             = cert.domain_name
+    type             = "A"
+    ttl              = 60
+    resource_records = ["1.2.3.4"]
+}
+"#,
+        ),
+    ]);
+
+    let diags = cli_validate(&fixture);
+    assert!(
+        !diags.iter().any(|d| d.contains("populated asynchronously")),
+        "non-deferred attribute access must not trip the rule; got: {diags:?}",
+    );
+}

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -324,6 +324,14 @@ pub struct StructField {
     pub provider_name: Option<String>,
     /// Alternative block name for repeated block syntax (e.g., "transition" for "transitions")
     pub block_name: Option<String>,
+    /// Whether the value of this nested field is populated by the
+    /// provider asynchronously *after* the Create call returns.
+    /// Reached when a chained access traverses a `Struct` (e.g.
+    /// `cert.domain_validation_options[0].resource_record_value` —
+    /// the inner struct field is the deferred-populate one, not the
+    /// outer list attribute). See `AttributeSchema::deferred_populate`
+    /// (carina#3034).
+    pub deferred_populate: bool,
 }
 
 impl StructField {
@@ -335,6 +343,7 @@ impl StructField {
             description: None,
             provider_name: None,
             block_name: None,
+            deferred_populate: false,
         }
     }
 
@@ -355,6 +364,13 @@ impl StructField {
 
     pub fn with_block_name(mut self, name: impl Into<String>) -> Self {
         self.block_name = Some(name.into());
+        self
+    }
+
+    /// Mark this nested field as populated asynchronously by the
+    /// provider after Create. See the field doc on `deferred_populate`.
+    pub fn deferred_populate(mut self) -> Self {
+        self.deferred_populate = true;
         self
     }
 }
@@ -2111,6 +2127,21 @@ pub struct AttributeSchema {
     /// (e.g., Route 53 RecordSet `type` differentiates A vs AAAA records with the
     /// same name and hosted zone).
     pub identity: bool,
+    /// Whether the value of this attribute is populated by the provider
+    /// asynchronously *after* the Create call returns. Downstream
+    /// resources that read this attribute via a chained access
+    /// (`<binding>.<this_attr>...`) without a synchronizing `wait`
+    /// block on the binding will be rejected at validate time
+    /// (carina#3034). Examples:
+    /// - ACM `Certificate.status` (PENDING_VALIDATION → ISSUED)
+    /// - CloudFront `Distribution.domain_name`
+    /// - RDS `DBInstance.endpoint`
+    ///
+    /// Independent of `read_only`: a deferred-populate attribute may
+    /// also be `read_only` (the user cannot set it), but a `read_only`
+    /// attribute is not necessarily deferred-populate (it may be
+    /// populated synchronously, e.g. an ARN echoed back by Create).
+    pub deferred_populate: bool,
 }
 
 impl AttributeSchema {
@@ -2129,6 +2160,7 @@ impl AttributeSchema {
             block_name: None,
             write_only: false,
             identity: false,
+            deferred_populate: false,
         }
     }
 
@@ -2154,6 +2186,13 @@ impl AttributeSchema {
 
     pub fn identity(mut self) -> Self {
         self.identity = true;
+        self
+    }
+
+    /// Mark this attribute as populated asynchronously by the provider
+    /// after Create. See the field doc on `deferred_populate`.
+    pub fn deferred_populate(mut self) -> Self {
+        self.deferred_populate = true;
         self
     }
 

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -1,0 +1,548 @@
+//! Reject chained references to schema-flagged "deferred-populate"
+//! attributes that lack a synchronizing `wait` block (carina#3034).
+//!
+//! ACM `Certificate.domain_validation_options[*].resource_record_value`
+//! is the canonical example: AWS does not populate the inner
+//! `resource_record_*` fields until *after* `RequestCertificate`
+//! returns, so a downstream `route53.RecordSet` that reads
+//! `cert.domain_validation_options[0].resource_record_value` directly
+//! will fail at apply time. The provider author has marked the
+//! offending struct fields with `.deferred_populate()`; this pass
+//! flags any chained access that traverses such a field unless the
+//! user has declared `wait <binding> { until = ... }` against the
+//! same target binding (or a transitive dependency thereof).
+//!
+//! Synchronization model: existence of *any* `wait` block on the
+//! binding satisfies the rule. We do not require the wait predicate
+//! to mention the specific accessed attribute — by the time a user
+//! has declared a wait, they have asserted "this resource has reached
+//! a steady state", which transitively guarantees the populated-
+//! attribute set. Tightening the rule to "the wait predicate must
+//! reference *this exact attribute*" would force users into one wait
+//! per accessed attribute, which is impractical for nested structs
+//! (the cert's wait predicate is `cert.status == ISSUED`, which
+//! transitively guarantees DVO is populated, but the rule wouldn't
+//! see the connection). See
+//! `notes/specs/2026-05-14-deferred-populate-attribute-design.md`.
+//!
+//! Defense-in-depth: the apply-time fail-fast in
+//! `executor/basic.rs::assert_fully_resolved` (carina#3032 / #3033)
+//! still catches misannotated attributes at apply time. This pass
+//! moves the *common* case to validate time so the user gets the
+//! error in milliseconds, with an actionable suggestion, rather than
+//! after a multi-minute apply.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::parser::File;
+use crate::resource::{
+    AccessPath, ConcreteValue, DeferredValue, InterpolationPart, PathSegment, Value,
+};
+use crate::schema::{AttributeSchema, AttributeType, SchemaKind, SchemaRegistry};
+
+/// One diagnostic for a deferred-populate-bound chained reference
+/// that lacks a synchronizing `wait` block.
+///
+/// `binding` and `attribute_path` carry structured location hints so
+/// the LSP can resolve a per-span anchor without re-parsing the
+/// message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeferredPopulateDiagnostic {
+    /// The error message (same wording for `carina validate` and LSP).
+    pub message: String,
+    /// The DSL binding name of the resource holding the offending
+    /// attribute (e.g. the route53 RecordSet's binding).
+    pub holder_binding: Option<String>,
+    /// The attribute key on the holder resource that contains the
+    /// offending chained reference (e.g. `resource_records`).
+    pub attribute_key: String,
+    /// The full unresolved path as the user wrote it (e.g.
+    /// `cert.domain_validation_options[0].resource_record_value`).
+    pub unresolved_path: String,
+    /// The target binding that needs a `wait` (e.g. `cert`).
+    pub target_binding: String,
+}
+
+/// Run the deferred-populate diagnostic against a parsed file +
+/// schema registry.
+pub fn validate_deferred_populate_refs<E>(
+    parsed: &File<E>,
+    schemas: &SchemaRegistry,
+) -> Vec<DeferredPopulateDiagnostic> {
+    // binding name → (provider, resource_type) for schema lookup.
+    // Walks both top-level resources and for-expression bodies so a
+    // chained ref inside a `for` body still finds its target binding.
+    let mut by_binding: HashMap<String, (String, String)> = HashMap::new();
+    for (_, r) in parsed.iter_all_resources() {
+        if let Some(b) = &r.binding {
+            by_binding.insert(
+                b.clone(),
+                (r.id.provider.clone(), r.id.resource_type.clone()),
+            );
+        }
+    }
+    if by_binding.is_empty() {
+        return Vec::new();
+    }
+
+    // Set of binding names that have a `wait` block declared against
+    // them in the same directory. A wait on binding `cert` satisfies
+    // the rule for ANY chained access on `cert` (see module doc).
+    let synchronized: HashSet<&str> = parsed
+        .wait_bindings
+        .iter()
+        .map(|wb| wb.target.as_str())
+        .collect();
+
+    let mut out: Vec<DeferredPopulateDiagnostic> = Vec::new();
+    for (_, r) in parsed.iter_all_resources() {
+        for (key, value) in &r.attributes {
+            collect_unsynchronized_refs(
+                value,
+                key,
+                r.binding.as_deref(),
+                &by_binding,
+                &synchronized,
+                schemas,
+                &mut out,
+            );
+        }
+    }
+    out
+}
+
+/// Walk `value` recursively, emitting one diagnostic per chained ref
+/// that targets a deferred-populate-flagged attribute on an
+/// unsynchronized binding.
+fn collect_unsynchronized_refs(
+    value: &Value,
+    attribute_key: &str,
+    holder_binding: Option<&str>,
+    by_binding: &HashMap<String, (String, String)>,
+    synchronized: &HashSet<&str>,
+    schemas: &SchemaRegistry,
+    out: &mut Vec<DeferredPopulateDiagnostic>,
+) {
+    match value {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            check_ref(
+                path,
+                attribute_key,
+                holder_binding,
+                by_binding,
+                synchronized,
+                schemas,
+                out,
+            );
+        }
+        Value::Concrete(ConcreteValue::List(items)) => {
+            for item in items {
+                collect_unsynchronized_refs(
+                    item,
+                    attribute_key,
+                    holder_binding,
+                    by_binding,
+                    synchronized,
+                    schemas,
+                    out,
+                );
+            }
+        }
+        Value::Concrete(ConcreteValue::Map(map)) => {
+            for v in map.values() {
+                collect_unsynchronized_refs(
+                    v,
+                    attribute_key,
+                    holder_binding,
+                    by_binding,
+                    synchronized,
+                    schemas,
+                    out,
+                );
+            }
+        }
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
+            for part in parts {
+                if let InterpolationPart::Expr(v) = part {
+                    collect_unsynchronized_refs(
+                        v,
+                        attribute_key,
+                        holder_binding,
+                        by_binding,
+                        synchronized,
+                        schemas,
+                        out,
+                    );
+                }
+            }
+        }
+        Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
+            for arg in args {
+                collect_unsynchronized_refs(
+                    arg,
+                    attribute_key,
+                    holder_binding,
+                    by_binding,
+                    synchronized,
+                    schemas,
+                    out,
+                );
+            }
+        }
+        Value::Deferred(DeferredValue::Secret(inner)) => {
+            collect_unsynchronized_refs(
+                inner,
+                attribute_key,
+                holder_binding,
+                by_binding,
+                synchronized,
+                schemas,
+                out,
+            );
+        }
+        _ => {}
+    }
+}
+
+/// Check one `ResourceRef` against the schema and the wait set.
+fn check_ref(
+    path: &AccessPath,
+    attribute_key: &str,
+    holder_binding: Option<&str>,
+    by_binding: &HashMap<String, (String, String)>,
+    synchronized: &HashSet<&str>,
+    schemas: &SchemaRegistry,
+    out: &mut Vec<DeferredPopulateDiagnostic>,
+) {
+    let target = path.binding();
+    if synchronized.contains(target) {
+        return;
+    }
+    let Some((provider, resource_type)) = by_binding.get(target) else {
+        // Unknown binding (typo, cross-file ref the parser couldn't
+        // resolve, …). Other passes report that — staying silent here
+        // avoids spurious double diagnostics.
+        return;
+    };
+    let Some(schema) = schemas.get(provider, resource_type, SchemaKind::Managed) else {
+        return;
+    };
+    let Some(attr_schema) = schema.attributes.get(path.attribute()) else {
+        return;
+    };
+
+    if path_traverses_deferred(attr_schema, path.segments()) {
+        out.push(DeferredPopulateDiagnostic {
+            message: format!(
+                "attribute `{attribute_key}` references `{}`, which is populated asynchronously by the provider after Create. \
+                 Add a `wait {target} {{ until = ... }}` block in this directory before downstream resources read this attribute.",
+                path.to_dot_string(),
+            ),
+            holder_binding: holder_binding.map(str::to_string),
+            attribute_key: attribute_key.to_string(),
+            unresolved_path: path.to_dot_string(),
+            target_binding: target.to_string(),
+        });
+    }
+}
+
+/// Walk `(top_attr, segments)` over the schema graph; return true if
+/// any hop traverses a `deferred_populate=true` attribute or struct
+/// field. The top-level attribute itself counts (an
+/// `AttributeSchema.deferred_populate=true` value is deferred-bound
+/// for *every* downstream chained access on it, even with no
+/// segments).
+fn path_traverses_deferred(top_attr: &AttributeSchema, segments: &[PathSegment]) -> bool {
+    if top_attr.deferred_populate {
+        return true;
+    }
+    let mut current_type = &top_attr.attr_type;
+    for segment in segments {
+        // Peel List wrappers introduced by `[idx]` segments. A
+        // `Subscript::Int` traverses `List<T>` to `T`; a
+        // `Subscript::Str` traverses `Map<_, V>` to `V`. Either way
+        // the resulting `current_type` is the element type — no
+        // deferred flag lives on List/Map themselves (they have no
+        // such field on their builders).
+        match (current_type, segment) {
+            (AttributeType::List { inner, .. }, PathSegment::Subscript { .. }) => {
+                current_type = inner;
+            }
+            (AttributeType::Map { value, .. }, PathSegment::Subscript { .. }) => {
+                current_type = value;
+            }
+            (AttributeType::Struct { fields, .. }, PathSegment::Field { name }) => {
+                let Some(field) = fields.iter().find(|f| &f.name == name) else {
+                    return false;
+                };
+                if field.deferred_populate {
+                    return true;
+                }
+                current_type = &field.field_type;
+            }
+            // `[idx]` against a Struct, `.field` against a List/Map,
+            // etc. — the type-narrowing pass (carina#3028) catches
+            // these as separate diagnostics. Bailing here matches the
+            // resolver's bail-on-mismatch behaviour and avoids
+            // surfacing a confusing double-diagnostic for the same
+            // typo.
+            _ => return false,
+        }
+        // After traversing a List<Struct> via [idx], the next field
+        // hop looks up against the inner Struct directly because
+        // `current_type` was just rebound to the list's element type.
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ParsedFile, WaitBinding};
+    use crate::resource::{
+        AccessPath, ConcreteValue, DeferredValue, PathSegment, Resource, ResourceId, Subscript,
+        Value,
+    };
+    use crate::schema::{
+        AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField,
+    };
+
+    fn cert_schema_with_dvo_inner_field_deferred() -> ResourceSchema {
+        ResourceSchema::new("acm.Certificate").attribute(AttributeSchema::new(
+            "domain_validation_options",
+            AttributeType::list(AttributeType::Struct {
+                name: "DomainValidationOption".to_string(),
+                fields: vec![
+                    StructField::new("domain_name", AttributeType::String),
+                    StructField::new("resource_record_value", AttributeType::String)
+                        .deferred_populate(),
+                ],
+            }),
+        ))
+    }
+
+    fn rrset_schema() -> ResourceSchema {
+        ResourceSchema::new("route53.RecordSet")
+            .attribute(AttributeSchema::new(
+                "resource_records",
+                AttributeType::list(AttributeType::String),
+            ))
+            .attribute(AttributeSchema::new("name", AttributeType::String))
+    }
+
+    fn dvo_chained_ref(field: &str) -> Value {
+        let path = AccessPath::with_segments(
+            "cert",
+            "domain_validation_options",
+            vec![
+                PathSegment::Subscript {
+                    index: Subscript::Int { index: 0 },
+                },
+                PathSegment::Field {
+                    name: field.to_string(),
+                },
+            ],
+        );
+        Value::Deferred(DeferredValue::ResourceRef { path })
+    }
+
+    /// Build a `ParsedFile` with a cert binding + a route53 RecordSet
+    /// that references the deferred field.
+    fn parsed_with_unsynchronized_chained_ref() -> ParsedFile {
+        let mut cert = Resource::new("acm.Certificate", "cert");
+        cert.id = ResourceId::new("acm.Certificate", "cert");
+        cert.id.provider = "aws".to_string();
+        cert.binding = Some("cert".to_string());
+
+        let mut record = Resource::new("route53.RecordSet", "record");
+        record.id = ResourceId::new("route53.RecordSet", "record");
+        record.id.provider = "aws".to_string();
+        record.binding = Some("record".to_string());
+        record.set_attr(
+            "resource_records",
+            Value::Concrete(ConcreteValue::List(vec![dvo_chained_ref(
+                "resource_record_value",
+            )])),
+        );
+
+        ParsedFile {
+            resources: vec![cert, record],
+            ..ParsedFile::default()
+        }
+    }
+
+    fn registry_for_acm() -> SchemaRegistry {
+        let mut r = SchemaRegistry::new();
+        r.insert("aws", cert_schema_with_dvo_inner_field_deferred());
+        r.insert("aws", rrset_schema());
+        r
+    }
+
+    #[test]
+    fn list_wrapped_chained_ref_to_deferred_inner_field_is_flagged() {
+        let parsed = parsed_with_unsynchronized_chained_ref();
+        let diags = validate_deferred_populate_refs(&parsed, &registry_for_acm());
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        let d = &diags[0];
+        assert_eq!(d.target_binding, "cert");
+        assert_eq!(d.attribute_key, "resource_records");
+        assert!(
+            d.unresolved_path
+                .contains("domain_validation_options[0].resource_record_value"),
+            "got: {}",
+            d.unresolved_path
+        );
+        assert!(d.message.contains("wait cert"), "got: {}", d.message);
+    }
+
+    #[test]
+    fn wait_block_on_target_binding_satisfies_the_rule() {
+        let mut parsed = parsed_with_unsynchronized_chained_ref();
+        // A wait on the cert binding — predicate text is irrelevant
+        // for this pass; presence is the contract.
+        parsed.wait_bindings.push(WaitBinding {
+            binding: "cert_issued".to_string(),
+            target: "cert".to_string(),
+            until_raw: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
+            until_predicate: crate::parser::UntilPredicateAst {
+                lhs_segments: vec!["cert".to_string(), "status".to_string()],
+                rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+            },
+            timeout_secs: None,
+            depends_on: vec![],
+            line: 0,
+        });
+        let diags = validate_deferred_populate_refs(&parsed, &registry_for_acm());
+        assert!(diags.is_empty(), "got: {diags:?}");
+    }
+
+    #[test]
+    fn chained_ref_to_non_deferred_inner_field_is_not_flagged() {
+        let mut record = Resource::new("route53.RecordSet", "record");
+        record.id = ResourceId::new("route53.RecordSet", "record");
+        record.id.provider = "aws".to_string();
+        record.binding = Some("record".to_string());
+        record.set_attr("name", dvo_chained_ref("domain_name"));
+
+        let mut cert = Resource::new("acm.Certificate", "cert");
+        cert.id = ResourceId::new("acm.Certificate", "cert");
+        cert.id.provider = "aws".to_string();
+        cert.binding = Some("cert".to_string());
+
+        let p = ParsedFile {
+            resources: vec![cert, record],
+            ..ParsedFile::default()
+        };
+        let diags = validate_deferred_populate_refs(&p, &registry_for_acm());
+        assert!(diags.is_empty(), "got: {diags:?}");
+    }
+
+    #[test]
+    fn unknown_target_binding_does_not_emit_double_diagnostic() {
+        // A typo in the binding name produces an undefined-identifier
+        // error elsewhere; this pass must not pile on.
+        let mut record = Resource::new("route53.RecordSet", "record");
+        record.id = ResourceId::new("route53.RecordSet", "record");
+        record.id.provider = "aws".to_string();
+        record.binding = Some("record".to_string());
+        let path = AccessPath::with_segments(
+            "typo_cert", // <-- unknown binding
+            "domain_validation_options",
+            vec![
+                PathSegment::Subscript {
+                    index: Subscript::Int { index: 0 },
+                },
+                PathSegment::Field {
+                    name: "resource_record_value".to_string(),
+                },
+            ],
+        );
+        record.set_attr(
+            "resource_records",
+            Value::Concrete(ConcreteValue::List(vec![Value::Deferred(
+                DeferredValue::ResourceRef { path },
+            )])),
+        );
+
+        let p = ParsedFile {
+            resources: vec![record],
+            ..ParsedFile::default()
+        };
+        let diags = validate_deferred_populate_refs(&p, &registry_for_acm());
+        assert!(diags.is_empty(), "got: {diags:?}");
+    }
+
+    #[test]
+    fn top_level_attribute_marked_deferred_flags_any_segment_chain() {
+        // Mirror RDS DBInstance.endpoint shape: the whole attribute
+        // is undefined immediately post-Create.
+        let schema = ResourceSchema::new("rds.DBInstance").attribute(
+            AttributeSchema::new(
+                "endpoint",
+                AttributeType::Struct {
+                    name: "Endpoint".to_string(),
+                    fields: vec![StructField::new("address", AttributeType::String)],
+                },
+            )
+            .deferred_populate(),
+        );
+        let consumer = ResourceSchema::new("ec2.Instance")
+            .attribute(AttributeSchema::new("user_data", AttributeType::String));
+        let mut r = SchemaRegistry::new();
+        r.insert("aws", schema);
+        r.insert("aws", consumer);
+
+        let mut db = Resource::new("rds.DBInstance", "db");
+        db.id = ResourceId::new("rds.DBInstance", "db");
+        db.id.provider = "aws".to_string();
+        db.binding = Some("db".to_string());
+
+        let mut inst = Resource::new("ec2.Instance", "i");
+        inst.id = ResourceId::new("ec2.Instance", "i");
+        inst.id.provider = "aws".to_string();
+        inst.binding = Some("i".to_string());
+        let path = AccessPath::with_segments(
+            "db",
+            "endpoint",
+            vec![PathSegment::Field {
+                name: "address".to_string(),
+            }],
+        );
+        inst.set_attr(
+            "user_data",
+            Value::Deferred(DeferredValue::ResourceRef { path }),
+        );
+
+        let p = ParsedFile {
+            resources: vec![db, inst],
+            ..ParsedFile::default()
+        };
+        let diags = validate_deferred_populate_refs(&p, &r);
+        assert_eq!(diags.len(), 1, "got: {diags:?}");
+        assert_eq!(diags[0].target_binding, "db");
+    }
+
+    #[test]
+    fn schema_lookup_miss_does_not_panic_or_emit() {
+        // Resource type not in the registry — pass should bail
+        // silently. Other passes report unknown resource types.
+        let mut record = Resource::new("unknown.thing", "x");
+        record.id = ResourceId::new("unknown.thing", "x");
+        record.id.provider = "aws".to_string();
+        record.binding = Some("x".to_string());
+        record.set_attr(
+            "resource_records",
+            Value::Concrete(ConcreteValue::List(vec![dvo_chained_ref(
+                "resource_record_value",
+            )])),
+        );
+        let p = ParsedFile {
+            resources: vec![record],
+            ..ParsedFile::default()
+        };
+        let diags = validate_deferred_populate_refs(&p, &registry_for_acm());
+        // Schema for "unknown.thing" missing means nothing to check;
+        // crucially no panic.
+        assert!(diags.is_empty(), "got: {diags:?}");
+    }
+}

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -1,5 +1,6 @@
 //! Validation utilities for resources and modules
 
+pub mod deferred_populate;
 pub mod depends_on;
 pub mod wait;
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -412,6 +412,7 @@ fn make_schema(resource_type: &str, attrs: Vec<(&str, AttributeType)>) -> Resour
                 block_name: None,
                 write_only: false,
                 identity: false,
+                deferred_populate: false,
             },
         );
     }

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -2031,6 +2031,62 @@ impl DiagnosticEngine {
             })
             .collect()
     }
+
+    /// Lint chained references to schema-flagged "deferred-populate"
+    /// attributes that lack a synchronizing `wait` block. Delegates to
+    /// `carina_core::validation::deferred_populate` so the LSP and
+    /// `carina validate` produce identical wording (carina#3034).
+    ///
+    /// Source anchor: the attribute key on the *holding* resource
+    /// (e.g. `resource_records` on the route53.RecordSet). The full
+    /// path of the offending ref (`cert.dvo[0].rrv`) appears verbatim
+    /// in the message, so the user sees both the holder and the
+    /// upstream they need to wait on.
+    pub(super) fn check_deferred_populate_refs(
+        &self,
+        doc: &Document,
+        parsed: &ParsedFile,
+    ) -> Vec<Diagnostic> {
+        let diags = carina_core::validation::deferred_populate::validate_deferred_populate_refs(
+            parsed,
+            &self.schemas,
+        );
+        if diags.is_empty() {
+            return Vec::new();
+        }
+        let text = doc.text();
+        diags
+            .into_iter()
+            .map(|d| {
+                let (line, col, end_col) =
+                    deferred_populate_anchor(&text, d.holder_binding.as_deref(), &d.attribute_key);
+                carina_diagnostic(line, col, end_col, DiagnosticSeverity::ERROR, d.message)
+            })
+            .collect()
+    }
+}
+
+/// Anchor for a deferred-populate diagnostic: the attribute key as it
+/// appears on the holding resource. Falls back to `(0, 0, 0)` so the
+/// editor still surfaces the message even without a precise span.
+fn deferred_populate_anchor(
+    text: &str,
+    holder_binding: Option<&str>,
+    attribute_key: &str,
+) -> (u32, u32, u32) {
+    let lines: Vec<&str> = text.lines().collect();
+    // Scope the forward scan to the holder binding's `let <binding> =`
+    // line when available, so identical attribute keys on different
+    // resources don't all anchor to the first occurrence.
+    let start = holder_binding
+        .and_then(|b| find_binding_line(&lines, b))
+        .unwrap_or(0);
+    for (i, line) in lines.iter().enumerate().skip(start) {
+        if let Some((col, end_col)) = find_word_on_line(line, attribute_key) {
+            return (i as u32, col, end_col);
+        }
+    }
+    (0, 0, 0)
 }
 
 /// Find the source anchor for a wait diagnostic. Returns

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -164,9 +164,11 @@ impl DiagnosticEngine {
         if let Some(parsed) = merged.as_ref() {
             diagnostics.extend(self.check_depends_on(doc, parsed));
             diagnostics.extend(self.check_wait_bindings(doc, parsed));
+            diagnostics.extend(self.check_deferred_populate_refs(doc, parsed));
         } else if let Some(parsed) = doc.parsed() {
             diagnostics.extend(self.check_depends_on(doc, parsed));
             diagnostics.extend(self.check_wait_bindings(doc, parsed));
+            diagnostics.extend(self.check_deferred_populate_refs(doc, parsed));
         }
 
         // Provider-attribute finalize diagnostic (#2717 / #2753): if a

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -650,6 +650,10 @@ fn proto_attr_schema_to_core(a: &proto::AttributeSchema) -> CoreAttributeSchema 
         block_name: a.block_name.clone(),
         write_only: a.write_only,
         identity: a.identity,
+        // The WIT contract does not transmit `deferred_populate` —
+        // the annotation lives entirely in the host-side schema; see
+        // `proto_struct_field_to_core` for the rationale.
+        deferred_populate: false,
     }
 }
 
@@ -713,6 +717,13 @@ fn proto_struct_field_to_core(f: &proto::StructField) -> CoreStructField {
         description: f.description.clone(),
         provider_name: f.provider_name.clone(),
         block_name: f.block_name.clone(),
+        // The WIT contract does not transmit `deferred_populate` —
+        // the annotation lives entirely in the host-side schema (set
+        // by the provider's codegen output in
+        // `carina-provider-{aws,awscc}/.../schemas/generated/`),
+        // which is loaded directly via the SchemaRegistry rather
+        // than crossing the WASM boundary. carina#3034.
+        deferred_populate: false,
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the staging fix from `notes/specs/2026-05-14-deferred-populate-attribute-design.md` (landed in #3035): schema-level annotation that catches chained references to attributes the provider populates asynchronously after Create at validate time, before `carina apply`. Refs #3034.

## What landed

**Schema** (`carina-core/src/schema/mod.rs`):
- `AttributeSchema.deferred_populate: bool` + builder
- `StructField.deferred_populate: bool` + builder
- Two placements because real schemas have both shapes (whole attribute deferred vs. inner field deferred)

**Validation** (`carina-core/src/validation/deferred_populate.rs`):
- `validate_deferred_populate_refs(parsed, schemas) -> Vec<DeferredPopulateDiagnostic>`
- Walks every attribute value (including for-body resources via `iter_all_resources()`), descending through `List` / `Map` / `Secret` / `Interpolation` / `FunctionCall`
- Looks up the schema along `path.attribute() + path.segments()`; flags if any hop is `deferred_populate=true` and the binding has no `wait` block

**Synchronization model**: existence of any `wait <binding>` block satisfies the rule for any chained access on that binding. We do not require the wait predicate to mention each accessed attribute (would force one wait per attribute, impractical for nested structs).

**CLI + LSP**: `validate_deferred_populate_refs_with_ctx` runs alongside `validate_wait_bindings_with_ctx`. LSP `check_deferred_populate_refs` mirrors the CLI surface, anchoring diagnostics to the offending attribute key on the holder resource.

**WIT contract**: unchanged. The annotation lives entirely in the host-side schema set by provider codegen; `carina-plugin-host::wasm_convert` defaults `deferred_populate: false` when lowering proto schemas.

## Tests

- 6 unit tests in `validation::deferred_populate::tests` cover the variant matrix (top-level deferred, struct-field deferred, wait satisfies, non-deferred unflagged, unknown binding silent, schema lookup miss safe).
- 3 directory-scoped end-to-end tests in `carina-cli/tests/deferred_populate_validate_e2e.rs` use `tempfile::tempdir()` multi-file fixtures (acm.crn + route53.crn ± wait.crn + providers.crn). The load-bearing test confirms a `wait` declared in `wait.crn` satisfies refs in `route53.crn` — the directory-scoped property of the feature.
- The apply-time fail-fast in `executor::basic::assert_fully_resolved` (carina#3032 / #3033) stays in place as defense-in-depth.

## Test plan

- [x] `cargo nextest run --workspace` — 3313/3313 pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — clean
- [ ] Provider codegen follow-ups (aws + awscc) needed before #3032 closes; this PR only adds the mechanism

## Follow-ups

- carina-provider-aws codegen — apply `.deferred_populate()` to the ACM Certificate rows enumerated in the design doc.
- carina-provider-awscc codegen — same for AWSCC's overlapping coverage.
- carina#3032 closes when the aws codegen lands and `carina-rs/infra/usecases/registry` validates clean (the diagnostic must name `cert.domain_validation_options[0].resource_record_value` and suggest `wait cert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
