### PR TITLE
test: pin module-expanded provider-instance routing (refs #3040)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,9 @@ plan-fixtures:
 	@echo ""
 	@echo "=== multi_instance_create ==="
 	@$(MAKE) plan-multi-instance-create
+	@echo ""
+	@echo "=== multi_instance_module ==="
+	@$(MAKE) plan-multi-instance-module
 
 plan-upstream-state:
 	$(PLAN_FIXTURE) upstream_state
@@ -220,6 +223,8 @@ plan-server-default-struct-leaf:
 	$(PLAN_FIXTURE) server_default_struct_leaf
 plan-multi-instance-create:
 	$(PLAN_FIXTURE) multi_instance_create
+plan-multi-instance-module:
+	$(PLAN_FIXTURE) multi_instance_module
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
         plan-list-diff-modified-with-unchanged \
@@ -233,7 +238,7 @@ plan-multi-instance-create:
         plan-policy-pretty-nested plan-policy-pretty-dynamic-key-list \
         plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
         plan-module-anonymous-resource plan-server-default-struct-leaf \
-        plan-multi-instance-create \
+        plan-multi-instance-create plan-multi-instance-module \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -159,6 +159,47 @@ fn multi_instance_create_propagates_provider_instance() {
     );
 }
 
+/// carina#3040 regression: when a named provider instance routes a
+/// resource that lives *inside an expanded module* (the real-infra
+/// shape — `usecases/registry/acm.crn` consumed via `use { source =
+/// ... }`, with `directives { provider = us }` on the module-internal
+/// resource), the directive must survive module expansion onto
+/// `ResourceId.provider_instance`. Before the fix the create call
+/// routed to the kind default (ap-northeast-1) even though the state
+/// row recorded `provider_instance: "us"`, leaving an ACM cert in the
+/// wrong region. The companion `multi_instance_create_propagates_
+/// provider_instance` test covers the non-module shape; this one
+/// covers the module-expanded shape specifically.
+#[test]
+fn module_routed_instance_propagates_provider_instance() {
+    let (plan, _schemas, _moved) = build_plan_from_fixture("multi_instance_module");
+
+    let routed: Vec<(String, Option<String>)> = plan
+        .effects()
+        .iter()
+        .map(|e| {
+            let id = e.resource_id();
+            (id.name_str().to_string(), id.provider_instance.clone())
+        })
+        .collect();
+
+    let cert = routed
+        .iter()
+        .find(|(name, _)| name.ends_with("cert"))
+        .unwrap_or_else(|| {
+            panic!("expected a module-expanded `cert` resource in the plan, got {routed:?}")
+        });
+
+    assert_eq!(
+        cert.1,
+        Some("us".to_string()),
+        "module-internal resource carries `directives {{ provider = us }}` — it must reach \
+         the plan with ResourceId.provider_instance == Some(\"us\") so apply-time \
+         ProviderRouter routing sends the create call to the `us` instance, not the \
+         kind default. Got {routed:?}"
+    );
+}
+
 /// Locks in the no-trailing-dot regression from #2516. The hash-with-
 /// instance-prefix path is covered by the unit tests in
 /// `carina-core/src/identifier/tests.rs`; fixture mode skips the hash

--- a/carina-cli/tests/fixtures/plan_display/multi_instance_module/exports.crn
+++ b/carina-cli/tests/fixtures/plan_display/multi_instance_module/exports.crn
@@ -1,0 +1,3 @@
+exports {
+  cert_bucket_name = reg.cert.bucket_name
+}

--- a/carina-cli/tests/fixtures/plan_display/multi_instance_module/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/multi_instance_module/main.crn
@@ -1,0 +1,14 @@
+# Reproduces carina#3040: a named provider instance (`us`) is passed
+# implicitly to a module, and the module-internal resource carries
+# `directives { provider = us }`. After module expansion the resource
+# must still reach the plan with `ResourceId.provider_instance ==
+# Some("us")` so apply-time `ProviderRouter` routing sends the create
+# call to the `us` instance (us-east-1), not the kind default
+# (ap-northeast-1).
+let registry = use {
+  source = './reg-module'
+}
+
+let reg = registry {
+  cert_name = 'multi-instance-module-cert'
+}

--- a/carina-cli/tests/fixtures/plan_display/multi_instance_module/providers.crn
+++ b/carina-cli/tests/fixtures/plan_display/multi_instance_module/providers.crn
@@ -1,0 +1,12 @@
+# Default instance of the `awscc` provider kind.
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+# Named instance targeting a different region. The module-internal
+# resource tagged `directives { provider = us }` must route here, not
+# the default — reproduces carina#3040 (module-expanded resource lost
+# its provider-instance routing on the way to the plan/create call).
+let us = provider awscc {
+  region = awscc.Region.us_east_1
+}

--- a/carina-cli/tests/fixtures/plan_display/multi_instance_module/reg-module/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/multi_instance_module/reg-module/main.crn
@@ -1,0 +1,14 @@
+arguments {
+  cert_name: String
+}
+
+# This resource routes to the named `us` instance declared in the
+# parent stack's providers.crn. The directive must survive module
+# expansion onto ResourceId.provider_instance.
+let cert = awscc.s3.Bucket {
+  bucket_name = cert_name
+
+  directives {
+    provider = us
+  }
+}


### PR DESCRIPTION
## Summary

carina#3040 is a **duplicate of #3038** — same reproduction (`carina-rs/infra` T6c: an ACM cert that must be issued in `us-east-1` for CloudFront was created in `ap-northeast-1` because `directives { provider = us }` was not honored at create time). #3038 was fixed by:

- #3039 (`fix: preserve provider_instance through module expansion`)
- the `refactor: make provider-instance-less ResourceId unrepresentable` change

The bug is no longer reproducible — the cert now lands in `us-east-1` as expected (confirmed on real infra).

This PR adds an **end-to-end plan-snapshot regression** that complements the expander-level unit tests already added by #3038. The new `multi_instance_module` fixture mirrors the real-infra shape: a named provider instance (`us`) is passed implicitly into a module, the module-internal resource carries `directives { provider = us }`, and the test asserts the directive survives module expansion onto `ResourceId.provider_instance` through the full plan path (not just the expander unit).

## Verification

- `module_routed_instance_propagates_provider_instance` **PASSES** on current `main`.
- Temporarily dropping `provider_instance` during module expansion (simulating the pre-#3038 bug) makes it **FAIL** — confirming it is a true regression guard, not a vacuous assertion.
- Added the matching `plan-multi-instance-module` Makefile target (CI `Check Plan Fixtures` requires one per fixture dir).
- `cargo nextest run -p carina-cli` (415 passed), doctests, `cargo clippy -p carina-cli --all-targets -- -D warnings`, all `scripts/check-*.sh` green.

Closes #3040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)