### PR TITLE
parser: extend namespaced_id tail to accept dotted-numeric identifiers

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -236,7 +236,13 @@ attribute = { (identifier | string) ~ trivia* ~ equals ~ trivia* ~ expression }
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Namespaced identifier: aws.s3_bucket, aws.Region.ap_northeast_1, Type.ipsec.1
-namespaced_id = @{ identifier ~ ("." ~ (identifier | ASCII_DIGIT+))+ }
+// Trailing segments accept `identifier`, or `numeric_tail` (digit-led with
+// optional alphanumerics/underscores) for date-like enum values such as
+// `aws.iam.PolicyDocument.Version.2012_10_17` (carina#3051). Mirrors the
+// main parser's `namespaced_id` for round-trip parity.
+namespaced_id = @{ identifier ~ ("." ~ (identifier | numeric_tail))+ }
+// Silent rule (`_{...}`): not surfaced as a `Rule` variant.
+numeric_tail = _{ ASCII_DIGIT ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Namespaced identifier with a trailing chain of `[index]` /
 // `.field` continuations: `orgs.accounts[0]`,

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -382,6 +382,12 @@ impl<'a> CstBuilder<'a> {
             // `use_keyword` is a negative-predicate helper used inside
             // `module_call`; it never produces a child node here.
             Rule::use_keyword => None,
+
+            // `numeric_tail` is a silent rule (`_{...}`) used inside the
+            // atomic `namespaced_id`. Pest still generates the `Rule` variant
+            // but suppresses its output, so this arm should be unreachable
+            // in practice. Exists only so the exhaustive match compiles.
+            Rule::numeric_tail => None,
         }
     }
 

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -220,8 +220,19 @@ nested_block = { identifier ~ "{" ~ block_content* ~ "}" }
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Namespaced identifier: aws.s3_bucket, aws.Region.ap_northeast_1
-// Segments after the first dot can also be digit-only (e.g., "Type.ipsec.1")
-namespaced_id = @{ identifier ~ ("." ~ (identifier | ASCII_DIGIT+))+ }
+//
+// Trailing segments accept three shapes:
+//   - identifier (alpha-led): "Region", "ap_northeast_1", "ipsec_1"
+//   - numeric_tail (digit-led with optional alphanumerics/underscores):
+//     "1", "2012", "2012_10_17", "v1" — used for date-like enum values
+//     such as `aws.iam.PolicyDocument.Version.2012_10_17` (carina#3051).
+//     Subsumes the previous `ASCII_DIGIT+`-only shape (`Type.ipsec.1`).
+namespaced_id = @{ identifier ~ ("." ~ (identifier | numeric_tail))+ }
+// Silent rule (`_{...}`): not surfaced as a `Rule` variant, so the
+// formatter's exhaustive dispatch does not need a counterpart. The
+// containing `namespaced_id` is atomic, so the tail text is captured
+// verbatim by the parent rule anyway.
+numeric_tail = _{ ASCII_DIGIT ~ (ASCII_ALPHANUMERIC | "_")* }
 
 // Namespaced identifier followed by one or more `[index]` subscripts
 // and/or `.field` continuations: `orgs.accounts[0]`,

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -460,6 +460,55 @@ fn namespaced_id_with_digit_segment() {
 }
 
 #[test]
+fn namespaced_id_with_numeric_tail() {
+    // Digit-led tails with underscores (e.g. `2012_10_17`) parse as the
+    // trailing segment of a namespaced enum value — the shape needed for
+    // IAM policy version identifiers (`aws.iam.PolicyDocument.Version.2012_10_17`,
+    // carina#3051). Subsumes the previous `ASCII_DIGIT+`-only rule.
+    let input = r#"
+        let role = aws.iam.Role {
+            assume_role_policy_document = {
+                version = aws.iam.PolicyDocument.Version.2012_10_17
+            }
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    let policy = result.resources[0]
+        .get_attr("assume_role_policy_document")
+        .expect("policy doc attr");
+    let Value::Concrete(ConcreteValue::Map(map)) = policy else {
+        panic!("expected map, got {:?}", policy);
+    };
+    assert_eq!(
+        map.get("version"),
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
+        )))
+    );
+}
+
+#[test]
+fn namespaced_id_numeric_tail_preserves_pure_digits() {
+    // The new `numeric_tail` rule must not regress the prior `ASCII_DIGIT+`
+    // behavior. Pure-digit tails (e.g. `.1`) still parse and surface as
+    // `EnumIdentifier` exactly as before.
+    let input = r#"
+        let gw = awscc.ec2.vpn_gateway {
+            kind = Type.1
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(
+        result.resources[0].get_attr("kind"),
+        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            "Type.1".to_string()
+        )))
+    );
+}
+
+#[test]
 fn parse_nested_blocks_terraform_style() {
     let input = r#"
         let web_sg = aws.security_group {

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -1036,6 +1036,38 @@ mod tests {
             )
             .is_ok()
         );
+        // 5-part with digit-led tail (`2012_10_17`) — used for IAM policy
+        // version identifiers (carina#3051). TypeName at index 3 is preserved.
+        assert!(
+            validate_enum_namespace(
+                "aws.iam.PolicyDocument.Version.2012_10_17",
+                "Version",
+                "aws.iam.PolicyDocument"
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_namespaced_id_parse_numeric_tail() {
+        // Digit-led tail with underscores parses through the 5-part shape
+        // and flows into `value` verbatim (carina#3051).
+        let id =
+            NamespacedId::parse("aws.iam.PolicyDocument.Version.2012_10_17").expect("should parse");
+        match id {
+            NamespacedId::FullyQualified {
+                provider,
+                segments_str,
+                type_name,
+                value,
+            } => {
+                assert_eq!(provider, "aws");
+                assert_eq!(segments_str, "iam.PolicyDocument");
+                assert_eq!(type_name, "Version");
+                assert_eq!(value, "2012_10_17");
+            }
+            other => panic!("expected FullyQualified, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Today's `namespaced_id` rule (`carina-core/src/parser/carina.pest`) allows trailing segments that are either alpha-led identifiers (`Region`, `ipsec_1`) or pure digit runs (`Type.ipsec.1`). Date-like enum values such as IAM policy versions (`2012-10-17`, `2008-10-17`) get rewritten to `2012_10_17` / `2008_10_17` under the existing snake_case alias convention — but those bare forms do not parse because they are digit-led with underscores.

Add a `numeric_tail` alternative to the tail-segment rule:

```pest
numeric_tail = _{ ASCII_DIGIT ~ (ASCII_ALPHANUMERIC | "_")* }
```

Subsumes the prior `ASCII_DIGIT+` shape (`Type.ipsec.1` still parses) and additionally accepts digit-led identifiers with underscores or trailing alphanumerics, enabling `aws.iam.PolicyDocument.Version.2012_10_17` etc. Declared silent (`_{...}`) so its content is captured verbatim by the atomic `namespaced_id` parent — downstream consumers (`NamespacedId::parse`, the formatter CST builder) see no new structure.

Closes #3051.

## Unblocks

`carina-rs/carina-provider-aws#303` (version half of `iam_policy_effect` / `iam_policy_version` Custom → StringEnum). The effect half shipped at `carina-provider-aws#309`; the version half waited on this parser change.

## Test plan

- [x] `cargo nextest run` (3325 tests pass)
- [x] `cargo test --workspace --doc` (all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check-docs-use-new-spellings.sh` / `check-example-warnings.sh` / `check-no-direct-resources-access.sh` / `check-plan-fixtures.sh` / `check-provider-boundaries.sh`
- [x] `tmlanguage_keyword_parity` test passes (TextMate grammar unaffected)
- [x] `pest_grammar_parity::every_main_rule_has_a_formatter_counterpart` passes — `numeric_tail` added to both grammars symmetrically and the formatter dispatch closes the `Rule::numeric_tail` arm with a `None` (silent rule, never produces output at runtime; arm exists only for exhaustiveness).
- [x] New tests:
  - `parser::tests::namespaced_id_with_numeric_tail` — IAM policy `version = aws.iam.PolicyDocument.Version.2012_10_17` end-to-end.
  - `parser::tests::namespaced_id_numeric_tail_preserves_pure_digits` — regression guard for the prior `ASCII_DIGIT+` shape (`Type.1`).
  - `utils::tests::test_namespaced_id_parse_numeric_tail` — `NamespacedId::parse` 5-part FullyQualified shape with digit-led tail.
  - `utils::tests::test_validate_namespace_5_part_valid` extended for the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)