### PR TITLE
fix: lift provider-read current_states enums too (awscc#251 follow-up)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -971,6 +971,17 @@ async fn run_apply_locked(
         &remote_bindings,
     );
 
+    // awscc#251: lift the provider-read `current_states` (not just
+    // `saved_attrs` above) — a refresh whose `provider.read()` returns
+    // plain-`String` IAM enum values must be lifted before the differ
+    // consumes it, same as the plan path. Both refresh phases have
+    // populated `current_states` by here.
+    carina_core::utils::lift_current_state_string_enums(
+        &mut current_states,
+        &parsed.resources,
+        ctx.schemas(),
+    );
+
     // Resolve references and enum identifiers, then create initial plan for display
     let mut resources_for_plan = sorted_resources.clone();
     resolve_refs_with_state_and_remote(&mut resources_for_plan, &current_states, &remote_bindings)?;

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -752,6 +752,15 @@ pub(crate) async fn run_state_refresh_locked(
         ctx.schemas(),
     );
     provider.hydrate_read_state(&mut current_states, &saved_attrs);
+    // awscc#251: also lift the provider-read `current_states` (not just
+    // `saved_attrs`) — the values read at the refresh loop above arrive
+    // as plain `String` for IAM enum fields and must be lifted before
+    // they are written back / compared.
+    carina_core::utils::lift_current_state_string_enums(
+        &mut current_states,
+        &parsed.resources,
+        ctx.schemas(),
+    );
 
     let mut state = state_file.take().unwrap();
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1441,6 +1441,20 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
     // `resolve_refs_with_state_and_remote` and still errors on
     // unresolved upstream references.
     let mut resources = sorted_resources.clone();
+    // awscc#251 (follow-up to #3055): #3055 lifted only `saved_attrs`.
+    // On a refresh the live value comes from `provider.read()` into
+    // `current_states`, a different map. A provider returning an IAM
+    // policy doc with plain `String` `version`/`effect` (the wire shape
+    // for a field that was `Custom` at create time, now `StringEnum`
+    // after awscc#250) flows un-lifted into the differ and the strict
+    // carina#2986 validator rejects it. Lift `current_states` here —
+    // both refresh branches have populated it by now, before the
+    // resolver / differ consume it.
+    carina_core::utils::lift_current_state_string_enums(
+        &mut current_states,
+        &parsed.resources,
+        ctx.schemas(),
+    );
     resolve_refs_for_plan(&mut resources, &current_states, remote_bindings)?;
 
     // Type-level canonicalization for `Union[String, list(String)]`

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -726,6 +726,42 @@ pub fn lift_saved_state_string_enums(
     }
 }
 
+/// Apply [`lift_state_string_enums_to_identifiers`] to every resource's
+/// **read-back** state attributes (`current_states`), resolving each
+/// resource's schema from `registry`.
+///
+/// [`lift_saved_state_string_enums`] only migrates the cached
+/// `saved_attrs` map (state-file JSON). On a refresh, the live value is
+/// produced by `provider.read()` and lands in `current_states`, a
+/// *different* map the saved-attrs lift never touches. A provider that
+/// returns an IAM policy document with plain `String` `version` /
+/// `effect` (the on-the-wire shape for a field that was `Custom` when
+/// the resource was created, now `StringEnum` after awscc#250) then
+/// flows un-lifted into the differ, where the strict carina#2986
+/// validator rejects it — the exact failure awscc#251's first cut
+/// (#3055) did not fix because it only covered `saved_attrs`. Call this
+/// once after both refresh branches have populated `current_states`,
+/// before the differ / resolver consume it.
+///
+/// Resources whose schema is not in `registry` (or that have no state)
+/// are skipped.
+pub fn lift_current_state_string_enums(
+    current_states: &mut std::collections::HashMap<
+        crate::resource::ResourceId,
+        crate::resource::State,
+    >,
+    resources: &[crate::resource::Resource],
+    registry: &crate::schema::SchemaRegistry,
+) {
+    for resource in resources {
+        if let Some(schema) = registry.get_for(resource)
+            && let Some(state) = current_states.get_mut(&resource.id)
+        {
+            lift_state_string_enums_to_identifiers(&mut state.attributes, schema);
+        }
+    }
+}
+
 /// Value-level worker for [`lift_state_string_enums_to_identifiers`].
 ///
 /// Returns `Some(new_value)` when at least one nested value was lifted,
@@ -2178,6 +2214,67 @@ mod tests {
             saved[&unknown.id]["whatever"],
             Value::Concrete(ConcreteValue::String("Allow".to_string())),
             "resource absent from registry is skipped unchanged"
+        );
+    }
+
+    /// awscc#251 follow-up: the read-back map (`current_states`) must be
+    /// lifted too — #3055 only covered `saved_attrs`, so a refresh whose
+    /// `provider.read()` returns plain-String IAM enum values still
+    /// failed the strict validator.
+    #[test]
+    fn lift_current_state_string_enums_lifts_provider_read_state() {
+        use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+        use crate::schema::{
+            AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField,
+        };
+        use std::collections::HashMap;
+
+        let version_enum = AttributeType::StringEnum {
+            name: "Version".to_string(),
+            values: vec!["2012-10-17".to_string()],
+            namespace: Some("aws.iam.PolicyDocument".to_string()),
+            dsl_aliases: vec![("2012-10-17".to_string(), "2012_10_17".to_string())],
+        };
+        let policy_struct = AttributeType::Struct {
+            name: "PolicyDocument".to_string(),
+            fields: vec![StructField::new("version", version_enum)],
+        };
+        let mut registry = SchemaRegistry::new();
+        registry.insert(
+            "awscc",
+            ResourceSchema::new("iam.Role").attribute(AttributeSchema::new(
+                "assume_role_policy_document",
+                policy_struct,
+            )),
+        );
+
+        let role = Resource::with_provider("awscc", "iam.Role", "bs.bootstrap.role", None);
+
+        let mut pd = indexmap::IndexMap::new();
+        pd.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+        );
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "assume_role_policy_document".to_string(),
+            Value::Concrete(ConcreteValue::Map(pd)),
+        );
+
+        let mut current: HashMap<ResourceId, State> = HashMap::new();
+        current.insert(role.id.clone(), State::existing(role.id.clone(), attrs));
+
+        lift_current_state_string_enums(&mut current, std::slice::from_ref(&role), &registry);
+
+        let Value::Concrete(ConcreteValue::Map(pd)) =
+            &current[&role.id].attributes["assume_role_policy_document"]
+        else {
+            panic!("assume_role_policy_document map");
+        };
+        assert_eq!(
+            pd["version"],
+            Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+            "provider-read state String must be lifted to EnumIdentifier"
         );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3055, which was structurally incomplete. Refs `carina-rs/carina-provider-awscc#251` (reopened — cross-repo, will update + verify via real-infra plan before closing).

#3055 lifted `String`→`EnumIdentifier` only on `saved_attrs` (state-file cache). On a refresh, the live value comes from `provider.read()` into `current_states` — a different map the saved-attrs lift never touched. A provider returning an IAM policy doc with plain `String` `version`/`effect` (wire shape for a field `Custom` at create, now `StringEnum` after awscc#250) flowed un-lifted into the differ, where the strict carina#2986 validator rejected it. This is the actual `carina plan` failure on the reopened issue (the `carina validate` repro is plan-gated; verified by instrumented local reproduction).

Root cause confirmed by three investigations; two earlier hypotheses disproven with real-infra evidence:
- "config still quoted `version = '2012-10-17'`" — FALSE: failing `usecases/bootstrap` already uses namespaced form; `carina validate` passes.
- "module-prefixed ResourceId keying mismatch" — FALSE: instrumented prints show `build_saved_attrs`/`parsed.resources`/lift all agree on `bs.bootstrap.role`.

## Fix

- New `carina_core::utils::lift_current_state_string_enums` — mirrors `lift_saved_state_string_enums` but iterates `current_states`, lifting `state.attributes` via unchanged `lift_state_string_enums_to_identifiers`.
- Wired into all three seams: `carina plan` (wiring/mod.rs, before `resolve_refs_for_plan`), `carina apply` (apply/mod.rs, before `resolve_refs_with_state_and_remote`), `carina state` (state.rs, after `hydrate_read_state`). Plan-only wiring would leave `apply` broken — same gap class as #3055, caught in round-4 self-review.
- Idempotent with the `saved_attrs` lift; recognized members only → no masked drift.

## Verification

- `cargo nextest run --workspace` → 3330 passed, 0 failed (incl. new regression test).
- doctest 0 failed; `clippy --workspace --all-targets -D warnings` clean; 5 check scripts OK.
- 5-round self-review: round 4 found+fixed the apply/state gap; final pass cleared all 3 seams incl. the #3055 keying concern (ids proven consistent — id-reconcilers run before `current_states` population at every seam).
- Real-infra `carina plan` verification is user-driven (S3/aws-vault); awscc#251 stays open until it passes — no repeat of #3055's premature close.

## Test plan

- [ ] CI green
- [ ] User confirms `carina plan registry/dev/bootstrap` against the real infra worktree
- [ ] Then update + close `carina-rs/carina-provider-awscc#251` (cross-repo, manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)