### PR TITLE
plan: close indicatif spinner-bar region so the separator renders as a blank line (Closes #3150)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,6 +846,7 @@ dependencies = [
  "indexmap",
  "indicatif",
  "insta",
+ "portable-pty",
  "regex-lite",
  "semver",
  "serde",
@@ -1646,6 +1647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +1787,17 @@ checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -2527,6 +2545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,6 +2661,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
@@ -2797,6 +2830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,6 +2858,20 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -3077,6 +3133,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
 ]
 
 [[package]]
@@ -3699,6 +3776,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3719,6 +3838,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3967,6 +4102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5372,6 +5516,15 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winx"

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -45,6 +45,11 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "io-
 async-trait = "0.1"
 carina-lsp = { path = "../carina-lsp" }
 insta = "1"
+# Real PTY for the refresh-separator regression test (#3150). The bug only
+# manifests under a TTY (indicatif leaves the last spinner line unterminated);
+# a piped-stdout test cannot observe it — which is exactly how #3149 shipped
+# the broken fix.
+portable-pty = "0.8"
 regex-lite = "0.1"
 tempfile = "3"
 tower-lsp = "0.20"

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1010,6 +1010,10 @@ async fn run_apply_locked(
         residual_deferred_for,
         new_child_ids,
         refreshable_child_ids,
+        // `printed_warnings` drives the plan path's spinner-bar-region
+        // close (#3150); the apply path's post-refresh bar handling is
+        // tracked separately in #3151 and does not consume it here.
+        printed_warnings: _,
     } = crate::wiring::expand_same_config_deferred_for(
         parsed,
         &sorted_resources,

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io::IsTerminal;
 use std::path::Path;
 
 #[cfg(test)]
@@ -1189,6 +1190,13 @@ pub struct DeferredForExpansion {
     /// via [`RefreshableChildIds::select`]; see that type's doc for why
     /// it is a newtype (compile-time plan/apply parity).
     pub refreshable_child_ids: RefreshableChildIds,
+    /// Whether `print_warnings()` emitted any `⚠` line during expansion.
+    /// A printed warning is newline-terminated and lands on top of
+    /// indicatif's open spinner bar line, so it *closes* the bar region
+    /// the refresh phases left open. [`finish_refresh_bar_region`] uses
+    /// this to avoid adding a second, spurious blank line on the
+    /// deferred-for-with-warnings TTY path (#3150 Round-4 finding).
+    pub printed_warnings: bool,
 }
 
 /// Pure core of the carina#3132 fix: project the post-refresh
@@ -1240,12 +1248,13 @@ pub fn expand_same_config_deferred_for<E: Clone>(
     // expansion would remove none of them, so `parsed`'s set is exactly
     // what the post-expansion path would have printed.
     if parsed.deferred_for_expressions.is_empty() {
-        parsed.print_warnings();
+        let printed_warnings = parsed.print_warnings();
         return Ok(DeferredForExpansion {
             sorted_resources: sorted_resources.to_vec(),
             residual_deferred_for: Vec::new(),
             new_child_ids: HashSet::new(),
             refreshable_child_ids: RefreshableChildIds::default(),
+            printed_warnings,
         });
     }
 
@@ -1263,7 +1272,7 @@ pub fn expand_same_config_deferred_for<E: Clone>(
     // the augmented resource set / residual deferred list back out.
     let mut expanded: carina_core::parser::File<E> = (*parsed).clone();
     expanded.expand_deferred_for_expressions(&iterable_bindings);
-    expanded.print_warnings();
+    let printed_warnings = expanded.print_warnings();
     let residual_deferred_for = expanded.deferred_for_expressions.clone();
 
     let pre_ids: HashSet<ResourceId> = sorted_resources.iter().map(|r| r.id.clone()).collect();
@@ -1314,6 +1323,7 @@ pub fn expand_same_config_deferred_for<E: Clone>(
         residual_deferred_for,
         new_child_ids,
         refreshable_child_ids,
+        printed_warnings,
     })
 }
 
@@ -1395,6 +1405,17 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // in `commands/apply/mod.rs`.
     let mut orphan_refreshed_ids: HashSet<ResourceId> = HashSet::new();
 
+    // Running state: is indicatif's spinner bar region currently *open*
+    // (cursor parked on an unterminated `✓` line)? Set true by any refresh
+    // phase that draws bars (managed, orphan, data-source, deferred-for
+    // children); set back to false when `print_warnings` emits a
+    // newline-terminated `⚠` line over the open bar (which closes the
+    // region). `finish_refresh_bar_region` reads the final value to close
+    // the region exactly once, before the plan is printed (#3150). It is a
+    // running flag, not a cumulative OR: a printed warning between phases
+    // resets it (Round-4 finding — see the reset after expansion below).
+    let mut refresh_printed_bars = false;
+
     if refresh {
         RefreshProgress::start_header();
         let multi = refresh_multi_progress();
@@ -1427,7 +1448,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         // from their dependencies (#1683). Phase 1: managed resources in
         // parallel. Phase 2: data sources whose input attributes have
         // been resolved against phase 1's `current_states`.
-        refresh_resource_set(
+        refresh_printed_bars |= refresh_resource_set(
             provider_ref,
             &multi,
             sorted_resources.iter(),
@@ -1447,6 +1468,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
                 sorted_resources.iter().map(|r| r.id.clone()).collect();
             let orphan_states: Vec<(ResourceId, State)> =
                 sf.build_orphan_states(&desired_ids).into_iter().collect();
+            refresh_printed_bars |= !orphan_states.is_empty();
             let orphan_results: Vec<Result<(ResourceId, State), AppError>> =
                 stream::iter(orphan_states)
                     .map(|(id, state)| {
@@ -1527,6 +1549,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
             ctx.schemas(),
             &ds_wait_aliases,
         )?;
+        refresh_printed_bars |= !resolved_data_sources.is_empty();
         let phase2_results: Vec<Result<(ResourceId, State), AppError>> =
             stream::iter(resolved_data_sources.iter())
                 .map(|resource| {
@@ -1615,6 +1638,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         residual_deferred_for,
         new_child_ids,
         refreshable_child_ids,
+        printed_warnings,
     } = expand_same_config_deferred_for(
         parsed,
         &sorted_resources,
@@ -1626,6 +1650,17 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     )?;
     sorted_resources = resorted;
 
+    // A printed `⚠` warning is newline-terminated and is written on top of
+    // indicatif's open spinner bar line, so it closes the bar region the
+    // refresh phases above left open — the cursor is no longer parked on an
+    // unterminated `✓` line. Clear the flag so `finish_refresh_bar_region`
+    // does not add a second, spurious blank line on the
+    // deferred-for-with-warnings TTY path (#3150 Round-4 finding). The
+    // child-refresh phase below may re-open the region if it draws bars.
+    if printed_warnings {
+        refresh_printed_bars = false;
+    }
+
     if !new_child_ids.is_empty() {
         // Refresh only `refreshable_child_ids` (carina#3141): a child
         // that is also a `moved` target keeps the migrated state from
@@ -1636,7 +1671,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         // cannot diverge between the two paths (compile-time parity).
         let children = || refreshable_child_ids.select(&sorted_resources);
         if refresh {
-            refresh_resource_set(
+            refresh_printed_bars |= refresh_resource_set(
                 &provider,
                 &refresh_multi_progress(),
                 children(),
@@ -1666,6 +1701,10 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
             }
         }
     }
+
+    // All refresh phases are done. Close indicatif's open bar line so the
+    // separator + plan render below it instead of being swallowed (#3150).
+    finish_refresh_bar_region(refresh_printed_bars);
 
     // Build orphan dependency bindings from state file for tree structure
     let orphan_dependencies = if let Some(sf) = state_file.as_ref() {
@@ -2053,6 +2092,10 @@ pub async fn read_with_retry(
 /// does not return (#1565); pass an empty map when there is nothing to
 /// restore (the new loop children have no prior state-file dep
 /// bindings).
+/// Returns `true` iff at least one refresh spinner bar was started (i.e. the
+/// filtered iterator was non-empty). The caller uses this to decide whether
+/// the indicatif bar region needs an explicit terminating newline before the
+/// plan is printed — see [`finish_refresh_bar_region`].
 pub(crate) async fn refresh_resource_set<'a>(
     provider: &dyn Provider,
     multi: &indicatif::MultiProgress,
@@ -2060,10 +2103,12 @@ pub(crate) async fn refresh_resource_set<'a>(
     state_file: &Option<StateFile>,
     saved_dep_bindings: &HashMap<ResourceId, BTreeSet<String>>,
     current_states: &mut HashMap<ResourceId, State>,
-) -> Result<(), AppError> {
+) -> Result<bool, AppError> {
+    let mut started_bar = false;
     let results: Vec<Result<(ResourceId, State), AppError>> =
         stream::iter(resources.filter(|r| !r.is_virtual() && !r.is_data_source()))
             .map(|resource| {
+                started_bar = true;
                 let progress = RefreshProgress::begin_multi(multi, &resource.id);
                 let identifier = state_file
                     .as_ref()
@@ -2087,7 +2132,39 @@ pub(crate) async fn refresh_resource_set<'a>(
         let (id, state) = result?;
         current_states.insert(id, state);
     }
-    Ok(())
+    Ok(started_bar)
+}
+
+/// Terminate indicatif's spinner-bar region so a following `print!` starts on
+/// a fresh line.
+///
+/// Root cause of #3150: indicatif draws the refresh spinners to **stderr**
+/// (`MultiProgress::new()`'s default draw target in indicatif 0.17) and
+/// leaves the **last** finished bar line *without* a terminating newline
+/// (the cursor is parked at the end of `✓ <name> [<elapsed>s]`). Under a
+/// TTY stdout and stderr are the *same terminal device*, so the next thing
+/// written to stdout — the `\n` separator from
+/// [`crate::display::refresh_plan_separator`] — lands right after that open
+/// bar line and is consumed just closing it, so no blank line appears
+/// before `Execution Plan:` / `No changes.`. This emits the one newline
+/// that closes the bar region; the separator then renders as the single
+/// intended blank line.
+///
+/// Only needed when the bar region is actually open on the terminal the
+/// plan prints to. `started_bar` is the running "region open" state
+/// (false for the empty-config header-only case, and reset when a
+/// `print_warnings` `⚠` line already closed the region). The
+/// `stdout().is_terminal()` gate excludes the piped path: there
+/// `refresh_multi_progress` redirects bars to stderr-only (keyed on
+/// exactly `!stdout().is_terminal()`) while the plan goes to a piped
+/// stdout whose `Refreshing state...` header is already newline-terminated
+/// by its `println!`, so no close is needed. On a TTY both fds are the
+/// same device, so `stdout().is_terminal()` correctly proxies "the open
+/// bar line is on the device we are about to print the plan to".
+pub(crate) fn finish_refresh_bar_region(started_bar: bool) {
+    if started_bar && std::io::stdout().is_terminal() {
+        println!();
+    }
 }
 
 /// Read a data source resource via the provider with retry on throttling errors.

--- a/carina-cli/tests/plan_refresh_separator_pty.rs
+++ b/carina-cli/tests/plan_refresh_separator_pty.rs
@@ -1,0 +1,277 @@
+//! PTY regression test for issue #3150 (follow-up to #3148 / #3149).
+//!
+//! #3149 added a blank-line separator between the refresh-progress block and
+//! the plan terminal section, but verified it only with piped stdout. Under a
+//! pipe the `✓` spinner lines are redirected to stderr and the plain
+//! `Refreshing state...` header (a `println!`, newline-terminated) is the only
+//! refresh output on stdout, so a single `\n` separator looked correct.
+//!
+//! Under a real TTY, indicatif draws the spinner bars to stderr (its default
+//! draw target) and leaves the **last** finished bar line *without a
+//! terminating newline* (the cursor is parked at the end of
+//! `✓ <name> [<elapsed>s]`). Because stdout and stderr are the same terminal
+//! device on a TTY, the single separator `\n` written to stdout is then
+//! entirely consumed just terminating that open bar line, so zero blank
+//! lines appear between the refresh block and `Execution Plan:` /
+//! `No changes.`. Only a PTY-backed test can observe this (a piped stdout
+//! splits the two fds, hiding it) — which is the whole point of this file.
+
+use std::io::Read;
+
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use tempfile::TempDir;
+
+/// Run `carina <args...>` attached to a real PTY and return everything it
+/// wrote to the terminal (stdout+stderr are the same stream on a PTY, which
+/// is exactly the user-facing reality this test must reproduce).
+fn run_on_pty(args: &[&str], cwd: &std::path::Path) -> String {
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 40,
+            cols: 120,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+
+    let mut cmd = CommandBuilder::new(env!("CARGO_BIN_EXE_carina"));
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.cwd(cwd);
+    // Keep the child deterministic regardless of the runner's environment.
+    // `clean()` strips ANSI either way, but removing these avoids any
+    // color/log env skewing the line structure the assertions inspect.
+    cmd.env_remove("CLICOLOR_FORCE");
+    cmd.env_remove("NO_COLOR");
+    cmd.env_remove("RUST_LOG");
+
+    let mut child = pty.slave.spawn_command(cmd).expect("spawn under pty");
+    // Drop the slave so EOF is delivered to the reader once the child exits.
+    drop(pty.slave);
+
+    let mut reader = pty.master.try_clone_reader().expect("pty reader");
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).expect("read pty output");
+    let status = child.wait().expect("child wait");
+    assert!(
+        status.success(),
+        "carina {args:?} failed under pty.\noutput:\n{}",
+        String::from_utf8_lossy(&buf)
+    );
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Strip CSI escape sequences and drop carriage returns so the assertions
+/// can reason about newline-delimited line structure.
+///
+/// This is deliberately narrow, not a terminal emulator. It removes CSI
+/// sequences (`ESC [ … final-byte`) — which is all indicatif emits here
+/// (SGR colors, `\x1b[2K` erase-line, cursor moves) — and drops `\r`
+/// instead of treating it as a column reset. The cleaned text is therefore
+/// a *concatenation of redraw frames*, NOT a reconstruction of the final
+/// screen. That is sufficient — and only sufficient — for the single thing
+/// every assertion here checks: whether the line immediately above a
+/// terminal-section marker (`Execution Plan:` / `No changes.`) is an empty
+/// `\n`-delimited line. The decisive separators in that region are true
+/// `\n`s emitted after the spinner finishes, so frame concatenation on the
+/// `✓` line above cannot mask or fabricate that blank line. Do not reuse
+/// `clean()` for full-screen assertions. indicatif does not emit OSC
+/// sequences on this path, so OSC is intentionally not handled (a lone
+/// non-CSI ESC just drops the following byte).
+fn clean(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            if chars.peek() == Some(&'[') {
+                // CSI: ESC [ … <final byte in @-~ range>.
+                chars.next();
+                for x in chars.by_ref() {
+                    if x.is_ascii_alphabetic() || x == '~' {
+                        break;
+                    }
+                }
+            } else {
+                // Non-CSI ESC (not emitted by indicatif here): drop the
+                // ESC and its single following byte.
+                chars.next();
+            }
+            continue;
+        }
+        if c == '\r' {
+            continue;
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// The line immediately above the first line that, after trimming, starts
+/// with `marker`. Panics with the full output if the marker is missing or is
+/// the first line.
+fn line_above<'a>(text: &'a str, marker: &str) -> &'a str {
+    let lines: Vec<&str> = text.lines().collect();
+    let idx = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with(marker))
+        .unwrap_or_else(|| panic!("marker {marker:?} not found in:\n{text}"));
+    assert!(
+        idx > 0,
+        "marker {marker:?} is the first line; expected a refresh block above:\n{text}"
+    );
+    lines[idx - 1]
+}
+
+fn init_project(body: &str) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("main.crn"), body).unwrap();
+    run_on_pty(&["init", tmp.path().to_str().unwrap()], tmp.path());
+    tmp
+}
+
+/// With resources to refresh, the TTY path renders `✓` spinner lines; the
+/// `Execution Plan:` header must be separated from the last `✓` line by
+/// exactly one blank line.
+#[test]
+fn execution_plan_separated_from_refresh_bars_on_pty() {
+    let tmp = init_project(
+        "backend local { path = \"carina.state.json\" }\n\
+         mock.test.resource { name = \"r1\" }\n",
+    );
+
+    let out = clean(&run_on_pty(
+        &["plan", tmp.path().to_str().unwrap()],
+        tmp.path(),
+    ));
+
+    assert!(
+        out.contains("Execution Plan:"),
+        "expected Execution Plan section.\n{out}"
+    );
+    assert!(
+        out.contains('✓'),
+        "expected at least one ✓ refresh line on the TTY path.\n{out}"
+    );
+    assert_eq!(
+        line_above(&out, "Execution Plan:"),
+        "",
+        "expected exactly one blank line between the refresh ✓ block and \
+         the Execution Plan header on a TTY (issue #3150).\n{out}"
+    );
+}
+
+// NOTE on the "No changes." terminal section under a TTY:
+//
+// There is intentionally no PTY test that asserts the blank line above
+// `No changes. Infrastructure is up-to-date.` *with refresh bars present*.
+// Reaching that state needs a resource that exists in state so `plan`
+// reports no diff. The CLI loads the mock provider as a WASM plugin
+// (`carina-provider-mock/src/main.rs`), whose `create` fails
+// (`carina apply` against a mock resource exits non-zero with
+// `Apply failed. 0 succeeded, 1 failed.` and persists nothing — verified
+// at runtime, not inferred from the in-process `MockProvider` in
+// `lib.rs`, which is a different type the CLI does not use). So
+// apply-then-plan cannot produce "No changes" while still rendering `✓`
+// bars, and a no-AWS test has no other way to get there.
+//
+// This is not a coverage gap, and the justification rests solely on a
+// structural argument, not on the mock's limitation: `finish_refresh_bar_region`
+// is called once, before `print_plan`, and is *section-agnostic* — it
+// closes the indicatif bar region regardless of which terminal section
+// `print_plan` then emits. `Execution Plan:` and `No changes.` are
+// printed by the same `print_plan` call below the same closed bar region,
+// so proving the close for one section proves it for both.
+// `execution_plan_separated_from_refresh_bars_on_pty` proves the
+// bar-region close on the TTY path; the non-PTY
+// `plan_refresh_separator_e2e.rs::no_changes_has_blank_line_after_refresh_block`
+// proves the no-changes section gets its separator. Together those two
+// plus the section-agnostic single close cover the no-changes-with-bars
+// case by construction.
+
+/// `--refresh=false` prints no refresh block, so the terminal section must
+/// NOT be preceded by a separator blank line (no regression of #3148's
+/// "no spurious blank line" guarantee).
+#[test]
+fn refresh_false_has_no_separator_on_pty() {
+    let tmp = init_project(
+        "backend local { path = \"carina.state.json\" }\n\
+         mock.test.resource { name = \"r1\" }\n",
+    );
+
+    let out = clean(&run_on_pty(
+        &["plan", tmp.path().to_str().unwrap(), "--refresh=false"],
+        tmp.path(),
+    ));
+
+    assert!(
+        out.contains("Execution Plan:"),
+        "expected Execution Plan section.\n{out}"
+    );
+    assert_ne!(
+        line_above(&out, "Execution Plan:"),
+        "",
+        "with --refresh=false there is no refresh block; the line above \
+         Execution Plan must not be blank (issue #3148/#3150).\n{out}"
+    );
+}
+
+/// Count consecutive empty lines directly above the first line that, after
+/// trimming, starts with `marker`.
+fn blank_lines_above(text: &str, marker: &str) -> usize {
+    let lines: Vec<&str> = text.lines().collect();
+    let idx = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with(marker))
+        .unwrap_or_else(|| panic!("marker {marker:?} not found in:\n{text}"));
+    let mut n = 0;
+    while idx > n && lines[idx - 1 - n].is_empty() {
+        n += 1;
+    }
+    n
+}
+
+/// Round-4 regression (#3150): when refresh bars are drawn AND a parse
+/// warning is printed AND there is no deferred-for child refresh, the
+/// printed `⚠` line already closes indicatif's open bar region. A
+/// cumulative "any bar drawn" flag would make `finish_refresh_bar_region`
+/// emit a second newline → TWO blank lines before `Execution Plan:`
+/// (warning terminator + spurious close + #3149 separator). The running
+/// `bar_region_open` flag (reset when `print_warnings` emits) must keep it
+/// at exactly ONE blank line.
+#[test]
+fn warning_after_bars_yields_single_blank_line_on_pty() {
+    // `mock.test.resource` → refresh bars. The static `for` loop with an
+    // unused binding `x` emits a top-level parse warning but resolves
+    // immediately (no deferred-for child refresh phase).
+    let tmp = init_project(
+        "backend local { path = \"carina.state.json\" }\n\
+         mock.test.resource { name = \"r1\" }\n\
+         for x in [\"a\", \"b\"] {\n\
+         \u{20}\u{20}mock.test.resource { name = \"static\" }\n\
+         }\n",
+    );
+
+    let out = clean(&run_on_pty(
+        &["plan", tmp.path().to_str().unwrap()],
+        tmp.path(),
+    ));
+
+    assert!(
+        out.contains("for-loop binding 'x' is unused"),
+        "expected the unused-for-binding warning.\n{out}"
+    );
+    assert!(
+        out.contains("Execution Plan:"),
+        "expected Execution Plan section.\n{out}"
+    );
+    assert!(out.contains('✓'), "expected ✓ refresh lines.\n{out}");
+    assert_eq!(
+        blank_lines_above(&out, "Execution Plan:"),
+        1,
+        "expected exactly ONE blank line between the warning and the \
+         Execution Plan header — two would mean the cumulative bar flag \
+         double-counted a region the warning already closed (#3150 \
+         Round-4).\n{out}"
+    );
+}

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -820,7 +820,13 @@ impl<E> File<E> {
     }
 
     /// Print all collected warnings to stderr.
-    pub fn print_warnings(&self) {
+    ///
+    /// Returns `true` iff at least one warning line was printed. Callers that
+    /// interleave this with indicatif progress output use the return value to
+    /// know the terminal's last line is now a newline-terminated `⚠` line
+    /// (not an open spinner bar) — see
+    /// `carina-cli`'s `finish_refresh_bar_region`.
+    pub fn print_warnings(&self) -> bool {
         for w in &self.warnings {
             let location = match &w.file {
                 Some(f) => format!("{}:{}", f, w.line),
@@ -828,6 +834,7 @@ impl<E> File<E> {
             };
             eprintln!("  ⚠ {}: {}", location, w.message);
         }
+        !self.warnings.is_empty()
     }
 
     /// Expand deferred for-expressions against the resolved binding view.


### PR DESCRIPTION
Closes #3150

## Problem

#3149 (for #3148) added a blank-line separator between the refresh-progress block and the plan terminal section, but was only verified with **piped stdout**. Under a real TTY the blank line landed in the wrong place — *after* the summary instead of *between* the `✓` progress block and `Execution Plan:` / `No changes.`.

## Root cause (confirmed via PTY byte capture)

indicatif 0.17 draws the spinner bars to **stderr** (its default draw target) and leaves the **last** finished bar line *without a terminating newline* — the cursor is parked at the end of `✓ <name> [<elapsed>s]`. On a TTY stdout and stderr are the same device, so #3149's single separator `\n` was consumed just *closing that open bar line*; zero blank lines appeared before the terminal section. The trailing gap the user saw was `format_plan`'s own pre-existing trailing `writeln!` (untouched here — separate concern).

This is the classic unit-test-path ≠ apply-path trap: a piped-stdout test splits the two fds and cannot observe it, which is exactly how #3149 shipped broken.

## Fix (scoped to `carina plan`)

Additive, in `carina-cli/src/wiring/mod.rs`:

- `finish_refresh_bar_region(...)` — called once after all refresh phases, before `print_plan`, emits one `println!()` iff the bar region is open on a terminal. The #3149 separator then renders as the single intended blank line.
- `refresh_resource_set` now returns whether it started any bars.
- `refresh_printed_bars` is a **running "region open" flag** (not a cumulative OR): set by any bar-drawing phase, and **reset when `print_warnings` emits** a newline-terminated `⚠` line (which already closes the region). Without the reset, the deferred-for-with-warnings TTY path produced *two* blank lines (Round-4 self-review finding).
- `print_warnings` now returns whether it printed anything; `DeferredForExpansion` carries it out as `printed_warnings`.

The #3149 `refresh_plan_separator` in `plan.rs` is unchanged. Non-TTY / `--refresh=false` / empty-config paths are unaffected; `format_plan` is byte-identical (snapshots unaffected).

## Verification (all under real PTY)

| Case | Result |
|---|---|
| TTY + bars → `Execution Plan:` | exactly one blank line ✓ |
| TTY + bars + warning + no deferred-for | exactly one blank line (was two) ✓ |
| `--refresh=false` TTY | no spurious blank line ✓ |
| non-TTY pipe | one blank line, no regression ✓ |

New PTY regression suite (`portable-pty`, **dev-dependency only — not in the release binary**) runs the real `carina plan` binary under a pseudo-tty and asserts the blank-line structure on actual terminal output.

Verify: workspace 3430 tests pass, doctests ok, clippy clean, all `scripts/check-*.sh` pass.

## Follow-up

`carina apply` has the same latent bar-region bug (different post-refresh flow — a confirmation prompt), out of scope here and tracked in #3151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)