### PR TITLE
docs: semantic_name redesign design (discussion)

### DIFF
--- a/notes/specs/2026-05-16-semantic-name-redesign-design.md
+++ b/notes/specs/2026-05-16-semantic-name-redesign-design.md
@@ -1,15 +1,17 @@
 # Semantic Name Redesign — Design
 
-Status: **Direction + boundary + cross-cutting policy decided; ONE
-open question (E) needs user input.** Structured type-identity keyed on
-`provider + service/resource + kind`; generic/anonymous boundary is
-per-axis emptiness (no new flag); generic ARN is `aws.Arn`
-(AWS-scoped). The string round-trip is killed at all three boundaries
-(WIT contract / `ExpectedEnumVariant` / `type_name()` API) in one
-effort, not partially. **Open: E — whether the dotted identifier is
-also *input* (grammar change) or *display-only*.** Mechanism details
-(struct shape, WIT wire encoding, projection) deferred to
-implementation.
+Status: **All policy decided — no open questions.** Structured
+type-identity keyed on `provider + service/resource + kind`;
+generic/anonymous boundary is per-axis emptiness (no new flag); generic
+ARN is `aws.Arn` (AWS-scoped). The dotted identifier is **input
+syntax** (E-1) and rides the **existing** `TypeExpr::SchemaType`
+mechanism — no grammar change. The string round-trip is killed at all
+boundaries (WIT contract / `ExpectedEnumVariant` / `Custom.namespace` /
+`type_name()` API) in one effort by collapsing the **four** existing
+provider-axis representations onto one shared axis-struct, with a
+single owner for identity + `is_schema_type` resolution + projection.
+Only mechanism (struct shape, WIT wire encoding, registry concrete
+form) is left to the implementation phase.
 Date: 2026-05-16
 
 <!-- constrained-by ./2026-05-12-strict-enum-identifier-design.md -->
@@ -237,26 +239,55 @@ decision, not a mechanism detail. Safety valve: the mock provider does
 **not** implement `validate-custom-type`, so `carina-plugin-host`
 tests are insulated; blast radius is the aws/awscc plugins only.
 
-### B/F. Unify the three existing provider-axis representations
+### B/F/E. Unify the FOUR existing provider-axis representations
 
-The provider/service axis is **already** represented three times, all
-string-encoded:
+The provider/service axis is **already** represented four times. The
+fourth one resolves E.
 
+- `semantic_name: String` — flat, schema side (the headline target).
 - `ExpectedEnumVariant { provider: Option<String>, segments:
   Vec<String>, type_name: String }` (`schema/mod.rs`) — nearly the
   exact target shape, plus enum-only `value`/`is_alias`, and a
-  `Display` that already does struct→dotted projection.
+  `Display` that already does struct→dotted projection. Its
+  `from_namespaced` recovers axes via `split('.')`.
 - `Custom { namespace: Option<String> }` — e.g. `"aws.vpc"`, a
   provider+service string used for enum-shorthand resolution.
-- the flat `semantic_name` itself.
+- **`TypeExpr::SchemaType { provider, path, type_name }`**
+  (`parser/ast.rs:111`) — the **input-side** representation. Users
+  **already** write `fn f(x: awscc.ec2.VpcId)`; `parser/types.rs:142`
+  parses the dotted annotation and, when the tail is PascalCase and
+  `config.is_schema_type(provider, path, type_name)` is true, produces
+  `SchemaType`, else falls back to `Ref` (resource-type reference).
 
-**Policy: extract the axis structure
-(`provider` + `segments` + `type_name`) as one shared identity base.**
-`ExpectedEnumVariant` becomes that base plus `value`/`is_alias`;
-`Custom.namespace` folds into the same structure. Do **not** introduce
-a fourth, parallel struct — that re-creates the dispersion this
-redesign exists to remove. `from_namespaced`'s `split('.')` is
-replaced by carrying the structure directly.
+**E is resolved by this, not open.** E-1 ("dotted name is also input
+syntax") needs **no grammar extension** — the `SchemaType` atom and
+its `Ref`-vs-`SchemaType` disambiguation already exist. An earlier
+draft's claim that `type_simple` is a dotless identifier and a grammar
+change is required was **wrong** (it overlooked `type_ref` →
+`SchemaType`) and is withdrawn. E-1 is satisfied by riding the
+existing `SchemaType` mechanism.
+
+**Policy: collapse all four onto one shared axis-struct identity.**
+`SchemaType` is the input-syntax face of that identity;
+`semantic_name`'s structured form is the identity itself;
+`ExpectedEnumVariant` is the identity + `value`/`is_alias`;
+`Custom.namespace` carries the same axes. Do **not** add a fifth
+parallel struct. Consequence: the input→identity match
+(`SchemaType` annotation vs the attribute's `semantic_name`), today
+routed through `type_name()` string comparison in `validation/mod.rs`
+(the very anti-pattern D removes), becomes a **structural** comparison
+with no string in the path. `from_namespaced`'s `split('.')` and
+`Custom.namespace`'s string form are replaced by the structure
+directly.
+
+**Ownership: the `is_schema_type(provider, path, type_name)`
+resolver** (`parser/types.rs` disambiguation) and the identity
+registry are the **same owner**. Whatever component owns "is this a
+registered schema type" must also own identity comparison and the
+struct→dotted projection — one owner for the axis-struct, not the
+current split between parser context and schema. This is a
+*policy* (single ownership) decision; the registry's concrete form is
+mechanism.
 
 ### D. `type_name()` becomes display-only
 
@@ -275,29 +306,18 @@ restructure needs **no state migration** and breaks no existing state
 files. Recorded here so the implementation PR does not invent a
 migration.
 
-## Open question requiring user input
+### E. Dotted identifier is input syntax — RESOLVED (rides existing `SchemaType`)
 
-### E. Is the dotted identifier *input* syntax, or *display-only*?
-
-The grammar (`parser/carina.pest:124`) defines the type-annotation
-atom as `type_simple = @{ identifier }` — a **single identifier, no
-dots**. `type_ref = resource_type_path` (`identifier(.identifier)+`)
-*is* dotted but is reserved for **resource-type references**. So
-"user-facing dotted string" is currently ambiguous on one point this
-doc has not resolved:
-
-- **E-1: input too.** Users may write
-  `fn f(x: aws.iam.Role.Arn)` in a type annotation. Requires extending
-  `type_simple` to accept dots **and** disambiguating it from
-  `type_ref` — this widens the design scope into the grammar/parser.
-- **E-2: display-only.** The dotted form appears only in validate
-  errors / LSP; type annotations keep a non-dotted spelling (or the
-  feature is not annotation-writable at all). No grammar change; but
-  "user-facing surface" then means *output presentation only*.
-
-This changes what "the user-facing surface stays a dotted string"
-means and whether the parser is in scope. **Unresolved — needs a user
-decision before the doc is final.**
+Decided E-1 (user, 2026-05-16): the dotted name is writable in type
+annotations, not display-only. Critically, this needs **no grammar
+extension**: `parser/ast.rs:111` `TypeExpr::SchemaType { provider,
+path, type_name }` and the `parser/types.rs:142` `Ref`-vs-`SchemaType`
+disambiguation (PascalCase tail + `config.is_schema_type(...)`)
+**already implement input-side dotted type annotations**
+(`fn f(x: awscc.ec2.VpcId)` parses today). E-1 is satisfied by
+unifying the new identity with `SchemaType` (see B/F/E above), not by
+touching the grammar. The earlier "grammar change required" framing
+was a mistake and is withdrawn.
 
 ## Remaining mechanism (implementation phase, not policy)
 

--- a/notes/specs/2026-05-16-semantic-name-redesign-design.md
+++ b/notes/specs/2026-05-16-semantic-name-redesign-design.md
@@ -1,0 +1,132 @@
+# Semantic Name Redesign — Design
+
+Status: **Draft / discussion** (naming format intentionally NOT yet decided)
+Date: 2026-05-16
+
+<!-- constrained-by ./2026-05-12-strict-enum-identifier-design.md -->
+
+## Problem
+
+`carina-aws-types` attaches a flat PascalCase `semantic_name` to every
+`AttributeType::Custom` it produces — `IamRoleArn`, `IamPolicyArn`,
+`KmsKeyArn`, `VpcId`, `SubnetId`, … The name conflates two unrelated
+axes into one undifferentiated token:
+
+- **Resource the value points at** — `IamRole`, `Vpc`, `Subnet`.
+- **Kind of reference** — an ARN, an ID, an Effect enum, etc.
+
+There is no namespacing and no relationship to the DSL's existing
+dotted-identifier convention (`aws.iam.Role`, `aws.s3.Bucket`). The
+user's prompting question — *"should these be renamed, e.g.
+`aws.iam.Role.ARN`?"* — is the trigger for this document.
+
+This document records the **facts and constraints** so a naming format
+can be chosen with the trade-offs visible. It does **not** pick a
+format yet (per the decision to defer until the survey is in hand).
+
+## Inventory (as of 2026-05-16)
+
+Both provider repos carry an independent copy of `carina-aws-types`
+(triplicated; see project memory `project_aws_types_triplicated_copies`).
+Counts below are from
+`carina-provider-aws/carina-aws-types/src/lib.rs` and
+`carina-provider-awscc/carina-aws-types/src/lib.rs`.
+
+### ID family (largest group)
+
+`AwsResourceId`, `VpcId`, `SubnetId`, `SecurityGroupId`,
+`InternetGatewayId`, `RouteTableId`, `NatGatewayId`,
+`VpcPeeringConnectionId`, `TransitGatewayId`,
+`VpcCidrBlockAssociationId`, `TgwRouteTableId`, `VpnGatewayId`,
+`EgressOnlyInternetGatewayId`, `VpcEndpointId`, `InstanceId`,
+`NetworkInterfaceId`, `AllocationId`, `PrefixListId`,
+`CarrierGatewayId`, `LocalGatewayId`, `NetworkAclId`,
+`TransitGatewayAttachmentId`, `FlowLogId`, `IpamId`,
+`SubnetRouteTableAssociationId`, `SecurityGroupRuleId`, `IamRoleId`,
+`AwsAccountId`, `KmsKeyId`, `IpamPoolId`, `AvailabilityZoneId`
+(awscc adds `IdentityStoreId`).
+
+### ARN family
+
+`Arn` (generic), `IamRoleArn`, `IamPolicyArn`, `KmsKeyArn`
+(awscc adds `SsoInstanceArn`, `SsoPermissionSetArn`,
+`IamOidcProviderArn`).
+
+### Enum family (awscc only, currently)
+
+`IamPolicyEffect`, `IamPolicyVersion`, plus `SsoPrincipalId` and
+`PolicyConditionValue` (the latter is defined in
+`carina-core/src/value.rs:2975`, not in the aws-types copy).
+
+### Asymmetry note
+
+aws and awscc copies are **not** identical: awscc has 41 semantic
+names, aws has 35; the SSO/Identity-Store and OIDC entries exist only
+in awscc. Any rename must be applied per-repo and reconciled, not
+diffed mechanically.
+
+## The load-bearing constraint: `semantic_name` is a type-identity key
+
+`semantic_name` is **not** a display-only label. It participates in
+type-compatibility checking through a PascalCase ⇄ snake_case
+round-trip:
+
+- `carina-core/src/validation/inference.rs:561-564` —
+  `Custom { semantic_name: Some(name), .. }` →
+  `TypeExpr::Simple(pascal_to_snake(name))`. The DSL annotation arm
+  matches by `pascal_to_snake` equality, so the token **must** survive
+  a `PascalCase → snake_case` projection that lines up with what the
+  user writes in a type annotation.
+- `carina-core/src/parser/util.rs:31` — snake→Pascal conversion is
+  defined so its result *matches* `semantic_name` values.
+- `carina-lsp/src/completion/values.rs:1947,1981-1987` and
+  `top_level.rs:975,994` — LSP carries the PascalCase form as
+  `semantic_name` and assumes single-token PascalCase.
+- `carina-lsp/src/diagnostics/mod.rs:535,552` — diagnostics read
+  `semantic_name` for editor warnings (ARN family branch at
+  `completion/values.rs:608-629`).
+- `carina-core/src/upstream_exports.rs:2094-2151` and
+  `value.rs:2975` — hand-written sites embed literal semantic names
+  (`KmsKeyArn`, `Arn`, `AwsAccountId`, `PolicyConditionValue`); these
+  must move in lockstep.
+
+**Implication:** the format choice is bounded by this pipeline. A flat
+PascalCase token (`IamRoleArn`) round-trips today. A dotted namespaced
+form (`aws.iam.Role.ARN`) does **not** survive `pascal_to_snake`
+unchanged and would require redesigning the projection in
+`inference.rs` / `parser/util.rs` / LSP completion — i.e. it is not a
+rename, it is a type-identity-representation change.
+
+## Naming format options (NOT yet decided)
+
+| Option | Example | Round-trips through current pipeline? | Cost |
+| --- | --- | --- | --- |
+| A. Status quo | `IamRoleArn` | Yes | none |
+| B. PascalCase, lowercase tail | `IamRoleArn` → keep, document convention | Yes | docs only |
+| C. Dotted namespaced, Pascal tail | `aws.iam.Role.Arn` | **No** — needs new projection | redesign inference/parser/LSP + 3-repo sweep |
+| D. Dotted namespaced, upper tail | `aws.iam.Role.ARN` (user's original) | **No** | as C, plus `ARN` all-caps diverges from the existing namespaced-identifier tail convention (`enabled`, lowercase) — see strict-enum-identifier design |
+
+Open sub-questions to resolve before picking:
+
+1. Is the goal **disambiguation** (resource × kind) or **namespace
+   consistency** with DSL identifiers? They imply different formats.
+2. Does the ID family need the same treatment as the ARN family, or
+   only ARNs? (31 ID names vs 4–7 ARN names — scope differs hugely.)
+3. If dotted: who owns the projection that maps the dotted identity to
+   a `TypeExpr`? This is the real design work, not the string.
+
+## Scope / sequencing (per project memory)
+
+- Design doc PR must merge **before** any implementation PR
+  (`feedback_design_before_implementation_in_pr`).
+- 1 PR = 1 topic (`feedback_scope_discipline`); the eventual
+  implementation spans 3 repos (carina + aws + awscc copies) and must
+  be sequenced, not bundled.
+- Real-infra smoke against `carina-rs/infra` is user-driven, not part
+  of this doc.
+
+## Non-goals
+
+- Picking the final format (deferred by explicit instruction).
+- Touching the ID family unless the resolved scope includes it.
+- Any code change in this PR — documentation only.

--- a/notes/specs/2026-05-16-semantic-name-redesign-design.md
+++ b/notes/specs/2026-05-16-semantic-name-redesign-design.md
@@ -101,19 +101,81 @@ rename, it is a type-identity-representation change.
 
 | Option | Example | Round-trips through current pipeline? | Cost |
 | --- | --- | --- | --- |
-| A. Status quo | `IamRoleArn` | Yes | none |
-| B. PascalCase, lowercase tail | `IamRoleArn` → keep, document convention | Yes | docs only |
-| C. Dotted namespaced, Pascal tail | `aws.iam.Role.Arn` | **No** — needs new projection | redesign inference/parser/LSP + 3-repo sweep |
+| A. Status quo | `IamRoleArn` | Yes | **Rejected** — gives neither disambiguation nor namespace consistency |
+| B. PascalCase, lowercase tail | `IamRoleArn` (documented) | Yes | **Rejected** — same reason as A |
+| C. Dotted namespaced, Pascal tail | `aws.iam.Role.Arn` | **No** — needs new projection owner | redesign inference/parser/LSP + 3-repo sweep |
 | D. Dotted namespaced, upper tail | `aws.iam.Role.ARN` (user's original) | **No** | as C, plus `ARN` all-caps diverges from the existing namespaced-identifier tail convention (`enabled`, lowercase) — see strict-enum-identifier design |
 
-Open sub-questions to resolve before picking:
+A and B are struck because the resolved goal requires **both**
+disambiguation and namespace consistency (next section). The live
+choice is between C and D (tail casing), conditional on the projection
+owner being designed explicitly.
 
-1. Is the goal **disambiguation** (resource × kind) or **namespace
-   consistency** with DSL identifiers? They imply different formats.
-2. Does the ID family need the same treatment as the ARN family, or
-   only ARNs? (31 ID names vs 4–7 ARN names — scope differs hugely.)
-3. If dotted: who owns the projection that maps the dotted identity to
-   a `TypeExpr`? This is the real design work, not the string.
+### Resolved direction (user, 2026-05-16)
+
+- **Goal: both.** The format must simultaneously give
+  *disambiguation* (the resource × kind axes must be separately
+  readable in the name) **and** *namespace consistency* with the DSL's
+  existing dotted identifiers (`aws.iam.Role`,
+  `aws.s3.Bucket.VersioningStatus.enabled`). A format that satisfies
+  only one is rejected. This eliminates options A and B (flat
+  PascalCase gives neither cleanly) and points at a dotted,
+  axis-structured form — i.e. the work is in option C/D territory and
+  the projection redesign below is unavoidable, not optional.
+- **Scope: the whole `semantic_name` surface, not just ARNs.** All
+  families — ID (31), ARN (4–7), and the enum-ish entries
+  (`IamPolicyEffect`, `IamPolicyVersion`, `PolicyConditionValue`, …) —
+  across both the aws and awscc copies. The rename is uniform; there
+  is no "ARN-only" partial rollout.
+
+### The real design work: who owns the projection?
+
+"Projection" = the step that converts a schema-side type identity
+(`semantic_name`) into the declaration-side form a user writes in a DSL
+type annotation, so the two can be matched.
+
+Today this projection is trivial and **owned implicitly by
+`pascal_to_snake`**:
+
+```
+schema side                         declaration side (user's DSL)
+Custom { semantic_name:             let x: iam_role_arn = ...
+  "IamRoleArn" }            ←──────────────  ^^^^^^^^^^^^
+        │ pascal_to_snake
+        ▼
+   "iam_role_arn"  ── string-equality compare ──┘
+```
+
+`validation/inference.rs:561-564` maps
+`Custom { semantic_name: Some(name) }` →
+`TypeExpr::Simple(pascal_to_snake(name))`; `parser/util.rs` defines the
+inverse so the strings line up. No component "owns" the type-name
+representation — it is an emergent property of one string transform.
+
+A dotted, axis-structured name (`aws.iam.Role.Arn`) breaks this,
+raising the questions that are the actual design:
+
+1. **What does the user write?** Is the DSL annotation literally
+   `aws.iam.Role.Arn`, or a shorter alias? The dotted form already
+   means *resource reference* (`aws.iam.Role`) and *enum value*
+   (`aws.s3.Bucket.VersioningStatus.enabled`) in the grammar — a third
+   meaning (type name) needs a disambiguation rule the parser can
+   apply.
+2. **Which component resolves it?** The parser
+   (`parser/carina.pest` + `parser/util.rs`), type inference
+   (`inference.rs`), or a *new* explicit type-name registry that owns
+   the mapping rather than leaving it emergent? This is the
+   architectural decision the implementation PR cannot avoid.
+3. **How do LSP completion/diagnostics
+   (`completion/values.rs:1947`, `diagnostics/mod.rs:535`) consume the
+   new identity?** They currently hard-assume single-token PascalCase.
+
+The recommendation of this doc is that the implementation phase must
+**introduce an explicit owner for type-name representation** (a
+registry / dedicated `TypeExpr` variant) rather than extend the
+implicit `pascal_to_snake` round-trip. Renaming the strings without
+this is the failure mode that turns a "rename PR" into an unscoped
+type-system change mid-flight.
 
 ## Scope / sequencing (per project memory)
 
@@ -127,6 +189,8 @@ Open sub-questions to resolve before picking:
 
 ## Non-goals
 
-- Picking the final format (deferred by explicit instruction).
-- Touching the ID family unless the resolved scope includes it.
-- Any code change in this PR — documentation only.
+- Picking the exact tail casing (C vs D) — deferred; the goal and
+  scope are resolved, the string spelling is not.
+- Any code change in this PR — documentation only. Scope is resolved
+  as the **whole `semantic_name` surface** (ID + ARN + enum-ish,
+  aws + awscc); no partial ARN-only rollout.

--- a/notes/specs/2026-05-16-semantic-name-redesign-design.md
+++ b/notes/specs/2026-05-16-semantic-name-redesign-design.md
@@ -1,12 +1,15 @@
 # Semantic Name Redesign — Design
 
-Status: **Direction + boundary principle decided.** Structured
-type-identity keyed on `provider + service/resource + kind`;
-user-facing surface stays a dotted string (`aws.iam.Role.Arn`); the
-generic/anonymous boundary is per-axis emptiness (no new flag), generic
-ARN is `aws.Arn` (AWS-scoped, not provider-agnostic). Only mechanism
-(exact struct shape, WIT wire encoding, projection) is open for the
-implementation phase.
+Status: **Direction + boundary + cross-cutting policy decided; ONE
+open question (E) needs user input.** Structured type-identity keyed on
+`provider + service/resource + kind`; generic/anonymous boundary is
+per-axis emptiness (no new flag); generic ARN is `aws.Arn`
+(AWS-scoped). The string round-trip is killed at all three boundaries
+(WIT contract / `ExpectedEnumVariant` / `type_name()` API) in one
+effort, not partially. **Open: E — whether the dotted identifier is
+also *input* (grammar change) or *display-only*.** Mechanism details
+(struct shape, WIT wire encoding, projection) deferred to
+implementation.
 Date: 2026-05-16
 
 <!-- constrained-by ./2026-05-12-strict-enum-identifier-design.md -->
@@ -201,19 +204,108 @@ yields exactly the required distinctions —
 identity-free. No separate generic/specific flag is introduced; the
 `Some/None` binary is simply generalized per axis.
 
-## Open question for the implementation phase
+## Cross-cutting principle: kill the string round-trip everywhere
 
-The boundary principle above is **decided**. What remains for the
-implementation PR is mechanism, not policy:
+The "collapse a structure into a string, then `split`/`pascal_to_snake`
+it back" anti-pattern this redesign removes is **not localized to
+`semantic_name`**. Code inspection (2026-05-16) found it already
+present in three places:
 
-- Exact struct field shape and the WIT-contract change it implies for
-  the aws/awscc copies.
-- How an empty axis is encoded on the wire (e.g. `Option` per axis vs
-  a sentinel) — must make the base-chain monotone invariant
-  un-violable, not merely conventional.
-- LSP/diagnostics projection from struct → dotted display string.
+1. **WIT boundary** — `validate-custom-type(type-name: string)`
+   (`provider.wit:114`) is called with `pascal_to_snake(type_name)`
+   (`parser/functions.rs:205,350,452`); the plugin re-keys off that
+   string.
+2. **`ExpectedEnumVariant::from_namespaced`** — recovers axes via
+   `ns.split('.')` (`schema/mod.rs:~1762`).
+3. **Internal `type_name()` API** — used for type comparison in 6+
+   `validation/mod.rs` sites, including the double round-trip
+   `pascal_to_snake(&current.type_name())` at `mod.rs:471`.
 
-This doc fixes *policy/direction*; the above is *mechanism*.
+**Principle: structure the identity at all three boundaries in the
+same effort. A partial migration that keeps any one of them
+string-keyed just relocates the anti-pattern** (project memory
+`feedback_root_cause_over_per_site_patch`). The per-boundary policy:
+
+### A. WIT contract — restructure, do not pass a string
+
+`validate-custom-type`'s `type-name: string` parameter must become a
+structured record carrying the identity axes. Passing the dotted
+string and having the aws/awscc plugin `split('.')` it merely exports
+the anti-pattern across the plugin boundary. This is a **breaking WIT
+contract change** (`carina-plugin-wit` + aws + awscc), a policy
+decision, not a mechanism detail. Safety valve: the mock provider does
+**not** implement `validate-custom-type`, so `carina-plugin-host`
+tests are insulated; blast radius is the aws/awscc plugins only.
+
+### B/F. Unify the three existing provider-axis representations
+
+The provider/service axis is **already** represented three times, all
+string-encoded:
+
+- `ExpectedEnumVariant { provider: Option<String>, segments:
+  Vec<String>, type_name: String }` (`schema/mod.rs`) — nearly the
+  exact target shape, plus enum-only `value`/`is_alias`, and a
+  `Display` that already does struct→dotted projection.
+- `Custom { namespace: Option<String> }` — e.g. `"aws.vpc"`, a
+  provider+service string used for enum-shorthand resolution.
+- the flat `semantic_name` itself.
+
+**Policy: extract the axis structure
+(`provider` + `segments` + `type_name`) as one shared identity base.**
+`ExpectedEnumVariant` becomes that base plus `value`/`is_alias`;
+`Custom.namespace` folds into the same structure. Do **not** introduce
+a fourth, parallel struct — that re-creates the dispersion this
+redesign exists to remove. `from_namespaced`'s `split('.')` is
+replaced by carrying the structure directly.
+
+### D. `type_name()` becomes display-only
+
+`type_name() -> String` is consumed for **type comparison** in 6+
+sites; comparison must move to a structure-based predicate
+(`is_same_identity(&TypeIdentity)` or similar). `type_name()` is
+demoted to **display-only**, and using it for comparison becomes a
+documented invariant violation. `accepts_type_name(&str)` takes the
+structured identity or is removed.
+
+### C. State persistence — verified safe, no migration
+
+`carina-state/src/` does **not** persist `semantic_name` / `type_name`
+/ `TypeExpr`. Type identity is not baked into state v3, so the
+restructure needs **no state migration** and breaks no existing state
+files. Recorded here so the implementation PR does not invent a
+migration.
+
+## Open question requiring user input
+
+### E. Is the dotted identifier *input* syntax, or *display-only*?
+
+The grammar (`parser/carina.pest:124`) defines the type-annotation
+atom as `type_simple = @{ identifier }` — a **single identifier, no
+dots**. `type_ref = resource_type_path` (`identifier(.identifier)+`)
+*is* dotted but is reserved for **resource-type references**. So
+"user-facing dotted string" is currently ambiguous on one point this
+doc has not resolved:
+
+- **E-1: input too.** Users may write
+  `fn f(x: aws.iam.Role.Arn)` in a type annotation. Requires extending
+  `type_simple` to accept dots **and** disambiguating it from
+  `type_ref` — this widens the design scope into the grammar/parser.
+- **E-2: display-only.** The dotted form appears only in validate
+  errors / LSP; type annotations keep a non-dotted spelling (or the
+  feature is not annotation-writable at all). No grammar change; but
+  "user-facing surface" then means *output presentation only*.
+
+This changes what "the user-facing surface stays a dotted string"
+means and whether the parser is in scope. **Unresolved — needs a user
+decision before the doc is final.**
+
+## Remaining mechanism (implementation phase, not policy)
+
+- Exact struct field shape and the WIT record layout it implies.
+- How an empty axis is encoded on the wire (`Option` per axis vs
+  sentinel) — must make the base-chain monotone invariant
+  un-violable by construction, not by convention.
+- The struct → dotted display projection implementation.
 
 ## Scope / sequencing (per project memory)
 

--- a/notes/specs/2026-05-16-semantic-name-redesign-design.md
+++ b/notes/specs/2026-05-16-semantic-name-redesign-design.md
@@ -1,6 +1,8 @@
 # Semantic Name Redesign — Design
 
-Status: **Draft / discussion** (naming format intentionally NOT yet decided)
+Status: **Format decided** — Option C (dotted, PascalCase tail:
+`aws.iam.Role.Arn`). Projection-owner design is the open implementation
+question.
 Date: 2026-05-16
 
 <!-- constrained-by ./2026-05-12-strict-enum-identifier-design.md -->
@@ -107,9 +109,15 @@ rename, it is a type-identity-representation change.
 | D. Dotted namespaced, upper tail | `aws.iam.Role.ARN` (user's original) | **No** | as C, plus `ARN` all-caps diverges from the existing namespaced-identifier tail convention (`enabled`, lowercase) — see strict-enum-identifier design |
 
 A and B are struck because the resolved goal requires **both**
-disambiguation and namespace consistency (next section). The live
-choice is between C and D (tail casing), conditional on the projection
-owner being designed explicitly.
+disambiguation and namespace consistency (next section).
+
+**Decided (user, 2026-05-16): Option C — `aws.iam.Role.Arn`.** The
+PascalCase tail (`Arn`, not `ARN`) is chosen because the existing
+namespaced-identifier convention keeps tails in a lower/PascalCase
+register (`enabled`), and an all-caps `ARN` segment visually diverges
+from that convention (see strict-enum-identifier design). The
+acronym-uppercasing question is closed; the remaining open item is
+purely the projection-owner architecture below.
 
 ### Resolved direction (user, 2026-05-16)
 
@@ -189,8 +197,9 @@ type-system change mid-flight.
 
 ## Non-goals
 
-- Picking the exact tail casing (C vs D) — deferred; the goal and
-  scope are resolved, the string spelling is not.
+- Designing the projection-owner architecture in detail (registry vs
+  `TypeExpr` variant vs parser rule) — that is the implementation
+  PR's job; this doc only mandates that an explicit owner exist.
 - Any code change in this PR — documentation only. Scope is resolved
   as the **whole `semantic_name` surface** (ID + ARN + enum-ish,
   aws + awscc); no partial ARN-only rollout.

--- a/notes/specs/2026-05-16-semantic-name-redesign-design.md
+++ b/notes/specs/2026-05-16-semantic-name-redesign-design.md
@@ -1,205 +1,175 @@
 # Semantic Name Redesign — Design
 
-Status: **Format decided** — Option C (dotted, PascalCase tail:
-`aws.iam.Role.Arn`). Projection-owner design is the open implementation
-question.
+Status: **Direction decided** — structured type-identity keyed on
+`provider + service + resource + kind`. User-facing surface stays a
+dotted string (`aws.iam.Role.Arn`). Implementation-architecture detail
+(exact struct shape, WIT contract, generic-type wildcard handling) is
+the open question for the implementation phase.
 Date: 2026-05-16
 
 <!-- constrained-by ./2026-05-12-strict-enum-identifier-design.md -->
 
-## Problem
+> **Revision note.** Earlier drafts of this doc framed the problem as
+> *display-string inconsistency* and proposed renaming the flat
+> PascalCase `semantic_name` to a dotted string. That framing
+> mistook the motivation. The real driver (clarified by the user,
+> 2026-05-16) is **multi-provider type-identity collision**. The
+> display-only analysis and the "Option A–D / projection-owner"
+> sections are superseded by what follows.
 
-`carina-aws-types` attaches a flat PascalCase `semantic_name` to every
-`AttributeType::Custom` it produces — `IamRoleArn`, `IamPolicyArn`,
-`KmsKeyArn`, `VpcId`, `SubnetId`, … The name conflates two unrelated
-axes into one undifferentiated token:
+## Problem (corrected)
 
-- **Resource the value points at** — `IamRole`, `Vpc`, `Subnet`.
-- **Kind of reference** — an ARN, an ID, an Effect enum, etc.
+`carina-aws-types` attaches a flat PascalCase `semantic_name`
+(`Region`, `IamRoleArn`, `VpcId`, …) to every
+`AttributeType::Custom`. That string is **both** the internal
+type-identity key and the user-facing display name. The type-identity
+half is the problem.
 
-There is no namespacing and no relationship to the DSL's existing
-dotted-identifier convention (`aws.iam.Role`, `aws.s3.Bucket`). The
-user's prompting question — *"should these be renamed, e.g.
-`aws.iam.Role.ARN`?"* — is the trigger for this document.
+Type compatibility is decided by `semantic_name` string equality:
+`carina-core/src/schema/mod.rs:1303` — *Custom→Custom with both
+`semantic_name: Some` and names differ ⇒ NG*. The contrapositive is
+the bug: **same `semantic_name` ⇒ treated as the same type.**
 
-This document records the **facts and constraints** so a naming format
-can be chosen with the trade-offs visible. It does **not** pick a
-format yet (per the decision to defer until the survey is in hand).
+Today every provider is AWS, so this is latent. It stops being latent
+the moment a second provider lands. Concrete example (user's): add a
+Google Cloud provider and both define a `region` attribute:
+
+- `aws` region: `"ap-northeast-1"` (hyphen-segmented pattern)
+- `gcp` region: `"asia-northeast1"` (different pattern)
+
+If both carry `semantic_name = "Region"`, the type system declares
+them the **same type**. An `aws` region value would validate as
+acceptable where a `gcp` region is expected, and the pattern checks
+cross-contaminate. `region` is just the first instance; any
+cross-provider concept with a shared noun but a provider-specific
+format (ARNs, resource IDs, account/project identifiers, zones) has
+the same failure.
+
+This is a **type-safety correctness** problem, not a presentation
+problem. The fix must put provider (and service/resource) into the
+type-identity key so that `aws`'s `Region` and `gcp`'s `Region` are
+**distinct types**.
 
 ## Inventory (as of 2026-05-16)
 
 Both provider repos carry an independent copy of `carina-aws-types`
 (triplicated; see project memory `project_aws_types_triplicated_copies`).
-Counts below are from
-`carina-provider-aws/carina-aws-types/src/lib.rs` and
-`carina-provider-awscc/carina-aws-types/src/lib.rs`.
+From `carina-provider-aws/carina-aws-types/src/lib.rs` (35 names) and
+`carina-provider-awscc/carina-aws-types/src/lib.rs` (41 names) — the
+two copies are **asymmetric**, so any change is per-repo and
+reconciled, not mechanically diffed.
 
-### ID family (largest group)
+- **ID family (~31):** `VpcId`, `SubnetId`, `IamRoleId`,
+  `AwsAccountId`, `KmsKeyId`, … (awscc adds `IdentityStoreId`).
+- **ARN family (4–7):** `Arn` (generic), `IamRoleArn`, `IamPolicyArn`,
+  `KmsKeyArn` (awscc adds `SsoInstanceArn`, `SsoPermissionSetArn`,
+  `IamOidcProviderArn`).
+- **enum-ish:** `IamPolicyEffect`, `IamPolicyVersion`,
+  `PolicyConditionValue` (last one in `carina-core/src/value.rs:2975`).
 
-`AwsResourceId`, `VpcId`, `SubnetId`, `SecurityGroupId`,
-`InternetGatewayId`, `RouteTableId`, `NatGatewayId`,
-`VpcPeeringConnectionId`, `TransitGatewayId`,
-`VpcCidrBlockAssociationId`, `TgwRouteTableId`, `VpnGatewayId`,
-`EgressOnlyInternetGatewayId`, `VpcEndpointId`, `InstanceId`,
-`NetworkInterfaceId`, `AllocationId`, `PrefixListId`,
-`CarrierGatewayId`, `LocalGatewayId`, `NetworkAclId`,
-`TransitGatewayAttachmentId`, `FlowLogId`, `IpamId`,
-`SubnetRouteTableAssociationId`, `SecurityGroupRuleId`, `IamRoleId`,
-`AwsAccountId`, `KmsKeyId`, `IpamPoolId`, `AvailabilityZoneId`
-(awscc adds `IdentityStoreId`).
+Scope of the eventual change is the **whole surface** (all families,
+both aws and awscc copies), not an ARN-only or Region-only slice — the
+collision class is general.
 
-### ARN family
+## Where `semantic_name` is load-bearing
 
-`Arn` (generic), `IamRoleArn`, `IamPolicyArn`, `KmsKeyArn`
-(awscc adds `SsoInstanceArn`, `SsoPermissionSetArn`,
-`IamOidcProviderArn`).
+It is consumed in two distinct roles:
 
-### Enum family (awscc only, currently)
+1. **Type-identity key.** `schema/mod.rs:1303` Custom→Custom
+   assignability; `validation/inference.rs:561-564`
+   (`semantic_name → TypeExpr::Simple(pascal_to_snake(name))`);
+   `parser/util.rs:31` defines the inverse so the strings line up.
+2. **User-facing display.** `schema/mod.rs:1306` `type_name()` →
+   `custom_display_name(semantic_name, …)` surfaces it verbatim in
+   validate errors and LSP diagnostics
+   (`carina-lsp/src/diagnostics/mod.rs:535`,
+   `completion/values.rs:608-629`).
 
-`IamPolicyEffect`, `IamPolicyVersion`, plus `SsoPrincipalId` and
-`PolicyConditionValue` (the latter is defined in
-`carina-core/src/value.rs:2975`, not in the aws-types copy).
+The redesign must fix role 1 while keeping role 2's output a clean
+dotted string. **These two are separable** (see Decision).
 
-### Asymmetry note
+## Decision
 
-aws and awscc copies are **not** identical: awscc has 41 semantic
-names, aws has 35; the SSO/Identity-Store and OIDC entries exist only
-in awscc. Any rename must be applied per-repo and reconciled, not
-diffed mechanically.
+### What the user sees: unchanged in shape, dotted string
 
-## The load-bearing constraint: `semantic_name` is a type-identity key
+The display surface is a dotted identifier consistent with the DSL's
+existing namespaced identifiers (`aws.iam.Role`,
+`aws.s3.Bucket.VersioningStatus.enabled`): e.g. `aws.iam.Role.Arn`,
+`aws.Region`, `gcp.Region`. Tail casing is PascalCase (`Arn`, not
+`ARN`) to match the existing namespaced-identifier tail register
+(see strict-enum-identifier design). This satisfies the secondary
+benefits (disambiguation + namespace consistency) for free — but they
+are *consequences*, not the goal. The goal is collision-free identity.
 
-`semantic_name` is **not** a display-only label. It participates in
-type-compatibility checking through a PascalCase ⇄ snake_case
-round-trip:
+### Internal representation: structured, not a string
 
-- `carina-core/src/validation/inference.rs:561-564` —
-  `Custom { semantic_name: Some(name), .. }` →
-  `TypeExpr::Simple(pascal_to_snake(name))`. The DSL annotation arm
-  matches by `pascal_to_snake` equality, so the token **must** survive
-  a `PascalCase → snake_case` projection that lines up with what the
-  user writes in a type annotation.
-- `carina-core/src/parser/util.rs:31` — snake→Pascal conversion is
-  defined so its result *matches* `semantic_name` values.
-- `carina-lsp/src/completion/values.rs:1947,1981-1987` and
-  `top_level.rs:975,994` — LSP carries the PascalCase form as
-  `semantic_name` and assumes single-token PascalCase.
-- `carina-lsp/src/diagnostics/mod.rs:535,552` — diagnostics read
-  `semantic_name` for editor warnings (ARN family branch at
-  `completion/values.rs:608-629`).
-- `carina-core/src/upstream_exports.rs:2094-2151` and
-  `value.rs:2975` — hand-written sites embed literal semantic names
-  (`KmsKeyArn`, `Arn`, `AwsAccountId`, `PolicyConditionValue`); these
-  must move in lockstep.
+`semantic_name: Option<String>` becomes a **structured type identity**
+keyed on `provider + service + resource + kind` (exact field shape is
+implementation-phase work). Identity comparison is field equality;
+the user-facing dotted string is *derived* from the structure via a
+`Display`-style projection. The string is an output, never the source
+of truth, and is never re-parsed to recover the axes.
 
-**Implication:** the format choice is bounded by this pipeline. A flat
-PascalCase token (`IamRoleArn`) round-trips today. A dotted namespaced
-form (`aws.iam.Role.ARN`) does **not** survive `pascal_to_snake`
-unchanged and would require redesigning the projection in
-`inference.rs` / `parser/util.rs` / LSP completion — i.e. it is not a
-rename, it is a type-identity-representation change.
+Identity axis depth (user decision, 2026-05-16):
+**provider + service/resource.** `aws.iam.Role.Arn` and
+`aws.acm.Certificate.Arn` are distinct types; `aws.Region` and
+`gcp.Region` are distinct types.
 
-## Naming format options (NOT yet decided)
+### Why structured over a dotted string (rationale)
 
-| Option | Example | Round-trips through current pipeline? | Cost |
-| --- | --- | --- | --- |
-| A. Status quo | `IamRoleArn` | Yes | **Rejected** — gives neither disambiguation nor namespace consistency |
-| B. PascalCase, lowercase tail | `IamRoleArn` (documented) | Yes | **Rejected** — same reason as A |
-| C. Dotted namespaced, Pascal tail | `aws.iam.Role.Arn` | **No** — needs new projection owner | redesign inference/parser/LSP + 3-repo sweep |
-| D. Dotted namespaced, upper tail | `aws.iam.Role.ARN` (user's original) | **No** | as C, plus `ARN` all-caps diverges from the existing namespaced-identifier tail convention (`enabled`, lowercase) — see strict-enum-identifier design |
+A dotted-string key (`semantic_name = "aws.iam.Role.Arn"`) would also
+make `aws.Region ≠ gcp.Region`, so on the collision requirement alone
+the two are equivalent. The structure wins on long-term type-safety
+grounds (consistent with project memory
+`feedback_type_safety_over_runtime_checks`,
+`feedback_long_term_and_type_safety`, `feedback_strict_typing`):
 
-A and B are struck because the resolved goal requires **both**
-disambiguation and namespace consistency (next section).
+1. **The motivation is type safety itself.** Provider-keyed identity
+   is the requirement. A struct makes "different `provider` ⇒
+   different type" self-evident at the type level; a string defers it
+   to equality semantics that a reader must reconstruct.
+2. **A string re-introduces the exact anti-pattern this redesign
+   removes.** Collapsing axes into `"aws.iam.Role.Arn"` and recovering
+   them with `split('.')` is the same implicit, fragile round-trip as
+   today's `pascal_to_snake`. `split` cannot reject malformed
+   `"aws..Role"`; a struct cannot represent it.
+3. **Extensibility under more providers.** Each new provider (GCP,
+   then Azure, …) is a *data* addition to a named field, not a new
+   "which dotted segment is the provider" convention duplicated across
+   every consumer site.
+4. **Cost is necessary, not waste.** The WIT-contract / aws / awscc
+   blast radius is the price of enforcing the collision boundary in
+   the type system. An earlier draft's "don't change the internal
+   key" conclusion mistook the motivation and is withdrawn.
 
-**Decided (user, 2026-05-16): Option C — `aws.iam.Role.Arn`.** The
-PascalCase tail (`Arn`, not `ARN`) is chosen because the existing
-namespaced-identifier convention keeps tails in a lower/PascalCase
-register (`enabled`), and an all-caps `ARN` segment visually diverges
-from that convention (see strict-enum-identifier design). The
-acronym-uppercasing question is closed; the remaining open item is
-purely the projection-owner architecture below.
+## Open question for the implementation phase
 
-### Resolved direction (user, 2026-05-16)
-
-- **Goal: both.** The format must simultaneously give
-  *disambiguation* (the resource × kind axes must be separately
-  readable in the name) **and** *namespace consistency* with the DSL's
-  existing dotted identifiers (`aws.iam.Role`,
-  `aws.s3.Bucket.VersioningStatus.enabled`). A format that satisfies
-  only one is rejected. This eliminates options A and B (flat
-  PascalCase gives neither cleanly) and points at a dotted,
-  axis-structured form — i.e. the work is in option C/D territory and
-  the projection redesign below is unavoidable, not optional.
-- **Scope: the whole `semantic_name` surface, not just ARNs.** All
-  families — ID (31), ARN (4–7), and the enum-ish entries
-  (`IamPolicyEffect`, `IamPolicyVersion`, `PolicyConditionValue`, …) —
-  across both the aws and awscc copies. The rename is uniform; there
-  is no "ARN-only" partial rollout.
-
-### The real design work: who owns the projection?
-
-"Projection" = the step that converts a schema-side type identity
-(`semantic_name`) into the declaration-side form a user writes in a DSL
-type annotation, so the two can be matched.
-
-Today this projection is trivial and **owned implicitly by
-`pascal_to_snake`**:
-
-```
-schema side                         declaration side (user's DSL)
-Custom { semantic_name:             let x: iam_role_arn = ...
-  "IamRoleArn" }            ←──────────────  ^^^^^^^^^^^^
-        │ pascal_to_snake
-        ▼
-   "iam_role_arn"  ── string-equality compare ──┘
-```
-
-`validation/inference.rs:561-564` maps
-`Custom { semantic_name: Some(name) }` →
-`TypeExpr::Simple(pascal_to_snake(name))`; `parser/util.rs` defines the
-inverse so the strings line up. No component "owns" the type-name
-representation — it is an emergent property of one string transform.
-
-A dotted, axis-structured name (`aws.iam.Role.Arn`) breaks this,
-raising the questions that are the actual design:
-
-1. **What does the user write?** Is the DSL annotation literally
-   `aws.iam.Role.Arn`, or a shorter alias? The dotted form already
-   means *resource reference* (`aws.iam.Role`) and *enum value*
-   (`aws.s3.Bucket.VersioningStatus.enabled`) in the grammar — a third
-   meaning (type name) needs a disambiguation rule the parser can
-   apply.
-2. **Which component resolves it?** The parser
-   (`parser/carina.pest` + `parser/util.rs`), type inference
-   (`inference.rs`), or a *new* explicit type-name registry that owns
-   the mapping rather than leaving it emergent? This is the
-   architectural decision the implementation PR cannot avoid.
-3. **How do LSP completion/diagnostics
-   (`completion/values.rs:1947`, `diagnostics/mod.rs:535`) consume the
-   new identity?** They currently hard-assume single-token PascalCase.
-
-The recommendation of this doc is that the implementation phase must
-**introduce an explicit owner for type-name representation** (a
-registry / dedicated `TypeExpr` variant) rather than extend the
-implicit `pascal_to_snake` round-trip. Renaming the strings without
-this is the failure mode that turns a "rename PR" into an unscoped
-type-system change mid-flight.
+**Generic / provider-agnostic types.** Some Custom types should NOT be
+provider-partitioned: a bare `String`-based wrapper, a truly generic
+`Arn`. Partitioning those by provider would wrongly reject valid
+cross-provider assignment. The struct must express "this identity has
+no provider axis / matches across providers" explicitly — e.g.
+`provider: Option<…>` or an explicit `Generic` variant. A string key
+would face the same question implicitly and worse; the struct makes it
+a first-class, designed decision. Resolving the exact shape (and the
+WIT-contract change it implies for aws/awscc) is the implementation
+PR's job; this doc only fixes the *direction*.
 
 ## Scope / sequencing (per project memory)
 
-- Design doc PR must merge **before** any implementation PR
+- This design doc PR merges **before** any implementation PR
   (`feedback_design_before_implementation_in_pr`).
-- 1 PR = 1 topic (`feedback_scope_discipline`); the eventual
-  implementation spans 3 repos (carina + aws + awscc copies) and must
-  be sequenced, not bundled.
+- Implementation spans 3 repos (carina + aws + awscc copies) plus the
+  WIT contract; sequenced, not bundled (`feedback_scope_discipline`).
+- The aws/awscc `carina-aws-types` copies are asymmetric and must each
+  be migrated and reconciled (`project_aws_types_triplicated_copies`).
 - Real-infra smoke against `carina-rs/infra` is user-driven, not part
   of this doc.
 
 ## Non-goals
 
-- Designing the projection-owner architecture in detail (registry vs
-  `TypeExpr` variant vs parser rule) — that is the implementation
-  PR's job; this doc only mandates that an explicit owner exist.
-- Any code change in this PR — documentation only. Scope is resolved
-  as the **whole `semantic_name` surface** (ID + ARN + enum-ish,
-  aws + awscc); no partial ARN-only rollout.
+- The exact struct field shape / WIT contract / generic-type wildcard
+  mechanism — implementation-phase work; this doc fixes direction only.
+- Any code change in this PR — documentation only.
+- A partial (ARN-only / Region-only) rollout — the collision class is
+  general; scope is the whole `semantic_name` surface.

--- a/notes/specs/2026-05-16-semantic-name-redesign-design.md
+++ b/notes/specs/2026-05-16-semantic-name-redesign-design.md
@@ -1,10 +1,12 @@
 # Semantic Name Redesign — Design
 
-Status: **Direction decided** — structured type-identity keyed on
-`provider + service + resource + kind`. User-facing surface stays a
-dotted string (`aws.iam.Role.Arn`). Implementation-architecture detail
-(exact struct shape, WIT contract, generic-type wildcard handling) is
-the open question for the implementation phase.
+Status: **Direction + boundary principle decided.** Structured
+type-identity keyed on `provider + service/resource + kind`;
+user-facing surface stays a dotted string (`aws.iam.Role.Arn`); the
+generic/anonymous boundary is per-axis emptiness (no new flag), generic
+ARN is `aws.Arn` (AWS-scoped, not provider-agnostic). Only mechanism
+(exact struct shape, WIT wire encoding, projection) is open for the
+implementation phase.
 Date: 2026-05-16
 
 <!-- constrained-by ./2026-05-12-strict-enum-identifier-design.md -->
@@ -142,18 +144,76 @@ grounds (consistent with project memory
    the type system. An earlier draft's "don't change the internal
    key" conclusion mistook the motivation and is withdrawn.
 
+## Boundary principle (the "what is generic" line)
+
+The question "`Region` must be provider-distinct, but a bare `String`
+wrapper must not be" turns out **not** to need a new classification
+flag. The existing type system already encodes the line, and the
+struct generalizes it:
+
+### The line is per-axis emptiness, not a generic/specific flag
+
+`semantic_name: None` already means "no identity — anonymous wrapper"
+(`schema/mod.rs:1303` anonymous-source rule). `Some(name)` means
+"named identity". The struct generalizes this binary into per-axis
+emptiness:
+
+| Type | provider | service/resource | Meaning |
+| --- | --- | --- | --- |
+| bare `String` wrapper | — (none) | — | no identity at all (existing `semantic_name: None`) — unchanged, no new work |
+| generic `Arn` → **`aws.Arn`** | `aws` | empty | AWS-scoped, resource-agnostic base |
+| `aws.Region` | `aws` | empty/Region | provider-distinct from `gcp.Region` |
+| `aws.iam.Role.Arn` | `aws` | iam/Role | fully specified, narrowest |
+
+**Principle: two types are the same type iff every *populated* axis is
+equal. An empty axis means "not distinguished on this axis" — it is
+not a wildcard; it places the type *higher in the base chain* (wider).**
+The truly anonymous wrapper (all axes empty) is exactly today's
+`semantic_name: None` behavior, preserved for free.
+
+### Generic `Arn` is `aws.Arn`, not provider-agnostic (user, 2026-05-16)
+
+The generic `arn()` carries `pattern: ^arn:(aws|aws-cn|aws-us-gov):` —
+it is **AWS-specific**, not provider-neutral. GCP has no ARN concept;
+`gcp.Arn` does not exist. So the generic ARN is **`aws.Arn`**:
+`provider = aws`, service/resource axes empty. Its "generic" quality is
+*resource-agnostic within AWS*, not *provider-agnostic*. This makes the
+base chain provider-axis-monotone:
+
+```
+aws.iam.Role.Arn  →  aws.Arn  →  String
+{aws, iam, Role}     {aws, —}     (no identity)
+provider stays `aws` down the chain, then relaxes to none.
+```
+
+**Base-chain invariant:** descending `base` the provider axis is
+monotone — it never *changes* provider, only stays equal or relaxes to
+empty. Rule 4's recursive `base` check must preserve this; an
+implementation that lets provider flip mid-chain is a bug.
+
+### What rule 3 becomes
+
+Today rule 3 is raw string inequality ⇒ NG. Under the struct it
+becomes: **same type iff all populated identity axes are equal**, which
+yields exactly the required distinctions —
+`aws.iam.Role.Arn ≠ aws.acm.Certificate.Arn` (service/resource differ),
+`aws.Region ≠ gcp.Region` (provider differs), bare wrapper stays
+identity-free. No separate generic/specific flag is introduced; the
+`Some/None` binary is simply generalized per axis.
+
 ## Open question for the implementation phase
 
-**Generic / provider-agnostic types.** Some Custom types should NOT be
-provider-partitioned: a bare `String`-based wrapper, a truly generic
-`Arn`. Partitioning those by provider would wrongly reject valid
-cross-provider assignment. The struct must express "this identity has
-no provider axis / matches across providers" explicitly — e.g.
-`provider: Option<…>` or an explicit `Generic` variant. A string key
-would face the same question implicitly and worse; the struct makes it
-a first-class, designed decision. Resolving the exact shape (and the
-WIT-contract change it implies for aws/awscc) is the implementation
-PR's job; this doc only fixes the *direction*.
+The boundary principle above is **decided**. What remains for the
+implementation PR is mechanism, not policy:
+
+- Exact struct field shape and the WIT-contract change it implies for
+  the aws/awscc copies.
+- How an empty axis is encoded on the wire (e.g. `Option` per axis vs
+  a sentinel) — must make the base-chain monotone invariant
+  un-violable, not merely conventional.
+- LSP/diagnostics projection from struct → dotted display string.
+
+This doc fixes *policy/direction*; the above is *mechanism*.
 
 ## Scope / sequencing (per project memory)
 


### PR DESCRIPTION
## Summary

Design / discussion doc triggered by the question of whether
`carina-aws-types` semantic names (`IamRoleArn`, `KmsKeyArn`, …) should
be renamed to a namespaced form like `aws.iam.Role.ARN`.

The doc deliberately **does not pick a naming format** — per instruction,
it gathers the facts first:

- Full inventory of `semantic_name` values across the aws/awscc copies
  (they are asymmetric: 35 vs 41 names).
- The load-bearing constraint: `semantic_name` is a **type-identity
  key**, not a label. It round-trips PascalCase ⇄ snake_case through
  `validation/inference.rs`, `parser/util.rs`, and LSP completion. A
  dotted form (`aws.iam.Role.ARN`) does not survive `pascal_to_snake`
  and is therefore a representation change, not a rename.
- Four format options (A status quo … D user's original `.ARN`) with
  round-trip feasibility and cost.
- Open sub-questions to resolve before choosing a format.

Documentation only — no code change. Design PR is intentionally
separate from (and must merge before) any implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)