### PR TITLE
fmt: dispatch WaitExpr so wait blocks round-trip (closes #3049)

### DIFF
--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -214,6 +214,7 @@ impl Formatter {
             NodeKind::FunctionCall => self.format_function_call(node),
             NodeKind::VariableRef => self.format_variable_ref(node),
             NodeKind::SubscriptedId => self.format_subscripted_id(node),
+            NodeKind::WaitExpr => self.format_wait_expr(node),
             NodeKind::List => self.format_list(node),
             NodeKind::Map => self.format_map(node),
             NodeKind::MapEntry => self.format_map_entry(node),
@@ -2231,5 +2232,83 @@ aws.s3.Bucket {
         let first = format(input, &config).unwrap();
         let second = format(&first, &config).unwrap();
         assert_eq!(first, second, "depends_on sort must be idempotent");
+    }
+
+    // carina#3049 — `wait <target> { ... }` had no `format_node` arm, so
+    // it fell through to `format_default`. That handler skips Trivia and
+    // joins tokens with no whitespace, producing unparseable output like
+    // `waitcert{until=...issueddepends_on=[...]timeout=75min}`.
+    #[test]
+    fn issue_3049_wait_block_is_idempotent_and_parseable() {
+        let input = "let cert_issued = wait cert {\n  until      = cert.status == aws.acm.Certificate.Status.Issued\n  depends_on = [validation_record]\n  timeout    = 75min\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+
+        assert!(
+            result.contains("let cert_issued = wait cert {"),
+            "header must preserve spaces between wait/target/brace, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("until"),
+            "until attribute must be preserved, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("depends_on = [validation_record]"),
+            "depends_on attribute must keep `=` and brackets, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("timeout"),
+            "timeout attribute must be preserved, got:\n{}",
+            result
+        );
+        // The corruption signature from the issue: collapsed identifiers.
+        assert!(
+            !result.contains("waitcert"),
+            "wait/target must not be collapsed, got:\n{}",
+            result
+        );
+        assert!(
+            !result.contains("issueddepends_on"),
+            "attribute boundary must not be collapsed, got:\n{}",
+            result
+        );
+
+        let second = format(&result, &config).unwrap();
+        assert_eq!(result, second, "wait-block formatting must be idempotent");
+    }
+
+    #[test]
+    fn issue_3049_wait_block_collapses_unformatted_source() {
+        // Unformatted single-line source must produce the canonical
+        // multi-line shape, with proper spacing in the header and around
+        // every `=`.
+        let input = "let cert_issued=wait cert{until=cert.status == aws.acm.Certificate.Status.Issued\ndepends_on=[validation_record]\ntimeout=75min}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+
+        assert!(
+            result.contains("let cert_issued = wait cert {"),
+            "header should be canonical, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("  until      = cert.status == aws.acm.Certificate.Status.Issued")
+                || result.contains("  until = cert.status == aws.acm.Certificate.Status.Issued"),
+            "until attribute should be indented and aligned, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("  depends_on = [validation_record]"),
+            "depends_on attribute should be indented, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("  timeout") && result.contains("= 75min"),
+            "timeout attribute should be indented, got:\n{}",
+            result
+        );
     }
 }

--- a/carina-core/src/formatter/rules/expressions.rs
+++ b/carina-core/src/formatter/rules/expressions.rs
@@ -314,4 +314,163 @@ impl Formatter {
         }
         self.write("]");
     }
+
+    /// `wait <target> { until = ..., depends_on = [...], timeout = ... }`.
+    ///
+    /// carina#3049: without this handler the node fell through to
+    /// `format_default`, which strips trivia and concatenates tokens —
+    /// producing `waitcert{until=...}` and silently corrupting source.
+    /// Shape mirrors `format_for_expr`: keyword + target on one line,
+    /// each attribute on its own indented line, closing brace at the
+    /// caller's current indent.
+    pub(in crate::formatter) fn format_wait_expr(&mut self, node: &CstNode) {
+        self.write("wait");
+
+        let attrs: Vec<&CstNode> = node
+            .children
+            .iter()
+            .filter_map(|child| match child {
+                CstChild::Node(n) if n.kind == NodeKind::WaitAttr => Some(n),
+                _ => None,
+            })
+            .collect();
+
+        let max_key_len = if self.config.align_attributes {
+            attrs
+                .iter()
+                .filter_map(|n| Self::wait_attr_key(n))
+                .map(|k| k.len())
+                .max()
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        let mut wrote_target = false;
+        let mut wrote_open_brace = false;
+
+        for child in &node.children {
+            match child {
+                CstChild::Token(token) => {
+                    if token.text == "wait" {
+                        continue;
+                    }
+                    if token.text == "{" {
+                        self.write(" {");
+                        self.write_newline();
+                        self.current_indent += 1;
+                        wrote_open_brace = true;
+                        continue;
+                    }
+                    if token.text == "}" {
+                        self.current_indent -= 1;
+                        self.write_indent();
+                        self.write("}");
+                        continue;
+                    }
+                    if !wrote_target && self.is_identifier(&token.text) {
+                        self.write(" ");
+                        self.write_token(&token.text);
+                        wrote_target = true;
+                    }
+                }
+                CstChild::Node(n) if n.kind == NodeKind::WaitAttr => {
+                    if !wrote_open_brace {
+                        continue;
+                    }
+                    self.format_wait_attr(n, max_key_len);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn wait_attr_key(node: &CstNode) -> Option<&'static str> {
+        for child in &node.children {
+            if let CstChild::Node(n) = child {
+                return match n.kind {
+                    NodeKind::WaitUntilAttr => Some("until"),
+                    NodeKind::WaitTimeoutAttr => Some("timeout"),
+                    NodeKind::WaitDependsOnAttr => Some("depends_on"),
+                    _ => None,
+                };
+            }
+        }
+        None
+    }
+
+    fn format_wait_attr(&mut self, node: &CstNode, align_to: usize) {
+        for child in &node.children {
+            if let CstChild::Node(n) = child {
+                match n.kind {
+                    NodeKind::WaitUntilAttr => self.format_wait_kv_attr(n, "until", align_to),
+                    NodeKind::WaitTimeoutAttr => self.format_wait_kv_attr(n, "timeout", align_to),
+                    NodeKind::WaitDependsOnAttr => {
+                        self.format_wait_depends_on_attr(n, align_to);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn format_wait_kv_attr(&mut self, node: &CstNode, key: &str, align_to: usize) {
+        self.write_indent();
+        self.write(key);
+        self.write_alignment_padding(key.len(), align_to);
+        self.write(" = ");
+
+        // The grammar guarantees exactly one RHS — either a duration
+        // literal (timeout, emitted as a Token) or a validate_expr (until,
+        // emitted as a Node). Iterate over both shapes.
+        for child in &node.children {
+            match child {
+                CstChild::Token(token) => {
+                    if token.text == key || token.text == "=" {
+                        continue;
+                    }
+                    self.write_token(&token.text);
+                }
+                CstChild::Node(n) => {
+                    self.format_node(n);
+                }
+                CstChild::Trivia(_) => {}
+            }
+        }
+        self.write_newline();
+    }
+
+    fn format_wait_depends_on_attr(&mut self, node: &CstNode, align_to: usize) {
+        self.write_indent();
+        let key = "depends_on";
+        self.write(key);
+        self.write_alignment_padding(key.len(), align_to);
+        self.write(" = [");
+
+        let mut first = true;
+        for child in &node.children {
+            if let CstChild::Token(token) = child {
+                match token.text.as_str() {
+                    "depends_on" | "=" | "[" | "]" | "," => continue,
+                    s if self.is_identifier(s) => {
+                        if !first {
+                            self.write(", ");
+                        }
+                        self.write_token(s);
+                        first = false;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        self.write("]");
+        self.write_newline();
+    }
+
+    fn write_alignment_padding(&mut self, key_len: usize, align_to: usize) {
+        if align_to > 0 && key_len < align_to {
+            let padding = align_to - key_len;
+            self.write(&" ".repeat(padding));
+        }
+    }
 }

--- a/carina-core/tests/fixtures/fmt_smoke/wait-cert-issued/main.crn
+++ b/carina-core/tests/fixtures/fmt_smoke/wait-cert-issued/main.crn
@@ -1,0 +1,12 @@
+let cert = aws.acm.Certificate {
+  domain_name       = 'registry.example.com'
+  validation_method = 'DNS'
+}
+
+let validation_record = aws.route53.RecordSet {
+  hosted_zone_id   = 'Z123'
+  name             = '_acme.registry.example.com'
+  type             = 'CNAME'
+  ttl              = 60
+  resource_records = ['validation.example.com']
+}

--- a/carina-core/tests/fixtures/fmt_smoke/wait-cert-issued/wait.crn
+++ b/carina-core/tests/fixtures/fmt_smoke/wait-cert-issued/wait.crn
@@ -1,0 +1,5 @@
+let cert_issued = wait cert {
+  until      = cert.status == aws.acm.Certificate.Status.Issued
+  depends_on = [validation_record]
+  timeout    = 75min
+}

--- a/carina-core/tests/fmt_infra_smoke.rs
+++ b/carina-core/tests/fmt_infra_smoke.rs
@@ -163,6 +163,66 @@ fn fmt_idempotent_on_carina_state_fixture() {
     }
 }
 
+// `wait-cert-issued/` mirrors the directory layout of an ACM-DNS-validation
+// stack (`carina-rs/infra` pattern): `main.crn` declares the cert + DNS
+// record, `wait.crn` declares a `let X = wait <target> { ... }` binding.
+//
+// carina#3049: before this fix, `format_node` had no arm for `WaitExpr`,
+// so the node fell through to `format_default` — which strips trivia
+// and concatenates tokens, producing `waitcert{until=...}timeout=75min}`
+// (unparseable). The pre-commit hook in `carina-rs/infra` then silently
+// corrupted the file. This fixture guards the directory-scoped shape.
+#[test]
+fn fmt_accepts_wait_cert_issued_fixture() {
+    let dir = fixture_dir("wait-cert-issued");
+    let result = format_all_crn_files(&dir);
+    assert!(
+        result.is_ok(),
+        "`carina fmt` must parse every .crn file in {}. Failures:\n{}",
+        dir.display(),
+        result.unwrap_err()
+    );
+}
+
+#[test]
+fn fmt_idempotent_on_wait_cert_issued_fixture() {
+    let dir = fixture_dir("wait-cert-issued");
+    let config = FormatConfig::default();
+    let entries = fs::read_dir(&dir).expect("read_dir");
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "crn") {
+            let source = fs::read_to_string(&path).expect("read file");
+            let first = format(&source, &config)
+                .unwrap_or_else(|e| panic!("{}: format failed: {}", path.display(), e));
+            let second = format(&first, &config)
+                .unwrap_or_else(|e| panic!("{}: second format failed: {}", path.display(), e));
+            assert_eq!(
+                first,
+                second,
+                "format must be idempotent on {}",
+                path.display()
+            );
+        }
+    }
+}
+
+// Fixture must already be in canonical fmt — any drift here means the
+// formatter's wait-block emitter changed shape and a reviewer should see
+// the snapshot move explicitly.
+#[test]
+fn fmt_wait_cert_issued_fixture_is_canonical() {
+    let dir = fixture_dir("wait-cert-issued");
+    let config = FormatConfig::default();
+    let path = dir.join("wait.crn");
+    let source = fs::read_to_string(&path).expect("read wait.crn");
+    let formatted = format(&source, &config).expect("format must succeed");
+    assert_eq!(
+        source, formatted,
+        "wait-block fixture has drifted from canonical fmt — re-format and update the fixture"
+    );
+}
+
 #[test]
 fn fmt_preserves_comments_in_carina_state_fixture() {
     let dir = fixture_dir("carina-state");


### PR DESCRIPTION
## Summary

`format_node` had no arm for `NodeKind::WaitExpr`, so the node fell through to `format_default` — which drops every `Trivia` and concatenates the remaining tokens with no separators.

Reproducer from #3049:

```crn
let cert_issued = wait cert {
  until      = cert.status == aws.acm.Certificate.Status.Issued
  depends_on = [validation_record]
  timeout    = 75min
}
```

became

```crn
let cert_issued = waitcert{until=cert.status == ...issueddepends_on=[validation_record]timeout=75min}
```

silently — `carina-rs/infra`'s pre-commit hook ran `carina fmt` and landed the corruption in PR #58 / commit `c6d9c9a`.

This is the same shape as #3030 (chained access fmt lagging parser): the wait grammar landed in #2825 / #2968 but the formatter dispatch was not updated alongside.

## Fix

- Add `format_wait_expr` (plus three `wait_*_attr` handlers) in `rules/expressions.rs`, shaped after `format_for_expr` / `format_if_expr`: keyword + target on the header line, each attribute on its own indented line with aligned `=` columns.
- Dispatch `NodeKind::WaitExpr` from `format.rs:format_node`.

## Test plan

- [x] `carina-core` unit tests `issue_3049_wait_block_is_idempotent_and_parseable` and `issue_3049_wait_block_collapses_unformatted_source` cover the corruption signatures from the issue.
- [x] `wait-cert-issued/` directory fixture under `fmt_smoke/` + three `fmt_infra_smoke` tests (accept, idempotent, canonical), per the "Directory-scoped, never single-file" rule in CLAUDE.md.
- [x] Manual: `cargo run --bin carina -- fmt /tmp/wait_dir` over the unformatted reproducer produces canonical output and `carina validate` accepts the round-trip.
- [x] `cargo nextest run --workspace` — 3319 passed, 74 skipped.
- [x] `cargo test --workspace --doc` — passing.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `scripts/check-*.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
