### PR TITLE
plan: detect TOCTOU state drift and warn instead of holding a lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,54 @@ merged uniformly — no file name (including `main.crn`) is privileged.
 - CLI: `load_module()` / `ModuleResolver::load_module` require a directory path.
 - LSP: Module loading in `diagnostics/checks.rs` handles directory modules for proper validation.
 
+### Plan Concurrency Contract
+
+<!-- constrained-by #key-abstractions -->
+
+`carina plan` **takes no state lock.** `apply`/`destroy` acquire an
+exclusive lock (`backend.acquire_lock(...)`); `plan` deliberately does
+not. A lock on a read-only operation is overkill, and because the
+backend lock API is exclusive-only it would serialize concurrent
+`plan`s and let a long `plan` block deploys — too strong for a command
+whose output is only a prediction. (This was a deliberate decision for
+issue #3111; options considered were: (1) document as intentional,
+(2) acquire a shared/read lock, (3) detect drift and warn. Option 3
+was chosen — option 1 is weaker than Terraform and leaves the user
+unaware of staleness; option 2 needs a shared-lock mode the backends
+do not have and is only justified once a saved-plan/`plan -out`→`apply`
+workflow exists.)
+
+Because `plan` reads state once at `T0` and computes the diff against
+that snapshot with no lock held, a concurrent `apply`/`destroy` can
+make the displayed plan stale (a TOCTOU window — *not* a torn read;
+both backends write state atomically). To bound this, `plan`:
+
+1. Fingerprints state at `T0` (`StateFile::serial` + `lineage`) right
+   after the initial read — `StateSnapshot::capture` in
+   `carina-cli/src/commands/plan.rs`.
+2. Re-reads state just before display and compares
+   (`detect_state_drift`). A `lineage` change (state recreated) is
+   reported in preference to a `serial` bump (concurrent write).
+3. On drift, prints a **warning** to stderr and still shows the plan.
+   Drift is never fatal: the plan is a prediction, and `apply`
+   re-acquires the lock and recomputes the diff before mutating
+   anything, so final correctness is enforced on the `apply` side.
+
+`plan --out <file>` still writes the saved plan even when drift is
+detected (the warning goes to stderr; the plan file is the command's
+product). This is safe because the saved-plan apply path
+(`run_apply_from_plan_locked`) records the plan's `state_lineage` /
+`state_serial` and, under the apply lock, hard-errors on a lineage
+mismatch and warns on a serial bump before mutating — so a stale saved
+plan cannot be silently applied.
+
+The contract is "best-effort snapshot with drift warning", not "locked
+read". A failed re-read is also a warning, not an error. Regression
+coverage: pure classification in
+`commands::plan::state_drift_tests`; the real `carina plan` path
+(concurrent writer slipped into the `T0..T1` window via a deterministic
+file-handshake seam) in `carina-cli/tests/plan_state_drift_e2e.rs`.
+
 ### Directory-scoped, never single-file
 
 **Carina configurations are directory units.** Every feature that reads DSL

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -180,6 +180,131 @@ fn format_plan_save_error(e: &carina_core::value::SerializationError, flag: &str
     }
 }
 
+/// A point-in-time fingerprint of the state file captured immediately
+/// after `plan` first reads state (T0). `plan` takes no state lock
+/// (issue #3111: a lock on a read-only operation is overkill and would
+/// serialize concurrent `plan`s), so a concurrent `apply`/`destroy`
+/// can mutate state between this snapshot and when the plan is
+/// displayed. Comparing this snapshot against a re-read at T1 lets
+/// `plan` warn that its output may be stale (TOCTOU drift detection).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StateSnapshot {
+    /// `StateFile::serial` — monotonically increasing per state write.
+    serial: u64,
+    /// `StateFile::lineage` — changes only if the state was recreated
+    /// from scratch (e.g. a destroy + fresh apply, or `state` surgery).
+    lineage: String,
+}
+
+impl StateSnapshot {
+    /// Capture the snapshot from the state read at T0. `None` when no
+    /// state exists yet (first-ever plan): there is nothing a
+    /// concurrent writer could make stale, so drift detection is moot.
+    pub(crate) fn capture(state: Option<&StateFile>) -> Option<Self> {
+        state.map(|s| Self {
+            serial: s.serial,
+            lineage: s.lineage.clone(),
+        })
+    }
+}
+
+/// How the state changed between the T0 snapshot and the T1 re-read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StateDrift {
+    /// Same lineage, higher serial: a concurrent `apply`/`destroy`
+    /// wrote state while this `plan` was computing its diff.
+    SerialAdvanced { from: u64, to: u64 },
+    /// Lineage changed: the state was recreated entirely (destroy +
+    /// fresh apply, or `carina state` surgery) under this `plan`.
+    LineageChanged { from: String, to: String },
+    /// State existed at T0 but is gone at T1 (deleted concurrently).
+    StateRemoved,
+}
+
+impl StateDrift {
+    /// User-facing warning line explaining the plan may be stale.
+    pub(crate) fn warning(&self) -> String {
+        let detail = match self {
+            StateDrift::SerialAdvanced { from, to } => {
+                format!("state serial advanced {from} -> {to}")
+            }
+            StateDrift::LineageChanged { from, to } => {
+                format!("state lineage changed {from} -> {to}")
+            }
+            StateDrift::StateRemoved => "state was removed".to_string(),
+        };
+        format!(
+            "Warning: state changed during plan ({detail}); a concurrent \
+             apply/destroy ran while this plan was being computed. The \
+             plan output may be stale — re-run `carina plan`."
+        )
+    }
+}
+
+/// Compare the T0 snapshot against the state re-read at T1 (just
+/// before plan display) and classify any drift.
+///
+/// `before` is `None` only when no state existed at T0, in which case
+/// nothing could have gone stale — return `None`. A lineage change is
+/// reported in preference to a serial change because it is the
+/// stronger signal (the entire state was replaced).
+pub(crate) fn detect_state_drift(
+    before: Option<&StateSnapshot>,
+    after: Option<&StateFile>,
+) -> Option<StateDrift> {
+    let before = before?;
+    match after {
+        None => Some(StateDrift::StateRemoved),
+        Some(after) => {
+            if after.lineage != before.lineage {
+                Some(StateDrift::LineageChanged {
+                    from: before.lineage.clone(),
+                    to: after.lineage.clone(),
+                })
+            } else if after.serial != before.serial {
+                Some(StateDrift::SerialAdvanced {
+                    from: before.serial,
+                    to: after.serial,
+                })
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Test-only rendezvous between `plan`'s T0 state read and its T1
+/// re-read. Production builds never set the env var, so this is a
+/// no-op (one failed `getenv`); when set by the drift e2e test it is a
+/// file handshake — not a sleep — so the test can place a concurrent
+/// writer *deterministically* in the T0..T1 window (a fixed sleep
+/// would race the binary's own startup cost and flake). The binary
+/// signals "T0 captured" by creating `<dir>/t0_done`, then blocks
+/// until the test creates `<dir>/proceed`. The wait is bounded so a
+/// broken test cannot hang the binary forever. It has no effect on
+/// the concurrency contract.
+async fn drift_detection_test_barrier() {
+    const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+    // Matches the test side's t0_done tolerance. Generous because the
+    // repo runs process-per-test under heavily parallel nextest, where
+    // the test thread can be starved between observing t0_done and
+    // creating proceed; a tight bound here would flake. Unbounded is
+    // unnecessary (a runaway test is already capped by nextest's slow
+    // timeout) and this is test-only anyway, so it cannot hang prod.
+    const MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+
+    let Ok(dir) = std::env::var("CARINA_TEST_PLAN_DRIFT_HANDSHAKE_DIR") else {
+        return;
+    };
+    let dir = std::path::PathBuf::from(dir);
+    let _ = std::fs::write(dir.join("t0_done"), b"");
+    let proceed = dir.join("proceed");
+    let deadline = tokio::time::Instant::now() + MAX_WAIT;
+    while !proceed.exists() && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_plan(
     path: &Path,
@@ -272,6 +397,9 @@ pub async fn run_plan(
         backend
     };
 
+    // T0 fingerprint; see `StateSnapshot` for the TOCTOU rationale.
+    let state_snapshot_t0 = StateSnapshot::capture(state_file.as_ref());
+
     // Show bootstrap plan if needed
     if will_create_state_bucket {
         let backend_provider = plan_backend
@@ -347,6 +475,40 @@ pub async fn run_plan(
     )
     .await?;
     let has_changes = ctx.plan.mutation_count() > 0;
+
+    // TOCTOU drift detection (#3111). `plan` took no state lock, so a
+    // concurrent apply/destroy may have written state while the diff
+    // above was being computed. Re-read state now and compare against
+    // the T0 fingerprint; warn (do not fail) if it moved — the plan is
+    // a prediction, and apply re-locks + recomputes before mutating.
+    //
+    // Skipped entirely when no state existed at T0 (first-ever plan, or
+    // a bootstrap run that will create the backend): there is no
+    // baseline, so nothing could have gone stale and even a re-read
+    // *failure* is not worth a "may be stale" warning.
+    if let Some(snapshot_t0) = state_snapshot_t0.as_ref() {
+        drift_detection_test_barrier().await;
+        match plan_backend.read_state().await {
+            Ok(state_t1) => {
+                if let Some(drift) = detect_state_drift(Some(snapshot_t0), state_t1.as_ref()) {
+                    eprintln!("{}", drift.warning().yellow());
+                }
+            }
+            // A failed re-read is not fatal: the plan already computed
+            // against the T0 snapshot. Surface it so the user knows
+            // drift could not be checked, but let the plan print.
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    format!(
+                        "Warning: could not re-read state to check for \
+                         concurrent changes ({e}); plan output may be stale."
+                    )
+                    .yellow()
+                );
+            }
+        }
+    }
 
     // Check for prevent_destroy violations
     if ctx.plan.has_errors() {
@@ -1435,5 +1597,95 @@ mod plan_serialization_error_tests {
                 other => panic!("expected UnknownNotAllowed for {label}, got: {other:?}"),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod state_drift_tests {
+    use super::*;
+
+    fn state(serial: u64, lineage: &str) -> StateFile {
+        let mut s = StateFile::new();
+        s.serial = serial;
+        s.lineage = lineage.to_string();
+        s
+    }
+
+    #[test]
+    fn no_state_at_t0_means_no_drift() {
+        let before = StateSnapshot::capture(None);
+        let after = state(5, "abc");
+        assert_eq!(detect_state_drift(before.as_ref(), Some(&after)), None);
+    }
+
+    #[test]
+    fn unchanged_serial_and_lineage_is_no_drift() {
+        let s = state(7, "abc");
+        let before = StateSnapshot::capture(Some(&s));
+        assert_eq!(detect_state_drift(before.as_ref(), Some(&s)), None);
+    }
+
+    #[test]
+    fn advanced_serial_same_lineage_is_serial_drift() {
+        let t0 = state(7, "abc");
+        let before = StateSnapshot::capture(Some(&t0));
+        let t1 = state(8, "abc");
+        assert_eq!(
+            detect_state_drift(before.as_ref(), Some(&t1)),
+            Some(StateDrift::SerialAdvanced { from: 7, to: 8 })
+        );
+    }
+
+    #[test]
+    fn changed_lineage_is_lineage_drift_even_if_serial_lower() {
+        let t0 = state(9, "old-lineage");
+        let before = StateSnapshot::capture(Some(&t0));
+        // Fresh state after destroy+apply: new lineage, serial reset.
+        let t1 = state(0, "new-lineage");
+        assert_eq!(
+            detect_state_drift(before.as_ref(), Some(&t1)),
+            Some(StateDrift::LineageChanged {
+                from: "old-lineage".to_string(),
+                to: "new-lineage".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn state_removed_between_t0_and_t1_is_removed_drift() {
+        let t0 = state(3, "abc");
+        let before = StateSnapshot::capture(Some(&t0));
+        assert_eq!(
+            detect_state_drift(before.as_ref(), None),
+            Some(StateDrift::StateRemoved)
+        );
+    }
+
+    #[test]
+    fn warning_message_names_the_drift_kind() {
+        assert!(
+            StateDrift::SerialAdvanced { from: 1, to: 2 }
+                .warning()
+                .contains("serial advanced 1 -> 2")
+        );
+        assert!(
+            StateDrift::LineageChanged {
+                from: "a".into(),
+                to: "b".into()
+            }
+            .warning()
+            .contains("lineage changed a -> b")
+        );
+        assert!(
+            StateDrift::StateRemoved
+                .warning()
+                .contains("state was removed")
+        );
+        // Every variant must steer the user to re-run plan.
+        assert!(
+            StateDrift::StateRemoved
+                .warning()
+                .contains("re-run `carina plan`")
+        );
     }
 }

--- a/carina-cli/tests/plan_state_drift_e2e.rs
+++ b/carina-cli/tests/plan_state_drift_e2e.rs
@@ -1,0 +1,224 @@
+//! End-to-end test for issue #3111.
+//!
+//! `carina plan` takes no state lock (a lock on a read-only operation
+//! would be overkill and serialize concurrent plans). It instead
+//! detects TOCTOU drift: it fingerprints state at T0 (right after the
+//! initial read) and re-reads just before display; if a concurrent
+//! `apply`/`destroy` wrote state in that window, `plan` prints a
+//! warning so the user knows the displayed plan may be stale.
+//!
+//! The unit tests in `commands::plan::state_drift_tests` pin the pure
+//! classification (`detect_state_drift`). They do **not** prove the
+//! real `run_plan` path actually re-reads state and emits the warning
+//! — a green unit test calling the helper directly is not evidence the
+//! apply/runtime path runs it. This file drives the real `carina plan`
+//! binary with a deterministic concurrent writer slipped into the
+//! T0..T1 window via the `CARINA_TEST_PLAN_DRIFT_HANDSHAKE_DIR` seam.
+
+use std::fs;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+fn plain_text_command(bin: &str) -> Command {
+    let mut cmd = Command::new(bin);
+    cmd.env("NO_COLOR", "1").env_remove("CLICOLOR_FORCE");
+    cmd
+}
+
+/// Write a minimal local-backend project plus a hand-authored state
+/// file so state already exists at T0 (drift detection is moot when no
+/// state exists yet — there is nothing a concurrent writer could
+/// stale). Returns the path to `carina.state.json`.
+fn init_project_with_state(
+    dir: &std::path::Path,
+    serial: u64,
+    lineage: &str,
+) -> std::path::PathBuf {
+    fs::write(
+        dir.join("main.crn"),
+        r#"backend local { path = "carina.state.json" }
+exports { region: String = "ap-northeast-1" }"#,
+    )
+    .unwrap();
+
+    let state = serde_json::json!({
+        "version": 6,
+        "serial": serial,
+        "lineage": lineage,
+        "carina_version": "0.0.0-test",
+        "resources": [],
+        "exports": { "region": "ap-northeast-1" }
+    });
+    let state_path = dir.join("carina.state.json");
+    fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let status = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .args(["init", dir.to_str().unwrap()])
+        .status()
+        .expect("failed to execute carina init");
+    assert!(status.success(), "carina init failed");
+
+    state_path
+}
+
+/// Spawn `carina plan` and run `concurrent_writer` *deterministically*
+/// between the binary's T0 state read and its T1 re-read, using the
+/// binary's file-handshake seam (a fixed sleep would race the binary's
+/// own startup cost and flake). The binary creates `t0_done` once it
+/// has captured the T0 fingerprint and then blocks until this function
+/// creates `proceed`; the concurrent write happens strictly in that
+/// window. Pass a no-op closure for the control (no-drift) case.
+/// Returns the child's stderr.
+fn plan_with_concurrent_writer(dir: &std::path::Path, concurrent_writer: impl FnOnce()) -> String {
+    let handshake = TempDir::new().unwrap();
+    let t0_done = handshake.path().join("t0_done");
+    let proceed = handshake.path().join("proceed");
+
+    // Run from inside the project dir, exactly as a real user would
+    // (`cd project && carina plan .`). The `backend local { path =
+    // "carina.state.json" }` path is relative and resolves against the
+    // process CWD, not the plan-path arg — without this the binary
+    // would read an unrelated state file and never observe the drift.
+    let child = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .current_dir(dir)
+        .args(["plan", "."])
+        .env(
+            "CARINA_TEST_PLAN_DRIFT_HANDSHAKE_DIR",
+            handshake.path().to_str().unwrap(),
+        )
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn carina plan");
+
+    // Wait for the binary to signal it has captured the T0 snapshot.
+    let start = std::time::Instant::now();
+    while !t0_done.exists() {
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "carina plan never reached the T0 handshake"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    // T0 is captured; mutate state now — strictly inside the window.
+    concurrent_writer();
+
+    // Release the binary into its T1 re-read.
+    fs::write(&proceed, b"").unwrap();
+
+    let output = child.wait_with_output().expect("wait for carina plan");
+
+    assert!(
+        output.status.success(),
+        "carina plan should still succeed (drift is a warning, not an error).\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stderr).expect("stderr is not UTF-8")
+}
+
+#[test]
+fn concurrent_apply_between_read_and_display_emits_drift_warning() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    let state_path = init_project_with_state(dir, 7, "lineage-A");
+
+    let writer_path = state_path.clone();
+    let stderr = plan_with_concurrent_writer(dir, move || {
+        // Simulate a concurrent `apply`: same lineage, bumped serial.
+        let state = serde_json::json!({
+            "version": 6,
+            "serial": 8,
+            "lineage": "lineage-A",
+            "carina_version": "0.0.0-test",
+            "resources": [],
+            "exports": { "region": "ap-northeast-1" }
+        });
+        fs::write(&writer_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+    });
+
+    assert!(
+        stderr.contains("state changed during plan") && stderr.contains("serial advanced 7 -> 8"),
+        "expected a serial-drift warning on stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn no_concurrent_writer_emits_no_drift_warning() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    init_project_with_state(dir, 7, "lineage-A");
+
+    // Control: nothing writes state during the window.
+    let stderr = plan_with_concurrent_writer(dir, || {});
+
+    assert!(
+        !stderr.contains("state changed during plan"),
+        "no concurrent writer => no drift warning, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn unreadable_state_at_t1_warns_it_could_not_be_rechecked() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    let state_path = init_project_with_state(dir, 7, "lineage-A");
+
+    let writer_path = state_path.clone();
+    let stderr = plan_with_concurrent_writer(dir, move || {
+        // Concurrent writer corrupts state mid-write: the T1 re-read
+        // fails to deserialize, exercising the read-error branch
+        // (which must warn, not abort — the plan already computed
+        // against the intact T0 snapshot).
+        fs::write(&writer_path, b"{ this is not valid json").unwrap();
+    });
+
+    assert!(
+        stderr.contains("could not re-read state to check for concurrent changes"),
+        "expected a re-read-failure warning on stderr, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn no_state_at_t0_skips_drift_check_entirely() {
+    // First-ever plan: no state file exists. There is no T0 baseline,
+    // so the whole re-read/warn block must be skipped — neither the
+    // drift warning nor the "could not re-read state" warning may
+    // appear (the latter was a spurious-warning regression risk on
+    // first-run / bootstrap plans with a transient backend error).
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    fs::write(
+        dir.join("main.crn"),
+        r#"backend local { path = "carina.state.json" }
+exports { region: String = "ap-northeast-1" }"#,
+    )
+    .unwrap();
+    let status = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .args(["init", dir.to_str().unwrap()])
+        .status()
+        .expect("failed to execute carina init");
+    assert!(status.success(), "carina init failed");
+
+    let output = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .current_dir(dir)
+        .args(["plan", "."])
+        .output()
+        .expect("failed to execute carina plan");
+    assert!(
+        output.status.success(),
+        "carina plan failed.\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8(output.stderr).expect("stderr is not UTF-8");
+
+    assert!(
+        !stderr.contains("state changed during plan")
+            && !stderr.contains("could not re-read state"),
+        "no state at T0 => no drift / re-read warning of any kind, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Closes #3111

## Problem

`carina plan` does not acquire a state lock, while `apply`/`destroy` do. Because `plan` reads state once and computes the diff against that in-memory snapshot, a concurrent `apply`/`destroy` against the same state can make the displayed plan stale (a TOCTOU window — *not* a torn read; both backends write atomically).

## Decision

The issue asked to decide and document the concurrency contract among three options. **Option 3 — detect drift and warn — was chosen** (user-confirmed):

- **Option 1 (document as intentional)**: weaker than Terraform; leaves the user unaware of staleness. Rejected.
- **Option 2 (shared/read lock)**: the backend lock API is exclusive-only, so a `plan` lock would serialize concurrent `plan`s and let a long `plan` block deploys — too strong for a read-only command whose output is only a prediction. Only justified once a saved-plan workflow needs it; the existing saved-plan apply path already guards lineage/serial. Rejected for now.
- **Option 3 (drift detection + warn)**: `StateFile` already carries a monotonic `serial` and a `lineage`, so this is cheap and needs no backend lock-mode changes. Chosen.

## Implementation

- `StateSnapshot` — captures `(serial, lineage)` at T0, right after the initial `read_state()`. `None` when no state exists yet.
- `StateDrift` + `detect_state_drift` — pure, unit-tested classification: `SerialAdvanced`, `LineageChanged` (preferred over serial), `StateRemoved`.
- `run_plan` re-reads state just before display and warns on stderr if it moved. Drift is never fatal — the plan is a prediction; `apply` re-acquires the lock and recomputes before mutating.
- The whole re-read+warn block is **skipped when no state existed at T0** (first-ever / bootstrap plan), so no spurious warning is emitted even if a transient backend error occurs at T1.
- A failed re-read is a warning, not an error.

## Testing

Per the "unit-test path ≠ apply path" rule, the pure classifier is unit-tested (`commands::plan::state_drift_tests`, 6 tests) **and** the real `carina plan` binary is driven end-to-end (`carina-cli/tests/plan_state_drift_e2e.rs`, 4 tests): serial drift, no-drift control, re-read failure, and no-state-at-T0-skips-everything. The concurrent writer is placed deterministically in the T0..T1 window via an env-gated file-handshake test seam (no-op in production) rather than a racy sleep.

## Docs

`CLAUDE.md` gains a "Plan Concurrency Contract" section recording the contract, the decision among options 1/2/3, and the rationale (issue acceptance criteria 1 & 2).

## Follow-up

#3154 — unify the duplicated serial/lineage comparison with apply's inline guard and fix apply's stdout/stderr warning inconsistency. Kept out of scope here (1 PR = 1 topic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
