### PR TITLE
site: bump code-block attr/type contrast (slate-300 → slate-400)

### DIFF
--- a/site/src/grammars/carina-dark.theme.json
+++ b/site/src/grammars/carina-dark.theme.json
@@ -35,7 +35,7 @@
         "constant.character.escape.crn",
         "meta.embedded.expression.crn"
       ],
-      "settings": { "foreground": "#cbd5e1" }
+      "settings": { "foreground": "#94a3b8" }
     },
 
     {
@@ -79,7 +79,7 @@
         "storage.type",
         "storage.type.crn"
       ],
-      "settings": { "foreground": "#cbd5e1" }
+      "settings": { "foreground": "#94a3b8" }
     },
 
     {
@@ -96,7 +96,7 @@
         "variable.other",
         "variable.other.crn"
       ],
-      "settings": { "foreground": "#cbd5e1" }
+      "settings": { "foreground": "#94a3b8" }
     },
 
     {


### PR DESCRIPTION
## Summary
In `carina-dark.theme.json` three scope blocks resolved to `#cbd5e1` (slate-300):

- `variable` / `variable.other` / `variable.other.crn` — attr names (`region`, `cidr_block`)
- `storage.type` / `storage.type.crn` — type annotations (`String`, `int`)
- `constant.character.escape` / `meta.embedded.expression.crn`

Slate-300 reads as near-white on the `#1e293b` panel bg, too close to the `#f1f5f9` body foreground (function names, braces), so attr names merged with body text.

## Fix
Replace all three `#cbd5e1` → `#94a3b8` (slate-400): one step darker, keeping a clear gap from body color above and the comment color (`#64748b` slate-500) below.

Unchanged: `entity.name.type.resource.*` (`#fef9c3` cream), `entity.name.function` / body (`#f1f5f9`), comment / string / keyword / numeric / boolean, and `editor.foreground`.

## Test plan
- [x] JSON valid; `npm run build` clean (Shiki cache busted).
- [x] Rendered HTML on `/getting-started/core-concepts/`, `/guides/writing-resources/`, `/reference/dsl/built-in-functions/`: zero `#cbd5e1` left, `#94A3B8` now applied (21 / 76 / 94 spans), `#FEF9C3` resource-type and `#F1F5F9` function/body untouched.
- [ ] After deploy, eyeball the three pages: keyword → type → attr → string should read as four distinct steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
