### PR TITLE
apply: preserve provider_instance through module expansion (closes #3038)

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -15,7 +15,7 @@ fn build_state_after_apply_finds_write_only_with_provider_prefix() {
     // Schema is registered with provider-prefixed key
     schemas.insert("awscc", schema);
 
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -94,7 +94,7 @@ fn build_state_after_apply_preserves_block_name_attribute() {
     schemas.insert("awscc", schema);
 
     // Resource with resolved block name (policy -> policies)
-    let mut resource = Resource::with_provider("awscc", "iam.role", "test-role");
+    let mut resource = Resource::with_provider("awscc", "iam.role", "test-role", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("test-role".to_string())),
@@ -195,7 +195,8 @@ fn build_state_after_apply_preserves_block_name_attribute() {
 
     // Now simulate second plan: build_saved_attrs should return the policies
     let saved_attrs = state.build_saved_attrs();
-    let id = carina_core::resource::ResourceId::with_provider("awscc", "iam.role", "test-role");
+    let id =
+        carina_core::resource::ResourceId::with_provider("awscc", "iam.role", "test-role", None);
     let attrs = saved_attrs.get(&id).unwrap();
     assert!(
         attrs.contains_key("policies"),
@@ -232,7 +233,7 @@ fn block_name_attribute_no_diff_when_hydrated() {
         );
 
     // Desired resource (after resolve_block_names: "policy" -> "policies")
-    let mut resource = Resource::with_provider("awscc", "iam.role", "test-role");
+    let mut resource = Resource::with_provider("awscc", "iam.role", "test-role", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("test-role".to_string())),
@@ -342,7 +343,7 @@ fn block_name_attribute_state_roundtrip() {
     schemas.insert("awscc", schema);
 
     // Resource with resolved block name
-    let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam");
+    let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam", None);
     resource.set_attr(
         "operating_regions".to_string(),
         Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
@@ -424,7 +425,8 @@ fn block_name_attribute_state_roundtrip() {
 
     // Verify roundtrip through saved_attrs
     let saved_attrs = state.build_saved_attrs();
-    let id = carina_core::resource::ResourceId::with_provider("awscc", "ec2.ipam", "test-ipam");
+    let id =
+        carina_core::resource::ResourceId::with_provider("awscc", "ec2.ipam", "test-ipam", None);
     let attrs = saved_attrs.get(&id).unwrap();
     let operating_regions = attrs
         .get("operating_regions")
@@ -517,7 +519,7 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     // with a binding; provider-returned attributes flow in via
     // `current_states` derived from `state.resources`.
     let mut registry_prod =
-        Resource::with_provider("awscc", "organizations.account", "registry-prod");
+        Resource::with_provider("awscc", "organizations.account", "registry-prod", None);
     registry_prod.binding = Some("registry_prod".to_string());
     let sorted_resources = vec![registry_prod];
 
@@ -566,7 +568,7 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
     };
 
     let mut role_resource =
-        Resource::with_provider("awscc", "iam.Role", "github_actions_carina.role");
+        Resource::with_provider("awscc", "iam.Role", "github_actions_carina.role", None);
     role_resource.binding = Some("github_actions_carina.role".to_string());
 
     // Virtual resource as `expand_module_call` produces it: binding is
@@ -642,7 +644,7 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
         serde_json::from_value::<StateFile>(json).unwrap()
     };
 
-    let mut role_resource = Resource::with_provider("awscc", "iam.Role", "outer.inner.role");
+    let mut role_resource = Resource::with_provider("awscc", "iam.Role", "outer.inner.role", None);
     role_resource.binding = Some("outer.inner.role".to_string());
 
     let mut inner_virtual = Resource::new("_virtual", "outer.inner");

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -1057,7 +1057,7 @@ mod tests {
             .exports
             .insert("vpc_id".to_string(), serde_json::json!("vpc-12345"));
 
-        let destroyed = vec![ResourceId::with_provider("awscc", "ec2.Vpc", "main")];
+        let destroyed = vec![ResourceId::with_provider("awscc", "ec2.Vpc", "main", None)];
         apply_destroy_to_state(&mut state, &destroyed);
 
         assert!(state.resources.is_empty(), "resource should be removed");

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -110,7 +110,7 @@ pub(crate) fn resolve_exports(
         .resources
         .iter()
         .map(|rs| {
-            let id = ResourceId::with_provider_and_instance(
+            let id = ResourceId::with_provider(
                 &rs.provider,
                 &rs.resource_type,
                 &rs.name,

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -358,8 +358,12 @@ async fn run_state_lookup(
 fn build_plan_from_state(state: &StateFile) -> Plan {
     let mut plan = Plan::new();
     for rs in &state.resources {
-        let mut resource = Resource::with_provider(&rs.provider, &rs.resource_type, &rs.name);
-        resource.id.provider_instance = rs.directives.provider_instance.clone();
+        let mut resource = Resource::with_provider(
+            &rs.provider,
+            &rs.resource_type,
+            &rs.name,
+            rs.directives.provider_instance.clone(),
+        );
         resource.directives = rs.directives.clone();
 
         // Set typed metadata fields from state
@@ -549,8 +553,14 @@ async fn run_state_bucket_delete(
     println!("{}", "Emptying bucket...".cyan());
 
     // Delete the bucket resource (identifier is the bucket name)
-    let bucket_id =
-        ResourceId::with_provider(backend_provider_name, backend_resource_type, bucket_name);
+    // Backend bucket is provider-default; named-instance routing is
+    // a DSL concern that doesn't apply to the implicit state bucket.
+    let bucket_id = ResourceId::with_provider(
+        backend_provider_name,
+        backend_resource_type,
+        bucket_name,
+        None,
+    );
     match bucket_provider
         .delete(
             &bucket_id,
@@ -702,7 +712,7 @@ pub(crate) async fn run_state_refresh_locked(
             sf.resources
                 .iter()
                 .filter_map(|rs| {
-                    let id = ResourceId::with_provider_and_instance(
+                    let id = ResourceId::with_provider(
                         &rs.provider,
                         &rs.resource_type,
                         &rs.name,
@@ -911,8 +921,12 @@ fn diff_display_update_resource(
         let res = match resource {
             Some(r) => r,
             None => {
-                owned_resource =
-                    Resource::with_provider(&id.provider, &id.resource_type, id.name_str());
+                owned_resource = Resource::with_provider(
+                    &id.provider,
+                    &id.resource_type,
+                    id.name_str(),
+                    id.provider_instance.clone(),
+                );
                 &owned_resource
             }
         };

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1258,7 +1258,7 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
 #[test]
 fn format_effect_delete_uses_binding_name() {
     let effect = Effect::Delete {
-        id: ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929"),
+        id: ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None),
         identifier: "vpc-12345".to_string(),
         directives: Directives::default(),
         binding: Some("my_vpc".to_string()),
@@ -1271,7 +1271,7 @@ fn format_effect_delete_uses_binding_name() {
 #[test]
 fn format_effect_delete_falls_back_to_id_name() {
     let effect = Effect::Delete {
-        id: ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929"),
+        id: ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None),
         identifier: "vpc-12345".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -1290,14 +1290,14 @@ fn format_effect_delete_falls_back_to_id_name() {
 #[test]
 fn format_effect_create_separates_type_and_name_with_space() {
     let mut r = Resource::new("s3.Bucket", "state_bucket");
-    r.id = ResourceId::with_provider("aws", "s3.Bucket", "state_bucket");
+    r.id = ResourceId::with_provider("aws", "s3.Bucket", "state_bucket", None);
     let effect = Effect::Create(r);
     assert_eq!(format_effect(&effect), "Create aws.s3.Bucket state_bucket");
 }
 
 #[test]
 fn format_effect_update_separates_type_and_name_with_space() {
-    let id = ResourceId::with_provider("awscc", "iam.Role", "bs.bootstrap.role");
+    let id = ResourceId::with_provider("awscc", "iam.Role", "bs.bootstrap.role", None);
     let mut to = Resource::new("iam.Role", "bs.bootstrap.role");
     to.id = id.clone();
     let effect = Effect::Update {
@@ -1306,6 +1306,7 @@ fn format_effect_update_separates_type_and_name_with_space() {
             "awscc",
             "iam.Role",
             "bs.bootstrap.role",
+            None,
         ))),
         to,
         changed_attributes: Vec::new(),
@@ -1318,13 +1319,13 @@ fn format_effect_update_separates_type_and_name_with_space() {
 
 #[test]
 fn format_effect_replace_separates_type_and_name_with_space() {
-    let id = ResourceId::with_provider("awscc", "ec2.Vpc", "vpc");
+    let id = ResourceId::with_provider("awscc", "ec2.Vpc", "vpc", None);
     let mut to = Resource::new("ec2.Vpc", "vpc");
     to.id = id.clone();
     let effect = Effect::Replace {
         id,
         from: Box::new(State::not_found(ResourceId::with_provider(
-            "awscc", "ec2.Vpc", "vpc",
+            "awscc", "ec2.Vpc", "vpc", None,
         ))),
         to,
         directives: Directives::default(),
@@ -1339,7 +1340,7 @@ fn format_effect_replace_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_import_separates_type_and_name_with_space() {
     let effect = Effect::Import {
-        id: ResourceId::with_provider("aws", "s3.Bucket", "logs"),
+        id: ResourceId::with_provider("aws", "s3.Bucket", "logs", None),
         identifier: "my-logs-bucket".to_string(),
     };
     assert_eq!(
@@ -1351,7 +1352,7 @@ fn format_effect_import_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_remove_separates_type_and_name_with_space() {
     let effect = Effect::Remove {
-        id: ResourceId::with_provider("awscc", "ec2.Vpc", "old_vpc"),
+        id: ResourceId::with_provider("awscc", "ec2.Vpc", "old_vpc", None),
     };
     assert_eq!(
         format_effect(&effect),
@@ -1362,8 +1363,8 @@ fn format_effect_remove_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_move_separates_type_and_name_with_space() {
     let effect = Effect::Move {
-        from: ResourceId::with_provider("awscc", "ec2.Vpc", "vpc_a"),
-        to: ResourceId::with_provider("awscc", "ec2.Vpc", "vpc_b"),
+        from: ResourceId::with_provider("awscc", "ec2.Vpc", "vpc_a", None),
+        to: ResourceId::with_provider("awscc", "ec2.Vpc", "vpc_b", None),
     };
     assert_eq!(
         format_effect(&effect),

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -106,7 +106,7 @@ impl Provider for TestProvider {
 
 #[tokio::test]
 async fn refresh_pending_states_updates_saved_state_from_provider_read() {
-    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket");
+    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket", None);
     let id = resource.id.clone();
     let identifier = "bucket-123";
 
@@ -168,7 +168,7 @@ async fn refresh_pending_states_updates_saved_state_from_provider_read() {
 
 #[tokio::test]
 async fn refresh_pending_states_removes_not_found_resource_from_saved_state() {
-    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket");
+    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket", None);
     let id = resource.id.clone();
     let identifier = "bucket-123";
 
@@ -215,7 +215,7 @@ async fn refresh_pending_states_removes_not_found_resource_from_saved_state() {
 
 #[tokio::test]
 async fn refresh_pending_states_does_not_overwrite_with_stale_snapshot_when_refresh_fails() {
-    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket");
+    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket", None);
     let id = resource.id.clone();
     let identifier = "bucket-123";
 
@@ -270,13 +270,13 @@ fn plan_file_serde_round_trip() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::with_provider("aws", "s3.Bucket", "my-bucket").with_attribute(
+        Resource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
         ),
     ));
     plan.add(Effect::Delete {
-        id: ResourceId::with_provider("aws", "s3.Bucket", "old-bucket"),
+        id: ResourceId::with_provider("aws", "s3.Bucket", "old-bucket", None),
         identifier: "old-bucket".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -285,15 +285,20 @@ fn plan_file_serde_round_trip() {
     });
 
     let sorted_resources = vec![
-        Resource::with_provider("aws", "s3.Bucket", "my-bucket").with_attribute(
+        Resource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
         ),
     ];
 
     let current_states = vec![CurrentStateEntry {
-        id: ResourceId::with_provider("aws", "s3.Bucket", "my-bucket"),
-        state: State::not_found(ResourceId::with_provider("aws", "s3.Bucket", "my-bucket")),
+        id: ResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None),
+        state: State::not_found(ResourceId::with_provider(
+            "aws",
+            "s3.Bucket",
+            "my-bucket",
+            None,
+        )),
     }];
 
     let plan_file = PlanFile {
@@ -358,7 +363,7 @@ fn plan_file_serde_round_trip() {
 #[test]
 #[ignore = "requires provider binary for schema-based prefix resolution"]
 fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -388,7 +393,7 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
 #[test]
 fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
     // If base attr doesn't exist in schema, leave _prefix as-is
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "nonexistent_attr_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("some-value".to_string())),
@@ -409,7 +414,7 @@ fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
 #[test]
 #[ignore = "requires provider binary for schema-based prefix resolution"]
 fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -433,7 +438,7 @@ fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
 #[test]
 #[ignore = "requires provider binary for schema-based prefix resolution"]
 fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("".to_string())),
@@ -449,7 +454,7 @@ fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
 #[ignore = "requires provider binary for schema-based name resolution"]
 fn test_resolve_names_handles_block_name_before_prefix() {
     // resolve_names should first resolve block names, then resolve attr prefixes
-    let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam");
+    let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam", None);
     resource.set_attr(
         "operating_region".to_string(),
         Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
@@ -474,7 +479,7 @@ fn test_resolve_names_handles_block_name_before_prefix() {
 
 #[test]
 fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -507,7 +512,7 @@ fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
 
 #[test]
 fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "new-prefix-".to_string());
@@ -540,7 +545,7 @@ fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
 
 #[test]
 fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -612,13 +617,13 @@ fn make_awscc_provider(region_dsl: &str) -> ProviderConfig {
 #[ignore = "requires provider binary for identity_attributes"]
 fn test_anonymous_id_different_regions_produce_different_identifiers() {
     // Two anonymous ec2_vpc resources with same cidr_block but different provider regions
-    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "");
+    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r1.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
-    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "");
+    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r2.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -649,13 +654,13 @@ fn test_anonymous_id_different_regions_produce_different_identifiers() {
 #[ignore = "requires provider binary for identity_attributes"]
 fn test_anonymous_id_same_region_same_create_only_collides() {
     // Two anonymous ec2_vpc resources with same cidr_block and same provider region -> collision
-    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "");
+    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r1.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
-    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "");
+    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r2.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -672,13 +677,13 @@ fn test_anonymous_id_same_region_same_create_only_collides() {
 #[ignore = "requires provider binary for identity_attributes"]
 fn test_anonymous_id_different_create_only_same_region_no_collision() {
     // Two anonymous ec2_vpc resources with different cidr_block in same provider region -> no collision
-    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "");
+    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r1.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
-    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "");
+    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r2.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
@@ -696,7 +701,7 @@ fn test_anonymous_id_different_create_only_same_region_no_collision() {
 #[test]
 fn test_anonymous_id_named_resources_are_skipped() {
     // Named resources should not be processed by compute_anonymous_identifiers
-    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "my_vpc");
+    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "my_vpc", None);
     r1.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -716,7 +721,7 @@ fn test_find_state_bucket_resource_matching_type() {
         providers: vec![],
         backend: None,
         resources: vec![
-            Resource::with_provider("aws", "s3.Bucket", "my-bucket").with_attribute(
+            Resource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
                 "bucket",
                 Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
             ),
@@ -762,7 +767,7 @@ fn test_find_state_bucket_resource_matching_type() {
 #[test]
 #[ignore = "requires provider binary for resource type validation"]
 fn validate_data_source_without_read_keyword_errors() {
-    let resource = Resource::with_provider("aws", "sts.caller_identity", "identity");
+    let resource = Resource::with_provider("aws", "sts.caller_identity", "identity", None);
     // read_only defaults to false, simulating missing `read` keyword
     let result = validate_resources(&[resource]);
     assert!(result.is_err());
@@ -782,8 +787,8 @@ fn validate_data_source_without_read_keyword_errors() {
 #[test]
 #[ignore = "requires provider binary for resource type validation"]
 fn validate_data_source_with_read_keyword_passes() {
-    let resource =
-        Resource::with_provider("aws", "sts.caller_identity", "identity").with_read_only(true);
+    let resource = Resource::with_provider("aws", "sts.caller_identity", "identity", None)
+        .with_read_only(true);
     let result = validate_resources(&[resource]);
     assert!(
         result.is_ok(),
@@ -795,7 +800,7 @@ fn validate_data_source_with_read_keyword_passes() {
 #[test]
 #[ignore = "requires provider binary for resource type validation"]
 fn validate_regular_resource_without_read_keyword_passes() {
-    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket")
+    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket", None)
         .with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -816,9 +821,9 @@ fn validate_regular_resource_without_read_keyword_passes() {
 fn destroy_plan_excludes_data_sources() {
     // Simulate the destroy filtering logic: data sources (read_only=true)
     // should be excluded from the destroy candidate list.
-    let managed = Resource::with_provider("awscc", "ec2.Vpc", "vpc");
-    let data_source =
-        Resource::with_provider("awscc", "sts.caller_identity", "identity").with_read_only(true);
+    let managed = Resource::with_provider("awscc", "ec2.Vpc", "vpc", None);
+    let data_source = Resource::with_provider("awscc", "sts.caller_identity", "identity", None)
+        .with_read_only(true);
 
     let destroy_order = vec![managed, data_source];
 
@@ -868,7 +873,7 @@ fn destroy_plan_excludes_data_sources() {
 fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
     // --- First run (apply) ---
     // 1. Parse: anonymous resource with bucket_name_prefix
-    let mut resource_run1 = Resource::with_provider("awscc", "s3.Bucket", "");
+    let mut resource_run1 = Resource::with_provider("awscc", "s3.Bucket", "", None);
     resource_run1.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -922,7 +927,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
 
     // --- Second run (plan-verify) ---
     // 1. Parse again: same anonymous resource with bucket_name_prefix
-    let mut resource_run2 = Resource::with_provider("awscc", "s3.Bucket", "");
+    let mut resource_run2 = Resource::with_provider("awscc", "s3.Bucket", "", None);
     resource_run2.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -972,7 +977,7 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     let providers = vec![make_awscc_provider("awscc.Region.ap_northeast_1")];
 
     // --- First run ---
-    let mut resource_run1 = Resource::with_provider("awscc", "iam.role", "");
+    let mut resource_run1 = Resource::with_provider("awscc", "iam.role", "", None);
     resource_run1.set_attr(
         "role_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("carina-acc-test-".to_string())),
@@ -1030,7 +1035,7 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     state_file.upsert_resource(resource_state);
 
     // --- Second run ---
-    let mut resource_run2 = Resource::with_provider("awscc", "iam.role", "");
+    let mut resource_run2 = Resource::with_provider("awscc", "iam.role", "", None);
     resource_run2.set_attr(
         "role_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("carina-acc-test-".to_string())),
@@ -1080,7 +1085,7 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     let providers = vec![make_awscc_provider("awscc.Region.ap_northeast_1")];
 
     // --- First run ---
-    let mut resource_run1 = Resource::with_provider("awscc", "ec2.flow_log", "");
+    let mut resource_run1 = Resource::with_provider("awscc", "ec2.flow_log", "", None);
     resource_run1.set_attr(
         "resource_id".to_string(),
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -1137,7 +1142,7 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     state_file.upsert_resource(resource_state);
 
     // --- Second run ---
-    let mut resource_run2 = Resource::with_provider("awscc", "ec2.flow_log", "");
+    let mut resource_run2 = Resource::with_provider("awscc", "ec2.flow_log", "", None);
     resource_run2.set_attr(
         "resource_id".to_string(),
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -1199,7 +1204,7 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
 
 #[tokio::test]
 async fn detect_drift_errors_when_resource_missing_from_planned_states() {
-    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket");
+    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket", None);
     let id = resource.id.clone();
 
     // Provider returns a non-existing state (identifier is None since no planned state)
@@ -1224,7 +1229,7 @@ async fn detect_drift_errors_when_resource_missing_from_planned_states() {
 
 #[tokio::test]
 async fn detect_drift_returns_none_when_no_drift() {
-    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket");
+    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket", None);
     let id = resource.id.clone();
     let identifier = "my-bucket";
 
@@ -1248,7 +1253,7 @@ async fn detect_drift_returns_none_when_no_drift() {
 
 #[tokio::test]
 async fn detect_drift_returns_messages_when_drift_detected() {
-    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket");
+    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket", None);
     let id = resource.id.clone();
     let identifier = "my-bucket";
 
@@ -1305,7 +1310,7 @@ fn orphaned_state_resource_produces_delete_effect() {
 
     // Config only has "keep-bucket" -- "removed-bucket" was deleted from .crn
     let desired = vec![
-        Resource::with_provider("aws", "s3.Bucket", "keep-bucket").with_attribute(
+        Resource::with_provider("aws", "s3.Bucket", "keep-bucket", None).with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("keep-bucket".to_string())),
         ),
@@ -1702,7 +1707,12 @@ impl Provider for RecordingProvider {
                 }
             }
         }
-        let mut to = Resource::with_provider(&id.provider, &id.resource_type, id.name_str());
+        let mut to = Resource::with_provider(
+            &id.provider,
+            &id.resource_type,
+            id.name_str(),
+            id.provider_instance.clone(),
+        );
         for (k, v) in &attrs {
             to.set_attr(k.clone(), v.clone());
         }
@@ -1778,7 +1788,7 @@ impl Provider for RenameFailProvider {
 async fn rename_failure_in_create_before_destroy_counts_as_failure() {
     use carina_core::effect::TemporaryName;
 
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket", None);
 
     let old_state = State::existing(
         id.clone(),
@@ -1789,10 +1799,11 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
     )
     .with_identifier("my-bucket");
 
-    let new_resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket").with_attribute(
-        "bucket_name",
-        Value::Concrete(ConcreteValue::String("my-bucket-tmp123".to_string())),
-    );
+    let new_resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None)
+        .with_attribute(
+            "bucket_name",
+            Value::Concrete(ConcreteValue::String("my-bucket-tmp123".to_string())),
+        );
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
@@ -2325,7 +2336,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
             .with_attribute("region", json!("ap-northeast-1")),
     );
 
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -2345,7 +2356,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
     }
 
     // Verify state was loaded from state file
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     let cached_state = current_states.get(&id).unwrap();
     assert!(cached_state.exists, "State should exist from state file");
     assert_eq!(
@@ -2443,7 +2454,7 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
 fn refresh_false_without_state_file_treats_resources_as_new() {
     use carina_core::differ::create_plan;
 
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "new-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "new-bucket", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("new-bucket".to_string())),
@@ -2487,7 +2498,7 @@ fn import_effect_preserves_resource_metadata_in_state() {
     // overwrite the ResourceState with a bare ResourceState::new(), stripping
     // directives, prefixes, desired_keys, binding, and dependency_bindings.
 
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc")
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None)
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -2576,7 +2587,7 @@ fn build_state_after_apply_persists_write_only_attributes() {
     use carina_core::schema::{AttributeSchema, AttributeType};
 
     // Set up a resource with a write-only attribute (ipv4_netmask_length)
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -2654,7 +2665,7 @@ fn build_state_after_apply_write_only_detects_value_change() {
     use carina_core::schema::{AttributeSchema, AttributeType};
 
     // Simulate: user changed ipv4_netmask_length from 16 to 24
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/24".to_string())),
@@ -2734,7 +2745,7 @@ fn plan_file_serialization_redacts_secrets() {
         ConcreteValue::String("super-secret-pw".to_string()),
     ))));
 
-    let resource_with_secret = Resource::with_provider("awscc", "rds.db_instance", "my-db")
+    let resource_with_secret = Resource::with_provider("awscc", "rds.db_instance", "my-db", None)
         .with_attribute(
             "name",
             Value::Concrete(ConcreteValue::String("my-db".to_string())),
@@ -2751,7 +2762,7 @@ fn plan_file_serialization_redacts_secrets() {
     );
     state_attrs.insert("master_password".to_string(), secret_password.clone());
     let state_with_secret = State::existing(
-        ResourceId::with_provider("awscc", "rds.db_instance", "my-db"),
+        ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None),
         state_attrs,
     );
 
@@ -2768,7 +2779,7 @@ fn plan_file_serialization_redacts_secrets() {
         plan: redact_secrets_in_plan(&plan).unwrap(),
         sorted_resources: vec![redact_secrets_in_resource(&resource_with_secret).unwrap()],
         current_states: vec![CurrentStateEntry {
-            id: ResourceId::with_provider("awscc", "rds.db_instance", "my-db"),
+            id: ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None),
             state: redact_secrets_in_state(&state_with_secret).unwrap(),
         }],
         upstream_snapshot: HashMap::new(),

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1705,7 +1705,7 @@ fn resolve_import_target(
             if let Some(serde_json::Value::String(s)) = rs.attributes.get(attr)
                 && s == to.name_str()
             {
-                return ResourceId::with_provider_and_instance(
+                return ResourceId::with_provider(
                     &rs.provider,
                     &rs.resource_type,
                     &rs.name,

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -6,7 +6,8 @@ use carina_core::parser::ParsedFile;
 fn test_resolve_enum_aliases_ip_protocol_all() {
     // After normalize_desired, ip_protocol "all" becomes a namespaced DSL value.
     // resolve_enum_aliases should resolve the alias "all" -> "-1".
-    let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule");
+    let mut resource =
+        Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
     resource.set_attr(
         "ip_protocol".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -28,7 +29,8 @@ fn test_resolve_enum_aliases_ip_protocol_all() {
 fn test_resolve_enum_aliases_no_alias() {
     // "tcp" has no alias mapping, so it should be converted from DSL enum
     // to its raw form by convert_enum_value but not further changed.
-    let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule");
+    let mut resource =
+        Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
     resource.set_attr(
         "ip_protocol".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -52,7 +54,8 @@ fn test_resolve_enum_aliases_no_alias() {
 #[ignore = "requires provider binary for enum alias resolution"]
 fn test_resolve_enum_aliases_aws_provider() {
     // Same alias resolution should work for the aws provider
-    let mut resource = Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule");
+    let mut resource =
+        Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule", None);
     resource.set_attr(
         "ip_protocol".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -74,7 +77,7 @@ fn test_resolve_enum_aliases_aws_provider() {
 fn test_resolve_enum_aliases_in_states() {
     // Current states should also have aliases resolved
     let ctx = WiringContext::new(vec![]);
-    let id = ResourceId::with_provider("awscc", "ec2.security_group_egress", "test-rule");
+    let id = ResourceId::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
     let mut attrs = HashMap::new();
     attrs.insert(
         "ip_protocol".to_string(),
@@ -98,7 +101,7 @@ fn test_resolve_enum_aliases_in_states() {
 #[ignore = "requires provider binary for enum alias resolution"]
 fn test_resolve_enum_aliases_in_struct_field() {
     // Aliases within struct fields (maps inside lists) should also be resolved
-    let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg");
+    let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
     let mut egress_map = IndexMap::new();
     egress_map.insert(
         "ip_protocol".to_string(),
@@ -163,7 +166,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
     let ctx = WiringContext::new(vec![]);
 
     // Desired resource with normalized DSL enum value (after normalize_desired)
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
     resource.set_attr(
         "instance_tenancy".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -250,7 +253,7 @@ fn test_merge_default_tags_prevents_false_diff() {
     schemas.insert("awscc", schema);
 
     // Desired resource without explicit tags
-    let resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
 
     // State already has the default tags (from a previous apply)
     let id = resource.id.clone();
@@ -346,7 +349,7 @@ fn test_merge_default_tags_prevents_false_diff() {
 #[test]
 fn test_resolve_enum_aliases_non_enum_values_unchanged() {
     // Non-DSL-enum strings should not be affected
-    let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg");
+    let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
     resource.set_attr(
         "group_description".to_string(),
         Value::Concrete(ConcreteValue::String("My security group".to_string())),
@@ -386,7 +389,7 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     schemas.insert("awscc", bucket_schema);
 
     // Anonymous resource with hash name but bucket_name = "carina-rs-state"
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "s3_bucket_1d43a664");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "s3_bucket_1d43a664", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
@@ -396,7 +399,7 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
 
     // Import block with the logical name (not the hash)
     let state_blocks = vec![StateBlock::Import {
-        to: ResourceId::with_provider("awscc", "s3.Bucket", "carina-rs-state"),
+        to: ResourceId::with_provider("awscc", "s3.Bucket", "carina-rs-state", None),
         id: "carina-rs-state".to_string(),
     }];
 
@@ -444,7 +447,7 @@ fn import_fallback_skips_when_already_in_state_by_name_attribute() {
 
     let mut plan = Plan::new();
     let state_blocks = vec![StateBlock::Import {
-        to: ResourceId::with_provider("awscc", "s3.Bucket", "carina-rs-state"),
+        to: ResourceId::with_provider("awscc", "s3.Bucket", "carina-rs-state", None),
         id: "carina-rs-state".to_string(),
     }];
 
@@ -470,11 +473,11 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
     let identity_store_id = "d-9067c29a4b";
 
     // Managed resource with a binding — phase 1 would have refreshed it.
-    let mut sso = Resource::with_provider("awscc", "sso.Instance", "carina-rs");
+    let mut sso = Resource::with_provider("awscc", "sso.Instance", "carina-rs", None);
     sso.binding = Some("sso".to_string());
 
     // Data source referencing `sso.identity_store_id`.
-    let mut mizzy = Resource::with_provider("aws", "identitystore.user", "mizzy");
+    let mut mizzy = Resource::with_provider("aws", "identitystore.user", "mizzy", None);
     mizzy.kind = ResourceKind::DataSource;
     mizzy.attributes.insert(
         "identity_store_id".to_string(),
@@ -1290,7 +1293,7 @@ mod read_with_retry_identifier_tests {
     #[tokio::test]
     async fn read_with_retry_short_circuits_when_identifier_is_none() {
         let provider = RecordingProvider::new();
-        let id = ResourceId::with_provider("awscc", "iam.Role", "fresh");
+        let id = ResourceId::with_provider("awscc", "iam.Role", "fresh", None);
 
         let state = read_with_retry(&provider, &id, None).await.unwrap();
 
@@ -1309,7 +1312,7 @@ mod read_with_retry_identifier_tests {
     #[tokio::test]
     async fn read_with_retry_forwards_when_identifier_is_some() {
         let provider = RecordingProvider::new();
-        let id = ResourceId::with_provider("awscc", "iam.Role", "existing");
+        let id = ResourceId::with_provider("awscc", "iam.Role", "existing", None);
 
         let _state = read_with_retry(&provider, &id, Some("AROABC123"))
             .await

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -760,7 +760,7 @@ fn secret_with_context_no_change_when_hash_matches() {
     use crate::resource::{ConcreteValue, DeferredValue, ResourceId};
     use crate::value::{SecretHashContext, value_to_json_with_context};
 
-    let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db");
+    let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None);
     let ctx = SecretHashContext::new(
         resource_id.display_type(),
         resource_id.name_str(),
@@ -794,7 +794,7 @@ fn secret_with_context_detects_change() {
     use crate::resource::ResourceId;
     use crate::value::{SecretHashContext, value_to_json_with_context};
 
-    let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db");
+    let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None);
     let ctx = SecretHashContext::new(
         resource_id.display_type(),
         resource_id.name_str(),
@@ -845,7 +845,7 @@ fn secret_same_password_different_resources_produces_different_hashes() {
     );
 
     // Each hash should match its own context
-    let id1 = ResourceId::with_provider("awscc", "rds.db_instance", "db-1");
+    let id1 = ResourceId::with_provider("awscc", "rds.db_instance", "db-1", None);
     let desired1 = HashMap::from([("master_password".to_string(), secret.clone())]);
     let current1 = HashMap::from([(
         "master_password".to_string(),
@@ -858,7 +858,7 @@ fn secret_same_password_different_resources_produces_different_hashes() {
     );
 
     // But not the other resource's context
-    let id2 = ResourceId::with_provider("awscc", "rds.db_instance", "db-2");
+    let id2 = ResourceId::with_provider("awscc", "rds.db_instance", "db-2", None);
     let desired2 = HashMap::from([("master_password".to_string(), secret)]);
     let current2 = HashMap::from([(
         "master_password".to_string(),
@@ -913,7 +913,7 @@ fn secret_in_map_with_refresh_no_false_diff() {
     use crate::resource::ResourceId;
     use crate::schema::{AttributeSchema, ResourceSchema};
 
-    let resource_id = ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929");
+    let resource_id = ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None);
 
     // Desired: tags map with a secret value (as written in .crn)
     let desired_tags = Value::Concrete(ConcreteValue::Map(IndexMap::from([

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -658,7 +658,7 @@ fn replace_with_provider_prefixed_schema_key() {
     // In production, schemas are keyed by "awscc.ec2.Vpc" but resource_type is "ec2.Vpc"
     // The resource must have provider set so the generic lookup works
     let resources = vec![
-        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc").with_attribute(
+        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         ),
@@ -671,9 +671,9 @@ fn replace_with_provider_prefixed_schema_key() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::with_provider("awscc", "ec2.Vpc", "my-vpc"),
+        ResourceId::with_provider("awscc", "ec2.Vpc", "my-vpc", None),
         State::existing(
-            ResourceId::with_provider("awscc", "ec2.Vpc", "my-vpc"),
+            ResourceId::with_provider("awscc", "ec2.Vpc", "my-vpc", None),
             attrs,
         ),
     );
@@ -1039,51 +1039,52 @@ fn diff_no_change_for_struct_list_with_saved_state_egress_rules() {
 
     // Desired state (post-normalization, post-alias-resolution)
     // "all" -> "-1" (alias resolved), "tcp" stays as namespaced identifier
-    let desired = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg").with_attribute(
-        "security_group_egress",
-        Value::Concrete(ConcreteValue::List(vec![
-            Value::Concrete(ConcreteValue::Map(IndexMap::from([
-                (
-                    "ip_protocol".to_string(),
-                    Value::Concrete(ConcreteValue::String(
-                        "awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string(),
-                    )),
-                ),
-                (
-                    "from_port".to_string(),
-                    Value::Concrete(ConcreteValue::Int(443)),
-                ),
-                (
-                    "to_port".to_string(),
-                    Value::Concrete(ConcreteValue::Int(443)),
-                ),
-                (
-                    "cidr_ip".to_string(),
-                    Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
-                ),
-                (
-                    "description".to_string(),
-                    Value::Concrete(ConcreteValue::String("Allow HTTPS outbound".to_string())),
-                ),
-            ]))),
-            Value::Concrete(ConcreteValue::Map(IndexMap::from([
-                (
-                    "ip_protocol".to_string(),
-                    Value::Concrete(ConcreteValue::String("-1".to_string())),
-                ),
-                (
-                    "cidr_ip".to_string(),
-                    Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
-                ),
-                (
-                    "description".to_string(),
-                    Value::Concrete(ConcreteValue::String(
-                        "Allow all to private ranges".to_string(),
-                    )),
-                ),
-            ]))),
-        ])),
-    );
+    let desired = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None)
+        .with_attribute(
+            "security_group_egress",
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::Map(IndexMap::from([
+                    (
+                        "ip_protocol".to_string(),
+                        Value::Concrete(ConcreteValue::String(
+                            "awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string(),
+                        )),
+                    ),
+                    (
+                        "from_port".to_string(),
+                        Value::Concrete(ConcreteValue::Int(443)),
+                    ),
+                    (
+                        "to_port".to_string(),
+                        Value::Concrete(ConcreteValue::Int(443)),
+                    ),
+                    (
+                        "cidr_ip".to_string(),
+                        Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
+                    ),
+                    (
+                        "description".to_string(),
+                        Value::Concrete(ConcreteValue::String("Allow HTTPS outbound".to_string())),
+                    ),
+                ]))),
+                Value::Concrete(ConcreteValue::Map(IndexMap::from([
+                    (
+                        "ip_protocol".to_string(),
+                        Value::Concrete(ConcreteValue::String("-1".to_string())),
+                    ),
+                    (
+                        "cidr_ip".to_string(),
+                        Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
+                    ),
+                    (
+                        "description".to_string(),
+                        Value::Concrete(ConcreteValue::String(
+                            "Allow all to private ranges".to_string(),
+                        )),
+                    ),
+                ]))),
+            ])),
+        );
 
     // Current state (from AWS read, post-normalization, post-alias-resolution)
     // Same as desired, but the "all" rule also has from_port: -1, to_port: -1 from AWS
@@ -1141,7 +1142,7 @@ fn diff_no_change_for_struct_list_with_saved_state_egress_rules() {
         ])),
     )]);
     let current = State::existing(
-        ResourceId::with_provider("awscc", "ec2.SecurityGroup", "test-sg"),
+        ResourceId::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None),
         current_attrs,
     );
 
@@ -1288,12 +1289,13 @@ fn diff_false_positive_when_ordered_true_for_struct_list() {
         ),
     ])));
 
-    let desired = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg").with_attribute(
-        "security_group_egress",
-        Value::Concrete(ConcreteValue::List(vec![item_a.clone(), item_b.clone()])),
-    );
+    let desired = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None)
+        .with_attribute(
+            "security_group_egress",
+            Value::Concrete(ConcreteValue::List(vec![item_a.clone(), item_b.clone()])),
+        );
     let current = State::existing(
-        ResourceId::with_provider("awscc", "ec2.SecurityGroup", "test-sg"),
+        ResourceId::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None),
         HashMap::from([(
             "security_group_egress".to_string(),
             // AWS returns items in reversed order
@@ -1365,7 +1367,7 @@ fn diff_no_change_for_compound_word_dsl_alias() {
 
     // Desired: API-canonical bare spelling (output of pass-2 in
     // AwsNormalizer::resolve_enum_identifiers).
-    let desired = Resource::with_provider("aws", "s3.BucketOwnershipControls", "test")
+    let desired = Resource::with_provider("aws", "s3.BucketOwnershipControls", "test", None)
         .with_attribute(
             "object_ownership",
             Value::Concrete(ConcreteValue::String("BucketOwnerEnforced".to_string())),
@@ -1381,7 +1383,7 @@ fn diff_no_change_for_compound_word_dsl_alias() {
         )),
     );
     let current = State::existing(
-        ResourceId::with_provider("aws", "s3.BucketOwnershipControls", "test"),
+        ResourceId::with_provider("aws", "s3.BucketOwnershipControls", "test", None),
         attrs,
     );
 

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -551,10 +551,10 @@ mod tests {
     /// underlying resources their attributes reference.
     #[test]
     fn build_dependency_map_follows_virtual_module_binding() {
-        let mut role = Resource::with_provider("awscc", "iam.Role", "bootstrap.role");
+        let mut role = Resource::with_provider("awscc", "iam.Role", "bootstrap.role", None);
         role.binding = Some("bootstrap.role".to_string());
 
-        let mut virt = Resource::with_provider("_virtual", "_virtual", "bootstrap");
+        let mut virt = Resource::with_provider("_virtual", "_virtual", "bootstrap", None);
         virt.binding = Some("bootstrap".to_string());
         virt.kind = ResourceKind::Virtual {
             module_name: "github-oidc".to_string(),
@@ -565,7 +565,7 @@ mod tests {
             Value::resource_ref("bootstrap.role", "role_name", vec![]),
         );
 
-        let mut role_policy = Resource::with_provider("awscc", "iam.RolePolicy", "rp");
+        let mut role_policy = Resource::with_provider("awscc", "iam.RolePolicy", "rp", None);
         role_policy.set_attr(
             "role_name",
             Value::resource_ref("bootstrap", "role_name", vec![]),

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1263,10 +1263,10 @@ mod tests {
     /// resource(s) it references.
     #[test]
     fn build_phase_dependency_map_follows_virtual_module_binding() {
-        let mut role = Resource::with_provider("awscc", "iam.Role", "bootstrap.role");
+        let mut role = Resource::with_provider("awscc", "iam.Role", "bootstrap.role", None);
         role.binding = Some("bootstrap.role".to_string());
 
-        let mut virt = Resource::with_provider("_virtual", "_virtual", "bootstrap");
+        let mut virt = Resource::with_provider("_virtual", "_virtual", "bootstrap", None);
         virt.binding = Some("bootstrap".to_string());
         virt.kind = ResourceKind::Virtual {
             module_name: "github-oidc".to_string(),
@@ -1279,7 +1279,7 @@ mod tests {
             Value::resource_ref("bootstrap.role", "role_name", vec![]),
         );
 
-        let mut role_policy = Resource::with_provider("awscc", "iam.RolePolicy", "rp");
+        let mut role_policy = Resource::with_provider("awscc", "iam.RolePolicy", "rp", None);
         role_policy.set_attr(
             "role_name",
             Value::resource_ref("bootstrap", "role_name", vec![]),
@@ -1310,10 +1310,10 @@ mod tests {
     /// through both layers to the underlying resource.
     #[test]
     fn build_phase_dependency_map_follows_nested_virtual_module_bindings() {
-        let mut role = Resource::with_provider("awscc", "iam.Role", "outer.inner.role");
+        let mut role = Resource::with_provider("awscc", "iam.Role", "outer.inner.role", None);
         role.binding = Some("outer.inner.role".to_string());
 
-        let mut inner_virt = Resource::with_provider("_virtual", "_virtual", "outer.inner");
+        let mut inner_virt = Resource::with_provider("_virtual", "_virtual", "outer.inner", None);
         inner_virt.binding = Some("outer.inner".to_string());
         inner_virt.kind = ResourceKind::Virtual {
             module_name: "inner-mod".to_string(),
@@ -1324,7 +1324,7 @@ mod tests {
             Value::resource_ref("outer.inner.role", "role_name", vec![]),
         );
 
-        let mut outer_virt = Resource::with_provider("_virtual", "_virtual", "outer");
+        let mut outer_virt = Resource::with_provider("_virtual", "_virtual", "outer", None);
         outer_virt.binding = Some("outer".to_string());
         outer_virt.kind = ResourceKind::Virtual {
             module_name: "outer-mod".to_string(),
@@ -1335,7 +1335,7 @@ mod tests {
             Value::resource_ref("outer.inner", "role_name", vec![]),
         );
 
-        let mut caller = Resource::with_provider("awscc", "iam.RolePolicy", "rp");
+        let mut caller = Resource::with_provider("awscc", "iam.RolePolicy", "rp", None);
         caller.set_attr(
             "role_name",
             Value::resource_ref("outer", "role_name", vec![]),
@@ -1366,9 +1366,9 @@ mod tests {
     fn topological_sort_replaces_respects_depends_on() {
         use crate::resource::{Directives, State};
 
-        let mut role = Resource::with_provider("test", "iam.Role", "role");
+        let mut role = Resource::with_provider("test", "iam.Role", "role", None);
         role.binding = Some("role".to_string());
-        let mut bucket = Resource::with_provider("test", "s3.Bucket", "bucket");
+        let mut bucket = Resource::with_provider("test", "s3.Bucket", "bucket", None);
         bucket.binding = Some("bucket".to_string());
         bucket.directives = Directives {
             depends_on: vec!["role".to_string()],

--- a/carina-core/src/explicit.rs
+++ b/carina-core/src/explicit.rs
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn build_from_resource_skips_underscore_attrs() {
-        let mut r = Resource::with_provider("aws", "s3.Bucket", "x");
+        let mut r = Resource::with_provider("aws", "s3.Bucket", "x", None);
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String("hi".into())),

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -536,12 +536,8 @@ pub fn compute_anonymous_identifiers(
         let provider = resources[idx].id.provider.clone();
         let resource_type = resources[idx].id.resource_type.clone();
         let provider_instance = resources[idx].id.provider_instance.clone();
-        resources[idx].id = ResourceId::with_provider_and_instance(
-            &provider,
-            &resource_type,
-            identifier,
-            provider_instance,
-        );
+        resources[idx].id =
+            ResourceId::with_provider(&provider, &resource_type, identifier, provider_instance);
     }
 
     Ok(())
@@ -679,7 +675,7 @@ pub fn reconcile_anonymous_identifiers(
         // Only reconcile if there is exactly one partial match (unique best match).
         // Multiple partial matches are ambiguous - skip to avoid rebinding wrong.
         if partial_matches.len() == 1 {
-            resource.id = ResourceId::with_provider_and_instance(
+            resource.id = ResourceId::with_provider(
                 &resource.id.provider,
                 &resource.id.resource_type,
                 partial_matches[0],
@@ -823,7 +819,7 @@ pub fn detect_anonymous_to_named_renames(
         };
 
         if let Some(name) = matched_name {
-            let from = ResourceId::with_provider_and_instance(
+            let from = ResourceId::with_provider(
                 &resource.id.provider,
                 &resource.id.resource_type,
                 name,

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -23,7 +23,7 @@ fn test_generate_random_suffix_format() {
 
 #[test]
 fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -53,7 +53,7 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
 
 #[test]
 fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "nonexistent_attr_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("some-value".to_string())),
@@ -74,7 +74,7 @@ fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
 
 #[test]
 fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -93,7 +93,7 @@ fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
 
 #[test]
 fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("".to_string())),
@@ -108,7 +108,7 @@ fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
 
 #[test]
 fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -140,7 +140,7 @@ fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
 
 #[test]
 fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "new-prefix-".to_string());
@@ -175,7 +175,7 @@ fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
 
 #[test]
 fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -219,7 +219,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     // Step 1: compute identifier with path="/"
-    let mut r1 = Resource::with_provider("awscc", "iam.role", "");
+    let mut r1 = Resource::with_provider("awscc", "iam.role", "", None);
     r1.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-role".to_string())),
@@ -233,7 +233,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with path="/carina/" (changed create-only)
-    let mut r2 = Resource::with_provider("awscc", "iam.role", "");
+    let mut r2 = Resource::with_provider("awscc", "iam.role", "", None);
     r2.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-role".to_string())),
@@ -276,7 +276,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
+    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("new-role".to_string())),
@@ -317,7 +317,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
+    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-role".to_string())),
@@ -358,7 +358,7 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "ec2_vpc_aabbccdd");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "ec2_vpc_aabbccdd", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
@@ -412,7 +412,7 @@ fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
-    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "", None);
     r.set_attr(
         "policy_name".to_string(),
         Value::Concrete(ConcreteValue::String("inline".to_string())),
@@ -467,7 +467,7 @@ fn test_anonymous_resource_no_create_only_properties() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
-    let mut r = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r = Resource::with_provider("awscc", "ec2.eip", "", None);
     r.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -507,7 +507,7 @@ fn test_anonymous_resource_no_create_only_deterministic() {
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
     let make_resource = || {
-        let mut r = Resource::with_provider("awscc", "ec2.eip", "");
+        let mut r = Resource::with_provider("awscc", "ec2.eip", "", None);
         r.set_attr(
             "domain".to_string(),
             Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -543,13 +543,13 @@ fn test_anonymous_resource_no_create_only_collision() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r1.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
     );
 
-    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r2.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -592,7 +592,7 @@ fn test_identity_attribute_prevents_collision() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r1 = Resource::with_provider("awscc", "route53.record_set", "");
+    let mut r1 = Resource::with_provider("awscc", "route53.record_set", "", None);
     r1.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs.dev".to_string())),
@@ -606,7 +606,7 @@ fn test_identity_attribute_prevents_collision() {
         Value::Concrete(ConcreteValue::String("A".to_string())),
     );
 
-    let mut r2 = Resource::with_provider("awscc", "route53.record_set", "");
+    let mut r2 = Resource::with_provider("awscc", "route53.record_set", "", None);
     r2.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs.dev".to_string())),
@@ -724,7 +724,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
     // Step 1: compute identifier with tag_env="production"
-    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r1.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -742,7 +742,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     let old_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with tag_env="staging" (one attribute changed)
-    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r2.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -790,7 +790,8 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
     schemas.insert("awscc", schema);
 
     // Resource with a computed identifier
-    let mut resource = Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344");
+    let mut resource =
+        Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344", None);
     resource.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -835,7 +836,7 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     // Compute identifier without setting the create-only property
-    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r1.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1023,7 +1024,7 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
 
     // Compute 3 identifiers with different attributes
     let make_resource = |env: &str, team: &str| {
-        let mut r = Resource::with_provider("awscc", "ec2.eip", "");
+        let mut r = Resource::with_provider("awscc", "ec2.eip", "", None);
         r.set_attr(
             "domain".to_string(),
             Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1131,7 +1132,7 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r = Resource::with_provider("awscc", "ec2.eip", "", None);
     r.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1161,7 +1162,8 @@ fn test_reconcile_no_create_only_empty_state() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let mut resource = Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344");
+    let mut resource =
+        Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344", None);
     resource.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1197,7 +1199,7 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     let make_resource = |env: &str| {
-        let mut r = Resource::with_provider("awscc", "ec2.internet_gateway", "");
+        let mut r = Resource::with_provider("awscc", "ec2.internet_gateway", "", None);
         r.set_attr(
             "tag_name".to_string(),
             Value::Concrete(ConcreteValue::String("my-igw".to_string())),
@@ -1259,7 +1261,7 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut vpc = Resource::with_provider("awscc", "ec2.Vpc", "");
+    let mut vpc = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     vpc.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -1269,7 +1271,7 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
         Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
     );
 
-    let mut eip = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut eip = Resource::with_provider("awscc", "ec2.eip", "", None);
     eip.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1304,7 +1306,7 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
     schemas.insert("awscc", schema);
 
     // Resource with both create-only props set
-    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
+    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-role".to_string())),
@@ -1361,7 +1363,7 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
 
     // Simulate two runs with different random suffixes but same prefix
     let make_resource = |generated_name: &str| {
-        let mut r = Resource::with_provider("awscc", "s3.Bucket", "");
+        let mut r = Resource::with_provider("awscc", "s3.Bucket", "", None);
         r.set_attr(
             "bucket_name".to_string(),
             Value::Concrete(ConcreteValue::String(generated_name.to_string())),
@@ -1405,7 +1407,7 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     let make_resource = |prefix: &str, generated_name: &str| {
-        let mut r = Resource::with_provider("awscc", "s3.Bucket", "");
+        let mut r = Resource::with_provider("awscc", "s3.Bucket", "", None);
         r.set_attr(
             "bucket_name".to_string(),
             Value::Concrete(ConcreteValue::String(generated_name.to_string())),
@@ -1441,7 +1443,7 @@ fn test_reconcile_skips_let_bound_resources() {
 
     // A let-bound resource whose name does NOT exist in state
     let mut ingress_new =
-        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_new");
+        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_new", None);
     ingress_new.binding = Some("ingress_new".to_string());
     ingress_new.set_attr(
         "cidr_ip".to_string(),
@@ -1500,6 +1502,7 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
         "aws",
         "ec2.security_group_ingress",
         "ec2_security_group_ingress_deadbeef",
+        None,
     );
     new_rule.set_attr(
         "cidr_ip".to_string(),
@@ -1595,7 +1598,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
     // Step 1: Create EIP with tags Environment=acceptance-test
-    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r1.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1619,7 +1622,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: Change tag Environment=staging (only tags changed)
-    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
+    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r2.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1687,7 +1690,7 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
 
     // Two named ingress resources with overlapping create-only attributes
     let mut ingress_http =
-        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_http");
+        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_http", None);
     ingress_http.set_attr(
         "cidr_ip".to_string(),
         Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
@@ -1702,7 +1705,7 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
     );
 
     let mut ingress_https =
-        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_https");
+        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_https", None);
     ingress_https.set_attr(
         "cidr_ip".to_string(),
         Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
@@ -1775,7 +1778,7 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
     // anonymous hash name to the binding name.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     resource.binding = Some("sso".to_string());
     resource.set_attr(
         "name".to_string(),
@@ -1808,7 +1811,7 @@ fn test_detect_rename_skips_when_binding_already_in_state() {
     // If state already has an entry for the binding name, nothing to rename.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     resource.binding = Some("sso".to_string());
     resource.set_attr(
         "name".to_string(),
@@ -1838,7 +1841,7 @@ fn test_detect_rename_ignores_anonymous_resources() {
     // Anonymous resources (binding=None) are not candidates for this rename.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso_instance_new");
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso_instance_new", None);
     // No binding set
     resource.set_attr(
         "name".to_string(),
@@ -1868,7 +1871,7 @@ fn test_detect_rename_skips_ambiguous_matches() {
     // Two orphan state entries match — skip to avoid rebinding the wrong one.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     resource.binding = Some("sso".to_string());
     resource.set_attr(
         "name".to_string(),
@@ -1907,7 +1910,7 @@ fn test_detect_rename_ignores_non_hash_state_names() {
     // treated as an anonymous candidate and must not be silently renamed.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     resource.binding = Some("sso".to_string());
     resource.set_attr(
         "name".to_string(),
@@ -1954,7 +1957,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
 
     // Step 1: generate the anonymous ID the previous `apply` would have
     // written to state, using the same inputs and the same code path.
-    let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
+    let mut anon = Resource::with_provider("awscc", "sso.Instance", "", None);
     anon.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
@@ -1968,7 +1971,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     );
 
     // Step 2: user wraps the same resource in a `let` binding.
-    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2007,7 +2010,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
     // Anonymous snapshot with many attributes.
-    let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
+    let mut anon = Resource::with_provider("awscc", "sso.Instance", "", None);
     anon.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("old-name".to_string())),
@@ -2030,7 +2033,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     let anonymous_name = anon_vec[0].id.name_str().to_string();
 
     // Let-bound resource with wildly different attributes.
-    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2084,7 +2087,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
     // Compute the exact-match name.
-    let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
+    let mut anon = Resource::with_provider("awscc", "sso.Instance", "", None);
     anon.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
@@ -2115,7 +2118,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
         },
     ];
 
-    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2148,7 +2151,7 @@ fn test_detect_rename_no_create_only_skips_8_char_hash_entries() {
     let providers: Vec<ProviderConfig> = Vec::new();
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
-    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2185,7 +2188,7 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
     // Compute the target SimHash.
-    let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
+    let mut anon = Resource::with_provider("awscc", "sso.Instance", "", None);
     anon.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
@@ -2206,7 +2209,7 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
         },
     ];
 
-    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2247,7 +2250,7 @@ fn anonymous_identifier_includes_provider_prefix() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "", None);
     r.set_attr(
         "policy_name".to_string(),
         Value::Concrete(ConcreteValue::String("foo".to_string())),
@@ -2285,7 +2288,7 @@ fn anonymous_identifier_provider_prefix_for_aws_provider() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r = Resource::with_provider("aws", "s3.Bucket", "");
+    let mut r = Resource::with_provider("aws", "s3.Bucket", "", None);
     r.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("example".to_string())),
@@ -2321,7 +2324,7 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
 
     // Build a resource and let compute_anonymous_identifiers assign its
     // freshly-computed new-format name.
-    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "", None);
     r.set_attr(
         "policy_name".to_string(),
         Value::Concrete(ConcreteValue::String("inline".to_string())),

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -193,11 +193,7 @@ impl ModuleResolver<'_> {
             // story (#2516).
             if let ResourceName::Bound(name) = &new_resource.id.name {
                 let new_name = format!("{}.{}", instance_prefix, name);
-                new_resource.id = ResourceId::with_provider(
-                    &new_resource.id.provider,
-                    &new_resource.id.resource_type,
-                    new_name,
-                );
+                new_resource.id.set_name(new_name);
             }
 
             // Rewrite binding with instance path (dot-separated)
@@ -580,7 +576,7 @@ pub fn reconcile_anonymous_module_instances(
         if let Some(&target) = prefix_remap.get(&(module.to_string(), simhash)) {
             let new_prefix = format!("{}_{:016x}", module, target);
             let new_name = format!("{}.{}", new_prefix, rest);
-            r.id = ResourceId::with_provider(&r.id.provider, &r.id.resource_type, new_name.clone());
+            r.id.set_name(new_name);
             if let Some(ref binding) = r.binding
                 && let Some((_, binding_rest)) = split_instance_prefix(binding)
             {

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -137,7 +137,7 @@ fn create_test_module_with_anonymous_resource() -> ParsedFile {
     ParsedFile {
         providers: vec![],
         resources: vec![Resource {
-            id: ResourceId::with_provider("awscc", "iam.RolePolicy", ""),
+            id: ResourceId::with_provider("awscc", "iam.RolePolicy", "", None),
             attributes: {
                 let mut attrs = IndexMap::new();
                 attrs.insert(
@@ -276,12 +276,7 @@ fn create_module_with_named_provider_instance() -> ParsedFile {
     ParsedFile {
         providers: vec![],
         resources: vec![Resource {
-            id: ResourceId::with_provider_and_instance(
-                "aws",
-                "acm.Certificate",
-                "cert",
-                Some("us".to_string()),
-            ),
+            id: ResourceId::with_provider("aws", "acm.Certificate", "cert", Some("us".to_string())),
             attributes: {
                 let mut attrs = IndexMap::new();
                 attrs.insert(
@@ -370,7 +365,7 @@ fn test_reconcile_anonymous_module_instances_preserves_provider_instance() {
     let state_name = format!("thing_{:016x}.role", state_hash);
 
     let mut resources = vec![Resource {
-        id: ResourceId::with_provider_and_instance(
+        id: ResourceId::with_provider(
             "aws",
             "iam.Role",
             format!("{}.role", current_prefix),

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -260,6 +260,162 @@ fn test_expand_module_call() {
     assert!(!sg.attributes.contains_key("_module_instance"));
 }
 
+/// Module whose resource targets a named provider instance via
+/// `directives.provider_instance`. Reproduces carina#3038: expansion
+/// rebuilt `id` with `with_provider(...)`, silently dropping the
+/// `provider_instance` field. `ProviderRouter` keys on
+/// `(id.provider, id.provider_instance)`, so the lost binding made
+/// `create` dispatch to the kind's default instance even though
+/// state-writeback (which reads `directives.provider_instance` from
+/// the `Resource`, not the `id`) still recorded the routing
+/// correctly. Net effect for users: an ACM cert that should live in
+/// `us-east-1` (where CloudFront viewer certs *must* live) lands in
+/// the default region instead, and subsequent `read` against the
+/// recorded `us` instance fails with `ResourceNotFoundException`.
+fn create_module_with_named_provider_instance() -> ParsedFile {
+    ParsedFile {
+        providers: vec![],
+        resources: vec![Resource {
+            id: ResourceId::with_provider_and_instance(
+                "aws",
+                "acm.Certificate",
+                "cert",
+                Some("us".to_string()),
+            ),
+            attributes: {
+                let mut attrs = IndexMap::new();
+                attrs.insert(
+                    "domain_name".to_string(),
+                    Value::Concrete(ConcreteValue::String("example.com".to_string())),
+                );
+                attrs
+            },
+            kind: ResourceKind::Managed,
+            directives: Directives {
+                provider_instance: Some("us".to_string()),
+                ..Directives::default()
+            },
+            prefixes: HashMap::new(),
+            binding: Some("cert".to_string()),
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: std::collections::HashSet::new(),
+        }],
+        variables: IndexMap::new(),
+        uses: vec![],
+        module_calls: vec![],
+        arguments: vec![],
+        attribute_params: vec![],
+        export_params: vec![],
+        backend: None,
+        state_blocks: vec![],
+        user_functions: HashMap::new(),
+        upstream_states: vec![],
+        wait_bindings: vec![],
+        requires: vec![],
+        structural_bindings: HashSet::new(),
+        warnings: vec![],
+        deferred_for_expressions: vec![],
+    }
+}
+
+#[test]
+fn test_expand_module_call_preserves_provider_instance_on_id() {
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert(
+            "registry".to_string(),
+            create_module_with_named_provider_instance(),
+        );
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "registry".to_string(),
+        binding_name: Some("acme".to_string()),
+        arguments: HashMap::new(),
+    };
+
+    let expanded = resolver.expand_module_call(&call, "acme", None).unwrap();
+    assert_eq!(expanded.len(), 1);
+    let cert = &expanded[0];
+    assert_eq!(
+        cert.id.provider_instance.as_deref(),
+        Some("us"),
+        "module expansion must preserve `id.provider_instance` so \
+         ProviderRouter dispatches `create` through the named \
+         instance (carina#3038)"
+    );
+    // The directives copy stays correct (and is what state writeback
+    // already reads from) — assert it too so a regression that flips
+    // *both* sides at once is still caught.
+    assert_eq!(
+        cert.directives.provider_instance.as_deref(),
+        Some("us"),
+        "directives.provider_instance must survive module expansion"
+    );
+}
+
+#[test]
+fn test_reconcile_anonymous_module_instances_preserves_provider_instance() {
+    // The SimHash-remap path in `reconcile_anonymous_module_instances`
+    // was the second `with_provider(...)` site that dropped
+    // `provider_instance` before carina#3038. A close-but-different
+    // SimHash in state triggers a name rewrite, so this test must
+    // assert that the named-instance routing survives the rewrite.
+    use crate::resource::{ConcreteValue, Resource, ResourceId, ResourceKind, Value};
+
+    let current_prefix = format!("thing_{:016x}", 0xABCDu64);
+    let state_hash = 0xABCDu64 ^ 1; // flip one bit — within SimHash threshold
+    let state_name = format!("thing_{:016x}.role", state_hash);
+
+    let mut resources = vec![Resource {
+        id: ResourceId::with_provider_and_instance(
+            "aws",
+            "iam.Role",
+            format!("{}.role", current_prefix),
+            Some("us".to_string()),
+        ),
+        attributes: {
+            let mut attrs = IndexMap::new();
+            attrs.insert(
+                "role_name".to_string(),
+                Value::Concrete(ConcreteValue::String("r".to_string())),
+            );
+            attrs
+        },
+        kind: ResourceKind::Managed,
+        directives: Directives {
+            provider_instance: Some("us".to_string()),
+            ..Directives::default()
+        },
+        prefixes: HashMap::new(),
+        binding: Some(format!("{}.role", current_prefix)),
+        dependency_bindings: BTreeSet::new(),
+        module_source: Some(crate::resource::ModuleSource::Module {
+            name: "thing".to_string(),
+            instance: current_prefix.clone(),
+        }),
+        quoted_string_attrs: std::collections::HashSet::new(),
+    }];
+
+    let state_lookup = |_: &str, _: &str| vec![state_name.clone()];
+    reconcile_anonymous_module_instances(&mut resources, &state_lookup);
+
+    assert_eq!(
+        resources[0].id.name_str(),
+        state_name,
+        "precondition: remap must actually have rewritten the name",
+    );
+    assert_eq!(
+        resources[0].id.provider_instance.as_deref(),
+        Some("us"),
+        "reconcile_anonymous_module_instances must preserve \
+         id.provider_instance through the SimHash prefix rewrite \
+         (carina#3038)"
+    );
+}
+
 /// Module with two resources where one references the other via _binding / ResourceRef.
 fn create_module_with_intra_refs() -> ParsedFile {
     ParsedFile {

--- a/carina-core/src/parser/blocks/resource.rs
+++ b/carina-core/src/parser/blocks/resource.rs
@@ -52,7 +52,7 @@ pub(in crate::parser) fn parse_anonymous_resource(
     // Extract directives block from attributes (it's a meta-argument, not a real attribute)
     let directives = extract_directives(&mut attributes)?;
 
-    let id = ResourceId::with_provider_and_instance(
+    let id = ResourceId::with_provider(
         provider,
         resource_type,
         resource_name,
@@ -224,7 +224,7 @@ pub(crate) fn parse_resource_expr(
         Value::Concrete(ConcreteValue::String(namespaced_type.clone())),
     );
 
-    let id = ResourceId::with_provider_and_instance(
+    let id = ResourceId::with_provider(
         provider,
         resource_type,
         resource_name,
@@ -281,7 +281,7 @@ pub(crate) fn parse_read_resource_expr(
         Value::Concrete(ConcreteValue::String(namespaced_type.clone())),
     );
 
-    let id = ResourceId::with_provider_and_instance(
+    let id = ResourceId::with_provider(
         provider,
         resource_type,
         resource_name,

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -106,7 +106,14 @@ pub(crate) fn parse_resource_address(
     // Split namespaced id into provider and resource_type
     let (provider, resource_type) = split_namespaced_id(&namespaced);
 
-    Ok(ResourceId::with_provider(provider, resource_type, name))
+    // `to`/`moved` addresses don't carry instance routing — the resolved
+    // resource supplies its own `provider_instance` from the DSL.
+    Ok(ResourceId::with_provider(
+        provider,
+        resource_type,
+        name,
+        None,
+    ))
 }
 
 pub(crate) fn extract_string_from_pair(

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -1254,7 +1254,8 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("input-aware".to_string(), Box::new(InputAwareProvider));
 
-        let mut resource = Resource::with_provider("input-aware", "identitystore.user", "mizzy");
+        let mut resource =
+            Resource::with_provider("input-aware", "identitystore.user", "mizzy", None);
         resource.set_attr(
             "user_name".to_string(),
             Value::Concrete(ConcreteValue::String("x".to_string())),
@@ -1285,7 +1286,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let id = ResourceId::with_provider("mock", "test", "example");
+        let id = ResourceId::with_provider("mock", "test", "example", None);
         let state = router.read(&id, None, ReadRequest).await.unwrap();
         assert!(!state.exists);
     }
@@ -1295,7 +1296,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let resource = Resource::with_provider("mock", "test", "example");
+        let resource = Resource::with_provider("mock", "test", "example", None);
         let id = resource.id.clone();
         let state = router
             .create(&id, CreateRequest { resource })
@@ -1474,7 +1475,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let id = ResourceId::with_provider("mock", "test", "example");
+        let id = ResourceId::with_provider("mock", "test", "example", None);
         let from = State::existing(id.clone(), HashMap::new());
         let request = UpdateRequest {
             from,
@@ -1489,7 +1490,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let id = ResourceId::with_provider("mock", "test", "example");
+        let id = ResourceId::with_provider("mock", "test", "example", None);
         let request = DeleteRequest::default();
         let result = router.delete(&id, "mock-id-123", request).await;
         assert!(result.is_ok());
@@ -1498,7 +1499,7 @@ mod tests {
     #[tokio::test]
     async fn provider_router_returns_error_for_unknown_provider() {
         let router = ProviderRouter::new();
-        let id = ResourceId::with_provider("nonexistent", "test", "example");
+        let id = ResourceId::with_provider("nonexistent", "test", "example", None);
         let result = router.read(&id, None, ReadRequest).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -1572,7 +1573,7 @@ mod tests {
             Box::new(TaggedProvider { tag: "us" }),
         );
 
-        let default_id = ResourceId::with_provider("mock", "test", "a");
+        let default_id = ResourceId::with_provider("mock", "test", "a", None);
         let state = router.read(&default_id, None, ReadRequest).await.unwrap();
         assert_eq!(
             state.attributes.get("tag"),
@@ -1582,8 +1583,7 @@ mod tests {
             "resources without provider_instance must route to the kind's default instance"
         );
 
-        let us_id =
-            ResourceId::with_provider_and_instance("mock", "test", "b", Some("us".to_string()));
+        let us_id = ResourceId::with_provider("mock", "test", "b", Some("us".to_string()));
         let state = router.read(&us_id, None, ReadRequest).await.unwrap();
         assert_eq!(
             state.attributes.get("tag"),
@@ -1597,12 +1597,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let id = ResourceId::with_provider_and_instance(
-            "mock",
-            "test",
-            "x",
-            Some("missing".to_string()),
-        );
+        let id = ResourceId::with_provider("mock", "test", "x", Some("missing".to_string()));
         let err = router.read(&id, None, ReadRequest).await.unwrap_err();
         let msg = err.message();
         assert!(
@@ -1922,7 +1917,7 @@ mod tests {
         router.add_normalizer(Box::new(TestNormalizer));
 
         let mut resources = vec![
-            Resource::with_provider("normalizing", "test", "example").with_attribute(
+            Resource::with_provider("normalizing", "test", "example", None).with_attribute(
                 "key",
                 Value::Concrete(ConcreteValue::String("val".to_string())),
             ),

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -104,22 +104,16 @@ impl ResourceId {
         }
     }
 
+    /// Construct a `ResourceId` with explicit routing.
+    ///
+    /// `provider_instance` is the binding name of the routed provider
+    /// instance — `None` resolves to the kind's default instance,
+    /// `Some(name)` to a `let <name> = provider <kind> { ... }`
+    /// declaration. Taking `Option<String>` here (instead of offering
+    /// a sibling 3-arg constructor that silently sets `None`) forces
+    /// every call site to consciously pick a routing target — the
+    /// hidden default that caused carina#3038 is no longer expressible.
     pub fn with_provider(
-        provider: impl Into<String>,
-        resource_type: impl Into<String>,
-        name: impl Into<String>,
-    ) -> Self {
-        Self {
-            provider: provider.into(),
-            resource_type: resource_type.into(),
-            name: ResourceName::from_string(name.into()),
-            provider_instance: None,
-        }
-    }
-
-    /// As [`with_provider`], plus the binding name of the routed
-    /// provider instance (`None` → kind default).
-    pub fn with_provider_and_instance(
         provider: impl Into<String>,
         resource_type: impl Into<String>,
         name: impl Into<String>,
@@ -1597,9 +1591,10 @@ impl Resource {
         provider: impl Into<String>,
         resource_type: impl Into<String>,
         name: impl Into<String>,
+        provider_instance: Option<String>,
     ) -> Self {
         Self {
-            id: ResourceId::with_provider(provider, resource_type, name),
+            id: ResourceId::with_provider(provider, resource_type, name, provider_instance),
             attributes: IndexMap::new(),
             kind: ResourceKind::Managed,
             directives: Directives::default(),

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -57,7 +57,7 @@ fn value_serde_round_trip() {
 
 #[test]
 fn resource_id_serde_round_trip() {
-    let id = ResourceId::with_provider("awscc", "ec2.Vpc", "main-vpc");
+    let id = ResourceId::with_provider("awscc", "ec2.Vpc", "main-vpc", None);
     let json = serde_json::to_string(&id).unwrap();
     let deserialized: ResourceId = serde_json::from_str(&json).unwrap();
     assert_eq!(id, deserialized);
@@ -97,7 +97,7 @@ fn resource_id_pending_serde_round_trips_as_empty_string() {
 
 #[test]
 fn resource_id_bound_serde_round_trips_as_string() {
-    let id = ResourceId::with_provider("aws", "ec2.Subnet", "my-subnet");
+    let id = ResourceId::with_provider("aws", "ec2.Subnet", "my-subnet", None);
     let json = serde_json::to_string(&id).unwrap();
     assert!(json.contains("\"name\":\"my-subnet\""), "got: {json}");
     let deserialized: ResourceId = serde_json::from_str(&json).unwrap();
@@ -129,7 +129,7 @@ fn resource_id_rename_pending_to_bound() {
     }
     // After renaming, the same string can produce an equal ResourceId
     // from any other code path (e.g. building a key for a sibling map).
-    let constructed = ResourceId::with_provider("aws", "ec2.Subnet", "app-subnet");
+    let constructed = ResourceId::with_provider("aws", "ec2.Subnet", "app-subnet", None);
     assert_eq!(id, constructed);
 }
 
@@ -146,7 +146,7 @@ fn state_serde_round_trip() {
     );
 
     let state = State::existing(
-        ResourceId::with_provider("aws", "s3.Bucket", "my-bucket"),
+        ResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None),
         attrs,
     )
     .with_identifier("my-bucket");
@@ -1397,7 +1397,12 @@ fn unknown_cannot_round_trip_through_serde_json() {
 
 #[test]
 fn human_display_separates_type_from_name_with_space() {
-    let id = ResourceId::with_provider("awscc", "iam.OidcProvider", "bs.bootstrap.oidc_provider");
+    let id = ResourceId::with_provider(
+        "awscc",
+        "iam.OidcProvider",
+        "bs.bootstrap.oidc_provider",
+        None,
+    );
     assert_eq!(
         format!("{}", id.human()),
         "awscc.iam.OidcProvider bs.bootstrap.oidc_provider",
@@ -1419,7 +1424,7 @@ fn human_display_does_not_alter_logical_display() {
     // The default Display remains the canonical dotted form because state
     // files, hashmap keys, binding fallbacks, and DSL identifiers all rely
     // on it. Only the human() wrapper changes shape.
-    let id = ResourceId::with_provider("aws", "s3.Bucket", "state_bucket");
+    let id = ResourceId::with_provider("aws", "s3.Bucket", "state_bucket", None);
     assert_eq!(format!("{}", id), "aws.s3.Bucket.state_bucket");
 }
 
@@ -1427,7 +1432,7 @@ fn human_display_does_not_alter_logical_display() {
 fn human_display_handles_pending_name() {
     // ResourceName::Pending renders as empty in Display; human() should
     // still emit the separating space so callers can rely on a stable shape.
-    let mut id = ResourceId::with_provider("awscc", "ec2.Vpc", "");
+    let mut id = ResourceId::with_provider("awscc", "ec2.Vpc", "", None);
     id.name = ResourceName::Pending;
     assert_eq!(format!("{}", id.human()), "awscc.ec2.Vpc ");
 }

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -3850,8 +3850,8 @@ fn schema_registry_get_picks_kind_from_resource() {
     registry.insert("aws", ResourceSchema::new("s3.Bucket"));
     registry.insert("aws", ResourceSchema::new("s3.Bucket").as_data_source());
 
-    let managed_res = Resource::with_provider("aws", "s3.Bucket", "new");
-    let data_res = Resource::with_provider("aws", "s3.Bucket", "existing")
+    let managed_res = Resource::with_provider("aws", "s3.Bucket", "new", None);
+    let data_res = Resource::with_provider("aws", "s3.Bucket", "existing", None)
         .with_kind(crate::resource::ResourceKind::DataSource);
 
     let m = registry

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -1129,7 +1129,7 @@ mod tests {
         // degrading to `NonInferableBinding`.
         use crate::parser::UpstreamState;
         use crate::resource::Resource;
-        let resource = Resource::with_provider("awscc", "ec2.Vpc", "main").with_binding("x");
+        let resource = Resource::with_provider("awscc", "ec2.Vpc", "main", None).with_binding("x");
         let upstream = UpstreamState {
             binding: "x".to_string(),
             source: std::path::PathBuf::from("../other"),
@@ -1247,7 +1247,7 @@ mod tests {
     #[test]
     fn apply_inference_fills_inferable_export_with_inferred_type() {
         let mut parsed = crate::parser::ParsedFile::default();
-        let res = crate::resource::Resource::with_provider("awscc", "ec2.Vpc", "main")
+        let res = crate::resource::Resource::with_provider("awscc", "ec2.Vpc", "main", None)
             .with_binding("main");
         parsed.resources.push(res); // allow: direct — fixture test inspection
         parsed.export_params.push(crate::parser::ParsedExportParam {
@@ -1331,6 +1331,7 @@ mod tests {
             "awscc",
             "ec2.Vpc",
             "github_actions_carina.role",
+            None,
         )
         .with_binding("github_actions_carina.role");
         parsed.resources.push(role); // allow: direct — fixture test inspection

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -58,7 +58,7 @@ fn used_binding_no_warning() {
     let mut parsed = empty_parsed();
 
     // Resource with a binding
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc")
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -67,7 +67,7 @@ fn used_binding_no_warning() {
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     // Resource that references the binding
-    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet").with_attribute(
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
         "vpc_id",
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
@@ -80,7 +80,7 @@ fn used_binding_no_warning() {
 fn unused_binding_warns() {
     let mut parsed = empty_parsed();
 
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc")
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -97,7 +97,7 @@ fn anonymous_resource_no_warning() {
     let mut parsed = empty_parsed();
 
     // Anonymous resource (no _binding attribute)
-    let bucket = Resource::with_provider("awscc", "s3.Bucket", "my-bucket").with_attribute(
+    let bucket = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None).with_attribute(
         "bucket_name",
         Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
@@ -110,7 +110,7 @@ fn anonymous_resource_no_warning() {
 fn binding_referenced_in_nested_value() {
     let mut parsed = empty_parsed();
 
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc").with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     // Reference inside a Map inside a List
@@ -119,7 +119,7 @@ fn binding_referenced_in_nested_value() {
         "vpc_id".to_string(),
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
-    let sg = Resource::with_provider("awscc", "ec2.SecurityGroup", "web-sg").with_attribute(
+    let sg = Resource::with_provider("awscc", "ec2.SecurityGroup", "web-sg", None).with_attribute(
         "tags",
         Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
             ConcreteValue::Map(map),
@@ -134,7 +134,7 @@ fn binding_referenced_in_nested_value() {
 fn binding_referenced_in_module_call() {
     let mut parsed = empty_parsed();
 
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc").with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     let mut args = HashMap::new();
@@ -155,14 +155,15 @@ fn binding_referenced_in_module_call() {
 fn multiple_bindings_some_unused() {
     let mut parsed = empty_parsed();
 
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc").with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
-    let sg = Resource::with_provider("awscc", "ec2.SecurityGroup", "web-sg").with_binding("web_sg");
+    let sg = Resource::with_provider("awscc", "ec2.SecurityGroup", "web-sg", None)
+        .with_binding("web_sg");
     parsed.resources.push(sg); // allow: direct — fixture test inspection
 
     // Only vpc is referenced
-    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet").with_attribute(
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
         "vpc_id",
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
@@ -176,7 +177,7 @@ fn multiple_bindings_some_unused() {
 fn binding_referenced_in_attributes_not_warned() {
     let mut parsed = empty_parsed();
 
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc").with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     parsed
@@ -198,7 +199,7 @@ fn binding_referenced_in_attributes_not_warned() {
 fn binding_referenced_in_exports_not_warned() {
     let mut parsed = empty_parsed();
 
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc").with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     parsed.export_params.push(crate::parser::ExportParameter {
@@ -440,7 +441,7 @@ fn unknown_binding_reference_reports_error() {
     );
 
     // Subnet references "vpc" binding which doesn't exist
-    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet").with_attribute(
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
         "vpc_id",
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
@@ -467,7 +468,7 @@ fn unknown_attribute_reference_reports_error() {
     );
 
     // VPC resource with binding
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc")
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -475,7 +476,7 @@ fn unknown_attribute_reference_reports_error() {
         );
 
     // Subnet references vpc.nonexistent_attr which doesn't exist on the VPC schema
-    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet").with_attribute(
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
         "vpc_id",
         Value::resource_ref("vpc".to_string(), "nonexistent_attr".to_string(), vec![]),
     );
@@ -511,10 +512,11 @@ fn unknown_attribute_reference_suggests_similar_name() {
         ),
     );
 
-    let igw = Resource::with_provider("awscc", "ec2.internet_gateway", "igw").with_binding("igw");
+    let igw =
+        Resource::with_provider("awscc", "ec2.internet_gateway", "igw", None).with_binding("igw");
 
     // Typo: internet_gateway_idd instead of internet_gateway_id
-    let route = Resource::with_provider("awscc", "ec2.route", "main-route").with_attribute(
+    let route = Resource::with_provider("awscc", "ec2.route", "main-route", None).with_attribute(
         "gateway_id",
         Value::resource_ref(
             "igw".to_string(),
@@ -547,10 +549,10 @@ fn unknown_attribute_reference_no_suggestion_when_too_different() {
         make_schema("ec2.Subnet", vec![("vpc_id", AttributeType::String)]),
     );
 
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc").with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
 
     // Completely unrelated attribute name - no suggestion expected
-    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet").with_attribute(
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
         "vpc_id",
         Value::resource_ref(
             "vpc".to_string(),
@@ -1095,8 +1097,8 @@ fn validate_type_expr_value_schema_type_rejects_int() {
 fn discard_binding_no_warning() {
     let mut parsed = empty_parsed();
 
-    let caller =
-        Resource::with_provider("aws", "sts.caller_identity", "caller_identity").with_binding("_");
+    let caller = Resource::with_provider("aws", "sts.caller_identity", "caller_identity", None)
+        .with_binding("_");
     parsed.resources.push(caller); // allow: direct — fixture test inspection
 
     assert!(check_unused_bindings(&parsed).is_empty());
@@ -1574,7 +1576,7 @@ fn attribute_param_ref_type_mismatch_detected() {
     use crate::schema::{AttributeSchema, ResourceSchema};
 
     // Build a resource with schema: role_name is String, arn is IamRoleArn (Custom)
-    let role = Resource::with_provider("awscc", "iam.role", "github-role")
+    let role = Resource::with_provider("awscc", "iam.role", "github-role", None)
         .with_binding("role")
         .with_attribute(
             "role_name",
@@ -2022,7 +2024,7 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
         ),
     );
 
-    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
+    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod", None)
         .with_binding("registry_prod")
         .with_attribute(
             "account_id",
@@ -2067,7 +2069,7 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
         ),
     );
 
-    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
+    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod", None)
         .with_binding("registry_prod")
         .with_attribute(
             "account_id",
@@ -2133,7 +2135,7 @@ fn validate_export_param_ref_types_against_inferred_inputs() {
     // Smoke test: a happy-path post-inference shape (bare TypeExpr,
     // matching attribute type) typechecks cleanly through the new
     // signature.
-    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
+    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod", None)
         .with_binding("registry_prod")
         .with_attribute(
             "account_id",
@@ -2188,14 +2190,15 @@ fn validate_resources_accepts_resource_ref_in_list_position() {
         ),
     );
 
-    let record_set = Resource::with_provider("aws", "route53.RecordSet", "ns").with_attribute(
-        "resource_records",
-        Value::resource_ref(
-            "registry_dev".to_string(),
-            "nameservers".to_string(),
-            vec![],
-        ),
-    );
+    let record_set = Resource::with_provider("aws", "route53.RecordSet", "ns", None)
+        .with_attribute(
+            "resource_records",
+            Value::resource_ref(
+                "registry_dev".to_string(),
+                "nameservers".to_string(),
+                vec![],
+            ),
+        );
 
     let mut known = HashSet::new();
     known.insert("aws".to_string());
@@ -2242,7 +2245,7 @@ fn validate_resources_accepts_resource_ref_in_struct_field_position() {
         Value::resource_ref("vpc".to_string(), "name".to_string(), vec![]),
     );
 
-    let holder = Resource::with_provider("aws", "test.StructHolder", "h")
+    let holder = Resource::with_provider("aws", "test.StructHolder", "h", None)
         .with_attribute("config", Value::Concrete(ConcreteValue::Map(config)));
 
     let mut known = HashSet::new();
@@ -2277,7 +2280,7 @@ fn validate_resources_accepts_resource_ref_in_map_position() {
         ),
     );
 
-    let holder = Resource::with_provider("aws", "test.MapHolder", "h").with_attribute(
+    let holder = Resource::with_provider("aws", "test.MapHolder", "h", None).with_attribute(
         "tags",
         Value::resource_ref("orgs".to_string(), "tag_map".to_string(), vec![]),
     );
@@ -2313,7 +2316,7 @@ fn validate_resources_rejects_missing_exclusive_required() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None);
 
     let mut known = HashSet::new();
     known.insert("awscc".to_string());
@@ -2623,7 +2626,7 @@ fn ref_with_chained_subscript_then_field_narrows_through_list() {
         make_schema("route53.RecordSet", vec![("name", AttributeType::String)]),
     );
 
-    let cert = Resource::with_provider("aws", "acm.Certificate", "main").with_binding("cert");
+    let cert = Resource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
 
     // `cert.domain_validation_options[0].resource_record_name`
     let path = AccessPath::with_segments(
@@ -2638,10 +2641,11 @@ fn ref_with_chained_subscript_then_field_narrows_through_list() {
             },
         ],
     );
-    let record = Resource::with_provider("aws", "route53.RecordSet", "validation").with_attribute(
-        "name",
-        Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
-    );
+    let record = Resource::with_provider("aws", "route53.RecordSet", "validation", None)
+        .with_attribute(
+            "name",
+            Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
+        );
 
     let mut parsed = empty_parsed();
     parsed.resources.push(cert); // allow: direct — fixture test inspection
@@ -2685,7 +2689,7 @@ fn ref_with_chained_subscript_then_field_rejects_real_mismatch() {
         make_schema("route53.RecordSet", vec![("name", AttributeType::String)]),
     );
 
-    let cert = Resource::with_provider("aws", "acm.Certificate", "main").with_binding("cert");
+    let cert = Resource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
 
     let path = AccessPath::with_segments(
         "cert",
@@ -2699,10 +2703,11 @@ fn ref_with_chained_subscript_then_field_rejects_real_mismatch() {
             },
         ],
     );
-    let record = Resource::with_provider("aws", "route53.RecordSet", "validation").with_attribute(
-        "name",
-        Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
-    );
+    let record = Resource::with_provider("aws", "route53.RecordSet", "validation", None)
+        .with_attribute(
+            "name",
+            Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
+        );
 
     let mut parsed = empty_parsed();
     parsed.resources.push(cert); // allow: direct — fixture test inspection

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -310,7 +310,12 @@ pub fn core_to_wit_resource_id(id: &CoreResourceId) -> wit::ResourceId {
 }
 
 pub fn wit_to_core_resource_id(id: &wit::ResourceId) -> CoreResourceId {
-    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name)
+    // The WIT `resource-id` record has no `provider-instance` field
+    // yet, so this boundary cannot round-trip a named instance.
+    // Tracked as a follow-up to extend the WIT contract; until then,
+    // callers that need routing must thread it through alongside the
+    // converted id.
+    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name, None)
 }
 
 // -- State --
@@ -348,8 +353,11 @@ pub fn core_to_wit_resource(
 
 pub fn wit_to_core_resource(resource: &wit::ResourceDef) -> CoreResource {
     let id = wit_to_core_resource_id(&resource.id);
+    // `id` came from `wit_to_core_resource_id`, which has no
+    // `provider_instance` to forward (WIT contract limitation); pass
+    // `None` explicitly to match.
     let mut core_resource =
-        CoreResource::with_provider(&id.provider, &id.resource_type, id.name_str());
+        CoreResource::with_provider(&id.provider, &id.resource_type, id.name_str(), None);
     core_resource.attributes = resource
         .attributes
         .iter()
@@ -1039,7 +1047,7 @@ mod tests {
 
     #[test]
     fn test_resource_id_roundtrip() {
-        let core = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket");
+        let core = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None);
         let wit = core_to_wit_resource_id(&core);
         assert_eq!(wit.provider, "aws");
         assert_eq!(wit.resource_type, "s3.Bucket");
@@ -1052,7 +1060,7 @@ mod tests {
 
     #[test]
     fn test_state_roundtrip() {
-        let id = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket");
+        let id = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None);
         let mut attrs = HashMap::new();
         attrs.insert(
             "name".into(),
@@ -1074,7 +1082,7 @@ mod tests {
 
     #[test]
     fn test_state_with_identifier_roundtrip() {
-        let id = CoreResourceId::with_provider("aws", "ec2.Vpc", "main");
+        let id = CoreResourceId::with_provider("aws", "ec2.Vpc", "main", None);
         let attrs = HashMap::from([(
             "cidr".into(),
             CoreValue::Concrete(ConcreteValue::String("10.0.0.0/16".into())),
@@ -1110,7 +1118,7 @@ mod tests {
 
     #[test]
     fn test_resource_roundtrip() {
-        let mut resource = CoreResource::with_provider("aws", "s3.Bucket", "my-bucket");
+        let mut resource = CoreResource::with_provider("aws", "s3.Bucket", "my-bucket", None);
         resource.attributes = indexmap::IndexMap::from([
             (
                 "name".into(),
@@ -1191,7 +1199,7 @@ mod tests {
         // flattened to a string at the boundary because WIT cannot
         // carry `dyn std::error::Error`.
         let cause = std::io::Error::other("inner io error");
-        let id = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket");
+        let id = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None);
         let err = CoreProviderError::api_error("Failed to read")
             .with_cause(cause)
             .for_resource(id.clone())

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -77,7 +77,7 @@ async fn test_wasm_mock_provider_create_and_read() {
     assert_eq!(provider.name(), "mock");
 
     // Read before create - should return a state with no identifier and empty attributes
-    let id = ResourceId::with_provider("mock", "test.resource", "my-resource");
+    let id = ResourceId::with_provider("mock", "test.resource", "my-resource", None);
     let state = provider
         .read(&id, None, ReadRequest)
         .await
@@ -86,7 +86,7 @@ async fn test_wasm_mock_provider_create_and_read() {
     assert!(state.attributes.is_empty());
 
     // Create a resource
-    let mut resource = Resource::with_provider("mock", "test.resource", "my-resource");
+    let mut resource = Resource::with_provider("mock", "test.resource", "my-resource", None);
     resource.attributes = indexmap::IndexMap::from([
         (
             "name".into(),
@@ -155,10 +155,10 @@ async fn test_wasm_mock_provider_update_and_delete() {
         .await
         .expect("provider should init");
 
-    let id = ResourceId::with_provider("mock", "test.resource", "updatable");
+    let id = ResourceId::with_provider("mock", "test.resource", "updatable", None);
 
     // Create first
-    let mut resource = Resource::with_provider("mock", "test.resource", "updatable");
+    let mut resource = Resource::with_provider("mock", "test.resource", "updatable", None);
     resource.attributes = indexmap::IndexMap::from([
         (
             "color".into(),
@@ -273,7 +273,7 @@ async fn test_wasm_mock_provider_normalizer() {
 
     // normalize_desired: mock provider returns resources unchanged
     let mut resources = vec![{
-        let mut r = Resource::with_provider("mock", "test.resource", "norm-test");
+        let mut r = Resource::with_provider("mock", "test.resource", "norm-test", None);
         r.attributes = indexmap::IndexMap::from([(
             "key".into(),
             Value::Concrete(ConcreteValue::String("value".into())),
@@ -285,7 +285,7 @@ async fn test_wasm_mock_provider_normalizer() {
     assert_eq!(resources[0].resolved_attributes(), original_attrs);
 
     // normalize_state: mock provider returns states unchanged
-    let id = ResourceId::with_provider("mock", "test.resource", "norm-test");
+    let id = ResourceId::with_provider("mock", "test.resource", "norm-test", None);
     let attrs = HashMap::from([(
         "key".into(),
         Value::Concrete(ConcreteValue::String("value".into())),
@@ -316,7 +316,12 @@ async fn test_wasm_mock_provider_merge_default_tags_dispatches_through_wit() {
         .await;
 
     let registry = carina_core::schema::SchemaRegistry::new();
-    let mut resources = vec![Resource::with_provider("mock", "test.resource", "tag-test")];
+    let mut resources = vec![Resource::with_provider(
+        "mock",
+        "test.resource",
+        "tag-test",
+        None,
+    )];
     let default_tags = indexmap::IndexMap::from([
         (
             "Env".to_string(),
@@ -350,7 +355,12 @@ async fn test_wasm_mock_provider_merge_default_tags_empty_short_circuits() {
         .await;
 
     let registry = carina_core::schema::SchemaRegistry::new();
-    let mut resources = vec![Resource::with_provider("mock", "test.resource", "no-tags")];
+    let mut resources = vec![Resource::with_provider(
+        "mock",
+        "test.resource",
+        "no-tags",
+        None,
+    )];
     let default_tags: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
 
     normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
@@ -375,9 +385,9 @@ async fn test_wasm_mock_provider_merge_default_tags_preserves_order() {
 
     let registry = carina_core::schema::SchemaRegistry::new();
     let mut resources = vec![
-        Resource::with_provider("mock", "test.resource", "alpha"),
-        Resource::with_provider("mock", "test.resource", "beta"),
-        Resource::with_provider("mock", "test.resource", "gamma"),
+        Resource::with_provider("mock", "test.resource", "alpha", None),
+        Resource::with_provider("mock", "test.resource", "beta", None),
+        Resource::with_provider("mock", "test.resource", "gamma", None),
     ];
     let default_tags = indexmap::IndexMap::from([(
         "Env".to_string(),
@@ -413,7 +423,7 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
         .await
         .expect("provider should init");
 
-    let mut resource = Resource::with_provider("mock", "test.data_source", "example");
+    let mut resource = Resource::with_provider("mock", "test.data_source", "example", None);
     resource.attributes = indexmap::IndexMap::from([
         (
             "identity_store_id".into(),

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -175,7 +175,7 @@ impl StateFile {
     pub fn build_directives(&self) -> HashMap<ResourceId, Directives> {
         let mut directives_map = HashMap::new();
         for rs in &self.resources {
-            let id = ResourceId::with_provider_and_instance(
+            let id = ResourceId::with_provider(
                 &rs.provider,
                 &rs.resource_type,
                 &rs.name,
@@ -190,7 +190,7 @@ impl StateFile {
     pub fn build_saved_attrs(&self) -> HashMap<ResourceId, HashMap<String, Value>> {
         let mut result = HashMap::new();
         for rs in &self.resources {
-            let id = ResourceId::with_provider_and_instance(
+            let id = ResourceId::with_provider(
                 &rs.provider,
                 &rs.resource_type,
                 &rs.name,
@@ -214,7 +214,7 @@ impl StateFile {
         let mut result = HashMap::new();
         for rs in &self.resources {
             if !is_empty_explicit(&rs.explicit) {
-                let id = ResourceId::with_provider_and_instance(
+                let id = ResourceId::with_provider(
                     &rs.provider,
                     &rs.resource_type,
                     &rs.name,
@@ -261,7 +261,7 @@ impl StateFile {
     ) -> HashMap<ResourceId, State> {
         let mut result = HashMap::new();
         for rs in &self.resources {
-            let id = ResourceId::with_provider_and_instance(
+            let id = ResourceId::with_provider(
                 &rs.provider,
                 &rs.resource_type,
                 &rs.name,
@@ -305,7 +305,7 @@ impl StateFile {
     ) -> HashMap<ResourceId, BTreeSet<String>> {
         let mut result = HashMap::new();
         for rs in &self.resources {
-            let id = ResourceId::with_provider_and_instance(
+            let id = ResourceId::with_provider(
                 &rs.provider,
                 &rs.resource_type,
                 &rs.name,
@@ -327,7 +327,7 @@ impl StateFile {
         let mut result = HashMap::new();
         for rs in &self.resources {
             if !rs.name_overrides.is_empty() {
-                let id = ResourceId::with_provider_and_instance(
+                let id = ResourceId::with_provider(
                     &rs.provider,
                     &rs.resource_type,
                     &rs.name,

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -157,7 +157,7 @@ fn test_get_identifier_for_resource_from_state() {
         ResourceState::new("s3.Bucket", "my-bucket", "awscc").with_identifier("my-bucket-abcd1234");
     state.upsert_resource(rs);
 
-    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     assert_eq!(
         state.get_identifier_for_resource(&resource),
         Some("my-bucket-abcd1234".to_string())
@@ -169,7 +169,7 @@ fn test_get_identifier_for_resource_returns_none() {
     use carina_core::resource::Resource;
 
     let state = StateFile::new();
-    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     assert_eq!(state.get_identifier_for_resource(&resource), None);
 }
 
@@ -183,7 +183,7 @@ fn test_build_directives() {
     state.upsert_resource(rs);
 
     let directives_map = state.build_directives();
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     assert!(directives_map.get(&id).unwrap().force_delete);
 }
 
@@ -197,7 +197,7 @@ fn test_build_saved_attrs() {
     state.upsert_resource(rs);
 
     let saved = state.build_saved_attrs();
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     let attrs = saved.get(&id).unwrap();
     assert_eq!(
         attrs.get("region"),
@@ -256,7 +256,7 @@ fn test_resource_state_deserialization_without_v3_fields() {
 fn test_from_provider_state() {
     use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     resource.directives.force_delete = true;
     resource
         .prefixes
@@ -294,7 +294,7 @@ fn test_from_provider_state() {
 fn test_from_provider_state_without_existing() {
     use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let resource = Resource::with_provider("aws", "s3.Bucket", "test");
+    let resource = Resource::with_provider("aws", "s3.Bucket", "test", None);
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("test-id".to_string()),
@@ -339,13 +339,13 @@ fn test_multi_provider_resources_do_not_collide() {
     assert_eq!(found_awscc.identifier, Some("awscc-bucket-id".to_string()));
 
     // get_identifier_for_resource should return provider-scoped identifiers
-    let aws_res = Resource::with_provider("aws", "s3.Bucket", "main");
+    let aws_res = Resource::with_provider("aws", "s3.Bucket", "main", None);
     assert_eq!(
         state.get_identifier_for_resource(&aws_res),
         Some("aws-bucket-id".to_string())
     );
 
-    let awscc_res = Resource::with_provider("awscc", "s3.Bucket", "main");
+    let awscc_res = Resource::with_provider("awscc", "s3.Bucket", "main", None);
     assert_eq!(
         state.get_identifier_for_resource(&awscc_res),
         Some("awscc-bucket-id".to_string())
@@ -395,8 +395,8 @@ fn test_build_directives_provider_scoped() {
     state.upsert_resource(awscc_rs);
 
     let directives_map = state.build_directives();
-    let aws_id = ResourceId::with_provider("aws", "s3.Bucket", "main");
-    let awscc_id = ResourceId::with_provider("awscc", "s3.Bucket", "main");
+    let aws_id = ResourceId::with_provider("aws", "s3.Bucket", "main", None);
+    let awscc_id = ResourceId::with_provider("awscc", "s3.Bucket", "main", None);
 
     assert!(directives_map.get(&aws_id).unwrap().force_delete);
     assert!(!directives_map.get(&awscc_id).unwrap().force_delete);
@@ -416,8 +416,8 @@ fn test_build_saved_attrs_provider_scoped() {
     state.upsert_resource(awscc_rs);
 
     let saved = state.build_saved_attrs();
-    let aws_id = ResourceId::with_provider("aws", "s3.Bucket", "main");
-    let awscc_id = ResourceId::with_provider("awscc", "s3.Bucket", "main");
+    let aws_id = ResourceId::with_provider("aws", "s3.Bucket", "main", None);
+    let awscc_id = ResourceId::with_provider("awscc", "s3.Bucket", "main", None);
 
     assert_eq!(
         saved.get(&aws_id).unwrap().get("region"),
@@ -444,7 +444,7 @@ fn test_build_state_for_resource_existing() {
             .with_attribute("region".to_string(), serde_json::json!("ap-northeast-1")),
     );
 
-    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     let result = state.build_state_for_resource(&resource);
 
     assert!(result.exists);
@@ -460,7 +460,8 @@ fn test_build_state_for_resource_existing() {
 #[test]
 fn test_build_state_for_resource_not_found() {
     let state = StateFile::new();
-    let resource = carina_core::resource::Resource::with_provider("awscc", "s3.Bucket", "missing");
+    let resource =
+        carina_core::resource::Resource::with_provider("awscc", "s3.Bucket", "missing", None);
     let result = state.build_state_for_resource(&resource);
 
     assert!(!result.exists);
@@ -477,7 +478,8 @@ fn test_build_state_for_resource_without_identifier() {
             .with_attribute("region".to_string(), serde_json::json!("us-east-1")),
     );
 
-    let resource = carina_core::resource::Resource::with_provider("awscc", "s3.Bucket", "pending");
+    let resource =
+        carina_core::resource::Resource::with_provider("awscc", "s3.Bucket", "pending", None);
     let result = state.build_state_for_resource(&resource);
 
     assert!(!result.exists);
@@ -488,7 +490,7 @@ fn test_build_state_for_resource_without_identifier() {
 fn test_from_provider_state_stores_binding_and_dependencies() {
     use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let mut resource = Resource::with_provider("awscc", "ec2.Subnet", "my-subnet");
+    let mut resource = Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None);
     resource.binding = Some("my_subnet".to_string());
     resource.set_attr(
         "vpc_id".to_string(),
@@ -530,7 +532,7 @@ fn test_build_orphan_states_injects_binding() {
     let desired_ids = std::collections::HashSet::new();
     let orphans = state.build_orphan_states(&desired_ids);
 
-    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "orphan-subnet");
+    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "orphan-subnet", None);
     let orphan_state = orphans.get(&id).unwrap();
     assert!(orphan_state.exists);
     assert_eq!(
@@ -555,7 +557,7 @@ fn test_build_orphan_dependencies() {
     let desired_ids = std::collections::HashSet::new();
     let deps = state.build_orphan_dependencies(&desired_ids);
 
-    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "orphan-subnet");
+    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "orphan-subnet", None);
     assert_eq!(
         deps.get(&id).unwrap(),
         &BTreeSet::from(["my_vpc".to_string()])
@@ -578,7 +580,7 @@ fn test_build_orphan_dependencies_excludes_desired() {
     rs.dependency_bindings = BTreeSet::from(["my_vpc".to_string()]);
     state.upsert_resource(rs);
 
-    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "kept-subnet");
+    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "kept-subnet", None);
     let mut desired_ids = std::collections::HashSet::new();
     desired_ids.insert(id.clone());
 
@@ -684,7 +686,7 @@ fn test_merge_write_only_attributes() {
     use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     // Simulate a VPC resource with a write-only attribute (ipv4_netmask_length)
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -733,7 +735,7 @@ fn test_merge_write_only_attributes_not_in_desired() {
     use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     // Resource without write-only attribute specified
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -768,7 +770,7 @@ fn test_merge_write_only_skips_if_already_in_provider_state() {
     use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     // Resource with a write-only attribute
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "some_attr".to_string(),
         Value::Concrete(ConcreteValue::String("desired".to_string())),
@@ -842,7 +844,7 @@ fn test_from_provider_state_secret_stored_as_hash() {
     };
     use carina_core::value::SECRET_PREFIX;
 
-    let mut resource = Resource::with_provider("awscc", "rds.db_instance", "my-db");
+    let mut resource = Resource::with_provider("awscc", "rds.db_instance", "my-db", None);
     resource.set_attr(
         "master_password".to_string(),
         Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
@@ -891,7 +893,7 @@ fn test_from_provider_state_secret_in_map_stored_as_hash() {
     };
     use carina_core::value::SECRET_PREFIX;
 
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     let mut tags_map = IndexMap::new();
     tags_map.insert(
         "Name".to_string(),
@@ -961,7 +963,7 @@ fn test_from_provider_state_secret_in_map_preserves_provider_extra_keys() {
     use carina_core::value::SECRET_PREFIX;
 
     // User specifies only SecretTag in tags
-    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     let mut tags_map = IndexMap::new();
     tags_map.insert(
         "SecretTag".to_string(),
@@ -1034,7 +1036,7 @@ fn test_from_provider_state_secret_in_list_stored_as_hash() {
     };
     use carina_core::value::SECRET_PREFIX;
 
-    let mut resource = Resource::with_provider("awscc", "test.resource", "my-res");
+    let mut resource = Resource::with_provider("awscc", "test.resource", "my-res", None);
     resource.set_attr(
         "values".to_string(),
         Value::Concrete(ConcreteValue::List(vec![
@@ -1178,7 +1180,7 @@ fn from_provider_state_rejects_resource_ref_in_provider_attributes() {
         AccessPath, DeferredValue, Resource, State as ProviderState, Value,
     };
 
-    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("my-bucket".to_string()),
@@ -1282,7 +1284,7 @@ fn build_explicit_yields_per_resource_trees() {
     state.upsert_resource(rs);
 
     let map = state.build_explicit();
-    let id = ResourceId::with_provider("aws", "s3.Bucket", "my-bucket");
+    let id = ResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None);
     assert!(map.contains_key(&id));
     assert!(matches!(map[&id], ExplicitFields::Struct { .. }));
 }
@@ -1303,19 +1305,15 @@ fn build_directives_keys_include_provider_instance() {
     state.upsert_resource(rs);
 
     let map = state.build_directives();
-    let expected = ResourceId::with_provider_and_instance(
-        "aws",
-        "s3.Bucket",
-        "shared-name",
-        Some("us".to_string()),
-    );
+    let expected =
+        ResourceId::with_provider("aws", "s3.Bucket", "shared-name", Some("us".to_string()));
     assert!(
         map.contains_key(&expected),
         "build_directives must construct ResourceId with provider_instance, got keys: {:?}",
         map.keys().collect::<Vec<_>>()
     );
     // Without the instance, the legacy ResourceId must NOT match.
-    let legacy = ResourceId::with_provider("aws", "s3.Bucket", "shared-name");
+    let legacy = ResourceId::with_provider("aws", "s3.Bucket", "shared-name", None);
     assert!(
         !map.contains_key(&legacy),
         "ResourceId without provider_instance must not match a Some(_) entry"

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -564,10 +564,10 @@ fn tab_complete_with_provider_prefix() {
     // Resource types with provider prefix (e.g., "awscc.ec2.Vpc")
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc").with_binding("vpc"),
+        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
     ));
     plan.add(Effect::Create(
-        Resource::with_provider("awscc", "ec2.Subnet", "my-subnet").with_binding("subnet"),
+        Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None).with_binding("subnet"),
     ));
     let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;

--- a/carina-tui/src/lib.rs
+++ b/carina-tui/src/lib.rs
@@ -483,13 +483,14 @@ mod tests {
     fn make_provider_prefixed_app() -> App {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            Resource::with_provider("awscc", "ec2.Vpc", "my-vpc").with_binding("vpc"),
+            Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
         ));
         plan.add(Effect::Create(
-            Resource::with_provider("awscc", "ec2.Subnet", "my-subnet").with_binding("subnet"),
+            Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None)
+                .with_binding("subnet"),
         ));
         plan.add(Effect::Create(
-            Resource::with_provider("awscc", "s3.Bucket", "my-bucket").with_binding("bucket"),
+            Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None).with_binding("bucket"),
         ));
         App::new(&plan, &SchemaRegistry::new())
     }


### PR DESCRIPTION
## Summary

Fixes carina#3038 in two layers:

**1. Direct fix** (commit 1): `module_resolver::expander.rs` rebuilt `ResourceId` via `ResourceId::with_provider(...)` at two sites, and that constructor hard-coded `provider_instance: None` — silently erasing the routing during module expansion. Replaced both with `id.set_name(new_name)` so only the `name` field changes.

**2. Type-safety refactor** (commit 2): the `with_provider` constructor *itself* was the footgun — it offered a way to construct a `ResourceId` without thinking about routing. Collapsed the two constructors (`with_provider` / `with_provider_and_instance`) into a single 4-arg form that takes `provider_instance: Option<String>` explicitly. The provider-instance-less constructor is now unrepresentable, so the same class of bug can't recur:

```rust
// before — easy to pick the wrong one
ResourceId::with_provider(provider, type, name)            // drops instance
ResourceId::with_provider_and_instance(provider, type, name, instance)

// after — can't skip the routing axis
ResourceId::with_provider(provider, type, name, instance)
```

State was already recording `provider_instance: \"us\"` correctly because writeback reads `directives.provider_instance` from the `Resource` (not from the `id`). The bug was that `ProviderRouter` keys on `ResourceId.provider_instance`, so the lost `id` field made `create()` dispatch to the wrong provider while state simultaneously recorded the right one — a silent cross-region apply.

**Real-world impact** (from the issue): an ACM cert intended for `us-east-1` (required for CloudFront viewer certificates) was created in `ap-northeast-1`, and subsequent `read` against the recorded `us` instance returned `ResourceNotFoundException`.

## What the type-safety refactor surfaced

- `carina-plugin-host::wasm_convert::wit_to_core_resource_id` silently dropped `provider_instance` on every WIT→core conversion (the WIT contract has no such field). Compile error forced an explicit `None` + a comment marking the WIT-extension follow-up.
- `carina-cli::commands::state::build_plan_from_state` was doing post-construction `resource.id.provider_instance = ...` mutation, a smell that only existed because the constructor couldn't accept the field. Collapsed into a single atomic constructor call.

## Test plan

- [x] `cargo nextest run --workspace` — 3315 passed (one more than before)
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all pass
- [x] Two new regression tests cover both fix sites in `expander.rs` (prefix-application + SimHash remap); both confirmed to fail without the fix.
- [ ] T6c real-infra smoke (`aws-vault exec ... carina apply` against `carina-rs/infra` PR #55) — user-driven per the project convention; the buggy state from the issue still needs cleanup (either `carina destroy` or manual `aws acm delete-certificate`).

## Follow-ups (separate issues)

- Extend WIT `resource-id` record to carry `provider-instance` (requires bumping carina-plugin-wit + aws + awscc plugins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)