### PR TITLE
feat: post-refresh deferred-for expansion + typed iterable view (refs #3132)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 
 use futures::stream::{self, StreamExt};
 
-use carina_core::binding_index::{ResolvedBindings, WaitAliasSpec};
+use carina_core::binding_index::{IterableBindings, ResolvedBindings, WaitAliasSpec};
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
@@ -792,7 +792,14 @@ async fn run_apply_locked(
     // Expand deferred for-expressions now that remote values are available.
     // Must happen BEFORE sort_resources_by_dependencies so expanded resources
     // are included in the sorted set used for planning (#1844).
-    parsed.expand_deferred_for_expressions(&remote_bindings);
+    //
+    // The apply path still expands pre-refresh against upstream-only
+    // bindings (carina#3132 PR-1 is plan-path only; PR-2 moves this to a
+    // post-refresh stage so plan/apply do not diverge on same-config
+    // read iterables).
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(
+        remote_bindings.clone(),
+    ));
 
     // Print warnings after expansion (resolved ones are removed)
     parsed.print_warnings();

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -334,12 +334,10 @@ pub async fn run_plan(
     )
     .await?;
 
-    // Expand deferred for-expressions now that remote values are available
-    parsed.expand_deferred_for_expressions(&remote_bindings);
-
-    // Print warnings after expansion (resolved deferred for-expressions have their warnings removed)
-    parsed.print_warnings();
-
+    // carina#3132: deferred-for expansion runs inside
+    // `create_plan_from_parsed_with_upstream` (post-refresh), which also
+    // prints post-expansion warnings and returns the still-unresolved
+    // loops via `ctx.residual_deferred_for`.
     let ctx = create_plan_from_parsed_with_upstream(
         &parsed,
         &state_file,
@@ -414,7 +412,7 @@ pub async fn run_plan(
             Some(wiring.schemas()),
             &ctx.moved_origins,
             &export_changes,
-            &parsed.deferred_for_expressions,
+            &ctx.residual_deferred_for,
             Some(&ctx.prev_explicit),
         );
     }

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use colored::Colorize;
 use futures::stream::{self, StreamExt};
 
-use carina_core::binding_index::WaitAliasSpec;
+use carina_core::binding_index::{ResolvedBindings, WaitAliasSpec};
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
@@ -51,6 +51,14 @@ pub struct PlanContext {
     /// Forwarded to the display layer so server-side default fields the
     /// user never wrote do not surface in plan output (refs awscc#206).
     pub prev_explicit: HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
+    /// Deferred-for loops still unresolved after the post-refresh
+    /// expansion (carina#3132). The iterable is genuinely unknowable at
+    /// plan time (e.g. depends on a not-yet-created resource); the loop
+    /// legitimately stays deferred and is rendered as the carina#3128
+    /// validate/plan placeholder. Replaces the pre-refresh
+    /// `parsed.deferred_for_expressions` the caller used to pass to
+    /// `print_plan` — expansion no longer mutates `parsed`.
+    pub residual_deferred_for: Vec<carina_core::parser::DeferredForExpression>,
 }
 
 /// Cached provider factories and schemas, constructed once per CLI invocation.
@@ -1117,12 +1125,107 @@ pub async fn create_providers_from_configs(
     Ok((router, ctx))
 }
 
+/// Outcome of the carina#3132 post-refresh deferred-for expansion.
+pub struct DeferredForExpansion {
+    /// The augmented, re-sorted resource set: every original resource
+    /// plus the materialized loop children, topologically ordered.
+    /// Equal in length to the input when no loop resolved.
+    pub sorted_resources: Vec<Resource>,
+    /// Loops still unresolved (iterable genuinely unknowable at plan
+    /// time) — rendered as the carina#3128 validate/plan placeholder.
+    pub residual_deferred_for: Vec<carina_core::parser::DeferredForExpression>,
+    /// Ids of the resources materialized by this expansion (empty when
+    /// no loop resolved). The caller targeted-refreshes exactly these.
+    pub new_child_ids: HashSet<ResourceId>,
+}
+
+/// Pure core of the carina#3132 fix: project the post-refresh
+/// `ResolvedBindings` into the typed iterable view, expand every
+/// deferred-for whose iterable is now resolvable, and re-sort the
+/// augmented set.
+///
+/// `from_resources_with_state` merges local DSL ⊕ refreshed
+/// `current_states` ⊕ `upstream_state`/`wait` bindings, so a same-config
+/// `cert.domain_validation_options` loop and an `upstream_state` loop
+/// resolve through the *identical* view — one resolution point, no
+/// upstream-only carve-out.
+///
+/// Pure (no provider I/O) so it is unit-testable with a hand-built
+/// post-refresh `current_states`; `create_plan_from_parsed_with_upstream`
+/// calls exactly this function, then targeted-refreshes
+/// `new_child_ids`.
+pub fn expand_same_config_deferred_for<E: Clone>(
+    parsed: &carina_core::parser::File<E>,
+    sorted_resources: &[Resource],
+    current_states: &HashMap<ResourceId, State>,
+    remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    wait_aliases: &[WaitAliasSpec],
+) -> Result<DeferredForExpansion, AppError> {
+    // Common case: no deferred-for at all. Skip the binding projection
+    // and the whole-`File` clone entirely (this runs on every plan /
+    // validate). Parse warnings still print — with no deferred-for,
+    // expansion would remove none of them, so `parsed`'s set is exactly
+    // what the post-expansion path would have printed.
+    if parsed.deferred_for_expressions.is_empty() {
+        parsed.print_warnings();
+        return Ok(DeferredForExpansion {
+            sorted_resources: sorted_resources.to_vec(),
+            residual_deferred_for: Vec::new(),
+            new_child_ids: HashSet::new(),
+        });
+    }
+
+    let iterable_bindings = ResolvedBindings::from_resources_with_state(
+        sorted_resources,
+        current_states,
+        remote_bindings,
+        wait_aliases,
+    )
+    .project_iterable_bindings();
+
+    // `expand_deferred_for_expressions` is a `&mut self` method that
+    // appends generated resources and drops resolved entries. `parsed`
+    // is borrowed immutably here, so expand on a local clone and read
+    // the augmented resource set / residual deferred list back out.
+    let mut expanded: carina_core::parser::File<E> = (*parsed).clone();
+    expanded.expand_deferred_for_expressions(&iterable_bindings);
+    expanded.print_warnings();
+    let residual_deferred_for = expanded.deferred_for_expressions.clone();
+
+    let pre_ids: HashSet<ResourceId> = sorted_resources.iter().map(|r| r.id.clone()).collect();
+
+    // A length delta means a loop materialized. Compare against the
+    // input slice length (not the deduped `pre_ids` set) so the test is
+    // a pure "did expansion add resources" check. Re-sort the augmented
+    // set: `topological_sort` preserves declaration order for
+    // independent resources (#1071), so already-planned resources keep
+    // their relative order (carina#3132 re-sort stability requirement)
+    // and the children are slotted in per their refs.
+    let materialized = expanded.resources.len() != sorted_resources.len();
+    let resorted = if materialized {
+        sort_resources_by_dependencies(&expanded.resources).map_err(AppError::Validation)?
+    } else {
+        sorted_resources.to_vec()
+    };
+    let new_child_ids: HashSet<ResourceId> = resorted
+        .iter()
+        .map(|r| r.id.clone())
+        .filter(|id| !pre_ids.contains(id))
+        .collect();
+
+    Ok(DeferredForExpansion {
+        sorted_resources: resorted,
+        residual_deferred_for,
+        new_child_ids,
+    })
+}
+
 /// Create a plan from parsed configuration (without upstream state bindings).
 ///
 /// This is a convenience wrapper around `create_plan_from_parsed_with_upstream`
 /// for callers that don't use upstream_state blocks.
 #[allow(dead_code)]
-pub async fn create_plan_from_parsed<E>(
+pub async fn create_plan_from_parsed<E: Clone>(
     parsed: &carina_core::parser::File<E>,
     state_file: &Option<StateFile>,
     refresh: bool,
@@ -1132,7 +1235,7 @@ pub async fn create_plan_from_parsed<E>(
         .await
 }
 
-pub async fn create_plan_from_parsed_with_upstream<E>(
+pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     parsed: &carina_core::parser::File<E>,
     state_file: &Option<StateFile>,
     refresh: bool,
@@ -1141,7 +1244,13 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
 ) -> Result<PlanContext, AppError> {
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let ctx = WiringContext::new(factories);
-    let sorted_resources =
+    // Mutable: a same-config deferred-for loop is expanded into concrete
+    // resources *after* refresh (carina#3132) and the augmented set is
+    // re-sorted in place below. Every use up to that point sees the
+    // pre-expansion set (the loop's iterable source — e.g. `let cert` —
+    // is a normal top-level resource already here and refreshed by the
+    // normal phase-1 pass; only the loop's generated children are added).
+    let mut sorted_resources =
         sort_resources_by_dependencies(&parsed.resources).map_err(AppError::Validation)?;
 
     // Select appropriate Provider based on configuration
@@ -1212,36 +1321,15 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         // from their dependencies (#1683). Phase 1: managed resources in
         // parallel. Phase 2: data sources whose input attributes have
         // been resolved against phase 1's `current_states`.
-        let phase1_results: Vec<Result<(ResourceId, State), AppError>> = stream::iter(
-            sorted_resources
-                .iter()
-                .filter(|r| !r.is_virtual() && !r.is_data_source()),
+        refresh_resource_set(
+            provider_ref,
+            &multi,
+            sorted_resources.iter(),
+            state_file,
+            &saved_dep_bindings,
+            &mut current_states,
         )
-        .map(|resource| {
-            let progress = RefreshProgress::begin_multi(&multi, &resource.id);
-            let identifier = state_file
-                .as_ref()
-                .and_then(|sf| sf.get_identifier_for_resource(resource));
-            let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
-            async move {
-                let mut state = read_with_retry(provider_ref, &resource.id, identifier.as_deref())
-                    .await
-                    .map_err(AppError::Provider)?;
-                // Restore dependency_bindings from state file (#1565).
-                if let Some(deps) = dep_bindings {
-                    state.dependency_bindings = deps;
-                }
-                progress.finish();
-                Ok((resource.id.clone(), state))
-            }
-        })
-        .buffer_unordered(5)
-        .collect()
-        .await;
-        for result in phase1_results {
-            let (id, state) = result?;
-            current_states.insert(id, state);
-        }
+        .await?;
 
         // Refresh orphaned resources (#844). These are tracked in state
         // but removed from the .crn config — they're looked up by their
@@ -1401,6 +1489,70 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         }
     }
 
+    let wait_aliases: Vec<WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(WaitAliasSpec::from)
+        .collect();
+
+    // carina#3132: expand same-config deferred-for loops after refresh,
+    // against the same post-refresh `ResolvedBindings` view every
+    // non-loop `ResourceRef` resolves against. Pure expand+re-sort is
+    // factored into `expand_same_config_deferred_for` (see its doc);
+    // here we perform the I/O half — targeted-refresh of the children
+    // so a re-plan after they were applied sees their live state
+    // instead of a phantom Create.
+    let DeferredForExpansion {
+        sorted_resources: resorted,
+        residual_deferred_for,
+        new_child_ids,
+    } = expand_same_config_deferred_for(
+        parsed,
+        &sorted_resources,
+        &current_states,
+        remote_bindings,
+        &wait_aliases,
+    )?;
+    sorted_resources = resorted;
+
+    if !new_child_ids.is_empty() {
+        let children = || {
+            sorted_resources
+                .iter()
+                .filter(|r| new_child_ids.contains(&r.id))
+        };
+        if refresh {
+            refresh_resource_set(
+                &provider,
+                &refresh_multi_progress(),
+                children(),
+                state_file,
+                &HashMap::new(),
+                &mut current_states,
+            )
+            .await?;
+            provider
+                .hydrate_read_state(&mut current_states, &saved_attrs)
+                .await;
+        } else if let Some(sf) = state_file.as_ref() {
+            // --refresh=false: restore children's state from the cached
+            // state file, same as the original resources. A child not in
+            // cached state stays `not_found` → Create (mirrors the
+            // non-loop ref's behavior under --refresh=false).
+            for resource in children() {
+                let state = sf.build_state_for_resource(resource);
+                current_states.insert(resource.id.clone(), state);
+            }
+            provider
+                .hydrate_read_state(&mut current_states, &saved_attrs)
+                .await;
+        } else {
+            for resource in children() {
+                current_states.insert(resource.id.clone(), State::not_found(resource.id.clone()));
+            }
+        }
+    }
+
     // Build orphan dependency bindings from state file for tree structure
     let orphan_dependencies = if let Some(sf) = state_file.as_ref() {
         let desired_ids: HashSet<ResourceId> =
@@ -1430,11 +1582,6 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         &parsed.resources,
         ctx.schemas(),
     );
-    let wait_aliases: Vec<WaitAliasSpec> = parsed
-        .wait_bindings
-        .iter()
-        .map(WaitAliasSpec::from)
-        .collect();
     resolve_refs_for_plan(
         &mut resources,
         &current_states,
@@ -1504,6 +1651,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         moved_origins,
         upstream_snapshot: remote_bindings.clone(),
         prev_explicit,
+        residual_deferred_for,
     })
 }
 
@@ -1778,6 +1926,52 @@ pub async fn read_with_retry(
         }
     }
     unreachable!()
+}
+
+/// Refresh a set of managed resources concurrently and merge the
+/// results into `current_states`.
+///
+/// Shared by the phase-1 refresh and the carina#3132 post-expansion
+/// child refresh: same `stream::iter → begin_multi → read_with_retry →
+/// buffer_unordered(5)` pipeline. `saved_dep_bindings` restores
+/// carina-only `dependency_bindings` the provider's `read()` does not
+/// return (#1565); pass an empty map when there is nothing to restore
+/// (the new loop children have no prior state-file dep bindings).
+async fn refresh_resource_set<'a>(
+    provider: &dyn Provider,
+    multi: &indicatif::MultiProgress,
+    resources: impl Iterator<Item = &'a Resource>,
+    state_file: &Option<StateFile>,
+    saved_dep_bindings: &HashMap<ResourceId, BTreeSet<String>>,
+    current_states: &mut HashMap<ResourceId, State>,
+) -> Result<(), AppError> {
+    let results: Vec<Result<(ResourceId, State), AppError>> =
+        stream::iter(resources.filter(|r| !r.is_virtual() && !r.is_data_source()))
+            .map(|resource| {
+                let progress = RefreshProgress::begin_multi(multi, &resource.id);
+                let identifier = state_file
+                    .as_ref()
+                    .and_then(|sf| sf.get_identifier_for_resource(resource));
+                let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
+                async move {
+                    let mut state = read_with_retry(provider, &resource.id, identifier.as_deref())
+                        .await
+                        .map_err(AppError::Provider)?;
+                    if let Some(deps) = dep_bindings {
+                        state.dependency_bindings = deps;
+                    }
+                    progress.finish();
+                    Ok((resource.id.clone(), state))
+                }
+            })
+            .buffer_unordered(5)
+            .collect()
+            .await;
+    for result in results {
+        let (id, state) = result?;
+        current_states.insert(id, state);
+    }
+    Ok(())
 }
 
 /// Read a data source resource via the provider with retry on throttling errors.

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -1324,3 +1324,366 @@ mod read_with_retry_identifier_tests {
         assert_eq!(calls[0].1.as_deref(), Some("AROABC123"));
     }
 }
+
+// ---------------------------------------------------------------------
+// carina#3132 PR-1: `expand_same_config_deferred_for` — the pure
+// post-refresh expansion the plan path calls. Tested with a hand-built
+// post-refresh `current_states` (the documented refresh-phase output);
+// `create_plan_from_parsed_with_upstream` invokes this exact function,
+// so this is the real plan-path expansion, not a transform in
+// isolation (cf. MEMORY "unit-test path ≠ apply path").
+//
+// `--refresh=false` needs no dedicated case here: the pure function is
+// refresh-agnostic (it expands against whatever `current_states` it is
+// given — cached-state and live-refresh are the same input shape, both
+// covered below). The only refresh-specific code is the child-state
+// restore in `create_plan_from_parsed_with_upstream`, which routes the
+// new children through the *same* `sf.build_state_for_resource` /
+// `State::not_found` path the original resources already use under
+// `--refresh=false` (via the shared `children()` filter).
+// ---------------------------------------------------------------------
+mod expand_same_config_deferred_for_tests {
+    use super::*;
+    use carina_core::binding_index::WaitAliasSpec;
+    use carina_core::parser::{ProviderContext, parse};
+    use carina_core::resource::{ConcreteValue, State, Value};
+    use std::collections::HashMap;
+
+    /// `let cert` (same-config) + a `for` over its provider-read
+    /// `account_ids`, plus a plain independent resource so re-sort
+    /// stability has something to preserve order against.
+    ///
+    /// The loop body uses the **bare** loop variable (`target = id`),
+    /// the shape the deferred-for substitution machinery supports
+    /// today. Chained loop-var field access (`opt.resource_record.name`)
+    /// is a *separate, pre-existing* unsupported case — see
+    /// `chained_loop_var_field_access_is_a_known_limitation` below — and
+    /// is out of PR-1 scope (the design's "Changing the deferred-for
+    /// parse" non-goal).
+    const SRC: &str = r#"
+        let cert = aws.acm.Certificate {
+            domain_name       = "registry.example.com"
+            validation_method = "DNS"
+        }
+
+        aws.ec2.Vpc {
+            name       = "anchor"
+            cidr_block = "10.0.0.0/16"
+        }
+
+        for (_, id) in cert.account_ids {
+            aws.sso.Assignment {
+                instance_arn = "arn:aws:sso:::instance/ssoins-1"
+                target_id    = id
+                target_type  = "AWS_ACCOUNT"
+            }
+        }
+    "#;
+
+    /// Build `current_states` as the refresh phase would: the parsed
+    /// `cert` resource's own id → an existing State carrying the
+    /// provider-read list attribute the loop iterates.
+    fn states_with_cert(
+        parsed: &ParsedFile,
+        attr: &str,
+        value: Value,
+    ) -> HashMap<ResourceId, State> {
+        let cert = parsed
+            .resources
+            .iter()
+            .find(|r| r.binding.as_deref() == Some("cert"))
+            .expect("parsed cert resource");
+        let mut attrs = HashMap::new();
+        attrs.insert(attr.to_string(), value);
+        let mut states = HashMap::new();
+        states.insert(cert.id.clone(), State::existing(cert.id.clone(), attrs));
+        states
+    }
+
+    fn account_ids() -> Value {
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("111111111111".into())),
+            Value::Concrete(ConcreteValue::String("222222222222".into())),
+        ]))
+    }
+
+    #[test]
+    fn same_config_read_iterable_materializes_in_plan_resources() {
+        let parsed = parse(SRC, &ProviderContext::default()).expect("parse");
+        assert_eq!(
+            parsed.deferred_for_expressions.len(),
+            1,
+            "loop must be deferred at parse time (iterable is a same-config provider-read)"
+        );
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+        let states = states_with_cert(&parsed, "account_ids", account_ids());
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+        )
+        .expect("expand");
+
+        let assignments: Vec<_> = out
+            .sorted_resources
+            .iter()
+            .filter(|r| r.id.resource_type.contains("Assignment"))
+            .collect();
+        assert_eq!(
+            assignments.len(),
+            2,
+            "one concrete Assignment per cert.account_ids entry; got {:?}",
+            out.sorted_resources
+                .iter()
+                .map(|r| r.id.to_string())
+                .collect::<Vec<_>>()
+        );
+
+        // The bare loop variable must be substituted from the
+        // *refreshed* cert value — proving the post-refresh
+        // ResolvedBindings view (not the empty pre-refresh map) fed the
+        // expansion. This is the carina#3132 fix.
+        let mut targets: Vec<String> = assignments
+            .iter()
+            .filter_map(|r| match r.get_attr("target_id") {
+                Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        targets.sort();
+        assert_eq!(
+            targets,
+            vec!["111111111111".to_string(), "222222222222".to_string()],
+            "target_id must be substituted from the refreshed \
+             cert.account_ids entries"
+        );
+
+        assert!(
+            out.residual_deferred_for.is_empty(),
+            "resolved loop must leave no residual; got {:?}",
+            out.residual_deferred_for
+        );
+    }
+
+    #[test]
+    fn resort_preserves_pre_expansion_relative_order() {
+        // carina#3132 highest-risk requirement: appending loop children
+        // and re-sorting must not reorder already-planned resources
+        // (SimHash / moved-matching stability).
+        let parsed = parse(SRC, &ProviderContext::default()).expect("parse");
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+        let pre_order: Vec<String> = sorted.iter().map(|r| r.id.to_string()).collect();
+        let states = states_with_cert(&parsed, "account_ids", account_ids());
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+        )
+        .expect("expand");
+
+        let post_filtered: Vec<String> = out
+            .sorted_resources
+            .iter()
+            .map(|r| r.id.to_string())
+            .filter(|id| pre_order.contains(id))
+            .collect();
+        assert_eq!(
+            post_filtered, pre_order,
+            "re-sort must preserve the relative order of already-planned resources"
+        );
+        // The two materialized Assignment children — and only those —
+        // are reported as new (none of the pre-expansion ids leak in).
+        assert_eq!(
+            out.new_child_ids.len(),
+            2,
+            "new_child_ids must be exactly the materialized loop children"
+        );
+        assert!(
+            out.new_child_ids
+                .iter()
+                .all(|id| !pre_order.contains(&id.to_string())),
+            "new_child_ids must not include any pre-expansion resource"
+        );
+    }
+
+    #[test]
+    fn unresolvable_iterable_stays_deferred_no_misexpansion() {
+        // No cert state → iterable genuinely unknowable. The loop must
+        // stay in residual (carina#3128 placeholder), NOT mis-expand.
+        let parsed = parse(SRC, &ProviderContext::default()).expect("parse");
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+        let empty_states: HashMap<ResourceId, State> = HashMap::new();
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &empty_states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+        )
+        .expect("expand");
+
+        assert!(
+            out.sorted_resources
+                .iter()
+                .all(|r| !r.id.resource_type.contains("Assignment")),
+            "no Assignment may materialize without a resolvable iterable"
+        );
+        assert_eq!(
+            out.residual_deferred_for.len(),
+            1,
+            "the unresolvable loop must remain deferred so the validate/\
+             plan placeholder still renders"
+        );
+        assert_eq!(
+            out.sorted_resources.len(),
+            sorted.len(),
+            "resource set unchanged when nothing materialized"
+        );
+    }
+
+    #[test]
+    fn upstream_state_iterable_still_expands_via_unified_view() {
+        // Regression guard: the pre-existing `upstream_state` iterable
+        // path must keep working now that it flows through the same
+        // projected ResolvedBindings (design non-goal: must not regress
+        // the upstream path).
+        let src = r#"
+            let orgs = upstream_state {
+                source = "../organizations"
+            }
+
+            for account_id in orgs.accounts {
+                awscc.sso.Assignment {
+                    instance_arn = 'arn:aws:sso:::instance/ssoins-1'
+                    target_id    = account_id
+                    target_type  = 'AWS_ACCOUNT'
+                }
+            }
+        "#;
+        let parsed = parse(src, &ProviderContext::default()).expect("parse");
+        assert_eq!(parsed.deferred_for_expressions.len(), 1);
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert(
+            "accounts".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("111111111111".to_string())),
+                Value::Concrete(ConcreteValue::String("222222222222".to_string())),
+            ])),
+        );
+        let mut remote = HashMap::new();
+        remote.insert("orgs".to_string(), orgs_attrs);
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &HashMap::new(),
+            &remote,
+            &[] as &[WaitAliasSpec],
+        )
+        .expect("expand");
+
+        let assignments = out
+            .sorted_resources
+            .iter()
+            .filter(|r| r.id.resource_type.contains("Assignment"))
+            .count();
+        assert_eq!(
+            assignments, 2,
+            "upstream_state iterable must still expand via the unified view"
+        );
+        assert!(out.residual_deferred_for.is_empty());
+    }
+
+    #[test]
+    fn chained_loop_var_field_access_is_a_known_limitation() {
+        // Chained field access on the loop variable
+        // (`opt.resource_record.name`) is stored as a
+        // `ResourceRef { binding: "opt", .. }`, which
+        // `substitute_placeholder` never replaces (only the bare
+        // `ForValue` is). The loop materializes but its attributes stay
+        // unresolved. Pre-existing limitation, tracked in carina#3136;
+        // PR-1 is necessary but not sufficient for #3132's real-infra
+        // acceptance. This pins current behavior so #3136's fix has a
+        // regression target and PR-3 does not silently fail.
+        let src = r#"
+            let cert = aws.acm.Certificate {
+                domain_name       = "r.example.com"
+                validation_method = "DNS"
+            }
+
+            for (_, opt) in cert.domain_validation_options {
+                aws.route53.RecordSet {
+                    name             = opt.resource_record.name
+                    type             = "CNAME"
+                    resource_records = [opt.resource_record.value]
+                }
+            }
+        "#;
+        let parsed = parse(src, &ProviderContext::default()).expect("parse");
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+
+        let mut rr = indexmap::IndexMap::new();
+        rr.insert(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("_a1.r.example.com".into())),
+        );
+        rr.insert(
+            "value".to_string(),
+            Value::Concrete(ConcreteValue::String("_a1.acm-validations.aws.".into())),
+        );
+        let mut entry = indexmap::IndexMap::new();
+        entry.insert(
+            "resource_record".to_string(),
+            Value::Concrete(ConcreteValue::Map(rr)),
+        );
+        let dvo = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(entry),
+        )]));
+        let states = states_with_cert(&parsed, "domain_validation_options", dvo);
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+        )
+        .expect("expand");
+
+        let record_sets: Vec<_> = out
+            .sorted_resources
+            .iter()
+            .filter(|r| r.id.resource_type.contains("RecordSet"))
+            .collect();
+        // The loop DOES materialize (PR-1's expansion+re-sort works) ...
+        assert_eq!(
+            record_sets.len(),
+            1,
+            "loop still materializes one RecordSet (expansion itself works)"
+        );
+        // ... but the chained loop-var ref is NOT substituted yet: this
+        // is the tracked limitation. When the follow-up lands, flip this
+        // assertion to expect the concrete String.
+        let name = record_sets[0].get_attr("name");
+        assert!(
+            matches!(
+                name,
+                Some(Value::Deferred(
+                    carina_core::resource::DeferredValue::ResourceRef { .. }
+                ))
+            ),
+            "KNOWN LIMITATION: chained loop-var field access stays an \
+             unresolved ResourceRef (tracked follow-up); got {:?}",
+            name
+        );
+    }
+}

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -560,6 +560,69 @@ impl ResolvedBindings {
             },
         );
     }
+
+    /// Project this resolved view into the [`IterableBindings`] a
+    /// deferred-for expansion consumes.
+    ///
+    /// Every entry's merged attribute map (local DSL ⊕ refreshed state,
+    /// with upstream and wait-alias entries already folded in by
+    /// [`Self::from_resources_with_state`]) is exposed under its binding
+    /// name. This is the *only* same-config-aware constructor of
+    /// `IterableBindings`: a deferred-for iterable resolves against the
+    /// exact post-refresh view every non-loop `ResourceRef` resolves
+    /// against (carina#3132 — one resolution timing, no upstream-only
+    /// carve-out). The projection is a verbatim clone of the merged
+    /// maps; no new join logic.
+    pub fn project_iterable_bindings(&self) -> IterableBindings {
+        IterableBindings {
+            by_binding: self
+                .by_name
+                .iter()
+                .map(|(name, rb)| (name.clone(), rb.attributes.clone()))
+                .collect(),
+        }
+    }
+}
+
+/// The set of every binding a deferred-for iterable may legally
+/// reference: same-config `let` resources (post-refresh), `upstream_state`
+/// data, and `wait` aliases — all merged.
+///
+/// Exists as a distinct newtype, rather than a bare
+/// `HashMap<String, HashMap<String, Value>>`, so the input to
+/// [`File::expand_deferred_for_expressions`] *names* its contract. Before
+/// carina#3132 the expander took the raw map and the only caller passed
+/// the upstream-only `remote_bindings`; a same-config `let cert`'s
+/// refreshed `domain_validation_options` was therefore never in scope and
+/// the loop stayed deferred forever. Routing construction through
+/// [`ResolvedBindings::project_iterable_bindings`] (the merged view) —
+/// or the explicitly-named [`Self::from_upstream_only`] for the
+/// upstream-only unit tests — makes "iterable resolved against the wrong
+/// map" unrepresentable.
+#[derive(Debug, Default, Clone)]
+pub struct IterableBindings {
+    by_binding: HashMap<String, HashMap<String, Value>>,
+}
+
+impl IterableBindings {
+    /// Construct from an upstream-only binding map.
+    ///
+    /// Named to make the upstream-only nature explicit at the call site:
+    /// the runtime plan/apply paths must use
+    /// [`ResolvedBindings::project_iterable_bindings`] so same-config
+    /// `let` reads are in scope. This constructor exists for the
+    /// carina-core parser tests that exercise the `upstream_state`
+    /// iterable path with hand-built bindings.
+    pub fn from_upstream_only(remote_bindings: HashMap<String, HashMap<String, Value>>) -> Self {
+        Self {
+            by_binding: remote_bindings,
+        }
+    }
+
+    /// Resolve a binding's attribute map (the iterable's source).
+    pub fn get(&self, binding: &str) -> Option<&HashMap<String, Value>> {
+        self.by_binding.get(binding)
+    }
 }
 
 #[cfg(test)]

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -6,6 +6,7 @@ use super::error::ParseWarning;
 use super::expressions::for_expr::ForBinding;
 use super::expressions::validate_expr::CompareOp;
 use super::util::snake_to_pascal;
+use crate::binding_index::IterableBindings;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, UnknownReason, Value};
 use crate::version_constraint::VersionConstraint;
 use indexmap::IndexMap;
@@ -829,17 +830,23 @@ impl<E> File<E> {
         }
     }
 
-    /// Expand deferred for-expressions using loaded upstream_state bindings.
+    /// Expand deferred for-expressions against the resolved binding view.
     ///
     /// For each deferred for-expression whose iterable can now be resolved
-    /// from `remote_bindings`, expand the template into concrete resources
-    /// and add them to `self.resources`. Resolved entries are removed from
+    /// from `bindings`, expand the template into concrete resources and
+    /// add them to `self.resources`. Resolved entries are removed from
     /// `deferred_for_expressions`; unresolved ones remain (with their
     /// warning preserved).
-    pub fn expand_deferred_for_expressions(
-        &mut self,
-        remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    ) {
+    ///
+    /// `bindings` is an [`IterableBindings`]: every binding an iterable
+    /// may reference — same-config `let` resources (post-refresh),
+    /// `upstream_state` data, and `wait` aliases — merged into one view.
+    /// Taking the typed view rather than the raw upstream-only map is the
+    /// carina#3132 fix: a same-config `let cert` read iterable
+    /// (`for _, opt in cert.domain_validation_options`) is in scope here
+    /// only because the caller projects the post-refresh
+    /// [`crate::binding_index::ResolvedBindings`] in.
+    pub fn expand_deferred_for_expressions(&mut self, bindings: &IterableBindings) {
         let mut expanded_resources = Vec::new();
         let mut resolved_indices = Vec::new();
         // Indices where the iterable resolved but had the wrong shape. These
@@ -850,8 +857,8 @@ impl<E> File<E> {
         let mut new_warnings: Vec<ParseWarning> = Vec::new();
 
         for (idx, deferred) in self.deferred_for_expressions.iter().enumerate() {
-            // Look up the iterable value in remote_bindings
-            let iterable = remote_bindings
+            // Look up the iterable value in the merged binding view
+            let iterable = bindings
                 .get(&deferred.iterable_binding)
                 .and_then(|attrs| attrs.get(&deferred.iterable_attr));
 

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::binding_index::IterableBindings;
 use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, Resource, Value};
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -7171,7 +7172,7 @@ fn expand_deferred_for_with_remote_bindings() {
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
     // Expand deferred for-expressions
-    parsed.expand_deferred_for_expressions(&remote_bindings);
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote_bindings));
 
     // Deferred should be resolved
     assert_eq!(
@@ -7233,7 +7234,7 @@ fn expand_deferred_for_no_remote_data_stays_deferred() {
 
     // Empty remote_bindings — upstream hasn't been applied yet
     let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
-    parsed.expand_deferred_for_expressions(&remote_bindings);
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote_bindings));
 
     // Should remain deferred
     assert_eq!(
@@ -7281,7 +7282,7 @@ fn expand_deferred_for_map_binding_substitutes_key_and_value() {
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-    parsed.expand_deferred_for_expressions(&remote_bindings);
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote_bindings));
 
     assert_eq!(parsed.deferred_for_expressions.len(), 0);
     assert_eq!(parsed.resources.len(), 2); // allow: direct — fixture test inspection
@@ -7341,7 +7342,7 @@ fn expand_deferred_for_indexed_binding_substitutes_index_and_value() {
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-    parsed.expand_deferred_for_expressions(&remote_bindings);
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote_bindings));
 
     assert_eq!(parsed.resources.len(), 2); // allow: direct — fixture test inspection
     assert_eq!(
@@ -7398,7 +7399,7 @@ fn expand_deferred_for_substitutes_placeholder_inside_interpolation() {
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-    parsed.expand_deferred_for_expressions(&remote_bindings);
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote_bindings));
     assert_eq!(parsed.resources.len(), 1); // allow: direct — fixture test inspection
 
     // label must have the placeholder substituted in the interpolation.
@@ -7488,7 +7489,7 @@ fn expand_deferred_for_simple_binding_with_map_iterable_warns() {
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-    parsed.expand_deferred_for_expressions(&remote_bindings);
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote_bindings));
 
     assert_eq!(
         parsed.resources.len(), // allow: direct — fixture test inspection
@@ -7535,7 +7536,7 @@ fn expand_deferred_for_map_binding_with_list_iterable_warns() {
     );
     remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-    parsed.expand_deferred_for_expressions(&remote_bindings);
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote_bindings));
 
     // Mismatch: should NOT expand silently with numeric indices
     assert_eq!(


### PR DESCRIPTION
## Summary

carina#3132 **PR-1** (plan path), implementing the merged design #3134 (Shape 3). A `for` loop whose iterable is a **same-config** provider-read attribute — `for (_, opt) in cert.domain_validation_options` where `let cert = ...` is in the same configuration — now **materializes into concrete resources at `carina plan`** instead of staying deferred forever.

Before this PR, `expand_deferred_for_expressions` ran *before* refresh against the upstream-only `remote_bindings` map, so a same-config `let cert`'s refreshed `domain_validation_options` was never in scope. This PR deletes that pre-refresh call and runs expansion *after* refresh against the **same** post-refresh `ResolvedBindings` view every non-loop `ResourceRef` resolves against — one resolution timing, no upstream-only carve-out.

## Changes

- **carina-core** (`binding_index.rs`): `IterableBindings` newtype + `ResolvedBindings::project_iterable_bindings()`. `expand_deferred_for_expressions` now takes `&IterableBindings` instead of a bare upstream-only `&HashMap` — the typed input makes "iterable resolved against the wrong map" (the bug class that produced #3132) unrepresentable. `IterableBindings::from_upstream_only` is the explicitly-named ctor for the carina-core parser tests; their ~7 call sites were mechanically migrated.
- **carina-cli** (`wiring/mod.rs`): deleted the pre-refresh `plan.rs` expansion call. Added the pure `expand_same_config_deferred_for` (project → expand → re-sort), called *post-refresh* inside `create_plan_from_parsed_with_upstream`, which then targeted-refreshes only the materialized children through the same `read_with_retry` path phase 1 uses. Residual unresolved loops flow to `print_plan` via `PlanContext.residual_deferred_for`. Extracted a shared `refresh_resource_set` helper (phase-1 + child refresh share it — no 4th near-duplicate of the stream pattern). An `is_empty()` early-return skips the binding projection and whole-`File` clone entirely when there is no deferred-for (the common path, every plan/validate).
- **apply path** is unchanged behaviorally — still pre-refresh upstream-only (wrapped to compile). **PR-2 owes the apply parity move** so plan/apply do not diverge.

## Tests

`carina-cli/src/wiring/tests.rs::expand_same_config_deferred_for_tests` — the pure function is the exact one the plan path calls, exercised with a hand-built post-refresh `current_states` (the documented refresh-phase output), not a transform in isolation:

1. **materializes** — same-config read iterable produces concrete resources; the loop var is substituted from the *refreshed* value (proves the post-refresh view fed expansion).
2. **re-sort stability** — the design's highest-risk item: already-planned resources keep their relative order; only the new children are reported.
3. **unresolvable stays deferred** — no mis-expansion; the carina#3128 placeholder still renders.
4. **upstream_state regression guard** — the pre-existing upstream path still expands via the unified view (design non-goal: must not regress it).
5. **chained-loop-var-ref limitation pin** — see below.

## Known limitation (discovered during implementation) — carina#3136

The real `carina-rs/infra` registry case uses a **chained** field access on the loop variable (`name = opt.resource_record.name`). `substitute_placeholder` only replaces the *bare* `ForValue` placeholder, never a loop-var `ResourceRef`, so the loop materializes but those attributes stay unresolved. This is a **pre-existing** limitation (every existing deferred-for test used a bare loop var) and the design's explicit "Changing the deferred-for parse" non-goal. **PR-1 is necessary but not sufficient to close #3132's real-infra acceptance (PR-3)**; the gap is filed and tracked as **carina#3136** and pinned by a regression test so PR-3 does not silently fail.

## Verify

- 3399 workspace nextest tests pass; 11 doctest groups ok
- clippy `-D warnings` clean (workspace, all targets); rustfmt clean
- all 5 `scripts/check-*.sh` pass
- 5-round self-review: 3 issues found and fixed (print_warnings regression on the no-deferred-for path; length-comparison robustness; `--refresh=false` coverage rationale)

refs #3132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
