### PR TITLE
fix: exclude orphan-prerefreshed for-loop children from post-expansion refresh (Closes #3145)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -882,6 +882,14 @@ async fn run_apply_locked(
     // rename transfer below so old-name entries are present for
     // `apply_anonymous_to_named_renames` to transfer.
     let mut orphan_dependencies: HashMap<ResourceId, BTreeSet<String>> = HashMap::new();
+    // Ids the orphan pass already live-read this run. A for-loop child
+    // applied previously is in state but not yet a desired resource at
+    // orphan time (expansion is post-refresh); the orphan pass live-reads
+    // it under the same state name the child resolves to.
+    // `expand_same_config_deferred_for` excludes these from the
+    // post-expansion child refresh so the same address is not read twice
+    // (carina#3145). Mirrors the plan path in `wiring/mod.rs`.
+    let mut orphan_refreshed_ids: HashSet<ResourceId> = HashSet::new();
     if let Some(sf) = state_file.as_ref() {
         let desired_ids: HashSet<ResourceId> =
             sorted_resources.iter().map(|r| r.id.clone()).collect();
@@ -912,6 +920,7 @@ async fn run_apply_locked(
         for result in orphan_results {
             let (id, refreshed) = result?;
             if refreshed.exists {
+                orphan_refreshed_ids.insert(id.clone());
                 current_states.entry(id).or_insert(refreshed);
             }
         }
@@ -1008,6 +1017,7 @@ async fn run_apply_locked(
         &remote_bindings,
         &wait_aliases,
         &moved_targets,
+        &orphan_refreshed_ids,
     )?;
     sorted_resources = resorted;
     // Expansion borrows `parsed` immutably (expands a clone), so

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -853,6 +853,7 @@ mod apply_deferred_for_parity {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
         )
         .expect("expand");
 
@@ -912,6 +913,7 @@ mod apply_deferred_for_parity {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
         )
         .expect("expand");
 
@@ -962,6 +964,7 @@ mod apply_deferred_for_parity {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
         )
         .expect("expand");
         assert_eq!(baseline.new_child_ids.len(), 1);
@@ -987,6 +990,7 @@ mod apply_deferred_for_parity {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &moved_targets,
+            &std::collections::HashSet::new(),
         )
         .expect("expand");
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1212,6 +1212,19 @@ pub struct DeferredForExpansion {
 /// paths before this call). Children whose id is in this set are kept
 /// out of `refreshable_child_ids` so their migrated state survives
 /// (carina#3141).
+///
+/// `already_refreshed` is the set of ResourceIds the phase-1 orphan pass
+/// already performed a live provider read for *this run*. A for-loop
+/// child applied on a previous run sits in the state file; because
+/// expansion happens *after* refresh, that child is not yet a desired
+/// resource when the orphan pass runs, so the orphan pass classifies it
+/// as an orphan and live-reads it (keyed by the same state name the
+/// post-expansion child resolves to → identical provider identity). Such
+/// a child is kept out of `refreshable_child_ids` so the post-expansion
+/// child refresh does not read the same address a second time
+/// (carina#3145). The decision is made here, once, alongside the
+/// moved-target exclusion, and carried in the typed `RefreshableChildIds`
+/// so the plan and apply paths cannot diverge.
 pub fn expand_same_config_deferred_for<E: Clone>(
     parsed: &carina_core::parser::File<E>,
     sorted_resources: &[Resource],
@@ -1219,6 +1232,7 @@ pub fn expand_same_config_deferred_for<E: Clone>(
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
     wait_aliases: &[WaitAliasSpec],
     moved_targets: &HashSet<ResourceId>,
+    already_refreshed: &HashSet<ResourceId>,
 ) -> Result<DeferredForExpansion, AppError> {
     // Common case: no deferred-for at all. Skip the binding projection
     // and the whole-`File` clone entirely (this runs on every plan /
@@ -1273,15 +1287,24 @@ pub fn expand_same_config_deferred_for<E: Clone>(
         .filter(|id| !pre_ids.contains(id))
         .collect();
 
-    // carina#3141: a child that is also a `moved` block `to` already
-    // holds the migrated state from `materialize_moved_states`. Exclude
-    // it from the refreshable set so the caller's targeted refresh does
-    // not overwrite that state with a `not_found` provider read (the
-    // state file still keys the old name, so no identifier resolves).
+    // Exclude a child from the post-expansion refresh when re-reading it
+    // would be wrong or redundant:
+    //
+    // - carina#3141: a child that is also a `moved` block `to` already
+    //   holds the migrated state from `materialize_moved_states`.
+    //   Re-reading it would overwrite that state with a `not_found`
+    //   provider read (the state file still keys the old name, so no
+    //   identifier resolves).
+    // - carina#3145: a child applied on a previous run is in the state
+    //   file but is not yet a desired resource when the phase-1 orphan
+    //   pass runs (expansion is post-refresh), so that pass already
+    //   live-read it under the same state name the child resolves to.
+    //   Reading it again here is a redundant second provider call for
+    //   the same address.
     let refreshable_child_ids = RefreshableChildIds(
         new_child_ids
             .iter()
-            .filter(|id| !moved_targets.contains(*id))
+            .filter(|id| !moved_targets.contains(*id) && !already_refreshed.contains(*id))
             .cloned()
             .collect(),
     );
@@ -1362,6 +1385,15 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // detected anonymous → let-bound renames. Populated inside the
     // refresh block so the later plan-building code sees them.
     let mut moved_pairs: Vec<(ResourceId, ResourceId)> = Vec::new();
+    // Ids the phase-1 orphan pass already performed a live provider read
+    // for this run. A for-loop child applied on a previous run is in the
+    // state file but not yet a desired resource at orphan time (expansion
+    // is post-refresh), so the orphan pass live-reads it under the same
+    // state name the child later resolves to. `expand_same_config_deferred_for`
+    // excludes these from the post-expansion child refresh so the same
+    // address is not read twice (carina#3145). Mirrored by the apply path
+    // in `commands/apply/mod.rs`.
+    let mut orphan_refreshed_ids: HashSet<ResourceId> = HashSet::new();
 
     if refresh {
         RefreshProgress::start_header();
@@ -1444,6 +1476,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
             for result in orphan_results {
                 let (id, refreshed) = result?;
                 if refreshed.exists {
+                    orphan_refreshed_ids.insert(id.clone());
                     current_states.entry(id).or_insert(refreshed);
                 }
             }
@@ -1589,6 +1622,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         remote_bindings,
         &wait_aliases,
         &moved_targets,
+        &orphan_refreshed_ids,
     )?;
     sorted_resources = resorted;
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -1470,6 +1470,7 @@ mod expand_same_config_deferred_for_tests {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
         )
         .expect("expand");
 
@@ -1531,6 +1532,7 @@ mod expand_same_config_deferred_for_tests {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
         )
         .expect("expand");
 
@@ -1573,6 +1575,7 @@ mod expand_same_config_deferred_for_tests {
             &empty_states,
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
+            &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
         )
         .expect("expand");
@@ -1636,6 +1639,7 @@ mod expand_same_config_deferred_for_tests {
             &HashMap::new(),
             &remote,
             &[] as &[WaitAliasSpec],
+            &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
         )
         .expect("expand");
@@ -1703,6 +1707,7 @@ mod expand_same_config_deferred_for_tests {
             &states,
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
+            &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
         )
         .expect("expand");
@@ -1806,6 +1811,7 @@ mod expand_same_config_deferred_for_tests {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
         )
         .expect("expand without moved targets");
 
@@ -1835,6 +1841,7 @@ mod expand_same_config_deferred_for_tests {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &moved_targets,
+            &std::collections::HashSet::new(),
         )
         .expect("expand with the child as a moved target");
 
@@ -1910,6 +1917,7 @@ mod expand_same_config_deferred_for_tests {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
         )
         .expect("expand");
         assert_eq!(
@@ -1933,6 +1941,7 @@ mod expand_same_config_deferred_for_tests {
             &HashMap::new(),
             &[] as &[WaitAliasSpec],
             &moved_targets,
+            &std::collections::HashSet::new(),
         )
         .expect("expand");
 
@@ -1947,6 +1956,130 @@ mod expand_same_config_deferred_for_tests {
         assert!(
             out.refreshable_child_ids.contains(&kept_child),
             "the non-moved child must still be refreshed"
+        );
+        assert_eq!(
+            out.refreshable_child_ids.len(),
+            1,
+            "exactly one of two children is refreshable; got {:?}",
+            out.refreshable_child_ids
+        );
+    }
+
+    /// carina#3145: a for-loop child that was applied on a previous run
+    /// is in the state file. On the next `plan`/`apply`, the phase-1
+    /// orphan pass classifies it as an orphan (it is not yet a desired
+    /// resource — expansion happens *after* refresh) and performs a live
+    /// provider read of it, storing the result in `current_states`. The
+    /// post-expansion child refresh then reads the *same* address a
+    /// second time. Two live provider reads for one resource.
+    ///
+    /// The fix decides "already live-read this run" *once*, in the same
+    /// place the moved-target exclusion is decided, and carries it in the
+    /// typed `RefreshableChildIds` so the plan and apply paths cannot
+    /// diverge. This test pins that contract: an id in `already_refreshed`
+    /// must materialize as a child but be excluded from
+    /// `refreshable_child_ids` (no redundant second read), while a child
+    /// not in that set stays refreshable.
+    #[test]
+    fn already_refreshed_child_is_excluded_from_refreshable_set() {
+        let src = r#"
+            let cert = aws.acm.Certificate {
+                domain_name       = "r.example.com"
+                validation_method = "DNS"
+            }
+
+            for (_, opt) in cert.domain_validation_options {
+                aws.route53.RecordSet {
+                    name             = opt.resource_record.name
+                    type             = "CNAME"
+                    resource_records = [opt.resource_record.value]
+                }
+            }
+        "#;
+        let parsed = parse(src, &ProviderContext::default()).expect("parse");
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+
+        let make_entry = |name: &str, value: &str| {
+            let mut rr = indexmap::IndexMap::new();
+            rr.insert(
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String(name.into())),
+            );
+            rr.insert(
+                "value".to_string(),
+                Value::Concrete(ConcreteValue::String(value.into())),
+            );
+            let mut entry = indexmap::IndexMap::new();
+            entry.insert(
+                "resource_record".to_string(),
+                Value::Concrete(ConcreteValue::Map(rr)),
+            );
+            Value::Concrete(ConcreteValue::Map(entry))
+        };
+        let dvo = Value::Concrete(ConcreteValue::List(vec![
+            make_entry("_apex.r.example.com", "_apex.acm-validations.aws."),
+            make_entry("_san.r.example.com", "_san.acm-validations.aws."),
+        ]));
+        let states = states_with_cert(&parsed, "domain_validation_options", dvo);
+
+        // Baseline: nothing pre-refreshed — both children materialize and
+        // are refreshable (the single live read happens post-expansion).
+        let baseline = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+        )
+        .expect("expand");
+        assert_eq!(
+            baseline.new_child_ids.len(),
+            2,
+            "two RecordSets materialized (apex + SAN)"
+        );
+        assert_eq!(
+            baseline.refreshable_child_ids.len(),
+            2,
+            "with nothing pre-refreshed both children are refreshable"
+        );
+
+        // The phase-1 orphan pass already live-read the first child this
+        // run (it is in the state file from a prior apply, not yet a
+        // desired resource at orphan time).
+        let mut ids: Vec<ResourceId> = baseline.new_child_ids.iter().cloned().collect();
+        ids.sort_by_key(|id| id.to_string());
+        let already_read = ids[0].clone();
+        let still_unread = ids[1].clone();
+
+        let mut already_refreshed = std::collections::HashSet::new();
+        already_refreshed.insert(already_read.clone());
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+            &std::collections::HashSet::new(),
+            &already_refreshed,
+        )
+        .expect("expand");
+
+        assert_eq!(
+            out.new_child_ids, baseline.new_child_ids,
+            "the already-refreshed exclusion must not change what materialized"
+        );
+        assert!(
+            !out.refreshable_child_ids.contains(&already_read),
+            "a child already live-read by the phase-1 orphan pass must be \
+             excluded from refreshable_child_ids so it is not read a \
+             second time (carina#3145)"
+        );
+        assert!(
+            out.refreshable_child_ids.contains(&still_unread),
+            "a child not yet read this run must still be refreshed"
         );
         assert_eq!(
             out.refreshable_child_ids.len(),


### PR DESCRIPTION
Closes #3145

## Problem

`carina plan` / `apply` refreshes each resource produced by a `let X = for ... { R { ... } }` expansion **twice** — once during the phase-1 orphan pass and once after materialization — for any for-loop child that was applied on a previous run.

## Root cause

The plan/apply refresh order is: phase-1 refresh → orphan pass → `materialize_moved_states` → `expand_same_config_deferred_for` → post-expansion child refresh.

A previously-applied for-loop child is in the state file. Because same-config deferred-for expansion happens **after** the refresh phase, that child is not yet a desired resource when the phase-1 orphan pass runs. `build_orphan_states` builds its orphan candidate set from the *pre-expansion* `desired_ids`, so the child is **misclassified as an orphan** and live-read once (keyed by the same state name the post-expansion child later resolves to — identical provider identity). Then `expand_same_config_deferred_for` materializes the same child and the post-expansion child refresh reads the identical address a **second** time.

The issue's "deferred placeholder + materialized address both in the refresh queue" hypothesis was directionally right; the precise mechanism is the orphan misclassification of a not-yet-expanded loop child.

## Fix

Capture the ids the orphan pass already live-read this run into `orphan_refreshed_ids`, and thread them into `expand_same_config_deferred_for` as a new `already_refreshed` parameter. Exclude them from `refreshable_child_ids` alongside the existing `moved_targets` (carina#3141) exclusion.

The decision is made **once**, in the single shared `expand_same_config_deferred_for`, and carried in the typed `RefreshableChildIds` newtype that both the plan and apply paths consume — so the exclusion cannot diverge between paths (compile-time parity, same design as #3141). No new untyped address-pattern classifier; no correctness regression.

## Why this design (long-term maintainability × type safety)

The alternative — string-pattern-matching state names against deferred-for `binding_name` to pre-exclude future loop addresses from the orphan set — was rejected: it reintroduces the untyped, hand-maintained plan/apply parity hazard the `RefreshableChildIds` newtype exists to prevent, and it would leak a loop-dropped child (no Delete state pre-read). Reusing the orphan pass's already-correct live read and skipping only the redundant second read keeps a single source of truth for the refresh set.

## Correctness notes for maintainers

- **Identity equivalence:** the orphan-pass read uses `rs.identifier` from the state entry keyed by the child's resolved name; the skipped post-expansion read would look up the same state entry by the same name and get the same identifier — identity-equivalent. The orphan-pass state is correct and complete (hydrated by the same `hydrate_read_state`/`saved_attrs` pass).
- **#3141 interaction (OLD-vs-NEW id disjointness):** the orphan pass runs *before* `materialize_moved_states`, so a `moved` for-loop child is orphan-read under its **OLD** name; `orphan_refreshed_ids` holds the OLD id while `moved_targets`/`new_child_ids` use the **NEW** id. The two exclusion terms are disjoint for moved children — `moved_targets` handles them via the NEW id, `already_refreshed` is inert. The combined `!moved_targets.contains && !already_refreshed.contains` filter is correct either way.
- **`--refresh=false`:** the orphan pass does not run, so `orphan_refreshed_ids` is empty and behavior is unchanged.
- **Loop drops a child (iterable shrank):** the child is not in `new_child_ids`, so the new filter never touches it; it remains a genuine orphan in `current_states` and still gets a `Delete`.
- **Out-of-band deletion:** `orphan_refreshed_ids` insert is gated on `refreshed.exists`, so a no-longer-existing child is not excluded and is still refreshed post-expansion (the second read is needed there to observe the deletion).

## Second symptom (double `No changes` line)

The issue also notes `No changes. Infrastructure is up-to-date.` printed twice, flagged there as "likely a separate but related symptom". `format_plan` (`carina-cli/src/display/mod.rs`) writes that line exactly once and `print_plan` is invoked once per plan command — there is no code-level double-print. The duplication is a PTY-capture artifact of the duplicate refresh producing two CR-separated `[0.8s]` spinner frames; removing the redundant refresh removes the duplicate frame. No display code change is warranted.

## Testing

- New regression test `already_refreshed_child_is_excluded_from_refreshable_set` (verified to fail without the production change): a child in `already_refreshed` still materializes (`new_child_ids` unchanged) but is excluded from `refreshable_child_ids`; a child not in the set stays refreshable.
- `cargo nextest run -p carina-cli`: 435 passed, 0 failed (incl. the #3141 regression guard).
- `cargo clippy -p carina-cli --all-targets -- -D warnings`: clean.
- All `scripts/check-*.sh` + `scripts/validate-crn-files.sh`: pass.

The orphan-pass↔child id identity is argued structurally because there is no provider-injection seam to drive the full refresh pipeline end-to-end in a test (the same gap pre-exists for #3141). Filed as follow-up #3146 (class-level testability improvement, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
