### PR TITLE
fix: route carina validate display through iter_all_resources (PR-1 of #3121)

### DIFF
--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -9,6 +9,7 @@ use carina_core::config_loader::{
 };
 use carina_core::lint::find_duplicate_attrs;
 use carina_core::parser::{File, ProviderContext, ResourceContext, UpstreamState};
+use carina_core::resource::{ResourceId, ResourceName};
 
 use super::validate_and_resolve_errors;
 use crate::error::AppError;
@@ -93,11 +94,12 @@ pub fn validate_with_factories(
 }
 
 /// Test-support twin of [`validate_with_factories`] that returns the
-/// resource identifier list `run_validate` would display, instead of
+/// rendered resource list `run_validate` would display, instead of
 /// the error strings. Runs the identical load + resolve pipeline, then
-/// derives the list via `validated_resource_ids` — the exact
-/// production display path — so e2e tests assert on what the user
-/// actually sees (including deferred-for loop bodies, carina#3121).
+/// derives the list via `validated_entries` and renders each through
+/// the same `Display` boundary the CLI uses — so e2e tests assert on
+/// exactly what the user sees (including deferred-for loop bodies,
+/// carina#3121).
 ///
 /// Not used outside test code.
 pub fn validated_resource_ids_with_factories(
@@ -127,7 +129,10 @@ pub fn validated_resource_ids_with_factories(
         std::collections::HashMap::new(),
     );
 
-    validated_resource_ids(&parsed)
+    validated_entries(&parsed)
+        .iter()
+        .map(ToString::to_string)
+        .collect()
 }
 
 /// Format `LoadedConfig.inference_errors` into "export '<name>': type
@@ -143,39 +148,93 @@ fn format_inference_errors(
         .collect()
 }
 
-/// The list of resource identifiers `validate` reports, derived from
-/// [`File::iter_all_resources`] so it stays in sync with every
-/// other resource-walking checker (the unified-walk invariant from
+/// One entry in `validate`'s resource enumeration, kept as a typed
+/// value until the output boundary so a non-address placeholder can
+/// never be mistaken for a resolvable resource id, and a not-yet-named
+/// resource can never silently render as a trailing-dot string
+/// (carina#3121). `Display` is the *only* place an entry becomes text.
+enum ValidatedEntry<'a> {
+    /// A direct resource whose name is already bound — the common
+    /// case, renders exactly as its [`ResourceId`].
+    Resolved(&'a ResourceId),
+    /// A direct resource still carrying a `Pending` name (anonymous,
+    /// `name` attribute not yet promoted at the point validate
+    /// enumerates). Rendering its `ResourceId` directly would emit a
+    /// meaningless trailing-dot string; this variant makes the
+    /// not-yet-named state explicit instead of relying on the empty
+    /// string `ResourceName::Pending` produces.
+    PendingDirect(&'a ResourceId),
+    /// The body of a `for` loop whose iterable is unresolved at parse
+    /// time (e.g. a same-config provider-read attribute). It is a
+    /// loop template, not a single resource — never a resolvable
+    /// address. The source location keeps two distinct anonymous
+    /// loops over the *same* iterable distinguishable (`binding` +
+    /// `header` alone are identical for `for _, opt in cert.dvo { … }`
+    /// repeated twice).
+    DeferredLoop {
+        resource_type: &'a str,
+        binding_name: &'a str,
+        header: &'a str,
+        file: Option<&'a str>,
+        line: usize,
+    },
+}
+
+impl std::fmt::Display for ValidatedEntry<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidatedEntry::Resolved(id) => write!(f, "{id}"),
+            ValidatedEntry::PendingDirect(id) => {
+                // `id.display_type()` is provider+type without the
+                // (empty) name — explicit `<pending>` beats a bare
+                // trailing dot.
+                write!(f, "{}.<pending>", id.display_type())
+            }
+            ValidatedEntry::DeferredLoop {
+                resource_type,
+                binding_name,
+                header,
+                file,
+                line,
+            } => {
+                let location = match file {
+                    Some(file) => format!("{file}:{line}"),
+                    None => line.to_string(),
+                };
+                write!(
+                    f,
+                    "{resource_type}.{binding_name}[?] (deferred: {header} @ {location})"
+                )
+            }
+        }
+    }
+}
+
+/// The resources `validate` enumerates, derived from
+/// [`File::iter_all_resources`] so it stays in sync with every other
+/// resource-walking checker (the unified-walk invariant from
 /// `notes/specs/2026-04-19-unify-resource-walk-design.md`).
 ///
-/// A `for` loop whose iterable is unresolved at parse time (e.g. a
-/// same-config provider-read attribute, carina#3121) contributes a
-/// `DeferredForExpression` whose `template_resource` has a `Pending`
-/// name — `resource.id` alone would render as a meaningless
-/// trailing-dot string. For those entries we render the loop's
-/// placeholder address form (`{resource_type}.{binding_name}[?]`) plus
-/// the source `for` header and its location so the user can see the
-/// loop body the planner intends to manage instead of it silently
-/// vanishing from the count and list. The location suffix also keeps
-/// two distinct anonymous loops over the *same* iterable
-/// distinguishable (`binding_name` + `header` alone are identical for
-/// `for _, opt in cert.dvo { … }` repeated twice). Direct resources
-/// render via their `id` unchanged.
-fn validated_resource_ids<E>(parsed: &File<E>) -> Vec<String> {
+/// Returns typed [`ValidatedEntry`] values, not pre-rendered strings:
+/// the json `resources` array and the human list both stringify these
+/// at their own boundary, so a deferred placeholder is structurally
+/// distinct from a resolved id rather than a string that happens to
+/// contain `[?]`.
+fn validated_entries<E>(parsed: &File<E>) -> Vec<ValidatedEntry<'_>> {
     parsed
         .iter_all_resources()
         .map(|(ctx, resource)| match ctx {
-            ResourceContext::Direct => resource.id.to_string(),
-            ResourceContext::Deferred(d) => {
-                let location = match &d.file {
-                    Some(file) => format!("{file}:{}", d.line),
-                    None => d.line.to_string(),
-                };
-                format!(
-                    "{}.{}[?] (deferred: {} @ {})",
-                    d.resource_type, d.binding_name, d.header, location
-                )
-            }
+            ResourceContext::Direct => match resource.id.name {
+                ResourceName::Bound(_) => ValidatedEntry::Resolved(&resource.id),
+                ResourceName::Pending => ValidatedEntry::PendingDirect(&resource.id),
+            },
+            ResourceContext::Deferred(d) => ValidatedEntry::DeferredLoop {
+                resource_type: &d.resource_type,
+                binding_name: &d.binding_name,
+                header: &d.header,
+                file: d.file.as_deref(),
+                line: d.line,
+            },
         })
         .collect()
 }
@@ -271,11 +330,11 @@ pub fn run_validate(
                 file: Some(file_path.display().to_string()),
             });
         }
-        let resources = validated_resource_ids(&parsed);
+        let entries = validated_entries(&parsed);
         let output = ValidateOutput {
             status: "ok",
-            resource_count: resources.len(),
-            resources,
+            resource_count: entries.len(),
+            resources: entries.iter().map(ToString::to_string).collect(),
             warnings,
         };
         println!(
@@ -286,16 +345,16 @@ pub fn run_validate(
         return Ok(());
     }
 
-    let resource_ids = validated_resource_ids(&parsed);
+    let entries = validated_entries(&parsed);
     println!(
         "{}",
-        format!("✓ {} resources validated successfully.", resource_ids.len())
+        format!("✓ {} resources validated successfully.", entries.len())
             .green()
             .bold()
     );
 
-    for id in &resource_ids {
-        println!("  • {}", id);
+    for entry in &entries {
+        println!("  • {}", entry);
     }
 
     for binding in &unused_warnings {
@@ -373,10 +432,11 @@ mod tests {
     /// loop body over an unresolved (deferred) iterable, not just the
     /// human-readable list. Builds `ValidateOutput` exactly as the
     /// `if json` branch of `run_validate` does — `resource_count` and
-    /// `resources` both derived from `validated_resource_ids` — and
-    /// asserts the serialized JSON contains the deferred placeholder
-    /// entry and a count that includes it. This pins the `--json` path
-    /// the e2e test reaches only through the shared helper.
+    /// `resources` both derived from `validated_entries` rendered at
+    /// the `Display` boundary — and asserts the serialized JSON
+    /// contains the deferred placeholder entry and a count that
+    /// includes it. This pins the `--json` path the e2e test reaches
+    /// only through the shared helper.
     #[test]
     fn json_output_enumerates_deferred_for_body() {
         let src = r#"
@@ -402,11 +462,11 @@ mod tests {
         // `deferred_for_expressions` — exactly the carina#3121 shape.
         assert_eq!(parsed.deferred_for_expressions.len(), 1);
 
-        let resources = validated_resource_ids(&parsed);
+        let entries = validated_entries(&parsed);
         let output = ValidateOutput {
             status: "ok",
-            resource_count: resources.len(),
-            resources,
+            resource_count: entries.len(),
+            resources: entries.iter().map(ToString::to_string).collect(),
             warnings: vec![],
         };
         let json = serde_json::to_string(&output).unwrap();
@@ -429,6 +489,40 @@ mod tests {
             "json must list the deferred for-loop body as a placeholder \
              entry; got: {listed:?}"
         );
+    }
+
+    /// Type-safety guarantee: a direct resource still carrying a
+    /// `Pending` name must NOT render as a trailing-dot string
+    /// (`aws.s3.Bucket.`). The `ValidatedEntry::PendingDirect` variant
+    /// makes the not-yet-named state explicit at the type level
+    /// instead of leaking the empty string `ResourceName::Pending`
+    /// produces. Guards the [[feedback_type_safety_over_runtime_checks]]
+    /// concern raised reviewing carina#3128.
+    #[test]
+    fn pending_named_direct_resource_does_not_render_trailing_dot() {
+        use carina_core::parser::ParsedFile;
+        use carina_core::resource::Resource;
+
+        let mut parsed = ParsedFile::default();
+        let mut res = Resource::new("s3.Bucket", "placeholder");
+        res.id.provider = "aws".to_string();
+        // Force the anonymous/not-yet-promoted state explicitly.
+        res.id.name = ResourceName::Pending;
+        parsed.resources.push(res);
+
+        let entries = validated_entries(&parsed);
+        assert_eq!(entries.len(), 1);
+        assert!(
+            matches!(entries[0], ValidatedEntry::PendingDirect(_)),
+            "a Pending-named direct resource must classify as PendingDirect"
+        );
+
+        let rendered = entries[0].to_string();
+        assert!(
+            !rendered.ends_with('.'),
+            "rendered Pending entry must not be a trailing-dot string; got: {rendered:?}"
+        );
+        assert_eq!(rendered, "aws.s3.Bucket.<pending>");
     }
 
     fn upstream(binding: &str, source: &str) -> UpstreamState {

--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -8,7 +8,7 @@ use carina_core::config_loader::{
     find_crn_files_in_dir, get_base_dir, load_configuration_with_config,
 };
 use carina_core::lint::find_duplicate_attrs;
-use carina_core::parser::{ProviderContext, UpstreamState};
+use carina_core::parser::{File, ProviderContext, ResourceContext, UpstreamState};
 
 use super::validate_and_resolve_errors;
 use crate::error::AppError;
@@ -92,6 +92,44 @@ pub fn validate_with_factories(
     error_reports
 }
 
+/// Test-support twin of [`validate_with_factories`] that returns the
+/// resource identifier list `run_validate` would display, instead of
+/// the error strings. Runs the identical load + resolve pipeline, then
+/// derives the list via `validated_resource_ids` — the exact
+/// production display path — so e2e tests assert on what the user
+/// actually sees (including deferred-for loop bodies, carina#3121).
+///
+/// Not used outside test code.
+pub fn validated_resource_ids_with_factories(
+    path: &Path,
+    factories: Vec<Box<dyn carina_core::provider::ProviderFactory>>,
+) -> Vec<String> {
+    let provider_context = ProviderContext::default();
+    let loaded = match load_configuration_with_config(
+        path,
+        &provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    ) {
+        Ok(l) => l,
+        Err(e) => panic!("fixture failed to load: {e}"),
+    };
+    let mut parsed = loaded.parsed;
+    let base_dir = get_base_dir(path);
+
+    // Run the same resolve/validate pass as the CLI so the parsed tree
+    // (and its `deferred_for_expressions`) is in the post-validation
+    // state the display path observes.
+    let _ = super::validate_and_resolve_errors_with_factories(
+        &mut parsed,
+        base_dir,
+        false,
+        factories,
+        std::collections::HashMap::new(),
+    );
+
+    validated_resource_ids(&parsed)
+}
+
 /// Format `LoadedConfig.inference_errors` into "export '<name>': type
 /// annotation required: <reason>" strings via the shared
 /// `inference::format_inference_error` helper so the CLI and LSP keep
@@ -102,6 +140,43 @@ fn format_inference_errors(
     errors
         .iter()
         .map(|(name, err)| carina_core::validation::inference::format_inference_error(name, err))
+        .collect()
+}
+
+/// The list of resource identifiers `validate` reports, derived from
+/// [`File::iter_all_resources`] so it stays in sync with every
+/// other resource-walking checker (the unified-walk invariant from
+/// `notes/specs/2026-04-19-unify-resource-walk-design.md`).
+///
+/// A `for` loop whose iterable is unresolved at parse time (e.g. a
+/// same-config provider-read attribute, carina#3121) contributes a
+/// `DeferredForExpression` whose `template_resource` has a `Pending`
+/// name — `resource.id` alone would render as a meaningless
+/// trailing-dot string. For those entries we render the loop's
+/// placeholder address form (`{resource_type}.{binding_name}[?]`) plus
+/// the source `for` header and its location so the user can see the
+/// loop body the planner intends to manage instead of it silently
+/// vanishing from the count and list. The location suffix also keeps
+/// two distinct anonymous loops over the *same* iterable
+/// distinguishable (`binding_name` + `header` alone are identical for
+/// `for _, opt in cert.dvo { … }` repeated twice). Direct resources
+/// render via their `id` unchanged.
+fn validated_resource_ids<E>(parsed: &File<E>) -> Vec<String> {
+    parsed
+        .iter_all_resources()
+        .map(|(ctx, resource)| match ctx {
+            ResourceContext::Direct => resource.id.to_string(),
+            ResourceContext::Deferred(d) => {
+                let location = match &d.file {
+                    Some(file) => format!("{file}:{}", d.line),
+                    None => d.line.to_string(),
+                };
+                format!(
+                    "{}.{}[?] (deferred: {} @ {})",
+                    d.resource_type, d.binding_name, d.header, location
+                )
+            }
+        })
         .collect()
 }
 
@@ -196,10 +271,11 @@ pub fn run_validate(
                 file: Some(file_path.display().to_string()),
             });
         }
+        let resources = validated_resource_ids(&parsed);
         let output = ValidateOutput {
             status: "ok",
-            resource_count: parsed.resources.len(), // allow: direct — display/reporting
-            resources: parsed.resources.iter().map(|r| r.id.to_string()).collect(), // allow: direct — display/reporting
+            resource_count: resources.len(),
+            resources,
             warnings,
         };
         println!(
@@ -210,18 +286,16 @@ pub fn run_validate(
         return Ok(());
     }
 
+    let resource_ids = validated_resource_ids(&parsed);
     println!(
         "{}",
-        format!(
-            "✓ {} resources validated successfully.",
-            parsed.resources.len() // allow: direct — display/reporting
-        )
-        .green()
-        .bold()
+        format!("✓ {} resources validated successfully.", resource_ids.len())
+            .green()
+            .bold()
     );
 
-    for resource in &parsed.resources {
-        println!("  • {}", resource.id);
+    for id in &resource_ids {
+        println!("  • {}", id);
     }
 
     for binding in &unused_warnings {
@@ -293,6 +367,68 @@ mod tests {
         assert_eq!(parsed["resources"].as_array().unwrap().len(), 2);
         // warnings should be omitted when empty
         assert!(parsed.get("warnings").is_none());
+    }
+
+    /// carina#3121 fix A: the `--json` output must enumerate a `for`
+    /// loop body over an unresolved (deferred) iterable, not just the
+    /// human-readable list. Builds `ValidateOutput` exactly as the
+    /// `if json` branch of `run_validate` does — `resource_count` and
+    /// `resources` both derived from `validated_resource_ids` — and
+    /// asserts the serialized JSON contains the deferred placeholder
+    /// entry and a count that includes it. This pins the `--json` path
+    /// the e2e test reaches only through the shared helper.
+    #[test]
+    fn json_output_enumerates_deferred_for_body() {
+        let src = r#"
+            let cert = aws.acm.Certificate {
+                domain_name       = "registry.example.com"
+                validation_method = "DNS"
+            }
+
+            for _, opt in cert.domain_validation_options {
+                aws.route53.RecordSet {
+                    hosted_zone_id   = "Z123"
+                    name             = opt.resource_record.name
+                    type             = "CNAME"
+                    ttl              = 300
+                    resource_records = [opt.resource_record.value]
+                }
+            }
+        "#;
+        let parsed =
+            carina_core::parser::parse(src, &ProviderContext::default()).expect("fixture parses");
+        // The loop is deferred (iterable is a same-config provider-read
+        // attribute), so it is not in `parsed.resources` but is in
+        // `deferred_for_expressions` — exactly the carina#3121 shape.
+        assert_eq!(parsed.deferred_for_expressions.len(), 1);
+
+        let resources = validated_resource_ids(&parsed);
+        let output = ValidateOutput {
+            status: "ok",
+            resource_count: resources.len(),
+            resources,
+            warnings: vec![],
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // cert (direct) + the deferred RecordSet body.
+        assert_eq!(value["resource_count"], 2);
+        let listed = value["resources"].as_array().unwrap();
+        assert!(
+            listed
+                .iter()
+                .any(|r| r.as_str().unwrap().contains("acm.Certificate")),
+            "json must list the let-bound certificate; got: {listed:?}"
+        );
+        assert!(
+            listed.iter().any(|r| {
+                let s = r.as_str().unwrap();
+                s.contains("route53.RecordSet") && s.contains("[?]") && s.contains("(deferred:")
+            }),
+            "json must list the deferred for-loop body as a placeholder \
+             entry; got: {listed:?}"
+        );
     }
 
     fn upstream(binding: &str, source: &str) -> UpstreamState {

--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -508,7 +508,7 @@ mod tests {
         res.id.provider = "aws".to_string();
         // Force the anonymous/not-yet-promoted state explicitly.
         res.id.name = ResourceName::Pending;
-        parsed.resources.push(res);
+        parsed.resources.push(res); // allow: direct — fixture test inspection
 
         let entries = validated_entries(&parsed);
         assert_eq!(entries.len(), 1);

--- a/carina-cli/tests/validate_deferred_for_enumeration_e2e.rs
+++ b/carina-cli/tests/validate_deferred_for_enumeration_e2e.rs
@@ -1,0 +1,250 @@
+//! End-to-end: `carina validate` must enumerate the body of a `for`
+//! loop whose iterable is a same-config provider-read attribute
+//! (carina#3121, design PR-1 / fix A).
+//!
+//! Before this fix, `validate` reported resources off `parsed.resources`
+//! directly. A `for opt in cert.domain_validation_options { ... }` loop
+//! over a same-config `let cert` is parsed into a `DeferredForExpression`
+//! and contributes *zero* entries to `parsed.resources`, so the loop
+//! body silently vanished from the `✓ N resources validated` count and
+//! list. The fix routes the display through
+//! `ParsedFile::iter_all_resources()` (the unified-walk invariant from
+//! `notes/specs/2026-04-19-unify-resource-walk-design.md`), which
+//! already yields every `DeferredForExpression.template_resource`.
+//!
+//! Per CLAUDE.md "directory-scoped, never single-file": the fixture is
+//! a multi-file `tempfile::tempdir()` layout mirroring the real
+//! `infra/.../registry` shape — `cert` is declared in `main.crn`, the
+//! loop body in `records.crn`, the provider in `providers.crn` — so we
+//! exercise the merged-parse path the CLI and LSP share, not a single
+//! buffer.
+
+use carina_core::provider::{
+    BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
+};
+use carina_core::resource::{Resource, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Minimal aws provider factory exposing the two resource types the
+// fixture references so the validate pipeline sees real types.
+// ---------------------------------------------------------------------------
+
+struct ForTestFactory;
+
+impl ProviderFactory for ForTestFactory {
+    fn name(&self) -> &str {
+        "aws"
+    }
+    fn display_name(&self) -> &str {
+        "AWS (for-loop test stub)"
+    }
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+        Ok(())
+    }
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "us-east-1".to_string()
+    }
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
+    }
+    fn create_normalizer(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+        Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+    }
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![cert_schema(), record_set_schema()]
+    }
+}
+
+fn cert_schema() -> ResourceSchema {
+    ResourceSchema::new("acm.Certificate")
+        .attribute(AttributeSchema::new("domain_name", AttributeType::String))
+        .attribute(AttributeSchema::new(
+            "validation_method",
+            AttributeType::String,
+        ))
+        // Provider-read/computed collection that the `for` iterates.
+        // Element type is immaterial here — the loop is deferred at
+        // parse time because `cert.domain_validation_options` is an
+        // unresolved provider-computed reference, not because of the
+        // element schema.
+        .attribute(AttributeSchema::new(
+            "domain_validation_options",
+            AttributeType::List {
+                inner: Box::new(AttributeType::String),
+                ordered: true,
+            },
+        ))
+}
+
+fn record_set_schema() -> ResourceSchema {
+    ResourceSchema::new("route53.RecordSet")
+        .attribute(AttributeSchema::new(
+            "hosted_zone_id",
+            AttributeType::String,
+        ))
+        .attribute(AttributeSchema::new("name", AttributeType::String))
+        .attribute(AttributeSchema::new("type", AttributeType::String))
+        .attribute(AttributeSchema::new("ttl", AttributeType::Int))
+        .attribute(AttributeSchema::new(
+            "resource_records",
+            AttributeType::List {
+                inner: Box::new(AttributeType::String),
+                ordered: true,
+            },
+        ))
+}
+
+struct NoopProvider;
+
+impl Provider for NoopProvider {
+    fn name(&self) -> &str {
+        "aws"
+    }
+    fn read(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: Option<&str>,
+        _request: carina_core::provider::ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::not_found(id)) })
+    }
+    fn read_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn create(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn update(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn delete(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn factories() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(ForTestFactory) as Box<dyn ProviderFactory>]
+}
+
+fn write_fixture(files: &[(&str, &str)]) -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (name, content) in files {
+        std::fs::write(dir.path().join(name), content).expect("write fixture");
+    }
+    dir
+}
+
+/// The real registry shape: `cert` (a `let`-bound same-config resource)
+/// in one file, a `for` over its provider-read `domain_validation_options`
+/// in a sibling file.
+fn registry_like_fixture() -> TempDir {
+    write_fixture(&[
+        (
+            "providers.crn",
+            r#"provider aws {
+    region = "us-east-1"
+}
+"#,
+        ),
+        (
+            "main.crn",
+            r#"let cert = aws.acm.Certificate {
+    domain_name       = "registry.example.com"
+    validation_method = "DNS"
+}
+"#,
+        ),
+        (
+            "records.crn",
+            r#"for _, opt in cert.domain_validation_options {
+    aws.route53.RecordSet {
+        hosted_zone_id   = "Z123"
+        name             = opt.resource_record.name
+        type             = "CNAME"
+        ttl              = 300
+        resource_records = [opt.resource_record.value]
+    }
+}
+"#,
+        ),
+    ])
+}
+
+#[test]
+fn validate_enumerates_deferred_for_body_over_same_config_read_attr() {
+    let fixture = registry_like_fixture();
+    let ids = carina_cli::commands::validate::validated_resource_ids_with_factories(
+        fixture.path(),
+        factories(),
+    );
+
+    // The same-config `let cert` resolves at parse time and is a direct
+    // resource.
+    assert!(
+        ids.iter()
+            .any(|id| id.contains("acm") && id.contains("cert")),
+        "the let-bound certificate must be enumerated; got: {:?}",
+        ids
+    );
+
+    // The loop body is the regression target: before fix A it was
+    // entirely absent from the list. It must now appear, tagged as
+    // deferred, so the user can see the resource the planner intends
+    // to manage instead of silent data loss.
+    // Pin the actual feature shape, not just loose substrings: the
+    // placeholder address form `{type}.{binding}[?]`, the
+    // `(deferred: <header>)` suffix, AND the `@ <file>:<line>`
+    // location (which keeps two distinct loops over the same iterable
+    // distinguishable) are the whole point of fix A — a regression
+    // that dropped any of them must fail this test.
+    assert!(
+        ids.iter().any(|id| id.contains("route53.RecordSet")
+            && id.contains("[?]")
+            && id.contains("(deferred:")
+            && id.contains(" @ ")),
+        "the for-loop body (aws.route53.RecordSet) over a same-config \
+         read attribute must be enumerated as a deferred placeholder \
+         entry (`route53.RecordSet…[?] (deferred: … @ <file>:<line>)`); \
+         got: {:?}",
+        ids
+    );
+}

--- a/site/src/content/reference/cli/validate.md
+++ b/site/src/content/reference/cli/validate.md
@@ -33,6 +33,30 @@ Validating...
   • aws.ec2.Subnet.public
 ```
 
+### Resources inside a `for` loop over an unresolved value
+
+<!-- derived-from ../../../../../notes/specs/2026-05-17-for-loop-same-config-read-iterable-design.md -->
+
+When a `for` loop iterates a value that is not known until plan/apply
+time (for example a provider-computed attribute such as
+`cert.domain_validation_options`), the loop body is enumerated as a
+single **deferred placeholder** entry rather than expanded:
+
+```
+✓ 2 resources validated successfully.
+  • aws.acm.Certificate.cert
+  • aws.route53.RecordSet._domain_validation_options[?] (deferred: for _, opt in cert.domain_validation_options @ records.crn:1)
+```
+
+The `[?]` marks an address the planner will assign once the iterable
+resolves, and the `(deferred: <for header> @ <file>:<line>)` suffix
+identifies the loop (`<file>` is the path as passed to
+`carina validate`; shortened to a basename above for readability). These entries are **not** resolvable resource
+addresses -- they describe a loop body, not a single resource. The
+count includes one entry per deferred loop (its element count is
+unknowable at validate time). The same entries appear in the
+`resources` array of `--json` output.
+
 Warnings are printed after the success message:
 
 ```


### PR DESCRIPTION
PR-1 / fix A of the carina#3121 design (`notes/specs/2026-05-17-for-loop-same-config-read-iterable-design.md`, merged in #3123).

## Problem

`carina validate`'s resource count + list were derived directly from `parsed.resources`, bypassing `ParsedFile::iter_all_resources()`. A `for` loop over a same-config provider-read attribute — `for _, opt in cert.domain_validation_options { aws.route53.RecordSet { ... } }` where `let cert` is in the same config — is parsed into a `DeferredForExpression` and contributes **zero** entries to `parsed.resources`. The loop body silently vanished from the `✓ N resources validated` count and list.

This violated the already-shipped 2026-04-19 unified-walk single-source-of-truth design, whose CI lint `check-no-direct-resources-access.sh` had `// allow: direct` escape hatches on exactly these display sites.

## Change

Route the count + list (both human-readable and `--json`) through one `validated_resource_ids(&File<E>)` helper that walks `iter_all_resources()`:

- Direct resources render via `resource.id` unchanged (no behavior change for the common case).
- Deferred templates have a `Pending` name, so they render as `{type}.{binding}[?] (deferred: {for header} @ {file}:{line})` instead of a meaningless trailing-dot id. The `@ file:line` keeps two anonymous loops over the *same* iterable distinguishable.

## Scope

carina-cli display only. **No plan/apply/carina-core change.** The destroy-only symptom from #3121 is fixed by PR-2 — hence `refs #3121`, not `Closes`.

## Tests

- Multi-file directory-scoped e2e fixture (`cert` in `main.crn`, loop in `records.crn`, provider in `providers.crn`) exercising the real `load_configuration_with_config` + resolve + display path. RED→GREEN verified: fails on direct `parsed.resources` (`got: ["aws.acm.Certificate.cert"]`), passes via `iter_all_resources()`.
- In-module `--json` serialization test asserting the deferred entry appears in the `ValidateOutput.resources` array and the count includes it.

## Docs

`site/src/content/reference/cli/validate.md` gains a subsection documenting the deferred placeholder entry in both human and `--json` output.

## Verification

- 422 carina-cli tests pass (incl. both new tests)
- `cargo clippy -p carina-cli --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `scripts/check-no-direct-resources-access.sh` exit 0 (unified-walk invariant — stale `// allow: direct` comments correctly removed)
- `scripts/check-docs-use-new-spellings.sh` `docs OK`
- 5-round self-review completed

## Follow-ups filed

- #3126 — `for` over an unresolved iterable inside an imported module is silently dropped (pre-existing, orthogonal to fix A, affects plan/apply too)
- #3127 — deduplicate copy-pasted test Provider stub across carina-cli e2e tests

refs #3121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
