### PR TITLE
ci(perf): debug=line-tables-only on dev/test profiles (post-merge-observed)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,20 @@ resolver = "2"
 version = "0.4.0"
 repository = "https://github.com/carina-rs/carina"
 homepage = "https://github.com/carina-rs/carina"
+
+# The CI Test job's nextest test-run phase is link-heavy across the
+# workspace's many test binaries. Default `debug = 2` emits full DWARF;
+# `line-tables-only` keeps file + line numbers in panics and backtraces
+# (test failures stay locatable) while dropping variable/type debuginfo,
+# producing lighter binaries that link and start faster. Measured on CI:
+# nextest test-run phase ~125s -> ~82-98s. The compile phase re-warms to
+# steady state once this is on the default branch (rust-cache only saves
+# there). No dependency or runtime/program-behavior change; interactive
+# debuggers (lldb/rust-gdb) lose variable/type inspection on debug builds
+# while panics and backtraces keep file+line. Reversible (a 1-commit
+# revert, which itself triggers one more re-warm). Refs #3104/#3089.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"


### PR DESCRIPTION
## What

Adds `[profile.dev]` and `[profile.test]` with `debug = "line-tables-only"` to the root workspace `Cargo.toml`.

## Why

Outcome of the #3089 CI-Test-time investigation. Every spike-measurable code/CI lever was exhausted (prebuilt .cwasm, job-split, Winch, CI sccache — all rejected on measured CI runs; details on #3089). This profile change is the one remaining free lever with a real, reproduced win.

`line-tables-only` keeps file+line in panics and backtraces (test failures stay locatable — verified with a panic probe: `panicked at …:1:48` retained) while dropping variable/type DWARF, producing lighter test binaries that link and start faster.

## Measured signal (cache-independent, reproduced across 2 spike CI runs, #3102)

| | main | with line-tables-only |
|---|---|---|
| nextest **test-run** phase | ~125s | 81.8s / 98.3s (**~25–43s faster**) |

This phase does not depend on the build cache, so it is directly comparable.

## Why total-time effect is NOT proven here (read before merging)

`Swatinem/rust-cache` only **saves** the cache on the default branch, never on PR branches. A profile change does not change the cache *key* (profile isn't hashed) so a branch restores main's cached `target/` — built with the **old** profile — and cargo full-recompiles every branch run without ever stabilizing. So a spike PR's compile-phase / total numbers are a perpetual cold-recompile artifact, **not** steady state. The true total effect only exists once this is on `main` and rust-cache re-warms with the new profile.

## Post-merge observation plan (this is why the issue stays open)

1. The merge commit pays a **one-time full recompile** on `main` (rust-cache re-warms with the new profile). Expected.
2. Observe `main`'s **Test job wall time over the next ~3–5 warm runs**.
3. Expected steady state: compile phase ≈ unchanged (cache re-warmed), test-run phase ~-25..-43s ⇒ net ~-25..-43s on the Test job.
4. **Report actual before/after on #3089.**
5. **If it does not net-improve, revert** — a clean 1-commit `Cargo.toml` revert (which itself triggers one more one-time re-warm, same as the merge commit).

Because the acceptance includes this post-merge obligation, this PR uses `Refs` (not `Closes`): #3104 stays open until the warm-run observation confirms net improvement (or the change is reverted). Per the project's no-premature-close rule.

## Tradeoff

Interactive debuggers (lldb/rust-gdb) lose variable/type inspection on local debug builds; panics and backtraces keep file+line. Global (all contributors), intentionally — a CI-only profile would not capture the test-run-phase win or would split the CI/local build contract. Fully reversible.

## Verify

`cargo nextest run --workspace --all-features` 3373 passed / 0 failed · doctests ok · clippy clean · `scripts/check-*.sh` pass · panic probe retains file:line. (Note: WASM suites were exercised under this exact profile by spike #3102's CI runs and passed; local nextest may skip them when the wasm fixture is absent — CI always builds it.)

Refs #3104
Refs #3089

🤖 Generated with [Claude Code](https://claude.com/claude-code)
