### PR TITLE
fix: hide terminal cursor for the whole command run, not just refresh (Closes #3158)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -38,7 +38,7 @@ use crate::commands::shared::state_writeback::{
     resolve_exports,
 };
 use crate::commands::state::map_lock_error;
-use crate::cursor::CursorGuard;
+use crate::cursor::CursorReveal;
 use crate::display::print_plan;
 use crate::error::AppError;
 use crate::wiring::{
@@ -824,9 +824,6 @@ async fn run_apply_locked(
     // Read states for all resources using identifier from state
     // In identifier-based approach, if there's no identifier in state, the resource doesn't exist
     // Skip virtual resources (module attribute containers) — they have no infrastructure.
-    // Hide the cursor for the refresh spinners; see `CursorGuard`. Apply
-    // always refreshes, so it is unconditional (#3153).
-    let cursor_guard = CursorGuard::stdout();
     RefreshProgress::start_header();
     let multi = refresh_multi_progress();
     let provider_ref = &provider;
@@ -1059,11 +1056,6 @@ async fn run_apply_locked(
             .hydrate_read_state(&mut current_states, &saved_attrs)
             .await;
     }
-
-    // Explicit drop (not scope exit): the cursor must be restored before
-    // the plan / confirmation prompt prints below, not at end of function.
-    // All refresh spinner phases are done by here (#3153).
-    drop(cursor_guard);
 
     // Build initial bindings for reference resolution (wait_aliases
     // defined above before Phase 2).
@@ -1705,12 +1697,17 @@ where
         "  {}",
         "Carina will perform the actions described above. Type 'yes' to confirm.".yellow()
     );
-    print!("\n  Enter a value: ");
-    std::io::Write::flush(&mut std::io::stdout()).map_err(|e| e.to_string())?;
+    // The cursor is hidden command-wide (#3158); reveal it for the prompt
+    // so the user does not type blind, and re-hide on scope exit.
+    let input = {
+        let _reveal = CursorReveal::new();
+        print!("\n  Enter a value: ");
+        std::io::Write::flush(&mut std::io::stdout()).map_err(|e| e.to_string())?;
 
-    let read_result = crate::signal::read_line_with_interrupt(reader, interrupt).await;
-    emit_newline_on_interrupt(&mut std::io::stdout(), &read_result);
-    let input = read_result?;
+        let read_result = crate::signal::read_line_with_interrupt(reader, interrupt).await;
+        emit_newline_on_interrupt(&mut std::io::stdout(), &read_result);
+        read_result?
+    };
 
     if input.trim() != "yes" {
         println!();

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -31,7 +31,7 @@ use crate::commands::shared::state_writeback::{
     apply_destroy_to_state, apply_name_overrides, build_orphan_resource,
 };
 use crate::commands::state::map_lock_error;
-use crate::cursor::CursorGuard;
+use crate::cursor::CursorReveal;
 use crate::display::{format_destroy_plan, format_effect};
 use crate::error::AppError;
 use crate::wiring::{
@@ -182,11 +182,6 @@ async fn run_destroy_locked(
     // Build current states -- either from provider (refresh=true) or from state file
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
 
-    // Hide the cursor for the refresh spinners; see `CursorGuard`. Only the
-    // `refresh` branch below draws spinners, so arm the guard only then
-    // (#3153).
-    let cursor_guard = refresh.then(CursorGuard::stdout);
-
     if refresh {
         RefreshProgress::start_header();
         let multi = refresh_multi_progress();
@@ -270,11 +265,6 @@ async fn run_destroy_locked(
             all_resources.push(orphan_resource);
         }
     }
-
-    // Explicit drop (not scope exit): the cursor must be restored before
-    // the destroy plan / "Type 'yes' to confirm" prompt prints below, not
-    // at end of function (#3153).
-    drop(cursor_guard);
 
     // Sort all resources (managed + orphans) for destroy ordering.
     // Uses depth-based pre-sorting to ensure stable ordering for independent
@@ -434,13 +424,19 @@ async fn run_destroy_locked(
             "  {}",
             "This action cannot be undone. Type 'yes' to confirm.".yellow()
         );
-        print!("\n  Enter a value: ");
-        std::io::Write::flush(&mut std::io::stdout()).map_err(|e| e.to_string())?;
-
+        // The cursor is hidden command-wide (#3158); reveal it for this
+        // irreversible-destroy confirmation so the user does not type
+        // blind, and re-hide on scope exit.
         let mut input = String::new();
-        std::io::stdin()
-            .read_line(&mut input)
-            .map_err(|e| e.to_string())?;
+        {
+            let _reveal = CursorReveal::new();
+            print!("\n  Enter a value: ");
+            std::io::Write::flush(&mut std::io::stdout()).map_err(|e| e.to_string())?;
+
+            std::io::stdin()
+                .read_line(&mut input)
+                .map_err(|e| e.to_string())?;
+        }
 
         if input.trim() != "yes" {
             println!();

--- a/carina-cli/src/cursor.rs
+++ b/carina-cli/src/cursor.rs
@@ -1,17 +1,25 @@
-//! Terminal cursor visibility control for the refresh-progress phase (#3153).
+//! Terminal cursor visibility control for the whole command run
+//! (#3153, #3158).
 //!
 //! `indicatif` manages line clearing and cursor *movement* but never emits
-//! DECTCEM hide/show. So while the refresh spinner runs the terminal's
-//! caret stays visible, parked on the active spinner row; screenshots of
-//! `carina plan` show a stray cursor and it reads as "the command is
-//! waiting for input".
+//! DECTCEM hide/show. So while a `carina` command runs the terminal's caret
+//! stays visible; screenshots show a stray cursor and a parked caret reads
+//! as "the command is waiting for input".
 //!
-//! Two cooperating mechanisms restore the cursor, coordinated by one
-//! process-global [`CURSOR_HIDDEN`] flag so exactly one of them emits the
-//! restore sequence:
+//! The cursor is hidden for the **entire command lifetime** — a single
+//! [`CursorGuard`] is constructed once at startup (`main.rs`, right after
+//! CLI parse) and held until process exit. #3153 originally scoped this to
+//! just the refresh-spinner phase, which made the cursor flicker (visible
+//! during provider load → hidden during refresh → visible again before the
+//! result printed); #3158 widened it to command-wide.
 //!
-//! 1. [`CursorGuard`] — an RAII guard covering the normal exit and `?`
-//!    error-unwind paths (stack unwinding runs its `Drop`).
+//! Three cooperating mechanisms manage the cursor, coordinated by one
+//! process-global [`CURSOR_HIDDEN`] flag so the restore sequence is emitted
+//! exactly once:
+//!
+//! 1. [`CursorGuard`] — the command-lifetime RAII guard. Hides on
+//!    construct, restores on `Drop` (covers normal exit and `?`
+//!    error-unwind).
 //! 2. [`install_restore_handlers`] — a SIGINT/SIGTERM signal handler plus a
 //!    panic hook that cover the abnormal exits unwinding can't: `plan` has
 //!    no Ctrl+C cancellation (it holds no state lock, so unlike
@@ -19,6 +27,12 @@
 //!    second Ctrl+C force-exits via `std::process::exit`, and a panic with
 //!    `panic = "abort"` does not unwind. In all of these `Drop` never runs,
 //!    so without this net the terminal is left with a hidden cursor.
+//! 3. [`CursorReveal`] — a scoped *inverse* guard for interactive
+//!    confirmation prompts (apply/destroy "Enter a value:" / "Type 'yes'").
+//!    With the cursor hidden command-wide the user would otherwise type
+//!    blind; `CursorReveal` temporarily shows the cursor for the prompt and
+//!    re-hides it on drop. This is the one intentional, user-driven reveal
+//!    (not flicker — it is exactly where the user is being asked to type).
 //!
 //! The signal handler runs in an async-signal context: it may only perform
 //! a raw `write(2)` and an `AtomicBool` swap, nothing else (no allocation,
@@ -38,6 +52,21 @@ const CURSOR_SHOW: &[u8] = b"\x1b[?25h";
 /// first (via [`AtomicBool::swap`]) — so the sequence is emitted exactly
 /// once no matter which exit path fires.
 static CURSOR_HIDDEN: AtomicBool = AtomicBool::new(false);
+
+/// Restore the cursor before a `std::process::exit`.
+///
+/// `process::exit` runs no destructors, so the command-wide [`CursorGuard`]'s
+/// `Drop` never fires, and it is neither a signal nor a panic so
+/// [`install_restore_handlers`]'s net does not catch it either. Every
+/// `process::exit` site that can be reached while the cursor is hidden —
+/// notably `main::handle_app_error`, the universal command-error path —
+/// must call this first, or the terminal is left with a hidden cursor on
+/// error (#3158: command-wide hiding makes this reachable from the very
+/// start of the run). Idempotent and claim-once with the guard/signal/panic
+/// paths, so calling it on a path that *also* unwinds is harmless.
+pub fn restore_cursor() {
+    restore_cursor_once(false);
+}
 
 /// Restore the cursor *iff* it is currently hidden, claiming the restore so
 /// no other path repeats it. `true` means this call performed the restore.
@@ -71,7 +100,7 @@ fn restore_cursor_once(async_signal_safe: bool) -> bool {
 }
 
 /// RAII guard that hides the terminal cursor for the lifetime of the
-/// refresh-progress phase and restores it on drop.
+/// command and restores it on drop.
 ///
 /// Construction emits `\x1b[?25l` and arms [`CURSOR_HIDDEN`]; `Drop` emits
 /// `\x1b[?25h` (claiming the restore via [`restore_cursor_once`]) on the
@@ -82,7 +111,7 @@ fn restore_cursor_once(async_signal_safe: bool) -> bool {
 /// [`crate::wiring::finish_refresh_bar_region`]'s gate: when stdout is not a
 /// TTY (CI capture, redirection to a file) nothing is emitted, so captured
 /// logs stay clean. With `should_hide` false the guard is fully inert.
-pub(crate) struct CursorGuard<W: std::io::Write> {
+pub struct CursorGuard<W: std::io::Write> {
     writer: W,
     should_hide: bool,
 }
@@ -104,10 +133,10 @@ impl<W: std::io::Write> CursorGuard<W> {
 }
 
 impl CursorGuard<std::io::Stdout> {
-    /// Hide the cursor on stdout for the refresh phase, restoring it on drop.
+    /// Hide the cursor on stdout for the whole command, restoring it on drop.
     ///
     /// Inert (writes nothing, ever) when stdout is not a terminal.
-    pub(crate) fn stdout() -> Self {
+    pub fn stdout() -> Self {
         let should_hide = std::io::stdout().is_terminal();
         Self::new(std::io::stdout(), should_hide)
     }
@@ -126,6 +155,70 @@ impl<W: std::io::Write> Drop for CursorGuard<W> {
             let _ = self.writer.write_all(CURSOR_SHOW);
             let _ = self.writer.flush();
         }
+    }
+}
+
+/// Scoped *inverse* of [`CursorGuard`]: temporarily reveal the cursor while
+/// an interactive confirmation prompt is on screen, then re-hide it.
+///
+/// With [`CursorGuard`] hiding the cursor command-wide, the apply/destroy
+/// confirmation prompts ("Enter a value:" / "Type 'yes' to confirm.")
+/// would have the user typing blind. Wrapping the prompt in a
+/// `CursorReveal` shows the caret for the duration of the prompt and
+/// restores the hidden state on drop. This is the single intentional,
+/// user-driven reveal — it lands exactly where the user is asked to type,
+/// so it is expected, not the #3158 flicker.
+///
+/// Coordination with [`CURSOR_HIDDEN`] / [`restore_cursor_once`]:
+///
+/// - On construct, if the cursor is currently hidden it is *claimed*
+///   (`swap(false)`) and `\x1b[?25h` is written — taking the flag away
+///   from the signal/panic net for the prompt's duration so they can't
+///   double-emit.
+/// - On drop, if this reveal performed the show, it re-hides
+///   (`\x1b[?25l`) and re-arms the flag, returning ownership to the
+///   command-wide guard. If a signal fired *during* the prompt it found
+///   the flag already `false` (this reveal had claimed it), did nothing,
+///   and `emulate_default_handler` terminated the process before this drop
+///   runs — leaving the cursor visible, which is the correct end state
+///   for an interrupted prompt.
+/// - If the cursor was not hidden at construct (non-TTY, or the
+///   command-wide guard is inert), the reveal is fully inert.
+pub(crate) struct CursorReveal {
+    /// True iff this reveal performed the show and therefore owes a re-hide.
+    revealed: bool,
+}
+
+impl CursorReveal {
+    /// Reveal the cursor for the lifetime of this value, if it is hidden.
+    pub(crate) fn new() -> Self {
+        // Claiming the hidden state and emitting show is exactly
+        // `restore_cursor_once`: it `swap(false)`s the flag and, iff it won
+        // that transition, writes `CURSOR_SHOW` via buffered stdout. Reusing
+        // it keeps the claim-once protocol in one place; the inverse half
+        // (re-hide + re-arm) has no equivalent and lives in `Drop`.
+        let revealed = restore_cursor_once(false);
+        Self { revealed }
+    }
+}
+
+impl Drop for CursorReveal {
+    fn drop(&mut self) {
+        if !self.revealed {
+            return;
+        }
+        // Re-hide and hand the flag back to the command-wide guard / net.
+        // Unconditional `store(true)` (not a `swap`) is the one place the
+        // strict "only the swap-winner mutates" discipline is relaxed: this
+        // reveal claimed the flag in `new`, the prompt is synchronous and
+        // single-threaded, and a SIGINT during it terminates the process
+        // before this drop runs — so nothing else can have touched the flag
+        // between `new` and here. Safe only under that sole-mutator invariant.
+        use std::io::Write;
+        let mut out = std::io::stdout();
+        let _ = out.write_all(CURSOR_HIDE);
+        let _ = out.flush();
+        CURSOR_HIDDEN.store(true, Ordering::SeqCst);
     }
 }
 
@@ -285,6 +378,47 @@ mod tests {
         assert!(
             !restore_cursor_once(true),
             "not armed: a second signal-safe call must be a no-op (no double restore)"
+        );
+    }
+
+    #[test]
+    fn reveal_shows_then_rehides_when_cursor_was_hidden() {
+        let _l = TEST_LOCK.lock().unwrap();
+        // Command-wide guard has hidden the cursor (flag armed).
+        CURSOR_HIDDEN.store(true, Ordering::SeqCst);
+        {
+            let r = CursorReveal::new();
+            assert!(r.revealed, "reveal claims the hidden state and shows");
+            assert!(
+                !CURSOR_HIDDEN.load(Ordering::SeqCst),
+                "flag taken from the signal/panic net for the prompt's duration"
+            );
+            // A signal arriving during the prompt finds the flag already
+            // false and must not double-restore.
+            assert!(
+                !restore_cursor_once(true),
+                "signal during prompt is a no-op (reveal owns the state)"
+            );
+            drop(r);
+        }
+        assert!(
+            CURSOR_HIDDEN.load(Ordering::SeqCst),
+            "after the prompt the hidden state is handed back to the guard"
+        );
+    }
+
+    #[test]
+    fn reveal_is_inert_when_cursor_not_hidden() {
+        let _l = TEST_LOCK.lock().unwrap();
+        // Non-TTY / inert command-wide guard: nothing was hidden.
+        CURSOR_HIDDEN.store(false, Ordering::SeqCst);
+        {
+            let r = CursorReveal::new();
+            assert!(!r.revealed, "nothing to reveal when not hidden");
+        }
+        assert!(
+            !CURSOR_HIDDEN.load(Ordering::SeqCst),
+            "an inert reveal must not arm the flag on drop"
         );
     }
 }

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -299,9 +299,9 @@ async fn main() {
 
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
 
-    // Restore the terminal cursor if a refresh spinner is interrupted by
-    // SIGINT/SIGTERM or a panic — exit paths the RAII `CursorGuard`'s
-    // `Drop` cannot reach (#3153).
+    // Restore the terminal cursor on the exit paths the command-wide
+    // `CursorGuard`'s `Drop` cannot reach — SIGINT/SIGTERM and panic
+    // (#3153, #3158).
     carina_cli::cursor::install_restore_handlers();
 
     // Create parser configuration with AWS KMS decryptor.
@@ -309,6 +309,12 @@ async fn main() {
     let provider_context = create_provider_context();
 
     let cli = Cli::parse();
+
+    // Command-wide cursor hide (#3158 — rationale in `cursor.rs`). Placed
+    // after `Cli::parse()` because that exits the process itself on
+    // --help/--version/parse error, so those paths must not hide; and
+    // before dispatch so all user-visible output runs cursor-hidden.
+    let _cursor_guard = carina_cli::cursor::CursorGuard::stdout();
 
     // Handle Plan separately since it returns Result<bool, String>
     if let Commands::Plan {
@@ -336,6 +342,9 @@ async fn main() {
         {
             Ok(has_changes) => {
                 if detailed_exitcode && has_changes {
+                    // process::exit skips Drop — restore the cursor first
+                    // (#3158); claim-once with the guard/net.
+                    carina_cli::cursor::restore_cursor();
                     std::process::exit(2);
                 }
             }
@@ -408,6 +417,9 @@ async fn main() {
             locked,
         } => {
             if let Err(e) = commands::init::run_init(&path, upgrade, locked) {
+                // process::exit skips Drop — restore the cursor first
+                // (#3158); claim-once with the guard/net.
+                carina_cli::cursor::restore_cursor();
                 eprintln!("{}", format!("Error: {e}").red());
                 std::process::exit(1);
             }
@@ -498,6 +510,10 @@ fn render_app_error(e: &error::AppError) -> AppErrorRendering {
 /// matches; everything else falls through to the generic `Error: ...`
 /// formatter (#2407).
 fn handle_app_error(e: error::AppError) -> ! {
+    // `process::exit` runs no destructors, so the command-wide CursorGuard
+    // would never restore the cursor on the error path — restore it here
+    // first (#3158). Claim-once, so this is harmless if a guard also ran.
+    carina_cli::cursor::restore_cursor();
     let rendering = render_app_error(&e);
     if !rendering.stderr.is_empty() {
         eprint!("{}", rendering.stderr);

--- a/carina-cli/src/signal.rs
+++ b/carina-cli/src/signal.rs
@@ -44,6 +44,10 @@ where
                         .red()
                         .bold()
                 );
+                // The SIGINT handler also restores on this second Ctrl+C,
+                // but `process::exit` skips Drop and handler ordering is
+                // not guaranteed — restore explicitly (claim-once, #3158).
+                crate::cursor::restore_cursor();
                 std::process::exit(130);
             });
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -32,7 +32,6 @@ use carina_provider_mock::MockProvider;
 use carina_state::StateFile;
 
 use crate::commands::shared::progress::{RefreshProgress, refresh_multi_progress};
-use crate::cursor::CursorGuard;
 use crate::error::AppError;
 
 /// Result of creating a plan, with context needed for saving
@@ -108,6 +107,9 @@ pub fn build_factories_from_providers(
     base_dir: &Path,
 ) -> (Vec<Box<dyn ProviderFactory>>, HashMap<String, String>) {
     if let Err(e) = carina_provider_resolver::validate_lock_constraints(base_dir, providers) {
+        // process::exit skips Drop — restore the cursor first (#3158);
+        // claim-once with the command-wide guard/net.
+        crate::cursor::restore_cursor();
         eprintln!("{}", e.red());
         std::process::exit(1);
     }
@@ -1417,10 +1419,6 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // resets it (Round-4 finding — see the reset after expansion below).
     let mut refresh_printed_bars = false;
 
-    // Hide the cursor for the refresh spinners; see `CursorGuard`. Armed
-    // only when `refresh` actually draws spinners (#3153).
-    let cursor_guard = refresh.then(CursorGuard::stdout);
-
     if refresh {
         RefreshProgress::start_header();
         let multi = refresh_multi_progress();
@@ -1710,10 +1708,6 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // All refresh phases are done. Close indicatif's open bar line so the
     // separator + plan render below it instead of being swallowed (#3150).
     finish_refresh_bar_region(refresh_printed_bars);
-
-    // Explicit drop (not scope exit): the cursor must be restored before
-    // the plan prints below, not at end of function (#3153).
-    drop(cursor_guard);
 
     // Build orphan dependency bindings from state file for tree structure
     let orphan_dependencies = if let Some(sf) = state_file.as_ref() {

--- a/carina-cli/tests/plan_refresh_cursor_hide_pty.rs
+++ b/carina-cli/tests/plan_refresh_cursor_hide_pty.rs
@@ -1,21 +1,23 @@
-//! PTY regression test for issue #3153.
+//! PTY regression test for issues #3153 / #3158.
 //!
-//! `carina plan` (and `apply` / `destroy`) draws the refresh spinner with
-//! indicatif, which manages line clearing and cursor *movement* but never
-//! emits DECTCEM cursor hide/show (`\x1b[?25l` / `\x1b[?25h`). So while the
-//! spinner runs the terminal's text caret stays visible, parked on the
-//! active spinner row; screenshots of `carina plan` show a stray cursor
-//! and it reads as "the command is waiting for input".
+//! `carina` draws the refresh spinner with indicatif, which manages line
+//! clearing and cursor *movement* but never emits DECTCEM cursor hide/show
+//! (`\x1b[?25l` / `\x1b[?25h`). Without intervention the caret stays
+//! visible the whole run; screenshots show a stray cursor and a parked
+//! caret reads as "the command is waiting for input".
 //!
-//! The fix wraps the refresh phase in a `CursorGuard` (emits `\x1b[?25l`
-//! on entry, `\x1b[?25h` on the normal / `?`-error drop) backed by a
-//! SIGINT/SIGTERM + panic restore net for the non-unwinding exits (see
-//! `carina-cli/src/cursor.rs`; the signal/panic coordination is unit-tested
-//! there). This test asserts the happy path against a real PTY (the
-//! user-facing reality — under a pipe the spinner is suppressed entirely):
-//! both sequences present, in stream order. It deliberately inspects the
-//! **raw** PTY bytes, not a CSI-stripped copy, because the sequences under
-//! test are themselves CSI.
+//! #3153 added a `CursorGuard`; #3158 widened it to the **whole command
+//! run** (a single guard built in `main.rs`, held to process exit) because
+//! the refresh-only scope made the cursor flicker (visible during provider
+//! load → hidden during refresh → visible again before the result). The
+//! plan path has no interactive prompt, so the correct user-facing
+//! behavior is: hide once near the start, **no `\x1b[?25h` until the very
+//! end** (no mid-run reveal), restore exactly once at exit.
+//!
+//! This test asserts that against a real PTY (the user-facing reality —
+//! under a pipe the spinner is suppressed entirely). It deliberately
+//! inspects the **raw** PTY bytes, not a CSI-stripped copy, because the
+//! sequences under test are themselves CSI.
 
 use std::io::Read;
 
@@ -66,10 +68,12 @@ fn init_project(body: &str) -> TempDir {
     tmp
 }
 
-/// On a TTY, `carina plan` with resources to refresh must hide the cursor
-/// before the spinner runs and restore it after, in that order (#3153).
+/// On a TTY, `carina plan` must hide the cursor once near the start and
+/// not reveal it again until the very end — no mid-run flicker (#3158).
+/// The plan path has no confirmation prompt, so there must be exactly one
+/// hide and exactly one show, the show coming after the final plan output.
 #[test]
-fn plan_hides_and_restores_cursor_around_refresh_on_pty() {
+fn plan_keeps_cursor_hidden_for_whole_command_no_flicker_on_pty() {
     let tmp = init_project(
         "backend local { path = \"carina.state.json\" }\n\
          mock.test.resource { name = \"r1\" }\n",
@@ -84,18 +88,54 @@ fn plan_hides_and_restores_cursor_around_refresh_on_pty() {
         "expected at least one ✓ refresh line on the TTY path.\n{raw}"
     );
 
-    let hide = raw.find("\x1b[?25l").unwrap_or_else(|| {
-        panic!("expected DECTCEM cursor-hide (ESC[?25l) during refresh.\n{raw:?}")
-    });
-    let show = raw.rfind("\x1b[?25h").unwrap_or_else(|| {
-        panic!("expected DECTCEM cursor-show (ESC[?25h) after refresh.\n{raw:?}")
-    });
+    let hides: Vec<usize> = raw.match_indices("\x1b[?25l").map(|(i, _)| i).collect();
+    let shows: Vec<usize> = raw.match_indices("\x1b[?25h").map(|(i, _)| i).collect();
 
-    assert!(
-        hide < show,
-        "cursor must be hidden (ESC[?25l) before it is restored (ESC[?25h); \
-         got hide@{hide} show@{show}.\n{raw:?}"
+    // Exactly one hide/show pair: command-wide guard hides once at startup,
+    // restores once at exit. More than one show before the end would be the
+    // #3158 flicker (a reveal in the middle of the run).
+    assert_eq!(
+        hides.len(),
+        1,
+        "expected exactly one cursor-hide (command-wide), got {}: {raw:?}",
+        hides.len()
     );
+    assert_eq!(
+        shows.len(),
+        1,
+        "expected exactly one cursor-show (restore at exit); more than one \
+         means the cursor flickered mid-run (#3158), got {}: {raw:?}",
+        shows.len()
+    );
+
+    let hide = hides[0];
+    let show = shows[0];
+
+    // Hide must come before any refresh output (the guard is installed in
+    // main.rs before command dispatch, so it precedes `Refreshing state...`).
+    let refreshing = raw
+        .find("Refreshing state")
+        .unwrap_or_else(|| panic!("expected 'Refreshing state' in output.\n{raw:?}"));
+    assert!(
+        hide < refreshing,
+        "cursor-hide (@{hide}) must precede 'Refreshing state' (@{refreshing}) \
+         — the whole command runs with the cursor hidden (#3158).\n{raw:?}"
+    );
+
+    // The single show must come after the last visible output (the plan /
+    // No-changes terminal section), i.e. it is the exit restore, not a
+    // mid-run reveal.
+    let last_content = raw
+        .rfind("No changes")
+        .or_else(|| raw.rfind("Execution Plan"))
+        .or_else(|| raw.rfind('✓'))
+        .unwrap_or_else(|| panic!("expected a plan terminal section.\n{raw:?}"));
+    assert!(
+        show > last_content,
+        "the only cursor-show (@{show}) must come AFTER the final plan \
+         output (@{last_content}); a show before it is the #3158 flicker.\n{raw:?}"
+    );
+
     assert_cursor_not_left_hidden(&raw);
 }
 
@@ -117,6 +157,68 @@ fn assert_cursor_not_left_hidden(raw: &str) {
              cursor-show at all.\n{raw:?}"
         ),
     }
+}
+
+/// Like [`run_on_pty`] but does NOT assert success — for the error-path
+/// test, where `carina` is expected to exit non-zero via
+/// `main::handle_app_error` → `std::process::exit`.
+fn run_on_pty_allow_failure(args: &[&str], cwd: &std::path::Path) -> String {
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 40,
+            cols: 120,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+
+    let mut cmd = CommandBuilder::new(env!("CARGO_BIN_EXE_carina"));
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.cwd(cwd);
+    cmd.env_remove("CLICOLOR_FORCE");
+    cmd.env_remove("NO_COLOR");
+    cmd.env_remove("RUST_LOG");
+
+    let mut child = pty.slave.spawn_command(cmd).expect("spawn under pty");
+    drop(pty.slave);
+
+    let mut reader = pty.master.try_clone_reader().expect("pty reader");
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).expect("read pty output");
+    let _ = child.wait();
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// On the error path, `carina` exits via `process::exit` (which runs no
+/// destructors) — neither the command-wide `CursorGuard`'s `Drop` nor the
+/// signal/panic net fires. `main::handle_app_error` must restore the cursor
+/// explicitly, or the terminal is left with a hidden cursor on every
+/// command error (#3158: command-wide hiding makes this reachable from the
+/// very start of the run).
+#[test]
+fn plan_error_path_does_not_leave_cursor_hidden_on_pty() {
+    let tmp = TempDir::new().unwrap();
+    // A parse error: forces validation/load failure → `handle_app_error`
+    // → `std::process::exit`, bypassing Drop.
+    std::fs::write(tmp.path().join("main.crn"), "this is not valid carina {{\n").unwrap();
+
+    let raw = run_on_pty_allow_failure(&["plan", tmp.path().to_str().unwrap()], tmp.path());
+
+    // Non-vacuous by construction: the command-wide guard arms right after
+    // Cli::parse() (before dispatch), and this parse error is detected
+    // *during* dispatch, so on a PTY the cursor is always hidden before the
+    // error — proving the error path genuinely entered the guarded state.
+    assert!(
+        raw.contains("\x1b[?25l"),
+        "expected the cursor to have been hidden before the error \
+         (command-wide guard arms before dispatch).\n{raw:?}"
+    );
+    // The decisive invariant: the error path (process::exit, skips Drop)
+    // must still restore the cursor — `handle_app_error` calls
+    // `restore_cursor()`.
+    assert_cursor_not_left_hidden(&raw);
 }
 
 // NOTE on the SIGINT/SIGTERM restore path:


### PR DESCRIPTION
Closes #3158

## Problem

#3153 hid the cursor only during the refresh-spinner phase, so it flickered: visible right after launch / during provider load (`Using awscc …`), hidden during refresh, visible again before the result printed. The #3153 motivation (clean screenshots) wants the cursor hidden for the **whole command run**.

## Fix (design decided on #3158)

- **Command-wide guard**: a single `CursorGuard` in `main.rs`, constructed right after `Cli::parse()` (clap exits the process itself on `--help`/`--version`/parse error, so those never hide) and before command dispatch, held to process exit. Removed the per-command guards + explicit drops in `wiring`/`apply`/`destroy`. `Using awscc …` is emitted during dispatch (after the guard), so all three reported symptoms are fixed.
- **`CursorReveal`** (inverse RAII): apply/destroy confirmation prompts would have the user typing blind under command-wide hiding. `CursorReveal` shows the cursor for the prompt and re-hides on drop, coordinated with the process-global `CURSOR_HIDDEN` claim-once protocol (a SIGINT during the prompt does not double-emit; end state is correctly visible). This is the one intentional, user-driven reveal — it lands exactly where the user is asked to type.
- **`restore_cursor()` before every `process::exit`** (which skips `Drop`): `handle_app_error` (the universal command-error path), detailed-exitcode exit, init error, `signal.rs` second-Ctrl+C, and the provider lock-constraint failure in `build_factories_from_providers`. Without these the terminal is left with a hidden cursor on error.

## Tests

- `cursor.rs` unit tests: `CursorReveal` show/re-hide + claim-once coordination with the signal path; inert when not hidden.
- PTY tests (real binary): no-flicker invariant (exactly one hide before `Refreshing state`, one show after the final plan output) and an error-path regression (parse error → `handle_app_error` → `process::exit` must still restore; non-vacuous — the cursor is asserted hidden first).

## Review

5-round self-review completed; round 1 found a missed `process::exit` site (`wiring/mod.rs` provider lock-constraint failure) that would leave the cursor hidden on that error — fixed and covered. Rounds 2–5 clean (no #3150 separator interaction; headline 3 symptoms verified fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)