### PR TITLE
validate: flag chained-access typos with did-you-mean (closes #3041)

### DIFF
--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -14,6 +14,16 @@ use crate::provider::ProviderFactory;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
+/// Render the trailing `" Did you mean 'X'?"` segment for an unknown
+/// name in a diagnostic, or an empty string when nothing close enough
+/// is found. The leading space is part of the convention so callers
+/// can concat unconditionally onto an already-punctuated message.
+fn did_you_mean(unknown: &str, known: &[&str]) -> String {
+    suggest_similar_name(unknown, known)
+        .map(|s| format!(" Did you mean '{}'?", s))
+        .unwrap_or_default()
+}
+
 /// Validate resources against their schemas.
 ///
 /// Two-sided check: a `read` resource requires a `DataSource` registry entry,
@@ -155,29 +165,48 @@ pub fn validate_resource_ref_types<E>(
             let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr.as_str()) else {
                 let known_attrs: Vec<&str> =
                     ref_schema.attributes.keys().map(|s| s.as_str()).collect();
-                let suggestion = suggest_similar_name(&ref_attr, &known_attrs)
-                    .map(|s| format!(" Did you mean '{}'?", s))
-                    .unwrap_or_default();
                 all_errors.push(format!(
                     "{}: unknown attribute '{}' on '{}' in reference {}.{}{}",
-                    resource.id, ref_attr, ref_binding, ref_binding, ref_attr, suggestion,
+                    resource.id,
+                    ref_attr,
+                    ref_binding,
+                    ref_binding,
+                    ref_attr,
+                    did_you_mean(&ref_attr, &known_attrs),
                 ));
                 continue;
             };
 
             // Narrow through the path's segments — `[idx]` peels one
             // `List<T>` / `Map<_,V>` layer, `.field` descends a
-            // `Struct`. carina#3028. When a segment doesn't fit the
-            // shape (e.g. `.x` against a scalar), skip the type check
-            // rather than emit a noisy mismatch: schema-level
-            // attribute validation already reports unknown fields and
-            // resolver-time evaluation catches the shape error with
-            // location context.
-            let Some(narrowed) =
-                narrow_attribute_type(&ref_attr_schema.attr_type, ref_path.segments())
-            else {
-                continue;
-            };
+            // `Struct`. carina#3028. Unknown struct fields are a
+            // real typo (carina#3041) and get reported here with a
+            // suggestion; other shape mismatches stay silent because
+            // resolver-time evaluation catches them with full location
+            // context.
+            let narrowed =
+                match narrow_attribute_type(&ref_attr_schema.attr_type, ref_path.segments()) {
+                    Ok(t) => t,
+                    Err(NarrowError::UnknownStructField {
+                        field,
+                        struct_name,
+                        known_fields,
+                    }) => {
+                        let known: Vec<&str> = known_fields.iter().map(|s| s.as_str()).collect();
+                        all_errors.push(format!(
+                            "{}: unknown field '{}' on struct '{}' in reference {}; \
+                         known fields: {}.{}",
+                            resource.id,
+                            field,
+                            struct_name,
+                            ref_path.to_dot_string(),
+                            known.join(", "),
+                            did_you_mean(&field, &known),
+                        ));
+                        continue;
+                    }
+                    Err(NarrowError::ShapeMismatch) => continue,
+                };
             let ref_type_name = narrowed.type_name();
 
             // Directional check: source (the referenced attribute, post
@@ -1088,28 +1117,28 @@ pub(crate) fn narrow_type_expr(
 /// free mix of `.field` (descend into a `Struct`) and `[idx]` (peel one
 /// `List<T>` / `Map<_, V>` layer) continuations (carina#3025).
 ///
-/// Returns `None` when any segment doesn't fit the container shape at
-/// its position (`.x` against a scalar, `[0]` against a `Struct`, …).
-/// The caller decides whether that's a hard error or — when the path
-/// is "permissive" (chained access into a shape the checker doesn't
-/// yet narrow precisely) — silent.
-///
-/// Borrows so deep paths don't pay an O(depth) clone chain. Used by
-/// `validate_resource_ref_types` to honour the carina#3025 segments
-/// representation when type-checking cross-resource references
-/// (carina#3028).
+/// Borrows so deep paths don't pay an O(depth) clone chain. The error
+/// variant ([`NarrowError`]) distinguishes a real field typo
+/// (actionable, suggest a sibling) from a structural shape mismatch
+/// (caller decides whether resolver-time location context is enough).
 pub(crate) fn narrow_attribute_type<'a>(
     start: &'a AttributeType,
     segments: &[crate::resource::PathSegment],
-) -> Option<&'a AttributeType> {
+) -> Result<&'a AttributeType, NarrowError> {
     use crate::resource::{PathSegment, Subscript};
     let mut current = start;
     for seg in segments {
         current = match (seg, current) {
-            (PathSegment::Field { name }, AttributeType::Struct { fields, .. }) => fields
-                .iter()
-                .find(|f| f.name == *name)
-                .map(|f| &f.field_type)?,
+            (PathSegment::Field { name }, AttributeType::Struct { fields, name: sn }) => {
+                let Some(field) = fields.iter().find(|f| f.name == *name) else {
+                    return Err(NarrowError::UnknownStructField {
+                        field: name.clone(),
+                        struct_name: sn.clone(),
+                        known_fields: fields.iter().map(|f| f.name.clone()).collect(),
+                    });
+                };
+                &field.field_type
+            }
             // Dot-form key access against a `map(_, V)` projects to
             // `V`, mirroring the resolver's behaviour (carina#2447).
             (PathSegment::Field { .. }, AttributeType::Map { value, .. }) => value.as_ref(),
@@ -1125,10 +1154,26 @@ pub(crate) fn narrow_attribute_type<'a>(
                 },
                 AttributeType::Map { value, .. },
             ) => value.as_ref(),
-            _ => return None,
+            _ => return Err(NarrowError::ShapeMismatch),
         };
     }
-    Some(current)
+    Ok(current)
+}
+
+/// Reason [`narrow_attribute_type`] rejected a path.
+#[derive(Debug)]
+pub(crate) enum NarrowError {
+    /// A `.field` segment named a field that doesn't exist on the
+    /// current `Struct`. Carries the struct's declared name and the
+    /// names of its fields so the caller can render a suggestion.
+    UnknownStructField {
+        field: String,
+        struct_name: String,
+        known_fields: Vec<String>,
+    },
+    /// A segment didn't fit the container at its position
+    /// (e.g. `.x` against a scalar, `[0]` against a struct).
+    ShapeMismatch,
 }
 
 pub mod inference;

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -2718,3 +2718,116 @@ fn ref_with_chained_subscript_then_field_rejects_real_mismatch() {
         "expected real Int→String mismatch to be flagged, got: {err}"
     );
 }
+
+/// carina#3041: when a chained `[idx].field` references a struct
+/// field that does not exist (typically because the user is still on
+/// an older flat shape like `domain_validation_options[0].resource_record_name`
+/// while the schema has migrated to a nested
+/// `domain_validation_options[0].resource_record.name`), validation
+/// must flag the unknown field by name with a suggestion. Pre-fix
+/// `narrow_attribute_type` returned `None` silently, the caller
+/// swallowed it, and the failure only surfaced at apply time with a
+/// misleading "Add a `wait` block" message — `wait` could never have
+/// helped, because the attribute will never exist under that spelling.
+#[test]
+fn ref_with_chained_field_on_struct_flags_unknown_field() {
+    use crate::resource::{AccessPath, PathSegment, Subscript, Value};
+    use crate::schema::StructField;
+
+    let mut schemas = SchemaRegistry::new();
+    // Mirror the real `aws.acm.Certificate` shape after aws#295:
+    // `domain_validation_options[*].resource_record: Struct{name, value}`.
+    // Note: NO flat `resource_record_name` / `resource_record_value`
+    // fields on the inner struct — those were removed by the nested
+    // migration.
+    schemas.insert(
+        "aws",
+        make_schema(
+            "acm.Certificate",
+            vec![(
+                "domain_validation_options",
+                AttributeType::List {
+                    inner: Box::new(AttributeType::Struct {
+                        name: "DomainValidation".to_string(),
+                        fields: vec![
+                            StructField::new("domain_name", AttributeType::String),
+                            StructField::new(
+                                "resource_record",
+                                AttributeType::Struct {
+                                    name: "ResourceRecord".to_string(),
+                                    fields: vec![
+                                        StructField::new("name", AttributeType::String),
+                                        StructField::new("value", AttributeType::String),
+                                    ],
+                                },
+                            ),
+                        ],
+                    }),
+                    ordered: true,
+                },
+            )],
+        ),
+    );
+    schemas.insert(
+        "aws",
+        make_schema("route53.RecordSet", vec![("name", AttributeType::String)]),
+    );
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
+
+    // User wrote `cert.domain_validation_options[0].resource_record_name`
+    // — the old flat spelling that the nested-shape migration replaced
+    // with `[0].resource_record.name`.
+    let path = AccessPath::with_segments(
+        "cert",
+        "domain_validation_options",
+        vec![
+            PathSegment::Subscript {
+                index: Subscript::Int { index: 0 },
+            },
+            PathSegment::Field {
+                name: "resource_record_name".to_string(),
+            },
+        ],
+    );
+    let record = Resource::with_provider("aws", "route53.RecordSet", "validation", None)
+        .with_attribute(
+            "name",
+            Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
+        );
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.resources.push(record); // allow: direct — fixture test inspection
+    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    assert!(
+        err.contains("resource_record_name"),
+        "error must name the unknown field, got: {err}",
+    );
+    // Struct name must appear (not a fuzzy "the word 'struct'" match —
+    // the diagnostic commits to naming the enclosing struct so the
+    // user knows where to look).
+    assert!(
+        err.contains("DomainValidation"),
+        "error must identify the enclosing struct, got: {err}",
+    );
+    // Sibling fields must be enumerated so the user can discover the
+    // new spelling (`resource_record.name`) even when `suggest_similar_name`'s
+    // Levenshtein threshold (3 for a 20-char identifier) doesn't fire
+    // on this specific typo distance. The `known fields:` prefix pins
+    // the list, not the path — the path also contains `resource_record`
+    // and would otherwise produce a trivially-satisfied assertion.
+    assert!(
+        err.contains("known fields:"),
+        "error must enumerate known fields, got: {err}"
+    );
+    let known_section = err.split("known fields:").nth(1).unwrap_or("");
+    assert!(
+        known_section.contains("resource_record"),
+        "known fields list must include the renamed field, got: {err}",
+    );
+    assert!(
+        known_section.contains("domain_name"),
+        "known fields list must enumerate all siblings, got: {err}",
+    );
+}


### PR DESCRIPTION
## Summary

Closes #3041.

The user-reported symptom was `carina apply` failing with `attribute X references Y which has not been published yet by the upstream resource. Add a 'wait' block on the upstream binding...` — but `wait` could never have helped, because the referenced attribute did not exist on the schema at all.

**Root cause** (from a careful read of the failing CI log + `infra/usecases/registry/acm.crn` + the post-aws#295 generated schema): the user's `.crn` used the legacy flat field name `domain_validation_options[0].resource_record_name`, while the schema had migrated to a nested shape `domain_validation_options[0].resource_record.name`. The type checker's `narrow_attribute_type` helper silently returned `None` on an unknown struct field, the caller swallowed it, and the failure surfaced at apply time with the wrong-direction error message.

**Fix**: convert `narrow_attribute_type` from `Option<&AttributeType>` to `Result<&AttributeType, NarrowError>` with two variants:

- `NarrowError::UnknownStructField { field, struct_name, known_fields }` — a real typo; the caller renders an actionable diagnostic with a "did you mean" suggestion and the full list of sibling fields. This is what carina#3041 was missing.
- `NarrowError::ShapeMismatch` — caller still treats this as silent (resolver-time evaluation catches it with full location context). No behavioral change for the existing path.

The runtime apply-time message at `executor/basic.rs::assert_fully_resolved` is **intentionally unchanged**. Post-fix, it only fires for paths the type checker has already deemed structurally valid — in which case "Add a `wait` block" is the correct advice (genuinely unpublished post-create attribute). The misleading reading was a side effect of the typo slipping past validate, which this PR fixes upstream.

## What the user will now see

For `cert.domain_validation_options[0].resource_record_name` against today's schema, `carina validate` (and `plan` / `apply`) produces:

```
aws.route53.RecordSet.validation: unknown field 'resource_record_name' on struct 'DomainValidation' in reference cert.domain_validation_options[0].resource_record_name; known fields: domain_name, http_redirect, resource_record, validation_domain, validation_emails, validation_method, validation_status.
```

The suggestion (`Did you mean 'X'?`) renders when `suggest_similar_name`'s Levenshtein threshold fires; for the headline typo (`resource_record_name` → `resource_record`, distance 5, threshold 3) it does not, but the enumerated `known fields:` list still surfaces the renamed field by name.

## Test plan

- [x] `cargo nextest run --workspace` — 3316 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all pass
- [x] One new regression test (`ref_with_chained_field_on_struct_flags_unknown_field`) covers the exact failure shape from the issue (post-aws#295 nested schema, legacy `resource_record_name` reference). Confirmed to fail without the fix.
- [ ] Real-infra: `carina-rs/infra/usecases/registry/acm.crn` still uses the legacy flat names; user-driven migration to `cert.domain_validation_options[0].resource_record.name` will produce a green `carina validate` once this lands.

## Follow-ups (separate issues — see comments)

- Wire `validate_resource_ref_types` into the LSP diagnostic path so the same typo lights up in-editor. This is a pre-existing structural gap — only `validate_export_param_ref_types` is routed into the LSP today; the same gap applies to `validate_resource_ref_types` and `validate_attribute_param_ref_types`.
- Apply the same diagnostic uplift to `narrow_type_expr`, the sibling helper used by `upstream_exports.rs` and `validation::inference`.
- Type-safety polish (low priority): borrow `&'a str` instead of cloning `String` in `NarrowError::UnknownStructField`, and consider splitting `NarrowError` into a `Result<Result<T, UnknownStructField>, ShapeMismatch>` shape so the "real typo vs. shape carve-out" distinction is encoded at the type level.
- Truly type-safe direction (large): make the parser schema-aware so a `PathSegment::Field { name }` referencing a non-existent struct field is unrepresentable. Out of scope here; would require restructuring the parse-then-validate pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
