### PR TITLE
fix: resolve wait target identifier at apply time, not plan time

### DIFF
--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::deps::get_resource_dependencies;
-use crate::effect::{CascadingUpdate, Effect, TemporaryName};
+use crate::effect::{CascadingUpdate, Effect, TemporaryName, WaitTarget};
 use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
@@ -433,9 +433,18 @@ pub fn create_plan(
             value: wb.until_predicate.rhs.clone(),
         };
         let target_id = target_resource.id.clone();
-        let target_identifier = current_states
+        // The target's identifier is only known at plan time if it
+        // already exists in state. When the target is created/updated
+        // in this same run it has no prior state, so the executor must
+        // resolve the real identifier from the just-applied state — see
+        // [`WaitTarget`] and carina#3119.
+        let target = match current_states
             .get(&target_id)
-            .and_then(|s| s.identifier.clone());
+            .and_then(|s| s.identifier.clone())
+        {
+            Some(id) => WaitTarget::Known(id),
+            None => WaitTarget::ResolvedAtApply,
+        };
         let schema = registry.get(
             &target_id.provider,
             &target_id.resource_type,
@@ -455,7 +464,7 @@ pub fn create_plan(
             // type tracked for its own newtype migration (carina#3066).
             binding: wb.binding.as_str().to_string(),
             target_id,
-            target_identifier,
+            target,
             until,
             until_surface: wb.until_raw.clone(),
             timeout,

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -40,6 +40,44 @@ pub struct CascadingUpdate {
     pub to: Resource,
 }
 
+/// How an [`Effect::Wait`] obtains the cloud provider identifier its
+/// polling `read()` needs.
+///
+/// The differ cannot always know the target's identifier at plan time:
+/// when the target is *created in the same apply run* it has no prior
+/// state, so its real identifier (e.g. an ACM certificate ARN) only
+/// exists after the `Create` effect completes. Splitting "known now"
+/// from "resolve at apply" into the type — instead of overloading
+/// `Option<String>`'s `None` — forces the executor to handle the
+/// apply-time case explicitly via an exhaustive `match`, so future code
+/// cannot silently pass a stale plan-time `None` to `provider.read`
+/// (carina#3119).
+///
+/// Guard: the old `Option<String>`-shaped pattern — treating the
+/// plan-time value as something you can `.as_deref()` straight into the
+/// poll loop — no longer type-checks. `WaitTarget` has no `Option`-like
+/// API, so there is no `None` to forward:
+///
+/// ```compile_fail
+/// use carina_core::effect::WaitTarget;
+/// let t = WaitTarget::ResolvedAtApply;
+/// // Was: `target_identifier.as_deref()` — `WaitTarget` has no
+/// // `as_deref`, forcing callers through an exhaustive match that
+/// // handles the apply-time resolution explicitly.
+/// let _ = t.as_deref();
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WaitTarget {
+    /// The target already exists; its identifier was resolved from
+    /// `current_states` at plan time.
+    Known(String),
+    /// The target is created or updated in this same run. The executor
+    /// resolves the real identifier from the just-applied state
+    /// (`applied_states`) before polling; falls back to no identifier
+    /// only when the target was never produced in this plan.
+    ResolvedAtApply,
+}
+
 /// Effect representing an operation on a resource
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Effect {
@@ -141,8 +179,9 @@ pub enum Effect {
         /// Resolved id of the target resource (`wait cert { ... }` →
         /// `cert`'s `ResourceId`).
         target_id: ResourceId,
-        /// Cloud provider identifier of the target, when already known.
-        target_identifier: Option<String>,
+        /// How the executor obtains the target's cloud provider
+        /// identifier for its polling `read()`. See [`WaitTarget`].
+        target: WaitTarget,
         /// Typed predicate evaluated against each `read()` snapshot.
         until: WaitPredicate,
         /// Surface form of the `until` expression as the user wrote it
@@ -485,7 +524,7 @@ mod tests {
         let _ = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target_identifier: None,
+            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -506,7 +545,7 @@ mod tests {
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target_identifier: None,
+            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -528,7 +567,7 @@ mod tests {
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target_identifier: None,
+            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -551,7 +590,7 @@ mod tests {
         let original = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target_identifier: None,
+            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use futures::stream::{FuturesUnordered, StreamExt};
 
 use crate::deps::find_failed_dependency;
-use crate::effect::Effect;
+use crate::effect::{Effect, WaitTarget};
 use crate::provider::Provider;
 use crate::resource::{Resource, ResourceId, State, Value};
 
@@ -292,6 +292,27 @@ pub(super) async fn execute_effects_sequential(
 
             // Snapshot bindings for this effect's resolution
             let binding_snapshot = input.bindings.clone();
+            // Resolve the wait target's identifier *now*, before the
+            // dispatch closure: a target created in this same run has no
+            // plan-time identifier (`WaitTarget::ResolvedAtApply`), so
+            // we read it from the just-completed effect's state held in
+            // `applied_states`. The scheduler guarantees the producing
+            // Create/Update/Replace ran before this Wait is dispatched
+            // (see the Wait-dependency edges above), so the entry is
+            // present. Falls back to no identifier only when the target
+            // was never produced in this plan (refresh-only apply).
+            // carina#3119.
+            let wait_identifier: Option<String> = match effect {
+                Effect::Wait {
+                    target_id, target, ..
+                } => match target {
+                    WaitTarget::Known(id) => Some(id.clone()),
+                    WaitTarget::ResolvedAtApply => applied_states
+                        .get(target_id)
+                        .and_then(|s| s.identifier.clone()),
+                },
+                _ => None,
+            };
             let unresolved = &input.unresolved_resources;
             let pipeline = RenormalizePipeline {
                 normalizer: input.normalizer,
@@ -364,7 +385,6 @@ pub(super) async fn execute_effects_sequential(
                     Effect::Wait {
                         binding,
                         target_id,
-                        target_identifier,
                         until,
                         timeout,
                         interval,
@@ -380,7 +400,7 @@ pub(super) async fn execute_effects_sequential(
                         match super::wait::execute_wait_effect(
                             provider,
                             target_id,
-                            target_identifier.as_deref(),
+                            wait_identifier.as_deref(),
                             until,
                             *timeout,
                             *interval,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -2306,7 +2306,7 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
         target_id: cert_id.clone(),
-        target_identifier: None,
+        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -2453,7 +2453,7 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
         target_id: cert_id.clone(),
-        target_identifier: None,
+        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -2551,7 +2551,7 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
         target_id: cert_id.clone(),
-        target_identifier: None,
+        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -2925,5 +2925,180 @@ async fn test_chained_index_then_nested_field_resolves_from_post_create_state() 
         )])),
         "`resource_records` list element must resolve from chained \
          access into the post-create state; got: {resource_records:?}",
+    );
+}
+
+// -----------------------------------------------------------------------
+// carina#3119: wait target identifier must be resolved at apply time from
+// the just-created resource's state, not the plan-time value.
+// -----------------------------------------------------------------------
+
+/// Provider whose `read` only succeeds when handed the *correct* created
+/// identifier; with `None` (or a wrong identifier) it returns not-found,
+/// exactly like the real AWS ACM provider. It records every identifier
+/// passed to `read` so the test can assert what the apply path threaded
+/// through.
+struct IdentifierAwareProvider {
+    expected_identifier: String,
+    /// State returned by `create` (carries the real identifier + the
+    /// attribute the wait predicate checks).
+    created_state: Mutex<Option<State>>,
+    read_identifiers: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+impl IdentifierAwareProvider {
+    fn new(expected_identifier: &str, created_state: State) -> Self {
+        Self {
+            expected_identifier: expected_identifier.to_string(),
+            created_state: Mutex::new(Some(created_state)),
+            read_identifiers: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn read_identifiers(&self) -> Vec<Option<String>> {
+        self.read_identifiers.lock().unwrap().clone()
+    }
+}
+
+impl Provider for IdentifierAwareProvider {
+    fn name(&self) -> &str {
+        "identifier-aware"
+    }
+
+    fn read(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+        _request: ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let owned = identifier.map(|s| s.to_string());
+        self.read_identifiers.lock().unwrap().push(owned.clone());
+        let id = id.clone();
+        let expected = self.expected_identifier.clone();
+        let state = self.created_state.lock().unwrap().clone();
+        Box::pin(async move {
+            match owned {
+                Some(ref got) if got == &expected => {
+                    state.ok_or_else(|| ProviderError::api_error("no canned state for read"))
+                }
+                _ => Err(ProviderError::not_found(format!(
+                    "wait target {id} not found (deleted out-of-band?)"
+                ))
+                .for_resource(id)),
+            }
+        })
+    }
+
+    fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        self.read(&resource.id, None, ReadRequest)
+    }
+
+    fn create(
+        &self,
+        _id: &ResourceId,
+        _request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let state = self.created_state.lock().unwrap().clone();
+        Box::pin(
+            async move { state.ok_or_else(|| ProviderError::api_error("no canned create state")) },
+        )
+    }
+
+    fn update(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _request: UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        Box::pin(async move { Err(ProviderError::api_error("update not expected")) })
+    }
+
+    fn delete(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _request: DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Err(ProviderError::api_error("delete not expected")) })
+    }
+}
+
+/// Regression for carina#3119: a resource created *in the same apply run*
+/// has no plan-time identifier, so the differ emits
+/// `WaitTarget::ResolvedAtApply` on `Effect::Wait`. The executor must
+/// resolve the real identifier from the just-completed Create's state
+/// (held in `applied_states`), not poll `provider.read` with no
+/// identifier.
+///
+/// This exercises the real apply path (`execute_plan`). The pre-existing
+/// wait unit tests in `wait.rs` use a provider that ignores the
+/// identifier, so they never caught this.
+#[tokio::test]
+async fn wait_resolves_target_identifier_from_just_created_state() {
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let mut cert = Resource::new("test", "cert");
+    cert.binding = Some("cert".to_string());
+    let cert_id = cert.id.clone();
+
+    // Post-create state: the provider hands back the real identifier
+    // (unknown at plan time) plus the attribute the wait predicate reads.
+    let mut created_attrs = HashMap::new();
+    created_attrs.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("issued".to_string())),
+    );
+    let created_state =
+        State::existing(cert_id.clone(), created_attrs).with_identifier("cert-arn-real");
+
+    let provider = IdentifierAwareProvider::new("cert-arn-real", created_state);
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::Wait {
+        binding: "cert_issued".to_string(),
+        target_id: cert_id.clone(),
+        // The differ emits `ResolvedAtApply` because the cert does not
+        // exist at plan time (created in this same run).
+        target: crate::effect::WaitTarget::ResolvedAtApply,
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        until_surface: "cert.status == \"issued\"".to_string(),
+        timeout: std::time::Duration::from_secs(5),
+        interval: std::time::Duration::from_millis(10),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+
+    assert_eq!(
+        result.failure_count,
+        0,
+        "wait must not fail; the just-created identifier should reach \
+         provider.read. read identifiers seen: {:?}",
+        provider.read_identifiers()
+    );
+    assert_eq!(result.success_count, 2, "both Create and Wait must succeed");
+    assert!(
+        provider
+            .read_identifiers()
+            .iter()
+            .any(|i| i.as_deref() == Some("cert-arn-real")),
+        "the wait read must be called with the created identifier \
+         resolved from applied_states, not the plan-time None; got: {:?}",
+        provider.read_identifiers()
     );
 }

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -427,7 +427,7 @@ mod tests {
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target_identifier: None,
+            target: crate::effect::WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -454,7 +454,7 @@ mod tests {
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target_identifier: None,
+            target: crate::effect::WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),


### PR DESCRIPTION
## Problem

`carina apply` in `carina-rs/infra registry/dev/registry` failed when a `wait` ran against a resource created in the same apply run:

```
✓ Create aws.acm.Certificate r.cert [8.2s] 1/8
✗ Wait r.cert_issued (until cert.status == aws.acm.Certificate.Status.issued) [0.0s] 4/8
    → [acm.Certificate.r.cert] wait target aws.acm.Certificate.r.cert not found (deleted out-of-band?)
```

The Create succeeded 4 steps earlier in the same run, yet the wait reported the target missing.

## Root cause

`Effect::Wait.target_identifier` was computed at **plan time** in `carina-core/src/differ/plan.rs` from `current_states`. A resource created in this same run has no prior state, so `target_identifier` was `None` — and that stale `None` was frozen into the effect. At apply time the executor passed it verbatim to `provider.read(target_id, None, …)`, which the AWS ACM provider resolves as not-found.

The just-completed Create's post-apply state — including the real ARN — was already in the executor's `applied_states`, but the wait dispatch never consulted it. The pre-existing wait tests use a provider that ignores the identifier argument, so they never exercised this (unit-test path is not the apply path).

## Fix

- Replace `Effect::Wait.target_identifier: Option<String>` with a `WaitTarget` enum (`Known(String)` / `ResolvedAtApply`). "Unknown until apply" is now explicit in the type, so the executor must handle it via an exhaustive match — a future code path cannot silently forward a stale plan-time `None`. A `compile_fail` doctest guards against reintroducing the old `Option`-style direct-pass.
- The differ emits `Known` when the target already exists in `current_states`, `ResolvedAtApply` otherwise.
- The executor resolves `ResolvedAtApply` from `applied_states[target_id].identifier` before dispatching the wait. The scheduler already guarantees the producing Create/Update/Replace completed first, so the entry is present; falls back to no identifier only for refresh-only applies where the target was never produced in this plan.

Scope is limited to `Effect::Wait`'s identifier field; no broader `Effect` reshape.

## Testing

- New regression test `wait_resolves_target_identifier_from_just_created_state` drives the real `execute_plan` apply path with an identifier-aware provider (returns not-found unless handed the correct created identifier) and asserts the created ARN reaches `provider.read`. Verified it fails on the pre-fix code (`read_identifiers = [None]`, the wait fails) and passes after the fix.
- `compile_fail` doctest on `WaitTarget` proves the old `.as_deref()`-style pattern no longer type-checks.
- Full workspace: `cargo nextest run --workspace` (3382 passed), `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -- -D warnings`, all `scripts/check-*.sh` — green.

Wait effects are not persisted to `carina.state.json` (recomputed every plan/apply), so the changed serde shape needs no state-file migration.

Closes #3119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
