### PR TITLE
fix: lift pre-StringEnum-migration state to EnumIdentifier (awscc#251)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -797,6 +797,15 @@ async fn run_apply_locked(
         .as_ref()
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
+    // awscc#251: lift pre-StringEnum-migration state (`ConcreteValue::
+    // String` at a now-`StringEnum` position) before the differ /
+    // `hydrate_read_state` consume it, so apply does not diff lifted
+    // desired against un-lifted saved state. Same seam as the plan path.
+    carina_core::utils::lift_saved_state_string_enums(
+        &mut saved_attrs,
+        &parsed.resources,
+        ctx.schemas(),
+    );
     let mut prev_explicit = state_file
         .as_ref()
         .map(|sf| sf.build_explicit())

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -740,10 +740,17 @@ pub(crate) async fn run_state_refresh_locked(
     }
 
     // Restore unreturned attributes from state file (CloudControl doesn't always return them)
-    let saved_attrs = state_file
+    let mut saved_attrs = state_file
         .as_ref()
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
+    // awscc#251: lift pre-StringEnum-migration state before
+    // `hydrate_read_state` carries it forward into read state.
+    carina_core::utils::lift_saved_state_string_enums(
+        &mut saved_attrs,
+        &parsed.resources,
+        ctx.schemas(),
+    );
     provider.hydrate_read_state(&mut current_states, &saved_attrs);
 
     let mut state = state_file.take().unwrap();

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1191,6 +1191,21 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         .as_ref()
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
+    // awscc#251: state files written before a provider promoted an
+    // attribute from `Custom` to `StringEnum` (e.g. awscc#250 for IAM
+    // policy `version`/`effect`) store enum values as plain JSON
+    // strings. `build_saved_attrs` bridges those through the
+    // schema-blind `json_to_dsl_value` into `ConcreteValue::String`,
+    // which the strict carina#2986 Phase 4 validator then rejects at
+    // the now-`StringEnum` position. Lift recognized members to
+    // `ConcreteValue::EnumIdentifier` against each resource's current
+    // schema before any diff/validation consumes the loaded state.
+    // carina-state stays schema-free; the registry only exists here.
+    carina_core::utils::lift_saved_state_string_enums(
+        &mut saved_attrs,
+        &parsed.resources,
+        ctx.schemas(),
+    );
     let mut prev_explicit = state_file
         .as_ref()
         .map(|sf| sf.build_explicit())

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -4580,3 +4580,195 @@ fn validate_map_with_string_enum_key_rejects_unknown_variant() {
         other => panic!("expected MapKeyError, got: {other:?}"),
     }
 }
+
+// awscc#251: persisted state files written before awscc#250 made IAM
+// policy `version`/`effect` into `StringEnum` store these as plain JSON
+// strings. On load they become `ConcreteValue::String`. The carina#2986
+// Phase 4 strict validator then rejects them at the `StringEnum`
+// position because it demands `ConcreteValue::EnumIdentifier`. The
+// schema-aware state-migration lift in
+// `crate::utils::lift_state_string_enums_to_identifiers` walks loaded
+// attributes against their schema and lifts recognized API-canonical /
+// alias strings to `EnumIdentifier` so old state validates again.
+#[test]
+fn lift_state_string_enums_to_identifiers_fixes_awscc251() {
+    use crate::utils::lift_state_string_enums_to_identifiers;
+    use indexmap::IndexMap;
+
+    let version_enum = AttributeType::StringEnum {
+        name: "Version".to_string(),
+        values: vec!["2012-10-17".to_string(), "2008-10-17".to_string()],
+        namespace: Some("aws.iam.PolicyDocument".to_string()),
+        dsl_aliases: vec![
+            ("2012-10-17".to_string(), "2012_10_17".to_string()),
+            ("2008-10-17".to_string(), "2008_10_17".to_string()),
+        ],
+    };
+    let effect_enum = AttributeType::StringEnum {
+        name: "Effect".to_string(),
+        values: vec!["Allow".to_string(), "Deny".to_string()],
+        namespace: Some("aws.iam.PolicyDocument".to_string()),
+        dsl_aliases: vec![
+            ("Allow".to_string(), "allow".to_string()),
+            ("Deny".to_string(), "deny".to_string()),
+        ],
+    };
+    let statement_struct = AttributeType::Struct {
+        name: "Statement".to_string(),
+        fields: vec![StructField::new("effect", effect_enum)],
+    };
+    let policy_struct = AttributeType::Struct {
+        name: "PolicyDocument".to_string(),
+        fields: vec![
+            StructField::new("version", version_enum),
+            StructField::new(
+                "statement",
+                AttributeType::List {
+                    inner: Box::new(statement_struct),
+                    ordered: false,
+                },
+            ),
+        ],
+    };
+    let schema = ResourceSchema::new("aws.iam.role_policy")
+        .attribute(AttributeSchema::new("policy", policy_struct));
+
+    // Attributes exactly as loaded from persisted state JSON: enum
+    // positions hold `ConcreteValue::String`, not `EnumIdentifier`.
+    let mut statement = IndexMap::new();
+    statement.insert(
+        "effect".to_string(),
+        Value::Concrete(ConcreteValue::String("Allow".to_string())),
+    );
+    let mut policy = IndexMap::new();
+    policy.insert(
+        "version".to_string(),
+        Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+    );
+    policy.insert(
+        "statement".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(statement),
+        )])),
+    );
+    let mut attrs: HashMap<String, Value> = HashMap::new();
+    attrs.insert(
+        "policy".to_string(),
+        Value::Concrete(ConcreteValue::Map(policy)),
+    );
+
+    // BEFORE the lift: strict validator rejects the loaded String.
+    let before = schema.validate(&attrs);
+    let errs = before.expect_err("loaded state String must fail strict StringEnum validation");
+    fn has_string_literal_expected_enum(errs: &[TypeError]) -> bool {
+        errs.iter().any(|e| match e {
+            TypeError::StringLiteralExpectedEnum { .. } => true,
+            TypeError::StructFieldError { inner, .. }
+            | TypeError::ListItemError { inner, .. }
+            | TypeError::MapValueError { inner, .. } => {
+                has_string_literal_expected_enum(std::slice::from_ref(inner))
+            }
+            _ => false,
+        })
+    }
+    assert!(
+        has_string_literal_expected_enum(&errs),
+        "expected StringLiteralExpectedEnum, got: {errs:?}"
+    );
+
+    // Apply the lift.
+    lift_state_string_enums_to_identifiers(&mut attrs, &schema);
+
+    // AFTER the lift: validation passes.
+    schema
+        .validate(&attrs)
+        .expect("lifted state must pass strict StringEnum validation");
+
+    // The lifted values are EnumIdentifier in the DSL spelling: the
+    // strict carina#2986 validator requires the alias form when a
+    // `dsl_aliases` entry rewrites the API value (carina#2980).
+    let Value::Concrete(ConcreteValue::Map(policy)) = &attrs["policy"] else {
+        panic!("policy should be a Map");
+    };
+    assert_eq!(
+        policy["version"],
+        Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string()))
+    );
+    let Value::Concrete(ConcreteValue::List(stmts)) = &policy["statement"] else {
+        panic!("statement should be a List");
+    };
+    let Value::Concrete(ConcreteValue::Map(stmt)) = &stmts[0] else {
+        panic!("statement[0] should be a Map");
+    };
+    assert_eq!(
+        stmt["effect"],
+        Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string()))
+    );
+}
+
+#[test]
+fn lift_state_string_enums_is_idempotent_and_preserves_invalid() {
+    use crate::utils::lift_state_string_enums_to_identifiers;
+    use indexmap::IndexMap;
+
+    let version_enum = AttributeType::StringEnum {
+        name: "Version".to_string(),
+        values: vec!["2012-10-17".to_string()],
+        namespace: Some("aws.iam.PolicyDocument".to_string()),
+        dsl_aliases: vec![("2012-10-17".to_string(), "2012_10_17".to_string())],
+    };
+    let policy_struct = AttributeType::Struct {
+        name: "PolicyDocument".to_string(),
+        fields: vec![StructField::new("version", version_enum)],
+    };
+    let schema = ResourceSchema::new("aws.iam.role_policy")
+        .attribute(AttributeSchema::new("policy", policy_struct));
+
+    // Case 1: already an EnumIdentifier (post-fix re-plan) — no-op.
+    let mut already = IndexMap::new();
+    already.insert(
+        "version".to_string(),
+        Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+    );
+    let mut attrs: HashMap<String, Value> = HashMap::new();
+    attrs.insert(
+        "policy".to_string(),
+        Value::Concrete(ConcreteValue::Map(already.clone())),
+    );
+    lift_state_string_enums_to_identifiers(&mut attrs, &schema);
+    let Value::Concrete(ConcreteValue::Map(p)) = &attrs["policy"] else {
+        panic!("map");
+    };
+    assert_eq!(
+        p["version"],
+        Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+        "already-lifted EnumIdentifier must pass through unchanged"
+    );
+
+    // Case 2: unrecognized string — left as String so the strict
+    // validator still rejects genuinely-invalid persisted state rather
+    // than masking it.
+    let mut bad = IndexMap::new();
+    bad.insert(
+        "version".to_string(),
+        Value::Concrete(ConcreteValue::String("1999-01-01".to_string())),
+    );
+    let mut attrs2: HashMap<String, Value> = HashMap::new();
+    attrs2.insert(
+        "policy".to_string(),
+        Value::Concrete(ConcreteValue::Map(bad)),
+    );
+    lift_state_string_enums_to_identifiers(&mut attrs2, &schema);
+    let Value::Concrete(ConcreteValue::Map(p2)) = &attrs2["policy"] else {
+        panic!("map");
+    };
+    assert_eq!(
+        p2["version"],
+        Value::Concrete(ConcreteValue::String("1999-01-01".to_string())),
+        "unrecognized member must stay String (validator still rejects it)"
+    );
+    assert!(
+        schema.validate(&attrs2).is_err(),
+        "invalid persisted state must still fail validation, not be masked"
+    );
+}

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -632,6 +632,181 @@ pub fn resolve_enum_value_recursive(value: &Value, attr_type: &AttributeType) ->
     }
 }
 
+/// Lift every `ConcreteValue::String` that sits at a `StringEnum`-typed
+/// position to `ConcreteValue::EnumIdentifier`, descending into struct
+/// fields, list elements, and map values, when (and only when) the
+/// string is a recognized member of that enum.
+///
+/// # Why this exists (awscc#251)
+///
+/// carina#2986 Phase 4 made the schema validator *strict*: a
+/// `StringEnum` position only accepts `ConcreteValue::EnumIdentifier`,
+/// never `ConcreteValue::String` (a bare quoted string at an enum
+/// position is a form error — see the `StringLiteralExpectedEnum`
+/// diagnostic). awscc#250 then promoted IAM policy `version`/`effect`
+/// from `Custom` to `StringEnum`.
+///
+/// Persisted state files (S3/local JSON) written *before* that schema
+/// change store these values as plain JSON strings. On load the
+/// schema-blind bridge `json_to_dsl_value` (carina-state) turns them
+/// into `ConcreteValue::String`. `carina validate`/`plan` then
+/// re-validate upstream-state-referenced resources against the *new*
+/// schema, and the loaded `String` is rejected at the now-`StringEnum`
+/// position even though the stored value is perfectly valid.
+///
+/// This function is the read/state-load counterpart to
+/// [`resolve_enum_value_recursive`] (which handles the desired-side,
+/// parser-fed direction). It is intentionally schema-aware and general:
+/// it does not name IAM, `version`, or `effect` anywhere, so any
+/// current or future `Custom`→`StringEnum` migration is covered without
+/// further changes. It is *not* a validator carve-out — the validator
+/// stays strict; old state is migrated in memory before validation.
+///
+/// Only recognized members are lifted. A string is recognized when it
+/// equals one of the enum's API-canonical `values` or appears on either
+/// side of a `dsl_aliases` pair. Unrecognized strings are left as
+/// `ConcreteValue::String` so the strict validator still rejects
+/// genuinely-invalid state instead of silently masking it.
+///
+/// The variant tag changes from `String` to `EnumIdentifier` (mirroring
+/// the carina#2996 map-key precedent in `AttributeType::validate_map`,
+/// schema/mod.rs). The text is normalized to the **DSL spelling** via
+/// `DslMap::dsl_for` because the strict validator rejects the
+/// API-canonical form whenever a `dsl_aliases` entry rewrites it (the
+/// DSL surface convention is the alias spelling — see
+/// `feedback_dsl_enum_snake_case_convention.md` and carina#2980). For
+/// enums with no rewriting alias the DSL spelling equals the API
+/// spelling, so the text is unchanged in that case.
+///
+/// `Union` types are not recursed into, matching
+/// [`resolve_enum_value_recursive`]'s documented contract.
+pub fn lift_state_string_enums_to_identifiers(
+    attributes: &mut std::collections::HashMap<String, Value>,
+    schema: &crate::schema::ResourceSchema,
+) {
+    for (name, attr) in &schema.attributes {
+        if let Some(value) = attributes.get(name)
+            && let Some(lifted) = lift_string_enum_leaves(value, &attr.attr_type)
+        {
+            attributes.insert(name.clone(), lifted);
+        }
+    }
+}
+
+/// Apply [`lift_state_string_enums_to_identifiers`] to every resource's
+/// loaded prior-state attributes, resolving each resource's schema from
+/// `registry`.
+///
+/// This is the single entry point every persisted-state load seam must
+/// call before the state reaches the differ or the validator. There are
+/// three such seams in the CLI — `carina plan`, `carina apply`, and
+/// `carina state` — each builds its own `saved_attrs` map from
+/// `StateFile::build_saved_attrs`. Wiring this helper at all three keeps
+/// the migration uniform: fixing only the plan seam (awscc#251's first
+/// cut) left `apply` carrying un-lifted `String` state, which the
+/// already-lifted desired side then diffed against as a spurious
+/// `String` vs `EnumIdentifier` change on every apply.
+///
+/// Resources whose schema is not in `registry` (or that have no saved
+/// attributes) are skipped.
+pub fn lift_saved_state_string_enums(
+    saved_attrs: &mut std::collections::HashMap<
+        crate::resource::ResourceId,
+        std::collections::HashMap<String, Value>,
+    >,
+    resources: &[crate::resource::Resource],
+    registry: &crate::schema::SchemaRegistry,
+) {
+    for resource in resources {
+        if let Some(schema) = registry.get_for(resource)
+            && let Some(attrs) = saved_attrs.get_mut(&resource.id)
+        {
+            lift_state_string_enums_to_identifiers(attrs, schema);
+        }
+    }
+}
+
+/// Value-level worker for [`lift_state_string_enums_to_identifiers`].
+///
+/// Returns `Some(new_value)` when at least one nested value was lifted,
+/// `None` when nothing changed — mirroring
+/// [`resolve_enum_value_recursive`]'s "rewrite only on diff" contract so
+/// callers can skip cloning.
+pub fn lift_string_enum_leaves(value: &Value, attr_type: &AttributeType) -> Option<Value> {
+    // Leaf case: this position is itself a StringEnum.
+    if let Some((_, values, _, dsl_map)) = attr_type.string_enum_parts() {
+        if let Value::Concrete(ConcreteValue::String(s)) = value {
+            let is_member = values.iter().any(|v| v == s)
+                || match dsl_map {
+                    crate::schema::DslMap::Aliases(pairs) => {
+                        pairs.iter().any(|(api, dsl)| api == s || dsl == s)
+                    }
+                    crate::schema::DslMap::Closure(_) => false,
+                };
+            if is_member {
+                // Normalize to the DSL spelling: the strict validator
+                // requires the alias form when one rewrites the API
+                // value. `dsl_for` is identity for non-aliased members
+                // and idempotent when the stored value is already the
+                // DSL spelling.
+                let dsl = dsl_map.dsl_for(s);
+                return Some(Value::Concrete(ConcreteValue::EnumIdentifier(dsl)));
+            }
+        }
+        // Recognized-or-not, a StringEnum leaf has no children.
+        return None;
+    }
+
+    match attr_type {
+        AttributeType::Struct { fields, .. } => {
+            let Value::Concrete(ConcreteValue::Map(map)) = value else {
+                return None;
+            };
+            let mut rewritten = map.clone();
+            let mut changed = false;
+            for field in fields {
+                if let Some(field_value) = map.get(&field.name)
+                    && let Some(new_field) = lift_string_enum_leaves(field_value, &field.field_type)
+                {
+                    rewritten.insert(field.name.clone(), new_field);
+                    changed = true;
+                }
+            }
+            changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
+        }
+        AttributeType::List { inner, .. } => {
+            let Value::Concrete(ConcreteValue::List(items)) = value else {
+                return None;
+            };
+            let mut rewritten = items.clone();
+            let mut changed = false;
+            for (i, item) in items.iter().enumerate() {
+                if let Some(new_item) = lift_string_enum_leaves(item, inner) {
+                    rewritten[i] = new_item;
+                    changed = true;
+                }
+            }
+            changed.then_some(Value::Concrete(ConcreteValue::List(rewritten)))
+        }
+        AttributeType::Map { value: inner, .. } => {
+            let Value::Concrete(ConcreteValue::Map(map)) = value else {
+                return None;
+            };
+            let mut rewritten = map.clone();
+            let mut changed = false;
+            for (k, v) in map {
+                if let Some(new_v) = lift_string_enum_leaves(v, inner) {
+                    rewritten.insert(k.clone(), new_v);
+                    changed = true;
+                }
+            }
+            changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
+        }
+        // Scalars and Union: nothing to descend into.
+        _ => None,
+    }
+}
+
 /// Normalize a single state enum value to its fully-qualified namespaced DSL format.
 ///
 /// Unlike `resolve_enum_value`, this also handles values that contain dots but are
@@ -1932,5 +2107,77 @@ mod tests {
                 "ap-northeast-1"
             );
         }
+    }
+
+    /// awscc#251: pin the wiring-level helper, not just the leaf walker.
+    /// Proves registry resolution + per-`ResourceId` keying work end to
+    /// end — the part the isolated `ResourceSchema::validate` test in
+    /// schema/tests.rs does not exercise. A resource whose schema is in
+    /// the registry gets its loaded `String` state lifted; a resource
+    /// absent from the registry is skipped without panic.
+    #[test]
+    fn lift_saved_state_string_enums_resolves_schema_per_resource() {
+        use crate::resource::{ConcreteValue, Resource, ResourceId, Value};
+        use crate::schema::{
+            AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField,
+        };
+        use std::collections::HashMap;
+
+        let version_enum = AttributeType::StringEnum {
+            name: "Version".to_string(),
+            values: vec!["2012-10-17".to_string()],
+            namespace: Some("aws.iam.PolicyDocument".to_string()),
+            dsl_aliases: vec![("2012-10-17".to_string(), "2012_10_17".to_string())],
+        };
+        let policy_struct = AttributeType::Struct {
+            name: "PolicyDocument".to_string(),
+            fields: vec![StructField::new("version", version_enum)],
+        };
+        let mut registry = SchemaRegistry::new();
+        registry.insert(
+            "awscc",
+            ResourceSchema::new("iam.RolePolicy")
+                .attribute(AttributeSchema::new("policy_document", policy_struct)),
+        );
+
+        let known = Resource::with_provider("awscc", "iam.RolePolicy", "rp", None);
+        let unknown = Resource::with_provider("awscc", "iam.Unknown", "x", None);
+
+        let mut pd = indexmap::IndexMap::new();
+        pd.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+        );
+        let mut known_attrs = HashMap::new();
+        known_attrs.insert(
+            "policy_document".to_string(),
+            Value::Concrete(ConcreteValue::Map(pd)),
+        );
+        let mut unknown_attrs = HashMap::new();
+        unknown_attrs.insert(
+            "whatever".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
+
+        let mut saved: HashMap<ResourceId, HashMap<String, Value>> = HashMap::new();
+        saved.insert(known.id.clone(), known_attrs);
+        saved.insert(unknown.id.clone(), unknown_attrs);
+
+        lift_saved_state_string_enums(&mut saved, &[known.clone(), unknown.clone()], &registry);
+
+        let Value::Concrete(ConcreteValue::Map(pd)) = &saved[&known.id]["policy_document"] else {
+            panic!("policy_document map");
+        };
+        assert_eq!(
+            pd["version"],
+            Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+            "resource present in registry must have its state lifted"
+        );
+        // Schema-less resource: untouched, no panic.
+        assert_eq!(
+            saved[&unknown.id]["whatever"],
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+            "resource absent from registry is skipped unchanged"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes `carina-rs/carina-provider-awscc#251` (cross-repo — GitHub will **not** auto-close; will close manually after merge).

State files written before a provider promoted an attribute from `Custom` to `StringEnum` (awscc#250: IAM policy `version`/`effect`) store enum values as plain JSON strings. `StateFile::build_saved_attrs` bridges them through the schema-blind `json_to_dsl_value` into `ConcreteValue::String`, which the strict carina#2986 Phase 4 validator rejects at the now-`StringEnum` position (`StringLiteralExpectedEnum`). This blocks `carina plan`/`apply` on every `carina-rs/infra` resource whose persisted state predates the schema change (`carina-rs/infra#58`).

## Fix (general, schema-aware, core-side — user-chosen approach)

- **`lift_string_enum_leaves` / `lift_state_string_enums_to_identifiers`** (`carina-core/src/utils.rs`): walk loaded state against the resolved `ResourceSchema`; at every `StringEnum` leaf lift a recognized `String` member to `EnumIdentifier`, normalizing to the DSL spelling via `DslMap::dsl_for` (strict validator requires the alias form when a `dsl_aliases` entry rewrites the API value — carina#2980). Recurses Struct/List/Map, not Union (mirrors `resolve_enum_value_recursive`). Unrecognized strings stay `String` so genuinely-invalid state is still rejected. **Not IAM-specific** — covers any current/future `Custom`→`StringEnum` migration with zero provider-side edits.
- **`lift_saved_state_string_enums`**: shared wiring helper, wired into **all three** persisted-state load seams — `carina plan` (`wiring/mod.rs`), `carina apply` (`apply/mod.rs`), `carina state` (`state.rs`). Fixing only the plan seam left `apply` diffing the lifted desired side against un-lifted saved state (spurious diff every apply) — caught in self-review round 3.

## Verification

- `cargo nextest run --workspace` → **3329 passed, 0 failed**.
- `cargo test --workspace --doc` → 0 failed; `cargo clippy --workspace --all-targets -- -D warnings` → clean; all 6 `scripts/check-*.sh` → exit 0.
- Tests: schema before/after validate round-trip incl. nested `statement[].effect`; idempotency; unrecognized-string-still-rejected; wiring-helper registry resolution + per-`ResourceId` keying.
- 5-round self-review: rounds 1-2 clean; round 3 found+fixed the apply/state coverage gap; round 4 found+fixed missing wiring-level test; round 5 minor/process.

## Honest note on the issue's reproduction

The issue's literal `carina validate <dir>` repro **cannot** load persisted state — `run_validate` ends after static validation and explicitly skips upstream-state type validation (`commands/mod.rs:331-334`), confirmed by two independent investigations. The real blocker is the **plan/apply diff path**, which this fixes (matching the issue's own Severity: *"blocks every infra apply"*). The repro command label is imprecise; the substantive bug is resolved. Real-infra smoke (`carina-rs/infra#58`) is user-driven.

## Test plan

- [ ] CI green
- [ ] Manually close `carina-rs/carina-provider-awscc#251` after merge (cross-repo)
- [ ] `carina-rs/infra#58` unblocked (user-driven real-infra smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)