### PR TITLE
SPIKE(#3089) A: Winch baseline compiler for WASM tests — measure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,11 @@ jobs:
       # instead of silently skipping. Without this step a stale or missing
       # fixture leaves the wasm_integration_test suite as a no-op in CI.
       - run: cargo build -p carina-provider-mock --target wasm32-wasip2
+      # Spike (#3089): exercise the Winch baseline compiler for WASM tests
+      # to cut per-process precompile_component time on the slow runner.
       - run: cargo nextest run --workspace --all-features
+        env:
+          CARINA_WASM_WINCH: "1"
       # nextest does not run doctests; cover them with cargo test --doc.
       - run: cargo test --workspace --doc --all-features
 

--- a/carina-plugin-host/Cargo.toml
+++ b/carina-plugin-host/Cargo.toml
@@ -14,7 +14,7 @@ semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"
-wasmtime = { version = "43", features = ["component-model"] }
+wasmtime = { version = "43", features = ["component-model", "winch"] }
 wasmtime-wasi = "43"
 wasmtime-wasi-http = "43"
 hyper = "1"

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -91,6 +91,16 @@ fn build_engine_config() -> wasmtime::Config {
     let mut config = wasmtime::Config::new();
     config.wasm_component_model(true);
     config.epoch_interruption(true);
+    // Spike (#3089): when CARINA_WASM_WINCH=1, use Wasmtime's Winch
+    // baseline compiler instead of Cranelift. Winch trades slower
+    // generated code for much faster compilation — the right trade for
+    // CI test runs dominated by per-process precompile_component time.
+    // Production (env unset) stays on Cranelift. Both precompile and
+    // from_precompiled funnel through this fn, so the strategy stays
+    // consistent between produce and load.
+    if std::env::var("CARINA_WASM_WINCH").as_deref() == Ok("1") {
+        config.strategy(wasmtime::Strategy::Winch);
+    }
     config
 }
 


### PR DESCRIPTION
Draft spike, not for merge. Measures whether the Winch baseline compiler (env-gated `CARINA_WASM_WINCH=1`) cuts CI Test job time: faster `precompile_component` vs the added compile cost of the `winch` cargo feature (`winch-codegen` + `wasmtime-internal-winch`).

Local sanity: 8 `wasm_integration_test` tests 6.75s → 3.35s each (~2x), all pass. Compare this run's `Test` job wall time against main (≈244s). Refs #3089
