### PR TITLE
refactor: single classified module-expansion merge surface (PR-A of #3126)

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::parser::{self, InferredFile, ParsedFile, ProviderContext};
+use crate::parser::{self, File, InferredFile, ParsedFile, ProviderContext};
 use crate::schema::SchemaRegistry;
 use crate::validation::inference::InferenceError;
 
@@ -271,29 +271,100 @@ pub fn parse_directory_with_overrides(
     Ok(merged)
 }
 
-/// Merge fields from `source` into `target`.
-pub(crate) fn merge_parsed_file(target: &mut ParsedFile, source: ParsedFile) {
-    target.providers.extend(source.providers);
-    target.resources.extend(source.resources);
-    target.variables.extend(source.variables);
-    target.uses.extend(source.uses);
-    target.module_calls.extend(source.module_calls);
-    target.arguments.extend(source.arguments);
-    target.attribute_params.extend(source.attribute_params);
-    target.export_params.extend(source.export_params);
-    target.state_blocks.extend(source.state_blocks);
-    target.user_functions.extend(source.user_functions);
-    target.upstream_states.extend(source.upstream_states);
-    target.wait_bindings.extend(source.wait_bindings);
-    target.requires.extend(source.requires);
-    target
-        .structural_bindings
-        .extend(source.structural_bindings);
-    target.warnings.extend(source.warnings);
+/// Re-label a parsed file's export-param phase (`File<A>` → `File<B>`)
+/// when it carries **no** export params.
+///
+/// Module expansion produces a concrete `ParsedFile` contribution (it
+/// is a parser-phase operation), but the caller's target is a generic
+/// `File<E>` (`resolve_modules_with_config<E>`). Today every
+/// production caller instantiates `E = ParsedExportParam`, so this is
+/// a same-phase no-op; the `<A, B>` generality keeps
+/// `resolve_modules_with_config` phase-agnostic for a future
+/// inferred-phase caller without re-introducing a hand-listed field
+/// list. A module contribution never re-exports raw export params —
+/// `export_params` is always empty — so the relabel is total and
+/// lossless.
+///
+/// Delegates to [`File::map_export_params`](crate::parser::File), the
+/// single exhaustive-destructure phase-axis surface (the carina#3126 /
+/// carina#3061 compile-time forcing function: a new `File<E>` field
+/// stops `map_export_params` from compiling until classified, so the
+/// module-expansion bridge can never silently drop a field).
+/// `debug_assert!`s `export_params` is empty — a contract tripwire for
+/// a future caller that violates the precondition; not reachable from
+/// the sole current caller (`expand_module_call` pins
+/// `export_params: Vec::new()`).
+pub(crate) fn relabel_export_phase<A, B>(f: File<A>) -> File<B> {
+    f.map_export_params(|export_params| {
+        // Tripwire for a future caller that violates the precondition.
+        // `debug_assert!` (not `assert!`): carina-core is a library;
+        // the real enforcement is the exhaustive destructure in
+        // `map_export_params`, and the sole current caller pins
+        // `export_params: Vec::new()`, so this is unreachable today —
+        // a release-build crash here would be a strictly worse failure
+        // mode than the test/CI catch a debug assert already gives.
+        debug_assert!(
+            export_params.is_empty(),
+            "relabel_export_phase: only an export-param-free file may cross \
+             phases; a module contribution must never carry export_params"
+        );
+        Vec::new()
+    })
+}
+
+/// Fold one parsed file's content into another (the sibling-`.crn`
+/// directory merge, and the module-load merge).
+///
+/// `source` is **destructured exhaustively** rather than field-accessed:
+/// this is the single source of truth for "every mergeable `File<E>`
+/// field", and the destructure is a compile-time forcing function — if
+/// a field is added to `File<E>`, this stops compiling until someone
+/// decides how it merges. Without that guard a new field is silently
+/// dropped on this path, which is exactly the carina#3126 / carina#3061
+/// class of bug (a `File<E>` field that one merge path forgot). Generic
+/// over the export-param phase `E` so the parser phase and inferred
+/// phase share one merge.
+pub(crate) fn merge_parsed_file<E>(target: &mut File<E>, source: File<E>) {
+    let File {
+        providers,
+        resources,
+        variables,
+        uses,
+        module_calls,
+        arguments,
+        attribute_params,
+        export_params,
+        backend,
+        state_blocks,
+        user_functions,
+        upstream_states,
+        wait_bindings,
+        requires,
+        structural_bindings,
+        warnings,
+        deferred_for_expressions,
+    } = source;
+
+    target.providers.extend(providers);
+    target.resources.extend(resources);
+    target.variables.extend(variables);
+    target.uses.extend(uses);
+    target.module_calls.extend(module_calls);
+    target.arguments.extend(arguments);
+    target.attribute_params.extend(attribute_params);
+    target.export_params.extend(export_params);
+    target.state_blocks.extend(state_blocks);
+    target.user_functions.extend(user_functions);
+    target.upstream_states.extend(upstream_states);
+    target.wait_bindings.extend(wait_bindings);
+    target.requires.extend(requires);
+    target.structural_bindings.extend(structural_bindings);
+    target.warnings.extend(warnings);
     target
         .deferred_for_expressions
-        .extend(source.deferred_for_expressions);
-    if let Some(backend) = source.backend {
+        .extend(deferred_for_expressions);
+    // `backend` is config, not accumulated content: last file wins.
+    if let Some(backend) = backend {
         target.backend = Some(backend);
     }
 }

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -5,7 +5,9 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use indexmap::IndexMap;
 
-use crate::parser::{ArgumentParameter, BindingName, ModuleCall, WaitBinding};
+use crate::parser::{
+    ArgumentParameter, BindingName, DeferredForExpression, ModuleCall, ParsedFile, WaitBinding,
+};
 use crate::resource::{
     ConcreteValue, DeferredValue, Directives, Resource, ResourceId, ResourceKind, ResourceName,
     Value,
@@ -15,23 +17,6 @@ use super::error::ModuleError;
 use super::resolver::ModuleResolver;
 use super::typecheck::check_module_arg_type;
 use super::validation::{evaluate_require_expr, evaluate_validate_expr, format_value_for_error};
-
-/// Result of expanding a single module call.
-///
-/// A module call contributes both resources and `wait` declarations to
-/// the caller; both must reach the caller for a module-internal `wait`
-/// to keep synchronizing its downstream consumers (carina#3061).
-#[derive(Debug)]
-pub struct ExpandedModule {
-    /// Expanded, instance-prefixed resources (plus the virtual
-    /// attribute proxy when the module declares `attributes`).
-    pub resources: Vec<Resource>,
-    /// The module's `wait` declarations, with every binding-name field
-    /// (`binding`, `target`, the predicate LHS root, `depends_on`)
-    /// rewritten with the call's `instance_prefix` so they match the
-    /// prefixed resource bindings and the prefixed downstream refs.
-    pub wait_bindings: Vec<WaitBinding>,
-}
 
 impl ModuleResolver<'_> {
     /// Expand a module call into resources.
@@ -46,12 +31,34 @@ impl ModuleResolver<'_> {
     /// enclosing module's declared types so a pass-through arg ref like
     /// `inner_arg = outer_arg` can be checked structurally before the
     /// parent's argument substitution erases the type tag (#2549).
+    /// Returns the contribution as a concrete `ParsedFile` — module
+    /// expansion is a parser-phase operation (it reads parser-phase
+    /// module data from `imported_modules`), so the honest return type
+    /// is `ParsedFile`, not a phantom `File<E>`.
+    ///
+    /// carina#3126 root fix: the caller folds this in via the *one*
+    /// shared [`merge_parsed_file`](crate::config_loader) — there is no
+    /// second hand-maintained field list that can silently diverge
+    /// from `File<E>` (the carina#3061 / carina#3126 bug class: a
+    /// module-internal `wait` / `for` dropped because the expansion
+    /// path forgot a field). The contribution is built below with an
+    /// **exhaustive struct literal**, so a new `File<E>` field cannot
+    /// compile until it is classified as "populated from the module
+    /// (instance-prefixed)" or "consumed during expansion, not
+    /// propagated". The generic-`File<E>` caller
+    /// (`resolve_modules_with_config<E>`) routes the contribution
+    /// through [`relabel_export_phase`](crate::config_loader) before
+    /// the merge so it stays phase-agnostic (today every caller is
+    /// `E = ParsedExportParam`, making that a same-phase no-op;
+    /// `export_params` is always empty so the relabel is total
+    /// regardless). The recursive parser-phase caller
+    /// (`resolve_nested_modules`) merges directly.
     pub fn expand_module_call(
         &self,
         call: &ModuleCall,
         instance_prefix: &str,
         enclosing_args: Option<&[ArgumentParameter]>,
-    ) -> Result<ExpandedModule, ModuleError> {
+    ) -> Result<ParsedFile, ModuleError> {
         let module = self
             .imported_modules
             .get(&call.module_name)
@@ -309,9 +316,59 @@ impl ModuleResolver<'_> {
             .map(|wb| prefix_wait_binding(wb, instance_prefix))
             .collect();
 
-        Ok(ExpandedModule {
+        // carina#3126: propagate the module's deferred for-expressions
+        // (previously dropped at this boundary). PR-A passes them
+        // through; PR-B fills in the instance-prefixing classified in
+        // `prefix_deferred_for_expression`.
+        let expanded_deferred_for_expressions: Vec<DeferredForExpression> = module
+            .deferred_for_expressions
+            .iter()
+            .map(|d| prefix_deferred_for_expression(d, instance_prefix))
+            .collect();
+
+        // The contribution is a full `ParsedFile` built with an
+        // **exhaustive struct literal** (no `..Default::default()`):
+        // adding a `File<E>` field breaks this until someone decides
+        // whether a module instance contributes it. Fields a module
+        // does *not* propagate are explicitly empty *here*, with the
+        // reason — never silently absent (the carina#3126 fix).
+        Ok(ParsedFile {
+            // Populated from the module, instance-prefixed:
             resources: expanded_resources,
             wait_bindings: expanded_wait_bindings,
+            deferred_for_expressions: expanded_deferred_for_expressions,
+
+            // Consumed *inside* expansion, not propagated to the caller
+            // (a module instance does not re-export these as raw
+            // collections — they are inlined / surfaced via the
+            // virtual attribute resource above):
+            //   - `providers`: modules inherit the caller's providers.
+            //   - `variables` / `user_functions`: module-local, already
+            //     substituted into the expanded resources.
+            //   - `uses` / `module_calls`: nested modules are resolved
+            //     within `expand_module_call`, not re-emitted.
+            //   - `arguments` / `attribute_params` / `export_params`:
+            //     the call's args are bound here; outputs reach the
+            //     caller through the `_virtual` attribute resource.
+            //   - `requires`: evaluated against this call's args here.
+            //   - `state_blocks` / `backend`: a module does not own
+            //     caller state/backend config.
+            //   - `structural_bindings` / `warnings`: scoped to the
+            //     module's own parse, not merged upward.
+            providers: Vec::new(),
+            variables: IndexMap::new(),
+            uses: Vec::new(),
+            module_calls: Vec::new(),
+            arguments: Vec::new(),
+            attribute_params: Vec::new(),
+            export_params: Vec::new(),
+            backend: None,
+            state_blocks: Vec::new(),
+            user_functions: HashMap::new(),
+            upstream_states: Vec::new(),
+            requires: Vec::new(),
+            structural_bindings: HashSet::new(),
+            warnings: Vec::new(),
         })
     }
 }
@@ -384,6 +441,71 @@ fn prefix_wait_binding(wb: &WaitBinding, instance_prefix: &str) -> WaitBinding {
         timeout_secs: *timeout_secs,
         depends_on: depends_on.iter().map(prefixed_name).collect(),
         line: *line,
+    }
+}
+
+/// Instance-prefix a [`DeferredForExpression`] crossing a module
+/// boundary, mirroring [`prefix_wait_binding`].
+///
+/// The struct is **destructured exhaustively** — the same carina#3061
+/// compile-time forcing function: if a field is added to
+/// `DeferredForExpression`, this stops compiling until someone
+/// classifies it as binding-name (prefix), value/provenance (pass
+/// through), or loop-local (pass through). That guard is the whole
+/// point of carina#3126's single merge surface — a new field cannot
+/// be silently dropped at the module boundary.
+///
+/// **PR-A scope:** every field is passed through *unchanged*. This
+/// already fixes the carina#3126 silent-drop (the entry now reaches
+/// the caller). The binding-name fields that still need
+/// instance-prefixing for a *correct* expansion under a module
+/// instance are called out per-field below and are PR-B's payload;
+/// each is marked `// PR-B:` so the follow-up is mechanical and the
+/// classification is recorded at the type level now.
+fn prefix_deferred_for_expression(
+    d: &DeferredForExpression,
+    _instance_prefix: &str,
+) -> DeferredForExpression {
+    let DeferredForExpression {
+        file,
+        line,
+        header,
+        resource_type,
+        attributes,
+        binding_name,
+        iterable_binding,
+        iterable_attr,
+        binding,
+        template_resource,
+    } = d;
+
+    DeferredForExpression {
+        // provenance — pass through (like WaitBinding.line)
+        file: file.clone(),
+        line: *line,
+        // verbatim user-surface display text — pass through
+        // (like WaitBinding.until_raw)
+        header: header.clone(),
+        // provider-qualified type — not a binding
+        resource_type: resource_type.clone(),
+        // PR-B: `Value`s may carry ResourceRef/BindingRef into
+        // module-internal bindings — must run rewrite_intra_module_refs
+        // + substitute_arguments like module.resources attributes.
+        attributes: attributes.clone(),
+        // PR-B: generated-resource binding prefix — must
+        // apply_instance_prefix (mirrors Resource.binding prefixing).
+        binding_name: binding_name.clone(),
+        // PR-B: iterable root binding — must apply_instance_prefix
+        // (mirrors prefix_wait_binding's lhs_segments[0] head).
+        iterable_binding: iterable_binding.clone(),
+        // attribute path tail — not a binding
+        iterable_attr: iterable_attr.clone(),
+        // loop-var pattern kind — loop-local, not a module binding
+        binding: binding.clone(),
+        // PR-B: full Resource — must get the same treatment as a
+        // module.resources entry (id/binding prefix + ref-rewrite +
+        // arg-substitute + canonicalize).
+        template_resource: template_resource.clone(),
     }
 }
 

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -29,9 +29,7 @@ mod typecheck;
 mod validation;
 
 pub use error::ModuleError;
-pub use expander::{
-    ExpandedModule, instance_prefix_for_call, reconcile_anonymous_module_instances,
-};
+pub use expander::{instance_prefix_for_call, reconcile_anonymous_module_instances};
 pub use loader::{
     derive_module_name, get_parsed_file, load_directory_module, load_module,
     load_module_from_directory,

--- a/carina-core/src/module_resolver/resolver.rs
+++ b/carina-core/src/module_resolver/resolver.rs
@@ -186,20 +186,31 @@ impl<'cfg> ModuleResolver<'cfg> {
 
         // Expand the module's own module_calls. Pass the parent module's
         // argument signature so the inner type-check can resolve any
-        // pass-through arg refs (#2549). The `module_calls` clone is
-        // needed because the loop body extends `parsed.resources` while
-        // iterating; the borrow checker treats the two as one borrow even
-        // though the fields are disjoint.
+        // pass-through arg refs (#2549). `module_calls` and
+        // `enclosing_args` are cloned because the loop body now folds
+        // the contribution in via `merge_parsed_file(parsed, …)` — a
+        // whole-`&mut parsed` borrow that conflicts with any live
+        // immutable borrow of a `parsed` field (the old per-field
+        // `.extend()` only needed a disjoint field borrow; the single
+        // merge surface needs the whole struct).
+        //
+        // The pre-loop `enclosing_args` snapshot is behaviour-equivalent
+        // to the old live `&parsed.arguments` borrow *because* a module
+        // contribution never adds `arguments` (`expand_module_call`'s
+        // exhaustive literal pins `arguments: Vec::new()`), so the merge
+        // can't grow `parsed.arguments` mid-loop. That invariant is
+        // enforced by the same exhaustive literal this PR introduces.
         let module_calls = parsed.module_calls.clone();
-        let enclosing_args: &[ArgumentParameter] = &parsed.arguments;
+        let enclosing_args: Vec<ArgumentParameter> = parsed.arguments.clone();
         for call in &module_calls {
             let instance_prefix = instance_prefix_for_call(call);
 
-            match self.expand_module_call(call, &instance_prefix, Some(enclosing_args)) {
+            match self.expand_module_call(call, &instance_prefix, Some(&enclosing_args)) {
                 Ok(expanded) => {
-                    parsed.resources.extend(expanded.resources); // allow: direct — module expansion, handled separately
-                    // Propagate instance-prefixed wait bindings (carina#3061).
-                    parsed.wait_bindings.extend(expanded.wait_bindings);
+                    // The module contribution is a `ParsedFile`; fold it
+                    // in via the one shared merge surface so no field can
+                    // be silently dropped here (carina#3126 / carina#3061).
+                    crate::config_loader::merge_parsed_file(parsed, expanded);
                 }
                 Err(e) => {
                     self.base_dir = original_base_dir;
@@ -242,13 +253,22 @@ pub fn resolve_modules_with_config<E>(
     // Process imports
     resolver.process_imports(&parsed.uses)?;
 
-    // Expand module calls
-    for call in &parsed.module_calls {
+    // Expand module calls. `module_calls` is cloned because the loop
+    // body folds each contribution in via `merge_parsed_file(parsed,
+    // …)`, a whole-`&mut parsed` borrow that conflicts with iterating
+    // `&parsed.module_calls` in place.
+    let module_calls = parsed.module_calls.clone();
+    for call in &module_calls {
         let instance_prefix = instance_prefix_for_call(call);
         let expanded = resolver.expand_module_call(call, &instance_prefix, None)?;
-        parsed.resources.extend(expanded.resources); // allow: direct — module expansion, handled separately
-        // Propagate instance-prefixed wait bindings (carina#3061).
-        parsed.wait_bindings.extend(expanded.wait_bindings);
+        // `expand_module_call` returns a parser-phase `ParsedFile`;
+        // this caller's `parsed` is a generic `File<E>` (the CLI
+        // validate path passes an `InferredFile`). Relabel the
+        // export-param-free contribution to the target phase, then
+        // fold it in via the one shared merge surface so no field can
+        // be silently dropped here (carina#3126 / carina#3061).
+        let expanded = crate::config_loader::relabel_export_phase(expanded);
+        crate::config_loader::merge_parsed_file(parsed, expanded);
     }
 
     Ok(())

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -3970,3 +3970,188 @@ m { foo = 'x' }
         "expected DuplicateBinding for `foo`; got {msg}"
     );
 }
+
+/// carina#3126 / PR-A structural invariant: a `for` over an
+/// unresolved iterable declared **inside a module** must survive
+/// `expand_module_call` and reach the caller. Before the single
+/// merge surface, the expansion result carried only `resources` +
+/// `wait_bindings`, so a module-internal `deferred_for_expressions`
+/// entry was silently dropped — invisible to validate/plan/apply
+/// (the real `carina-rs/infra usecases/registry/acm.crn` case).
+///
+/// PR-A only asserts the entry is *propagated* (no longer dropped).
+/// Instance-prefixing of its binding-name fields is PR-B; this test
+/// deliberately does not assert prefixing so it stays green across
+/// the PR-A → PR-B boundary.
+#[test]
+fn test_expand_module_call_propagates_deferred_for_expressions() {
+    use crate::parser::{DeferredForExpression, ForBinding};
+
+    let module = {
+        let mut m = create_module_with_intra_refs();
+        m.deferred_for_expressions.push(DeferredForExpression {
+            file: None,
+            line: 7,
+            header: "for _, opt in cert.domain_validation_options".to_string(),
+            resource_type: "aws.route53.RecordSet".to_string(),
+            attributes: vec![],
+            binding_name: "_domain_validation_options".to_string(),
+            iterable_binding: "cert".to_string(),
+            iterable_attr: "domain_validation_options".to_string(),
+            binding: ForBinding::Map("_".to_string(), "opt".to_string()),
+            template_resource: Resource {
+                id: ResourceId::new("route53.RecordSet", "placeholder"),
+                attributes: HashMap::new().into_iter().collect(),
+                kind: ResourceKind::Managed,
+                directives: Directives::default(),
+                prefixes: HashMap::new(),
+                binding: None,
+                dependency_bindings: BTreeSet::new(),
+                module_source: None,
+                quoted_string_attrs: std::collections::HashSet::new(),
+            },
+        });
+        m
+    };
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert("registry".to_string(), module);
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "registry".to_string(),
+        binding_name: Some("r".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            args.insert(
+                "cidr".to_string(),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            );
+            args
+        },
+    };
+
+    let expanded = resolver.expand_module_call(&call, "r", None).unwrap();
+
+    // The structural invariant: the module-internal deferred-for
+    // reached the caller instead of vanishing at the expansion
+    // boundary.
+    assert_eq!(
+        expanded.deferred_for_expressions.len(),
+        1,
+        "module-internal deferred-for must survive expand_module_call (carina#3126)"
+    );
+    let d = &expanded.deferred_for_expressions[0];
+    assert_eq!(d.resource_type, "aws.route53.RecordSet");
+    assert_eq!(d.iterable_attr, "domain_validation_options");
+    // PR-A contract: binding-name fields pass through *unchanged*
+    // (call instance is "r"). PR-B will instance-prefix these — this
+    // is exactly the assertion PR-B must flip, so it locks PR-A's
+    // pass-through behavior and pre-stages the PR-B boundary.
+    assert_eq!(
+        d.binding_name, "_domain_validation_options",
+        "PR-A must NOT prefix binding_name (PR-B owes that)"
+    );
+    assert_eq!(
+        d.iterable_binding, "cert",
+        "PR-A must NOT prefix iterable_binding (PR-B owes that)"
+    );
+}
+
+/// carina#3126 / PR-A end-to-end: `wait_bindings` AND
+/// `deferred_for_expressions` declared inside an **imported module
+/// directory** must survive the *full* `resolve_modules` pipeline —
+/// i.e. through the new single merge surface (`relabel_export_phase`
+/// + `merge_parsed_file`), not just `expand_module_call` in isolation.
+///
+/// The other module tests call `expand_module_call` directly and so
+/// bypass the merge surface this PR introduces; a classified-but-
+/// mis-merged field (destructured then forgotten in the rebuild)
+/// still compiles and those tests would not catch it. This test
+/// drives `resolve_modules` so the merge path is actually exercised
+/// — the [[feedback_unit_test_path_is_not_apply_path]] guard.
+///
+/// Mirrors the real `carina-rs/infra usecases/registry` shape: a
+/// module with a `wait` (carina#3061) and a `for` over a provider-read
+/// attribute (carina#3126), consumed via a module call.
+#[test]
+fn resolve_modules_propagates_module_wait_and_deferred_for_through_merge() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let module_dir = tmp.path().join("modules/registry");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+        module_dir.join("main.crn"),
+        r#"
+arguments {
+  domain_name: String
+}
+
+let cert = aws.acm.Certificate {
+  domain_name       = domain_name
+  validation_method = dns
+}
+
+for _, opt in cert.domain_validation_options {
+  aws.route53.RecordSet {
+    hosted_zone_id   = "Z123"
+    name             = opt.resource_record.name
+    type             = cname
+    ttl              = 300
+    resource_records = [opt.resource_record.value]
+  }
+}
+
+let cert_issued = wait cert {
+  until   = cert.status == "ISSUED"
+  timeout = 75min
+}
+"#,
+    )
+    .unwrap();
+
+    let root_dir = tmp.path().join("root");
+    fs::create_dir_all(&root_dir).unwrap();
+    let root_body = r#"
+let registry = use {
+  source = "../modules/registry"
+}
+
+let r = registry {
+  domain_name = "registry-dev.example.com"
+}
+"#;
+    fs::write(root_dir.join("main.crn"), root_body).unwrap();
+
+    let mut parsed = crate::parser::parse(root_body, &ProviderContext::default()).unwrap();
+    resolve_modules(&mut parsed, &root_dir).expect("resolve_modules should succeed");
+
+    // carina#3126: the module-internal deferred-for survived the full
+    // resolve_modules pipeline (through relabel_export_phase +
+    // merge_parsed_file), not just expand_module_call.
+    assert_eq!(
+        parsed.deferred_for_expressions.len(),
+        1,
+        "module-internal deferred-for must reach the caller through the \
+         single merge surface (carina#3126); got: {:?}",
+        parsed.deferred_for_expressions
+    );
+    let d = &parsed.deferred_for_expressions[0];
+    assert_eq!(d.resource_type, "aws.route53.RecordSet");
+    assert_eq!(d.iterable_attr, "domain_validation_options");
+
+    // carina#3061: the module-internal wait binding still survives the
+    // same pipeline and is instance-prefixed (the existing invariant,
+    // now exercised *through* the shared merge, not bypassing it).
+    assert_eq!(
+        parsed.wait_bindings.len(),
+        1,
+        "module-internal wait must reach the caller through the single \
+         merge surface (carina#3061); got: {:?}",
+        parsed.wait_bindings
+    );
+    assert_eq!(parsed.wait_bindings[0].binding, "r.cert_issued");
+    assert_eq!(parsed.wait_bindings[0].target, "r.cert");
+}

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -730,6 +730,61 @@ impl<E> Default for File<E> {
 }
 
 impl<E> File<E> {
+    /// Transform only the export-param phase (`File<E>` → `File<B>`),
+    /// applying `f` to the export params and moving every other field
+    /// through unchanged.
+    ///
+    /// This is the **single** place the "every non-export field passes
+    /// a phase change untouched" knowledge lives. The struct is
+    /// **destructured exhaustively** — the carina#3126 / carina#3061
+    /// compile-time forcing function for the *phase axis*: a new
+    /// `File<E>` field cannot compile until it is moved through here
+    /// too. Both [`relabel_export_phase`](crate::config_loader) (module
+    /// contribution → caller phase, export params asserted empty) and
+    /// `apply_inference` (parser → inferred, export params type-inferred)
+    /// delegate here instead of hand-listing every field each.
+    pub fn map_export_params<B>(self, f: impl FnOnce(Vec<E>) -> Vec<B>) -> File<B> {
+        let File {
+            providers,
+            resources,
+            variables,
+            uses,
+            module_calls,
+            arguments,
+            attribute_params,
+            export_params,
+            backend,
+            state_blocks,
+            user_functions,
+            upstream_states,
+            wait_bindings,
+            requires,
+            structural_bindings,
+            warnings,
+            deferred_for_expressions,
+        } = self;
+
+        File {
+            providers,
+            resources,
+            variables,
+            uses,
+            module_calls,
+            arguments,
+            attribute_params,
+            export_params: f(export_params),
+            backend,
+            state_blocks,
+            user_functions,
+            upstream_states,
+            wait_bindings,
+            requires,
+            structural_bindings,
+            warnings,
+            deferred_for_expressions,
+        }
+    }
+
     /// Iterate every resource reachable from the parsed file — both
     /// top-level `resources` and the `template_resource` of each deferred
     /// for-expression — tagged with its origin context.

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -632,28 +632,11 @@ pub fn apply_inference(
     schemas: &SchemaRegistry,
 ) -> (crate::parser::InferredFile, Vec<(String, InferenceError)>) {
     let (inferred_exports, errors) = infer_export_params(&parsed, schemas);
-    (
-        crate::parser::InferredFile {
-            providers: parsed.providers,
-            resources: parsed.resources,
-            variables: parsed.variables,
-            uses: parsed.uses,
-            module_calls: parsed.module_calls,
-            arguments: parsed.arguments,
-            attribute_params: parsed.attribute_params,
-            export_params: inferred_exports,
-            backend: parsed.backend,
-            state_blocks: parsed.state_blocks,
-            user_functions: parsed.user_functions,
-            upstream_states: parsed.upstream_states,
-            wait_bindings: parsed.wait_bindings,
-            requires: parsed.requires,
-            structural_bindings: parsed.structural_bindings,
-            warnings: parsed.warnings,
-            deferred_for_expressions: parsed.deferred_for_expressions,
-        },
-        errors,
-    )
+    // Single phase-axis surface (carina#3126): only `export_params`
+    // changes phase; every other field moves through `map_export_params`
+    // so a new `File<E>` field cannot be silently dropped on the
+    // parser→inferred relabel.
+    (parsed.map_export_params(|_| inferred_exports), errors)
 }
 
 /// Borrowing variant of [`apply_inference`] that returns just the


### PR DESCRIPTION
PR-A of the carina#3126 design (`notes/specs/2026-05-17-module-expansion-merge-surface-design.md`, merged in #3130). **Behavior-preserving refactor** that closes the carina#3061 / carina#3126 drift class *structurally*.

## Problem (root cause)

Two divergent hand-maintained `File<E>`-field lists with no type connecting them:

1. `merge_parsed_file` — all 17 fields, sibling-`.crn` merge.
2. a bespoke 2-field `ExpandedModule` — module expansion.

Adding a `File<E>` field updated path 1 but silently skipped path 2. carina#3061 (`wait_bindings` dropped) and carina#3126 (`deferred_for_expressions` dropped) are the **same bug recurring**. The user's real `carina-rs/infra registry/dev/registry` case (a `for` over a provider-read attr inside the imported `usecases/registry` module) is invisible to validate/plan/apply because of this.

## Fix — one classified surface, three exhaustive compile-time forcing functions

- **`File::map_export_params<B>`** (`parser/ast.rs`): the single phase-axis surface. `relabel_export_phase` *and* `apply_inference` delegate here instead of each hand-listing 17 fields (collapses the duplication the reuse review flagged — `apply_inference` was a 4th hand-listed relabel).
- **`merge_parsed_file<E>`** (`config_loader.rs`): generic + exhaustively destructures `source` (merge-axis guard).
- **`expand_module_call -> ParsedFile`** (`expander.rs`): builds the contribution via an exhaustive `ParsedFile { … }` literal classifying every field as "populated from the module (instance-prefixed)" or "consumed during expansion, not propagated".

Both resolver sites fold the contribution in via the *one* shared `merge_parsed_file` (site B relabels phase first; today every caller is `E = ParsedExportParam`, so that relabel is a same-phase no-op kept for future phase-agnostic callers). Dead `ExpandedModule` indirection removed.

**Empirically proven**: a hypothetical 18th `File<E>` field breaks compilation at every exhaustive site — the carina#3061/#3126 silent-drop class is now impossible, not patched.

## Scope: `refs #3126`, not `Closes`

`deferred_for_expressions` is propagated **unprefixed** in PR-A. The silent-drop is fixed (the entry reaches the caller), but instance-prefixing its binding-name fields for a *correct* expansion under a module instance is **PR-B** (each field marked `// PR-B:` in `prefix_deferred_for_expression`; classification recorded at the type level now). PR-B does the user-visible fix + the real-infra `registry/dev/registry` acceptance, so it carries `Closes #3126`.

carina-cli/lsp untouched; no plan/apply/differ change.

## Deliberate design deviation

The design names one unified `prefix_module_contribution`; the implementation keeps `prefix_wait_binding` + `prefix_deferred_for_expression` as separate per-carrier exhaustive-destructured fns. The single *classification* surface is the `expand_module_call` literal; the prefixers are leaves it calls. Two small focused fns each with their own forcing function is clearer than one mega-fn and adds no safety gap. (Behavior-equivalent; noted so the doc/impl divergence is conscious.)

## Tests / verification

- New structural unit test + a `resolve_modules`-level **e2e test** driving the *full* pipeline (relabel + merge), proving both `wait_bindings` (carina#3061) and `deferred_for_expressions` (carina#3126) survive the new surface — **mutation-tested** in review as a genuine guard (dropping either field in `merge_parsed_file` fails it).
- 3393 workspace tests pass; doctests pass; `cargo clippy --workspace --all-targets -- -D warnings` clean; `check-no-direct-resources-access.sh` / `check-docs-use-new-spellings.sh` clean.
- 5-round self-review completed (Round 4 added the e2e merge-path coverage, corrected over-claimed docs, `assert!`→`debug_assert!`; Round 5 clean).

refs #3126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
