### PR TITLE
fix: do not strike indentation of multi-line deleted plan values

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1013,6 +1013,35 @@ fn color_lines(rendered: &str, ref_binding: bool) -> String {
     out
 }
 
+/// Apply red + strikethrough to a (possibly multi-line)
+/// `format_value_pretty` payload **per line**, leaving each line's
+/// leading indentation whitespace unstyled.
+///
+/// Styling the whole multi-line string in one shot
+/// (`pretty.red().strikethrough()`) opens the ANSI style once and
+/// resets it once, so the style spans the newline-leading indentation
+/// of every continuation line — the terminal then paints the strike
+/// across the indent, making the line look far longer than its
+/// content (#3115). This mirrors `color_lines`' indent handling so
+/// the strike starts at the content column, not the left edge.
+fn strike_lines(rendered: &str) -> String {
+    let mut out = String::with_capacity(rendered.len());
+    for (i, line) in rendered.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let indent_end = line
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(line.len());
+        let (indent, body) = line.split_at(indent_end);
+        out.push_str(indent);
+        if !body.is_empty() {
+            out.push_str(&body.red().strikethrough().to_string());
+        }
+    }
+    out
+}
+
 /// Apply type-based coloring to a value, with dimmed modifier for default values.
 fn colored_value_dimmed(rendered: &str) -> String {
     // List: color each element individually
@@ -1096,7 +1125,7 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
             };
             let pretty = format_value_pretty(value, layout);
             let cv = match effect {
-                Effect::Delete { .. } => pretty.red().strikethrough().to_string(),
+                Effect::Delete { .. } => strike_lines(&pretty),
                 _ => colored_value(&pretty, false),
             };
             writeln!(out, "{}{}: {}", attr_prefix, key, cv).unwrap();
@@ -1121,7 +1150,7 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
                 };
                 let pretty = carina_core::value::format_value_pretty(&entry.value, layout);
                 let cv = match effect {
-                    Effect::Delete { .. } => pretty.red().strikethrough().to_string(),
+                    Effect::Delete { .. } => strike_lines(&pretty),
                     _ => colored_value(&pretty, false),
                 };
                 if let Some(ann) = &entry.annotation {
@@ -1573,7 +1602,7 @@ fn render_added_removed_block(
         let pretty = format_value_pretty(value, layout);
         let cv = match kind {
             ListOfMapsDiffItemKind::Added => colored_value(&pretty, false),
-            ListOfMapsDiffItemKind::Removed => pretty.red().strikethrough().to_string(),
+            ListOfMapsDiffItemKind::Removed => strike_lines(&pretty),
         };
         writeln!(out, "{}{}: {}", field_indent, key, cv).unwrap();
     }

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1530,3 +1530,113 @@ fn format_deferred_value_duration_renders_canonical() {
     // but a resolved Duration must render verbatim.
     assert_eq!(result, "1min");
 }
+
+/// Regression for #3115: a deleted-effect attribute whose value is a
+/// multi-line `format_value_pretty` map (e.g. CloudFront
+/// `default_cache_behavior`) must not bleed the red strikethrough
+/// across the *leading indentation whitespace* of continuation lines.
+///
+/// `colored` places the ANSI style once at the start and the reset
+/// once at the end of the whole string. Styling the entire multi-line
+/// pretty payload in one shot makes the strike span the newline-leading
+/// indent spaces of every continuation line, so the strike appears to
+/// start at the left edge instead of at the content column.
+///
+/// Invariant asserted: on every rendered line, the first non-whitespace
+/// character must appear before any ANSI escape (`\x1b`). Equivalently,
+/// the leading-whitespace prefix of each line carries no escape byte.
+#[test]
+fn delete_pretty_attribute_does_not_strike_indentation() {
+    use indexmap::IndexMap;
+
+    // A nested map forces `format_value_pretty` into a multi-line
+    // vertical layout with indented continuation lines, mirroring the
+    // real CloudFront `default_cache_behavior` shape from the bug
+    // report.
+    let mut forwarded_values = IndexMap::new();
+    forwarded_values.insert(
+        "query_string".to_string(),
+        Value::Concrete(ConcreteValue::Bool(false)),
+    );
+    let mut cache_behavior = IndexMap::new();
+    cache_behavior.insert(
+        "viewer_protocol_policy".to_string(),
+        Value::Concrete(ConcreteValue::String("redirect-to-https".to_string())),
+    );
+    cache_behavior.insert(
+        "forwarded_values".to_string(),
+        Value::Concrete(ConcreteValue::Map(forwarded_values)),
+    );
+
+    let row = DetailRow::PrettyAttribute {
+        key: "default_cache_behavior".to_string(),
+        value: Value::Concrete(ConcreteValue::Map(cache_behavior)),
+    };
+    let effect = Effect::Delete {
+        id: carina_core::resource::ResourceId::new("cloudfront.Distribution", "dist"),
+        identifier: "E123".to_string(),
+        directives: Default::default(),
+        binding: None,
+        dependencies: Default::default(),
+        explicit_dependencies: Default::default(),
+    };
+
+    // Force ANSI styling on: the test harness' stdout is not a TTY, so
+    // `colored` auto-disables escapes and the bug (which is *in* the
+    // escape placement) would be invisible without this override.
+    colored::control::set_override(true);
+
+    let mut out = String::new();
+    // Non-empty `attr_prefix` so continuation lines have a real indent.
+    render_detail_row(&mut out, &row, &effect, "    ");
+
+    colored::control::unset_override();
+
+    // A style that opens on one line and resets on a later line keeps
+    // strikethrough/red active across the intervening newline(s), so
+    // the terminal paints the strike over the leading indentation of
+    // every continuation line. The correct shape (matching the
+    // non-delete `color_lines` path) opens and closes the style
+    // *within* each line, after that line's indentation.
+    //
+    // Invariant: at every `\n`, the ANSI style depth must be zero —
+    // no styling span may cross a line boundary.
+    let mut depth: i32 = 0;
+    let mut saw_open = false;
+    let bytes: Vec<char> = out.chars().collect();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == '\u{1b}' && i + 1 < bytes.len() && bytes[i + 1] == '[' {
+            // Parse a CSI `\x1b[...m` sequence.
+            let mut j = i + 2;
+            while j < bytes.len() && bytes[j] != 'm' {
+                j += 1;
+            }
+            let params: String = bytes[i + 2..j].iter().collect();
+            if params == "0" {
+                depth = (depth - 1).max(0);
+            } else {
+                depth += 1;
+                saw_open = true;
+            }
+            i = j + 1;
+            continue;
+        }
+        if c == '\n' {
+            assert_eq!(
+                depth, 0,
+                "an ANSI style span crossed a newline: strikethrough/red \
+                 bleeds across the leading indentation of the next line. \
+                 rendered: {:?}",
+                out,
+            );
+        }
+        i += 1;
+    }
+    assert!(
+        saw_open,
+        "no ANSI styling was emitted; the test must run with colored \
+         override on and exercise the Delete styling path",
+    );
+}


### PR DESCRIPTION
## Problem

In `carina plan` output, deleted-effect rows whose value is a multi-line pretty-printed map/list (e.g. CloudFront `default_cache_behavior`) rendered the red strikethrough across the **leading indentation whitespace** of continuation lines. The text was indented but the strike line started at the left edge, so the line looked far longer than the content.

## Root cause

`carina-cli/src/display/mod.rs` styled the whole multi-line string returned by `format_value_pretty()` in one shot at three sites — `DetailRow::PrettyAttribute`, `DetailRow::MapExpanded`, and `render_modified_fields` (`ListOfMapsDiffItemKind::Removed`):

```
pretty.red().strikethrough().to_string()
```

`colored` places the ANSI style once at the start and the reset once at the end, so the style spans the newline-leading indentation of every continuation line. The terminal renders strikethrough/red on those blank cells.

The non-delete path (`colored_value` -> `color_lines`) already splits each line into `(indent, body)` and styles only `body`. The delete path did not — that was the inconsistency.

Raw rendered bytes before the fix:

```
    default_cache_behavior: \x1b[9;31m\n      forwarded_values: {...}\n      ...\x1b[0m\n
```

The `\x1b[9;31m` opens, then a newline, then the indented continuation lines — all inside one unterminated style span.

## Fix

Add a `strike_lines` helper mirroring `color_lines`' per-line indent handling (leading whitespace emitted unstyled, body styled red+strikethrough) and use it at the three sites. Single-line values are byte-identical to the old output, so non-TTY snapshots are unaffected.

## Test

`delete_pretty_attribute_does_not_strike_indentation` builds a nested-map `PrettyAttribute`, renders it under `Effect::Delete` with `colored` override forced on (the test harness stdout is not a TTY, so escapes are auto-disabled otherwise), and asserts no ANSI style span crosses a newline. Fails before the fix, passes after.

## Out of scope

The same bug class exists in the TUI renderer (`carina-tui/src/ui/diff.rs`); filed as #3116 per 1-PR-1-topic discipline.

## Verify

- `cargo nextest run -p carina-cli` — 419 passed
- `cargo test -p carina-cli --doc` — ok
- `cargo clippy -p carina-cli --all-targets -- -D warnings` — clean
- `scripts/check-*.sh` — all pass

Closes #3115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
