### PR TITLE
fix: emit Effect::Wait only when it gates a pending change (closes #3101)

### DIFF
--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_wait_cert.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_wait_cert.snap
@@ -7,8 +7,6 @@ Execution Plan:
   + aws.acm.Certificate cert
       domain_name: "registry.example.com"
       validation_method: "DNS"
-        │
-        └─ > cert_issued (until cert.status == aws.acm.Certificate.Status.Issued)
   + aws.route53.RecordSet validation_record
       hosted_zone_id: "Z123"
       name: "_acme.registry.example.com"

--- a/carina-cli/tests/fixtures/plan_display/wait_cert/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/wait_cert/main.crn
@@ -1,6 +1,11 @@
 # Plan-display fixture exercising the `wait` construct (carina#2825).
-# `cert_issued` blocks downstream resources until ACM marks the cert
-# ISSUED; the snapshot pins how plan tree renders the wait line.
+# No resource here references `cert_issued`, so per carina#3101 the
+# wait gates nothing and is intentionally NOT rendered (it would
+# otherwise be a lone `> cert_issued (until …)` line that polls on
+# apply for no reason). The snapshot pins that suppression. The
+# wait-IS-rendered path (a consumer with a pending change) is covered
+# by `wait_emitted_when_a_consumer_has_a_pending_change` in
+# differ/plan_tests.rs.
 
 provider aws {
     region = "us-east-1"

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -399,6 +399,29 @@ pub fn create_plan(
             });
             continue;
         };
+        // A `wait`'s only purpose is to gate downstream resources that
+        // reference `<wait-binding>.<attr>` until the `until` predicate
+        // holds (design value semantics: consumers that don't need the
+        // wait reference the target directly and skip it). So emit the
+        // `Effect::Wait` only when at least one resource that depends
+        // on this wait binding has a pending infrastructure change in
+        // this plan. If every consumer is unchanged (or there is no
+        // consumer at all), the wait gates nothing — emitting it would
+        // render a lone `> <binding> (until …)` header on a no-change
+        // plan and poll the target on `apply` for no reason
+        // (carina#3101). A genuinely pending consumer change still
+        // produces the wait + its dependency edge (carina#3085 /
+        // carina#3061 behavior preserved).
+        let gates_a_pending_change = desired.iter().any(|r| {
+            get_resource_dependencies(r).contains(wb.binding.as_str())
+                && plan
+                    .effects()
+                    .iter()
+                    .any(|e| e.resource_id() == &r.id && e.is_mutating())
+        });
+        if !gates_a_pending_change {
+            continue;
+        }
         // `lhs_segments` is guaranteed non-empty and the first segment
         // equals `wb.target` (enforced by `parse_wait_expr`). The
         // predicate attribute path is therefore `lhs_segments[1..]`.

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1204,7 +1204,13 @@ fn wait_binding_lowers_to_wait_effect() {
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
     let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
-    let resources = vec![cert];
+    // A downstream consumer that references the wait binding and is
+    // itself a pending change (Create) — carina#3101: the wait is
+    // emitted only when it gates a real downstream change.
+    let mut consumer =
+        Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    consumer.dependency_bindings.insert("cert_issued".to_string());
+    let resources = vec![cert, consumer];
 
     let wait = WaitBinding {
         binding: "cert_issued".into(),
@@ -1276,7 +1282,12 @@ fn wait_uses_schema_default_timeout_when_omitted() {
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
     let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
-    let resources = vec![cert];
+    // Downstream consumer with a pending change so the wait gates
+    // something (carina#3101).
+    let mut consumer =
+        Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    consumer.dependency_bindings.insert("cert_issued".to_string());
+    let resources = vec![cert, consumer];
 
     let mut schemas = SchemaRegistry::new();
     schemas.insert(
@@ -1361,5 +1372,122 @@ fn wait_with_unknown_target_emits_plan_error() {
         plan.errors()[0].message.contains("nonexistent"),
         "error message should mention the missing target, got: {}",
         plan.errors()[0].message
+    );
+}
+
+/// carina#3101: a `wait` gates nothing when every downstream consumer
+/// is unchanged — no `Effect::Wait` (no lone `> binding (until …)`
+/// header on a 0-change plan, no apply-time poll). Mirrors the real
+/// `carina-rs/infra registry/dev/registry` shape: cert (unchanged) +
+/// distribution (unchanged) referencing `cert_issued`.
+#[test]
+fn wait_omitted_when_all_consumers_unchanged() {
+    use crate::effect::Effect;
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
+    let mut dist =
+        Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    dist.dependency_bindings.insert("cert_issued".to_string());
+    let resources = vec![cert, dist];
+
+    // Both resources already exist with identical state → NoChange,
+    // so neither produces a mutating effect.
+    let mut current_states = HashMap::new();
+    current_states.insert(
+        ResourceId::new("acm.Certificate", "cert"),
+        State::existing(ResourceId::new("acm.Certificate", "cert"), HashMap::new()),
+    );
+    current_states.insert(
+        ResourceId::new("cloudfront.Distribution", "dist"),
+        State::existing(
+            ResourceId::new("cloudfront.Distribution", "dist"),
+            HashMap::new(),
+        ),
+    );
+
+    let wait = WaitBinding {
+        binding: "cert_issued".into(),
+        target: "cert".into(),
+        until_raw: "cert.status == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        },
+        timeout_secs: Some(60),
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &current_states,
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+
+    assert!(
+        !plan
+            .effects()
+            .iter()
+            .any(|e| matches!(e, Effect::Wait { .. })),
+        "carina#3101: no Effect::Wait when every consumer is unchanged; \
+         effects were {:?}",
+        plan.effects()
+    );
+}
+
+/// carina#3101 counterpart (two-faced invariant, like carina#3085):
+/// the wait IS emitted when a downstream consumer has a pending change
+/// — the dependency-edge behavior (carina#3085 / carina#3061) must not
+/// regress just because the no-op case is now suppressed.
+#[test]
+fn wait_emitted_when_a_consumer_has_a_pending_change() {
+    use crate::effect::Effect;
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
+    // `dist` is new (absent from current_states) → Create → mutating.
+    let mut dist =
+        Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    dist.dependency_bindings.insert("cert_issued".to_string());
+    let resources = vec![cert, dist];
+
+    let wait = WaitBinding {
+        binding: "cert_issued".into(),
+        target: "cert".into(),
+        until_raw: "cert.status == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        },
+        timeout_secs: Some(60),
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &HashMap::new(),
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+
+    assert!(
+        plan.effects()
+            .iter()
+            .any(|e| matches!(e, Effect::Wait { binding, .. } if binding == "cert_issued")),
+        "carina#3101: the wait must still be emitted when a consumer \
+         has a pending change (carina#3085/#3061 not regressed); \
+         effects were {:?}",
+        plan.effects()
     );
 }

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1207,9 +1207,10 @@ fn wait_binding_lowers_to_wait_effect() {
     // A downstream consumer that references the wait binding and is
     // itself a pending change (Create) — carina#3101: the wait is
     // emitted only when it gates a real downstream change.
-    let mut consumer =
-        Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
-    consumer.dependency_bindings.insert("cert_issued".to_string());
+    let mut consumer = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    consumer
+        .dependency_bindings
+        .insert("cert_issued".to_string());
     let resources = vec![cert, consumer];
 
     let wait = WaitBinding {
@@ -1284,9 +1285,10 @@ fn wait_uses_schema_default_timeout_when_omitted() {
     let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
     // Downstream consumer with a pending change so the wait gates
     // something (carina#3101).
-    let mut consumer =
-        Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
-    consumer.dependency_bindings.insert("cert_issued".to_string());
+    let mut consumer = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    consumer
+        .dependency_bindings
+        .insert("cert_issued".to_string());
     let resources = vec![cert, consumer];
 
     let mut schemas = SchemaRegistry::new();
@@ -1386,8 +1388,7 @@ fn wait_omitted_when_all_consumers_unchanged() {
     use crate::parser::{UntilPredicateAst, WaitBinding};
 
     let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
-    let mut dist =
-        Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    let mut dist = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
     dist.dependency_bindings.insert("cert_issued".to_string());
     let resources = vec![cert, dist];
 
@@ -1452,8 +1453,7 @@ fn wait_emitted_when_a_consumer_has_a_pending_change() {
 
     let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
     // `dist` is new (absent from current_states) → Create → mutating.
-    let mut dist =
-        Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    let mut dist = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
     dist.dependency_bindings.insert("cert_issued".to_string());
     let resources = vec![cert, dist];
 


### PR DESCRIPTION
Closes #3101.

## Problem

A `wait`'s only purpose is the dependency edge — it blocks downstream resources that reference `<wait-binding>.<attr>` until the `until` predicate holds (design value semantics: consumers that don't need the wait reference the target directly and skip it). But `create_plan` lowered **every** `wait` into an `Effect::Wait` unconditionally, ignoring whether any downstream consumer has a pending change.

Result: after #3085/#3093 cleaned the `r.distribution` phantoms, `carina plan` on `carina-rs/infra registry/dev/registry` showed:

```
  > r.cert_issued (until cert.status == aws.acm.Certificate.Status.issued)

Plan: 0 to add, 0 to change, 0 to destroy.
```

A lone wait header on a no-change plan — confusing, and `carina apply` would poll the target via `provider.read()` for nothing.

## Fix

Guard the wait lowering in `differ/plan.rs`: emit the `Effect::Wait` only when at least one resource that depends on the wait binding (`get_resource_dependencies`, which includes the `dependency_bindings` snapshot) has a pending mutating effect (Create/Update/Replace/Delete) in this plan. If every consumer is unchanged — or there is no consumer — the wait gates nothing and is omitted: no phantom header, no apply-time poll.

Design choice (interpretation X, user-approved): the condition is purely "does a consumer have a pending change". `wait` gates downstream, not the target; if nothing downstream needs gating the wait is meaningless regardless of what the target does. A genuinely pending consumer change still produces the wait + its dependency edge — **carina#3085 / carina#3061 behavior preserved**.

## Tests

- New: `wait_omitted_when_all_consumers_unchanged` (the #3101 repro — revert-checked: FAILs with the guard disabled) and `wait_emitted_when_a_consumer_has_a_pending_change` (two-faced invariant, #3085/#3061 not regressed).
- Three existing wait tests updated to include a pending downstream consumer so their "wait is lowered" intent is preserved.
- The existing real-parse `wait_downstream_apply` E2E (added in #3085, consumer = distribution Create) still passes — covers the consumer-present path through the real parse pipeline.
- `wait_cert` plan-display snapshot now pins the suppression (no resource references `cert_issued`); fixture comment updated to record the #3101 intent (snapshot reviewed before accepting).

## Verify

- `cargo nextest run --workspace`: 3375 passed
- `cargo test --workspace --doc`: ok
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `scripts/check-*.sh`: all pass (incl. plan-fixtures: wait_cert Makefile target intact)
- Real-infra: `registry/dev/registry` now shows a clean 0-change plan with no wait line (user-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)