### PR TITLE
SPIKE(#3089) Option 2: debug=line-tables-only — measure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,16 @@ resolver = "2"
 version = "0.4.0"
 repository = "https://github.com/carina-rs/carina"
 homepage = "https://github.com/carina-rs/carina"
+
+# Spike (#3089): the CI Test job spends ~74s in the nextest compile+link
+# phase. Default `debug = 2` emits full DWARF, which dominates link time
+# for the workspace's many test binaries. `line-tables-only` keeps file
+# + line numbers in panics/backtraces (so test failures stay diagnosable)
+# while dropping the heavy variable/type debuginfo, cutting link time.
+# Zero new dependencies, so this cannot hit the uncached-compile wall
+# that cancelled the .cwasm/job-split/Winch spikes.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"


### PR DESCRIPTION
Draft spike, not for merge. Tests whether `debug = "line-tables-only"` on dev/test profiles cuts the ~74s nextest compile+link phase (full DWARF dominates link time across many test binaries). Zero new deps — cannot hit the uncached-compile wall that cancelled #3096/#3097/#3098. Compare `Test` job wall time vs main ≈244s. Refs #3089
