### PR TITLE
fix: re-apply provider normalizer on the apply path (root cause of aws#315)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -57,6 +57,7 @@ pub type ApplyResult = ExecutionResult;
 pub async fn execute_effects(
     plan: &Plan,
     provider: &dyn Provider,
+    normalizer: &dyn ProviderNormalizer,
     bindings: &mut ResolvedBindings,
     current_states: &mut HashMap<ResourceId, State>,
     unresolved_resources: &HashMap<ResourceId, Resource>,
@@ -66,6 +67,7 @@ pub async fn execute_effects(
         unresolved_resources,
         bindings: std::mem::take(bindings),
         current_states: std::mem::take(current_states),
+        normalizer,
     };
 
     let observer = CliObserver::new(plan);
@@ -1147,8 +1149,13 @@ async fn run_apply_locked(
         .map(|r| (r.id.clone(), r.clone()))
         .collect();
 
+    // `provider` is a `ProviderRouter`, which impls both `Provider` and
+    // `ProviderNormalizer`; the same object is passed in both positions
+    // so apply re-normalizes with exactly the plan-time normalizer
+    // (carina#3060). They must stay the same object.
     let mut result = execute_effects(
         &plan,
+        &provider,
         &provider,
         &mut bindings,
         &mut current_states,
@@ -1458,8 +1465,12 @@ async fn run_apply_from_plan_locked(
         .map(|r| (r.id.clone(), r.clone()))
         .collect();
 
+    // Same object in both positions: `ProviderRouter` is both the
+    // `Provider` and the `ProviderNormalizer`, so apply re-normalizes
+    // with the plan-time normalizer (carina#3060).
     let mut result = execute_effects(
         plan,
+        &provider,
         &provider,
         &mut bindings,
         &mut current_states,

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1833,6 +1833,7 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
     let result = execute_effects(
         &plan,
         &provider,
+        &carina_core::provider::NoopNormalizer,
         &mut bindings,
         &mut current_states,
         &unresolved_resources,
@@ -1995,6 +1996,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     let result = execute_effects(
         &plan,
         &provider,
+        &carina_core::provider::NoopNormalizer,
         &mut bindings,
         &mut current_states,
         &unresolved_resources,

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -8,7 +8,8 @@ use std::time::Instant;
 use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
 use crate::provider::{
-    CreateRequest, DeleteRequest, Provider, ReadRequest, UpdateRequest, build_update_patch,
+    CreateRequest, DeleteRequest, Provider, ProviderNormalizer, ReadRequest, UpdateRequest,
+    build_update_patch,
 };
 use crate::resolver::resolve_ref_value;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};
@@ -124,6 +125,7 @@ pub(super) async fn refresh_pending_states(
 pub(super) fn resolve_resource(
     resource: &Resource,
     bindings: &ResolvedBindings,
+    normalizer: &dyn ProviderNormalizer,
 ) -> Result<Resource, String> {
     let mut resolved = resource.clone();
     for (key, expr) in &resource.attributes {
@@ -131,7 +133,7 @@ pub(super) fn resolve_resource(
         assert_fully_resolved(&resolved_value, key)?;
         resolved.attributes.insert(key.clone(), resolved_value);
     }
-    Ok(resolved)
+    renormalize(resolved, normalizer)
 }
 
 /// Resolve a resource, preferring unresolved source for re-resolution.
@@ -143,6 +145,7 @@ pub(super) fn resolve_resource_with_source(
     target: &Resource,
     source: &Resource,
     bindings: &ResolvedBindings,
+    normalizer: &dyn ProviderNormalizer,
 ) -> Result<Resource, String> {
     let mut resolved = target.clone();
     for (key, expr) in &source.attributes {
@@ -150,6 +153,41 @@ pub(super) fn resolve_resource_with_source(
         assert_fully_resolved(&resolved_value, key)?;
         resolved.attributes.insert(key.clone(), resolved_value);
     }
+    renormalize(resolved, normalizer)
+}
+
+/// Re-apply the provider normalizer to a freshly resolved resource.
+///
+/// carina#3060: reference re-resolution rebuilds attributes from the
+/// un-normalized source, undoing the plan-time `normalize_desired`. Both
+/// resolve helpers funnel through here so apply-path resolution and
+/// plan-time `normalize_desired` can never diverge again — "resolved"
+/// always means "resolved and re-normalized" by construction.
+///
+/// Scope: this re-applies only `ProviderNormalizer::normalize_desired`.
+/// The plan-time pipeline (`PlanPreprocessor::prepare` + `apply/mod.rs`)
+/// also runs `carina_core::value::canonicalize_resources_with_schemas`
+/// (string/list-union coercion; carina-core, but needs the
+/// `SchemaRegistry` the executor is not given) and the carina-cli
+/// `resolve_enum_aliases_with_ctx` (enum-alias → canonical, e.g.
+/// `IpProtocol.all` → `"-1"`; `WiringContext`/factory-bound, genuinely
+/// unreachable from carina-core). Neither is re-applied here, so the
+/// alias/union axis of the same apply/plan divergence is intentionally
+/// out of scope and tracked in carina#3063 — closing it requires
+/// unifying the plan and apply resolve→normalize pipelines, a layering
+/// change beyond this fix.
+///
+/// Infallible today (`normalize_desired` returns `()`); the `Result` only
+/// mirrors the caller's signature — `resolve_resource{,_with_source}`
+/// fail-fast earlier on still-`Deferred` values — so this stays the tail
+/// expression without forcing `Ok(...)` at every call site.
+fn renormalize(
+    resolved: Resource,
+    normalizer: &dyn ProviderNormalizer,
+) -> Result<Resource, String> {
+    let mut one = [resolved];
+    normalizer.normalize_desired(&mut one);
+    let [resolved] = one;
     Ok(resolved)
 }
 
@@ -268,6 +306,18 @@ pub(super) fn count_actionable_effects(effects: &[Effect]) -> usize {
         .count()
 }
 
+/// Resolution + dispatch context for a basic effect, bundled to keep
+/// `execute_basic_effect`'s arity in check (clippy `too_many_arguments`)
+/// and mirroring `ReplaceContext`'s shape.
+pub(super) struct BasicEffectCtx<'a> {
+    pub(super) provider: &'a dyn Provider,
+    pub(super) bindings: &'a ResolvedBindings,
+    pub(super) unresolved: &'a HashMap<ResourceId, Resource>,
+    pub(super) normalizer: &'a dyn ProviderNormalizer,
+    pub(super) completed: &'a AtomicUsize,
+    pub(super) total: usize,
+}
+
 /// Execute a single Create, Update, or Delete effect.
 ///
 /// This helper encapsulates the shared dispatch logic: increment progress counter,
@@ -278,13 +328,15 @@ pub(super) fn count_actionable_effects(effects: &[Effect]) -> usize {
 /// Panics if called with a Replace, Read, Import, Remove, or Move effect.
 pub(super) async fn execute_basic_effect<'a>(
     effect: &'a Effect,
-    provider: &'a dyn Provider,
-    bindings: &'a ResolvedBindings,
-    unresolved: &'a HashMap<ResourceId, Resource>,
-    completed: &'a AtomicUsize,
-    total: usize,
+    ctx: &BasicEffectCtx<'a>,
     observer: &'a dyn ExecutionObserver,
 ) -> BasicEffectResult {
+    let provider = ctx.provider;
+    let bindings = ctx.bindings;
+    let unresolved = ctx.unresolved;
+    let normalizer = ctx.normalizer;
+    let completed = ctx.completed;
+    let total = ctx.total;
     let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
     let started = Instant::now();
     let progress = ProgressInfo {
@@ -295,7 +347,7 @@ pub(super) async fn execute_basic_effect<'a>(
 
     match effect {
         Effect::Create(resource) => {
-            let resolved = match resolve_resource(resource, bindings) {
+            let resolved = match resolve_resource(resource, bindings, normalizer) {
                 Ok(r) => r,
                 Err(e) => {
                     observer.on_event(&ExecutionEvent::EffectFailed {
@@ -355,21 +407,22 @@ pub(super) async fn execute_basic_effect<'a>(
             changed_attributes,
         } => {
             let resolve_source = unresolved.get(id).unwrap_or(to);
-            let resolved_to = match resolve_resource_with_source(to, resolve_source, bindings) {
-                Ok(r) => r,
-                Err(e) => {
-                    observer.on_event(&ExecutionEvent::EffectFailed {
-                        effect,
-                        error: &e,
-                        duration: started.elapsed(),
-                        progress,
-                    });
-                    return BasicEffectResult::Failure {
-                        binding: effect.binding_name(),
-                        refresh: None,
-                    };
-                }
-            };
+            let resolved_to =
+                match resolve_resource_with_source(to, resolve_source, bindings, normalizer) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        observer.on_event(&ExecutionEvent::EffectFailed {
+                            effect,
+                            error: &e,
+                            duration: started.elapsed(),
+                            progress,
+                        });
+                        return BasicEffectResult::Failure {
+                            binding: effect.binding_name(),
+                            refresh: None,
+                        };
+                    }
+                };
             let identifier = from.identifier.as_deref().unwrap_or("");
             // Augment plan-time `changed_attributes` with any
             // ResourceRef-derived attributes whose resolved value at

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
-use crate::provider::Provider;
+use crate::provider::{Provider, ProviderNormalizer};
 use crate::resource::{ResourceId, State};
 
 use parallel::execute_effects_sequential;
@@ -34,6 +34,13 @@ pub struct ExecutionInput<'a> {
     pub unresolved_resources: &'a HashMap<ResourceId, crate::resource::Resource>,
     pub bindings: ResolvedBindings,
     pub current_states: HashMap<ResourceId, State>,
+    /// The same provider normalizer that ran at plan time
+    /// (`PlanPreprocessor`). Apply-time reference re-resolution rebuilds
+    /// attributes from the un-normalized source, so the executor must
+    /// re-apply this after each resolution and before constructing the
+    /// provider request — otherwise plan-time normalization is silently
+    /// undone (carina#3060).
+    pub normalizer: &'a dyn ProviderNormalizer,
 }
 
 /// Result of executing a plan's effects.

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -12,8 +12,8 @@ use crate::provider::Provider;
 use crate::resource::{Resource, ResourceId, State, Value};
 
 use super::basic::{
-    ExecutionState, count_actionable_effects, execute_basic_effect, process_basic_result,
-    refresh_pending_states,
+    BasicEffectCtx, ExecutionState, count_actionable_effects, execute_basic_effect,
+    process_basic_result, refresh_pending_states,
 };
 use super::phased::DepResolver;
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
@@ -293,6 +293,7 @@ pub(super) async fn execute_effects_sequential(
             // Snapshot bindings for this effect's resolution
             let binding_snapshot = input.bindings.clone();
             let unresolved = &input.unresolved_resources;
+            let normalizer = input.normalizer;
             let completed_ref = &completed;
 
             in_flight.push(async move {
@@ -301,11 +302,14 @@ pub(super) async fn execute_effects_sequential(
                         SingleEffectResult::Basic(
                             execute_basic_effect(
                                 effect,
-                                provider,
-                                &binding_snapshot,
-                                unresolved,
-                                completed_ref,
-                                total,
+                                &BasicEffectCtx {
+                                    provider,
+                                    bindings: &binding_snapshot,
+                                    unresolved,
+                                    normalizer,
+                                    completed: completed_ref,
+                                    total,
+                                },
                                 observer,
                             )
                             .await,
@@ -340,6 +344,7 @@ pub(super) async fn execute_effects_sequential(
                                 temporary_name: temporary_name.as_ref(),
                                 bindings: &binding_snapshot,
                                 unresolved,
+                                normalizer,
                                 started,
                                 progress,
                             },

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -12,9 +12,9 @@ use crate::provider::{CreateRequest, DeleteRequest, Provider, UpdateRequest};
 use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use super::basic::{
-    BasicEffectResult, ExecutionState, count_actionable_effects, execute_basic_effect,
-    process_basic_result, queue_state_refresh, refresh_pending_states, resolve_resource,
-    resolve_resource_with_source,
+    BasicEffectCtx, BasicEffectResult, ExecutionState, count_actionable_effects,
+    execute_basic_effect, process_basic_result, queue_state_refresh, refresh_pending_states,
+    resolve_resource, resolve_resource_with_source,
 };
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
@@ -373,16 +373,20 @@ pub(super) async fn execute_effects_phased(
 
                 let binding_snapshot = input.bindings.clone();
                 let unresolved = &input.unresolved_resources;
+                let normalizer = input.normalizer;
                 let completed_ref = &completed;
 
                 in_flight.push(async move {
                     let basic = execute_basic_effect(
                         effect,
-                        provider,
-                        &binding_snapshot,
-                        unresolved,
-                        completed_ref,
-                        total,
+                        &BasicEffectCtx {
+                            provider,
+                            bindings: &binding_snapshot,
+                            unresolved,
+                            normalizer,
+                            completed: completed_ref,
+                            total,
+                        },
                         observer,
                     )
                     .await;
@@ -492,6 +496,7 @@ pub(super) async fn execute_effects_phased(
 
                 let binding_snapshot = input.bindings.clone();
                 let unresolved = &input.unresolved_resources;
+                let normalizer = input.normalizer;
 
                 in_flight.push(async move {
                     if let Effect::Replace {
@@ -508,6 +513,7 @@ pub(super) async fn execute_effects_phased(
                             to,
                             resolve_source,
                             &binding_snapshot,
+                            normalizer,
                         ) {
                             Ok(r) => r,
                             Err(e) => {
@@ -549,29 +555,29 @@ pub(super) async fn execute_effects_phased(
                                 let mut refreshes = Vec::new();
                                 let mut cascade_states = Vec::new();
                                 for cascade in cascading_updates {
-                                    let resolved_to =
-                                        match resolve_resource(&cascade.to, &local_bindings) {
-                                            Ok(r) => r,
-                                            Err(e) => {
-                                                observer.on_event(
-                                                    &ExecutionEvent::CascadeUpdateFailed {
-                                                        id: &cascade.id,
-                                                        error: &e,
-                                                    },
-                                                );
-                                                let cascade_identifier = cascade
-                                                    .from
-                                                    .identifier
-                                                    .as_deref()
-                                                    .unwrap_or("");
-                                                refreshes.push((
-                                                    cascade.id.clone(),
-                                                    cascade_identifier.to_string(),
-                                                ));
-                                                cascade_failed = true;
-                                                break;
-                                            }
-                                        };
+                                    let resolved_to = match resolve_resource(
+                                        &cascade.to,
+                                        &local_bindings,
+                                        normalizer,
+                                    ) {
+                                        Ok(r) => r,
+                                        Err(e) => {
+                                            observer.on_event(
+                                                &ExecutionEvent::CascadeUpdateFailed {
+                                                    id: &cascade.id,
+                                                    error: &e,
+                                                },
+                                            );
+                                            let cascade_identifier =
+                                                cascade.from.identifier.as_deref().unwrap_or("");
+                                            refreshes.push((
+                                                cascade.id.clone(),
+                                                cascade_identifier.to_string(),
+                                            ));
+                                            cascade_failed = true;
+                                            break;
+                                        }
+                                    };
                                     let cascade_identifier =
                                         cascade.from.identifier.as_deref().unwrap_or("");
                                     let cascade_patch =
@@ -968,6 +974,7 @@ pub(super) async fn execute_effects_phased(
 
                 let binding_snapshot = input.bindings.clone();
                 let unresolved = &input.unresolved_resources;
+                let normalizer = input.normalizer;
 
                 if let Effect::Replace {
                     id,
@@ -1102,6 +1109,7 @@ pub(super) async fn execute_effects_phased(
                                     to,
                                     resolve_source,
                                     &binding_snapshot,
+                                    normalizer,
                                 ) {
                                     Ok(r) => r,
                                     Err(e) => {

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
 use crate::provider::{
-    CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, UpdatePatch, UpdateRequest,
-    build_update_patch,
+    CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, ProviderNormalizer, UpdatePatch,
+    UpdateRequest, build_update_patch,
 };
 use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
@@ -88,6 +88,7 @@ pub(super) struct ReplaceContext<'a> {
     pub(super) temporary_name: Option<&'a crate::effect::TemporaryName>,
     pub(super) bindings: &'a ResolvedBindings,
     pub(super) unresolved: &'a HashMap<ResourceId, Resource>,
+    pub(super) normalizer: &'a dyn ProviderNormalizer,
     pub(super) started: Instant,
     pub(super) progress: ProgressInfo,
 }
@@ -115,7 +116,7 @@ pub(super) async fn execute_cbd_replace_parallel(
     ctx: &ReplaceContext<'_>,
     observer: &dyn ExecutionObserver,
 ) -> SingleEffectResult {
-    let resolved = match resolve_resource(ctx.to, ctx.bindings) {
+    let resolved = match resolve_resource(ctx.to, ctx.bindings, ctx.normalizer) {
         Ok(r) => r,
         Err(e) => {
             observer.on_event(&ExecutionEvent::EffectFailed {
@@ -153,19 +154,21 @@ pub(super) async fn execute_cbd_replace_parallel(
             // Execute cascading updates
             let mut cascade_failed = false;
             for cascade in ctx.cascading_updates {
-                let resolved_to = match resolve_resource(&cascade.to, &local_bindings) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        observer.on_event(&ExecutionEvent::CascadeUpdateFailed {
-                            id: &cascade.id,
-                            error: &e,
-                        });
-                        let cascade_identifier = cascade.from.identifier.as_deref().unwrap_or("");
-                        refreshes.push((cascade.id.clone(), cascade_identifier.to_string()));
-                        cascade_failed = true;
-                        break;
-                    }
-                };
+                let resolved_to =
+                    match resolve_resource(&cascade.to, &local_bindings, ctx.normalizer) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            observer.on_event(&ExecutionEvent::CascadeUpdateFailed {
+                                id: &cascade.id,
+                                error: &e,
+                            });
+                            let cascade_identifier =
+                                cascade.from.identifier.as_deref().unwrap_or("");
+                            refreshes.push((cascade.id.clone(), cascade_identifier.to_string()));
+                            cascade_failed = true;
+                            break;
+                        }
+                    };
                 let cascade_identifier = cascade.from.identifier.as_deref().unwrap_or("");
                 let cascade_patch = compute_full_diff_patch(&cascade.from, &resolved_to);
                 let cascade_request = UpdateRequest {
@@ -377,8 +380,12 @@ pub(super) async fn execute_dbd_replace_parallel(
     {
         Ok(()) => {
             let resolve_source = ctx.unresolved.get(&ctx.to.id).unwrap_or(ctx.to);
-            let resolved = match resolve_resource_with_source(ctx.to, resolve_source, ctx.bindings)
-            {
+            let resolved = match resolve_resource_with_source(
+                ctx.to,
+                resolve_source,
+                ctx.bindings,
+                ctx.normalizer,
+            ) {
                 Ok(r) => r,
                 Err(e) => {
                     observer.on_event(&ExecutionEvent::EffectFailed {

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::plan::Plan;
 use crate::provider::{
-    BoxFuture, CreateRequest, DeleteRequest, ProviderError, ProviderResult, ReadRequest,
-    UpdateRequest,
+    BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
+    ReadRequest, UpdateRequest,
 };
 use crate::resource::{ConcreteValue, DeferredValue, Directives, Resource, Value};
 use parallel::{build_dependency_levels, build_dependency_map};
@@ -24,6 +24,9 @@ struct MockProvider {
     /// assert that the executor handed the provider a fully-resolved
     /// resource (no remaining `Value::Deferred(ResourceRef)` etc.).
     create_resources: Arc<Mutex<Vec<Resource>>>,
+    /// `UpdateRequest`s passed in to `update()` in call order — lets a
+    /// test assert the patch carries re-normalized attribute values.
+    update_requests: Arc<Mutex<Vec<UpdateRequest>>>,
 }
 
 impl MockProvider {
@@ -35,6 +38,7 @@ impl MockProvider {
             read_results: Mutex::new(Vec::new()),
             call_log: Arc::new(Mutex::new(Vec::new())),
             create_resources: Arc::new(Mutex::new(Vec::new())),
+            update_requests: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -46,12 +50,10 @@ impl MockProvider {
         self.delete_results.lock().unwrap().push(result);
     }
 
-    #[allow(dead_code)]
     fn push_update(&self, result: ProviderResult<State>) {
         self.update_results.lock().unwrap().push(result);
     }
 
-    #[allow(dead_code)]
     fn push_read(&self, result: ProviderResult<State>) {
         self.read_results.lock().unwrap().push(result);
     }
@@ -62,6 +64,10 @@ impl MockProvider {
 
     fn captured_create_resources(&self) -> Vec<Resource> {
         self.create_resources.lock().unwrap().clone()
+    }
+
+    fn captured_update_requests(&self) -> Vec<UpdateRequest> {
+        self.update_requests.lock().unwrap().clone()
     }
 }
 
@@ -108,13 +114,14 @@ impl Provider for MockProvider {
         &self,
         id: &ResourceId,
         _identifier: &str,
-        _request: UpdateRequest,
+        request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id_str = id.to_string();
         self.call_log
             .lock()
             .unwrap()
             .push(("update".to_string(), id_str));
+        self.update_requests.lock().unwrap().push(request);
         let result = self.update_results.lock().unwrap().remove(0);
         Box::pin(async move { result })
     }
@@ -205,6 +212,72 @@ impl ExecutionObserver for MockObserver {
 }
 
 // -----------------------------------------------------------------------
+// Mock Normalizer
+// -----------------------------------------------------------------------
+
+/// Rewrites any string `"raw_dsl"` to `"CANONICAL"`, recursing into
+/// Map / List containers. Models a real provider normalizer that
+/// canonicalizes a DSL spelling nested under a struct field (the
+/// aws#315 IAM-policy `version`/`effect` shape). Used to prove the
+/// apply path re-runs `normalize_desired` after reference
+/// re-resolution (carina#3060).
+struct CanonicalizingNormalizer;
+
+fn canonicalize_value(v: &Value) -> Option<Value> {
+    match v {
+        Value::Concrete(ConcreteValue::String(s)) if s == "raw_dsl" => Some(Value::Concrete(
+            ConcreteValue::String("CANONICAL".to_string()),
+        )),
+        Value::Concrete(ConcreteValue::Map(m)) => {
+            let mut out = m.clone();
+            let mut changed = false;
+            for (k, val) in m {
+                if let Some(nv) = canonicalize_value(val) {
+                    out.insert(k.clone(), nv);
+                    changed = true;
+                }
+            }
+            changed.then_some(Value::Concrete(ConcreteValue::Map(out)))
+        }
+        Value::Concrete(ConcreteValue::List(items)) => {
+            let mut out = items.clone();
+            let mut changed = false;
+            for (i, item) in items.iter().enumerate() {
+                if let Some(nv) = canonicalize_value(item) {
+                    out[i] = nv;
+                    changed = true;
+                }
+            }
+            changed.then_some(Value::Concrete(ConcreteValue::List(out)))
+        }
+        _ => None,
+    }
+}
+
+impl crate::provider::ProviderNormalizer for CanonicalizingNormalizer {
+    fn normalize_desired(&self, resources: &mut [Resource]) {
+        for r in resources.iter_mut() {
+            let keys: Vec<String> = r.attributes.keys().cloned().collect();
+            for k in keys {
+                if let Some(v) = r.get_attr(&k)
+                    && let Some(nv) = canonicalize_value(v)
+                {
+                    r.set_attr(k, nv);
+                }
+            }
+        }
+    }
+
+    fn merge_default_tags(
+        &self,
+        _resources: &mut [Resource],
+        _default_tags: &indexmap::IndexMap<String, Value>,
+        _registry: &crate::schema::SchemaRegistry,
+    ) {
+    }
+}
+
+// -----------------------------------------------------------------------
 // Helper functions
 // -----------------------------------------------------------------------
 
@@ -258,6 +331,7 @@ async fn test_simple_create() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -270,6 +344,185 @@ async fn test_simple_create() {
             .events()
             .iter()
             .any(|e| e.starts_with("succeeded:"))
+    );
+}
+
+/// carina#3060: the apply execution path must re-apply the provider
+/// normalizer after reference re-resolution, before building the
+/// provider request. Plan-time normalization is undone when the
+/// executor rebuilds attributes from the (un-normalized) source, so
+/// without a re-normalize the provider receives the raw DSL spelling.
+///
+/// This exercises the *apply path* (`execute_plan`), not
+/// `normalize_desired` in isolation — the gap the prior
+/// carina-provider-aws#316 unit test missed.
+#[tokio::test]
+async fn test_apply_renormalizes_after_resolution() {
+    let provider = MockProvider::new();
+    let mut resource = make_resource("a", &[]);
+    // The DSL spelling a provider normalizer would canonicalize at
+    // plan time. The executor must re-canonicalize it on the apply
+    // path so the provider never sees `"raw_dsl"`.
+    resource.set_attr(
+        "marker",
+        Value::Concrete(ConcreteValue::String("raw_dsl".to_string())),
+    );
+    let rid = resource.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(resource));
+    provider.push_create(Ok(ok_state(&rid)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &CanonicalizingNormalizer,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 1);
+
+    let captured = provider.captured_create_resources();
+    assert_eq!(captured.len(), 1);
+    assert_eq!(
+        captured[0].get_attr("marker"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "CANONICAL".to_string()
+        ))),
+        "apply path must re-run normalize_desired so the provider \
+         receives the canonical value, not the raw DSL spelling"
+    );
+}
+
+/// carina#3060, Update path (the path closest to the aws#315 symptom —
+/// `aws.s3.BucketPolicy` failed on *Update*, not Create). The
+/// `UpdateRequest.patch` is built from the re-resolved `to`; without
+/// the apply-path re-normalize the patch would carry the raw DSL
+/// spelling and the provider would reject it (`MalformedPolicy`).
+#[tokio::test]
+async fn test_apply_renormalizes_update_path() {
+    let provider = MockProvider::new();
+    let mut to_resource = make_resource("a", &[]);
+    to_resource.set_attr(
+        "marker",
+        Value::Concrete(ConcreteValue::String("raw_dsl".to_string())),
+    );
+    let rid = to_resource.id.clone();
+
+    let mut from_attrs = HashMap::new();
+    from_attrs.insert(
+        "marker".to_string(),
+        Value::Concrete(ConcreteValue::String("old".to_string())),
+    );
+    let from_state = State::existing(rid.clone(), from_attrs).with_identifier("id-123");
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Update {
+        id: rid.clone(),
+        from: Box::new(from_state),
+        to: to_resource,
+        changed_attributes: vec!["marker".to_string()],
+    });
+    provider.push_update(Ok(ok_state(&rid)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &CanonicalizingNormalizer,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 1);
+
+    let reqs = provider.captured_update_requests();
+    assert_eq!(reqs.len(), 1);
+    let marker_op = reqs[0]
+        .patch
+        .ops
+        .iter()
+        .find(|op| op.key == "marker")
+        .expect("patch must contain the changed `marker` attribute");
+    assert_eq!(
+        marker_op.value,
+        Some(Value::Concrete(ConcreteValue::String(
+            "CANONICAL".to_string()
+        ))),
+        "Update patch must carry the re-normalized value, not raw DSL"
+    );
+}
+
+/// carina#3060 acceptance, exact shape: a normalizable value nested
+/// under a struct attribute *on a resource that also has a
+/// ResourceRef*. This is the real aws#315 regression shape — the ref
+/// forces `resolve_resource` to rebuild attributes from the
+/// un-normalized source, so the nested `marker` would revert to
+/// `"raw_dsl"` without the apply-path re-normalize. Exercises the real
+/// `execute_plan` path (Create `a` → state → Create `b` resolves
+/// `ref_a` from `a`'s post-create state).
+#[tokio::test]
+async fn test_apply_renormalizes_nested_value_under_ref_bearing_resource() {
+    let provider = MockProvider::new();
+    let ra = make_resource("a", &[]);
+    let ra_id = ra.id.clone();
+
+    // `b` depends on `a` (ResourceRef `ref_a`) AND carries a
+    // normalizable value nested inside a Map attribute `config`.
+    let mut rb = make_resource("b", &["a"]);
+    let mut config = indexmap::IndexMap::new();
+    config.insert(
+        "marker".to_string(),
+        Value::Concrete(ConcreteValue::String("raw_dsl".to_string())),
+    );
+    rb.set_attr("config", Value::Concrete(ConcreteValue::Map(config)));
+    let rb_id = rb.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(ra));
+    plan.add(Effect::Create(rb));
+    provider.push_create(Ok(ok_state(&ra_id)));
+    provider.push_create(Ok(ok_state(&rb_id)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &CanonicalizingNormalizer,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 2, "both creates should succeed");
+
+    let captured = provider.captured_create_resources();
+    let b = captured
+        .iter()
+        .find(|r| r.id == rb_id)
+        .expect("resource b must have been created");
+    let Some(Value::Concrete(ConcreteValue::Map(cfg))) = b.get_attr("config") else {
+        panic!("expected config Map on b, got {:?}", b.get_attr("config"));
+    };
+    assert_eq!(
+        cfg.get("marker"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "CANONICAL".to_string()
+        ))),
+        "nested value under a ref-bearing resource must be \
+         re-normalized at apply, not reverted to raw DSL"
+    );
+    // The ref itself must still have resolved correctly.
+    assert_eq!(
+        b.get_attr("ref_a"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "id-123".to_string()
+        ))),
+        "ResourceRef must resolve from a's post-create state"
     );
 }
 
@@ -295,6 +548,7 @@ async fn test_simple_delete() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -323,6 +577,7 @@ async fn test_failed_effect_propagates_to_dependent() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -370,6 +625,7 @@ async fn test_cbd_creates_before_deletes() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -411,6 +667,7 @@ async fn test_dbd_deletes_before_creates() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -485,6 +742,7 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -558,6 +816,7 @@ async fn test_phased_noncbd_creates_after_deletes() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -591,6 +850,7 @@ async fn test_observer_events_emitted_correctly() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -615,6 +875,7 @@ async fn test_read_effect_is_no_op() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -652,6 +913,7 @@ async fn test_independent_effects_run_in_parallel() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -699,6 +961,7 @@ async fn test_parallel_failure_skips_dependents() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -743,6 +1006,7 @@ async fn test_dependency_levels_sequential_chain() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -966,6 +1230,7 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1005,6 +1270,7 @@ async fn test_waiting_events_emitted_for_dependent_effects() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1176,6 +1442,7 @@ async fn test_update_effect_binding_map_propagation() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1291,6 +1558,7 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1471,6 +1739,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1557,6 +1826,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1644,6 +1914,7 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1707,6 +1978,7 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1820,6 +2092,7 @@ async fn test_chained_index_then_field_unresolved_at_apply_fails_with_clear_erro
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();
@@ -1996,6 +2269,7 @@ async fn test_chained_index_then_nested_field_resolves_from_post_create_state() 
         unresolved_resources: &HashMap::new(),
         bindings: ResolvedBindings::default(),
         current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
     };
 
     let observer = MockObserver::new();


### PR DESCRIPTION
## Summary

Closes #3060.

`ProviderNormalizer::normalize_desired` ran at plan time (`PlanPreprocessor`), but the apply executor rebuilt provider requests by re-resolving attributes from the **un-normalized** source resources and never re-applied the normalizer. Any value the normalizer canonicalized at plan time silently reverted to its raw DSL form before reaching the provider's `create`/`update` — the **root cause** of carina-rs/carina-provider-aws#315 (`aws.s3.BucketPolicy` apply failed `MalformedPolicy`: plan clean, apply broken). `grep -rn normalize_desired carina-core/src/executor/` was zero hits.

## Fix

Make resolution **inherently re-normalize** so plan and apply cannot diverge again:

- `resolve_resource` / `resolve_resource_with_source` (`carina-core/src/executor/basic.rs`) now funnel through a private `renormalize()` that re-runs `normalize_desired(&mut [resolved])`. "Resolved" now means "resolved **and re-normalized**" by construction.
- `&dyn ProviderNormalizer` threaded through `ExecutionInput`, `execute_basic_effect` (args bundled into a new `BasicEffectCtx` to stay within clippy's arity limit, mirroring the existing `ReplaceContext`), `ReplaceContext`, and the CLI `execute_effects`. Production passes the same `ProviderRouter` as both `Provider` and `ProviderNormalizer` (commented at both sites).

All apply-path resolve sites (Create, Update, Replace CBD/DBD, cascade — 5 logical sites across basic/replace/phased) go through the re-normalizing helpers.

## Scope

This closes the **`normalize_desired` axis**. The plan-time pipeline also runs `canonicalize_resources_with_schemas` (string/list-union, SchemaRegistry-bound) and the carina-cli `resolve_enum_aliases_with_ctx` (`WiringContext`-bound, unreachable from carina-core). The same apply/plan divergence for that axis is the same root-cause class but a layering change beyond this fix — tracked in #3063. (aws#315's IAM-policy headline is independently fixed provider-side by carina-provider-aws#319; this is the general core fix.)

## Tests

Three regression tests via the **real `execute_plan` path** (not `normalize_desired` in isolation — the gap the prior aws#316 unit test missed):

- `test_apply_renormalizes_after_resolution` — Create path
- `test_apply_renormalizes_update_path` — Update path (closest to the aws#315 symptom), asserts the `UpdateRequest.patch` op carries the canonical value
- `test_apply_renormalizes_nested_value_under_ref_bearing_resource` — the exact aws#315 acceptance shape: a value nested under a struct attribute on a resource that also has a `ResourceRef` (the ref forces rebuild-from-source)

## Test plan

- [x] `cargo nextest run --workspace` — 3333 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check-{example-warnings,no-direct-resources-access,plan-fixtures,provider-boundaries}.sh`
- [ ] Real-infra `carina-rs/infra` apply — user-driven (also covered provider-side by carina-provider-aws#319)

🤖 Generated with [Claude Code](https://claude.com/claude-code)