### PR TITLE
fix: resolve wait-binding refs via passthrough alias (closes #3085)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -945,8 +945,11 @@ async fn run_apply_locked(
     // (carina#3085). Built once here so every resolution phase below
     // (data-source refresh, initial bindings, ref resolution, exports)
     // applies the same passthrough.
-    let wait_aliases: Vec<WaitAliasSpec> =
-        parsed.wait_bindings.iter().map(WaitAliasSpec::from).collect();
+    let wait_aliases: Vec<WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(WaitAliasSpec::from)
+        .collect();
 
     // Phase 2: resolve data source inputs against the consolidated state
     // and refresh them via `read_data_source` (#1683, #1685).

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 
 use futures::stream::{self, StreamExt};
 
-use carina_core::binding_index::ResolvedBindings;
+use carina_core::binding_index::{ResolvedBindings, WaitAliasSpec};
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
@@ -298,7 +298,8 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
     // no source-side view of which exports the user intends — see the
     // `FinalizeApplyInput::export_params` doc-comment.
     if let Some(params) = input.export_params {
-        state.exports = resolve_exports(params, input.sorted_resources, &state)?;
+        state.exports =
+            resolve_exports(params, input.sorted_resources, &state, input.wait_aliases)?;
     }
 
     if let Some(lock) = input.lock {
@@ -352,9 +353,10 @@ pub(crate) async fn persist_exports_only(
     state_file: Option<StateFile>,
     sorted_resources: &[Resource],
     export_params: &[carina_core::parser::InferredExportParam],
+    wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
-    let exports = resolve_exports(export_params, sorted_resources, &state)?;
+    let exports = resolve_exports(export_params, sorted_resources, &state, wait_aliases)?;
     state.exports = exports;
     if let Some(lk) = lock {
         save_state_locked(backend, lk, &mut state).await?;
@@ -939,6 +941,13 @@ async fn run_apply_locked(
         pairs
     };
 
+    // Wait bindings become passthrough aliases to their targets
+    // (carina#3085). Built once here so every resolution phase below
+    // (data-source refresh, initial bindings, ref resolution, exports)
+    // applies the same passthrough.
+    let wait_aliases: Vec<WaitAliasSpec> =
+        parsed.wait_bindings.iter().map(WaitAliasSpec::from).collect();
+
     // Phase 2: resolve data source inputs against the consolidated state
     // and refresh them via `read_data_source` (#1683, #1685).
     let resolved_data_sources = resolve_data_source_refs_for_refresh(
@@ -946,6 +955,7 @@ async fn run_apply_locked(
         &current_states,
         &remote_bindings,
         ctx.schemas(),
+        &wait_aliases,
     )?;
     let phase2_results: Vec<Result<(ResourceId, State), AppError>> =
         stream::iter(resolved_data_sources.iter())
@@ -971,11 +981,13 @@ async fn run_apply_locked(
         current_states.insert(id, state);
     }
 
-    // Build initial bindings for reference resolution
+    // Build initial bindings for reference resolution (wait_aliases
+    // defined above before Phase 2).
     let mut bindings = ResolvedBindings::from_resources_with_state(
         &sorted_resources,
         &current_states,
         &remote_bindings,
+        &wait_aliases,
     );
 
     // awscc#251: lift the provider-read `current_states` (not just
@@ -991,7 +1003,12 @@ async fn run_apply_locked(
 
     // Resolve references and enum identifiers, then create initial plan for display
     let mut resources_for_plan = sorted_resources.clone();
-    resolve_refs_with_state_and_remote(&mut resources_for_plan, &current_states, &remote_bindings)?;
+    resolve_refs_with_state_and_remote(
+        &mut resources_for_plan,
+        &current_states,
+        &remote_bindings,
+        &wait_aliases,
+    )?;
 
     // Type-level canonicalization for `Union[String, list(String)]`
     // fields (IAM-style `string_or_list_of_strings`). See #2481, #2511.
@@ -1054,6 +1071,7 @@ async fn run_apply_locked(
             &parsed.export_params,
             &sorted_resources,
             &current_states,
+            &wait_aliases,
         );
         let empty_exports = HashMap::new();
         let current_exports = state_file
@@ -1101,6 +1119,7 @@ async fn run_apply_locked(
             state_file,
             &sorted_resources,
             &parsed.export_params,
+            &wait_aliases,
         )
         .await?;
         return Ok(());
@@ -1130,6 +1149,7 @@ async fn run_apply_locked(
         &parsed.export_params,
         &sorted_resources,
         &current_states,
+        &wait_aliases,
     );
     let current_exports = state_file
         .as_ref()
@@ -1202,6 +1222,7 @@ async fn run_apply_locked(
         lock,
         schemas,
         export_params: Some(&parsed.export_params),
+        wait_aliases: &wait_aliases,
     })
     .await?;
 
@@ -1469,10 +1490,25 @@ async fn run_apply_from_plan_locked(
     if !plan_file.upstream_sources.is_empty() {
         verify_upstream_snapshot(&plan_file.upstream_sources, &upstream_snapshot, base_dir).await?;
     }
+    // Rebuild the wait passthrough aliases from the persisted
+    // `(binding, target)` pairs so `apply --plan`'s cascade
+    // re-resolution resolves `<wait-binding>.<attr>` exactly as the
+    // plan path did (carina#3085). `PlanWaitBinding` (String) →
+    // `WaitAliasSpec` (typed `BindingName`); the parser `WaitBinding`
+    // is not serializable so it is reconstructed here, not deserialized.
+    let wait_aliases: Vec<WaitAliasSpec> = plan_file
+        .wait_bindings
+        .iter()
+        .map(|wb| WaitAliasSpec {
+            binding: carina_core::parser::BindingName::new(wb.binding.clone()),
+            target: carina_core::parser::BindingName::new(wb.target.clone()),
+        })
+        .collect();
     let mut bindings = ResolvedBindings::from_resources_with_state(
         sorted_resources,
         &current_states,
         &upstream_snapshot,
+        &wait_aliases,
     );
 
     println!("{}", "Applying changes...".cyan().bold());
@@ -1523,6 +1559,10 @@ async fn run_apply_from_plan_locked(
         // Source-driven `carina apply` reconciles exports from the
         // `.crn` directly (#2932).
         export_params: None,
+        // No export resolution runs here (export_params is None), but
+        // the field is required; pass the reconstructed aliases so the
+        // value is correct if a future plan file persists export_params.
+        wait_aliases: &wait_aliases,
     })
     .await?;
 

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -523,7 +523,7 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     registry_prod.binding = Some("registry_prod".to_string());
     let sorted_resources = vec![registry_prod];
 
-    let exports = resolve_exports(&export_params, &sorted_resources, &state).unwrap();
+    let exports = resolve_exports(&export_params, &sorted_resources, &state, &[]).unwrap();
 
     assert_eq!(
         exports.get("account_id"),
@@ -596,7 +596,7 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
         })),
     }];
 
-    let exports = resolve_exports(&export_params, &sorted_resources, &state).unwrap();
+    let exports = resolve_exports(&export_params, &sorted_resources, &state, &[]).unwrap();
 
     assert_eq!(
         exports.get("role_arn"),
@@ -683,7 +683,7 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
         })),
     }];
 
-    let exports = resolve_exports(&export_params, &sorted_resources, &state).unwrap();
+    let exports = resolve_exports(&export_params, &sorted_resources, &state, &[]).unwrap();
 
     assert_eq!(
         exports.get("role_arn"),

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -68,6 +68,32 @@ pub struct PlanFile {
     /// `apply --plan` can re-load each upstream and compare against
     /// `upstream_snapshot`.
     pub upstream_sources: Vec<UpstreamSource>,
+    /// `wait` binding → target binding pairs as declared in the
+    /// original `.crn` config (carina#3085). Persisted so `apply
+    /// --plan`'s cascade re-resolution can rebuild the wait
+    /// passthrough aliases (`<wait-binding>.<attr>` →
+    /// `<target>.<attr>`) without the parser `WaitBinding` (which is
+    /// not `Serialize` — same constraint that motivated
+    /// [`UpstreamSource`]). Only the `(binding, target)` pair is
+    /// persisted: the `until` predicate / timeout / `depends_on` are
+    /// effect-layer concerns already encoded in the serialized `plan`'s
+    /// `Effect::Wait`, not needed to rebuild the value-layer alias.
+    /// Empty when the configuration declares no `wait` bindings.
+    #[serde(default)]
+    pub wait_bindings: Vec<PlanWaitBinding>,
+}
+
+/// Serializable `(binding, target)` pair for a `wait` declaration —
+/// the value-layer half of a wait binding (carina#3085). The parser
+/// `carina_core::parser::WaitBinding` is not `Serialize`/`Deserialize`
+/// (pulling serde into `carina-core::parser::ast` has wider blast
+/// radius than warranted), so the plan file persists this minimal
+/// projection, mirroring [`UpstreamSource`]'s rationale. Converted to
+/// `carina_core::binding_index::WaitAliasSpec` at apply-from-plan time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanWaitBinding {
+    pub binding: String,
+    pub target: String,
 }
 
 /// Serializable representation of an `upstream_state` declaration's
@@ -127,6 +153,14 @@ fn build_plan_file<E>(
             .map(|us| UpstreamSource {
                 binding: us.binding.clone(),
                 source: us.source.clone(),
+            })
+            .collect(),
+        wait_bindings: parsed
+            .wait_bindings
+            .iter()
+            .map(|wb| PlanWaitBinding {
+                binding: wb.binding.as_str().to_string(),
+                target: wb.target.as_str().to_string(),
             })
             .collect(),
     })
@@ -357,10 +391,16 @@ pub async fn run_plan(
             .map_err(|e| AppError::Config(format!("TUI error: {}", e)))?;
     } else {
         // Resolve export values for display
+        let export_wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+            .wait_bindings
+            .iter()
+            .map(carina_core::binding_index::WaitAliasSpec::from)
+            .collect();
         let resolved_exports = resolve_export_values_for_display(
             &parsed.export_params,
             &ctx.sorted_resources,
             &ctx.current_states,
+            &export_wait_aliases,
         );
         let current_exports = state_file
             .as_ref()
@@ -418,11 +458,13 @@ pub(crate) fn resolve_export_values_for_display(
     export_params: &[carina_core::parser::InferredExportParam],
     resources: &[Resource],
     current_states: &HashMap<ResourceId, State>,
+    wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
 ) -> Vec<carina_core::parser::InferredExportParam> {
     let bindings = carina_core::binding_index::ResolvedBindings::from_resources_with_state(
         resources,
         current_states,
         &HashMap::new(),
+        wait_aliases,
     );
 
     export_params

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -80,6 +80,15 @@ pub(crate) struct FinalizeApplyInput<'a> {
     /// intact for the next source-driven `carina apply` to
     /// reconcile.
     pub export_params: Option<&'a [carina_core::parser::InferredExportParam]>,
+    /// Wait-binding aliases (carina#3085). When export expressions
+    /// reference a `wait` binding (`exports { x = cert_issued.arn }`),
+    /// these make `<wait-binding>.<attr>` resolve to `<target>.<attr>`
+    /// at writeback, the same passthrough the plan path now applies.
+    /// Empty when the configuration declares no `wait` bindings, or
+    /// for the `apply --plan` path that has no source-side wait view
+    /// (paired with `export_params: None`, so no export resolution
+    /// runs there anyway).
+    pub wait_aliases: &'a [carina_core::binding_index::WaitAliasSpec],
 }
 
 /// Resolve export expressions using bindings built from applied state.
@@ -96,6 +105,7 @@ pub(crate) fn resolve_exports(
     export_params: &[carina_core::parser::InferredExportParam],
     sorted_resources: &[Resource],
     state: &StateFile,
+    wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
 ) -> Result<HashMap<String, serde_json::Value>, carina_core::value::SerializationError> {
     use carina_core::binding_index::ResolvedBindings;
     use carina_core::resource::Value;
@@ -133,6 +143,7 @@ pub(crate) fn resolve_exports(
         sorted_resources,
         &current_states,
         &HashMap::new(),
+        wait_aliases,
     );
 
     let mut exports = HashMap::new();

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -804,10 +804,16 @@ pub(crate) async fn run_state_refresh_locked(
 
     // Re-resolve exports using refreshed state
     if !parsed.export_params.is_empty() {
+        let wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+            .wait_bindings
+            .iter()
+            .map(carina_core::binding_index::WaitAliasSpec::from)
+            .collect();
         state.exports = crate::commands::shared::state_writeback::resolve_exports(
             &parsed.export_params,
             &sorted_resources,
             &state,
+            &wait_aliases,
         )?;
     }
 

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -137,8 +137,18 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
     // loader is already lenient about missing upstream state files (see
     // the loop above that silently skips them).
     let mut resources = sorted_resources.clone();
-    resolve_refs_for_plan(&mut resources, &current_states, &remote_bindings)
-        .expect("Failed to resolve refs with state");
+    let wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(carina_core::binding_index::WaitAliasSpec::from)
+        .collect();
+    resolve_refs_for_plan(
+        &mut resources,
+        &current_states,
+        &remote_bindings,
+        &wait_aliases,
+    )
+    .expect("Failed to resolve refs with state");
 
     // Type-level canonicalization for `Union[String, list(String)]`
     // fields. See #2481, #2511, #2513.

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -342,6 +342,7 @@ fn plan_file_serde_round_trip() {
         current_states,
         upstream_snapshot: HashMap::new(),
         upstream_sources: Vec::new(),
+        wait_bindings: vec![],
     };
 
     let json = serde_json::to_string_pretty(&plan_file).unwrap();
@@ -1481,6 +1482,7 @@ async fn lock_released_on_write_state_failure() {
         lock: Some(&lock),
         schemas: &SchemaRegistry::new(),
         export_params: Some(&[]),
+        wait_aliases: &[],
     })
     .await;
 
@@ -1614,6 +1616,7 @@ async fn finalize_apply_uses_write_state_locked() {
         lock: Some(&lock),
         schemas: &SchemaRegistry::new(),
         export_params: Some(&[]),
+        wait_aliases: &[],
     })
     .await;
 
@@ -2203,6 +2206,7 @@ async fn finalize_apply_without_lock_uses_write_state() {
         lock: None, // No lock
         schemas: &SchemaRegistry::new(),
         export_params: Some(&[]),
+        wait_aliases: &[],
     })
     .await;
 
@@ -2790,6 +2794,7 @@ fn plan_file_serialization_redacts_secrets() {
         }],
         upstream_snapshot: HashMap::new(),
         upstream_sources: Vec::new(),
+        wait_bindings: vec![],
     };
 
     let json = serde_json::to_string_pretty(&plan_file).unwrap();
@@ -2885,6 +2890,7 @@ async fn persist_exports_only_clears_state_exports_when_params_empty() {
         Some(state_in),
         &[],
         &[],
+        &[],
     )
     .await;
 
@@ -2924,6 +2930,7 @@ async fn persist_exports_only_writes_state_with_new_exports() {
         Some(StateFile::new()),
         &[],
         &export_params,
+        &[],
     )
     .await;
 
@@ -2986,6 +2993,7 @@ async fn finalize_apply_clears_state_exports_when_params_empty() {
         lock: Some(&lock),
         schemas: &SchemaRegistry::new(),
         export_params: Some(&[]),
+        wait_aliases: &[],
     })
     .await;
 
@@ -3041,6 +3049,7 @@ async fn finalize_apply_preserves_state_exports_when_params_none() {
         lock: Some(&lock),
         schemas: &SchemaRegistry::new(),
         export_params: None,
+        wait_aliases: &[],
     })
     .await;
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use colored::Colorize;
 use futures::stream::{self, StreamExt};
 
+use carina_core::binding_index::WaitAliasSpec;
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
@@ -20,7 +21,6 @@ use carina_core::provider::{
     self as provider_mod, Provider, ProviderError, ProviderFactory, ProviderNormalizer,
     ProviderRouter,
 };
-use carina_core::binding_index::WaitAliasSpec;
 use carina_core::resolver::{resolve_refs_for_plan, resolve_refs_with_state_and_remote};
 use carina_core::resource::{
     ConcreteValue, DeferredValue, Resource, ResourceId, State, Value, contains_resource_ref,
@@ -1312,8 +1312,11 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
 
         // Phase 2: resolve data source refs against the consolidated
         // `current_states`, then refresh each via `read_data_source`.
-        let ds_wait_aliases: Vec<WaitAliasSpec> =
-            parsed.wait_bindings.iter().map(WaitAliasSpec::from).collect();
+        let ds_wait_aliases: Vec<WaitAliasSpec> = parsed
+            .wait_bindings
+            .iter()
+            .map(WaitAliasSpec::from)
+            .collect();
         let resolved_data_sources = resolve_data_source_refs_for_refresh(
             &sorted_resources,
             &current_states,
@@ -1417,8 +1420,11 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         &parsed.resources,
         ctx.schemas(),
     );
-    let wait_aliases: Vec<WaitAliasSpec> =
-        parsed.wait_bindings.iter().map(WaitAliasSpec::from).collect();
+    let wait_aliases: Vec<WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(WaitAliasSpec::from)
+        .collect();
     resolve_refs_for_plan(
         &mut resources,
         &current_states,

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -20,6 +20,7 @@ use carina_core::provider::{
     self as provider_mod, Provider, ProviderError, ProviderFactory, ProviderNormalizer,
     ProviderRouter,
 };
+use carina_core::binding_index::WaitAliasSpec;
 use carina_core::resolver::{resolve_refs_for_plan, resolve_refs_with_state_and_remote};
 use carina_core::resource::{
     ConcreteValue, DeferredValue, Resource, ResourceId, State, Value, contains_resource_ref,
@@ -1311,11 +1312,14 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
 
         // Phase 2: resolve data source refs against the consolidated
         // `current_states`, then refresh each via `read_data_source`.
+        let ds_wait_aliases: Vec<WaitAliasSpec> =
+            parsed.wait_bindings.iter().map(WaitAliasSpec::from).collect();
         let resolved_data_sources = resolve_data_source_refs_for_refresh(
             &sorted_resources,
             &current_states,
             remote_bindings,
             ctx.schemas(),
+            &ds_wait_aliases,
         )?;
         let phase2_results: Vec<Result<(ResourceId, State), AppError>> =
             stream::iter(resolved_data_sources.iter())
@@ -1413,7 +1417,14 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         &parsed.resources,
         ctx.schemas(),
     );
-    resolve_refs_for_plan(&mut resources, &current_states, remote_bindings)?;
+    let wait_aliases: Vec<WaitAliasSpec> =
+        parsed.wait_bindings.iter().map(WaitAliasSpec::from).collect();
+    resolve_refs_for_plan(
+        &mut resources,
+        &current_states,
+        remote_bindings,
+        &wait_aliases,
+    )?;
 
     // Type-level canonicalization for `Union[String, list(String)]`
     // fields (IAM-style `string_or_list_of_strings`). Done after refs
@@ -1792,10 +1803,16 @@ pub(crate) fn resolve_data_source_refs_for_refresh(
     current_states: &HashMap<ResourceId, State>,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
     schemas: &carina_core::schema::SchemaRegistry,
+    wait_aliases: &[WaitAliasSpec],
 ) -> Result<Vec<Resource>, AppError> {
     let mut resolved = sorted_resources.to_vec();
-    resolve_refs_with_state_and_remote(&mut resolved, current_states, remote_bindings)
-        .map_err(AppError::Validation)?;
+    resolve_refs_with_state_and_remote(
+        &mut resolved,
+        current_states,
+        remote_bindings,
+        wait_aliases,
+    )
+    .map_err(AppError::Validation)?;
     carina_core::value::canonicalize_resources_with_schemas(&mut resolved, schemas);
     Ok(resolved
         .into_iter()

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -508,6 +508,7 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
         &current_states,
         &HashMap::new(),
         &empty_registry,
+        &[],
     )
     .expect("resolution should succeed");
 

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -372,10 +372,16 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
     let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
     let mut resources_for_plan = sorted_resources.clone();
+    let wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(carina_core::binding_index::WaitAliasSpec::from)
+        .collect();
     carina_core::resolver::resolve_refs_with_state_and_remote(
         &mut resources_for_plan,
         &current_states,
         &remote_bindings,
+        &wait_aliases,
     )
     .expect("resolve_refs");
 

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -383,7 +383,9 @@ pub enum BindingValueSource {
     /// observable — the dependency edge is handled separately by
     /// `Effect::Wait` lowering and is not affected by this value-layer
     /// alias.
-    WaitAlias { target: BindingName },
+    WaitAlias {
+        target: BindingName,
+    },
 }
 
 /// One entry in [`ResolvedBindings`]: the merged attribute map and the
@@ -732,7 +734,8 @@ mod resolved_bindings_tests {
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved =
+            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
 
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
@@ -780,7 +783,8 @@ mod resolved_bindings_tests {
         );
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved =
+            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
 
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
@@ -813,7 +817,8 @@ mod resolved_bindings_tests {
         );
         remote.insert("network".to_string(), network_attrs);
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved =
+            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
 
         let attrs = resolved.get("network").expect("upstream binding present");
         assert_eq!(
@@ -841,7 +846,8 @@ mod resolved_bindings_tests {
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved =
+            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
         assert!(resolved.get("anonymous").is_none());
     }
 
@@ -871,7 +877,8 @@ mod resolved_bindings_tests {
             .collect(),
         );
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved =
+            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
         let attrs = resolved.get("shared").expect("shared binding present");
         assert_eq!(
             attrs.get("kind"),
@@ -918,7 +925,8 @@ mod resolved_bindings_tests {
         );
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved =
+            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert!(
             attrs.get("id").is_none(),
@@ -1210,7 +1218,9 @@ mod resolved_bindings_tests {
             resolved
                 .get("cert_issued")
                 .and_then(|a| a.get("certificate_arn")),
-            Some(&Value::Concrete(ConcreteValue::String("arn:old".to_string()))),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "arn:old".to_string()
+            ))),
             "wait alias is a snapshot: a later set('cert', …) must not mutate it"
         );
     }
@@ -1250,7 +1260,9 @@ mod resolved_bindings_tests {
         assert_eq!(a, b);
         assert_eq!(
             a,
-            Some(Value::Concrete(ConcreteValue::String("arn:shared".to_string())))
+            Some(Value::Concrete(ConcreteValue::String(
+                "arn:shared".to_string()
+            )))
         );
     }
 }

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -39,6 +39,7 @@
 //! }
 //! ```
 
+use crate::parser::BindingName;
 use crate::resource::{Resource, ResourceId, State, Value};
 use crate::schema::{ResourceSchema, SchemaRegistry};
 use std::collections::HashMap;
@@ -151,7 +152,13 @@ impl<'a> BindingIndex<'a> {
 ///
 /// `#[non_exhaustive]` so adding a new declaration form (a future
 /// `data` block, etc.) does not break downstream `match` arms.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// Not `Copy`: `Wait` carries an owned `BindingName` (the wait→target
+/// edge is a typed value, carina#3085 — not a string convention). The
+/// enum is read out by reference (`kind()` / `iter()`); the only
+/// in-crate consumers are within this module, so dropping `Copy` is
+/// contained.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum BindingNameKind {
     /// `let <name> = ...` resource binding.
@@ -173,6 +180,15 @@ pub enum BindingNameKind {
     /// addressable by `ResourceRef` (see the module doc for the
     /// pre-existing invariant).
     Structural,
+    /// `let <name> = wait <target> { ... }` wait binding (carina#3085).
+    /// Unlike `Structural`, a wait binding **is** addressable by
+    /// `ResourceRef`: `<name>.<attr>` is a passthrough to
+    /// `<target>.<attr>` (see `notes/specs/2026-05-09-wait-construct-design.md`
+    /// value semantics). The `target` is the binding name of the
+    /// resource the wait observes; carried here as a typed
+    /// [`BindingName`] so the wait→target edge cannot be confused with
+    /// an arbitrary string or point at a non-existent name undetected.
+    Wait { target: BindingName },
 }
 
 /// Name-only scope view: every identifier a parsed Carina configuration
@@ -222,6 +238,19 @@ impl BindingNameSet {
                     .or_insert(BindingNameKind::Resource);
             }
         }
+        // Wait bindings register right after resources: a wait binding
+        // is addressable by `ResourceRef` (passthrough to its target),
+        // so it belongs with the addressable forms, not with
+        // `Structural`. The parser enforces distinct binding names, so
+        // a name is a wait binding xor a resource binding — ordering
+        // here is documentation, not correctness-critical (carina#3085).
+        for wb in &parsed.wait_bindings {
+            by_name
+                .entry(wb.binding.as_str().to_string())
+                .or_insert(BindingNameKind::Wait {
+                    target: wb.target.clone(),
+                });
+        }
         for call in &parsed.module_calls {
             if let Some(name) = call.binding_name.as_deref() {
                 by_name
@@ -270,8 +299,8 @@ impl BindingNameSet {
 
     /// Declaration kind for `name`, or `None` if the name is not
     /// in scope.
-    pub fn kind(&self, name: &str) -> Option<BindingNameKind> {
-        self.by_name.get(name).copied()
+    pub fn kind(&self, name: &str) -> Option<&BindingNameKind> {
+        self.by_name.get(name)
     }
 
     /// Iterate every in-scope name. Order is unspecified.
@@ -280,8 +309,8 @@ impl BindingNameSet {
     }
 
     /// Iterate every (name, kind) pair. Order is unspecified.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, BindingNameKind)> {
-        self.by_name.iter().map(|(k, v)| (k.as_str(), *v))
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &BindingNameKind)> {
+        self.by_name.iter().map(|(k, v)| (k.as_str(), v))
     }
 
     pub fn len(&self) -> usize {
@@ -293,6 +322,38 @@ impl BindingNameSet {
     }
 }
 
+/// A `wait` binding's value-layer contract: `binding`'s
+/// `<binding>.<attr>` is a passthrough to `<target>.<attr>`
+/// (carina#3085). Both sides are the typed [`BindingName`] newtype so
+/// the wait→target edge cannot be confused with an arbitrary string.
+///
+/// This is the *only* thing `ResolvedBindings` needs from a wait
+/// declaration — deliberately **not** the full parser
+/// [`crate::parser::WaitBinding`] (which also carries the `until`
+/// predicate, timeout, `depends_on`, source line — all effect-layer /
+/// diagnostics concerns irrelevant to value resolution). Decoupling
+/// here means: (a) carina-core resolution does not depend on the
+/// parser AST shape, and (b) the apply-from-plan-file path — which
+/// reconstructs from a serialized `PlanFile` and has no `WaitBinding`
+/// — can supply the same typed spec without resurrecting the AST.
+/// `WaitBinding` provides a `From` conversion (the plan path); the
+/// plan-file path builds it from its serialized `(binding, target)`
+/// pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WaitAliasSpec {
+    pub binding: BindingName,
+    pub target: BindingName,
+}
+
+impl From<&crate::parser::WaitBinding> for WaitAliasSpec {
+    fn from(wb: &crate::parser::WaitBinding) -> Self {
+        Self {
+            binding: wb.binding.clone(),
+            target: wb.target.clone(),
+        }
+    }
+}
+
 /// Where the values for a binding came from. `Local` means a `let` binding
 /// in the current configuration; `Upstream` means an `upstream_state` data
 /// source bringing values in from another state file.
@@ -301,11 +362,28 @@ impl BindingNameSet {
 /// sources (`for` / `if` / module) — flagging the intent now keeps
 /// downstream `match` arms from becoming exhaustive against the current
 /// two variants.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Not `Copy`: `WaitAlias` carries an owned `BindingName` (the
+/// wait→target edge is a typed value, carina#3085). `source()` returns
+/// a borrow; the only in-crate value-position use is a `matches!`
+/// (`Copy`-independent), so dropping `Copy` is contained.
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum BindingValueSource {
     Local,
     Upstream,
+    /// The binding is a `wait` binding whose `<name>.<attr>` is a
+    /// passthrough to `target`'s attributes (carina#3085). The
+    /// attributes stored alongside this source are a snapshot of the
+    /// target's resolved attributes at construction time (see
+    /// `notes/specs/2026-05-09-wait-construct-design.md` value
+    /// semantics — "snapshot of the target captured by the read() that
+    /// satisfied until"). Retained as a distinct source (not flattened
+    /// to `Local`) so "did this value come *through* a wait?" stays
+    /// observable — the dependency edge is handled separately by
+    /// `Effect::Wait` lowering and is not affected by this value-layer
+    /// alias.
+    WaitAlias { target: BindingName },
 }
 
 /// One entry in [`ResolvedBindings`]: the merged attribute map and the
@@ -338,12 +416,22 @@ impl ResolvedBindings {
     ///
     /// DSL keys win over state keys on conflict. Upstream bindings are
     /// inserted last and overwrite any local binding of the same name.
-    /// Both rules match the pre-existing resolver behaviour so this
-    /// refactor is a pure internal change.
+    ///
+    /// `wait_aliases` materialises each `wait` binding as a passthrough
+    /// alias to its target: an entry whose attributes are a snapshot of
+    /// the target's resolved attributes and whose source is
+    /// [`BindingValueSource::WaitAlias`] (carina#3085). Materialising
+    /// the alias here — rather than via a second lookup in
+    /// `resolve_ref_value` — means a wait binding is resolved by exactly
+    /// the same code path as a resource binding (it simply *has* an
+    /// entry). The wait's *dependency edge* is independent and handled
+    /// separately by `Effect::Wait` lowering; this only restores the
+    /// value-identity half (design value semantics).
     pub fn from_resources_with_state(
         resources: &[Resource],
         current_states: &HashMap<ResourceId, State>,
         remote_bindings: &HashMap<String, HashMap<String, Value>>,
+        wait_aliases: &[WaitAliasSpec],
     ) -> Self {
         let mut by_name: HashMap<String, ResolvedBinding> = HashMap::new();
 
@@ -378,6 +466,33 @@ impl ResolvedBindings {
             );
         }
 
+        // Wait aliases materialise last, after both local and upstream
+        // entries exist, so a wait whose target is *either* a resource
+        // or an upstream binding sees the target's resolved attributes.
+        // The alias attributes are an independent snapshot (clone), not
+        // a shared reference: a later `set("target", …)` write-back
+        // must not mutate the alias and vice versa (design: the alias
+        // is a read-time snapshot). If the target has no entry (typo /
+        // scoped-out — the same condition `create_plan` reports as a
+        // `PlanError`), no alias is created: the ref stays unresolved
+        // and that existing error surfaces it, rather than a panic or a
+        // phantom.
+        for spec in wait_aliases {
+            let Some(target_entry) = by_name.get(spec.target.as_str()) else {
+                continue;
+            };
+            let snapshot = target_entry.attributes.clone();
+            by_name.insert(
+                spec.binding.as_str().to_string(),
+                ResolvedBinding {
+                    attributes: snapshot,
+                    source: BindingValueSource::WaitAlias {
+                        target: spec.target.clone(),
+                    },
+                },
+            );
+        }
+
         Self { by_name }
     }
 
@@ -385,8 +500,8 @@ impl ResolvedBindings {
         self.by_name.get(name).map(|b| &b.attributes)
     }
 
-    pub fn source(&self, name: &str) -> Option<BindingValueSource> {
-        self.by_name.get(name).map(|b| b.source)
+    pub fn source(&self, name: &str) -> Option<&BindingValueSource> {
+        self.by_name.get(name).map(|b| &b.source)
     }
 
     /// Record (or refresh) a binding after a `Create` / `Update` effect
@@ -617,7 +732,7 @@ mod resolved_bindings_tests {
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
+        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
 
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
@@ -626,7 +741,7 @@ mod resolved_bindings_tests {
                 "10.0.0.0/16".to_string()
             )))
         );
-        assert_eq!(resolved.source("vpc"), Some(BindingValueSource::Local));
+        assert_eq!(resolved.source("vpc"), Some(&BindingValueSource::Local));
     }
 
     #[test]
@@ -665,7 +780,7 @@ mod resolved_bindings_tests {
         );
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
+        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
 
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
@@ -698,7 +813,7 @@ mod resolved_bindings_tests {
         );
         remote.insert("network".to_string(), network_attrs);
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
+        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
 
         let attrs = resolved.get("network").expect("upstream binding present");
         assert_eq!(
@@ -709,7 +824,7 @@ mod resolved_bindings_tests {
         );
         assert_eq!(
             resolved.source("network"),
-            Some(BindingValueSource::Upstream)
+            Some(&BindingValueSource::Upstream)
         );
     }
 
@@ -726,7 +841,7 @@ mod resolved_bindings_tests {
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
+        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
         assert!(resolved.get("anonymous").is_none());
     }
 
@@ -756,7 +871,7 @@ mod resolved_bindings_tests {
             .collect(),
         );
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
+        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
         let attrs = resolved.get("shared").expect("shared binding present");
         assert_eq!(
             attrs.get("kind"),
@@ -767,7 +882,7 @@ mod resolved_bindings_tests {
         );
         assert_eq!(
             resolved.source("shared"),
-            Some(BindingValueSource::Upstream),
+            Some(&BindingValueSource::Upstream),
         );
     }
 
@@ -803,7 +918,7 @@ mod resolved_bindings_tests {
         );
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
+        let resolved = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert!(
             attrs.get("id").is_none(),
@@ -875,7 +990,7 @@ mod resolved_bindings_tests {
                 "10.0.0.0/16".to_string()
             ))),
         );
-        assert_eq!(resolved.source("vpc"), Some(BindingValueSource::Local));
+        assert_eq!(resolved.source("vpc"), Some(&BindingValueSource::Local));
     }
 
     #[test]
@@ -911,7 +1026,7 @@ mod resolved_bindings_tests {
         )];
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
-        let parent = ResolvedBindings::from_resources_with_state(&resources, &states, &remote);
+        let parent = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
 
         let mut child = parent.clone();
         let extra_state = State {
@@ -951,7 +1066,7 @@ mod resolved_bindings_tests {
         resolved.set("registry", initial, BindingValueSource::Upstream);
         assert_eq!(
             resolved.source("registry"),
-            Some(BindingValueSource::Upstream)
+            Some(&BindingValueSource::Upstream)
         );
         assert_eq!(
             resolved.get("registry").and_then(|a| a.get("kind")),
@@ -967,7 +1082,7 @@ mod resolved_bindings_tests {
         resolved.set("registry", replacement, BindingValueSource::Local);
         assert_eq!(
             resolved.source("registry"),
-            Some(BindingValueSource::Local),
+            Some(&BindingValueSource::Local),
             "set must replace the source as well as the attributes",
         );
         assert_eq!(
@@ -975,6 +1090,167 @@ mod resolved_bindings_tests {
             Some(&Value::Concrete(ConcreteValue::String(
                 "second".to_string()
             )))
+        );
+    }
+
+    // ---- carina#3085: wait-binding passthrough alias ----
+
+    fn wait_spec(binding: &str, target: &str) -> WaitAliasSpec {
+        WaitAliasSpec {
+            binding: BindingName::new(binding),
+            target: BindingName::new(target),
+        }
+    }
+
+    /// Test plan item 1: a wait binding resolves to its target's
+    /// attribute map, sourced as `WaitAlias { target }`.
+    #[test]
+    fn wait_alias_resolves_to_target_attributes() {
+        let cert = make_resource(
+            "cert",
+            Some("cert"),
+            vec![(
+                "certificate_arn",
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:acm:us-east-1:1:certificate/abc".to_string(),
+                )),
+            )],
+        );
+        let resolved = ResolvedBindings::from_resources_with_state(
+            &[cert],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[wait_spec("cert_issued", "cert")],
+        );
+        assert_eq!(
+            resolved
+                .get("cert_issued")
+                .and_then(|a| a.get("certificate_arn")),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "arn:aws:acm:us-east-1:1:certificate/abc".to_string()
+            ))),
+            "cert_issued.certificate_arn must passthrough to cert's value"
+        );
+        assert_eq!(
+            resolved.source("cert_issued"),
+            Some(&BindingValueSource::WaitAlias {
+                target: BindingName::new("cert")
+            }),
+            "source must record the wait→target edge, not flatten to Local"
+        );
+    }
+
+    /// Test plan item 1 (negative): a wait whose target has no entry
+    /// (typo / scoped-out) creates no alias — the ref stays unresolved
+    /// and the existing PlanError path (not a panic) surfaces it.
+    #[test]
+    fn wait_alias_absent_target_creates_no_entry() {
+        let resolved = ResolvedBindings::from_resources_with_state(
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[wait_spec("cert_issued", "nonexistent")],
+        );
+        assert!(
+            resolved.get("cert_issued").is_none(),
+            "no alias when target is absent (ref stays unresolved → existing PlanError)"
+        );
+    }
+
+    /// The target may be an upstream binding, not just a resource —
+    /// the alias must still mirror it (aliases materialise after both
+    /// local and upstream entries exist).
+    #[test]
+    fn wait_alias_target_can_be_upstream() {
+        let mut remote = HashMap::new();
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String("up-1".to_string())),
+        );
+        remote.insert("up".to_string(), attrs);
+        let resolved = ResolvedBindings::from_resources_with_state(
+            &[],
+            &HashMap::new(),
+            &remote,
+            &[wait_spec("waited", "up")],
+        );
+        assert_eq!(
+            resolved.get("waited").and_then(|a| a.get("id")),
+            Some(&Value::Concrete(ConcreteValue::String("up-1".to_string())))
+        );
+    }
+
+    /// Test plan item 5: the alias is an independent snapshot — a
+    /// later `set("cert", …)` write-back must not mutate the alias,
+    /// and vice versa (design: read-time snapshot).
+    #[test]
+    fn wait_alias_is_independent_snapshot() {
+        let cert = make_resource(
+            "cert",
+            Some("cert"),
+            vec![(
+                "certificate_arn",
+                Value::Concrete(ConcreteValue::String("arn:old".to_string())),
+            )],
+        );
+        let mut resolved = ResolvedBindings::from_resources_with_state(
+            &[cert],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[wait_spec("cert_issued", "cert")],
+        );
+        let mut new_attrs = HashMap::new();
+        new_attrs.insert(
+            "certificate_arn".to_string(),
+            Value::Concrete(ConcreteValue::String("arn:new".to_string())),
+        );
+        resolved.set("cert", new_attrs, BindingValueSource::Local);
+        assert_eq!(
+            resolved
+                .get("cert_issued")
+                .and_then(|a| a.get("certificate_arn")),
+            Some(&Value::Concrete(ConcreteValue::String("arn:old".to_string()))),
+            "wait alias is a snapshot: a later set('cert', …) must not mutate it"
+        );
+    }
+
+    /// Design Risks (multiple downstream consumers): the single wait
+    /// alias entry resolves consistently for every consumer that reads
+    /// it — there is one `cert_issued` entry, so N downstream resources
+    /// referencing `cert_issued.*` all see the same value. (The single
+    /// `Effect::Wait` fan-out to all consumers is the dependency-graph
+    /// machinery's job, unchanged by this value-layer alias and
+    /// covered by the wait_downstream_apply E2E.)
+    #[test]
+    fn wait_alias_resolves_consistently_for_repeated_lookups() {
+        let cert = make_resource(
+            "cert",
+            Some("cert"),
+            vec![(
+                "certificate_arn",
+                Value::Concrete(ConcreteValue::String("arn:shared".to_string())),
+            )],
+        );
+        let resolved = ResolvedBindings::from_resources_with_state(
+            &[cert],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[wait_spec("cert_issued", "cert")],
+        );
+        // Two independent consumers both resolve the same value.
+        let a = resolved
+            .get("cert_issued")
+            .and_then(|m| m.get("certificate_arn"))
+            .cloned();
+        let b = resolved
+            .get("cert_issued")
+            .and_then(|m| m.get("certificate_arn"))
+            .cloned();
+        assert_eq!(a, b);
+        assert_eq!(
+            a,
+            Some(Value::Concrete(ConcreteValue::String("arn:shared".to_string())))
         );
     }
 }
@@ -1000,7 +1276,7 @@ let vpc = aws.ec2.Vpc {
         let names = BindingNameSet::from_parsed(&parsed);
 
         assert!(names.contains("vpc"));
-        assert_eq!(names.kind("vpc"), Some(BindingNameKind::Resource));
+        assert_eq!(names.kind("vpc"), Some(&BindingNameKind::Resource));
     }
 
     #[test]
@@ -1014,7 +1290,7 @@ let network = upstream_state {
         let names = BindingNameSet::from_parsed(&parsed);
 
         assert!(names.contains("network"));
-        assert_eq!(names.kind("network"), Some(BindingNameKind::UpstreamState));
+        assert_eq!(names.kind("network"), Some(&BindingNameKind::UpstreamState));
     }
 
     #[test]
@@ -1028,7 +1304,7 @@ let region = "ap-northeast-1"
         let names = BindingNameSet::from_parsed(&parsed);
 
         assert!(names.contains("region"));
-        assert_eq!(names.kind("region"), Some(BindingNameKind::Variable));
+        assert_eq!(names.kind("region"), Some(&BindingNameKind::Variable));
     }
 
     #[test]
@@ -1042,7 +1318,7 @@ arguments {
         let names = BindingNameSet::from_parsed(&parsed);
 
         assert!(names.contains("env"));
-        assert_eq!(names.kind("env"), Some(BindingNameKind::Argument));
+        assert_eq!(names.kind("env"), Some(&BindingNameKind::Argument));
     }
 
     #[test]
@@ -1056,7 +1332,7 @@ fn double(x: Int) {
         let names = BindingNameSet::from_parsed(&parsed);
 
         assert!(names.contains("double"));
-        assert_eq!(names.kind("double"), Some(BindingNameKind::UserFunction));
+        assert_eq!(names.kind("double"), Some(&BindingNameKind::UserFunction));
     }
 
     #[test]
@@ -1074,7 +1350,7 @@ let cluster = module {
             "module-call binding must be in scope; got {:?}",
             names.iter_names().collect::<Vec<_>>()
         );
-        assert_eq!(names.kind("cluster"), Some(BindingNameKind::ModuleCall));
+        assert_eq!(names.kind("cluster"), Some(&BindingNameKind::ModuleCall));
     }
 
     #[test]
@@ -1134,7 +1410,7 @@ let chosen = if true { "primary" } else { "fallback" }
             "structural binding must be in scope; got {:?}",
             names.iter_names().collect::<Vec<_>>()
         );
-        assert_eq!(names.kind("chosen"), Some(BindingNameKind::Structural));
+        assert_eq!(names.kind("chosen"), Some(&BindingNameKind::Structural));
 
         // Value-side: `ResolvedBindings` does NOT carry an entry for
         // `chosen`, so a `ResourceRef` to `chosen.foo` cannot resolve.
@@ -1142,10 +1418,46 @@ let chosen = if true { "primary" } else { "fallback" }
             &parsed.resources,
             &HashMap::new(),
             &HashMap::new(),
+            &[],
         );
         assert!(
             resolved.get("chosen").is_none(),
             "structural bindings must stay invisible to ResourceRef resolution",
         );
+    }
+
+    /// carina#3085 Test plan item 2: a `wait` binding registers as
+    /// `BindingNameKind::Wait { target }` and — unlike `Structural` —
+    /// **is** addressable (`contains` is true), because
+    /// `<wait-binding>.<attr>` is a passthrough to its target.
+    #[test]
+    fn wait_binding_registers_as_wait_kind_and_is_addressable() {
+        let src = r#"
+let cert = aws.acm.Certificate {
+    domain_name       = "registry.example.com"
+    validation_method = "DNS"
+}
+
+let cert_issued = wait cert {
+    until = cert.status == aws.acm.Certificate.Status.Issued
+}
+"#;
+        let parsed = parsed_with(src);
+        let names = BindingNameSet::from_parsed(&parsed);
+
+        assert!(
+            names.contains("cert_issued"),
+            "a wait binding is addressable (passthrough), unlike Structural; got {:?}",
+            names.iter_names().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            names.kind("cert_issued"),
+            Some(&BindingNameKind::Wait {
+                target: BindingName::new("cert")
+            }),
+            "wait binding must carry its typed target edge"
+        );
+        // The target itself is still a plain resource binding.
+        assert_eq!(names.kind("cert"), Some(&BindingNameKind::Resource));
     }
 }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -29,16 +29,25 @@ pub fn resolve_refs_with_state(
     resources: &mut [Resource],
     current_states: &HashMap<ResourceId, State>,
 ) -> Result<(), String> {
-    resolve_refs_with_state_and_remote(resources, current_states, &HashMap::new())
+    resolve_refs_with_state_and_remote(resources, current_states, &HashMap::new(), &[])
 }
 
-/// Resolve all ResourceRef values in resources using current state and upstream state bindings.
+/// Resolve all ResourceRef values in resources using current state and
+/// upstream state bindings. `wait_aliases` makes `<wait-binding>.<attr>`
+/// resolve to `<target>.<attr>` (carina#3085 passthrough).
 pub fn resolve_refs_with_state_and_remote(
     resources: &mut [Resource],
     current_states: &HashMap<ResourceId, State>,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    wait_aliases: &[crate::binding_index::WaitAliasSpec],
 ) -> Result<(), String> {
-    resolve_refs_inner(resources, current_states, remote_bindings, false)
+    resolve_refs_inner(
+        resources,
+        current_states,
+        remote_bindings,
+        wait_aliases,
+        false,
+    )
 }
 
 /// Plan-only counterpart used when an upstream's state file is missing or
@@ -53,14 +62,22 @@ pub fn resolve_refs_for_plan(
     resources: &mut [Resource],
     current_states: &HashMap<ResourceId, State>,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    wait_aliases: &[crate::binding_index::WaitAliasSpec],
 ) -> Result<(), String> {
-    resolve_refs_inner(resources, current_states, remote_bindings, true)
+    resolve_refs_inner(
+        resources,
+        current_states,
+        remote_bindings,
+        wait_aliases,
+        true,
+    )
 }
 
 fn resolve_refs_inner(
     resources: &mut [Resource],
     current_states: &HashMap<ResourceId, State>,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    wait_aliases: &[crate::binding_index::WaitAliasSpec],
     mark_unresolved_upstream: bool,
 ) -> Result<(), String> {
     // Save dependency bindings before resolution destroys ResourceRef values.
@@ -73,8 +90,12 @@ fn resolve_refs_inner(
         }
     }
 
-    let bindings =
-        ResolvedBindings::from_resources_with_state(resources, current_states, remote_bindings);
+    let bindings = ResolvedBindings::from_resources_with_state(
+        resources,
+        current_states,
+        remote_bindings,
+        wait_aliases,
+    );
 
     let upstream_binding_names: std::collections::HashSet<&str> = if mark_unresolved_upstream {
         remote_bindings.keys().map(String::as_str).collect()
@@ -408,7 +429,12 @@ mod tests {
                 make_resource(&format!("{}-resource", binding), Some(binding), attrs)
             })
             .collect();
-        ResolvedBindings::from_resources_with_state(&resources, &HashMap::new(), &HashMap::new())
+        ResolvedBindings::from_resources_with_state(
+            &resources,
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+        )
     }
 
     #[test]
@@ -1432,7 +1458,7 @@ mod tests {
         );
         remote_bindings.insert("network".to_string(), network_map);
 
-        resolve_refs_with_state_and_remote(&mut resources, &current_states, &remote_bindings)
+        resolve_refs_with_state_and_remote(&mut resources, &current_states, &remote_bindings, &[])
             .unwrap();
 
         assert_eq!(
@@ -1485,7 +1511,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
             .unwrap();
 
         assert_eq!(
@@ -1539,7 +1565,7 @@ mod tests {
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
         let err =
-            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
                 .expect_err("missing key in concrete upstream map must error");
         assert!(
             err.contains("orgs.accounts") && err.contains("registry_qa"),
@@ -1583,7 +1609,7 @@ mod tests {
             )],
         )];
         let err =
-            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
                 .expect_err("empty map subscript must error");
         assert!(
             err.contains("<no keys>"),
@@ -1618,7 +1644,7 @@ mod tests {
         )];
 
         let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
-        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
             .expect("unloaded upstream subscript must not error");
         assert!(
             matches!(
@@ -1667,7 +1693,7 @@ mod tests {
                 }),
             )],
         )];
-        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
             .unwrap();
         assert_eq!(
             resources[0].get_attr("az"),
@@ -1716,7 +1742,7 @@ mod tests {
             )],
         )];
         let err =
-            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
                 .expect_err("chained subscript with missing key must error");
         assert!(
             err.contains("eu") && err.contains("us"),
@@ -1744,7 +1770,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_with_state_and_remote(&mut resources, &current_states, &remote_bindings)
+        resolve_refs_with_state_and_remote(&mut resources, &current_states, &remote_bindings, &[])
             .unwrap();
 
         // Should remain as ResourceRef since "nonexistent" binding is not found
@@ -1775,7 +1801,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
 
         match resources[0].get_attr("vpc_id") {
             Some(Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path }))) => {
@@ -1806,7 +1832,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
             .unwrap();
 
         assert!(matches!(
@@ -1838,7 +1864,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("bootstrap".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
 
         match resources[0].get_attr("raw") {
             Some(Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamBareRef {
@@ -1876,7 +1902,7 @@ mod tests {
         remote_bindings.insert("bootstrap".to_string(), HashMap::new());
         remote_bindings.insert("secondary".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
 
         match resources[0].get_attr("raws") {
             Some(Value::Concrete(ConcreteValue::List(items))) => {
@@ -1910,7 +1936,7 @@ mod tests {
         )];
         let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
 
         assert!(matches!(
             resources[0].get_attr("vpc_id"),
@@ -1940,7 +1966,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
 
         match resources[0].get_attr("security_group_ids") {
             Some(Value::Concrete(ConcreteValue::List(items))) => {
@@ -1979,7 +2005,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
 
         assert!(
             resources[0].dependency_bindings.contains("network"),
@@ -2007,7 +2033,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
 
         match resources[0].get_attr("tags") {
             Some(Value::Concrete(ConcreteValue::Map(m))) => match m.get("VpcId") {
@@ -2016,5 +2042,67 @@ mod tests {
             },
             other => panic!("expected Map, got {:?}", other),
         }
+    }
+
+    /// carina#3085 design Test plan item 3: `resolve_ref_value` on a
+    /// `<wait-binding>.<attr>` ResourceRef resolves through the
+    /// materialised wait alias to the target's value — not left as an
+    /// unresolved ref. Exercises the resolver layer directly (the
+    /// real-pipeline E2E lives in `tests/wait_downstream_apply.rs`).
+    #[test]
+    fn resolve_ref_value_resolves_wait_binding_passthrough() {
+        let cert = make_resource(
+            "cert",
+            Some("cert"),
+            vec![(
+                "certificate_arn",
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:acm:us-east-1:1:certificate/abc".to_string(),
+                )),
+            )],
+        );
+        let bindings = ResolvedBindings::from_resources_with_state(
+            &[cert],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[crate::binding_index::WaitAliasSpec {
+                binding: crate::parser::BindingName::new("cert_issued"),
+                target: crate::parser::BindingName::new("cert"),
+            }],
+        );
+        let path = crate::resource::AccessPath::new("cert_issued", "certificate_arn");
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
+        let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
+        assert_eq!(
+            resolved,
+            Value::Concrete(ConcreteValue::String(
+                "arn:aws:acm:us-east-1:1:certificate/abc".to_string()
+            )),
+            "cert_issued.certificate_arn must resolve through the wait \
+             alias to cert's value, not stay an unresolved ResourceRef"
+        );
+    }
+
+    /// A wait binding whose target is absent: the ref is left intact
+    /// (the existing `Ok(value.clone())` fallthrough), so the existing
+    /// PlanError path — not a panic — surfaces it.
+    #[test]
+    fn resolve_ref_value_wait_binding_absent_target_left_intact() {
+        let bindings = ResolvedBindings::from_resources_with_state(
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[crate::binding_index::WaitAliasSpec {
+                binding: crate::parser::BindingName::new("cert_issued"),
+                target: crate::parser::BindingName::new("nonexistent"),
+            }],
+        );
+        let path = crate::resource::AccessPath::new("cert_issued", "certificate_arn");
+        let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
+        let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
+        assert_eq!(
+            resolved, ref_value,
+            "no alias when target absent → ref stays intact (existing PlanError surfaces it)"
+        );
     }
 }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -1564,9 +1564,13 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-        let err =
-            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
-                .expect_err("missing key in concrete upstream map must error");
+        let err = resolve_refs_with_state_and_remote(
+            &mut resources,
+            &HashMap::new(),
+            &remote_bindings,
+            &[],
+        )
+        .expect_err("missing key in concrete upstream map must error");
         assert!(
             err.contains("orgs.accounts") && err.contains("registry_qa"),
             "error must name the upstream path and the missing key, got: {err}"
@@ -1608,9 +1612,13 @@ mod tests {
                 }),
             )],
         )];
-        let err =
-            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
-                .expect_err("empty map subscript must error");
+        let err = resolve_refs_with_state_and_remote(
+            &mut resources,
+            &HashMap::new(),
+            &remote_bindings,
+            &[],
+        )
+        .expect_err("empty map subscript must error");
         assert!(
             err.contains("<no keys>"),
             "empty-map error must say '<no keys>', got: {err}"
@@ -1741,9 +1749,13 @@ mod tests {
                 }),
             )],
         )];
-        let err =
-            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
-                .expect_err("chained subscript with missing key must error");
+        let err = resolve_refs_with_state_and_remote(
+            &mut resources,
+            &HashMap::new(),
+            &remote_bindings,
+            &[],
+        )
+        .expect_err("chained subscript with missing key must error");
         assert!(
             err.contains("eu") && err.contains("us"),
             "error must mention the missing key and known keys, got: {err}"

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -207,8 +207,18 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
     let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
     let mut resources_for_plan = sorted_resources.clone();
-    resolve_refs_with_state_and_remote(&mut resources_for_plan, &current_states, &remote_bindings)
-        .expect("resolve_refs should succeed");
+    let wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(carina_core::binding_index::WaitAliasSpec::from)
+        .collect();
+    resolve_refs_with_state_and_remote(
+        &mut resources_for_plan,
+        &current_states,
+        &remote_bindings,
+        &wait_aliases,
+    )
+    .expect("resolve_refs should succeed");
 
     let registry = SchemaRegistry::new();
     let plan = create_plan(
@@ -324,8 +334,18 @@ async fn nested_module_wait_binding_survives_two_expansions() {
     let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
     let mut resources_for_plan = sorted_resources.clone();
-    resolve_refs_with_state_and_remote(&mut resources_for_plan, &current_states, &remote_bindings)
-        .expect("resolve_refs should succeed");
+    let wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(carina_core::binding_index::WaitAliasSpec::from)
+        .collect();
+    resolve_refs_with_state_and_remote(
+        &mut resources_for_plan,
+        &current_states,
+        &remote_bindings,
+        &wait_aliases,
+    )
+    .expect("resolve_refs should succeed");
 
     let registry = SchemaRegistry::new();
     let plan = create_plan(
@@ -375,5 +395,112 @@ async fn nested_module_wait_binding_survives_two_expansions() {
     assert_eq!(
         result.skip_count, 0,
         "no effect should be skipped. Failures: {failures:?}"
+    );
+}
+
+/// carina#3085 repro (design Test plan item 4): the Distribution's
+/// `acm_certificate_arn = cert_issued.certificate_arn` must **resolve
+/// through the wait binding to the target `cert`'s value** during the
+/// real `resolve_refs_*` pipeline, so it no longer renders as a
+/// never-converging phantom diff (`… → r.cert_issued.certificate_arn`)
+/// — AND the `Effect::Wait` dependency edge must still be emitted. Both
+/// asserted together so a future change cannot fix the value half by
+/// breaking the dependency half (the two-faced invariant).
+///
+/// Mirrors the `carina-rs/infra` registry usecase that produced the
+/// reported phantom. Uses the directory fixture (multi-file caller +
+/// module), not a single-string unit test, per the repo's
+/// directory-scoped rule.
+#[tokio::test]
+async fn carina3085_distribution_wait_ref_resolves_no_phantom_via_real_pipeline() {
+    let mut caller = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    caller.push("tests/fixtures/wait/module_wait_downstream/caller");
+
+    let mut parsed = parse_directory(&caller, &ProviderContext::default())
+        .expect("parse_directory should succeed");
+    resolve_modules(&mut parsed, &caller).expect("module resolution should succeed");
+
+    let sorted_resources =
+        sort_resources_by_dependencies(&parsed.resources).expect("topological sort");
+
+    // State holds the resolved ARN for the wait target `r.cert` — the
+    // value `cert_issued.certificate_arn` must passthrough to.
+    let cert = sorted_resources
+        .iter()
+        .find(|r| r.id.resource_type == "acm.Certificate")
+        .expect("expanded Certificate must be present");
+    let arn = "arn:aws:acm:us-east-1:151116838382:certificate/3fc2dbff";
+    let mut cert_attrs = HashMap::new();
+    cert_attrs.insert(
+        "certificate_arn".to_string(),
+        Value::Concrete(ConcreteValue::String(arn.to_string())),
+    );
+    let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+    current_states.insert(cert.id.clone(), State::existing(cert.id.clone(), cert_attrs));
+    let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+
+    let wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(carina_core::binding_index::WaitAliasSpec::from)
+        .collect();
+
+    let mut resources_for_plan = sorted_resources.clone();
+    resolve_refs_with_state_and_remote(
+        &mut resources_for_plan,
+        &current_states,
+        &remote_bindings,
+        &wait_aliases,
+    )
+    .expect("resolve_refs should succeed");
+
+    // ---- The phantom is gone: the Distribution's nested
+    // `acm_certificate_arn` is the *resolved ARN string*, not a
+    // surviving `ResourceRef` to `r.cert_issued.certificate_arn`.
+    let dist = resources_for_plan
+        .iter()
+        .find(|r| r.id.resource_type == "cloudfront.Distribution")
+        .expect("Distribution must be present");
+    let dc = dist
+        .attributes
+        .get("distribution_config")
+        .expect("distribution_config present");
+    let arn_value = match dc {
+        Value::Concrete(ConcreteValue::Map(m)) => m
+            .get("viewer_certificate")
+            .and_then(|vc| match vc {
+                Value::Concrete(ConcreteValue::Map(vcm)) => vcm.get("acm_certificate_arn"),
+                _ => None,
+            })
+            .expect("viewer_certificate.acm_certificate_arn present"),
+        other => panic!("distribution_config must be a Map, got {other:?}"),
+    };
+    assert_eq!(
+        arn_value,
+        &Value::Concrete(ConcreteValue::String(arn.to_string())),
+        "carina#3085: acm_certificate_arn must resolve through the wait \
+         binding to cert's ARN, not stay an unresolved ResourceRef \
+         (got {arn_value:?})"
+    );
+
+    // ---- The dependency edge is intact: Effect::Wait still emitted.
+    let registry = SchemaRegistry::new();
+    let plan = create_plan(
+        &resources_for_plan,
+        &current_states,
+        &HashMap::new(),
+        &registry,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &parsed.wait_bindings,
+    );
+    assert!(
+        plan.effects().iter().any(|e| matches!(
+            e,
+            carina_core::effect::Effect::Wait { binding, .. } if binding == "r.cert_issued"
+        )),
+        "the value-layer alias fix must NOT remove the Effect::Wait \
+         dependency edge — both halves of the wait binding must hold"
     );
 }

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -436,7 +436,10 @@ async fn carina3085_distribution_wait_ref_resolves_no_phantom_via_real_pipeline(
         Value::Concrete(ConcreteValue::String(arn.to_string())),
     );
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
-    current_states.insert(cert.id.clone(), State::existing(cert.id.clone(), cert_attrs));
+    current_states.insert(
+        cert.id.clone(),
+        State::existing(cert.id.clone(), cert_attrs),
+    );
     let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
     let wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed


### PR DESCRIPTION
Closes #3085. Implements the merged design #3087.

## Problem

`<wait-binding>.<attr>` (e.g. `cert_issued.certificate_arn`) never resolved: `ResolvedBindings` was built from resources/state/remote only and never saw `wait_bindings`, `BindingNameKind` had no `Wait` variant, and `resolve_refs_*` was called without `wait_bindings`. The unresolved `ResourceRef` reached the differ against the state's concrete value → never-converging phantom diff on downstream resources (`acm_certificate_arn → r.cert_issued.certificate_arn`).

## Fix

- `BindingNameKind::Wait { target: BindingName }` and `BindingValueSource::WaitAlias { target: BindingName }` — the wait→target edge is a typed value (existing `BindingName` newtype), not a string convention. `WaitAliasSpec` decouples carina-core resolution from the parser `WaitBinding` so the serialized plan-file path needs no parser AST.
- The alias is materialised at `ResolvedBindings` construction as an independent snapshot of the target's resolved attributes, so `resolve_ref_value` needs **zero new branches** (a wait binding is handled identically to a resource binding). Target-absent ⇒ no alias ⇒ the existing `PlanError` surfaces it (no panic, no phantom).
- **Value identity and the dependency edge stay type-distinct**: only the value layer changes; `Effect::Wait` lowering is untouched. The repro test asserts both (phantom gone AND `Effect::Wait` still emitted) so one half cannot regress by fixing the other.

Threaded through **every** resolution path (user-directed root-cause coverage, not just the plan path): `resolve_refs_*`, the export-resolution chain (`resolve_exports` / `FinalizeApplyInput.wait_aliases` / `persist_exports_only` / `resolve_export_values_for_display`), and the apply-from-plan-file path (`PlanFile.wait_bindings` + `PlanWaitBinding` serde projection, mirroring `UpstreamSource`).

## Tests

Revert-checked — all FAIL with the materialise loop stubbed:
- `binding_index`: alias resolution / source / kind / write-back-isolation / upstream-target / absent-target / multi-consumer.
- `resolver`: direct `resolve_ref_value` passthrough + absent-target.
- Real-pipeline directory fixture (`tests/wait_downstream_apply.rs`, `module_wait_downstream` mirroring the `carina-rs/infra` registry usecase): asserts the phantom is gone **and** `Effect::Wait` survives.

## Verify

- `cargo nextest run --workspace`: 3373 passed
- `cargo test --workspace --doc`: ok
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `scripts/check-*.sh`: all pass
- **Real infra**: `aws-vault exec carina-registry-dev -- carina plan ~/src/github.com/carina-rs/infra/registry/dev/registry` — the `acm_certificate_arn → r.cert_issued.certificate_arn` phantom is **gone**.

## Out of scope (verified, not a regression)

A separate order-only `allowed_methods`/`cached_methods` diff becomes visible after this fix. Verified against the real DSL (`allowed_methods = [get, head]`) vs AWS state (`["head","get"]`): the order mismatch **pre-dates this change** and was previously masked by the `acm_certificate_arn` ResourceRef occupying the same `distribution_config` top-level key's diff rows. It is a distinct pre-existing bug (CloudFront list ordered-vs-unordered comparison), filed as #3093. 1 PR = 1 topic.

## Follow-ups

- #3093 — pre-existing CloudFront `allowed_methods`/`cached_methods` ordered-comparison bug (un-masked, distinct root cause).
- #3094 — design-doc scope follow-up (apply-from-plan-file + export paths not described in the merged #3087).

🤖 Generated with [Claude Code](https://claude.com/claude-code)