### PR TITLE
SPIKE(#3089) C-sccache: CI sccache + Winch — measure (needs 2 runs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,16 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # Spike (#3089): sccache with the GitHub Actions cache backend caches
+    # rustc invocations across runs — including workspace crates and
+    # feature-added deps that Swatinem/rust-cache does NOT cache. This is
+    # the missing piece that made the Winch spike (#3098) net-negative:
+    # winch-codegen/wasmtime-internal-winch recompiled every run. With
+    # sccache, Winch's -78s test-run win should flip net-positive.
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      CARINA_WASM_WINCH: "1"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -106,6 +116,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasip2
+      - uses: mozilla-actions/sccache-action@v0.0.6
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       # Build the WASM fixture so carina-plugin-host's integration tests run
@@ -115,6 +126,7 @@ jobs:
       - run: cargo nextest run --workspace --all-features
       # nextest does not run doctests; cover them with cargo test --doc.
       - run: cargo test --workspace --doc --all-features
+      - run: sccache --show-stats
 
   binary-build:
     name: Binary Build (linux-x86_64)

--- a/carina-plugin-host/Cargo.toml
+++ b/carina-plugin-host/Cargo.toml
@@ -14,7 +14,7 @@ semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"
-wasmtime = { version = "43", features = ["component-model"] }
+wasmtime = { version = "43", features = ["component-model", "winch"] }
 wasmtime-wasi = "43"
 wasmtime-wasi-http = "43"
 hyper = "1"

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -91,6 +91,16 @@ fn build_engine_config() -> wasmtime::Config {
     let mut config = wasmtime::Config::new();
     config.wasm_component_model(true);
     config.epoch_interruption(true);
+    // Spike (#3089): when CARINA_WASM_WINCH=1, use Wasmtime's Winch
+    // baseline compiler instead of Cranelift. Winch trades slower
+    // generated code for much faster compilation — the right trade for
+    // CI test runs dominated by per-process precompile_component time.
+    // Production (env unset) stays on Cranelift. Both precompile and
+    // from_precompiled funnel through this fn, so the strategy stays
+    // consistent between produce and load.
+    if std::env::var("CARINA_WASM_WINCH").as_deref() == Ok("1") {
+        config.strategy(wasmtime::Strategy::Winch);
+    }
     config
 }
 


### PR DESCRIPTION
Draft spike, not for merge. Tests whether CI sccache (GitHub Actions cache backend) + Winch flips the #3098 result net-positive: sccache caches the `winch-codegen`/`wasmtime-internal-winch` compile that Swatinem/rust-cache does not, so Winch's -78s test-run win should stop being cancelled.

Needs TWO runs: run 1 cold (populates sccache), run 2 warm (steady state — the real number). Compare warm `Test` wall time vs main ≈244s. `sccache --show-stats` at the end reports cache hit rate. Refs #3089
