### PR TITLE
fix: render list attributes vertically in delete plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ plan-mixed:
 	$(PLAN_FIXTURE) mixed_operations
 plan-delete:
 	$(PLAN_FIXTURE) delete_orphan
+plan-delete-list-of-maps:
+	$(PLAN_FIXTURE) delete_orphan_list_of_maps
 plan-state-blocks:
 	$(PLAN_FIXTURE) state_blocks
 plan-compact:
@@ -86,6 +88,9 @@ plan-fixtures:
 	@echo ""
 	@echo "=== delete_orphan ==="
 	@$(MAKE) plan-delete
+	@echo ""
+	@echo "=== delete_orphan_list_of_maps ==="
+	@$(MAKE) plan-delete-list-of-maps
 	@echo ""
 	@echo "=== compact ==="
 	@$(MAKE) plan-compact
@@ -225,7 +230,7 @@ plan-multi-instance-create:
 	$(PLAN_FIXTURE) multi_instance_create
 plan-multi-instance-module:
 	$(PLAN_FIXTURE) multi_instance_module
-.PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
+.PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-delete-list-of-maps plan-compact \
         plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
         plan-list-diff-modified-with-unchanged \
         plan-list-diff-modified-with-unchanged-nested \

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -371,6 +371,42 @@ fn snapshot_delete_orphan() {
     insta::assert_snapshot!(output);
 }
 
+/// A deleted orphan whose state carries a list-of-maps attribute
+/// (`domain_validation_options`) must render that attribute vertically
+/// (multi-line), not on one long unreadable line. Regression for the
+/// Delete path being asymmetric with the Create path in
+/// `build_detail_rows` / `build_delete_rows`.
+#[test]
+fn snapshot_delete_orphan_list_of_maps() {
+    use carina_core::resource::Value;
+    let (plan, current_states, schemas, _moved) =
+        build_plan_and_states_from_fixture("delete_orphan_list_of_maps");
+    let delete_attributes: HashMap<ResourceId, HashMap<String, Value>> = plan
+        .effects()
+        .iter()
+        .filter_map(|e| {
+            if let carina_core::effect::Effect::Delete { id, .. } = e {
+                current_states
+                    .get(id)
+                    .map(|s| (id.clone(), s.attributes.clone()))
+            } else {
+                None
+            }
+        })
+        .collect();
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &delete_attributes,
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+    ));
+    insta::assert_snapshot!(output);
+}
+
 #[test]
 fn snapshot_compact() {
     let (plan, _schemas, _moved) = build_plan_from_fixture("compact");

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_delete_orphan_list_of_maps.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_delete_orphan_list_of_maps.snap
@@ -1,0 +1,19 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  - aws.acm.Certificate orphan_cert
+      certificate_arn: "arn:aws:acm:us-east-1:151116838382:certificate/3fc2dbff-d965-4533-aeac-9e9d85ac527a"
+      domain_name: "registry-dev.carina-rs.dev"
+      domain_validation_options: 
+        * domain_name: "registry-dev.carina-rs.dev"
+          resource_record: 
+            name: "_b799e8cef71fc960510b85f44c464976.registry-dev.carina-rs.dev."
+            type: "CNAME"
+            value: "_914ec1412ad1bbde685f236a55c98d23.jkddzztszm.acm-validations.aws."
+          validation_method: "DNS"
+          validation_status: "SUCCESS"
+
+Plan: 0 to add, 0 to change, 1 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/delete_orphan_list_of_maps/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/delete_orphan_list_of_maps/carina.state.json
@@ -1,0 +1,50 @@
+{
+  "version": 6,
+  "serial": 1,
+  "lineage": "test-lineage-delete-orphan-list-of-maps",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "acm.Certificate",
+      "name": "orphan_cert",
+      "provider": "aws",
+      "identifier": "arn:aws:acm:us-east-1:151116838382:certificate/3fc2dbff-d965-4533-aeac-9e9d85ac527a",
+      "attributes": {
+        "certificate_arn": "arn:aws:acm:us-east-1:151116838382:certificate/3fc2dbff-d965-4533-aeac-9e9d85ac527a",
+        "domain_name": "registry-dev.carina-rs.dev",
+        "domain_validation_options": [
+          {
+            "domain_name": "registry-dev.carina-rs.dev",
+            "resource_record": {
+              "name": "_b799e8cef71fc960510b85f44c464976.registry-dev.carina-rs.dev.",
+              "type": "CNAME",
+              "value": "_914ec1412ad1bbde685f236a55c98d23.jkddzztszm.acm-validations.aws."
+            },
+            "validation_method": "DNS",
+            "validation_status": "SUCCESS"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "orphan_cert",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "certificate_arn": {
+            "kind": "leaf"
+          },
+          "domain_name": {
+            "kind": "leaf"
+          },
+          "domain_validation_options": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/delete_orphan_list_of_maps/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/delete_orphan_list_of_maps/main.crn
@@ -1,0 +1,11 @@
+# Delete orphan with a list-of-maps attribute in state.
+#
+# No resources are declared in config; the ACM certificate is present
+# in carina.state.json only, so it is an orphan to be deleted. Its
+# `domain_validation_options` is a list-of-maps and must render
+# vertically (multi-line) in the delete plan rather than on one long,
+# unreadable line.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -861,7 +861,17 @@ fn build_delete_rows(
         keys.sort();
         for key in keys {
             let value = &attrs[key];
-            if let Value::Concrete(ConcreteValue::Map(map)) = value {
+            // Route lists through PrettyAttribute so `format_value_pretty`
+            // applies its 80-col threshold and YAML-style vertical layout,
+            // mirroring `build_create_rows`. Without this, a list-of-maps
+            // like `domain_validation_options` renders on one long,
+            // unreadable line (the Delete path was asymmetric with Create).
+            if let Value::Concrete(ConcreteValue::List(_)) = value {
+                rows.push(DetailRow::PrettyAttribute {
+                    key: key.to_string(),
+                    value: value.clone(),
+                });
+            } else if let Value::Concrete(ConcreteValue::Map(map)) = value {
                 rows.push(build_expanded_map_row(key, map));
             } else {
                 let ref_binding = match value {
@@ -1827,6 +1837,64 @@ mod tests {
             }
             other => panic!("expected MapExpanded, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn delete_row_list_of_maps_emits_pretty_attribute() {
+        // Regression: the Delete path used to stringify list attributes onto
+        // one long line (asymmetric with build_create_rows). A list-of-maps
+        // like `domain_validation_options` must route through
+        // PrettyAttribute so format_value_pretty's vertical layout applies.
+        let id = ResourceId::new("acm.Certificate", "cert");
+        let effect = Effect::Delete {
+            id: id.clone(),
+            identifier: "cert".to_string(),
+            directives: crate::resource::Directives::default(),
+            binding: None,
+            dependencies: HashSet::new(),
+            explicit_dependencies: std::collections::HashSet::new(),
+        };
+        let mut entry = IndexMap::new();
+        entry.insert(
+            "domain_name".to_string(),
+            Value::Concrete(ConcreteValue::String(
+                "registry-dev.carina-rs.dev".to_string(),
+            )),
+        );
+        entry.insert(
+            "validation_method".to_string(),
+            Value::Concrete(ConcreteValue::String("DNS".to_string())),
+        );
+        let dvo = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(entry),
+        )]));
+        let mut delete_attrs: HashMap<ResourceId, HashMap<String, Value>> = HashMap::new();
+        delete_attrs.insert(
+            id.clone(),
+            [("domain_validation_options".to_string(), dvo)]
+                .into_iter()
+                .collect(),
+        );
+
+        let rows = build_detail_rows(&effect, None, DetailLevel::Full, Some(&delete_attrs), None);
+
+        let pretty_value = rows.iter().find_map(|row| match row {
+            DetailRow::PrettyAttribute { key, value } if key == "domain_validation_options" => {
+                Some(value)
+            }
+            _ => None,
+        });
+        assert!(
+            pretty_value.is_some(),
+            "expected PrettyAttribute row for domain_validation_options, got: {rows:?}"
+        );
+        assert!(
+            matches!(
+                pretty_value.unwrap(),
+                Value::Concrete(ConcreteValue::List(_))
+            ),
+            "PrettyAttribute should carry the raw Value::Concrete(ConcreteValue::List)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In a delete (orphan removal) plan, list attributes such as an ACM
Certificate's `domain_validation_options` rendered on a single very
long, unreadable line:

```
  - aws.acm.Certificate r.cert
      domain_validation_options: [{domain_name: "...", resource_record: {name: "...", type: "CNAME", value: "..."}, validation_method: "DNS", validation_status: "SUCCESS"}]
```

## Root cause

`build_delete_rows` sent `Value::Concrete(ConcreteValue::List(_))`
attributes through `format_value_with_key` (single line), while
`build_create_rows` routed the same shape through
`DetailRow::PrettyAttribute`, which applies `format_value_pretty`'s
80-column threshold and YAML-style vertical layout. The Delete path
was asymmetric with the Create path.

## Fix

Mirror the create-row list handling in `build_delete_rows`: lists go
through `DetailRow::PrettyAttribute`, maps keep `MapExpanded`, scalars
keep `Attribute`. The renderer's `Effect::Delete` arm already strikes
multi-line pretty output via `strike_lines`, so no renderer change is
needed.

Result:

```
  - aws.acm.Certificate orphan_cert
      domain_validation_options: 
        * domain_name: "registry-dev.carina-rs.dev"
          resource_record: 
            name: "_b799...registry-dev.carina-rs.dev."
            type: "CNAME"
            value: "_914e...acm-validations.aws."
          validation_method: "DNS"
          validation_status: "SUCCESS"
```

## Tests

- Unit regression `delete_row_list_of_maps_emits_pretty_attribute` in
  `carina-core/src/detail_rows.rs`.
- New `delete_orphan_list_of_maps` fixture + snapshot test
  `snapshot_delete_orphan_list_of_maps` + `plan-delete-list-of-maps`
  Makefile target.

Full workspace tests, doctests, clippy, and `scripts/check-*.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
