### PR TITLE
plan: blank line between refresh progress and plan terminal section (Closes #3148)

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -21,7 +21,7 @@ use carina_state::{
 use super::validate_and_resolve_with_config;
 use crate::DetailLevel;
 use crate::commands::shared::state_writeback::apply_name_overrides;
-use crate::display::print_plan;
+use crate::display::{print_plan, refresh_plan_separator};
 use crate::error::AppError;
 use crate::wiring::{
     WiringContext, build_factories_from_providers, create_plan_from_parsed_with_upstream,
@@ -405,6 +405,10 @@ pub async fn run_plan(
             .map(|s| s.exports.clone())
             .unwrap_or_default();
         let export_changes = compute_export_diffs(&resolved_exports, &current_exports);
+        // Separate the refresh-progress block (printed above when `refresh`)
+        // from the plan's terminal section so they don't read as a run-on
+        // (#3148).
+        print!("{}", refresh_plan_separator(refresh));
         print_plan(
             &ctx.plan,
             detail,

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -26,6 +26,21 @@ use carina_core::value::{format_value, format_value_with_key, is_list_of_maps, m
 
 use crate::DetailLevel;
 
+/// Separator emitted between the state-refresh progress block and the plan's
+/// terminal section.
+///
+/// `carina plan` prints the `Refreshing state...` header and a series of
+/// indented `✓ <name> [<elapsed>s]` lines, then the plan output. Without a
+/// separator the last refresh line and the plan's terminal section
+/// (`Execution Plan:` or `No changes. Infrastructure is up-to-date.`) sit on
+/// adjacent rows and read as a visual run-on (issue #3148). When a refresh
+/// occurred, return a single blank line to insert before the plan output;
+/// otherwise (e.g. `--refresh=false`, fixture/snapshot path) there is no
+/// progress block above the plan, so emit nothing.
+pub fn refresh_plan_separator(refreshed: bool) -> &'static str {
+    if refreshed { "\n" } else { "" }
+}
+
 /// Check if a resource has a `let` binding (i.e., is not anonymous).
 fn has_binding(resource: &carina_core::resource::Resource) -> bool {
     resource.binding.is_some()

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1640,3 +1640,18 @@ fn delete_pretty_attribute_does_not_strike_indentation() {
          override on and exercise the Delete styling path",
     );
 }
+
+/// When a state refresh has been printed above the plan output, a single
+/// blank line must separate the refresh-progress block from the plan's
+/// terminal section (`Execution Plan:` or `No changes.`). See issue #3148.
+#[test]
+fn test_refresh_plan_separator_emits_blank_line_after_refresh() {
+    assert_eq!(refresh_plan_separator(true), "\n");
+}
+
+/// Without a refresh (e.g. `--refresh=false`, fixture/snapshot path) there
+/// is no progress block above the plan, so no extra blank line is emitted.
+#[test]
+fn test_refresh_plan_separator_no_blank_line_without_refresh() {
+    assert_eq!(refresh_plan_separator(false), "");
+}

--- a/carina-cli/tests/plan_refresh_separator_e2e.rs
+++ b/carina-cli/tests/plan_refresh_separator_e2e.rs
@@ -1,0 +1,149 @@
+//! End-to-end test for issue #3148.
+//!
+//! `carina plan` prints the state-refresh progress block (`Refreshing
+//! state...` header + `✓ <name> [<elapsed>s]` lines) immediately above the
+//! plan's terminal section. Without a separator the last refresh line and the
+//! terminal section (`Execution Plan:` or `No changes. Infrastructure is
+//! up-to-date.`) sit on adjacent rows and read as a visual run-on.
+//!
+//! These tests run the real `carina plan` binary against the bundled mock
+//! provider (no AWS needed) and assert the blank-line separator on actual
+//! stdout — the unit tests in `display::tests` pin the pure helper contract,
+//! but only the real binary proves the refresh block and the plan terminal
+//! section are actually adjacent on the same stream.
+
+use std::fs;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Pin the child to plain-text output so the marker assertions are
+/// environment-independent. Without this, an inherited `CLICOLOR_FORCE=1`
+/// makes `carina plan` emit ANSI escapes and the `starts_with` matching
+/// (which compares against uncolored `Execution Plan:` / `No changes.`)
+/// fails for reasons unrelated to the separator under test.
+fn plain_text_command(bin: &str) -> Command {
+    let mut cmd = Command::new(bin);
+    cmd.env("NO_COLOR", "1").env_remove("CLICOLOR_FORCE");
+    cmd
+}
+
+fn init_project(dir: &std::path::Path, body: &str) {
+    fs::write(dir.join("main.crn"), body).unwrap();
+    let status = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .args(["init", dir.to_str().unwrap()])
+        .status()
+        .expect("failed to execute carina init");
+    assert!(status.success(), "carina init failed");
+}
+
+fn plan_stdout(dir: &std::path::Path, extra_args: &[&str]) -> String {
+    let mut args = vec!["plan", dir.to_str().unwrap()];
+    args.extend_from_slice(extra_args);
+    let output = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .args(&args)
+        .output()
+        .expect("failed to execute carina plan");
+    assert!(
+        output.status.success(),
+        "carina plan failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout is not UTF-8")
+}
+
+/// Return the line immediately preceding the first line that starts with
+/// `marker` (after trimming the leading indentation the plan terminal
+/// sections don't use, so this matches `Execution Plan:` / `No changes.`).
+fn line_before<'a>(stdout: &'a str, marker: &str) -> &'a str {
+    let lines: Vec<&str> = stdout.lines().collect();
+    let idx = lines
+        .iter()
+        .position(|l| l.starts_with(marker))
+        .unwrap_or_else(|| panic!("marker {marker:?} not found in stdout:\n{stdout}"));
+    assert!(
+        idx > 0,
+        "marker {marker:?} is the first line; expected a refresh block above it:\n{stdout}"
+    );
+    lines[idx - 1]
+}
+
+/// With refresh on (the default), the no-changes terminal section is
+/// separated from the refresh block by exactly one blank line.
+#[test]
+fn no_changes_has_blank_line_after_refresh_block() {
+    let tmp = TempDir::new().unwrap();
+    init_project(
+        tmp.path(),
+        r#"backend local { path = "carina.state.json" }
+"#,
+    );
+
+    let stdout = plan_stdout(tmp.path(), &[]);
+
+    assert!(
+        stdout.contains("No changes. Infrastructure is up-to-date."),
+        "expected the no-changes terminal section.\nstdout:\n{stdout}"
+    );
+    assert_eq!(
+        line_before(&stdout, "No changes."),
+        "",
+        "expected a blank line directly above the no-changes summary \
+         (issue #3148).\nstdout:\n{stdout}"
+    );
+}
+
+/// With refresh on (the default), the `Execution Plan:` header is separated
+/// from the refresh block by exactly one blank line.
+#[test]
+fn execution_plan_has_blank_line_after_refresh_block() {
+    let tmp = TempDir::new().unwrap();
+    init_project(
+        tmp.path(),
+        r#"backend local { path = "carina.state.json" }
+mock.test.resource { name = "r1" }
+"#,
+    );
+
+    let stdout = plan_stdout(tmp.path(), &[]);
+
+    assert!(
+        stdout.contains("Execution Plan:"),
+        "expected the Execution Plan terminal section.\nstdout:\n{stdout}"
+    );
+    assert_eq!(
+        line_before(&stdout, "Execution Plan:"),
+        "",
+        "expected a blank line directly above the Execution Plan header \
+         (issue #3148).\nstdout:\n{stdout}"
+    );
+}
+
+/// With `--refresh=false` there is no refresh block above the plan, so no
+/// separator blank line is introduced — the terminal section must not be
+/// preceded by a spurious empty line.
+#[test]
+fn refresh_false_has_no_separator_blank_line() {
+    let tmp = TempDir::new().unwrap();
+    init_project(
+        tmp.path(),
+        r#"backend local { path = "carina.state.json" }
+mock.test.resource { name = "r1" }
+"#,
+    );
+
+    let stdout = plan_stdout(tmp.path(), &["--refresh=false"]);
+
+    assert!(
+        stdout.contains("Execution Plan:"),
+        "expected the Execution Plan terminal section.\nstdout:\n{stdout}"
+    );
+    assert_ne!(
+        line_before(&stdout, "Execution Plan:"),
+        "",
+        "with --refresh=false there is no refresh block, so the line above \
+         the Execution Plan header must not be blank (issue #3148).\n\
+         stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #3148

## Problem

`carina plan` printed the state-refresh progress block (`Refreshing state...` header + indented `✓ <name> [<elapsed>s]` lines) immediately above the plan's terminal section with no separator:

```
  ✓ aws.route53.RecordSet r.validation_records[0] [0.8s]
No changes. Infrastructure is up-to-date.
```

The indented `✓` lines and the left-flush summary on adjacent rows read as a visual run-on, for both terminal cases (`No changes. Infrastructure is up-to-date.` and `Execution Plan:`).

## Change

- Add a pure helper `refresh_plan_separator(refreshed) -> &'static str` in `carina-cli/src/display/mod.rs` (returns `"\n"` when a refresh occurred, `""` otherwise).
- Emit it via `print!` immediately before `print_plan` in the human-output branch of `run_plan`.

The `refresh` flag gates the same `RefreshProgress::start_header()` call, so the separator appears iff the refresh block was printed — `--refresh=false` and the fixture/snapshot path get no spurious blank line. `format_plan` is left byte-identical, so existing snapshots are unaffected (no `.snap` churn). `--json` / `--tui` branches are untouched.

After:

```
  ✓ aws.route53.RecordSet r.validation_records[0] [0.8s]

No changes. Infrastructure is up-to-date.
```

Scope is `carina plan` only, matching the issue (apply/destroy have a different post-refresh UX and are explicitly out of the issue's scope).

## Tests

- Unit tests pin the pure helper contract.
- `carina-cli/tests/plan_refresh_separator_e2e.rs` runs the real `carina plan` binary against the bundled mock provider (no AWS) and asserts the blank line on actual stdout for the no-changes, `Execution Plan:`, and `--refresh=false` cases. The child process is pinned to plain-text output (`NO_COLOR=1`, `CLICOLOR_FORCE` removed) so an inherited `CLICOLOR_FORCE` cannot make ANSI codes break marker matching.

Verify: 440 carina-cli tests pass, doctests ok, clippy clean, all `scripts/check-*.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)