### PR TITLE
SPIKE(#3089) C: Test job on ubuntu-latest-4-core — measure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,12 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    # Spike (#3089): the Test bottleneck is CPU-bound WASM
+    # precompile_component, ~4x slower on the 2-vCPU ubuntu-latest than
+    # local. public repos get GitHub larger runners at no cost, so move
+    # only this job to a 4-core runner to attack the root cause directly
+    # (no added compilable code, unlike the 3 rejected code-side spikes).
+    runs-on: ubuntu-latest-4-core
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Draft spike, not for merge. Tests whether moving only the Test job to a GitHub `ubuntu-latest-4-core` larger runner cuts wall time by attacking the root cause (CPU-bound WASM `precompile_component`, ~4x slower on 2-vCPU). public repos get larger runners at no cost; no added compilable code, so it cannot hit the uncached-compile wall that cancelled #3096/#3097/#3098.

Watch: does the Test job **start** (if it queues forever, GitHub larger runners need org-level enablement — itself the finding). Compare Test wall time vs main ≈244s. Refs #3089
