### PR TITLE
SPIKE(#3089): CI-prebuilt shared .cwasm — measure Test job impact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,12 @@ jobs:
       # instead of silently skipping. Without this step a stale or missing
       # fixture leaves the wasm_integration_test suite as a no-op in CI.
       - run: cargo build -p carina-provider-mock --target wasm32-wasip2
+      # Precompile the mock fixture .wasm -> .cwasm ONCE for the whole job.
+      # nextest runs each test in its own process, so an in-process cache
+      # cannot share Wasmtime's ~25s precompile_component across the WASM
+      # tests on this slow runner. The carina-plugin-host tests load this
+      # shared .cwasm via from_precompiled instead (refs #3089).
+      - run: cargo run -p carina-plugin-host --example precompile-mock-fixture
       - run: cargo nextest run --workspace --all-features
       # nextest does not run doctests; cover them with cargo test --doc.
       - run: cargo test --workspace --doc --all-features

--- a/carina-plugin-host/examples/precompile-mock-fixture.rs
+++ b/carina-plugin-host/examples/precompile-mock-fixture.rs
@@ -1,0 +1,61 @@
+//! Precompile the mock provider `.wasm` fixture to a `.cwasm` once, for the
+//! whole CI Test job to share (refs #3089).
+//!
+//! `cargo nextest` runs every test in its own process, so a process-global
+//! `OnceCell` cannot share the ~25s `precompile_component` across the 15
+//! WASM tests on CI's slow runner. The only cross-process share is an
+//! on-disk artifact produced *outside* the test processes. This example is
+//! run as a CI build step (after the wasm fixture build, before
+//! `cargo nextest run`); the test helper then loads this prebuilt `.cwasm`
+//! via `from_precompiled` instead of re-running `precompile` per test.
+//!
+//! The `.cwasm` is wasmtime-version-matched because this example links the
+//! same `carina-plugin-host` crate (same wasmtime) as the test binaries.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use carina_plugin_host::WasmProviderFactory;
+
+/// Deterministic location of the mock fixture `.wasm` and its prebuilt
+/// `.cwasm`, relative to the workspace target dir. Kept in sync with the
+/// test helper's lookup (see `carina-plugin-host/tests/`).
+fn fixture_paths() -> Option<(PathBuf, PathBuf)> {
+    let target = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("target/wasm32-wasip2/debug");
+    for name in &["carina_provider_mock.wasm", "carina-provider-mock.wasm"] {
+        let wasm = target.join(name);
+        if wasm.exists() {
+            let cwasm = target.join("carina_provider_mock.precompiled.cwasm");
+            return Some((wasm, cwasm));
+        }
+    }
+    None
+}
+
+fn main() -> ExitCode {
+    let Some((wasm, cwasm)) = fixture_paths() else {
+        eprintln!(
+            "precompile-mock-fixture: mock .wasm not found under \
+             target/wasm32-wasip2/debug; build it first with \
+             `cargo build -p carina-provider-mock --target wasm32-wasip2`"
+        );
+        return ExitCode::from(1);
+    };
+
+    match WasmProviderFactory::precompile(&wasm, &cwasm) {
+        Ok(()) => {
+            eprintln!(
+                "precompile-mock-fixture: wrote {} ({} bytes)",
+                cwasm.display(),
+                std::fs::metadata(&cwasm).map(|m| m.len()).unwrap_or(0)
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("precompile-mock-fixture: precompile failed: {e}");
+            ExitCode::from(1)
+        }
+    }
+}

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -37,25 +37,50 @@ macro_rules! skip_if_no_wasm {
     };
 }
 
-/// Build a `WasmProviderFactory` using a per-test temporary cache directory.
+/// Path of the `.cwasm` the CI `precompile-mock-fixture` example writes
+/// next to the `.wasm` fixture, if present. Kept in sync with that
+/// example's `fixture_paths()`.
+fn prebuilt_cwasm() -> Option<std::path::PathBuf> {
+    let cwasm = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("target/wasm32-wasip2/debug/carina_provider_mock.precompiled.cwasm");
+    cwasm.exists().then_some(cwasm)
+}
+
+/// Build a `WasmProviderFactory` for a CRUD/WIT test.
 ///
-/// Tests in this binary run in parallel; if they all shared
-/// `WasmProviderFactory::new()`'s default `~/.carina/cache`, concurrent
-/// precompile runs race on the same `.cwasm` path and one test can observe
-/// a partially-written file (`"failed to load code for …"`). Each test gets
-/// its own cache dir via this helper to eliminate that race.
-async fn load_factory(wasm: &std::path::Path) -> (WasmProviderFactory, tempfile::TempDir) {
-    let cache = tempfile::tempdir().expect("Failed to create cache tempdir");
-    let factory = WasmProviderFactory::from_file_cached(wasm, cache.path())
+/// `cargo nextest` runs every test in its own process, so an in-process
+/// `OnceCell` cannot share the ~25s `precompile_component` across the 8
+/// tests here on CI's slow runner (refs #3089). Instead the CI Test job
+/// runs the `precompile-mock-fixture` example once to write a shared
+/// `.cwasm`; every test process then loads it via `from_precompiled`
+/// (a fast memory-mapped `Component::deserialize_file`), skipping
+/// `precompile` entirely.
+///
+/// When that prebuilt `.cwasm` is absent (local `cargo test`/`cargo
+/// nextest` without the CI step) the helper falls back to the original
+/// per-test `from_file_cached` path so local runs still pass. The
+/// fallback's cache dir is leaked so it outlives the factory's mmap for
+/// the whole test process — a single bounded leak per test, cheaper than
+/// the prior 8× redundant precompiles.
+async fn load_factory(wasm: &std::path::Path) -> WasmProviderFactory {
+    if let Some(cwasm) = prebuilt_cwasm() {
+        return WasmProviderFactory::from_precompiled(&cwasm)
+            .await
+            .expect("Failed to load WASM provider from prebuilt .cwasm");
+    }
+    let cache = Box::leak(Box::new(
+        tempfile::tempdir().expect("Failed to create cache tempdir"),
+    ));
+    WasmProviderFactory::from_file_cached(wasm, cache.path())
         .await
-        .expect("Failed to load WASM provider");
-    (factory, cache)
+        .expect("Failed to load WASM provider")
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_factory() {
     let path = skip_if_no_wasm!();
-    let (factory, _cache) = load_factory(&path).await;
+    let factory = load_factory(&path).await;
 
     assert_eq!(factory.name(), "mock");
     assert_eq!(factory.display_name(), "Mock Provider (Process)");
@@ -68,7 +93,7 @@ async fn test_wasm_mock_provider_factory() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_create_and_read() {
     let path = skip_if_no_wasm!();
-    let (factory, _cache) = load_factory(&path).await;
+    let factory = load_factory(&path).await;
     let provider = factory
         .create_provider(None, &indexmap::IndexMap::new())
         .await
@@ -149,7 +174,7 @@ async fn test_wasm_mock_provider_create_and_read() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_update_and_delete() {
     let path = skip_if_no_wasm!();
-    let (factory, _cache) = load_factory(&path).await;
+    let factory = load_factory(&path).await;
     let provider = factory
         .create_provider(None, &indexmap::IndexMap::new())
         .await
@@ -266,7 +291,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_normalizer() {
     let path = skip_if_no_wasm!();
-    let (factory, _cache) = load_factory(&path).await;
+    let factory = load_factory(&path).await;
     let normalizer = factory
         .create_normalizer(None, &indexmap::IndexMap::new())
         .await;
@@ -310,7 +335,7 @@ async fn test_wasm_mock_provider_merge_default_tags_dispatches_through_wit() {
     // echoes the host-supplied `default_tags` into a sentinel attribute;
     // its presence proves the WIT bridge round-tripped.
     let path = skip_if_no_wasm!();
-    let (factory, _cache) = load_factory(&path).await;
+    let factory = load_factory(&path).await;
     let normalizer = factory
         .create_normalizer(None, &indexmap::IndexMap::new())
         .await;
@@ -349,7 +374,7 @@ async fn test_wasm_mock_provider_merge_default_tags_empty_short_circuits() {
     // Empty `default_tags` must skip the WIT round-trip entirely; if it
     // didn't, the mock guest would still write its sentinel attribute.
     let path = skip_if_no_wasm!();
-    let (factory, _cache) = load_factory(&path).await;
+    let factory = load_factory(&path).await;
     let normalizer = factory
         .create_normalizer(None, &indexmap::IndexMap::new())
         .await;
@@ -378,7 +403,7 @@ async fn test_wasm_mock_provider_merge_default_tags_preserves_order() {
     // Multi-resource ordering: the host zips the guest's response by
     // index, so the guest must return resources in input order.
     let path = skip_if_no_wasm!();
-    let (factory, _cache) = load_factory(&path).await;
+    let factory = load_factory(&path).await;
     let normalizer = factory
         .create_normalizer(None, &indexmap::IndexMap::new())
         .await;
@@ -417,7 +442,7 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     // into state plus a sentinel `__mock_read_data_source__` flag. If
     // that flag shows up, the WASM bridge forwarded the call correctly.
     let path = skip_if_no_wasm!();
-    let (factory, _cache) = load_factory(&path).await;
+    let factory = load_factory(&path).await;
     let provider = factory
         .create_provider(None, &indexmap::IndexMap::new())
         .await


### PR DESCRIPTION
**Draft spike, not for merge.** Purpose: measure on a real CI run whether precompiling the mock WASM fixture once as a CI build step (then loading the shared `.cwasm` via `from_precompiled` in the 8 `wasm_integration_test` tests) reduces the Test job wall time.

Background: the original #3089 OnceCell approach was verified to be a **no-op under nextest** (process-per-test). This spike implements the corrected cross-process design.

Local proof-of-mechanism: 8 integration tests 6.7s → 2.0s each. Local hardware does NOT reproduce the CI ~25s/test bottleneck, so this CI run is the decisive measurement.

Compare this run's `Test` job wall time against main (`59d30b66`, Test ≈ 244s). The `wasm_precompile_test` cache-lifecycle tests are intentionally unchanged (they assert cache behavior).

Refs #3089