### PR TITLE
fix: schema-aware compute_string_list_change for List<StringEnum> (closes #3075)

### DIFF
--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -625,7 +625,7 @@ fn build_update_rows(
                 Some(row) => rows.push(row),
                 None => effectively_unchanged += 1,
             }
-        } else if let Some(diff) = compute_string_list_change(old_value, new_value) {
+        } else if let Some(diff) = compute_string_list_change(old_value, new_value, attr_type) {
             rows.push(DetailRow::StringListDiff {
                 key: key.to_string(),
                 unchanged: diff.unchanged,
@@ -751,7 +751,7 @@ fn build_replace_rows(
                 key: key.to_string(),
                 entries,
             });
-        } else if let Some(diff) = compute_string_list_change(old_value, new_value) {
+        } else if let Some(diff) = compute_string_list_change(old_value, new_value, attr_type) {
             rows.push(DetailRow::ReplaceStringListDiff {
                 key: key.to_string(),
                 unchanged: diff.unchanged,
@@ -1232,7 +1232,9 @@ fn compute_list_of_maps_diff_parts(
                         key: k.to_string(),
                         entries: nested,
                     });
-                } else if let Some(diff) = compute_string_list_change(old_val, &new_map[k]) {
+                } else if let Some(diff) =
+                    compute_string_list_change(old_val, &new_map[k], field_type)
+                {
                     fields.push(ListOfMapsDiffField::StringListChanged {
                         key: k.to_string(),
                         unchanged: diff.unchanged,
@@ -1355,17 +1357,45 @@ fn should_render_as_map_diff(old_value: Option<&Value>, new_value: &Value) -> bo
 fn compute_string_list_change(
     old_value: Option<&Value>,
     new_value: &Value,
+    attr_type: Option<&AttributeType>,
 ) -> Option<crate::diff_helpers::StringListDiff> {
-    let new_list = crate::value::as_string_list(new_value)?;
-    let old_list = match old_value {
+    let mut new_list = crate::value::as_string_list(new_value)?;
+    let mut old_list = match old_value {
         Some(ov) => crate::value::as_string_list(ov)?,
         None => Vec::new(),
     };
+    // carina#3075: when the element type is a `StringEnum`, the set-diff
+    // must compare enum *values*, not raw spellings — otherwise a
+    // DSL-alias element (`"allow"`) vs its API-canonical form
+    // (`"Allow"`) is reported as a phantom `- allow / + Allow` pair
+    // alongside any genuine add/remove. Canonicalize every element to
+    // the API spelling first, mirroring the differ's `StringEnum` arm
+    // (`extract_enum_value_with_values` → `DslMap::api_for`).
+    if let Some((_, values, _, dsl_map)) = attr_type
+        .and_then(string_list_inner_type)
+        .and_then(|t| t.string_enum_parts())
+    {
+        let valid: Vec<&str> = values.iter().map(String::as_str).collect();
+        for s in old_list.iter_mut().chain(new_list.iter_mut()) {
+            *s = crate::utils::canonicalize_enum_to_api(s, &valid, &dsl_map);
+        }
+    }
     let diff = crate::diff_helpers::compute_string_list_diff(&old_list, &new_list);
     if diff.added.is_empty() && diff.removed.is_empty() {
         return None;
     }
     Some(diff)
+}
+
+/// Return a `List`'s element type, descending recursively through
+/// `Union` members to find the first `List` arm. Returns `None` when
+/// `attr_type` resolves to nothing list-shaped.
+fn string_list_inner_type(attr_type: &AttributeType) -> Option<&AttributeType> {
+    match attr_type {
+        AttributeType::List { inner, .. } => Some(inner),
+        AttributeType::Union(members) => members.iter().find_map(string_list_inner_type),
+        _ => None,
+    }
 }
 
 /// Check whether a Value references the given binding name.
@@ -2405,5 +2435,128 @@ mod tests {
         // The displayed tally adds up: 1 rendered + 2 hidden == 3
         // total non-internal attributes.
         assert_eq!(changed_rows + hidden.unwrap(), 3);
+    }
+
+    fn modes_registry() -> SchemaRegistry {
+        let mode = AttributeType::StringEnum {
+            name: "Mode".to_string(),
+            values: vec!["Allow".to_string(), "Deny".to_string()],
+            namespace: None,
+            dsl_aliases: vec![
+                ("Allow".to_string(), "allow".to_string()),
+                ("Deny".to_string(), "deny".to_string()),
+            ],
+        };
+        let schema = ResourceSchema::new("x.Thing").attribute(AttributeSchema::new(
+            "modes",
+            AttributeType::List {
+                inner: Box::new(mode),
+                ordered: false,
+            },
+        ));
+        let mut registry = SchemaRegistry::new();
+        registry.insert("", schema);
+        registry
+    }
+
+    /// Real apply/plan-path element shape for a `List<StringEnum>`:
+    /// both state (lifted by `lift_saved_state_string_enums`) and
+    /// desired (parser-emitted per carina#2986) carry
+    /// `ConcreteValue::EnumIdentifier`, NOT `String`. Tests must use
+    /// this shape — a `String`-element test passes while the real path
+    /// is broken (unit-test-path ≠ apply-path).
+    fn enum_list(items: &[&str]) -> Value {
+        Value::Concrete(ConcreteValue::List(
+            items
+                .iter()
+                .map(|s| Value::Concrete(ConcreteValue::EnumIdentifier(s.to_string())))
+                .collect(),
+        ))
+    }
+
+    /// carina#3075: a `List<StringEnum>` attribute whose state holds the
+    /// DSL-alias spelling (`["allow"]`) and whose desired resolves to
+    /// API-canonical (`["Allow", "Deny"]`) — a genuine add of `Deny`
+    /// co-occurring with an enum-spelling-only element. The
+    /// `compute_string_list_change` set-diff was schema-blind, so it
+    /// reported a phantom `- allow / + Allow` alongside the real
+    /// `+ Deny`. Schema-aware: only the genuine add must render.
+    /// Elements are `EnumIdentifier` (the real runtime shape).
+    #[test]
+    fn update_string_list_of_string_enum_only_genuine_add_renders() {
+        let registry = modes_registry();
+        let from = State::existing(
+            ResourceId::new("x.Thing", "t"),
+            [("modes".to_string(), enum_list(&["allow"]))]
+                .into_iter()
+                .collect(),
+        );
+        let to =
+            Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
+        let effect = Effect::Update {
+            id: ResourceId::new("x.Thing", "t"),
+            from: Box::new(from),
+            to,
+            changed_attributes: vec!["modes".to_string()],
+        };
+        let rows = build_detail_rows(&effect, Some(&registry), DetailLevel::Explicit, None, None);
+        // Exactly one StringListDiff row, adding only the genuine
+        // `Deny` (the `allow`↔`Allow` element is enum-equal → not a
+        // phantom add/remove).
+        assert_eq!(rows.len(), 1, "expected one row, got: {rows:?}");
+        let DetailRow::StringListDiff { added, removed, .. } = &rows[0] else {
+            panic!("expected StringListDiff, got: {rows:?}");
+        };
+        assert!(
+            removed.is_empty(),
+            "no phantom removal of `allow`, got removed: {removed:?}"
+        );
+        assert_eq!(
+            added.len(),
+            1,
+            "only the genuine `Deny` add, got added: {added:?}"
+        );
+        assert!(
+            added[0].eq_ignore_ascii_case("deny"),
+            "the genuine add is Deny, got: {added:?}"
+        );
+    }
+
+    /// Negative (carina#3075, mirrors the carina#3073 fallback
+    /// convention): with no registry, `compute_string_list_change`
+    /// stays schema-blind — the raw-spelling set-diff still reports the
+    /// phantom `- allow` + `+ Allow` alongside the genuine `+ Deny`.
+    /// Pins that the canonicalization only engages when a schema is
+    /// available. Same real `EnumIdentifier` element shape.
+    #[test]
+    fn update_string_list_of_string_enum_no_registry_keeps_schema_blind() {
+        let from = State::existing(
+            ResourceId::new("x.Thing", "t"),
+            [("modes".to_string(), enum_list(&["allow"]))]
+                .into_iter()
+                .collect(),
+        );
+        let to =
+            Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
+        let effect = Effect::Update {
+            id: ResourceId::new("x.Thing", "t"),
+            from: Box::new(from),
+            to,
+            changed_attributes: vec!["modes".to_string()],
+        };
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
+        assert_eq!(rows.len(), 1, "expected one row, got: {rows:?}");
+        let DetailRow::StringListDiff { added, removed, .. } = &rows[0] else {
+            panic!("expected StringListDiff, got: {rows:?}");
+        };
+        // Schema-blind: `allow` (state) is not in the new raw set
+        // {`Allow`,`Deny`} → removed; both `Allow` and `Deny` are not
+        // in the old raw set {`allow`} → added.
+        assert_eq!(removed, &vec!["allow".to_string()], "schema-blind removal");
+        assert_eq!(
+            added,
+            &vec!["Allow".to_string(), "Deny".to_string()],
+            "schema-blind additions"
+        );
     }
 }

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -340,6 +340,41 @@ pub fn extract_enum_value_with_values<'a>(s: &'a str, valid_values: &[&str]) -> 
     extract_enum_value(s)
 }
 
+/// Canonicalize one `StringEnum` value to its API spelling: strip any
+/// namespace prefix ([`extract_enum_value_with_values`]) then map the
+/// DSL alias to the API form via [`crate::schema::DslMap::api_for`].
+///
+/// This is the exact-match canonicalization used by the plan renderer's
+/// `StringEnum`-list diff (carina#3075) and the carina-provider
+/// `api_canonicalize` normalizers. (The differ's `StringEnum` equality
+/// arm uses a deliberately *case-insensitive* alias fold for comparison
+/// — a different operation — and is intentionally not routed here.)
+///
+/// ```
+/// use carina_core::schema::DslMap;
+/// use carina_core::utils::canonicalize_enum_to_api;
+///
+/// let aliases = [("Allow".to_string(), "allow".to_string())];
+/// let dsl_map = DslMap::Aliases(&aliases);
+/// let valid = &["Allow", "Deny"];
+/// // DSL alias → API spelling
+/// assert_eq!(canonicalize_enum_to_api("allow", valid, &dsl_map), "Allow");
+/// // Already-canonical round-trips to itself
+/// assert_eq!(canonicalize_enum_to_api("Allow", valid, &dsl_map), "Allow");
+/// // Namespaced form is stripped, then canonicalized
+/// assert_eq!(
+///     canonicalize_enum_to_api("aws.x.Mode.allow", valid, &dsl_map),
+///     "Allow"
+/// );
+/// ```
+pub fn canonicalize_enum_to_api(
+    s: &str,
+    valid_values: &[&str],
+    dsl_map: &crate::schema::DslMap<'_>,
+) -> String {
+    dsl_map.api_for(extract_enum_value_with_values(s, valid_values))
+}
+
 /// Strip the namespace prefix from a DSL enum identifier and return the raw value.
 ///
 /// Handles the following patterns:

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1083,18 +1083,29 @@ pub fn is_list_of_maps(value: &Value) -> bool {
 }
 
 /// Extract a `Vec<String>` from a `Value::Concrete(ConcreteValue::StringList)` or a `Value::Concrete(ConcreteValue::List)`
-/// whose every element is `Value::Concrete(ConcreteValue::String)`. Returns `None` for other
-/// shapes. Empty lists return `Some(vec![])` so callers can distinguish
-/// "empty string list" from "not a string list" — needed by #2943's
-/// diff path so a list shrinking to empty still routes through
-/// per-element `-` lines instead of the inline `[a, b] → []` form.
+/// whose every element is a string-bearing scalar — `String` **or**
+/// `EnumIdentifier`. Returns `None` for other shapes. Empty lists
+/// return `Some(vec![])` so callers can distinguish "empty string
+/// list" from "not a string list" — needed by #2943's diff path so a
+/// list shrinking to empty still routes through per-element `-` lines
+/// instead of the inline `[a, b] → []` form.
+///
+/// `EnumIdentifier` is accepted (carina#3075): a `List<StringEnum>`
+/// reaches the renderer with `EnumIdentifier` elements on both sides
+/// (state lifted by `lift_saved_state_string_enums`, desired emitted
+/// by the parser per carina#2986). Treating it as its string payload —
+/// the same `String`/`EnumIdentifier` interchangeability the differ's
+/// `StringEnum` arm already relies on — lets the string-list diff path
+/// (and its schema-aware enum canonicalization) engage instead of the
+/// value falling to a coarse inline `Changed` row.
 pub fn as_string_list(value: &Value) -> Option<Vec<String>> {
     match value {
         Value::Concrete(ConcreteValue::StringList(items)) => Some(items.clone()),
         Value::Concrete(ConcreteValue::List(items)) => items
             .iter()
             .map(|v| match v {
-                Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
+                Value::Concrete(ConcreteValue::String(s))
+                | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.clone()),
                 _ => None,
             })
             .collect(),


### PR DESCRIPTION
Closes #3075

Follow-up from carina#3073's round-1 review. carina#3073 made the plan detail-row renderer schema-aware at five sites, but `compute_string_list_change` (the `List<...>` set-diff path) stayed schema-blind.

## Problem

For a `List<StringEnum>` attribute whose state holds the DSL-alias spelling (`["allow"]`) and whose desired resolves to the API-canonical spelling (`["Allow"]`), a *co-occurring genuine add/remove* (e.g. `+ Deny`) keeps the attribute out of carina#3073's site-1 short-circuit. The raw-spelling set-diff then reported a phantom `- allow / + Allow` alongside the real change — never converging.

## Fix

- `compute_string_list_change` gains an `attr_type` param; for a `StringEnum` element type it canonicalizes every element to its API spelling before the set-diff via the new shared `carina_core::utils::canonicalize_enum_to_api` (`extract_enum_value_with_values` → `DslMap::api_for`). Threaded at all three call sites.
- `string_list_inner_type` resolves the element type (recursing `Union` to the first `List` arm).
- **`as_string_list` (carina-core `value.rs`) now also accepts `ConcreteValue::EnumIdentifier` list elements.** This is the load-bearing enabling fix: on the real apply/plan path a `List<StringEnum>` arrives with `EnumIdentifier` elements on both sides (state lifted by `lift_saved_state_string_enums`, desired emitted by the parser per carina#2986). The prior `String`-only guard early-returned `None`, so the schema-aware canonicalization could never engage and the value fell to a coarse inline `Changed` row. Round-2 self-review caught this (a `String`-element test passed while the apply path was broken — unit-test-path ≠ apply-path). The extension mirrors the `String`/`EnumIdentifier` interchangeability the differ's `StringEnum` arm already relies on; it is strictly additive (only previously-`None` inputs change).

## Tests

Use the real `EnumIdentifier` element shape: positive (only the genuine `Deny` add renders, no phantom `allow`/`Allow`) + no-registry negative (schema-blind fallback unchanged) + a `canonicalize_enum_to_api` doctest. Both production tests were independently verified to **fail when the production hunks are reverted** (genuine apply-path coverage, not vacuous).

## Scope / follow-up

Confined to `carina-core/{detail_rows,value,utils}.rs`. No snapshot drift (the List<EnumIdentifier> → StringListDiff layout shift is a benign #2943-consistent improvement; zero existing fixtures exercised it).

- **carina#3077** (filed): unify the three StringEnum canonicalization sites. The differ's `StringEnum` equality arm uses a deliberately *case-insensitive* alias fold (load-bearing for aws#271 compound-alias equality) and schema validation is a different operation — folding them needs its own design + blast-radius, out of scope here.
- carina#3078 closed as folded-into-this-PR (it was the `as_string_list` real-path gap).

## Verification

- `cargo nextest run --workspace` → 3352 passed, 0 failed
- `cargo test --workspace --doc` → ok (incl. new `canonicalize_enum_to_api` doctest)
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean
- all 5 `scripts/check-*.sh` → exit 0
- 5-round self-review: round 2 caught + fixed the `as_string_list` real-path gap; rounds 3–5 clean, revert-sensitivity independently re-confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
