### PR TITLE
fix: propagate and instance-prefix wait bindings through module expansion (#3061)

### DIFF
--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -391,7 +391,7 @@ pub fn create_plan(
             .or_else(|| desired.iter().find(|r| r.id.name.as_str() == wb.target));
         let Some(target_resource) = resolved else {
             plan.add_error(PlanError {
-                resource_id: ResourceId::new("__wait", &wb.binding),
+                resource_id: ResourceId::new("__wait", wb.binding.as_str()),
                 message: format!(
                     "wait `{}`: target binding `{}` is not a known resource",
                     wb.binding, wb.target
@@ -427,14 +427,21 @@ pub fn create_plan(
             .unwrap_or(WAIT_DEFAULT_TIMEOUT);
         let interval = schema_interval.unwrap_or(WAIT_DEFAULT_INTERVAL);
         plan.add(Effect::Wait {
-            binding: wb.binding.clone(),
+            // Lower BindingName -> String at the AST→Effect seam: the
+            // executor IR (Effect) is string-keyed and is the separate
+            // type tracked for its own newtype migration (carina#3066).
+            binding: wb.binding.as_str().to_string(),
             target_id,
             target_identifier,
             until,
             until_surface: wb.until_raw.clone(),
             timeout,
             interval,
-            explicit_dependencies: wb.depends_on.iter().cloned().collect(),
+            explicit_dependencies: wb
+                .depends_on
+                .iter()
+                .map(|d| d.as_str().to_string())
+                .collect(),
         });
     }
 

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1207,8 +1207,8 @@ fn wait_binding_lowers_to_wait_effect() {
     let resources = vec![cert];
 
     let wait = WaitBinding {
-        binding: "cert_issued".to_string(),
-        target: "cert".to_string(),
+        binding: "cert_issued".into(),
+        target: "cert".into(),
         until_raw: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
         until_predicate: UntilPredicateAst {
             lhs_segments: vec!["cert".to_string(), "status".to_string()],
@@ -1288,8 +1288,8 @@ fn wait_uses_schema_default_timeout_when_omitted() {
     );
 
     let wait = WaitBinding {
-        binding: "cert_issued".to_string(),
-        target: "cert".to_string(),
+        binding: "cert_issued".into(),
+        target: "cert".into(),
         until_raw: "cert.status == ISSUED".to_string(),
         until_predicate: UntilPredicateAst {
             lhs_segments: vec!["cert".to_string(), "status".to_string()],
@@ -1331,8 +1331,8 @@ fn wait_with_unknown_target_emits_plan_error() {
     let resources: Vec<Resource> = vec![];
 
     let wait = WaitBinding {
-        binding: "cert_issued".to_string(),
-        target: "nonexistent".to_string(),
+        binding: "cert_issued".into(),
+        target: "nonexistent".into(),
         until_raw: "nonexistent.status == ISSUED".to_string(),
         until_predicate: UntilPredicateAst {
             lhs_segments: vec!["nonexistent".to_string(), "status".to_string()],

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -2057,6 +2057,7 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -1939,6 +1939,160 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
     assert_eq!(calls[4], ("create".to_string(), dist_id.to_string()));
 }
 
+/// carina#3061 — a downstream resource that references
+/// `<wait_binding>.<attr>` **nested inside a Map attribute** (the real
+/// `awscc.cloudfront.Distribution` shape:
+/// `distribution_config.viewer_certificate.acm_certificate_arn =
+/// cert_issued.certificate_arn`) must resolve to the wait target's
+/// post-`until` attribute value at apply time.
+///
+/// The regression: `dependency_bindings` is populated by the real
+/// resolver helper (`get_resource_value_ref_dependencies`), exactly as
+/// the apply pipeline does — *not* hand-set as in
+/// `test_wait_effect_polls_then_unblocks_downstream`. If the nested-map
+/// `ResourceRef` to the wait binding does not produce a scheduler edge
+/// to the `Effect::Wait`, the Distribution is dispatched before the
+/// wait records `cert_issued`'s attributes and `assert_fully_resolved`
+/// rejects the still-`Deferred` ref with the self-contradicting
+/// "add a `wait` block" error.
+#[tokio::test]
+async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let provider = MockProvider::new();
+
+    let cert = make_resource("cert", &[]);
+    let cert_id = cert.id.clone();
+
+    // `dist` references the wait binding from *inside a nested Map*,
+    // mirroring `viewer_certificate = { acm_certificate_arn =
+    // cert_issued.certificate_arn }`.
+    let mut dist = Resource::new("test", "dist");
+    dist.binding = Some("dist".to_string());
+    let mut viewer_certificate = indexmap::IndexMap::new();
+    viewer_certificate.insert(
+        "acm_certificate_arn".to_string(),
+        Value::resource_ref(
+            "cert_issued".to_string(),
+            "certificate_arn".to_string(),
+            vec![],
+        ),
+    );
+    let mut distribution_config = indexmap::IndexMap::new();
+    distribution_config.insert(
+        "viewer_certificate".to_string(),
+        Value::Concrete(ConcreteValue::Map(viewer_certificate)),
+    );
+    dist.set_attr(
+        "distribution_config".to_string(),
+        Value::Concrete(ConcreteValue::Map(distribution_config)),
+    );
+    // Populate dependency_bindings the way the real apply pipeline does
+    // (resolver.rs:70 -> get_resource_value_ref_dependencies), instead
+    // of hand-setting the set. This is the load-bearing difference from
+    // the existing flat-ref test.
+    dist.dependency_bindings = crate::deps::get_resource_value_ref_dependencies(&dist)
+        .into_iter()
+        .collect();
+    let dist_id = dist.id.clone();
+
+    // Sanity: the resolver helper must have recovered the wait binding
+    // from the *nested* ref. If this fails the scheduler can never link
+    // the Distribution to the wait.
+    assert!(
+        dist.dependency_bindings.contains("cert_issued"),
+        "get_resource_value_ref_dependencies must recover the nested \
+         `cert_issued` ref; got {:?}",
+        dist.dependency_bindings
+    );
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::Wait {
+        binding: "cert_issued".to_string(),
+        target_id: cert_id.clone(),
+        target_identifier: None,
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        },
+        until_surface: "cert.status == ISSUED".to_string(),
+        timeout: std::time::Duration::from_secs(60),
+        interval: std::time::Duration::from_millis(1),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+    plan.add(Effect::Create(dist));
+
+    // create cert → PENDING; wait polls read → PENDING → ISSUED+arn.
+    let mut create_attrs = HashMap::new();
+    create_attrs.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("PENDING_VALIDATION".to_string())),
+    );
+    provider.push_create(Ok(
+        State::existing(cert_id.clone(), create_attrs).with_identifier("acm-cert-id")
+    ));
+    let mut pending = HashMap::new();
+    pending.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("PENDING_VALIDATION".to_string())),
+    );
+    let mut issued = HashMap::new();
+    issued.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+    );
+    issued.insert(
+        "certificate_arn".to_string(),
+        Value::Concrete(ConcreteValue::String(
+            "arn:aws:acm:us-east-1:111:certificate/abc".to_string(),
+        )),
+    );
+    provider.push_read(Ok(State::existing(cert_id.clone(), pending)));
+    provider.push_read(Ok(State::existing(cert_id.clone(), issued)));
+    provider.push_create(Ok(ok_state(&dist_id)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+
+    assert_eq!(
+        result.failure_count,
+        0,
+        "no effect should fail; events: {:?}",
+        observer.events()
+    );
+    assert_eq!(
+        result.success_count,
+        3,
+        "cert create + wait + dist create must all succeed; events: {:?}",
+        observer.events()
+    );
+
+    // The Distribution's create must have run after the wait and seen
+    // the resolved `certificate_arn` nested in the Map.
+    let calls = provider.calls();
+    let dist_create_pos = calls
+        .iter()
+        .position(|(op, id)| op == "create" && id == &dist_id.to_string())
+        .expect("dist create must have happened");
+    let last_read_pos = calls
+        .iter()
+        .rposition(|(op, _)| op == "read")
+        .expect("wait must have polled via read");
+    assert!(
+        dist_create_pos > last_read_pos,
+        "dist create ({dist_create_pos}) must follow the wait's last \
+         poll ({last_read_pos}); calls: {calls:?}"
+    );
+}
+
 #[tokio::test]
 async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     use crate::wait::predicate::{AttrPath, WaitPredicate};

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use indexmap::IndexMap;
 
-use crate::parser::{ArgumentParameter, ModuleCall, WaitBinding};
+use crate::parser::{ArgumentParameter, BindingName, ModuleCall, WaitBinding};
 use crate::resource::{
     ConcreteValue, DeferredValue, Directives, Resource, ResourceId, ResourceKind, ResourceName,
     Value,
@@ -201,7 +201,12 @@ impl ModuleResolver<'_> {
             .resources
             .iter()
             .filter_map(|r| r.binding.clone())
-            .chain(module.wait_bindings.iter().map(|w| w.binding.clone()))
+            .chain(
+                module
+                    .wait_bindings
+                    .iter()
+                    .map(|w| w.binding.as_str().to_string()),
+            )
             .collect();
 
         // Expand resources with substituted values
@@ -325,6 +330,15 @@ fn apply_instance_prefix(instance_prefix: &str, name: &str) -> String {
     format!("{instance_prefix}.{name}")
 }
 
+/// `BindingName`-typed instance-prefix: the wait path's binding-name
+/// fields are `BindingName`, so prefixing them is a typed
+/// `BindingName -> BindingName` transition (a raw `String` can't slip
+/// into a binding-name position). Delegates to [`apply_instance_prefix`]
+/// for the single spelling.
+fn prefix_binding_name(instance_prefix: &str, name: &BindingName) -> BindingName {
+    BindingName::new(apply_instance_prefix(instance_prefix, name.as_str()))
+}
+
 /// Instance-prefix every binding-name field of a [`WaitBinding`] so a
 /// module-internal `wait` keeps referring to the same (now prefixed)
 /// target / dependencies after expansion.
@@ -351,20 +365,24 @@ fn prefix_wait_binding(wb: &WaitBinding, instance_prefix: &str) -> WaitBinding {
         depends_on,
         line,
     } = wb;
-    let prefixed = |name: &str| apply_instance_prefix(instance_prefix, name);
+    let prefixed_name = |n: &BindingName| prefix_binding_name(instance_prefix, n);
 
     let mut until_predicate = until_predicate.clone();
+    // `lhs_segments[0]` is the (string) target-binding segment of a
+    // mixed path `[target, attr, ...]`; only that head is a binding
+    // name, so it takes the string-level prefix spelling, not the
+    // `BindingName` wrapper (the rest are attribute path segments).
     if let Some(root) = until_predicate.lhs_segments.first_mut() {
-        *root = prefixed(root);
+        *root = apply_instance_prefix(instance_prefix, root);
     }
 
     WaitBinding {
-        binding: prefixed(binding),
-        target: prefixed(target),
+        binding: prefixed_name(binding),
+        target: prefixed_name(target),
         until_raw: until_raw.clone(),
         until_predicate,
         timeout_secs: *timeout_secs,
-        depends_on: depends_on.iter().map(|d| prefixed(d)).collect(),
+        depends_on: depends_on.iter().map(prefixed_name).collect(),
         line: *line,
     }
 }

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -19,12 +19,8 @@ use super::validation::{evaluate_require_expr, evaluate_validate_expr, format_va
 /// Result of expanding a single module call.
 ///
 /// A module call contributes both resources and `wait` declarations to
-/// the caller. Wait bindings were silently dropped before carina#3061
-/// because the expander only returned resources — any `wait` block
-/// inside a `use`d module vanished, so a downstream resource that
-/// referenced `<wait_binding>.<attr>` lost its synchronization edge and
-/// failed at apply with the self-contradicting "add a `wait` block"
-/// error.
+/// the caller; both must reach the caller for a module-internal `wait`
+/// to keep synchronizing its downstream consumers (carina#3061).
 #[derive(Debug)]
 pub struct ExpandedModule {
     /// Expanded, instance-prefixed resources (plus the virtual
@@ -197,12 +193,10 @@ impl ModuleResolver<'_> {
 
         // Collect intra-module binding names so we can rewrite
         // ResourceRefs. Wait-binding names are included alongside
-        // resource bindings: a downstream resource that references
-        // `<wait_binding>.<attr>` (e.g. the CloudFront Distribution's
-        // `cert_issued.certificate_arn`) must be instance-prefixed the
-        // same way, otherwise the rewritten resource points at an
-        // unprefixed `cert_issued` that no longer exists post-expansion
-        // and the dependency edge to the wait is lost (carina#3061).
+        // resource bindings so a downstream resource referencing
+        // `<wait_binding>.<attr>` is instance-prefixed the same way —
+        // otherwise its dependency edge to the wait is lost
+        // (carina#3061; see `prefix_wait_binding`).
         let intra_module_bindings: HashSet<String> = module
             .resources
             .iter()
@@ -302,12 +296,9 @@ impl ModuleResolver<'_> {
             expanded_resources.push(virtual_resource);
         }
 
-        // Propagate the module's `wait` declarations to the caller,
-        // instance-prefixing every binding-name field so they line up
-        // with the prefixed resource bindings and the prefixed
-        // downstream refs (carina#3061). The predicate RHS and
-        // `until_raw` surface text are value/display data, not binding
-        // names, and are carried through unchanged.
+        // Propagate the module's `wait` declarations, instance-prefixed
+        // (see `prefix_wait_binding`), so a module-internal `wait`
+        // reaches the caller's plan (carina#3061).
         let expanded_wait_bindings: Vec<WaitBinding> = module
             .wait_bindings
             .iter()

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -215,14 +215,13 @@ impl ModuleResolver<'_> {
             // `identifier::compute_anonymous_identifiers` for the full
             // story (#2516).
             if let ResourceName::Bound(name) = &new_resource.id.name {
-                let new_name = format!("{}.{}", instance_prefix, name);
+                let new_name = apply_instance_prefix(instance_prefix, name);
                 new_resource.id.set_name(new_name);
             }
 
             // Rewrite binding with instance path (dot-separated)
             if let Some(ref binding) = new_resource.binding {
-                let prefixed = format!("{}.{}", instance_prefix, binding);
-                new_resource.binding = Some(prefixed);
+                new_resource.binding = Some(apply_instance_prefix(instance_prefix, binding));
             }
 
             // Set typed module source info
@@ -312,31 +311,61 @@ impl ModuleResolver<'_> {
     }
 }
 
+/// Join a module-call `instance_prefix` to an intra-module binding name
+/// (`<prefix>.<name>`, dot-separated instance path).
+///
+/// This is the *single* definition of the instance-prefix spelling.
+/// Every site that prefixes a binding — resource ids, resource
+/// bindings, `rewrite_intra_module_refs`, and [`prefix_wait_binding`] —
+/// routes through here so the format can never drift between binding
+/// kinds (the carina#3061 class of bug was a binding kind that was
+/// *not* prefixed at all; keeping one spelling makes "is this kind
+/// prefixed?" a single, greppable call site per kind).
+fn apply_instance_prefix(instance_prefix: &str, name: &str) -> String {
+    format!("{instance_prefix}.{name}")
+}
+
 /// Instance-prefix every binding-name field of a [`WaitBinding`] so a
 /// module-internal `wait` keeps referring to the same (now prefixed)
 /// target / dependencies after expansion.
 ///
-/// Prefixed: `binding`, `target`, the predicate LHS root segment
-/// (`lhs_segments[0]`, which `parse_wait_expr` pins to the target
-/// binding), and every `depends_on` entry. `until_predicate.rhs` is a
-/// comparison value, not a binding, and `line` is source provenance —
-/// both pass through unchanged.
+/// The `WaitBinding` is **destructured exhaustively** rather than
+/// field-accessed: if a future field is added, this stops compiling
+/// until someone decides whether that field is a binding name (prefix
+/// it) or value/provenance (pass through). That compile-time forcing
+/// function is the carina#3061 guard — the original bug was a
+/// binding-carrying structure whose propagation silently skipped a
+/// part. Today: `binding`, `target`, the predicate LHS root segment
+/// (`lhs_segments[0]`, pinned to the target binding by
+/// `parse_wait_expr`), and every `depends_on` entry are prefixed;
+/// `until_raw` (verbatim user surface text), `until_predicate.rhs` (a
+/// comparison value), `timeout_secs`, and `line` are not binding names
+/// and pass through unchanged.
 fn prefix_wait_binding(wb: &WaitBinding, instance_prefix: &str) -> WaitBinding {
-    let prefixed = |name: &str| format!("{}.{}", instance_prefix, name);
+    let WaitBinding {
+        binding,
+        target,
+        until_raw,
+        until_predicate,
+        timeout_secs,
+        depends_on,
+        line,
+    } = wb;
+    let prefixed = |name: &str| apply_instance_prefix(instance_prefix, name);
 
-    let mut until_predicate = wb.until_predicate.clone();
+    let mut until_predicate = until_predicate.clone();
     if let Some(root) = until_predicate.lhs_segments.first_mut() {
         *root = prefixed(root);
     }
 
     WaitBinding {
-        binding: prefixed(&wb.binding),
-        target: prefixed(&wb.target),
-        until_raw: wb.until_raw.clone(),
+        binding: prefixed(binding),
+        target: prefixed(target),
+        until_raw: until_raw.clone(),
         until_predicate,
-        timeout_secs: wb.timeout_secs,
-        depends_on: wb.depends_on.iter().map(|d| prefixed(d)).collect(),
-        line: wb.line,
+        timeout_secs: *timeout_secs,
+        depends_on: depends_on.iter().map(|d| prefixed(d)).collect(),
+        line: *line,
     }
 }
 
@@ -416,7 +445,7 @@ pub(super) fn rewrite_intra_module_refs(
             if intra_module_bindings.contains(binding) =>
         {
             Value::Deferred(DeferredValue::BindingRef {
-                binding: format!("{}.{}", instance_prefix, binding),
+                binding: apply_instance_prefix(instance_prefix, binding),
             })
         }
         Value::Deferred(DeferredValue::ResourceRef { path })
@@ -424,7 +453,7 @@ pub(super) fn rewrite_intra_module_refs(
         {
             Value::Deferred(DeferredValue::ResourceRef {
                 path: crate::resource::AccessPath::with_segments(
-                    format!("{}.{}", instance_prefix, path.binding()),
+                    apply_instance_prefix(instance_prefix, path.binding()),
                     path.attribute().to_string(),
                     path.segments().to_vec(),
                 ),

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use indexmap::IndexMap;
 
-use crate::parser::{ArgumentParameter, ModuleCall};
+use crate::parser::{ArgumentParameter, ModuleCall, WaitBinding};
 use crate::resource::{
     ConcreteValue, DeferredValue, Directives, Resource, ResourceId, ResourceKind, ResourceName,
     Value,
@@ -15,6 +15,27 @@ use super::error::ModuleError;
 use super::resolver::ModuleResolver;
 use super::typecheck::check_module_arg_type;
 use super::validation::{evaluate_require_expr, evaluate_validate_expr, format_value_for_error};
+
+/// Result of expanding a single module call.
+///
+/// A module call contributes both resources and `wait` declarations to
+/// the caller. Wait bindings were silently dropped before carina#3061
+/// because the expander only returned resources — any `wait` block
+/// inside a `use`d module vanished, so a downstream resource that
+/// referenced `<wait_binding>.<attr>` lost its synchronization edge and
+/// failed at apply with the self-contradicting "add a `wait` block"
+/// error.
+#[derive(Debug)]
+pub struct ExpandedModule {
+    /// Expanded, instance-prefixed resources (plus the virtual
+    /// attribute proxy when the module declares `attributes`).
+    pub resources: Vec<Resource>,
+    /// The module's `wait` declarations, with every binding-name field
+    /// (`binding`, `target`, the predicate LHS root, `depends_on`)
+    /// rewritten with the call's `instance_prefix` so they match the
+    /// prefixed resource bindings and the prefixed downstream refs.
+    pub wait_bindings: Vec<WaitBinding>,
+}
 
 impl ModuleResolver<'_> {
     /// Expand a module call into resources.
@@ -34,7 +55,7 @@ impl ModuleResolver<'_> {
         call: &ModuleCall,
         instance_prefix: &str,
         enclosing_args: Option<&[ArgumentParameter]>,
-    ) -> Result<Vec<Resource>, ModuleError> {
+    ) -> Result<ExpandedModule, ModuleError> {
         let module = self
             .imported_modules
             .get(&call.module_name)
@@ -174,11 +195,19 @@ impl ModuleResolver<'_> {
             }
         }
 
-        // Collect intra-module binding names so we can rewrite ResourceRefs
+        // Collect intra-module binding names so we can rewrite
+        // ResourceRefs. Wait-binding names are included alongside
+        // resource bindings: a downstream resource that references
+        // `<wait_binding>.<attr>` (e.g. the CloudFront Distribution's
+        // `cert_issued.certificate_arn`) must be instance-prefixed the
+        // same way, otherwise the rewritten resource points at an
+        // unprefixed `cert_issued` that no longer exists post-expansion
+        // and the dependency edge to the wait is lost (carina#3061).
         let intra_module_bindings: HashSet<String> = module
             .resources
             .iter()
             .filter_map(|r| r.binding.clone())
+            .chain(module.wait_bindings.iter().map(|w| w.binding.clone()))
             .collect();
 
         // Expand resources with substituted values
@@ -273,7 +302,50 @@ impl ModuleResolver<'_> {
             expanded_resources.push(virtual_resource);
         }
 
-        Ok(expanded_resources)
+        // Propagate the module's `wait` declarations to the caller,
+        // instance-prefixing every binding-name field so they line up
+        // with the prefixed resource bindings and the prefixed
+        // downstream refs (carina#3061). The predicate RHS and
+        // `until_raw` surface text are value/display data, not binding
+        // names, and are carried through unchanged.
+        let expanded_wait_bindings: Vec<WaitBinding> = module
+            .wait_bindings
+            .iter()
+            .map(|wb| prefix_wait_binding(wb, instance_prefix))
+            .collect();
+
+        Ok(ExpandedModule {
+            resources: expanded_resources,
+            wait_bindings: expanded_wait_bindings,
+        })
+    }
+}
+
+/// Instance-prefix every binding-name field of a [`WaitBinding`] so a
+/// module-internal `wait` keeps referring to the same (now prefixed)
+/// target / dependencies after expansion.
+///
+/// Prefixed: `binding`, `target`, the predicate LHS root segment
+/// (`lhs_segments[0]`, which `parse_wait_expr` pins to the target
+/// binding), and every `depends_on` entry. `until_predicate.rhs` is a
+/// comparison value, not a binding, and `line` is source provenance —
+/// both pass through unchanged.
+fn prefix_wait_binding(wb: &WaitBinding, instance_prefix: &str) -> WaitBinding {
+    let prefixed = |name: &str| format!("{}.{}", instance_prefix, name);
+
+    let mut until_predicate = wb.until_predicate.clone();
+    if let Some(root) = until_predicate.lhs_segments.first_mut() {
+        *root = prefixed(root);
+    }
+
+    WaitBinding {
+        binding: prefixed(&wb.binding),
+        target: prefixed(&wb.target),
+        until_raw: wb.until_raw.clone(),
+        until_predicate,
+        timeout_secs: wb.timeout_secs,
+        depends_on: wb.depends_on.iter().map(|d| prefixed(d)).collect(),
+        line: wb.line,
     }
 }
 

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -29,7 +29,9 @@ mod typecheck;
 mod validation;
 
 pub use error::ModuleError;
-pub use expander::{instance_prefix_for_call, reconcile_anonymous_module_instances};
+pub use expander::{
+    ExpandedModule, instance_prefix_for_call, reconcile_anonymous_module_instances,
+};
 pub use loader::{
     derive_module_name, get_parsed_file, load_directory_module, load_module,
     load_module_from_directory,

--- a/carina-core/src/module_resolver/resolver.rs
+++ b/carina-core/src/module_resolver/resolver.rs
@@ -198,10 +198,7 @@ impl<'cfg> ModuleResolver<'cfg> {
             match self.expand_module_call(call, &instance_prefix, Some(enclosing_args)) {
                 Ok(expanded) => {
                     parsed.resources.extend(expanded.resources); // allow: direct — module expansion, handled separately
-                    // Propagate the module's (instance-prefixed) wait
-                    // declarations so a nested module's `wait` block is
-                    // not lost when its enclosing module is itself
-                    // expanded (carina#3061).
+                    // Propagate instance-prefixed wait bindings (carina#3061).
                     parsed.wait_bindings.extend(expanded.wait_bindings);
                 }
                 Err(e) => {
@@ -250,9 +247,7 @@ pub fn resolve_modules_with_config<E>(
         let instance_prefix = instance_prefix_for_call(call);
         let expanded = resolver.expand_module_call(call, &instance_prefix, None)?;
         parsed.resources.extend(expanded.resources); // allow: direct — module expansion, handled separately
-        // carina#3061: a `wait` block declared inside the `use`d module
-        // must reach the caller's plan, instance-prefixed, or the
-        // downstream consumer loses its synchronization edge.
+        // Propagate instance-prefixed wait bindings (carina#3061).
         parsed.wait_bindings.extend(expanded.wait_bindings);
     }
 

--- a/carina-core/src/module_resolver/resolver.rs
+++ b/carina-core/src/module_resolver/resolver.rs
@@ -196,7 +196,14 @@ impl<'cfg> ModuleResolver<'cfg> {
             let instance_prefix = instance_prefix_for_call(call);
 
             match self.expand_module_call(call, &instance_prefix, Some(enclosing_args)) {
-                Ok(expanded) => parsed.resources.extend(expanded), // allow: direct — module expansion, handled separately
+                Ok(expanded) => {
+                    parsed.resources.extend(expanded.resources); // allow: direct — module expansion, handled separately
+                    // Propagate the module's (instance-prefixed) wait
+                    // declarations so a nested module's `wait` block is
+                    // not lost when its enclosing module is itself
+                    // expanded (carina#3061).
+                    parsed.wait_bindings.extend(expanded.wait_bindings);
+                }
                 Err(e) => {
                     self.base_dir = original_base_dir;
                     self.imported_modules = original_imported;
@@ -242,7 +249,11 @@ pub fn resolve_modules_with_config<E>(
     for call in &parsed.module_calls {
         let instance_prefix = instance_prefix_for_call(call);
         let expanded = resolver.expand_module_call(call, &instance_prefix, None)?;
-        parsed.resources.extend(expanded); // allow: direct — module expansion, handled separately
+        parsed.resources.extend(expanded.resources); // allow: direct — module expansion, handled separately
+        // carina#3061: a `wait` block declared inside the `use`d module
+        // must reach the caller's plan, instance-prefixed, or the
+        // downstream consumer loses its synchronization edge.
+        parsed.wait_bindings.extend(expanded.wait_bindings);
     }
 
     Ok(())

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -1299,15 +1299,15 @@ fn test_expand_module_call_propagates_and_prefixes_wait_bindings() {
             quoted_string_attrs: std::collections::HashSet::new(),
         });
         m.wait_bindings.push(WaitBinding {
-            binding: "cert_issued".to_string(),
-            target: "main_vpc".to_string(),
+            binding: "cert_issued".into(),
+            target: "main_vpc".into(),
             until_raw: "main_vpc.state == \"available\"".to_string(),
             until_predicate: UntilPredicateAst {
                 lhs_segments: vec!["main_vpc".to_string(), "state".to_string()],
                 rhs: Value::Concrete(ConcreteValue::String("available".to_string())),
             },
             timeout_secs: Some(300),
-            depends_on: vec!["subnet".to_string()],
+            depends_on: vec!["subnet".into()],
             line: 1,
         });
         m

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -192,7 +192,8 @@ fn test_expand_anonymous_resource_in_named_module_keeps_name_pending() {
 
     let expanded = resolver
         .expand_module_call(&call, "bootstrap", None)
-        .unwrap();
+        .unwrap()
+        .resources;
     assert_eq!(expanded.len(), 1);
     let policy = &expanded[0];
     assert!(
@@ -237,7 +238,8 @@ fn test_expand_module_call() {
 
     let expanded = resolver
         .expand_module_call(&call, "my_instance", None)
-        .unwrap();
+        .unwrap()
+        .resources;
     assert_eq!(expanded.len(), 1);
 
     let sg = &expanded[0];
@@ -331,7 +333,10 @@ fn test_expand_module_call_preserves_provider_instance_on_id() {
         arguments: HashMap::new(),
     };
 
-    let expanded = resolver.expand_module_call(&call, "acme", None).unwrap();
+    let expanded = resolver
+        .expand_module_call(&call, "acme", None)
+        .unwrap()
+        .resources;
     assert_eq!(expanded.len(), 1);
     let cert = &expanded[0];
     assert_eq!(
@@ -513,10 +518,14 @@ fn test_multiple_module_instances_no_collision() {
         },
     };
 
-    let expanded_a = resolver.expand_module_call(&call_a, "prod", None).unwrap();
+    let expanded_a = resolver
+        .expand_module_call(&call_a, "prod", None)
+        .unwrap()
+        .resources;
     let expanded_b = resolver
         .expand_module_call(&call_b, "staging", None)
-        .unwrap();
+        .unwrap()
+        .resources;
 
     // binding must be prefixed so they don't collide (using dot notation)
     assert_eq!(
@@ -634,7 +643,10 @@ fn test_expand_module_call_creates_virtual_resource() {
         arguments: HashMap::new(),
     };
 
-    let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
+    let expanded = resolver
+        .expand_module_call(&call, "web", None)
+        .unwrap()
+        .resources;
     // 1 real resource + 1 virtual resource
     assert_eq!(expanded.len(), 2);
 
@@ -685,7 +697,8 @@ fn test_expand_module_call_without_binding_no_virtual() {
 
     let expanded = resolver
         .expand_module_call(&call, "web_tier", None)
-        .unwrap();
+        .unwrap()
+        .resources;
     // Only real resources, no virtual
     let virtual_count = expanded.iter().filter(|r| r.is_virtual()).count();
     assert_eq!(virtual_count, 0);
@@ -1196,7 +1209,8 @@ fn test_expand_module_call_uses_dot_path_addressing() {
 
     let expanded = resolver
         .expand_module_call(&call, "my_instance", None)
-        .unwrap();
+        .unwrap()
+        .resources;
     assert_eq!(expanded.len(), 1);
 
     let sg = &expanded[0];
@@ -1226,7 +1240,10 @@ fn test_module_dot_path_bindings_and_refs() {
         },
     };
 
-    let expanded = resolver.expand_module_call(&call, "prod", None).unwrap();
+    let expanded = resolver
+        .expand_module_call(&call, "prod", None)
+        .unwrap()
+        .resources;
 
     // Resource names should use dot notation
     assert_eq!(expanded[0].id.name_str(), "prod.main_vpc");
@@ -1247,6 +1264,113 @@ fn test_module_dot_path_bindings_and_refs() {
     );
 }
 
+/// carina#3061: a `wait` block declared inside a module must survive
+/// expansion. Every binding-name field is instance-prefixed, and a
+/// module resource that references the wait binding has that reference
+/// prefixed too (so the dependency edge to the `Effect::Wait` forms).
+#[test]
+fn test_expand_module_call_propagates_and_prefixes_wait_bindings() {
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+
+    let module = {
+        let mut m = create_module_with_intra_refs();
+        // A resource that consumes the wait binding the same way the
+        // real CloudFront Distribution consumes `cert_issued`.
+        m.resources.push(Resource {
+            id: ResourceId::new("cloudfront.Distribution", "distribution"),
+            attributes: {
+                let mut attrs = HashMap::new();
+                attrs.insert(
+                    "acm_certificate_arn".to_string(),
+                    Value::resource_ref(
+                        "cert_issued".to_string(),
+                        "certificate_arn".to_string(),
+                        vec![],
+                    ),
+                );
+                attrs.into_iter().collect()
+            },
+            kind: ResourceKind::Managed,
+            directives: Directives::default(),
+            prefixes: HashMap::new(),
+            binding: Some("distribution".to_string()),
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: std::collections::HashSet::new(),
+        });
+        m.wait_bindings.push(WaitBinding {
+            binding: "cert_issued".to_string(),
+            target: "main_vpc".to_string(),
+            until_raw: "main_vpc.state == \"available\"".to_string(),
+            until_predicate: UntilPredicateAst {
+                lhs_segments: vec!["main_vpc".to_string(), "state".to_string()],
+                rhs: Value::Concrete(ConcreteValue::String("available".to_string())),
+            },
+            timeout_secs: Some(300),
+            depends_on: vec!["subnet".to_string()],
+            line: 1,
+        });
+        m
+    };
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert("net".to_string(), module);
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "net".to_string(),
+        binding_name: Some("prod".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            args.insert(
+                "cidr".to_string(),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            );
+            args
+        },
+    };
+
+    let expanded = resolver.expand_module_call(&call, "prod", None).unwrap();
+
+    // The wait binding survived expansion and every binding-name field
+    // is instance-prefixed.
+    assert_eq!(expanded.wait_bindings.len(), 1);
+    let wb = &expanded.wait_bindings[0];
+    assert_eq!(wb.binding, "prod.cert_issued");
+    assert_eq!(wb.target, "prod.main_vpc");
+    assert_eq!(
+        wb.until_predicate.lhs_segments,
+        vec!["prod.main_vpc".to_string(), "state".to_string()]
+    );
+    assert_eq!(wb.depends_on, vec!["prod.subnet".to_string()]);
+    // RHS value and surface text are not binding names — unchanged.
+    assert_eq!(
+        wb.until_predicate.rhs,
+        Value::Concrete(ConcreteValue::String("available".to_string()))
+    );
+    assert_eq!(wb.timeout_secs, Some(300));
+
+    // The downstream resource's reference to the wait binding was
+    // rewritten to the prefixed name, so the dependency edge to the
+    // Effect::Wait can form at plan time.
+    let dist = expanded
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "cloudfront.Distribution")
+        .expect("distribution resource present");
+    assert_eq!(
+        dist.get_attr("acm_certificate_arn"),
+        Some(&Value::resource_ref(
+            "prod.cert_issued".to_string(),
+            "certificate_arn".to_string(),
+            vec![]
+        )),
+        "the module resource's `cert_issued` ref must be instance-prefixed"
+    );
+}
+
 #[test]
 fn test_module_virtual_resource_dot_path_refs() {
     let resolver = {
@@ -1262,7 +1386,10 @@ fn test_module_virtual_resource_dot_path_refs() {
         arguments: HashMap::new(),
     };
 
-    let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
+    let expanded = resolver
+        .expand_module_call(&call, "web", None)
+        .unwrap()
+        .resources;
 
     let virtual_res = expanded
         .iter()
@@ -1480,7 +1607,10 @@ fn test_expand_module_call_with_interpolation() {
         },
     };
 
-    let expanded = resolver.expand_module_call(&call, "dev_vpc", None).unwrap();
+    let expanded = resolver
+        .expand_module_call(&call, "dev_vpc", None)
+        .unwrap()
+        .resources;
     assert_eq!(expanded.len(), 1);
 
     let vpc = &expanded[0];
@@ -1630,7 +1760,10 @@ fn test_expand_module_call_with_function_call_argument() {
         },
     };
 
-    let expanded = resolver.expand_module_call(&call, "dev_vpc", None).unwrap();
+    let expanded = resolver
+        .expand_module_call(&call, "dev_vpc", None)
+        .unwrap()
+        .resources;
     assert_eq!(expanded.len(), 1);
 
     let vpc = &expanded[0];

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -504,6 +504,101 @@ pub struct UntilPredicateAst {
     pub rhs: crate::resource::Value,
 }
 
+/// A binding identifier (a `let`/`wait`/`depends_on` name such as
+/// `cert_issued` or its instance-prefixed form `r.cert_issued`).
+///
+/// This newtype exists so a binding name cannot be confused with an
+/// arbitrary `String` at a binding-expecting position, and so the
+/// instance-prefix operation is typed as `BindingName -> BindingName`
+/// (see `module_resolver::apply_instance_prefix`). It deliberately does
+/// **not** encode prefix state (Raw vs Prefixed): the wait-binding list
+/// mixes top-level (never-prefixed) and module-derived (prefixed)
+/// entries in one `Vec`, so a state-in-the-type distinction is not
+/// expressible here — that larger data-flow reshape is tracked
+/// separately (carina#3066).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BindingName(String);
+
+impl BindingName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::ops::Deref for BindingName {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for BindingName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for BindingName {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for BindingName {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Compare a `BindingName` directly against a string slice so existing
+/// `wb.target == some_str` / lookup sites don't need `.as_str()`
+/// ceremony. The newtype's value is preventing *accidental* String
+/// substitution at construction/parameter boundaries, not forbidding
+/// equality checks.
+impl PartialEq<str> for BindingName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
+    }
+}
+
+impl PartialEq<&str> for BindingName {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<BindingName> for str {
+    fn eq(&self, other: &BindingName) -> bool {
+        self == other.0
+    }
+}
+
+impl PartialEq<BindingName> for &str {
+    fn eq(&self, other: &BindingName) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialEq<String> for BindingName {
+    fn eq(&self, other: &String) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<BindingName> for String {
+    fn eq(&self, other: &BindingName) -> bool {
+        self == &other.0
+    }
+}
+
 /// A `wait <target> { ... }` declaration captured during parse.
 ///
 /// Carries the parsed surface form of the `until` predicate so plan
@@ -516,9 +611,9 @@ pub struct UntilPredicateAst {
 #[derive(Debug, Clone)]
 pub struct WaitBinding {
     /// The wait's binding name (e.g. `cert_issued`).
-    pub binding: String,
+    pub binding: BindingName,
     /// Identifier of the target resource binding (e.g. `cert`).
-    pub target: String,
+    pub target: BindingName,
     /// Surface form of the `until` expression as the user wrote it
     /// (e.g. `"cert.status == aws.acm.Certificate.Status.Issued"`).
     pub until_raw: String,
@@ -530,7 +625,7 @@ pub struct WaitBinding {
     /// Additional ordering edges declared via `depends_on = [...]`. The
     /// ordering machinery itself is shared with the per-resource
     /// `directives.depends_on` (carina#2823).
-    pub depends_on: Vec<String>,
+    pub depends_on: Vec<BindingName>,
     /// Source line of the `wait` keyword. Used by diagnostics.
     pub line: usize,
 }

--- a/carina-core/src/parser/expressions/wait_expr.rs
+++ b/carina-core/src/parser/expressions/wait_expr.rs
@@ -4,7 +4,7 @@
 //! design. The grammar piece lives in `carina.pest::wait_expr`.
 
 use super::primary::parse_duration_secs;
-use crate::parser::ast::{UntilPredicateAst, WaitBinding};
+use crate::parser::ast::{BindingName, UntilPredicateAst, WaitBinding};
 use crate::parser::error::ParseError;
 use crate::parser::{Rule, first_inner};
 use crate::resource::{ConcreteValue, Value};
@@ -113,12 +113,12 @@ pub(crate) fn parse_wait_expr(
     };
 
     Ok(WaitBinding {
-        binding: binding_name.to_string(),
-        target,
+        binding: BindingName::from(binding_name),
+        target: BindingName::from(target),
         until_raw,
         until_predicate,
         timeout_secs,
-        depends_on,
+        depends_on: depends_on.into_iter().map(BindingName::from).collect(),
         line,
     })
 }

--- a/carina-core/src/parser/let_binding.rs
+++ b/carina-core/src/parser/let_binding.rs
@@ -347,13 +347,14 @@ fn parse_primary_with_resource_or_module(
         Rule::wait_expr => {
             let (line, _) = inner.as_span().start_pos().line_col();
             let wb = parse_wait_expr(inner, binding_name)?;
-            if ctx.wait_bindings.contains_key(&wb.binding) {
+            if ctx.wait_bindings.contains_key(wb.binding.as_str()) {
                 return Err(ParseError::DuplicateBinding {
-                    name: wb.binding,
+                    name: wb.binding.into_string(),
                     line,
                 });
             }
-            ctx.wait_bindings.insert(wb.binding.clone(), wb);
+            ctx.wait_bindings
+                .insert(wb.binding.as_str().to_string(), wb);
             // The wait binding's value is a forward reference to the
             // captured target snapshot; downstream resolution treats
             // `<wait-binding>.<attr>` as passthrough of `<target>.<attr>`.

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -17,8 +17,8 @@ mod types;
 mod util;
 
 pub use ast::{
-    ArgumentParameter, AttributeParameter, BackendConfig, DeferredForExpression, ExportParamLike,
-    ExportParameter, File, FnParam, InferredExportParam, InferredFile, ModuleCall,
+    ArgumentParameter, AttributeParameter, BackendConfig, BindingName, DeferredForExpression,
+    ExportParamLike, ExportParameter, File, FnParam, InferredExportParam, InferredFile, ModuleCall,
     ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock, ResourceContext, ResourceTypePath,
     StateBlock, TypeExpr, UntilPredicateAst, UpstreamState, UseStatement, UserFunction,
     UserFunctionBody, ValidateExpr, ValidationBlock, WaitBinding,

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -181,7 +181,9 @@ pub fn resolve_resource_refs_with_config(
     // Register `wait` bindings the same way: downstream `<wait>.<attr>`
     // refs are passthrough of the target's snapshot, resolved at apply time.
     for wb in &parsed.wait_bindings {
-        binding_map.entry(wb.binding.clone()).or_default();
+        binding_map
+            .entry(wb.binding.as_str().to_string())
+            .or_default();
     }
 
     // Build a `ParseContext` once, populated with the merged
@@ -671,7 +673,9 @@ pub fn resolve_provider_unresolved_attributes<E>(
         binding_map.entry(us.binding.clone()).or_default();
     }
     for wb in &parsed.wait_bindings {
-        binding_map.entry(wb.binding.clone()).or_default();
+        binding_map
+            .entry(wb.binding.as_str().to_string())
+            .or_default();
     }
     let mut fn_ctx = super::ParseContext::new(config);
     fn_ctx.user_functions = parsed.user_functions.clone();

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -401,8 +401,8 @@ mod tests {
         // A wait on the cert binding — predicate text is irrelevant
         // for this pass; presence is the contract.
         parsed.wait_bindings.push(WaitBinding {
-            binding: "cert_issued".to_string(),
-            target: "cert".to_string(),
+            binding: "cert_issued".into(),
+            target: "cert".into(),
             until_raw: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             until_predicate: crate::parser::UntilPredicateAst {
                 lhs_segments: vec!["cert".to_string(), "status".to_string()],

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -836,9 +836,9 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     // LHS is rooted at the target (enforced by parser), so the target
     // covers the LHS path too.
     for wb in &parsed.wait_bindings {
-        referenced.insert(wb.target.clone());
+        referenced.insert(wb.target.as_str().to_string());
         for dep in &wb.depends_on {
-            referenced.insert(dep.clone());
+            referenced.insert(dep.as_str().to_string());
         }
     }
 

--- a/carina-core/src/validation/wait.rs
+++ b/carina-core/src/validation/wait.rs
@@ -50,14 +50,14 @@ pub fn validate_wait_bindings<E>(
     }
 
     for wb in &parsed.wait_bindings {
-        let Some((provider, resource_type)) = by_binding.get(&wb.target) else {
+        let Some((provider, resource_type)) = by_binding.get(wb.target.as_str()) else {
             out.push(WaitDiagnostic {
                 message: format!(
                     "wait `{}`: target binding `{}` is not a known resource",
                     wb.binding, wb.target
                 ),
-                binding_name: wb.binding.clone(),
-                target: wb.target.clone(),
+                binding_name: wb.binding.as_str().to_string(),
+                target: wb.target.as_str().to_string(),
                 attribute: None,
             });
             continue;
@@ -80,8 +80,8 @@ pub fn validate_wait_bindings<E>(
                     "wait `{}`: `until` references unknown attribute `{}.{}` on `{}.{}`",
                     wb.binding, wb.target, attr_name, provider, resource_type
                 ),
-                binding_name: wb.binding.clone(),
-                target: wb.target.clone(),
+                binding_name: wb.binding.as_str().to_string(),
+                target: wb.target.as_str().to_string(),
                 attribute: Some(attr_name.clone()),
             });
         }

--- a/carina-core/tests/fixtures/wait/module_wait_downstream/caller/main.crn
+++ b/carina-core/tests/fixtures/wait/module_wait_downstream/caller/main.crn
@@ -1,0 +1,17 @@
+# Mirrors carina-rs/infra registry/dev/registry/main.crn: a thin
+# wrapper that instantiates the usecase module via `use`. The wait
+# binding lives *inside* the module — module expansion must propagate
+# (and instance-prefix) it, otherwise the Distribution loses its
+# synchronization edge (carina#3061).
+
+let registry = use {
+  source = "../usecase"
+}
+
+let r = registry {
+  domain_name = "registry-dev.example.com"
+}
+
+exports {
+  certificate_arn = r.certificate_arn
+}

--- a/carina-core/tests/fixtures/wait/module_wait_downstream/usecase/acm.crn
+++ b/carina-core/tests/fixtures/wait/module_wait_downstream/usecase/acm.crn
@@ -1,0 +1,22 @@
+# Mirrors usecases/registry/acm.crn (the wait construct's intended
+# use case). The wait binding `cert_issued` is the synchronized alias
+# downstream resources read.
+
+let cert = aws.acm.Certificate {
+  domain_name       = domain_name
+  validation_method = "DNS"
+}
+
+let validation_record = aws.route53.RecordSet {
+  hosted_zone_id   = "Z123"
+  name             = "_acme.example.com"
+  type             = "CNAME"
+  ttl              = 300
+  resource_records = ["validation.example.com"]
+}
+
+let cert_issued = wait cert {
+  until      = cert.status == "ISSUED"
+  depends_on = [validation_record]
+  timeout    = 75min
+}

--- a/carina-core/tests/fixtures/wait/module_wait_downstream/usecase/cloudfront.crn
+++ b/carina-core/tests/fixtures/wait/module_wait_downstream/usecase/cloudfront.crn
@@ -1,0 +1,14 @@
+# Mirrors usecases/registry/cloudfront.crn: the Distribution reads the
+# wait binding (`cert_issued.certificate_arn`) from a nested Map
+# attribute, in a sibling file from where the wait is declared.
+
+let distribution = awscc.cloudfront.Distribution {
+  distribution_config = {
+    enabled = true
+    viewer_certificate = {
+      acm_certificate_arn      = cert_issued.certificate_arn
+      ssl_support_method       = "sni-only"
+      minimum_protocol_version = "TLSv1.2_2021"
+    }
+  }
+}

--- a/carina-core/tests/fixtures/wait/module_wait_downstream/usecase/main.crn
+++ b/carina-core/tests/fixtures/wait/module_wait_downstream/usecase/main.crn
@@ -1,0 +1,11 @@
+# Mirrors carina-rs/infra usecases/registry/main.crn: a module that
+# only declares arguments + attributes; resources/wait live in sibling
+# files merged into the module.
+
+arguments {
+  domain_name: String
+}
+
+attributes {
+  certificate_arn = cert_issued.certificate_arn
+}

--- a/carina-core/tests/fixtures/wait/module_wait_nested/inner/main.crn
+++ b/carina-core/tests/fixtures/wait/module_wait_nested/inner/main.crn
@@ -1,0 +1,30 @@
+# Innermost module: declares the `wait` and a resource that consumes
+# the wait binding from a nested Map (the carina#3061 shape), so we can
+# assert the wait survives *two* levels of instance-prefixing.
+
+arguments {
+  domain_name: String
+}
+
+attributes {
+  certificate_arn = cert_issued.certificate_arn
+}
+
+let cert = aws.acm.Certificate {
+  domain_name       = domain_name
+  validation_method = "DNS"
+}
+
+let cert_issued = wait cert {
+  until   = cert.status == "ISSUED"
+  timeout = 75min
+}
+
+let distribution = awscc.cloudfront.Distribution {
+  distribution_config = {
+    enabled = true
+    viewer_certificate = {
+      acm_certificate_arn = cert_issued.certificate_arn
+    }
+  }
+}

--- a/carina-core/tests/fixtures/wait/module_wait_nested/outer/main.crn
+++ b/carina-core/tests/fixtures/wait/module_wait_nested/outer/main.crn
@@ -1,0 +1,19 @@
+# Middle module: instantiates `inner`. Its own expansion must
+# re-prefix the (already inner-prefixed) wait binding so the
+# two-level-deep `wait` still reaches the root caller's plan.
+
+arguments {
+  domain_name: String
+}
+
+attributes {
+  certificate_arn = c.certificate_arn
+}
+
+let inner = use {
+  source = "../inner"
+}
+
+let c = inner {
+  domain_name = domain_name
+}

--- a/carina-core/tests/fixtures/wait/module_wait_nested/root/main.crn
+++ b/carina-core/tests/fixtures/wait/module_wait_nested/root/main.crn
@@ -1,0 +1,15 @@
+# Root caller: instantiates `outer`, which itself instantiates
+# `inner`. The wait declared two levels deep must survive both
+# expansions.
+
+let outer = use {
+  source = "../outer"
+}
+
+let o = outer {
+  domain_name = "registry-dev.example.com"
+}
+
+exports {
+  certificate_arn = o.certificate_arn
+}

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -34,7 +34,8 @@ use carina_core::executor::{ExecutionInput, ExecutionObserver, execute_plan};
 use carina_core::module_resolver::resolve_modules;
 use carina_core::parser::ProviderContext;
 use carina_core::provider::{
-    BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderResult, ReadRequest, UpdateRequest,
+    BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, Provider, ProviderResult, ReadRequest,
+    UpdateRequest,
 };
 use carina_core::resolver::resolve_refs_with_state_and_remote;
 use carina_core::resource::{ConcreteValue, ResourceId, State, Value};
@@ -243,6 +244,7 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
         unresolved_resources: &unresolved_resources,
         bindings: carina_core::binding_index::ResolvedBindings::default(),
         current_states,
+        normalizer: &NoopNormalizer,
     };
 
     let result = execute_plan(&provider, input, &observer).await;
@@ -355,6 +357,7 @@ async fn nested_module_wait_binding_survives_two_expansions() {
         unresolved_resources: &unresolved_resources,
         bindings: carina_core::binding_index::ResolvedBindings::default(),
         current_states,
+        normalizer: &NoopNormalizer,
     };
 
     let result = execute_plan(&provider, input, &observer).await;

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -177,7 +177,7 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
         wb.until_predicate.lhs_segments
     );
     assert!(
-        wb.depends_on.contains(&"r.validation_record".to_string()),
+        wb.depends_on.iter().any(|d| d == "r.validation_record"),
         "depends_on entries must be instance-prefixed; got {:?}",
         wb.depends_on
     );

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -259,3 +259,112 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
         "no effect should be skipped. Failures: {failures:?}"
     );
 }
+
+/// carina#3061, nested case: a `wait` declared *two module levels deep*
+/// (root → outer → inner, where `inner` holds the wait + the
+/// downstream Distribution) must survive both expansions, with the
+/// binding doubly instance-prefixed (`o.c.cert_issued`), in lockstep
+/// with the doubly-prefixed downstream ref. This guards the
+/// `resolve_nested_modules` propagation path that re-prefixes an
+/// already-prefixed wait binding.
+#[tokio::test]
+async fn nested_module_wait_binding_survives_two_expansions() {
+    let mut root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    root.push("tests/fixtures/wait/module_wait_nested/root");
+
+    let mut parsed = parse_directory(&root, &ProviderContext::default())
+        .expect("parse_directory should succeed for the nested root fixture");
+
+    resolve_modules(&mut parsed, &root).expect("nested module resolution should succeed");
+
+    // The two-level-deep wait binding survived, doubly instance-prefixed
+    // (outer call binding `o`, inner call binding `c`).
+    assert_eq!(
+        parsed.wait_bindings.len(),
+        1,
+        "the `wait` two modules deep must reach the root caller; got {:?}",
+        parsed
+            .wait_bindings
+            .iter()
+            .map(|w| (&w.binding, &w.target))
+            .collect::<Vec<_>>()
+    );
+    let wb = &parsed.wait_bindings[0];
+    assert_eq!(wb.binding, "o.c.cert_issued");
+    assert_eq!(wb.target, "o.c.cert");
+    assert_eq!(
+        wb.until_predicate.lhs_segments.first().map(String::as_str),
+        Some("o.c.cert"),
+        "until LHS root must be doubly-prefixed; got {:?}",
+        wb.until_predicate.lhs_segments
+    );
+
+    // The inner Distribution's nested ref was doubly-rewritten to match.
+    let dist = parsed
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "cloudfront.Distribution")
+        .expect("expanded Distribution must be present");
+    assert!(
+        carina_core::deps::get_resource_value_ref_dependencies(dist).contains("o.c.cert_issued"),
+        "Distribution must depend on the doubly-prefixed wait binding \
+         `o.c.cert_issued`; deps were {:?}",
+        carina_core::deps::get_resource_value_ref_dependencies(dist)
+    );
+
+    // End-to-end apply: the Distribution must wait, not fail/skip.
+    let sorted_resources =
+        sort_resources_by_dependencies(&parsed.resources).expect("topological sort should succeed");
+    let current_states: HashMap<ResourceId, State> = HashMap::new();
+    let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+
+    let mut resources_for_plan = sorted_resources.clone();
+    resolve_refs_with_state_and_remote(&mut resources_for_plan, &current_states, &remote_bindings)
+        .expect("resolve_refs should succeed");
+
+    let registry = SchemaRegistry::new();
+    let plan = create_plan(
+        &resources_for_plan,
+        &current_states,
+        &HashMap::new(),
+        &registry,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &parsed.wait_bindings,
+    );
+    assert!(
+        plan.effects().iter().any(|e| matches!(
+            e,
+            carina_core::effect::Effect::Wait { binding, .. } if binding == "o.c.cert_issued"
+        )),
+        "create_plan must emit Effect::Wait for the doubly-prefixed binding"
+    );
+
+    let unresolved_resources: HashMap<ResourceId, _> = sorted_resources
+        .iter()
+        .map(|r| (r.id.clone(), r.clone()))
+        .collect();
+
+    let provider = MockProvider;
+    let observer = CollectingObserver {
+        failures: Mutex::new(Vec::new()),
+    };
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &unresolved_resources,
+        bindings: carina_core::binding_index::ResolvedBindings::default(),
+        current_states,
+    };
+
+    let result = execute_plan(&provider, input, &observer).await;
+    let failures = observer.failures.lock().unwrap().clone();
+    assert_eq!(
+        result.failure_count, 0,
+        "nested-module wait must synchronize the Distribution. Failures: {failures:?}"
+    );
+    assert_eq!(
+        result.skip_count, 0,
+        "no effect should be skipped. Failures: {failures:?}"
+    );
+}

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -1,0 +1,261 @@
+//! carina#3061 — a `wait` block declared *inside a `use`d module* must
+//! survive module expansion (with instance-prefixing) so a downstream
+//! resource that references `<wait_binding>.<attr>` keeps its
+//! synchronization edge.
+//!
+//! Real infra shape (carina-rs/infra):
+//!   registry/dev/registry/main.crn : let r = registry { ... }   (caller)
+//!   usecases/registry/acm.crn      : let cert_issued = wait cert { ... }
+//!   usecases/registry/cloudfront.crn: distribution_config = {
+//!         viewer_certificate = { acm_certificate_arn =
+//!                                cert_issued.certificate_arn } }
+//!
+//! Pre-fix: `expand_module_call` returns only `Vec<Resource>`, so the
+//! module's `wait_bindings` are silently dropped and the module
+//! resources' references to the wait binding are never instance-
+//! prefixed. `create_plan` emits no `Effect::Wait`, the Distribution
+//! gets no dependency edge, dispatches immediately, and fails at 0.0s
+//! with the self-contradicting "add a `wait` block" error
+//! (`assert_fully_resolved` on the still-`Deferred`
+//! `cert_issued.certificate_arn`).
+//!
+//! Per CLAUDE.md "directory-scoped, never single-file": the fixture is
+//! a multi-file caller dir + multi-file module dir, exercising the real
+//! merged-parse + module-expansion path the CLI runs.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use carina_core::config_loader::parse_directory;
+use carina_core::deps::sort_resources_by_dependencies;
+use carina_core::differ::create_plan;
+use carina_core::executor::{ExecutionInput, ExecutionObserver, execute_plan};
+use carina_core::module_resolver::resolve_modules;
+use carina_core::parser::ProviderContext;
+use carina_core::provider::{
+    BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderResult, ReadRequest, UpdateRequest,
+};
+use carina_core::resolver::resolve_refs_with_state_and_remote;
+use carina_core::resource::{ConcreteValue, ResourceId, State, Value};
+use carina_core::schema::SchemaRegistry;
+
+/// cert read returns ISSUED (+ certificate_arn) immediately; other
+/// resources create/read trivially. Keeps a correct wait fast.
+struct MockProvider;
+
+impl Provider for MockProvider {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn read(
+        &self,
+        id: &ResourceId,
+        _identifier: Option<&str>,
+        _request: ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        Box::pin(async move {
+            if id.resource_type == "acm.Certificate" {
+                let mut attrs = HashMap::new();
+                attrs.insert(
+                    "status".to_string(),
+                    Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+                );
+                attrs.insert(
+                    "certificate_arn".to_string(),
+                    Value::Concrete(ConcreteValue::String(
+                        "arn:aws:acm:us-east-1:111:certificate/abc".to_string(),
+                    )),
+                );
+                Ok(State::existing(id, attrs).with_identifier("acm-cert-id"))
+            } else {
+                Ok(State::not_found(id))
+            }
+        })
+    }
+
+    fn read_data_source(
+        &self,
+        resource: &carina_core::resource::Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+    }
+
+    fn create(
+        &self,
+        id: &ResourceId,
+        _request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        Box::pin(async move {
+            let mut attrs = HashMap::new();
+            if id.resource_type == "acm.Certificate" {
+                attrs.insert(
+                    "status".to_string(),
+                    Value::Concrete(ConcreteValue::String("PENDING_VALIDATION".to_string())),
+                );
+            }
+            attrs.insert(
+                "id".to_string(),
+                Value::Concrete(ConcreteValue::String("id-123".to_string())),
+            );
+            Ok(State::existing(id, attrs).with_identifier("id-123"))
+        })
+    }
+
+    fn update(
+        &self,
+        id: &ResourceId,
+        _identifier: &str,
+        _request: UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+    }
+
+    fn delete(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _request: DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+struct CollectingObserver {
+    failures: Mutex<Vec<String>>,
+}
+
+impl ExecutionObserver for CollectingObserver {
+    fn on_event(&self, event: &carina_core::executor::ExecutionEvent) {
+        if let carina_core::executor::ExecutionEvent::EffectFailed { error, .. } = event {
+            self.failures.lock().unwrap().push(error.to_string());
+        }
+    }
+}
+
+#[tokio::test]
+async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
+    let mut caller = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    caller.push("tests/fixtures/wait/module_wait_downstream/caller");
+
+    let mut parsed = parse_directory(&caller, &ProviderContext::default())
+        .expect("parse_directory should succeed for the caller fixture");
+
+    resolve_modules(&mut parsed, &caller).expect("module resolution should succeed");
+
+    // ---- Root-cause assertion #1: the module's wait binding survived
+    // expansion, instance-prefixed with the module-call binding (`r`).
+    assert_eq!(
+        parsed.wait_bindings.len(),
+        1,
+        "the `wait cert` declared inside the `use`d module must be \
+         propagated to the caller after expansion; got {:?}",
+        parsed
+            .wait_bindings
+            .iter()
+            .map(|w| (&w.binding, &w.target))
+            .collect::<Vec<_>>()
+    );
+    let wb = &parsed.wait_bindings[0];
+    assert_eq!(
+        wb.binding, "r.cert_issued",
+        "wait binding must be instance-prefixed (r.cert_issued)"
+    );
+    assert_eq!(
+        wb.target, "r.cert",
+        "wait target must be instance-prefixed (r.cert)"
+    );
+    assert_eq!(
+        wb.until_predicate.lhs_segments.first().map(String::as_str),
+        Some("r.cert"),
+        "until predicate LHS root must be instance-prefixed; got {:?}",
+        wb.until_predicate.lhs_segments
+    );
+    assert!(
+        wb.depends_on.contains(&"r.validation_record".to_string()),
+        "depends_on entries must be instance-prefixed; got {:?}",
+        wb.depends_on
+    );
+
+    // ---- Root-cause assertion #2: the expanded Distribution's nested
+    // ref was rewritten to the prefixed wait binding, so it can be
+    // linked to the Effect::Wait.
+    let dist = parsed
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "cloudfront.Distribution")
+        .expect("expanded Distribution must be present");
+    assert!(
+        carina_core::deps::get_resource_value_ref_dependencies(dist).contains("r.cert_issued"),
+        "Distribution must depend on the prefixed wait binding \
+         `r.cert_issued`; deps were {:?}",
+        carina_core::deps::get_resource_value_ref_dependencies(dist)
+    );
+
+    // ---- Apply pipeline (mirrors `carina apply`): the Distribution
+    // must not fail / be skipped — it must wait for `r.cert_issued`.
+    let sorted_resources =
+        sort_resources_by_dependencies(&parsed.resources).expect("topological sort should succeed");
+
+    let current_states: HashMap<ResourceId, State> = HashMap::new();
+    let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+
+    let mut resources_for_plan = sorted_resources.clone();
+    resolve_refs_with_state_and_remote(&mut resources_for_plan, &current_states, &remote_bindings)
+        .expect("resolve_refs should succeed");
+
+    let registry = SchemaRegistry::new();
+    let plan = create_plan(
+        &resources_for_plan,
+        &current_states,
+        &HashMap::new(),
+        &registry,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &parsed.wait_bindings,
+    );
+
+    assert!(
+        plan.effects().iter().any(|e| matches!(
+            e,
+            carina_core::effect::Effect::Wait { binding, .. } if binding == "r.cert_issued"
+        )),
+        "create_plan must emit Effect::Wait for the prefixed wait binding"
+    );
+
+    let unresolved_resources: HashMap<ResourceId, _> = sorted_resources
+        .iter()
+        .map(|r| (r.id.clone(), r.clone()))
+        .collect();
+
+    let provider = MockProvider;
+    let observer = CollectingObserver {
+        failures: Mutex::new(Vec::new()),
+    };
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &unresolved_resources,
+        bindings: carina_core::binding_index::ResolvedBindings::default(),
+        current_states,
+    };
+
+    let result = execute_plan(&provider, input, &observer).await;
+
+    let failures = observer.failures.lock().unwrap().clone();
+    assert_eq!(
+        result.failure_count, 0,
+        "no effect should fail: the Distribution's \
+         `cert_issued.certificate_arn` must resolve after the wait, \
+         not fail immediately at dispatch. Failures: {failures:?}"
+    );
+    assert_eq!(
+        result.skip_count, 0,
+        "no effect should be skipped. Failures: {failures:?}"
+    );
+}


### PR DESCRIPTION
Closes #3061

## Root cause

The issue reported a downstream `<wait_binding>.<attr>` reference (the CloudFront `viewer_certificate.acm_certificate_arn = cert_issued.certificate_arn`) failing at apply with the self-contradicting *"add a `wait` block"* error. The decisive clue was the CI log: `✗ Create awscc.cloudfront.Distribution [0.0s]` — an **immediate** failure, not a 75min timeout.

The real `carina-rs/infra` `registry/dev/registry/` instantiates `usecases/registry` as a **module** (`let r = registry { ... }`). The `wait cert { ... }` and the Distribution both live *inside* that module.

`module_resolver::expander::expand_module_call` returned only `Vec<Resource>` — it **silently dropped the module's `wait_bindings` entirely**, and `intra_module_bindings` (the ref-rewrite set) excluded wait-binding names, so the Distribution's `cert_issued` ref was never instance-prefixed either.

Consequence: `create_plan` emitted no `Effect::Wait`, the Distribution got no dependency edge, dispatched immediately, and `assert_fully_resolved` rejected the still-`Deferred` ref at 0.0s — exactly the CI evidence (`3 succeeded, 1 failed, 3 skipped`, no timeout).

## Fix

- `expand_module_call` now returns `ExpandedModule { resources, wait_bindings }`.
- Wait-binding names are added to `intra_module_bindings` so the existing `rewrite_intra_module_refs` prefixes the downstream ref (`cert_issued` → `r.cert_issued`).
- New `prefix_wait_binding` instance-prefixes every binding-name field (`binding`, `target`, predicate LHS root, `depends_on`). `until_raw` (display surface) and `until_predicate.rhs` (comparison value) are not binding names and pass through unchanged.
- Both module-resolution call sites (`resolve_modules_with_config` and the nested `resolve_nested_modules`) merge the propagated, prefixed wait bindings into `parsed.wait_bindings`. Nested modules get a consistent double prefix (`o.c.cert_issued`) in lockstep with the doubly-prefixed downstream ref.

## Tests

Per CLAUDE.md "directory-scoped, never single-file":

- `module_wait_binding_survives_expansion_and_synchronizes_downstream` — directory fixture mirroring the real infra shape (caller `use` + module with `arguments`/`attributes` + sibling `acm.crn`/`cloudfront.crn` with the nested-map ref); drives the full parse → module-expand → `create_plan` → `execute_plan` path and asserts the Distribution waits instead of failing at dispatch.
- `nested_module_wait_binding_survives_two_expansions` — a `wait` declared two module levels deep survives both expansions with a doubly instance-prefixed binding.
- `test_expand_module_call_propagates_and_prefixes_wait_bindings` — unit-level prefix verification.
- `test_wait_downstream_nested_map_ref_resolves_at_apply` — executor-layer regression guard for nested-map wait-ref resolution.

Verify: workspace `cargo nextest run` (3334 passed), doctests (11 passed), `cargo clippy --all-targets -D warnings` clean, all 5 CI `scripts/check-*.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)