### PR TITLE
fix: resolve field access on struct/map for-loop variables (Closes #3136)

### DIFF
--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -1353,13 +1353,11 @@ mod expand_same_config_deferred_for_tests {
     /// `account_ids`, plus a plain independent resource so re-sort
     /// stability has something to preserve order against.
     ///
-    /// The loop body uses the **bare** loop variable (`target = id`),
-    /// the shape the deferred-for substitution machinery supports
-    /// today. Chained loop-var field access (`opt.resource_record.name`)
-    /// is a *separate, pre-existing* unsupported case — see
-    /// `chained_loop_var_field_access_is_a_known_limitation` below — and
-    /// is out of PR-1 scope (the design's "Changing the deferred-for
-    /// parse" non-goal).
+    /// The loop body uses the **bare** loop variable (`target = id`).
+    /// Chained loop-var field access (`opt.resource_record.name`) is
+    /// covered separately by
+    /// `chained_loop_var_field_access_resolves_post_expansion` below
+    /// (carina#3136).
     const SRC: &str = r#"
         let cert = aws.acm.Certificate {
             domain_name       = "registry.example.com"
@@ -1604,16 +1602,14 @@ mod expand_same_config_deferred_for_tests {
     }
 
     #[test]
-    fn chained_loop_var_field_access_is_a_known_limitation() {
-        // Chained field access on the loop variable
-        // (`opt.resource_record.name`) is stored as a
-        // `ResourceRef { binding: "opt", .. }`, which
-        // `substitute_placeholder` never replaces (only the bare
-        // `ForValue` is). The loop materializes but its attributes stay
-        // unresolved. Pre-existing limitation, tracked in carina#3136;
-        // PR-1 is necessary but not sufficient for #3132's real-infra
-        // acceptance. This pins current behavior so #3136's fix has a
-        // regression target and PR-3 does not silently fail.
+    fn chained_loop_var_field_access_resolves_post_expansion() {
+        // carina#3136 (the flipped carina#3132 PR-1 limitation pin):
+        // chained field access on the loop variable
+        // (`opt.resource_record.name`) is parsed to
+        // `Unknown(ForValuePath { path })` and re-navigated against the
+        // real element by `substitute_placeholder` at for-expansion.
+        // The loop materializes AND its attributes resolve to concrete
+        // values — this is the carina#3132 PR-3 real-registry shape.
         let src = r#"
             let cert = aws.acm.Certificate {
                 domain_name       = "r.example.com"
@@ -1664,26 +1660,30 @@ mod expand_same_config_deferred_for_tests {
             .iter()
             .filter(|r| r.id.resource_type.contains("RecordSet"))
             .collect();
-        // The loop DOES materialize (PR-1's expansion+re-sort works) ...
         assert_eq!(
             record_sets.len(),
             1,
-            "loop still materializes one RecordSet (expansion itself works)"
+            "loop materializes one RecordSet per domain_validation_options entry"
         );
-        // ... but the chained loop-var ref is NOT substituted yet: this
-        // is the tracked limitation. When the follow-up lands, flip this
-        // assertion to expect the concrete String.
-        let name = record_sets[0].get_attr("name");
-        assert!(
-            matches!(
-                name,
-                Some(Value::Deferred(
-                    carina_core::resource::DeferredValue::ResourceRef { .. }
-                ))
-            ),
-            "KNOWN LIMITATION: chained loop-var field access stays an \
-             unresolved ResourceRef (tracked follow-up); got {:?}",
-            name
+        // carina#3136: the chained loop-var ref is now substituted from
+        // the real refreshed element — `name` is the concrete String,
+        // not an unresolved ResourceRef.
+        assert_eq!(
+            record_sets[0].get_attr("name"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "_a1.r.example.com".into()
+            ))),
+            "name must resolve to the refreshed \
+             cert.domain_validation_options[0].resource_record.name"
+        );
+        // And the nested access inside a list literal
+        // (`resource_records = [opt.resource_record.value]`) resolves too.
+        assert_eq!(
+            record_sets[0].get_attr("resource_records"),
+            Some(&Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("_a1.acm-validations.aws.".into()))
+            ]))),
+            "resource_records[0] must resolve to ...resource_record.value"
         );
     }
 }

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -222,6 +222,9 @@ fn deterministic_value_string(value: &Value) -> String {
                 UnknownReason::ForKey => "Unknown(ForKey)".to_string(),
                 UnknownReason::ForIndex => "Unknown(ForIndex)".to_string(),
                 UnknownReason::ForValue => "Unknown(ForValue)".to_string(),
+                UnknownReason::ForValuePath { path } => {
+                    format!("Unknown(ForValuePath({}))", path.to_dot_string())
+                }
                 UnknownReason::EmptyInterpolation => "Unknown(EmptyInterpolation)".to_string(),
             }
         }

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -1000,6 +1000,19 @@ pub(super) fn substitute_placeholder(
         Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)) => {
             *v = value.clone();
         }
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath { path })) => {
+            // carina#3136: a field access on the loop variable
+            // (`opt.resource_record.name`). The element is now known
+            // (`value`); re-navigate it along the remembered path via
+            // the *same* navigator the parse-time resolved case uses
+            // (single source of truth). If it does not navigate (the
+            // element genuinely lacks that path), leave the placeholder
+            // so the existing "unresolved" surfacing applies rather
+            // than silently substituting a wrong value.
+            if let Some(resolved) = crate::resource::navigate_value_path(value, path) {
+                *v = resolved;
+            }
+        }
         Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)) => {
             if let Some(k) = key {
                 *v = Value::Concrete(ConcreteValue::String(k.to_string()));

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -12,8 +12,61 @@ use crate::parser::{
     ParseContext, ParseError, Rule, evaluate_user_function, extract_key_string, first_inner,
     is_static_value, next_pair, parse_block_contents, parse_expression, parse_expression_eval,
 };
-use crate::resource::{AccessPath, ConcreteValue, DeferredValue, PathSegment, Subscript, Value};
+use crate::resource::{
+    AccessPath, ConcreteValue, DeferredValue, PathSegment, Subscript, UnknownReason, Value,
+};
 use indexmap::IndexMap;
+
+/// Resolve a field-access path rooted at a **bound variable** (a
+/// `for`-loop value var, a `let`-of-struct), shared by the two parser
+/// entry points that can reach one (carina#3136). Returns:
+///
+/// - `Some(resolved)` — the variable is a concrete tree and the path
+///   navigates: the real nested value (resolved-for-loop / struct let).
+/// - `Some(ForValuePath)` — the variable is the deferred-for `ForValue`
+///   placeholder (element not yet known): the path-carrying loop-var
+///   placeholder, re-navigated post-expansion by
+///   `substitute_placeholder`.
+/// - `None` — bound, concrete, but the path does not navigate (a
+///   scalar, or a genuine key/shape miss). The caller applies its own
+///   miss policy (scalar diagnostic vs. legacy `ResourceRef`); the two
+///   call sites genuinely differ there, everything above is identical
+///   and must not drift (the plan-path symmetry this fix exists for).
+///
+/// The deferred-for template binds the value var to exactly the bare
+/// `ForValue` placeholder (`for_expr.rs`), so the placeholder test is a
+/// direct match, not a tree walk.
+fn resolve_bound_var_field_access(bound: &Value, path: &AccessPath) -> Option<EvalValue> {
+    if let Some(v) = crate::resource::navigate_value_path(bound, path) {
+        return Some(EvalValue::from_value(v));
+    }
+    if matches!(
+        bound,
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue))
+    ) {
+        return Some(EvalValue::from_value(Value::Deferred(
+            DeferredValue::Unknown(UnknownReason::ForValuePath { path: path.clone() }),
+        )));
+    }
+    None
+}
+
+/// True when `bound` is a scalar value, where field access
+/// (`s.foo` on `let s = "x"`) is genuinely meaningless — the domain of
+/// the Site B "not a resource" diagnostic.
+fn is_scalar_value(bound: &Value) -> bool {
+    matches!(
+        bound,
+        Value::Concrete(
+            ConcreteValue::String(_)
+                | ConcreteValue::Int(_)
+                | ConcreteValue::Float(_)
+                | ConcreteValue::Bool(_)
+                | ConcreteValue::Duration(_)
+                | ConcreteValue::EnumIdentifier(_)
+        )
+    )
+}
 
 /// Decode a duration literal (`75min`, `1h`, `30s`) into integer
 /// seconds.
@@ -145,17 +198,40 @@ fn parse_namespaced_id_value(
         return Ok(as_resource_ref(trailing_segments));
     }
 
-    if parts.len() == 2
-        && ctx.get_variable(parts[0]).is_some()
+    // carina#3136: `parts[0]` is a bound variable that is not a
+    // resource binding. Field access on a *scalar* variable
+    // (`let s = "x"; s.foo`) is genuinely meaningless → keep the
+    // error. But a struct/map-valued `for`-loop value variable
+    // (`for (_, o) in [{k=…}] { … o.k }`) is legitimate navigation:
+    // route it through the same navigator Site A uses.
+    if let Some(crate::eval_value::EvalValue::User(bound)) = ctx.get_variable(parts[0])
         && !ctx.is_resource_binding(parts[0])
     {
-        return Err(ParseError::InvalidExpression {
-            line: 0,
-            message: format!(
-                "'{}' is not a resource, cannot access attribute '{}'",
-                parts[0], parts[1]
-            ),
-        });
+        let mut segments: Vec<PathSegment> = parts[2..]
+            .iter()
+            .map(|s| PathSegment::Field {
+                name: (*s).to_string(),
+            })
+            .collect();
+        segments.extend(trailing_segments.clone());
+        let path = AccessPath::with_segments(parts[0].to_string(), parts[1].to_string(), segments);
+        if let Some(ev) = resolve_bound_var_field_access(bound, &path) {
+            return Ok(ev);
+        }
+        // Miss. A scalar can't have fields — the original user error.
+        if is_scalar_value(bound) {
+            return Err(ParseError::InvalidExpression {
+                line: 0,
+                message: format!(
+                    "'{}' is not a resource, cannot access attribute '{}'",
+                    parts[0], parts[1]
+                ),
+            });
+        }
+        // Non-scalar bound value whose path did not navigate (genuine
+        // key/shape miss): keep the legacy `ResourceRef` so existing
+        // scope/typo diagnostics still surface it.
+        return Ok(as_resource_ref(trailing_segments));
     }
 
     // Dotted IDs that aren't an enum shorthand are binding refs; emit
@@ -489,14 +565,34 @@ pub(crate) fn parse_primary_eval(
                 } else {
                     let attribute_name = field_names.remove(0);
                     let path = AccessPath::with_fields_and_subscripts(
-                        binding_name,
+                        binding_name.clone(),
                         attribute_name,
                         field_names,
                         subscripts,
                     );
-                    Ok(EvalValue::from_value(Value::Deferred(
-                        DeferredValue::ResourceRef { path },
-                    )))
+                    // carina#3136: field access on a bound **variable**
+                    // (a `for`-loop value var, a `let`-of-struct) is
+                    // not a resource reference. The no-field arm above
+                    // already consults `get_variable`; this arm must
+                    // too, or `o.rr.name` escapes as a
+                    // `ResourceRef{binding:o}` no resolver can resolve
+                    // (a loop var is never a `ResolvedBindings` entry).
+                    // A non-variable head is a genuine resource binding
+                    // (`cert.domain_validation_options`) and a miss on a
+                    // bound var falls back to `ResourceRef` so existing
+                    // scope/typo diagnostics still surface — Site A has
+                    // no scalar-error arm (its no-field sibling already
+                    // guards scalars upstream).
+                    if let Some(crate::eval_value::EvalValue::User(bound)) =
+                        ctx.get_variable(&binding_name)
+                        && let Some(ev) = resolve_bound_var_field_access(bound, &path)
+                    {
+                        Ok(ev)
+                    } else {
+                        Ok(EvalValue::from_value(Value::Deferred(
+                            DeferredValue::ResourceRef { path },
+                        )))
+                    }
                 }
             }
         }

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -10330,3 +10330,131 @@ fn access_path_serde_round_trips_mixed_segments() {
     let reloaded: AccessPath = serde_json::from_str(&json).unwrap();
     assert_eq!(original, reloaded);
 }
+
+// carina#3136: field access on a struct/map-valued for-loop variable.
+// The full behavior matrix that was ERR / unresolved before the fix
+// must now resolve; the scalar guard and the bare-var path must not
+// regress.
+mod loop_var_field_access_matrix {
+    use super::*;
+
+    fn first_name(src: &str) -> Value {
+        let p = parse(src, &ProviderContext::default()).expect("parse");
+        assert_eq!(
+            p.deferred_for_expressions.len(),
+            0,
+            "inline-list loop must fully expand at parse time"
+        );
+        p.resources
+            .first()
+            .expect("one resource")
+            .get_attr("name")
+            .expect("name attr")
+            .clone()
+    }
+
+    #[test]
+    fn one_level_field_on_indexed_binding_resolves() {
+        // Was: parse error "'o' is not a resource…" (Site B).
+        assert_eq!(
+            first_name(r#"for (_, o) in [{ k = "v1" }] { aws.ec2.Subnet { name = o.k } }"#),
+            Value::Concrete(ConcreteValue::String("v1".into()))
+        );
+    }
+
+    #[test]
+    fn two_level_field_resolves_the_registry_shape() {
+        // Was: unresolved ResourceRef{binding:o,…} (Site A). This is
+        // the carina#3132 real registry `opt.resource_record.name`.
+        assert_eq!(
+            first_name(
+                r#"for (_, o) in [{ rr = { name = "n1" } }] { aws.ec2.Subnet { name = o.rr.name } }"#
+            ),
+            Value::Concrete(ConcreteValue::String("n1".into()))
+        );
+    }
+
+    #[test]
+    fn one_level_field_on_simple_binding_resolves() {
+        assert_eq!(
+            first_name(r#"for o in [{ k = "v9" }] { aws.ec2.Subnet { name = o.k } }"#),
+            Value::Concrete(ConcreteValue::String("v9".into()))
+        );
+    }
+
+    #[test]
+    fn scalar_loop_var_field_access_still_errors() {
+        // The Site B guard's correct domain: field access on a scalar
+        // is meaningless and must keep erroring.
+        let err = parse(
+            r#"for s in ["x"] { aws.ec2.Subnet { name = s.foo } }"#,
+            &ProviderContext::default(),
+        );
+        assert!(
+            err.is_err(),
+            "field access on a scalar loop var must still error; got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn bare_loop_var_still_resolves_no_regression() {
+        assert_eq!(
+            first_name(r#"for (_, az) in ["a", "b"] { aws.ec2.Subnet { name = az } }"#),
+            Value::Concrete(ConcreteValue::String("a".into()))
+        );
+    }
+
+    #[test]
+    fn deferred_template_emits_for_value_path_then_substitutes() {
+        // The deferred path: iterable is an unresolved upstream ref, so
+        // the loop is deferred and the body's `o.k` is parsed to
+        // `Unknown(ForValuePath)`. Then expand with a concrete iterable
+        // and assert substitute_placeholder re-navigates it.
+        let src = r#"
+            let up = upstream_state { source = "../x" }
+            for (_, o) in up.items {
+                aws.ec2.Subnet { name = o.k }
+            }
+        "#;
+        let mut p = parse(src, &ProviderContext::default()).expect("parse");
+        assert_eq!(p.deferred_for_expressions.len(), 1, "loop deferred");
+        // The template body must carry the path-aware placeholder, not
+        // a resource ResourceRef (which would never resolve for a loop
+        // var) and not a bare ForValue (which would lose the `.k`).
+        let tmpl = &p.deferred_for_expressions[0].template_resource;
+        assert!(
+            matches!(
+                tmpl.get_attr("name"),
+                Some(Value::Deferred(DeferredValue::Unknown(
+                    crate::resource::UnknownReason::ForValuePath { .. }
+                )))
+            ),
+            "deferred template must carry ForValuePath; got {:?}",
+            tmpl.get_attr("name")
+        );
+
+        let mut items = IndexMap::new();
+        items.insert(
+            "k".to_string(),
+            Value::Concrete(ConcreteValue::String("resolved".into())),
+        );
+        let mut up_attrs = HashMap::new();
+        up_attrs.insert(
+            "items".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(items),
+            )])),
+        );
+        let mut remote = HashMap::new();
+        remote.insert("up".to_string(), up_attrs);
+        p.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote));
+
+        assert_eq!(p.deferred_for_expressions.len(), 0, "loop expanded");
+        assert_eq!(
+            p.resources.first().expect("one resource").get_attr("name"),
+            Some(&Value::Concrete(ConcreteValue::String("resolved".into()))),
+            "ForValuePath must re-navigate the resolved element"
+        );
+    }
+}

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use crate::binding_index::ResolvedBindings;
 use crate::resource::{
     ConcreteValue, DeferredValue, InterpolationPart, Resource, ResourceId, State, Value,
-    contains_resource_ref,
+    contains_resource_ref, peel_secrets, rewrap_secrets,
 };
 
 /// Resolve all ResourceRef values in resources using current state.
@@ -356,27 +356,10 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
     }
 }
 
-/// Strip leading `Value::Secret` wrappers, returning the inner value
-/// and the number of layers peeled. Pair with [`rewrap_secrets`] to
-/// preserve the secret tag end-to-end through `field_path` /
-/// `subscripts` projection (#2439). Plan-display redaction depends on
-/// the tag.
-fn peel_secrets(mut value: Value) -> (Value, usize) {
-    let mut depth = 0;
-    while let Value::Deferred(DeferredValue::Secret(inner)) = value {
-        value = *inner;
-        depth += 1;
-    }
-    (value, depth)
-}
-
-/// Re-wrap `value` in `depth` layers of `Value::Secret`. Inverse of
-/// [`peel_secrets`].
-fn rewrap_secrets(value: Value, depth: usize) -> Value {
-    (0..depth).fold(value, |acc, _| {
-        Value::Deferred(DeferredValue::Secret(Box::new(acc)))
-    })
-}
+// `peel_secrets` / `rewrap_secrets` live in `crate::resource` (next to
+// the `Secret` definition and `navigate_value_path`) so the
+// secret-tunnel discipline (#2439) has one home shared with
+// carina#3136's loop-var navigator.
 
 /// Format the "key not found; available keys: ..." error for a missing
 /// map entry. Shared by the `field_path` (dot-notation, #2447) and

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -482,6 +482,86 @@ impl std::fmt::Display for AccessPath {
     }
 }
 
+/// Peel `Value::Secret` wrappers, returning the inner value and the
+/// number of layers peeled. Pair with [`rewrap_secrets`] so dot-form /
+/// subscript access can descend into a secret container and re-tag the
+/// leaf (#2439; plan-display redaction depends on the tag). Single
+/// source of truth for the secret-tunnel discipline, shared by
+/// `resolver::resolve_ref_value` and [`navigate_value_path`].
+pub(crate) fn peel_secrets(mut value: Value) -> (Value, usize) {
+    let mut depth = 0;
+    while let Value::Deferred(DeferredValue::Secret(inner)) = value {
+        value = *inner;
+        depth += 1;
+    }
+    (value, depth)
+}
+
+/// Re-wrap `value` in `depth` layers of `Value::Secret`. Inverse of
+/// [`peel_secrets`].
+pub(crate) fn rewrap_secrets(value: Value, depth: usize) -> Value {
+    (0..depth).fold(value, |acc, _| {
+        Value::Deferred(DeferredValue::Secret(Box::new(acc)))
+    })
+}
+
+/// Navigate a value tree along an [`AccessPath`]'s `attribute` then
+/// ordered `segments`, returning the value at the leaf.
+///
+/// This is the single source of truth for "follow
+/// `attribute.field[subscript]…` into a concrete `Value`" used by
+/// loop-variable field-access resolution (carina#3136). The element a
+/// `for` loop binds its value variable to is a plain concrete tree
+/// (`Map`/`List`/scalar); `root` is that element, and the path's
+/// `binding` (the loop variable name) has already been matched by the
+/// caller, so navigation starts at `attribute`.
+///
+/// Semantics mirror the segment walk in
+/// [`crate::resolver::resolve_ref_value`] exactly — `Map`+`Field`,
+/// `List`+`Subscript::Int`, `Map`+`Subscript::Str` — including
+/// `Secret` peel/rewrap so a secret leaf keeps its tag. Any missing
+/// hop, shape mismatch (a field expected where the value is a scalar),
+/// or out-of-range index yields `None`: a loop-variable path that does
+/// not navigate is "not resolvable here", never a panic or a wrong
+/// value.
+pub fn navigate_value_path(root: &Value, path: &AccessPath) -> Option<Value> {
+    // The `attribute` head is the first hop: `root` is the loop
+    // element, `root[attribute]` is the first navigated value.
+    let (peeled_root, root_secret) = peel_secrets(root.clone());
+    let Value::Concrete(ConcreteValue::Map(root_map)) = &peeled_root else {
+        return None;
+    };
+    let mut current = rewrap_secrets(root_map.get(path.attribute())?.clone(), root_secret);
+
+    for segment in path.segments() {
+        let (peeled, secret_depth) = peel_secrets(current);
+        let next = match (&peeled, segment) {
+            (Value::Concrete(ConcreteValue::Map(map)), PathSegment::Field { name }) => {
+                map.get(name)?.clone()
+            }
+            (
+                Value::Concrete(ConcreteValue::List(items)),
+                PathSegment::Subscript {
+                    index: Subscript::Int { index },
+                },
+            ) => {
+                let i = usize::try_from(*index).ok().filter(|i| *i < items.len())?;
+                items[i].clone()
+            }
+            (
+                Value::Concrete(ConcreteValue::Map(map)),
+                PathSegment::Subscript {
+                    index: Subscript::Str { key },
+                },
+            ) => map.get(key)?.clone(),
+            _ => return None,
+        };
+        current = rewrap_secrets(next, secret_depth);
+    }
+
+    Some(current)
+}
+
 /// Serde adapter that maps `std::time::Duration` ↔ integer seconds.
 ///
 /// Without this, the default `Duration` serde impl emits
@@ -725,6 +805,20 @@ pub enum UnknownReason {
     /// Loop-variable value in a deferred for-expression
     /// (`for v in iterable`). Substituted with the actual element.
     ForValue,
+    /// Field access on a deferred for-expression's loop variable
+    /// (`for (_, opt) in iterable { … opt.resource_record.name … }`).
+    /// Carries the navigation path past the loop variable. The
+    /// `ForValue` sibling that additionally remembers *which* nested
+    /// value of the element is wanted: at template-parse time the
+    /// element is not yet known, so the parser emits this; once the
+    /// iterable resolves, `substitute_placeholder` re-navigates the
+    /// real element along `path` (carina#3136). Distinct from a
+    /// resource `ResourceRef` so `resolve_ref_value` — which only
+    /// resolves against resource bindings — never sees a loop variable
+    /// it cannot resolve. Lives under the `#[serde(skip)]`
+    /// `Unknown(..)` arm, so it inherits the never-equal `PartialEq`
+    /// invariant and is never serialized.
+    ForValuePath { path: AccessPath },
     /// Mid-edit empty `${}` interpolation. Carries no payload — the
     /// presence of the marker is enough for the LSP to surface a
     /// diagnostic at the `${}` span and for downstream resolvers to
@@ -1186,6 +1280,10 @@ impl Value {
                     // allocation.
                     UnknownReason::UpstreamRef { path } => path.hash(hasher),
                     UnknownReason::UpstreamBareRef { binding } => binding.hash(hasher),
+                    // Carries an `AccessPath` payload — hash it like
+                    // `UpstreamRef` so two distinct loop-var paths get
+                    // distinct hashes.
+                    UnknownReason::ForValuePath { path } => path.hash(hasher),
                     // `For{Key,Index,Value}` and `EmptyInterpolation`
                     // carry no payload; the discriminant alone already
                     // distinguishes them.

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -1582,3 +1582,125 @@ fn directives_provider_instance_deserialises_from_legacy_json_without_field() {
     let d: Directives = serde_json::from_str(legacy).unwrap();
     assert!(d.provider_instance.is_none());
 }
+
+// carina#3136: navigate_value_path — the single path-walking primitive
+// loop-variable field access resolves through.
+mod navigate_value_path_tests {
+    use super::*;
+
+    fn s(v: &str) -> Value {
+        Value::Concrete(ConcreteValue::String(v.to_string()))
+    }
+    fn map(pairs: &[(&str, Value)]) -> Value {
+        let mut m = indexmap::IndexMap::new();
+        for (k, v) in pairs {
+            m.insert(k.to_string(), v.clone());
+        }
+        Value::Concrete(ConcreteValue::Map(m))
+    }
+
+    #[test]
+    fn one_level_field() {
+        // root = { k = "v" }, path = _.k  → "v"
+        let root = map(&[("k", s("v"))]);
+        let path = AccessPath::new("o", "k");
+        assert_eq!(navigate_value_path(&root, &path), Some(s("v")));
+    }
+
+    #[test]
+    fn two_level_field_the_real_registry_shape() {
+        // root = { resource_record = { name = "n1" } }
+        // path = _.resource_record.name  → "n1"
+        let root = map(&[("resource_record", map(&[("name", s("n1"))]))]);
+        let path = AccessPath::with_fields("opt", "resource_record", vec!["name".into()]);
+        assert_eq!(navigate_value_path(&root, &path), Some(s("n1")));
+    }
+
+    #[test]
+    fn list_int_subscript_after_field() {
+        // root = { vals = ["a", "b"] }, path = _.vals[1]  → "b"
+        let root = map(&[(
+            "vals",
+            Value::Concrete(ConcreteValue::List(vec![s("a"), s("b")])),
+        )]);
+        let path = AccessPath::with_fields_and_subscripts(
+            "o",
+            "vals",
+            vec![],
+            vec![Subscript::Int { index: 1 }],
+        );
+        assert_eq!(navigate_value_path(&root, &path), Some(s("b")));
+    }
+
+    #[test]
+    fn map_str_subscript() {
+        // root = { tags = { Name = "x" } }, path = _.tags["Name"]  → "x"
+        let root = map(&[("tags", map(&[("Name", s("x"))]))]);
+        let path = AccessPath::with_fields_and_subscripts(
+            "o",
+            "tags",
+            vec![],
+            vec![Subscript::Str { key: "Name".into() }],
+        );
+        assert_eq!(navigate_value_path(&root, &path), Some(s("x")));
+    }
+
+    #[test]
+    fn missing_field_is_none() {
+        let root = map(&[("k", s("v"))]);
+        let path = AccessPath::new("o", "absent");
+        assert_eq!(navigate_value_path(&root, &path), None);
+    }
+
+    #[test]
+    fn scalar_root_rejects_field_access() {
+        // root is a scalar string — `.k` is meaningless → None (the
+        // Site B "not a resource" guard's correct domain).
+        let root = s("scalar");
+        let path = AccessPath::new("o", "k");
+        assert_eq!(navigate_value_path(&root, &path), None);
+    }
+
+    #[test]
+    fn out_of_range_index_is_none() {
+        let root = map(&[("vals", Value::Concrete(ConcreteValue::List(vec![s("a")])))]);
+        let path = AccessPath::with_fields_and_subscripts(
+            "o",
+            "vals",
+            vec![],
+            vec![Subscript::Int { index: 5 }],
+        );
+        assert_eq!(navigate_value_path(&root, &path), None);
+    }
+
+    #[test]
+    fn secret_leaf_keeps_its_tag() {
+        // root = { tok = secret("s") }; navigating to it must re-wrap
+        // the Secret so the tag survives end-to-end (#2439 parity).
+        let root = map(&[(
+            "tok",
+            Value::Deferred(DeferredValue::Secret(Box::new(s("s")))),
+        )]);
+        let path = AccessPath::new("o", "tok");
+        assert_eq!(
+            navigate_value_path(&root, &path),
+            Some(Value::Deferred(DeferredValue::Secret(Box::new(s("s")))))
+        );
+    }
+
+    #[test]
+    fn field_through_secret_wrapped_map() {
+        // root = secret({ name = "n" }); _.name peels the secret to
+        // descend, then re-wraps the leaf.
+        let inner = map(&[("name", s("n"))]);
+        let root = map(&[(
+            "rr",
+            Value::Deferred(DeferredValue::Secret(Box::new(inner))),
+        )]);
+        let path = AccessPath::with_fields("o", "rr", vec!["name".into()]);
+        assert_eq!(
+            navigate_value_path(&root, &path),
+            Some(Value::Deferred(DeferredValue::Secret(Box::new(s("n")))))
+        );
+    }
+}

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -113,6 +113,9 @@ impl std::fmt::Display for UnknownReason {
             UnknownReason::ForKey => write!(f, "deferred for-binding key"),
             UnknownReason::ForIndex => write!(f, "deferred for-binding index"),
             UnknownReason::ForValue => write!(f, "deferred for-binding value"),
+            UnknownReason::ForValuePath { path } => {
+                write!(f, "deferred for-binding value {}", path.to_dot_string())
+            }
             UnknownReason::EmptyInterpolation => write!(f, "empty interpolation"),
         }
     }
@@ -130,6 +133,9 @@ pub fn render_unknown(reason: &UnknownReason) -> String {
         UnknownReason::ForKey => "(known after upstream apply: key)".to_string(),
         UnknownReason::ForIndex => "(known after upstream apply: index)".to_string(),
         UnknownReason::ForValue => "(known after upstream apply)".to_string(),
+        UnknownReason::ForValuePath { path } => {
+            format!("(known after upstream apply: {})", path.to_dot_string())
+        }
         UnknownReason::EmptyInterpolation => "(empty interpolation)".to_string(),
     }
 }
@@ -1541,6 +1547,22 @@ mod tests {
         assert_eq!(
             render_unknown(&UnknownReason::ForValue),
             "(known after upstream apply)"
+        );
+    }
+
+    #[test]
+    fn render_unknown_for_value_path() {
+        // carina#3136: the path-carrying loop-var placeholder renders
+        // the path like every other payload-carrying arm (not the bare
+        // `ForValue` string), so an unresolved chained loop-var access
+        // stays distinguishable in plan output.
+        use crate::resource::AccessPath;
+        let r = UnknownReason::ForValuePath {
+            path: AccessPath::with_fields("opt", "resource_record", vec!["name".to_string()]),
+        };
+        assert_eq!(
+            render_unknown(&r),
+            "(known after upstream apply: opt.resource_record.name)"
         );
     }
 


### PR DESCRIPTION
## Summary

Implements the merged design #3138 — **carina#3136**. Field access on a struct/map-valued `for`-loop variable now resolves. This is the carina#3132 real-`registry` shape (`for (_, opt) in cert.domain_validation_options { name = opt.resource_record.name }`); **carina#3132 PR-3 (`Closes #3132`) unblocks once this lands**.

## Reframe vs the original issue

Empirical parser probes against merged PR-1 (`52c32c4c`) showed #3136 is **not** deferred-for-specific — it is a general parser gap. `primary.rs` `variable_ref` / `namespaced_id` field-access handling never consulted the in-scope bound loop variable:

| DSL | Before | After |
| --- | --- | --- |
| `for (_, o) in [{k="v"}] { name = o.k }` | parse error "'o' is not a resource…" | resolves `"v"` |
| `for (_, o) in [{rr={name="n"}}] { name = o.rr.name }` (the registry shape) | unresolved `ResourceRef{binding:o}` | resolves `"n"` |
| `for o in [{k="v"}] { name = o.k }` | parse error | resolves `"v"` |
| `for s in ["x"] { name = s.foo }` (scalar) | error | **still errors** (guard preserved) |
| bare loop var `name = az` | works | works (no regression) |

Both deferred and non-deferred for-loops share `parse_for_body`, so the fix is one parser change covering both.

## Changes

- **carina-core/resource**: pure `navigate_value_path` (the single path-walking primitive; mirrors `resolve_ref_value`'s segment walk incl. `Secret` peel/rewrap) + `UnknownReason::ForValuePath { path }` — parse-internal, `#[serde(skip)]` under `Unknown(..)`, inherits the never-equal `PartialEq` invariant. Deliberately **not** a new top-level `DeferredValue` variant (min blast radius under RFC #2972; design-justified).
- **primary.rs Sites A + B**: shared `resolve_bound_var_field_access` (navigate → `ForValuePath` → caller-specific miss policy); the "not a resource" guard scoped to genuine scalars. `substitute_placeholder` re-navigates `ForValuePath` against the resolved element post-expansion.
- **Dedup**: `peel_secrets`/`rewrap_secrets` moved to `crate::resource` — one home for the #2439 secret-tunnel discipline, shared with the navigator (resolver.rs imports them; behavior-preserving verbatim move).
- **Tests**: `navigate_value_path` isolation (9), full behavior-matrix parser tests (6) flipping ERR/unresolved → resolved, `render_unknown` arm, and the carina#3132 PR-1 limitation pin **flipped** from "stays ResourceRef" to "resolves to concrete String".

## Verify

- 3415 workspace nextest, 11 doctest groups, clippy `-D warnings` clean, rustfmt clean, all 5 `scripts/check-*.sh`
- 5-round self-review: 1 coverage gap found+fixed (render_unknown arm test); secret-redaction (#2439) invariant preserved and pinned by 2 navigator tests

Closes #3136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
