### PR TITLE
fix: make ProviderNormalizer async to remove nested block_on self-deadlock (#3112)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -920,7 +920,9 @@ async fn run_apply_locked(
 
     // Hydrate, transfer state for moved blocks and anonymous → let-bound
     // renames (#1685), then run phase 2 against the consolidated state.
-    provider.hydrate_read_state(&mut current_states, &saved_attrs);
+    provider
+        .hydrate_read_state(&mut current_states, &saved_attrs)
+        .await;
     let moved_pairs = {
         let mut pairs = crate::wiring::materialize_moved_states(
             &mut current_states,
@@ -1021,11 +1023,13 @@ async fn run_apply_locked(
 
     // Run the normalization pipeline (same as plan path in wiring.rs).
     let preprocessor = crate::wiring::PlanPreprocessor::new(&provider, ctx);
-    preprocessor.prepare(
-        &mut resources_for_plan,
-        &mut current_states,
-        &parsed.providers,
-    );
+    preprocessor
+        .prepare(
+            &mut resources_for_plan,
+            &mut current_states,
+            &parsed.providers,
+        )
+        .await;
 
     let directives_map = state_file
         .as_ref()

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -751,7 +751,9 @@ pub(crate) async fn run_state_refresh_locked(
         &parsed.resources,
         ctx.schemas(),
     );
-    provider.hydrate_read_state(&mut current_states, &saved_attrs);
+    provider
+        .hydrate_read_state(&mut current_states, &saved_attrs)
+        .await;
     // awscc#251: also lift the provider-read `current_states` (not just
     // `saved_attrs`) — the values read at the refresh loop above arrive
     // as plain `String` for IAM enum fields and must be lifted before

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -170,11 +170,12 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         }
         for provider_config in &parsed.providers {
             if !provider_config.default_tags.is_empty() {
-                router.merge_default_tags(
+                // Outermost runtime (see `normalize_desired_with_ctx`): not nested.
+                rt.block_on(router.merge_default_tags(
                     &mut resources,
                     &provider_config.default_tags,
                     wiring.schemas(),
-                );
+                ));
             }
         }
     }

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -567,7 +567,7 @@ impl<'a> PlanPreprocessor<'a> {
     /// Run the full normalization pipeline on desired resources and current states.
     ///
     /// Call after `resolve_refs_with_state_and_remote()` and before `create_plan()`.
-    pub fn prepare(
+    pub async fn prepare(
         &self,
         resources: &mut [Resource],
         current_states: &mut HashMap<ResourceId, State>,
@@ -592,13 +592,14 @@ impl<'a> PlanPreprocessor<'a> {
             !current_states_contain_unknown(current_states),
             "Value::Deferred(DeferredValue::Unknown) found in current_states — RFC #2371 constraint b violated"
         );
-        self.normalizer.normalize_desired(resources);
-        self.normalizer.normalize_state(current_states);
+        self.normalizer.normalize_desired(resources).await;
+        self.normalizer.normalize_state(current_states).await;
         let schemas = self.ctx.schemas();
         for config in provider_configs {
             if !config.default_tags.is_empty() {
                 self.normalizer
-                    .merge_default_tags(resources, &config.default_tags, schemas);
+                    .merge_default_tags(resources, &config.default_tags, schemas)
+                    .await;
             }
         }
         resolve_enum_aliases_with_ctx(self.ctx, resources);
@@ -733,7 +734,11 @@ pub fn normalize_desired_with_ctx(ctx: &WiringContext, resources: &mut [Resource
         let attrs = indexmap::IndexMap::new();
         router.add_normalizer(rt.block_on(factory.create_normalizer(None, &attrs)));
     }
-    router.normalize_desired(resources);
+    // `rt` is the outermost runtime here (sync helper for fixture/test
+    // plan paths), so this `block_on` is not a nested one — the
+    // self-deadlock class fixed by carina#3112 only existed when the
+    // sync normalizer's *own* body opened a nested runtime.
+    rt.block_on(router.normalize_desired(resources));
 }
 
 /// Normalize enum values in current states to match DSL format.
@@ -754,7 +759,8 @@ pub fn normalize_state_with_ctx(
         let attrs = indexmap::IndexMap::new();
         router.add_normalizer(rt.block_on(factory.create_normalizer(None, &attrs)));
     }
-    router.normalize_state(current_states);
+    // Outermost runtime (see `normalize_desired_with_ctx`): not nested.
+    rt.block_on(router.normalize_state(current_states));
 }
 
 /// Resolve enum alias values in resources to their canonical AWS form.
@@ -1284,7 +1290,9 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         // Hydrate now — before phase 2 resolves data source refs — so
         // any attributes the provider's read() didn't return are
         // available when building the binding map (#1685).
-        provider.hydrate_read_state(&mut current_states, &saved_attrs);
+        provider
+            .hydrate_read_state(&mut current_states, &saved_attrs)
+            .await;
 
         // Transfer state for explicit `moved` blocks and anonymous →
         // let-bound renames (#1685). Must run before phase 2 so the ref
@@ -1366,7 +1374,9 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
             // renames so the later `resolve_refs_with_state_and_remote`
             // call (and data-source-input resolution) sees entries
             // under their current binding names (#1685).
-            provider.hydrate_read_state(&mut current_states, &saved_attrs);
+            provider
+                .hydrate_read_state(&mut current_states, &saved_attrs)
+                .await;
             moved_pairs.extend(materialize_moved_states(
                 &mut current_states,
                 &mut prev_explicit,
@@ -1448,7 +1458,9 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
     // Run the normalization pipeline: normalize_desired → normalize_state →
     // merge_default_tags → resolve_enum_aliases (order matters).
     let preprocessor = PlanPreprocessor::new(&provider, &ctx);
-    preprocessor.prepare(&mut resources, &mut current_states, &parsed.providers);
+    preprocessor
+        .prepare(&mut resources, &mut current_states, &parsed.providers)
+        .await;
 
     // Build directives map from state file for orphaned resource deletion
     let directives_map = state_file

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -327,7 +327,7 @@ fn test_merge_default_tags_prevents_false_diff() {
         router.add_normalizer(rt.block_on(factory.create_normalizer(None, &attrs)));
     }
     let mut resources_with = vec![resource];
-    router.merge_default_tags(&mut resources_with, &default_tags, &schemas);
+    rt.block_on(router.merge_default_tags(&mut resources_with, &default_tags, &schemas));
 
     // After merging, desired now has tags matching state → no diff
     let plan_with = create_plan(

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -390,11 +390,13 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
 
     let provider = NoopProvider { cert_publishes_arn };
     let preprocessor = PlanPreprocessor::new(&NoopNormalizer, &ctx);
-    preprocessor.prepare(
-        &mut resources_for_plan,
-        &mut current_states,
-        &parsed.providers,
-    );
+    preprocessor
+        .prepare(
+            &mut resources_for_plan,
+            &mut current_states,
+            &parsed.providers,
+        )
+        .await;
 
     let plan = create_plan(
         &resources_for_plan,

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -21,5 +21,5 @@ indexmap = { version = "2", features = ["serde"] }
 tokio = { version = "1", features = ["time"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync"] }
 tempfile = "3"

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -122,7 +122,7 @@ pub(super) async fn refresh_pending_states(
 /// `wait` as the synchronization mechanism for upstream attributes
 /// that populate asynchronously (ACM `domain_validation_options`,
 /// CloudFront `domain_name`, etc.).
-pub(super) fn resolve_resource(
+pub(super) async fn resolve_resource(
     resource: &Resource,
     bindings: &ResolvedBindings,
     pipeline: &RenormalizePipeline<'_>,
@@ -133,7 +133,7 @@ pub(super) fn resolve_resource(
         assert_fully_resolved(&resolved_value, key)?;
         resolved.attributes.insert(key.clone(), resolved_value);
     }
-    renormalize(resolved, pipeline)
+    renormalize(resolved, pipeline).await
 }
 
 /// Resolve a resource, preferring unresolved source for re-resolution.
@@ -141,7 +141,7 @@ pub(super) fn resolve_resource(
 ///
 /// See [`resolve_resource`] for the fail-fast contract on
 /// still-deferred values.
-pub(super) fn resolve_resource_with_source(
+pub(super) async fn resolve_resource_with_source(
     target: &Resource,
     source: &Resource,
     bindings: &ResolvedBindings,
@@ -153,7 +153,7 @@ pub(super) fn resolve_resource_with_source(
         assert_fully_resolved(&resolved_value, key)?;
         resolved.attributes.insert(key.clone(), resolved_value);
     }
-    renormalize(resolved, pipeline)
+    renormalize(resolved, pipeline).await
 }
 
 /// The full plan-time normalization pipeline, threaded into the apply
@@ -202,10 +202,13 @@ pub(super) struct RenormalizePipeline<'a> {
 /// mirrors the caller's signature — `resolve_resource{,_with_source}`
 /// fail-fast earlier on still-`Deferred` values — so this stays the tail
 /// expression without forcing `Ok(...)` at every call site.
-fn renormalize(resolved: Resource, pipeline: &RenormalizePipeline<'_>) -> Result<Resource, String> {
+async fn renormalize(
+    resolved: Resource,
+    pipeline: &RenormalizePipeline<'_>,
+) -> Result<Resource, String> {
     let mut one = [resolved];
     crate::value::canonicalize_resources_with_schemas(&mut one, pipeline.schemas);
-    pipeline.normalizer.normalize_desired(&mut one);
+    pipeline.normalizer.normalize_desired(&mut one).await;
     crate::value::resolve_enum_aliases_for_resources(&mut one, pipeline.factories);
     let [resolved] = one;
     Ok(resolved)
@@ -367,7 +370,7 @@ pub(super) async fn execute_basic_effect<'a>(
 
     match effect {
         Effect::Create(resource) => {
-            let resolved = match resolve_resource(resource, bindings, pipeline) {
+            let resolved = match resolve_resource(resource, bindings, pipeline).await {
                 Ok(r) => r,
                 Err(e) => {
                     observer.on_event(&ExecutionEvent::EffectFailed {
@@ -428,7 +431,7 @@ pub(super) async fn execute_basic_effect<'a>(
         } => {
             let resolve_source = unresolved.get(id).unwrap_or(to);
             let resolved_to =
-                match resolve_resource_with_source(to, resolve_source, bindings, pipeline) {
+                match resolve_resource_with_source(to, resolve_source, bindings, pipeline).await {
                     Ok(r) => r,
                     Err(e) => {
                         observer.on_event(&ExecutionEvent::EffectFailed {

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -522,7 +522,9 @@ pub(super) async fn execute_effects_phased(
                             resolve_source,
                             &binding_snapshot,
                             &pipeline,
-                        ) {
+                        )
+                        .await
+                        {
                             Ok(r) => r,
                             Err(e) => {
                                 observer.on_event(&ExecutionEvent::EffectFailed {
@@ -567,7 +569,9 @@ pub(super) async fn execute_effects_phased(
                                         &cascade.to,
                                         &local_bindings,
                                         &pipeline,
-                                    ) {
+                                    )
+                                    .await
+                                    {
                                         Ok(r) => r,
                                         Err(e) => {
                                             observer.on_event(
@@ -1122,7 +1126,9 @@ pub(super) async fn execute_effects_phased(
                                     resolve_source,
                                     &binding_snapshot,
                                     &pipeline,
-                                ) {
+                                )
+                                .await
+                                {
                                     Ok(r) => r,
                                     Err(e) => {
                                         observer.on_event(&ExecutionEvent::EffectFailed {

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -118,7 +118,7 @@ pub(super) async fn execute_cbd_replace_parallel(
     ctx: &ReplaceContext<'_>,
     observer: &dyn ExecutionObserver,
 ) -> SingleEffectResult {
-    let resolved = match resolve_resource(ctx.to, ctx.bindings, ctx.pipeline) {
+    let resolved = match resolve_resource(ctx.to, ctx.bindings, ctx.pipeline).await {
         Ok(r) => r,
         Err(e) => {
             observer.on_event(&ExecutionEvent::EffectFailed {
@@ -157,6 +157,7 @@ pub(super) async fn execute_cbd_replace_parallel(
             let mut cascade_failed = false;
             for cascade in ctx.cascading_updates {
                 let resolved_to = match resolve_resource(&cascade.to, &local_bindings, ctx.pipeline)
+                    .await
                 {
                     Ok(r) => r,
                     Err(e) => {
@@ -386,7 +387,9 @@ pub(super) async fn execute_dbd_replace_parallel(
                 resolve_source,
                 ctx.bindings,
                 ctx.pipeline,
-            ) {
+            )
+            .await
+            {
                 Ok(r) => r,
                 Err(e) => {
                     observer.on_event(&ExecutionEvent::EffectFailed {

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -255,25 +255,46 @@ fn canonicalize_value(v: &Value) -> Option<Value> {
 }
 
 impl crate::provider::ProviderNormalizer for CanonicalizingNormalizer {
-    fn normalize_desired(&self, resources: &mut [Resource]) {
-        for r in resources.iter_mut() {
-            let keys: Vec<String> = r.attributes.keys().cloned().collect();
-            for k in keys {
-                if let Some(v) = r.get_attr(&k)
-                    && let Some(nv) = canonicalize_value(v)
-                {
-                    r.set_attr(k, nv);
+    fn normalize_desired<'a>(
+        &'a self,
+        resources: &'a mut [Resource],
+    ) -> crate::provider::BoxFuture<'a, ()> {
+        Box::pin(async move {
+            for r in resources.iter_mut() {
+                let keys: Vec<String> = r.attributes.keys().cloned().collect();
+                for k in keys {
+                    if let Some(v) = r.get_attr(&k)
+                        && let Some(nv) = canonicalize_value(v)
+                    {
+                        r.set_attr(k, nv);
+                    }
                 }
             }
-        }
+        })
     }
 
-    fn merge_default_tags(
-        &self,
-        _resources: &mut [Resource],
-        _default_tags: &indexmap::IndexMap<String, Value>,
-        _registry: &crate::schema::SchemaRegistry,
-    ) {
+    fn normalize_state<'a>(
+        &'a self,
+        _current_states: &'a mut HashMap<ResourceId, State>,
+    ) -> crate::provider::BoxFuture<'a, ()> {
+        crate::provider::ready_noop()
+    }
+
+    fn hydrate_read_state<'a>(
+        &'a self,
+        _current_states: &'a mut HashMap<ResourceId, State>,
+        _saved_attrs: &'a crate::provider::SavedAttrs,
+    ) -> crate::provider::BoxFuture<'a, ()> {
+        crate::provider::ready_noop()
+    }
+
+    fn merge_default_tags<'a>(
+        &'a self,
+        _resources: &'a mut [Resource],
+        _default_tags: &'a indexmap::IndexMap<String, Value>,
+        _registry: &'a crate::schema::SchemaRegistry,
+    ) -> crate::provider::BoxFuture<'a, ()> {
+        crate::provider::ready_noop()
     }
 }
 
@@ -769,6 +790,145 @@ async fn test_apply_renormalizes_nested_value_under_ref_bearing_resource() {
             "id-123".to_string()
         ))),
         "ResourceRef must resolve from a's post-create state"
+    );
+}
+
+/// carina#3112 regression: the apply-path `renormalize` (carina#3060)
+/// invokes `ProviderNormalizer::normalize_desired` from inside the
+/// async apply execution loop, multiple times in sequence (once per
+/// resource). The WASM normalizer host impl drives the async guest by
+/// `.await`ing a `tokio::sync::Mutex<Store>` lock.
+///
+/// While the trait was *synchronous*, `WasmProviderNormalizer` bridged
+/// sync→async with `block_in_place` + a nested
+/// `Handle::current().block_on(async { store.lock().await })`. A
+/// `tokio::sync::MutexGuard` from one nested `block_on` was not
+/// released before the next nested `block_on` re-acquired the same
+/// `Mutex` — a self-deadlock observed deterministically on the second
+/// `normalize_desired` of an apply.
+///
+/// This test models that exact shape with a normalizer that acquires a
+/// `tokio::sync::Mutex` *across an `.await`* inside `normalize_desired`,
+/// driven through the real `execute_plan` apply path over two
+/// resources (so `normalize_desired` runs twice in sequence). It only
+/// compiles once `ProviderNormalizer` is async (the impl `.await`s),
+/// and it only completes (rather than hanging) once the nested
+/// `block_on` is gone — `#[tokio::test(flavor = "current_thread")]`
+/// reproduces the single-runtime contention the real apply hits.
+#[tokio::test(flavor = "current_thread")]
+async fn test_async_normalizer_does_not_self_deadlock_on_apply_path() {
+    use tokio::sync::Mutex as AsyncMutex;
+
+    /// Holds an async `Mutex` and acquires it across an `.await` inside
+    /// `normalize_desired` — the same lock-across-await shape the WASM
+    /// store lock has. A nested `block_on` around this would deadlock
+    /// the second time it runs.
+    struct LockHoldingNormalizer {
+        store: AsyncMutex<u32>,
+    }
+
+    impl crate::provider::ProviderNormalizer for LockHoldingNormalizer {
+        fn normalize_desired<'a>(
+            &'a self,
+            resources: &'a mut [Resource],
+        ) -> crate::provider::BoxFuture<'a, ()> {
+            Box::pin(async move {
+                let mut guard = self.store.lock().await;
+                *guard += 1;
+                let n = *guard;
+                drop(guard);
+                for r in resources.iter_mut() {
+                    r.set_attr(
+                        "normalize_count",
+                        Value::Concrete(ConcreteValue::String(n.to_string())),
+                    );
+                }
+            })
+        }
+
+        fn normalize_state<'a>(
+            &'a self,
+            _current_states: &'a mut HashMap<ResourceId, State>,
+        ) -> crate::provider::BoxFuture<'a, ()> {
+            crate::provider::ready_noop()
+        }
+
+        fn hydrate_read_state<'a>(
+            &'a self,
+            _current_states: &'a mut HashMap<ResourceId, State>,
+            _saved_attrs: &'a crate::provider::SavedAttrs,
+        ) -> crate::provider::BoxFuture<'a, ()> {
+            crate::provider::ready_noop()
+        }
+
+        fn merge_default_tags<'a>(
+            &'a self,
+            _resources: &'a mut [Resource],
+            _default_tags: &'a indexmap::IndexMap<String, Value>,
+            _registry: &'a crate::schema::SchemaRegistry,
+        ) -> crate::provider::BoxFuture<'a, ()> {
+            crate::provider::ready_noop()
+        }
+    }
+
+    let provider = MockProvider::new();
+    let ra = make_resource("a", &[]);
+    let ra_id = ra.id.clone();
+    // `b` carries a ResourceRef to `a`, forcing `resolve_resource` to
+    // rebuild attributes — the exact path that runs `renormalize`.
+    let rb = make_resource("b", &["a"]);
+    let rb_id = rb.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(ra));
+    plan.add(Effect::Create(rb));
+    provider.push_create(Ok(ok_state(&ra_id)));
+    provider.push_create(Ok(ok_state(&rb_id)));
+
+    let normalizer = LockHoldingNormalizer {
+        store: AsyncMutex::new(0),
+    };
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &normalizer,
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+    };
+
+    let observer = MockObserver::new();
+    // This guards the structural property the fix establishes: the
+    // apply path drives a lock-across-await normalizer to completion
+    // once per resource, in sequence, without re-acquiring the lock
+    // before the prior guard dropped. The literal WASM self-deadlock
+    // required the old *sync* trait + a nested `block_on` and can only
+    // be reproduced with a real WASM guest (the issue's user-driven
+    // real-infra smoke); this test cannot even express the old shape
+    // because the trait is now async — that is the point.
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(
+        result.success_count, 2,
+        "both creates must complete — no self-deadlock acquiring the \
+         normalizer's async lock a second time"
+    );
+
+    // Each resource's `normalize_desired` acquired the lock exactly
+    // once and ran in sequence (counts 1 and 2), proving the futures
+    // were driven to completion sequentially, not concurrently.
+    let counts: std::collections::HashSet<String> = provider
+        .captured_create_resources()
+        .iter()
+        .filter_map(|r| match r.get_attr("normalize_count") {
+            Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        counts,
+        ["1".to_string(), "2".to_string()].into_iter().collect(),
+        "normalize_desired must have run once per resource, in sequence"
     );
 }
 

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -423,20 +423,40 @@ pub trait Provider: Send + Sync {
     ) -> BoxFuture<'_, ProviderResult<()>>;
 }
 
+/// Convenience for a `ProviderNormalizer` method that does nothing.
+///
+/// Returns an immediately-ready future. A `BoxFuture`-returning trait
+/// method cannot have an empty `{}` default body, so every "I don't
+/// normalize this" implementation returns this explicitly — keeping the
+/// no-op a deliberate, visible choice rather than a silent default
+/// (the hazard that caused carina-rs/carina-provider-awscc#192).
+pub fn ready_noop<'a>() -> BoxFuture<'a, ()> {
+    Box::pin(async {})
+}
+
 /// Plan-time normalizer for a provider.
 ///
 /// Normalizes desired state and read state so that diffs produce correct
 /// plans. Uses provider-specific schema knowledge. Separated from `Provider`
-/// because these operations are synchronous, plan-time concerns rather
-/// than runtime CRUD.
+/// because these are normalization concerns rather than runtime CRUD.
+///
+/// The methods are **async** (returning [`BoxFuture`], mirroring the
+/// [`Provider`] trait) so a host implementation that drives an async
+/// backend — e.g. `WasmProviderNormalizer` `.await`ing the WASM guest's
+/// store lock — does so directly, without a synchronous method bridging
+/// to async via a nested `block_on` (the self-deadlock fixed by
+/// carina#3112). Each method mutates its arguments in place and returns
+/// nothing; the returned future borrows the arguments for `'a`, so
+/// callers must `.await` it before the borrow ends (they always do —
+/// the futures are never run concurrently).
 pub trait ProviderNormalizer: Send + Sync {
     /// Normalize desired resource state before diffing.
     ///
     /// For example, resolves bare enum identifiers like `advanced` or
     /// `Tier.advanced` into fully-qualified DSL format like
     /// `awscc.ec2_ipam.Tier.advanced` based on schema definitions.
-    /// Default implementation is a no-op for providers without enum types.
-    fn normalize_desired(&self, _resources: &mut [Resource]) {}
+    /// Providers without enum types return [`ready_noop`].
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()>;
 
     /// Normalize current state values before diffing.
     ///
@@ -445,8 +465,11 @@ pub trait ProviderNormalizer: Send + Sync {
     /// (e.g., `"awscc.ec2.Subnet.AvailabilityZone.ap_northeast_1a"`).
     /// This prevents false diffs when state stores raw AWS values but
     /// desired state has been normalized.
-    /// Default implementation is a no-op.
-    fn normalize_state(&self, _current_states: &mut HashMap<ResourceId, State>) {}
+    /// Providers without enum types return [`ready_noop`].
+    fn normalize_state<'a>(
+        &'a self,
+        current_states: &'a mut HashMap<ResourceId, State>,
+    ) -> BoxFuture<'a, ()>;
 
     /// Hydrate read state with saved attributes that APIs don't return.
     ///
@@ -454,13 +477,12 @@ pub trait ProviderNormalizer: Send + Sync {
     /// responses (create-only properties, or normal properties like `description`
     /// on some resources). This method carries them forward from previously
     /// saved attribute values.
-    /// Default implementation is a no-op.
-    fn hydrate_read_state(
-        &self,
-        _current_states: &mut HashMap<ResourceId, State>,
-        _saved_attrs: &SavedAttrs,
-    ) {
-    }
+    /// Providers that don't hydrate return [`ready_noop`].
+    fn hydrate_read_state<'a>(
+        &'a self,
+        current_states: &'a mut HashMap<ResourceId, State>,
+        saved_attrs: &'a SavedAttrs,
+    ) -> BoxFuture<'a, ()>;
 
     /// Merge default tags from provider configuration into resources that support tags.
     ///
@@ -471,29 +493,49 @@ pub trait ProviderNormalizer: Send + Sync {
     /// Records which tag keys came from defaults in the `_default_tag_keys` internal
     /// metadata attribute.
     ///
-    /// No default: an implicit no-op silently swallowed
+    /// No default body: an implicit no-op silently swallowed
     /// `WasmProviderNormalizer`'s missing dispatch in
     /// carina-rs/carina-provider-awscc#192. Every implementation now picks
     /// explicitly between [`merge_default_tags_for_provider`], a custom
-    /// merge, or [`NoopNormalizer`]'s deliberate no-op.
-    fn merge_default_tags(
-        &self,
-        resources: &mut [Resource],
-        default_tags: &IndexMap<String, Value>,
-        registry: &SchemaRegistry,
-    );
+    /// merge, or [`ready_noop`]'s deliberate no-op.
+    fn merge_default_tags<'a>(
+        &'a self,
+        resources: &'a mut [Resource],
+        default_tags: &'a IndexMap<String, Value>,
+        registry: &'a SchemaRegistry,
+    ) -> BoxFuture<'a, ()>;
 }
 
 /// A no-op normalizer for providers that don't need plan-time normalization.
 #[derive(Debug, Clone, Copy)]
 pub struct NoopNormalizer;
 impl ProviderNormalizer for NoopNormalizer {
-    fn merge_default_tags(
-        &self,
-        _resources: &mut [Resource],
-        _default_tags: &IndexMap<String, Value>,
-        _registry: &SchemaRegistry,
-    ) {
+    fn normalize_desired<'a>(&'a self, _resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+        ready_noop()
+    }
+
+    fn normalize_state<'a>(
+        &'a self,
+        _current_states: &'a mut HashMap<ResourceId, State>,
+    ) -> BoxFuture<'a, ()> {
+        ready_noop()
+    }
+
+    fn hydrate_read_state<'a>(
+        &'a self,
+        _current_states: &'a mut HashMap<ResourceId, State>,
+        _saved_attrs: &'a SavedAttrs,
+    ) -> BoxFuture<'a, ()> {
+        ready_noop()
+    }
+
+    fn merge_default_tags<'a>(
+        &'a self,
+        _resources: &'a mut [Resource],
+        _default_tags: &'a IndexMap<String, Value>,
+        _registry: &'a SchemaRegistry,
+    ) -> BoxFuture<'a, ()> {
+        ready_noop()
     }
 }
 
@@ -696,37 +738,52 @@ impl Provider for ProviderRouter {
 }
 
 impl ProviderNormalizer for ProviderRouter {
-    fn normalize_desired(&self, resources: &mut [Resource]) {
-        for ext in &self.normalizers {
-            ext.normalize_desired(resources);
-        }
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            // Sequential, never concurrent: normalizers are not
+            // commutative, and `resources` is re-borrowed per iteration
+            // across the `.await`.
+            for ext in &self.normalizers {
+                ext.normalize_desired(resources).await;
+            }
+        })
     }
 
-    fn normalize_state(&self, current_states: &mut HashMap<ResourceId, State>) {
-        for ext in &self.normalizers {
-            ext.normalize_state(current_states);
-        }
+    fn normalize_state<'a>(
+        &'a self,
+        current_states: &'a mut HashMap<ResourceId, State>,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            for ext in &self.normalizers {
+                ext.normalize_state(current_states).await;
+            }
+        })
     }
 
-    fn hydrate_read_state(
-        &self,
-        current_states: &mut HashMap<ResourceId, State>,
-        saved_attrs: &SavedAttrs,
-    ) {
-        for ext in &self.normalizers {
-            ext.hydrate_read_state(current_states, saved_attrs);
-        }
+    fn hydrate_read_state<'a>(
+        &'a self,
+        current_states: &'a mut HashMap<ResourceId, State>,
+        saved_attrs: &'a SavedAttrs,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            for ext in &self.normalizers {
+                ext.hydrate_read_state(current_states, saved_attrs).await;
+            }
+        })
     }
 
-    fn merge_default_tags(
-        &self,
-        resources: &mut [Resource],
-        default_tags: &IndexMap<String, Value>,
-        registry: &SchemaRegistry,
-    ) {
-        for ext in &self.normalizers {
-            ext.merge_default_tags(resources, default_tags, registry);
-        }
+    fn merge_default_tags<'a>(
+        &'a self,
+        resources: &'a mut [Resource],
+        default_tags: &'a IndexMap<String, Value>,
+        registry: &'a SchemaRegistry,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            for ext in &self.normalizers {
+                ext.merge_default_tags(resources, default_tags, registry)
+                    .await;
+            }
+        })
     }
 }
 
@@ -1753,48 +1810,60 @@ mod tests {
         );
     }
 
-    #[test]
-    fn provider_normalizer_separate_from_runtime() {
+    #[tokio::test]
+    async fn provider_normalizer_separate_from_runtime() {
         // Verify that ProviderNormalizer can be implemented independently from Provider.
         // A provider implementing both traits should have its schema extension
         // methods callable without going through the Provider trait.
         struct SchemaOnlyProvider;
 
         impl ProviderNormalizer for SchemaOnlyProvider {
-            fn normalize_desired(&self, resources: &mut [Resource]) {
-                // Prefix all string attribute values with "normalized:"
-                for resource in resources.iter_mut() {
-                    for value in resource.attributes.values_mut() {
-                        if let Value::Concrete(ConcreteValue::String(s)) = value {
-                            *s = format!("normalized:{}", s);
+            fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+                Box::pin(async move {
+                    // Prefix all string attribute values with "normalized:"
+                    for resource in resources.iter_mut() {
+                        for value in resource.attributes.values_mut() {
+                            if let Value::Concrete(ConcreteValue::String(s)) = value {
+                                *s = format!("normalized:{}", s);
+                            }
                         }
                     }
-                }
+                })
             }
 
-            fn hydrate_read_state(
-                &self,
-                states: &mut HashMap<ResourceId, State>,
-                saved: &SavedAttrs,
-            ) {
-                for (id, saved_attrs) in saved {
-                    if let Some(state) = states.get_mut(id) {
-                        for (key, value) in saved_attrs {
-                            state
-                                .attributes
-                                .entry(key.clone())
-                                .or_insert_with(|| value.clone());
+            fn normalize_state<'a>(
+                &'a self,
+                _current_states: &'a mut HashMap<ResourceId, State>,
+            ) -> BoxFuture<'a, ()> {
+                ready_noop()
+            }
+
+            fn hydrate_read_state<'a>(
+                &'a self,
+                states: &'a mut HashMap<ResourceId, State>,
+                saved: &'a SavedAttrs,
+            ) -> BoxFuture<'a, ()> {
+                Box::pin(async move {
+                    for (id, saved_attrs) in saved {
+                        if let Some(state) = states.get_mut(id) {
+                            for (key, value) in saved_attrs {
+                                state
+                                    .attributes
+                                    .entry(key.clone())
+                                    .or_insert_with(|| value.clone());
+                            }
                         }
                     }
-                }
+                })
             }
 
-            fn merge_default_tags(
-                &self,
-                _resources: &mut [Resource],
-                _default_tags: &IndexMap<String, Value>,
-                _registry: &SchemaRegistry,
-            ) {
+            fn merge_default_tags<'a>(
+                &'a self,
+                _resources: &'a mut [Resource],
+                _default_tags: &'a IndexMap<String, Value>,
+                _registry: &'a SchemaRegistry,
+            ) -> BoxFuture<'a, ()> {
+                ready_noop()
             }
         }
 
@@ -1804,7 +1873,7 @@ mod tests {
             "key",
             Value::Concrete(ConcreteValue::String("value".to_string())),
         )];
-        ext.normalize_desired(&mut resources);
+        ext.normalize_desired(&mut resources).await;
         assert_eq!(
             resources[0].get_attr("key"),
             Some(&Value::Concrete(ConcreteValue::String(
@@ -1824,15 +1893,15 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("data".to_string())),
             )]),
         );
-        ext.hydrate_read_state(&mut states, &saved);
+        ext.hydrate_read_state(&mut states, &saved).await;
         assert_eq!(
             states.get(&id).unwrap().attributes.get("restored"),
             Some(&Value::Concrete(ConcreteValue::String("data".to_string())))
         );
     }
 
-    #[test]
-    fn provider_router_delegates_normalizer() {
+    #[tokio::test]
+    async fn provider_router_delegates_normalizer() {
         // Test that ProviderRouter delegates ProviderNormalizer methods to sub-providers
         struct NormalizingProvider;
 
@@ -1891,24 +1960,42 @@ mod tests {
         // Separate schema ext struct for the router
         struct TestNormalizer;
         impl ProviderNormalizer for TestNormalizer {
-            fn normalize_desired(&self, resources: &mut [Resource]) {
-                for resource in resources.iter_mut() {
-                    if resource.id.provider == "normalizing" {
-                        for value in resource.attributes.values_mut() {
-                            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                                *s = format!("norm:{}", s);
+            fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+                Box::pin(async move {
+                    for resource in resources.iter_mut() {
+                        if resource.id.provider == "normalizing" {
+                            for value in resource.attributes.values_mut() {
+                                if let Value::Concrete(ConcreteValue::String(s)) = value {
+                                    *s = format!("norm:{}", s);
+                                }
                             }
                         }
                     }
-                }
+                })
             }
 
-            fn merge_default_tags(
-                &self,
-                _resources: &mut [Resource],
-                _default_tags: &IndexMap<String, Value>,
-                _registry: &SchemaRegistry,
-            ) {
+            fn normalize_state<'a>(
+                &'a self,
+                _current_states: &'a mut HashMap<ResourceId, State>,
+            ) -> BoxFuture<'a, ()> {
+                ready_noop()
+            }
+
+            fn hydrate_read_state<'a>(
+                &'a self,
+                _current_states: &'a mut HashMap<ResourceId, State>,
+                _saved_attrs: &'a SavedAttrs,
+            ) -> BoxFuture<'a, ()> {
+                ready_noop()
+            }
+
+            fn merge_default_tags<'a>(
+                &'a self,
+                _resources: &'a mut [Resource],
+                _default_tags: &'a IndexMap<String, Value>,
+                _registry: &'a SchemaRegistry,
+            ) -> BoxFuture<'a, ()> {
+                ready_noop()
             }
         }
 
@@ -1922,7 +2009,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("val".to_string())),
             ),
         ];
-        router.normalize_desired(&mut resources);
+        router.normalize_desired(&mut resources).await;
         assert_eq!(
             resources[0].get_attr("key"),
             Some(&Value::Concrete(ConcreteValue::String(

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -1752,191 +1752,204 @@ unsafe impl Send for WasmProviderNormalizer {}
 unsafe impl Sync for WasmProviderNormalizer {}
 
 impl ProviderNormalizer for WasmProviderNormalizer {
-    fn normalize_desired(&self, resources: &mut [Resource]) {
-        let wit_resources: Vec<_> = expect_unresolvable_absent(
-            resources
-                .iter()
-                .map(wasm_convert::core_to_wit_resource)
-                .collect::<Result<Vec<_>, _>>(),
-            "normalize_desired",
-        );
+    fn normalize_desired<'a>(
+        &'a self,
+        resources: &'a mut [Resource],
+    ) -> carina_core::provider::BoxFuture<'a, ()> {
+        Box::pin(async move {
+            let wit_resources: Vec<_> = expect_unresolvable_absent(
+                resources
+                    .iter()
+                    .map(wasm_convert::core_to_wit_resource)
+                    .collect::<Result<Vec<_>, _>>(),
+                "normalize_desired",
+            );
 
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
+            // Plain `.await` on the store lock, not a nested `block_on`:
+            // the guard is acquired and dropped within this one polled
+            // future, so the apply-path `renormalize` calling this once
+            // per resource cannot self-deadlock (carina#3112).
+            let result = {
                 let mut store = self.instance.store.lock().await;
                 store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
                 self.instance
                     .bindings
                     .call_normalize_desired(&mut store, &wit_resources)
                     .await
-            })
-        });
+            };
 
-        match result {
-            Ok(result) => {
-                // `PlanPreprocessor::prepare` strips every attribute that
-                // recursively contains `Value::Deferred(DeferredValue::ResourceRef)` (alongside
-                // `Value::Deferred(DeferredValue::Unknown)`) before this normalizer runs and
-                // restores them afterwards (#2387), so we can blindly
-                // accept everything the WASM normalizer returns — the
-                // pre-#2387 `contains_resource_ref` overwrite-skip
-                // workaround is no longer reachable.
-                for (core_res, wit_res) in resources.iter_mut().zip(result.iter()) {
-                    let resolved = wasm_convert::wit_to_core_value_map(&wit_res.attributes);
-                    for (key, value) in resolved {
-                        core_res.attributes.insert(key, value);
+            match result {
+                Ok(result) => {
+                    // `PlanPreprocessor::prepare` strips every attribute that
+                    // recursively contains `Value::Deferred(DeferredValue::ResourceRef)` (alongside
+                    // `Value::Deferred(DeferredValue::Unknown)`) before this normalizer runs and
+                    // restores them afterwards (#2387), so we can blindly
+                    // accept everything the WASM normalizer returns — the
+                    // pre-#2387 `contains_resource_ref` overwrite-skip
+                    // workaround is no longer reachable.
+                    for (core_res, wit_res) in resources.iter_mut().zip(result.iter()) {
+                        let resolved = wasm_convert::wit_to_core_value_map(&wit_res.attributes);
+                        for (key, value) in resolved {
+                            core_res.attributes.insert(key, value);
+                        }
                     }
                 }
+                Err(e) => log::error!("WASM trap in normalize_desired: {e}"),
             }
-            Err(e) => log::error!("WASM trap in normalize_desired: {e}"),
-        }
+        })
     }
 
-    fn normalize_state(&self, current_states: &mut HashMap<ResourceId, State>) {
-        let wit_states: Vec<(String, _)> = current_states
-            .iter()
-            .map(|(id, state)| {
-                let wit = expect_unresolvable_absent(
-                    wasm_convert::core_to_wit_state(state),
-                    "normalize_state",
-                );
-                (id.to_string(), wit)
-            })
-            .collect();
+    fn normalize_state<'a>(
+        &'a self,
+        current_states: &'a mut HashMap<ResourceId, State>,
+    ) -> carina_core::provider::BoxFuture<'a, ()> {
+        Box::pin(async move {
+            let wit_states: Vec<(String, _)> = current_states
+                .iter()
+                .map(|(id, state)| {
+                    let wit = expect_unresolvable_absent(
+                        wasm_convert::core_to_wit_state(state),
+                        "normalize_state",
+                    );
+                    (id.to_string(), wit)
+                })
+                .collect();
 
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
+            // Plain `.await`, not a nested `block_on` — see `normalize_desired`.
+            let result = {
                 let mut store = self.instance.store.lock().await;
                 store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
                 self.instance
                     .bindings
                     .call_normalize_state(&mut store, &wit_states)
                     .await
-            })
-        });
+            };
 
-        match result {
-            Ok(result) => {
-                for state in current_states.values_mut() {
-                    let key = state.id.to_string();
-                    if let Some((_, wit_state)) = result.iter().find(|(k, _)| k == &key) {
-                        state.attributes =
-                            wasm_convert::wit_to_core_value_map(&wit_state.attributes);
+            match result {
+                Ok(result) => {
+                    for state in current_states.values_mut() {
+                        let key = state.id.to_string();
+                        if let Some((_, wit_state)) = result.iter().find(|(k, _)| k == &key) {
+                            state.attributes =
+                                wasm_convert::wit_to_core_value_map(&wit_state.attributes);
+                        }
                     }
                 }
+                Err(e) => log::error!("WASM trap in normalize_state: {e}"),
             }
-            Err(e) => log::error!("WASM trap in normalize_state: {e}"),
-        }
+        })
     }
 
-    fn hydrate_read_state(
-        &self,
-        current_states: &mut HashMap<ResourceId, State>,
-        saved_attrs: &SavedAttrs,
-    ) {
-        let wit_states: Vec<(String, _)> = current_states
-            .iter()
-            .map(|(id, state)| {
-                let wit = expect_unresolvable_absent(
-                    wasm_convert::core_to_wit_state(state),
-                    "hydrate_read_state (current_states)",
-                );
-                (id.to_string(), wit)
-            })
-            .collect();
+    fn hydrate_read_state<'a>(
+        &'a self,
+        current_states: &'a mut HashMap<ResourceId, State>,
+        saved_attrs: &'a SavedAttrs,
+    ) -> carina_core::provider::BoxFuture<'a, ()> {
+        Box::pin(async move {
+            let wit_states: Vec<(String, _)> = current_states
+                .iter()
+                .map(|(id, state)| {
+                    let wit = expect_unresolvable_absent(
+                        wasm_convert::core_to_wit_state(state),
+                        "hydrate_read_state (current_states)",
+                    );
+                    (id.to_string(), wit)
+                })
+                .collect();
 
-        let wit_saved: Vec<(String, Vec<(String, _)>)> = saved_attrs
-            .iter()
-            .map(|(id, attrs)| {
-                let wit = expect_unresolvable_absent(
-                    wasm_convert::core_to_wit_value_map(attrs),
-                    "hydrate_read_state (saved_attrs)",
-                );
-                (id.to_string(), wit)
-            })
-            .collect();
+            let wit_saved: Vec<(String, Vec<(String, _)>)> = saved_attrs
+                .iter()
+                .map(|(id, attrs)| {
+                    let wit = expect_unresolvable_absent(
+                        wasm_convert::core_to_wit_value_map(attrs),
+                        "hydrate_read_state (saved_attrs)",
+                    );
+                    (id.to_string(), wit)
+                })
+                .collect();
 
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
+            // Plain `.await`, not a nested `block_on` — see `normalize_desired`.
+            let result = {
                 let mut store = self.instance.store.lock().await;
                 store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
                 self.instance
                     .bindings
                     .call_hydrate_read_state(&mut store, &wit_states, &wit_saved)
                     .await
-            })
-        });
+            };
 
-        match result {
-            Ok(result) => {
-                for state in current_states.values_mut() {
-                    let key = state.id.to_string();
-                    if let Some((_, wit_state)) = result.iter().find(|(k, _)| k == &key) {
-                        state.attributes =
-                            wasm_convert::wit_to_core_value_map(&wit_state.attributes);
+            match result {
+                Ok(result) => {
+                    for state in current_states.values_mut() {
+                        let key = state.id.to_string();
+                        if let Some((_, wit_state)) = result.iter().find(|(k, _)| k == &key) {
+                            state.attributes =
+                                wasm_convert::wit_to_core_value_map(&wit_state.attributes);
+                        }
                     }
                 }
+                Err(e) => log::error!("WASM trap in hydrate_read_state: {e}"),
             }
-            Err(e) => log::error!("WASM trap in hydrate_read_state: {e}"),
-        }
+        })
     }
 
-    fn merge_default_tags(
-        &self,
-        resources: &mut [Resource],
-        default_tags: &IndexMap<String, Value>,
-        _registry: &carina_core::schema::SchemaRegistry,
-    ) {
-        if default_tags.is_empty() {
-            return;
-        }
+    fn merge_default_tags<'a>(
+        &'a self,
+        resources: &'a mut [Resource],
+        default_tags: &'a IndexMap<String, Value>,
+        _registry: &'a carina_core::schema::SchemaRegistry,
+    ) -> carina_core::provider::BoxFuture<'a, ()> {
+        Box::pin(async move {
+            if default_tags.is_empty() {
+                return;
+            }
 
-        let wit_resources: Vec<_> = expect_unresolvable_absent(
-            resources
+            let wit_resources: Vec<_> = expect_unresolvable_absent(
+                resources
+                    .iter()
+                    .map(wasm_convert::core_to_wit_resource)
+                    .collect::<Result<Vec<_>, _>>(),
+                "merge_default_tags",
+            );
+
+            // Per-key skip on serialize failure (vs. `core_to_wit_value_map`'s
+            // all-or-nothing) — one bad default tag must not nuke the whole
+            // merge for a multi-resource plan.
+            let wit_default_tags: Vec<(String, wit_types::Value)> = default_tags
                 .iter()
-                .map(wasm_convert::core_to_wit_resource)
-                .collect::<Result<Vec<_>, _>>(),
-            "merge_default_tags",
-        );
+                .filter_map(|(k, v)| match wasm_convert::core_to_wit_value(v) {
+                    Ok(wit_value) => Some((k.clone(), wit_value)),
+                    Err(e) => {
+                        log::error!("Skipping default_tag '{k}' with unresolvable value: {e}");
+                        None
+                    }
+                })
+                .collect();
 
-        // Per-key skip on serialize failure (vs. `core_to_wit_value_map`'s
-        // all-or-nothing) — one bad default tag must not nuke the whole
-        // merge for a multi-resource plan.
-        let wit_default_tags: Vec<(String, wit_types::Value)> = default_tags
-            .iter()
-            .filter_map(|(k, v)| match wasm_convert::core_to_wit_value(v) {
-                Ok(wit_value) => Some((k.clone(), wit_value)),
-                Err(e) => {
-                    log::error!("Skipping default_tag '{k}' with unresolvable value: {e}");
-                    None
-                }
-            })
-            .collect();
-
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
+            // Plain `.await`, not a nested `block_on` — see `normalize_desired`.
+            let result = {
                 let mut store = self.instance.store.lock().await;
                 store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
                 self.instance
                     .bindings
                     .call_merge_default_tags(&mut store, &wit_resources, &wit_default_tags)
                     .await
-            })
-        });
+            };
 
-        match result {
-            Ok(result) => {
-                // Guest preserves resource order; zip and overwrite
-                // attributes (merge may add `tags` and `_default_tag_keys`).
-                for (core_res, wit_res) in resources.iter_mut().zip(result.iter()) {
-                    let resolved = wasm_convert::wit_to_core_value_map(&wit_res.attributes);
-                    for (key, value) in resolved {
-                        core_res.attributes.insert(key, value);
+            match result {
+                Ok(result) => {
+                    // Guest preserves resource order; zip and overwrite
+                    // attributes (merge may add `tags` and `_default_tag_keys`).
+                    for (core_res, wit_res) in resources.iter_mut().zip(result.iter()) {
+                        let resolved = wasm_convert::wit_to_core_value_map(&wit_res.attributes);
+                        for (key, value) in resolved {
+                            core_res.attributes.insert(key, value);
+                        }
                     }
                 }
+                Err(e) => log::error!("WASM trap in merge_default_tags: {e}"),
             }
-            Err(e) => log::error!("WASM trap in merge_default_tags: {e}"),
-        }
+        })
     }
 }
 

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -281,7 +281,7 @@ async fn test_wasm_mock_provider_normalizer() {
         r
     }];
     let original_attrs = resources[0].resolved_attributes();
-    normalizer.normalize_desired(&mut resources);
+    normalizer.normalize_desired(&mut resources).await;
     assert_eq!(resources[0].resolved_attributes(), original_attrs);
 
     // normalize_state: mock provider returns states unchanged
@@ -292,7 +292,7 @@ async fn test_wasm_mock_provider_normalizer() {
     )]);
     let state = carina_core::resource::State::existing(id.clone(), attrs.clone());
     let mut states = HashMap::from([(id.clone(), state)]);
-    normalizer.normalize_state(&mut states);
+    normalizer.normalize_state(&mut states).await;
     let result_state = states.values().next().unwrap();
     assert_eq!(
         result_state.attributes.get("key"),
@@ -333,7 +333,9 @@ async fn test_wasm_mock_provider_merge_default_tags_dispatches_through_wit() {
         ),
     ]);
 
-    normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
+    normalizer
+        .merge_default_tags(&mut resources, &default_tags, &registry)
+        .await;
 
     let echoed = resources[0]
         .get_attr("__mock_merged_default_tags__")
@@ -363,7 +365,9 @@ async fn test_wasm_mock_provider_merge_default_tags_empty_short_circuits() {
     )];
     let default_tags: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
 
-    normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
+    normalizer
+        .merge_default_tags(&mut resources, &default_tags, &registry)
+        .await;
 
     assert!(
         resources[0]
@@ -394,7 +398,9 @@ async fn test_wasm_mock_provider_merge_default_tags_preserves_order() {
         Value::Concrete(ConcreteValue::String("dev".to_string())),
     )]);
 
-    normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
+    normalizer
+        .merge_default_tags(&mut resources, &default_tags, &registry)
+        .await;
 
     assert_eq!(resources[0].id.name.as_str(), "alpha");
     assert_eq!(resources[1].id.name.as_str(), "beta");


### PR DESCRIPTION
## Problem

`aws-vault exec carina-registry-dev -- carina apply` in `carina-rs/infra registry/dev/registry` **deadlocks** (spinner forever, Ctrl+C dead). Tracked as carina#3112, with empirical evidence (instrumented build + 100%-of-samples hung-process stack) in the issue.

Root cause: carina#3060's apply-path `renormalize` (`carina-core/src/executor/basic.rs`) calls the **sync** `ProviderNormalizer::normalize_desired` from inside the async apply loop, multiple times in sequence per resource. `WasmProviderNormalizer` bridged sync→async with `tokio::task::block_in_place` + a nested `Handle::current().block_on(async { store.lock().await })`. A `tokio::sync::MutexGuard` from one nested `block_on` is not released before the next nested `block_on` re-acquires the same store `Mutex` — a self-deadlock, observed deterministically on the AAAA RecordSet's second `normalize_desired`.

## Fix

Implements the design merged in #3113 (`notes/specs/2026-05-17-provider-normalizer-async-design.md`):

- `ProviderNormalizer` becomes an **async trait** returning `BoxFuture<'a, ()>`, mirroring the already-async `Provider` trait (hand-written `BoxFuture`, no `async-trait` macro).
- All four `WasmProviderNormalizer` methods drop the nested `block_on` for a plain `.await` on the store lock within one polled future — re-entering them can no longer self-deadlock.
- `ProviderRouter` sequences per-normalizer futures with an `.await` loop (order preserved — normalizers are not commutative).
- `.await` threaded through the apply path (`renormalize`, `resolve_resource{,_with_source}`, `PlanPreprocessor::prepare`) and read/state paths. Every `resolve_resource*` caller was already in an `async fn` — no sync→async inversion anywhere.
- `NoopNormalizer` / test impls return a shared `ready_noop()` helper (a `BoxFuture`-returning method cannot have an empty default body — keeps the no-op an explicit, visible choice; same discipline as awscc#192).

carina#3060's apply-path re-normalization is **preserved** (not reverted). WIT contract **unchanged**. Subsumes carina#3109 (same sync-nested-`block_on` class).

## Tests

- New regression test `test_async_normalizer_does_not_self_deadlock_on_apply_path` (carina-core): a normalizer acquiring a `tokio::sync::Mutex` across an `.await` inside `normalize_desired`, driven through the real `execute_plan` apply path over two resources, asserts both creates complete and `normalize_desired` ran once per resource in sequence. It cannot even express the old sync shape (the trait is now async — that is the point); the literal WASM deadlock requires the real-infra smoke below.

## Verify

- `cargo nextest run --workspace`: 3380 passed
- `cargo test --workspace --doc`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `bash scripts/check-*.sh`: all pass
- `cargo build --release -p carina-cli`: OK

## Acceptance condition — needs user-driven real-infra smoke

The issue's acceptance condition is a real-infra smoke: `aws-vault exec carina-registry-dev -- carina apply registry/dev/registry` reaching a normal plan/apply **without the deadlock**. That AWS-touching run is user-driven (credentials) and not run here. The release binary is built at `target/release/carina`.

## Follow-up

Provider repos follow in separate PRs with a `carina-core` pin bump (order carina → aws → awscc).

Closes #3112

🤖 Generated with [Claude Code](https://claude.com/claude-code)