### PR TITLE
fix: instance-prefix module-internal deferred-for expansion (PR-B of #3126)

### DIFF
--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -219,55 +219,13 @@ impl ModuleResolver<'_> {
         // Expand resources with substituted values
         let mut expanded_resources = Vec::new();
         for resource in &module.resources {
-            let mut new_resource = resource.clone();
-
-            // Only Bound names take the prefix here. Pending names stay
-            // Pending so `compute_anonymous_identifiers` can later attach
-            // both the hash and the instance prefix in one shot — see
-            // `identifier::compute_anonymous_identifiers` for the full
-            // story (#2516).
-            if let ResourceName::Bound(name) = &new_resource.id.name {
-                let new_name = apply_instance_prefix(instance_prefix, name);
-                new_resource.id.set_name(new_name);
-            }
-
-            // Rewrite binding with instance path (dot-separated)
-            if let Some(ref binding) = new_resource.binding {
-                new_resource.binding = Some(apply_instance_prefix(instance_prefix, binding));
-            }
-
-            // Set typed module source info
-            new_resource.module_source = Some(crate::resource::ModuleSource::Module {
-                name: call.module_name.clone(),
-                instance: instance_prefix.to_string(),
-            });
-
-            // Rewrite intra-module ResourceRefs BEFORE substituting inputs.
-            // This ensures that caller-provided ResourceRef values (which may
-            // coincidentally share a binding name with a module-internal binding)
-            // are not incorrectly prefixed.
-            // Preserve user-authored attribute order across the
-            // module-call expansion (#2222) — `IndexMap`, not `HashMap`.
-            let mut substituted_attrs: IndexMap<String, Value> = IndexMap::new();
-            for (key, expr) in &new_resource.attributes {
-                let rewritten =
-                    rewrite_intra_module_refs(expr, instance_prefix, &intra_module_bindings);
-                let mut substituted = substitute_arguments(&rewritten, &argument_values);
-                // After substitution, an `Interpolation` whose `${...}`
-                // parts collapsed to literal scalars must canonicalize
-                // back to a flat `String`. Without this, `role_name =
-                // "test-role-${env}"` keeps a single-arg `Interpolation`
-                // with `Expr(String("dev"))` instead of
-                // `String("test-role-dev")`, and downstream consumers
-                // that match on `Value::Concrete(ConcreteValue::String)` (state diff, plan
-                // rendering) miss the resolved value. Symmetric with
-                // the default-evaluation path above. #2815 / #2817.
-                substituted.canonicalize_in_place();
-                substituted_attrs.insert(key.clone(), substituted);
-            }
-            new_resource.attributes = substituted_attrs;
-
-            expanded_resources.push(new_resource);
+            expanded_resources.push(prefix_module_resource(
+                resource,
+                instance_prefix,
+                &call.module_name,
+                &intra_module_bindings,
+                &argument_values,
+            ));
         }
 
         // Create a virtual resource if the module has attributes and the call has a binding
@@ -317,13 +275,23 @@ impl ModuleResolver<'_> {
             .collect();
 
         // carina#3126: propagate the module's deferred for-expressions
-        // (previously dropped at this boundary). PR-A passes them
-        // through; PR-B fills in the instance-prefixing classified in
-        // `prefix_deferred_for_expression`.
+        // (previously dropped at this boundary). Each entry is
+        // instance-prefixed the same way `module.resources` are, so
+        // the loop resolves against the prefixed module bindings and
+        // its generated resources are isolated per module instance
+        // (carina#3126 PR-B).
         let expanded_deferred_for_expressions: Vec<DeferredForExpression> = module
             .deferred_for_expressions
             .iter()
-            .map(|d| prefix_deferred_for_expression(d, instance_prefix))
+            .map(|d| {
+                prefix_deferred_for_expression(
+                    d,
+                    instance_prefix,
+                    &call.module_name,
+                    &intra_module_bindings,
+                    &argument_values,
+                )
+            })
             .collect();
 
         // The contribution is a full `ParsedFile` built with an
@@ -444,27 +412,122 @@ fn prefix_wait_binding(wb: &WaitBinding, instance_prefix: &str) -> WaitBinding {
     }
 }
 
+/// Expand one attribute value crossing the module boundary:
+/// `rewrite_intra_module_refs` (prefix intra-module refs; a
+/// caller-provided ref that coincidentally shares a binding name is
+/// left alone) → `substitute_arguments` → `canonicalize_in_place`
+/// (collapse a fully-literal `Interpolation` back to a flat `String`,
+/// #2815 / #2817).
+///
+/// The single definition of "expand a module attribute value", shared
+/// by [`prefix_module_resource`] (a module resource's attrs) and
+/// [`prefix_deferred_for_expression`] (a loop body's attrs) so the two
+/// carriers can never drift — the exact carina#3126 bug class.
+fn prefix_attr_value(
+    value: &Value,
+    instance_prefix: &str,
+    intra_module_bindings: &HashSet<String>,
+    argument_values: &HashMap<String, Value>,
+) -> Value {
+    let rewritten = rewrite_intra_module_refs(value, instance_prefix, intra_module_bindings);
+    let mut substituted = substitute_arguments(&rewritten, argument_values);
+    substituted.canonicalize_in_place();
+    substituted
+}
+
+/// Instance-prefix one module resource: `Bound` id name + binding take
+/// the instance prefix, typed module-source is stamped, and every
+/// attribute is `rewrite_intra_module_refs` → `substitute_arguments`
+/// → `canonicalize_in_place` (the #2222 / #2815 / #2817 sequence).
+///
+/// The single definition of "expand a module resource", shared by the
+/// `module.resources` loop and `prefix_deferred_for_expression`'s
+/// `template_resource` so a loop body inside a module is prefixed
+/// identically to a top-level module resource (carina#3126 PR-B).
+fn prefix_module_resource(
+    resource: &Resource,
+    instance_prefix: &str,
+    module_name: &str,
+    intra_module_bindings: &HashSet<String>,
+    argument_values: &HashMap<String, Value>,
+) -> Resource {
+    let mut new_resource = resource.clone();
+
+    // Only Bound names take the prefix here. Pending names stay
+    // Pending so `compute_anonymous_identifiers` can later attach both
+    // the hash and the instance prefix in one shot (#2516).
+    if let ResourceName::Bound(name) = &new_resource.id.name {
+        let new_name = apply_instance_prefix(instance_prefix, name);
+        new_resource.id.set_name(new_name);
+    }
+
+    if let Some(ref binding) = new_resource.binding {
+        new_resource.binding = Some(apply_instance_prefix(instance_prefix, binding));
+    }
+
+    new_resource.module_source = Some(crate::resource::ModuleSource::Module {
+        name: module_name.to_string(),
+        instance: instance_prefix.to_string(),
+    });
+
+    // `IndexMap` preserves authored attribute order across expansion
+    // (#2222); each value goes through the shared `prefix_attr_value`.
+    let mut substituted_attrs: IndexMap<String, Value> = IndexMap::new();
+    for (key, expr) in &new_resource.attributes {
+        substituted_attrs.insert(
+            key.clone(),
+            prefix_attr_value(
+                expr,
+                instance_prefix,
+                intra_module_bindings,
+                argument_values,
+            ),
+        );
+    }
+    new_resource.attributes = substituted_attrs;
+
+    new_resource
+}
+
 /// Instance-prefix a [`DeferredForExpression`] crossing a module
-/// boundary, mirroring [`prefix_wait_binding`].
+/// boundary, expanding its loop body the same way the
+/// `module.resources` expansion ([`prefix_module_resource`]) does.
 ///
-/// The struct is **destructured exhaustively** — the same carina#3061
-/// compile-time forcing function: if a field is added to
-/// `DeferredForExpression`, this stops compiling until someone
+/// The struct is **destructured exhaustively** — the carina#3061 /
+/// carina#3126 compile-time forcing function: a new
+/// `DeferredForExpression` field stops this compiling until someone
 /// classifies it as binding-name (prefix), value/provenance (pass
-/// through), or loop-local (pass through). That guard is the whole
-/// point of carina#3126's single merge surface — a new field cannot
-/// be silently dropped at the module boundary.
+/// through), or loop-local (pass through).
 ///
-/// **PR-A scope:** every field is passed through *unchanged*. This
-/// already fixes the carina#3126 silent-drop (the entry now reaches
-/// the caller). The binding-name fields that still need
-/// instance-prefixing for a *correct* expansion under a module
-/// instance are called out per-field below and are PR-B's payload;
-/// each is marked `// PR-B:` so the follow-up is mechanical and the
-/// classification is recorded at the type level now.
+/// carina#3126 PR-B: the loop body declared inside a module must be
+/// expanded *as if it were a module resource* — otherwise its
+/// generated resources collide across module instances and its
+/// iterable resolves against the wrong (unprefixed) binding. Per
+/// field:
+/// - `binding_name` (the generated-resource address prefix, e.g.
+///   `_domain_validation_options`) → instance-prefixed
+///   unconditionally, exactly like `Resource.binding`, so each module
+///   instance's loop resources are uniquely addressed.
+/// - `iterable_binding` (the iterable's root binding, e.g. `cert`) →
+///   instance-prefixed **only when it is a module-internal binding**,
+///   the same caller-collision guard [`rewrite_intra_module_refs`]
+///   applies to a `ResourceRef` head (a caller-provided binding that
+///   coincidentally shares a name must not be prefixed). This is a
+///   deliberate, more-correct divergence from the design doc's PR-B
+///   table (which prescribed an unconditional prefix); see the
+///   per-field comment in the body for why the design's cited
+///   `prefix_wait_binding` mirror is unsafe to copy here.
+/// - `attributes` and `template_resource` → the full module-resource
+///   treatment via [`prefix_module_resource`] / the same
+///   ref-rewrite + arg-substitute + canonicalize as `module.resources`.
+/// - `file`/`line`/`header`/`resource_type`/`iterable_attr`/`binding`
+///   → provenance / display / non-binding / loop-local: pass through.
 fn prefix_deferred_for_expression(
     d: &DeferredForExpression,
-    _instance_prefix: &str,
+    instance_prefix: &str,
+    module_name: &str,
+    intra_module_bindings: &HashSet<String>,
+    argument_values: &HashMap<String, Value>,
 ) -> DeferredForExpression {
     let DeferredForExpression {
         file,
@@ -488,24 +551,61 @@ fn prefix_deferred_for_expression(
         header: header.clone(),
         // provider-qualified type — not a binding
         resource_type: resource_type.clone(),
-        // PR-B: `Value`s may carry ResourceRef/BindingRef into
-        // module-internal bindings — must run rewrite_intra_module_refs
-        // + substitute_arguments like module.resources attributes.
-        attributes: attributes.clone(),
-        // PR-B: generated-resource binding prefix — must
-        // apply_instance_prefix (mirrors Resource.binding prefixing).
-        binding_name: binding_name.clone(),
-        // PR-B: iterable root binding — must apply_instance_prefix
-        // (mirrors prefix_wait_binding's lhs_segments[0] head).
-        iterable_binding: iterable_binding.clone(),
+        // The loop body's attrs may reference module-internal bindings
+        // / module arguments — same shared `prefix_attr_value` the
+        // module resource attrs get.
+        attributes: attributes
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    prefix_attr_value(v, instance_prefix, intra_module_bindings, argument_values),
+                )
+            })
+            .collect(),
+        // Generated-resource address prefix — `binding_name` is a name
+        // the loop *synthesizes* for its own resources (e.g.
+        // `_domain_validation_options`), NOT a reference to a
+        // pre-existing binding, so the caller-collision concern does
+        // not apply: prefix it unconditionally (same as
+        // `Resource.binding`) to isolate each module instance's loop
+        // resources.
+        binding_name: apply_instance_prefix(instance_prefix, binding_name),
+        // Iterable root binding — this IS a reference to an existing
+        // binding (`cert` in `for _, opt in cert.dvo`), so it takes
+        // the same caller-collision guard as a `ResourceRef` head in
+        // `rewrite_intra_module_refs`: prefix only when it names a
+        // module-internal binding. A caller-passed binding that
+        // coincidentally shares the name must NOT be prefixed.
+        //
+        // NB: this is a *deliberate, more-correct* divergence from the
+        // design doc's PR-B table, which prescribed an *unconditional*
+        // prefix "mirroring `prefix_wait_binding`'s lhs_segments[0]".
+        // That mirror is wrong: `prefix_wait_binding` prefixes the
+        // `until` LHS root unconditionally (a known pre-existing
+        // looseness, safe only because that root is virtually always
+        // the module-internal wait/resource binding). Copying it here
+        // would silently break a module that iterates a caller-passed
+        // binding. The `rewrite_intra_module_refs` model is the right
+        // one — do not "simplify" this back to unconditional.
+        iterable_binding: if intra_module_bindings.contains(iterable_binding) {
+            apply_instance_prefix(instance_prefix, iterable_binding)
+        } else {
+            iterable_binding.clone()
+        },
         // attribute path tail — not a binding
         iterable_attr: iterable_attr.clone(),
         // loop-var pattern kind — loop-local, not a module binding
         binding: binding.clone(),
-        // PR-B: full Resource — must get the same treatment as a
-        // module.resources entry (id/binding prefix + ref-rewrite +
-        // arg-substitute + canonicalize).
-        template_resource: template_resource.clone(),
+        // Full module-resource treatment — identical to a
+        // `module.resources` entry.
+        template_resource: prefix_module_resource(
+            template_resource,
+            instance_prefix,
+            module_name,
+            intra_module_bindings,
+            argument_values,
+        ),
     }
 }
 

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -3989,6 +3989,22 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
 
     let module = {
         let mut m = create_module_with_intra_refs();
+        // The loop iterates `cert.domain_validation_options`, so `cert`
+        // must be a real module-internal binding for the
+        // intra-module-conditional prefix to apply (same condition as
+        // `rewrite_intra_module_refs`). Add it so this unit faithfully
+        // models the real `let cert = aws.acm.Certificate { … }` case.
+        m.resources.push(Resource {
+            id: ResourceId::new("acm.Certificate", "cert"),
+            attributes: HashMap::new().into_iter().collect(),
+            kind: ResourceKind::Managed,
+            directives: Directives::default(),
+            prefixes: HashMap::new(),
+            binding: Some("cert".to_string()),
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: std::collections::HashSet::new(),
+        });
         m.deferred_for_expressions.push(DeferredForExpression {
             file: None,
             line: 7,
@@ -4001,7 +4017,22 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
             binding: ForBinding::Map("_".to_string(), "opt".to_string()),
             template_resource: Resource {
                 id: ResourceId::new("route53.RecordSet", "placeholder"),
-                attributes: HashMap::new().into_iter().collect(),
+                attributes: {
+                    // The loop body references the module-internal
+                    // `cert` binding — the part of the template
+                    // treatment that actually SURVIVES materialization
+                    // (`substitute_attrs` does not re-run ref-rewrite).
+                    // PR-B must prefix this to `r.cert` so the
+                    // generated RecordSet wires to the prefixed module
+                    // certificate; without it the loop body silently
+                    // dangles. Round-3 review test gap.
+                    let mut a = IndexMap::new();
+                    a.insert(
+                        "validated_cert".to_string(),
+                        Value::resource_ref("cert".to_string(), "arn".to_string(), vec![]),
+                    );
+                    a
+                },
                 kind: ResourceKind::Managed,
                 directives: Directives::default(),
                 prefixes: HashMap::new(),
@@ -4046,17 +4077,129 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
     let d = &expanded.deferred_for_expressions[0];
     assert_eq!(d.resource_type, "aws.route53.RecordSet");
     assert_eq!(d.iterable_attr, "domain_validation_options");
-    // PR-A contract: binding-name fields pass through *unchanged*
-    // (call instance is "r"). PR-B will instance-prefix these — this
-    // is exactly the assertion PR-B must flip, so it locks PR-A's
-    // pass-through behavior and pre-stages the PR-B boundary.
+    // carina#3126 PR-B: binding-name fields are instance-prefixed so
+    // the loop-generated resources are isolated per module instance
+    // and the iterable resolves against the (now prefixed) module
+    // resource. Call instance is "r".
+    //
+    // `binding_name` is the generated-resource address prefix →
+    // prefixed unconditionally (mirrors `Resource.binding`).
     assert_eq!(
-        d.binding_name, "_domain_validation_options",
-        "PR-A must NOT prefix binding_name (PR-B owes that)"
+        d.binding_name, "r._domain_validation_options",
+        "PR-B must instance-prefix binding_name"
     );
+    // `cert` is a module-internal `let cert` binding → prefixed
+    // (same caller-collision guard `rewrite_intra_module_refs`
+    // applies to a `ResourceRef` head; a caller-shared name would
+    // NOT be prefixed — see prefix_deferred_for_expression).
     assert_eq!(
-        d.iterable_binding, "cert",
-        "PR-A must NOT prefix iterable_binding (PR-B owes that)"
+        d.iterable_binding, "r.cert",
+        "PR-B must instance-prefix the intra-module iterable root"
+    );
+
+    // The part of the template treatment that SURVIVES materialization
+    // (`substitute_attrs` does not re-run ref-rewrite): the loop body's
+    // intra-module ref must be prefixed, and module_source stamped, so
+    // the generated RecordSet wires to the prefixed module certificate.
+    // Round-3 review found this load-bearing path had zero coverage.
+    let validated_cert = d
+        .template_resource
+        .attributes
+        .get("validated_cert")
+        .expect("template attr preserved");
+    match validated_cert {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            assert_eq!(
+                path.binding(),
+                "r.cert",
+                "loop body's intra-module ref must be instance-prefixed"
+            );
+            assert_eq!(path.attribute(), "arn");
+        }
+        other => panic!("expected prefixed ResourceRef, got {other:?}"),
+    }
+    assert!(
+        matches!(
+            d.template_resource.module_source,
+            Some(crate::resource::ModuleSource::Module { ref instance, .. }) if instance == "r"
+        ),
+        "template_resource must carry the module instance source; got: {:?}",
+        d.template_resource.module_source
+    );
+}
+
+/// carina#3126 PR-B negative case: an `iterable_binding` that is NOT a
+/// module-internal binding (a caller-passed / argument binding that
+/// merely shares a name) must **not** be instance-prefixed — the same
+/// caller-collision guard `rewrite_intra_module_refs` applies to a
+/// `ResourceRef` head. This locks the `else` arm of the conditional
+/// and is the safety property the deliberate divergence from the
+/// design's unconditional-prefix table protects. Without this test a
+/// future "simplification" back to unconditional prefixing would pass
+/// CI while silently breaking caller-passed iterables.
+#[test]
+fn deferred_for_iterable_binding_not_prefixed_when_not_module_internal() {
+    use crate::parser::{DeferredForExpression, ForBinding};
+
+    let module = {
+        let mut m = create_module_with_intra_refs();
+        // No module resource/wait is bound `accounts` — it is meant to
+        // come from the caller (e.g. an argument), so it is NOT in
+        // `intra_module_bindings` and must survive unprefixed.
+        m.deferred_for_expressions.push(DeferredForExpression {
+            file: None,
+            line: 3,
+            header: "for _, a in accounts.list".to_string(),
+            resource_type: "awscc.sso.Assignment".to_string(),
+            attributes: vec![],
+            binding_name: "_list".to_string(),
+            iterable_binding: "accounts".to_string(),
+            iterable_attr: "list".to_string(),
+            binding: ForBinding::Map("_".to_string(), "a".to_string()),
+            template_resource: Resource {
+                id: ResourceId::new("sso.Assignment", "placeholder"),
+                attributes: HashMap::new().into_iter().collect(),
+                kind: ResourceKind::Managed,
+                directives: Directives::default(),
+                prefixes: HashMap::new(),
+                binding: None,
+                dependency_bindings: BTreeSet::new(),
+                module_source: None,
+                quoted_string_attrs: std::collections::HashSet::new(),
+            },
+        });
+        m
+    };
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert("net".to_string(), module);
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "net".to_string(),
+        binding_name: Some("prod".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            args.insert(
+                "cidr".to_string(),
+                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+            );
+            args
+        },
+    };
+
+    let expanded = resolver.expand_module_call(&call, "prod", None).unwrap();
+    let d = &expanded.deferred_for_expressions[0];
+    // `binding_name` is a synthesized address prefix → always prefixed.
+    assert_eq!(d.binding_name, "prod._list");
+    // `accounts` is NOT module-internal → must stay UNPREFIXED
+    // (caller-collision guard). A regression to unconditional
+    // prefixing would make this `prod.accounts` and fail here.
+    assert_eq!(
+        d.iterable_binding, "accounts",
+        "a non-module-internal iterable binding must NOT be prefixed"
     );
 }
 
@@ -4141,6 +4284,12 @@ let r = registry {
     let d = &parsed.deferred_for_expressions[0];
     assert_eq!(d.resource_type, "aws.route53.RecordSet");
     assert_eq!(d.iterable_attr, "domain_validation_options");
+    // carina#3126 PR-B: through the full resolve_modules pipeline the
+    // deferred-for's binding-name fields are instance-prefixed (call
+    // binding is `r`), so the loop resolves against the prefixed
+    // module `cert` and its generated resources are instance-scoped.
+    assert_eq!(d.binding_name, "r._domain_validation_options");
+    assert_eq!(d.iterable_binding, "r.cert");
 
     // carina#3061: the module-internal wait binding still survives the
     // same pipeline and is instance-prefixed (the existing invariant,


### PR DESCRIPTION
PR-B of carina#3126 — the user-visible fix. PR-A (#3131, merged) made the module-internal `deferred_for_expressions` survive the module boundary as a pass-through (every field marked `// PR-B:`) and built the single classified merge surface. PR-B instance-prefixes it so a `for` loop declared inside an imported module expands correctly under the module instance.

## Change

`prefix_deferred_for_expression` (was PR-A pass-through):

- **`binding_name`** → unconditional `apply_instance_prefix`. It is a name the loop *synthesizes* for its own generated resources (e.g. `_domain_validation_options`), not a reference to a pre-existing binding — same category as `Resource.binding`; isolates each module instance's loop resources.
- **`iterable_binding`** → prefixed *only when module-internal* (the same caller-collision guard `rewrite_intra_module_refs` applies to a `ResourceRef` head). **Deliberate, more-correct divergence from the design doc's unconditional rule**: the design cited `prefix_wait_binding`'s `lhs_segments[0]` as the mirror, but that is *unconditional* — a known pre-existing looseness, safe only because that root is virtually always module-internal. Copying it here would silently break a module iterating a caller-passed binding. An in-code NB block + a dedicated negative test CI-lock this against a future "simplify to unconditional".
- **`attributes`** + **`template_resource`** → the full module-resource treatment (ref-rewrite + arg-substitute + canonicalize + id/binding prefix + `module_source` stamp).

Extracted `prefix_attr_value` (shared per-attr rewrite→substitute→canonicalize) and `prefix_module_resource` (the `module.resources` expansion), used by *both* the resource loop and the deferred-for template — one definition so the two carriers cannot drift (the exact carina#3126 bug class).

## Scope (not overclaimed)

This `Closes #3126` for its **stated scope**: the module-boundary drop + instance-prefixing. After PR-A+PR-B the real `carina-rs/infra usecases/registry/acm.crn` loop body is visible in `carina validate` and present + correctly instance-prefixed in the parsed tree.

It does **not** yet emit concrete `RecordSet` resources at `carina plan`: `cert.domain_validation_options` is a *same-config provider-read attribute* that never enters `remote_bindings` (which `load_upstream_states` populates exclusively from `upstream_state` data). That same-config read-iterable bridge is the explicitly out-of-scope **carina#3121 B/C** axis — the carina#3126 design doc names it a Non-goal and open Risk. Filed as **#3132**. The `moved.crn` workaround in that stack remains necessary until #3132.

carina-core only (`expander.rs` + `tests.rs`). No carina-cli/lsp/plan/apply/differ change.

## Tests / verification

- Flipped the PR-A pass-through asserts to PR-B prefix expectations — **RED→GREEN proven** (the pass-through produced unprefixed `_domain_validation_options`/`cert` and failed the new asserts).
- Added a **negative test** locking the caller-collision `else` arm (a non-module-internal iterable binding must NOT be prefixed; reverting the conditional to unconditional fails it).
- Added assertions on the **surviving** template treatment (`template_resource.attributes` ref-rewrite to `r.cert` + `module_source` instance) — Round-3 review found this load-bearing path uncovered; RED→GREEN proven by reverting to `.clone()`.
- 3394 workspace tests pass; doctests pass; `cargo clippy --workspace --all-targets -- -D warnings` clean; `check-no-direct-resources-access.sh` / `check-docs-use-new-spellings.sh` clean.
- 5-round self-review completed (Round 2 surfaced and correctly classified the #3132 separate gap; Round 3 closed a test-coverage gap; Rounds 4-5 clean).

Closes #3126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
