### PR TITLE
carina init --migrate-state; remove carina state migrate

### DIFF
--- a/carina-cli/src/commands/init.rs
+++ b/carina-cli/src/commands/init.rs
@@ -4,10 +4,19 @@ use colored::Colorize;
 
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::parser::ProviderContext;
+use carina_state::BackendLock;
 
 use carina_provider_resolver::{self, LockMode};
 
-pub fn run_init(path: &Path, upgrade: bool, locked: bool) -> Result<(), String> {
+use crate::commands::migrate_state::{MigrationOutcome, SourceDisposition, run_init_migrate_state};
+
+pub async fn run_init(
+    path: &Path,
+    upgrade: bool,
+    locked: bool,
+    migrate_state: bool,
+    force: bool,
+) -> Result<(), String> {
     if upgrade && locked {
         return Err("--upgrade and --locked are mutually exclusive".to_string());
     }
@@ -76,9 +85,64 @@ pub fn run_init(path: &Path, upgrade: bool, locked: bool) -> Result<(), String> 
         );
     }
 
-    // Create backend lock so apply/destroy can detect backend config changes
-    crate::commands::ensure_backend_lock(base_dir, loaded.parsed.backend.as_ref())
-        .map_err(|e| format!("Failed to create backend lock: {e}"))?;
+    let backend_config = loaded.parsed.backend.as_ref();
+
+    // Backend lock lifecycle:
+    //
+    // - No lock yet            → first init, create it (nothing to migrate).
+    // - Lock matches config    → nothing to do.
+    // - Lock differs + no flag → refuse, point at --migrate-state.
+    // - Lock differs + flag    → migrate state, then re-lock.
+    let existing_lock =
+        BackendLock::load(base_dir).map_err(|e| format!("Failed to read backend lock: {e}"))?;
+    let configured = BackendLock::for_config(backend_config)
+        .map_err(|e| format!("Invalid backend configuration: {e}"))?;
+
+    match existing_lock {
+        None => {
+            crate::commands::ensure_backend_lock(base_dir, backend_config)
+                .map_err(|e| format!("Failed to create backend lock: {e}"))?;
+        }
+        Some(existing) if existing == configured => {
+            // Already initialized against this backend; nothing to do.
+        }
+        Some(existing) => {
+            if !migrate_state {
+                return Err(format!(
+                    "Backend configuration changed since the last init:\n\n{}\n\n\
+                     Re-run with `--migrate-state` to move the state file from the \
+                     old backend to the configured one, or revert the backend \
+                     configuration to match the lock.",
+                    existing.describe_diff(&configured)
+                ));
+            }
+            match run_init_migrate_state(base_dir, backend_config, force)
+                .await
+                .map_err(|e| e.to_string())?
+            {
+                MigrationOutcome::NotNeeded => {
+                    // Races with another init that already migrated; the
+                    // lock now matches, so this is a benign no-op.
+                }
+                MigrationOutcome::Migrated { resources, source } => {
+                    println!(
+                        "{}",
+                        format!("State migrated ({resources} resource(s)).").green()
+                    );
+                    // `DeleteFailed` already produced a precise stderr
+                    // warning inside the migration; only the deliberate
+                    // remote-backup case needs this extra hint here.
+                    if source == SourceDisposition::KeptAsBackup {
+                        println!(
+                            "The old state at the previous backend was kept as a \
+                             backup; remove it manually once you have confirmed \
+                             the new backend."
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     println!("{}", "Initialized successfully.".green());
 

--- a/carina-cli/src/commands/migrate_state.rs
+++ b/carina-cli/src/commands/migrate_state.rs
@@ -1,0 +1,448 @@
+//! Backend state migration for `carina init --migrate-state`.
+//!
+//! When the configured backend in `backend.crn` differs from the address
+//! recorded in `carina-backend.lock`, the state file must be moved from
+//! the *locked* (old) backend to the *configured* (new) backend before
+//! plan/apply will operate on the right state. This module performs that
+//! move.
+//!
+//! Scope (issue #3160, option 1 — "comment 2 surface only"):
+//!
+//! - Single-process ordering: read source → guard target → write target →
+//!   verify roundtrip → rewrite `carina-backend.lock` → optionally delete
+//!   the source.
+//! - Target guard: refuse to overwrite a non-empty, differently-lineaged
+//!   target unless `--force`.
+//! - The full dual-backend distributed lock + half-migration recovery
+//!   path from the issue's first comment is intentionally out of scope
+//!   and tracked as a separate follow-up issue.
+
+use std::path::Path;
+
+use colored::Colorize;
+
+#[cfg(test)]
+use carina_state::LocalBackend;
+use carina_state::{
+    BackendLock, StateBackend, StateFile, anchored_local_path, resolve_backend_anchored,
+};
+
+use crate::error::AppError;
+
+/// What happened to the old (source) state after a committed migration.
+///
+/// Distinguishing these is what lets the caller print the *right*
+/// follow-up: a kept remote backup vs. a failed local cleanup are very
+/// different user situations and must not collapse to one bool.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SourceDisposition {
+    /// Local source removed after the verified copy (nothing to do).
+    Deleted,
+    /// Remote source intentionally kept as a recoverable backup; the
+    /// user should remove it once they trust the new backend.
+    KeptAsBackup,
+    /// Local source removal was attempted and failed; the migration is
+    /// already committed but a stale old file remains. `run_init_migrate_state`
+    /// has already warned about this on stderr.
+    DeleteFailed,
+}
+
+/// Outcome of a migration attempt, returned so callers (and tests) can
+/// assert on what happened without scraping stdout.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MigrationOutcome {
+    /// Locked and configured backends are identical — nothing to do.
+    NotNeeded,
+    /// State was copied and the lock rewritten. `source` records what
+    /// happened to the old state afterwards.
+    Migrated {
+        resources: usize,
+        source: SourceDisposition,
+    },
+}
+
+/// Migrate state between two already-constructed backends.
+///
+/// This is the testable core: it takes the source/target backends and
+/// the cleanup policy and performs the read → guard → write → verify →
+/// (optional) delete sequence. Lock-file rewriting is the caller's
+/// responsibility (it owns `base_dir`).
+///
+/// `force` allows overwriting a target that already contains a
+/// *different* state (different lineage or non-empty resources). Without
+/// it, a populated target aborts the migration loudly.
+async fn perform_state_migration(
+    source: &dyn StateBackend,
+    target: &dyn StateBackend,
+    force: bool,
+) -> Result<StateFile, AppError> {
+    let state = source
+        .read_state()
+        .await
+        .map_err(AppError::Backend)?
+        .ok_or_else(|| {
+            AppError::Config(
+                "The locked backend holds no state. There is nothing to migrate; \
+                 re-run `carina init` (without --migrate-state) to adopt the new \
+                 backend, or revert the backend configuration."
+                    .to_string(),
+            )
+        })?;
+
+    // Target guard: refuse to clobber a populated, differently-lineaged
+    // target unless the operator explicitly opted in with --force.
+    if let Some(existing) = target.read_state().await.map_err(AppError::Backend)?
+        && (existing.lineage != state.lineage || !existing.resources.is_empty())
+        && !force
+    {
+        return Err(AppError::Config(format!(
+            "The configured backend already contains state (lineage {}, {} \
+             resources). Refusing to overwrite it. If this target is a stale \
+             copy you want to replace, re-run with --force; otherwise verify \
+             the backend configuration points where you expect.",
+            existing.lineage,
+            existing.resources.len()
+        )));
+    }
+
+    target
+        .write_state(&state)
+        .await
+        .map_err(AppError::Backend)?;
+
+    // Verify the copy landed before we rewrite the lock / delete the
+    // source — a migration that silently lost resources is the worst
+    // possible outcome.
+    let roundtrip = target
+        .read_state()
+        .await
+        .map_err(AppError::Backend)?
+        .ok_or_else(|| {
+            AppError::Config(
+                "Failed to read state back from the configured backend after \
+                 writing. The migration was aborted before touching the lock \
+                 or the source."
+                    .to_string(),
+            )
+        })?;
+    if roundtrip.lineage != state.lineage || roundtrip.resources.len() != state.resources.len() {
+        return Err(AppError::Config(
+            "State verification failed: the copy read back from the configured \
+             backend did not match the source. The source is untouched."
+                .to_string(),
+        ));
+    }
+
+    Ok(state)
+}
+
+/// Entry point used by `carina init --migrate-state`.
+///
+/// Compares `carina-backend.lock` against the configured backend; if they
+/// differ, migrates state from the locked address to the configured one,
+/// then rewrites the lock. A no-op (returns [`MigrationOutcome::NotNeeded`])
+/// when they already match.
+pub async fn run_init_migrate_state(
+    base_dir: &Path,
+    backend_config: Option<&carina_core::parser::BackendConfig>,
+    force: bool,
+) -> Result<MigrationOutcome, AppError> {
+    let configured = BackendLock::for_config(backend_config)?;
+    let locked = BackendLock::load(base_dir)
+        .map_err(AppError::Backend)?
+        .ok_or_else(|| {
+            AppError::Config(
+                "No backend lock found. Run `carina init` (without \
+                 --migrate-state) to initialize the project first."
+                    .to_string(),
+            )
+        })?;
+
+    if locked == configured {
+        return Ok(MigrationOutcome::NotNeeded);
+    }
+
+    println!(
+        "{}",
+        "Backend configuration changed; migrating state:"
+            .cyan()
+            .bold()
+    );
+    println!("{}", locked.describe_diff(&configured));
+
+    let locked_config = locked.to_state_config();
+
+    // Both addresses are reconstructed from the *locked* / *configured*
+    // snapshots, so a relative local `path` must be anchored at the
+    // project dir (not the binary's CWD) for `carina init <dir>` invoked
+    // from elsewhere.
+    let source = resolve_backend_anchored(Some(&locked_config), base_dir)
+        .await
+        .map_err(AppError::Backend)?;
+    let target = resolve_backend_anchored(Some(&configured.to_state_config()), base_dir)
+        .await
+        .map_err(AppError::Backend)?;
+
+    let state = perform_state_migration(source.as_ref(), target.as_ref(), force).await?;
+    println!(
+        "  {} copied {} resource(s) to the configured backend",
+        "✓".green(),
+        state.resources.len()
+    );
+
+    // Rewrite the lock *before* touching the source. This is the commit
+    // point: until it lands, both the lock and the (untouched) source
+    // still describe the old backend, and the source is never destroyed,
+    // so the state is never lost. After it lands the migration is
+    // logically complete and idempotent — a re-run sees `locked ==
+    // configured` and is a `NotNeeded` no-op. (A failure of this save
+    // itself leaves the verified copy at the target and the source
+    // intact; re-running re-copies onto the now-identical target, which
+    // needs `--force` because the target is non-empty — recovery of that
+    // narrow window is the deferred follow-up, not silent data loss.
+    // Deleting the source first, as an earlier revision did, could
+    // instead strand the project: a crash between the delete and the
+    // lock rewrite would point the lock at a now-missing source.)
+    configured.save(base_dir).map_err(AppError::Backend)?;
+    println!("  {} updated backend lock", "✓".green());
+
+    // A local source is deleted after the commit (matches the retired
+    // `state migrate`); a remote source is kept as a recoverable backup
+    // (remote → remote in this scope). A failure to delete here is *not*
+    // fatal: the migration already committed, so a leftover old file is
+    // harmless and the next run is a no-op.
+    let source = if locked.is_local() {
+        let path = anchored_local_path(&locked_config, base_dir);
+        if !path.exists() {
+            SourceDisposition::Deleted
+        } else {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    println!("  {} deleted source local state file", "✓".green());
+                    SourceDisposition::Deleted
+                }
+                Err(e) => {
+                    eprintln!(
+                        "  {} migration committed, but the old state file {} \
+                         could not be removed ({e}); delete it manually.",
+                        "warning:".yellow(),
+                        path.display()
+                    );
+                    SourceDisposition::DeleteFailed
+                }
+            }
+        }
+    } else {
+        SourceDisposition::KeptAsBackup
+    };
+
+    Ok(MigrationOutcome::Migrated {
+        resources: state.resources.len(),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_core::resource::{ConcreteValue, Value};
+    use carina_state::ResourceState;
+    use std::collections::HashMap;
+
+    fn state_with(lineage: &str, n_resources: usize) -> StateFile {
+        let mut s = StateFile::new();
+        s.lineage = lineage.to_string();
+        for i in 0..n_resources {
+            s.resources
+                .push(ResourceState::new("s3.Bucket", format!("r{i}"), "aws"));
+        }
+        s
+    }
+
+    #[tokio::test]
+    async fn migrates_state_from_source_to_empty_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src_path = tmp.path().join("old.state.json");
+        let dst_path = tmp.path().join("new.state.json");
+
+        let src = LocalBackend::with_path(src_path.clone());
+        let dst = LocalBackend::with_path(dst_path.clone());
+        src.write_state(&state_with("lin-1", 3)).await.unwrap();
+
+        let state = perform_state_migration(&src, &dst, false).await.unwrap();
+        assert_eq!(state.resources.len(), 3);
+
+        let migrated = dst.read_state().await.unwrap().unwrap();
+        assert_eq!(migrated.lineage, "lin-1");
+        assert_eq!(migrated.resources.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn refuses_populated_target_without_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = LocalBackend::with_path(tmp.path().join("a.json"));
+        let dst = LocalBackend::with_path(tmp.path().join("b.json"));
+        src.write_state(&state_with("lin-src", 1)).await.unwrap();
+        dst.write_state(&state_with("lin-dst", 2)).await.unwrap();
+
+        let err = perform_state_migration(&src, &dst, false)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Config(m) if m.contains("already contains state")),
+            "got: {err:?}"
+        );
+        // Target must be untouched on refusal.
+        let dst_state = dst.read_state().await.unwrap().unwrap();
+        assert_eq!(dst_state.lineage, "lin-dst");
+    }
+
+    #[tokio::test]
+    async fn force_overwrites_populated_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = LocalBackend::with_path(tmp.path().join("a.json"));
+        let dst = LocalBackend::with_path(tmp.path().join("b.json"));
+        src.write_state(&state_with("lin-src", 1)).await.unwrap();
+        dst.write_state(&state_with("lin-dst", 2)).await.unwrap();
+
+        perform_state_migration(&src, &dst, true).await.unwrap();
+        let dst_state = dst.read_state().await.unwrap().unwrap();
+        assert_eq!(dst_state.lineage, "lin-src");
+        assert_eq!(dst_state.resources.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn errors_when_source_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = LocalBackend::with_path(tmp.path().join("a.json"));
+        let dst = LocalBackend::with_path(tmp.path().join("b.json"));
+
+        let err = perform_state_migration(&src, &dst, false)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Config(m) if m.contains("no state")),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn not_needed_when_lock_matches_configured_local() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Lock = local_default; configured = None (also local default).
+        BackendLock::local_default().save(tmp.path()).unwrap();
+        let outcome = run_init_migrate_state(tmp.path(), None, false)
+            .await
+            .unwrap();
+        assert_eq!(outcome, MigrationOutcome::NotNeeded);
+    }
+
+    #[tokio::test]
+    async fn local_to_local_migration_deletes_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        // Locked = local default (carina.state.json under base_dir).
+        BackendLock::local_default().save(base).unwrap();
+        let src_path = base.join(LocalBackend::DEFAULT_STATE_FILE);
+        LocalBackend::with_path(src_path.clone())
+            .write_state(&state_with("lin-x", 2))
+            .await
+            .unwrap();
+
+        // Configured = a *different* local path (still "local" type but
+        // different attributes ⇒ lock differs ⇒ migration runs).
+        let dst_path = base.join("relocated.state.json");
+        let cfg = carina_core::parser::BackendConfig {
+            backend_type: "local".to_string(),
+            attributes: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "path".to_string(),
+                    Value::Concrete(ConcreteValue::String(
+                        dst_path.to_string_lossy().into_owned(),
+                    )),
+                );
+                m
+            },
+        };
+
+        let outcome = run_init_migrate_state(base, Some(&cfg), false)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            MigrationOutcome::Migrated {
+                resources: 2,
+                source: SourceDisposition::Deleted
+            }
+        );
+        assert!(
+            !src_path.exists(),
+            "source should be deleted (local cleanup)"
+        );
+        let migrated = LocalBackend::with_path(dst_path)
+            .read_state()
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(migrated.resources.len(), 2);
+
+        // Lock now reflects the configured backend ⇒ a second run is a no-op.
+        let second = run_init_migrate_state(base, Some(&cfg), false)
+            .await
+            .unwrap();
+        assert_eq!(second, MigrationOutcome::NotNeeded);
+    }
+
+    /// Regression: the lock must be committed to the *configured*
+    /// address before the source is removed. Concretely, once a
+    /// migration returns, the on-disk lock equals the configured lock,
+    /// so even with the source gone a re-run is a clean `NotNeeded`
+    /// rather than the old "locked points at a now-missing source"
+    /// wedge. (Round-3 finding: an earlier revision deleted the source
+    /// before rewriting the lock.)
+    #[tokio::test]
+    async fn lock_is_committed_before_source_removal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        BackendLock::local_default().save(base).unwrap();
+        LocalBackend::with_path(base.join(LocalBackend::DEFAULT_STATE_FILE))
+            .write_state(&state_with("lin-z", 1))
+            .await
+            .unwrap();
+        let dst_path = base.join("moved.state.json");
+        let cfg = carina_core::parser::BackendConfig {
+            backend_type: "local".to_string(),
+            attributes: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "path".to_string(),
+                    Value::Concrete(ConcreteValue::String(
+                        dst_path.to_string_lossy().into_owned(),
+                    )),
+                );
+                m
+            },
+        };
+
+        run_init_migrate_state(base, Some(&cfg), false)
+            .await
+            .unwrap();
+
+        // The lock on disk is the *configured* lock: the commit happened.
+        let on_disk = BackendLock::load(base).unwrap().unwrap();
+        let expected = BackendLock::for_config(Some(&cfg)).unwrap();
+        assert_eq!(
+            on_disk, expected,
+            "lock must be rewritten to the configured backend on commit"
+        );
+
+        // Source is gone; a re-run must NOT wedge — it sees the
+        // committed lock and is a clean no-op.
+        assert!(!base.join(LocalBackend::DEFAULT_STATE_FILE).exists());
+        let again = run_init_migrate_state(base, Some(&cfg), false)
+            .await
+            .unwrap();
+        assert_eq!(again, MigrationOutcome::NotNeeded);
+    }
+}

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod export;
 pub mod fmt;
 pub mod init;
 pub mod lint;
+pub mod migrate_state;
 pub mod module;
 pub mod plan;
 pub(crate) mod shared;
@@ -20,7 +21,6 @@ use carina_core::module_resolver;
 use carina_core::parser::{BackendConfig, ProviderContext};
 use carina_core::upstream_exports::UpstreamRefDiagnostic;
 use carina_state::BackendLock;
-use carina_state::backend::BackendConfig as StateBackendConfig;
 
 use crate::error::AppError;
 use crate::wiring::{
@@ -46,13 +46,7 @@ pub fn check_backend_lock(
     backend_config: Option<&BackendConfig>,
     reconfigure: bool,
 ) -> Result<(), AppError> {
-    let current = match backend_config {
-        Some(config) => {
-            let state_config = StateBackendConfig::from(config);
-            BackendLock::from_config(&state_config)?
-        }
-        None => BackendLock::local_default(),
-    };
+    let current = BackendLock::for_config(backend_config)?;
     let existing = BackendLock::load(base_dir).map_err(AppError::Backend)?;
 
     match existing {
@@ -65,8 +59,8 @@ pub fn check_backend_lock(
                     "Backend configuration has changed since the last run:\n\n{}\n\n\
                      Changing backend settings can silently redirect Carina at a \
                      different state file, which may cause state loss or drift.\n\n\
-                     To preserve existing state, run `carina state migrate` — it \
-                     will copy state from the old backend to the new one and \
+                     To preserve existing state, run `carina init --migrate-state` \
+                     — it will copy state from the old backend to the new one and \
                      update the backend lock.\n\n\
                      To discard the old state and start fresh with the new backend, \
                      re-run with --reconfigure.",
@@ -103,14 +97,9 @@ pub fn ensure_backend_lock(
     if lock_path.exists() {
         return Ok(());
     }
-    let lock = match backend_config {
-        Some(config) => {
-            let state_config = StateBackendConfig::from(config);
-            BackendLock::from_config(&state_config)?
-        }
-        None => BackendLock::local_default(),
-    };
-    lock.save(base_dir).map_err(AppError::Backend)
+    BackendLock::for_config(backend_config)?
+        .save(base_dir)
+        .map_err(AppError::Backend)
 }
 
 /// Run the common validation and module resolution pipeline.
@@ -533,7 +522,7 @@ mod tests {
         assert!(msg.contains("bucket"));
         assert!(msg.contains("old-bucket"));
         assert!(msg.contains("new-bucket"));
-        assert!(msg.contains("carina state migrate"));
+        assert!(msg.contains("carina init --migrate-state"));
         assert!(msg.contains("--reconfigure"));
     }
 

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -14,8 +14,8 @@ use carina_core::value::{
     redact_secrets_in_plan, redact_secrets_in_resource, redact_secrets_in_state,
 };
 use carina_state::{
-    BackendConfig as StateBackendConfig, LocalBackend, StateBackend, StateFile, create_backend,
-    create_local_backend, resolve_backend,
+    BackendConfig as StateBackendConfig, StateBackend, StateFile, create_backend,
+    create_local_backend, resolve_backend_anchored,
 };
 
 use super::validate_and_resolve_with_config;
@@ -905,29 +905,14 @@ async fn build_upstream_backend(
     ))
     .await?;
 
-    let backend: Box<dyn StateBackend> = match loaded.parsed.backend.as_ref() {
-        // Anchor local-backend state paths at the upstream's source directory
-        // so `path = "foo.json"` resolves relative to the upstream, not the
-        // downstream process's CWD.
-        Some(config) if config.backend_type == "local" => {
-            let state_path = StateBackendConfig::from(config)
-                .get_string("path")
-                .map(PathBuf::from)
-                .unwrap_or_else(|| PathBuf::from(LocalBackend::DEFAULT_STATE_FILE));
-            let anchored = if state_path.is_absolute() {
-                state_path
-            } else {
-                source_abs.join(state_path)
-            };
-            Box::new(LocalBackend::with_path(anchored))
-        }
-        Some(config) => resolve_backend(Some(config))
+    // Anchor local-backend state paths at the upstream's source directory
+    // so `path = "foo.json"` resolves relative to the upstream, not the
+    // downstream process's CWD.
+    let upstream_backend_config = loaded.parsed.backend.as_ref().map(StateBackendConfig::from);
+    let backend: Box<dyn StateBackend> =
+        resolve_backend_anchored(upstream_backend_config.as_ref(), source_abs)
             .await
-            .map_err(AppError::Backend)?,
-        None => Box::new(LocalBackend::with_path(
-            source_abs.join(LocalBackend::DEFAULT_STATE_FILE),
-        )),
-    };
+            .map_err(AppError::Backend)?;
 
     Ok(backend)
 }

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -162,16 +162,6 @@ pub enum StateCommands {
         #[arg(long)]
         json: bool,
     },
-    /// Migrate state from the local backend to the configured remote backend
-    Migrate {
-        /// Path to directory containing .crn files
-        #[arg(default_value = ".")]
-        path: PathBuf,
-
-        /// Skip confirmation prompt before deleting the old local state file
-        #[arg(long)]
-        auto_approve: bool,
-    },
 }
 
 /// Run state subcommands
@@ -194,9 +184,6 @@ pub async fn run_state_command(
         }
         StateCommands::Show { path, tui, json } => {
             run_state_show(&path, tui, json, provider_context).await
-        }
-        StateCommands::Migrate { path, auto_approve } => {
-            run_state_migrate(&path, auto_approve, provider_context).await
         }
     }
 }
@@ -961,172 +948,6 @@ fn diff_display_update_resource(
         state.remove_resource(&id.provider, &id.resource_type, id.name_str());
     }
 
-    Ok(())
-}
-
-/// Migrate state from the local backend to the configured remote backend.
-///
-/// Intended for the bootstrap use case where a user starts with local state,
-/// provisions the state bucket, and then adds a `backend s3 { ... }` block to
-/// move state to S3. The command:
-///
-/// 1. Verifies a `backend` block is configured in the .crn files
-/// 2. Reads the local `carina.state.json` (or errors if missing)
-/// 3. Writes it to the configured remote backend
-/// 4. Reads it back to verify the write
-/// 5. Prompts to delete the local file (unless `--auto-approve`)
-/// 6. Updates `carina-backend.lock` with the new remote config
-async fn run_state_migrate(
-    path: &Path,
-    auto_approve: bool,
-    provider_context: &ProviderContext,
-) -> Result<(), AppError> {
-    let mut parsed = load_configuration_with_config(
-        path,
-        provider_context,
-        &carina_core::schema::SchemaRegistry::new(),
-    )?
-    .parsed;
-    let base_dir = get_base_dir(path);
-    validate_and_resolve_with_config(&mut parsed, base_dir, true)?;
-
-    // A backend block is required to know where to migrate to.
-    let backend_config = parsed.backend.as_ref().ok_or_else(|| {
-        AppError::Config(
-            "No `backend` block configured. Add a backend block to your .crn files \
-             before running `carina state migrate`."
-                .to_string(),
-        )
-    })?;
-
-    // Only local → remote is supported in this command.
-    if backend_config.backend_type == "local" {
-        return Err(AppError::Config(
-            "The configured backend is already `local`; nothing to migrate.".to_string(),
-        ));
-    }
-
-    // Local state source path — defaults to `carina.state.json` next to the .crn files.
-    let local_state_path = base_dir.join(carina_state::LocalBackend::DEFAULT_STATE_FILE);
-    if !local_state_path.exists() {
-        return Err(AppError::Config(format!(
-            "No local state file found at {}. There is nothing to migrate.",
-            local_state_path.display()
-        )));
-    }
-
-    println!(
-        "{} {}",
-        "Migrating state from local to".cyan().bold(),
-        backend_config.backend_type
-    );
-    println!("  source: {}", local_state_path.display());
-
-    // Build the source (local) and destination (remote) backends.
-    let local_backend = carina_state::LocalBackend::with_path(local_state_path.clone());
-    let state = local_backend
-        .read_state()
-        .await
-        .map_err(AppError::Backend)?
-        .ok_or_else(|| {
-            AppError::Config(format!(
-                "Local state file at {} is empty or unreadable.",
-                local_state_path.display()
-            ))
-        })?;
-
-    let remote_state_config = StateBackendConfig::from(backend_config);
-    let remote_backend = create_backend(&remote_state_config)
-        .await
-        .map_err(AppError::Backend)?;
-
-    // Refuse to overwrite an existing remote state that has different resources.
-    if let Some(existing) = remote_backend
-        .read_state()
-        .await
-        .map_err(AppError::Backend)?
-        && (existing.lineage != state.lineage || !existing.resources.is_empty())
-    {
-        return Err(AppError::Config(format!(
-            "Remote backend already contains state (lineage {}, {} resources). \
-             Refusing to overwrite. Migrate manually if this is expected.",
-            existing.lineage,
-            existing.resources.len()
-        )));
-    }
-
-    println!("  destination: {} backend", backend_config.backend_type);
-    println!("  resources: {}", state.resources.len());
-
-    // Write state to the remote backend.
-    remote_backend
-        .write_state(&state)
-        .await
-        .map_err(AppError::Backend)?;
-
-    // Verify the write by reading it back.
-    let roundtrip = remote_backend
-        .read_state()
-        .await
-        .map_err(AppError::Backend)?
-        .ok_or_else(|| {
-            AppError::Config(
-                "Failed to read state back from the remote backend after writing.".to_string(),
-            )
-        })?;
-    if roundtrip.lineage != state.lineage || roundtrip.resources.len() != state.resources.len() {
-        return Err(AppError::Config(
-            "State verification failed: the roundtrip read from the remote backend did not \
-             match what was written."
-                .to_string(),
-        ));
-    }
-    println!("  {} remote state verified", "✓".green());
-
-    // Confirm deletion of the local state file unless --auto-approve was passed.
-    if !auto_approve {
-        print!(
-            "\nDelete the local state file at {}? [y/N]: ",
-            local_state_path.display()
-        );
-        use std::io::Write;
-        std::io::stdout().flush().ok();
-        let mut input = String::new();
-        std::io::stdin()
-            .read_line(&mut input)
-            .map_err(|e| AppError::Config(format!("Failed to read input: {e}")))?;
-        let confirmed = matches!(input.trim().to_lowercase().as_str(), "y" | "yes");
-        if !confirmed {
-            println!(
-                "{}",
-                "Aborted. The remote state was written but the local file was left in place."
-                    .yellow()
-            );
-            return Ok(());
-        }
-    }
-
-    std::fs::remove_file(&local_state_path).map_err(|e| {
-        AppError::Config(format!(
-            "Failed to delete {}: {}",
-            local_state_path.display(),
-            e
-        ))
-    })?;
-    println!("  {} deleted local state file", "✓".green());
-
-    // Update the backend lock so subsequent plan/apply runs don't report a
-    // "backend changed" error.
-    let new_lock = carina_state::BackendLock::from_config(&remote_state_config)?;
-    new_lock.save(base_dir).map_err(AppError::Backend)?;
-    println!("  {} updated backend lock", "✓".green());
-
-    println!(
-        "\n{}",
-        "Migration complete. State is now managed by the remote backend."
-            .green()
-            .bold()
-    );
     Ok(())
 }
 

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -175,7 +175,7 @@ enum Commands {
         #[command(subcommand)]
         command: StateCommands,
     },
-    /// Download and install provider binaries
+    /// Download and install provider binaries; migrate state on backend change
     Init {
         /// Path to directory containing .crn files
         #[arg(default_value = ".")]
@@ -187,6 +187,16 @@ enum Commands {
         /// provider is missing from the lock. Intended for CI (like cargo --locked).
         #[arg(long, conflicts_with = "upgrade")]
         locked: bool,
+        /// Migrate the state file from the backend recorded in
+        /// carina-backend.lock to the currently configured backend when
+        /// they differ. Without this flag, a backend change is a hard error.
+        #[arg(long)]
+        migrate_state: bool,
+        /// When migrating, overwrite a target backend that already
+        /// contains a different state. Has no effect without
+        /// --migrate-state.
+        #[arg(long, requires = "migrate_state")]
+        force: bool,
     },
     /// Lint .crn files for style issues
     Lint {
@@ -415,8 +425,12 @@ async fn main() {
             path,
             upgrade,
             locked,
+            migrate_state,
+            force,
         } => {
-            if let Err(e) = commands::init::run_init(&path, upgrade, locked) {
+            if let Err(e) =
+                commands::init::run_init(&path, upgrade, locked, migrate_state, force).await
+            {
                 // process::exit skips Drop — restore the cursor first
                 // (#3158); claim-once with the guard/net.
                 carina_cli::cursor::restore_cursor();

--- a/carina-cli/tests/init_migrate_state_e2e.rs
+++ b/carina-cli/tests/init_migrate_state_e2e.rs
@@ -1,0 +1,184 @@
+//! End-to-end tests for `carina init --migrate-state` (issue #3160).
+//!
+//! These drive the real `carina` binary against a multi-file project
+//! directory (mirroring the directory-scoped infra shape: `main.crn` +
+//! `backend.crn`), exercising the directory-refactor scenario from the
+//! issue: a backend address change must be a hard error without the
+//! flag, and must move the state file with it.
+//!
+//! Local → local is used so the test needs no AWS credentials while
+//! still exercising the real lock-drift detection + migration path
+//! through the binary.
+
+use std::fs;
+use std::process::Command;
+
+use carina_state::{ResourceState, StateFile};
+use tempfile::TempDir;
+
+/// Build a real `StateFile` JSON with `n` resources under `lineage`,
+/// serialized via serde so the shape always matches the current state
+/// schema (hand-written JSON drifts and misses fields like `kind`).
+fn state_json(lineage: &str, n: usize) -> String {
+    let mut s = StateFile::new();
+    s.serial = 3;
+    s.lineage = lineage.to_string();
+    for i in 0..n {
+        s.resources.push(
+            ResourceState::new("s3.Bucket", format!("demo{i}"), "aws")
+                .with_identifier(format!("demo-bucket-{i}")),
+        );
+    }
+    serde_json::to_string_pretty(&s).expect("serialize state fixture")
+}
+
+fn carina(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_carina"))
+        .args(args)
+        .output()
+        .expect("failed to execute carina")
+}
+
+/// Write the two-file project: a no-provider config plus a backend file
+/// pointing at `state_file` (relative to the project dir).
+fn write_project(project: &std::path::Path, state_file: &str) {
+    fs::write(
+        project.join("main.crn"),
+        // No providers ⇒ init does not need to download plugins.
+        "exports {\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("backend.crn"),
+        format!("backend local {{ path = \"{state_file}\" }}\n"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn init_then_backend_change_blocks_without_flag_and_migrates_with_it() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let project_str = project.to_str().unwrap();
+
+    // 1. Initialize against the original backend address.
+    write_project(project, "old.state.json");
+    let out = carina(&["init", project_str]);
+    assert!(
+        out.status.success(),
+        "first init should succeed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        project.join("carina-backend.lock").exists(),
+        "init should create the backend lock",
+    );
+
+    // Simulate real managed state at the old address (non-empty so the
+    // migration has something meaningful to move and verify).
+    fs::write(project.join("old.state.json"), state_json("lineage-abc", 1)).unwrap();
+
+    // 2. Refactor: the backend address changes (the issue's core case).
+    write_project(project, "new.state.json");
+
+    // Bare `carina init` must REFUSE and point at --migrate-state.
+    let out = carina(&["init", project_str]);
+    assert!(
+        !out.status.success(),
+        "init must fail on backend drift without --migrate-state",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Backend configuration changed") && stderr.contains("--migrate-state"),
+        "drift error must name --migrate-state, got:\n{stderr}",
+    );
+    assert!(
+        !project.join("new.state.json").exists(),
+        "a refused init must not create the new state file",
+    );
+    assert!(
+        project.join("old.state.json").exists(),
+        "a refused init must not touch the old state file",
+    );
+
+    // 3. `--migrate-state` moves the state and re-locks.
+    let out = carina(&["init", "--migrate-state", project_str]);
+    assert!(
+        out.status.success(),
+        "init --migrate-state should succeed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let new_state = project.join("new.state.json");
+    assert!(new_state.exists(), "state must be migrated to the new path");
+    let migrated = fs::read_to_string(&new_state).unwrap();
+    assert!(
+        migrated.contains("lineage-abc") && migrated.contains("demo-bucket"),
+        "migrated state must preserve lineage and resources, got:\n{migrated}",
+    );
+    // local → remote-style cleanup: source local file removed.
+    assert!(
+        !project.join("old.state.json").exists(),
+        "local source state should be deleted after a verified copy",
+    );
+
+    // 4. The lock now matches ⇒ a subsequent bare init is a clean no-op.
+    let out = carina(&["init", project_str]);
+    assert!(
+        out.status.success(),
+        "init after a completed migration should succeed (lock matches).\n\
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn force_required_to_overwrite_populated_target() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let project_str = project.to_str().unwrap();
+
+    write_project(project, "old.state.json");
+    assert!(carina(&["init", project_str]).status.success());
+
+    fs::write(project.join("old.state.json"), state_json("src-lineage", 1)).unwrap();
+    // A *different* state already sits at the target address.
+    fs::write(project.join("new.state.json"), state_json("dst-lineage", 1)).unwrap();
+
+    write_project(project, "new.state.json");
+
+    // Without --force: refuse, target untouched.
+    let out = carina(&["init", "--migrate-state", project_str]);
+    assert!(
+        !out.status.success(),
+        "migration into a populated target must fail without --force",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("already contains state"),
+        "expected populated-target refusal, got:\n{stderr}",
+    );
+    assert!(
+        fs::read_to_string(project.join("new.state.json"))
+            .unwrap()
+            .contains("dst-lineage"),
+        "target must be untouched on refusal",
+    );
+
+    // With --force: the target is overwritten by the source.
+    let out = carina(&["init", "--migrate-state", "--force", project_str]);
+    assert!(
+        out.status.success(),
+        "init --migrate-state --force should overwrite.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        fs::read_to_string(project.join("new.state.json"))
+            .unwrap()
+            .contains("src-lineage"),
+        "target should now hold the source state",
+    );
+}

--- a/carina-state/src/backend.rs
+++ b/carina-state/src/backend.rs
@@ -251,6 +251,11 @@ pub trait StateBackend: Send + Sync {
     }
 }
 
+/// Backend type identifier for the implicit/local filesystem backend.
+/// The single spelling shared by every "is this local?" decision so the
+/// literal `"local"` is not open-coded across modules.
+pub const LOCAL_BACKEND_TYPE: &str = "local";
+
 /// Configuration for a state backend
 #[derive(Debug, Clone)]
 pub struct BackendConfig {
@@ -284,6 +289,11 @@ impl BackendConfig {
     /// Get a boolean attribute with a default value
     pub fn get_bool_or(&self, key: &str, default: bool) -> bool {
         self.get_bool(key).unwrap_or(default)
+    }
+
+    /// Whether this configuration names the local filesystem backend.
+    pub fn is_local(&self) -> bool {
+        self.backend_type == LOCAL_BACKEND_TYPE
     }
 }
 

--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -65,9 +65,30 @@ impl BackendLock {
     /// `check_backend_lock` to detect local → remote transitions.
     pub fn local_default() -> Self {
         Self {
-            backend_type: "local".to_string(),
+            backend_type: crate::backend::LOCAL_BACKEND_TYPE.to_string(),
             attributes: BTreeMap::new(),
         }
+    }
+
+    /// Lock snapshot for an optional parser backend block: the configured
+    /// backend when present, the implicit local default when absent.
+    ///
+    /// This is the single source of truth for "what backend does this
+    /// configuration name"; `check_backend_lock`, `ensure_backend_lock`,
+    /// `init`'s drift check, and the migration path all go through it so
+    /// they cannot disagree.
+    pub fn for_config(
+        backend_config: Option<&carina_core::parser::BackendConfig>,
+    ) -> Result<Self, carina_core::value::SerializationError> {
+        match backend_config {
+            Some(cfg) => Self::from_config(&BackendConfig::from(cfg)),
+            None => Ok(Self::local_default()),
+        }
+    }
+
+    /// Whether this lock describes the local backend.
+    pub fn is_local(&self) -> bool {
+        self.backend_type == crate::backend::LOCAL_BACKEND_TYPE
     }
 
     /// Path to the lock file under `base_dir` (project root).
@@ -116,6 +137,61 @@ impl BackendLock {
         std::fs::write(&path, contents)
             .map_err(|e| BackendError::Io(format!("Failed to write {}: {}", path.display(), e)))?;
         Ok(())
+    }
+
+    /// Reconstruct a runtime [`BackendConfig`] from this locked snapshot.
+    ///
+    /// This is the inverse of [`from_config`]'s `value_to_json` step: it
+    /// is used by the `init --migrate-state` path to open the *old*
+    /// backend (the address recorded in `carina-backend.lock`) so its
+    /// state can be read and copied to the newly configured backend.
+    ///
+    /// Fidelity contract: every backend attribute that any backend
+    /// actually *reads* is a string or a bool (`bucket` / `key` /
+    /// `region` / `path` via `get_string`; `encrypt` / `auto_create` /
+    /// `use_lockfile` via `get_bool`). Those round-trip exactly, so the
+    /// reconstructed *source address* is always faithful. `from_config`
+    /// also accepts integers/durations (collapsed to a JSON number) and
+    /// writes `null` for anything else; numbers are reconstructed as
+    /// `Int` best-effort (an out-of-`i64` value falls back to its `f64`
+    /// truncation rather than being dropped — totality matters more than
+    /// precision for an attribute no backend consumes), and `null`
+    /// reconstructs as `Bool(false)` (an arbitrary non-dropping
+    /// placeholder; no backend reads a null-valued attribute). Crucially,
+    /// **no key is ever dropped**: a silently-missing attribute could
+    /// re-address the migration source, so the map is preserved
+    /// key-for-key.
+    ///
+    /// [`from_config`]: BackendLock::from_config
+    pub fn to_state_config(&self) -> BackendConfig {
+        use carina_core::resource::{ConcreteValue, Value};
+        let attributes = self
+            .attributes
+            .iter()
+            .map(|(k, v)| {
+                let value = match v {
+                    serde_json::Value::String(s) => {
+                        Value::Concrete(ConcreteValue::String(s.clone()))
+                    }
+                    serde_json::Value::Bool(b) => Value::Concrete(ConcreteValue::Bool(*b)),
+                    serde_json::Value::Number(n) => Value::Concrete(ConcreteValue::Int(
+                        n.as_i64()
+                            .unwrap_or_else(|| n.as_f64().unwrap_or(0.0) as i64),
+                    )),
+                    // `value_to_json` writes `null` only as its lossy
+                    // fallback for non-scalar attributes (which no
+                    // backend reads); keep the key so the address shape
+                    // is preserved rather than silently shrinking it.
+                    serde_json::Value::Null => Value::Concrete(ConcreteValue::Bool(false)),
+                    other => Value::Concrete(ConcreteValue::String(other.to_string())),
+                };
+                (k.clone(), value)
+            })
+            .collect();
+        BackendConfig {
+            backend_type: self.backend_type.clone(),
+            attributes,
+        }
     }
 
     /// Produce a human-readable diff description for error messages.
@@ -298,6 +374,104 @@ mod tests {
         let a = BackendLock::from_config(&make_config("b", "us-east-1")).unwrap();
         let b = BackendLock::from_config(&make_config("b", "us-east-1")).unwrap();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn to_state_config_roundtrips_remote_attributes() {
+        // A locked remote backend must be reconstructible into a
+        // `StateBackendConfig` so the migration path can read the OLD
+        // state from the address recorded in the lock.
+        let lock = BackendLock::from_config(&make_config("old-bucket", "us-east-1")).unwrap();
+        let cfg = lock.to_state_config();
+        assert_eq!(cfg.backend_type, "s3");
+        assert_eq!(cfg.get_string("bucket"), Some("old-bucket"));
+        assert_eq!(cfg.get_string("region"), Some("us-east-1"));
+    }
+
+    #[test]
+    fn to_state_config_preserves_bool_and_int() {
+        let mut attributes = HashMap::new();
+        attributes.insert(
+            "bucket".to_string(),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
+        );
+        attributes.insert(
+            "use_lockfile".to_string(),
+            Value::Concrete(ConcreteValue::Bool(true)),
+        );
+        attributes.insert(
+            "max_retries".to_string(),
+            Value::Concrete(ConcreteValue::Int(7)),
+        );
+        let config = BackendConfig {
+            backend_type: "s3".to_string(),
+            attributes,
+        };
+        let lock = BackendLock::from_config(&config).unwrap();
+        let cfg = lock.to_state_config();
+        assert_eq!(cfg.get_string("bucket"), Some("b"));
+        assert_eq!(cfg.get_bool("use_lockfile"), Some(true));
+        assert!(matches!(
+            cfg.attributes.get("max_retries"),
+            Some(Value::Concrete(ConcreteValue::Int(7)))
+        ));
+    }
+
+    #[test]
+    fn to_state_config_of_local_default_is_local() {
+        let cfg = BackendLock::local_default().to_state_config();
+        assert_eq!(cfg.backend_type, "local");
+        assert!(cfg.attributes.is_empty());
+    }
+
+    /// `from_config` collapses a `Duration` attribute to a JSON number;
+    /// the inverse cannot tell it apart from an `Int` (no backend reads
+    /// either, so this is acceptable) — but it must still preserve the
+    /// real string address attributes around it and never drop the key.
+    #[test]
+    fn to_state_config_duration_does_not_corrupt_sibling_address() {
+        use std::time::Duration;
+        let mut attributes = HashMap::new();
+        attributes.insert(
+            "bucket".to_string(),
+            Value::Concrete(ConcreteValue::String("real-bucket".to_string())),
+        );
+        attributes.insert(
+            "ttl".to_string(),
+            Value::Concrete(ConcreteValue::Duration(Duration::from_secs(42))),
+        );
+        let config = BackendConfig {
+            backend_type: "s3".to_string(),
+            attributes,
+        };
+        let cfg = BackendLock::from_config(&config).unwrap().to_state_config();
+        // The address attribute the backend actually reads is intact.
+        assert_eq!(cfg.get_string("bucket"), Some("real-bucket"));
+        // The duration key survives (as an Int) — not silently dropped.
+        assert!(
+            cfg.attributes.contains_key("ttl"),
+            "no attribute key may be dropped on reconstruction"
+        );
+    }
+
+    /// A JSON number outside `i64` range must not drop the key (which
+    /// would re-address the migration source); totality over precision.
+    #[test]
+    fn to_state_config_large_number_keeps_key() {
+        let mut lock = BackendLock::from_config(&make_config("b", "us-east-1")).unwrap();
+        lock.attributes.insert(
+            "huge".to_string(),
+            serde_json::Value::Number(serde_json::Number::from_f64(1e30).unwrap()),
+        );
+        lock.attributes
+            .insert("weird".to_string(), serde_json::Value::Null);
+        let cfg = lock.to_state_config();
+        assert_eq!(cfg.attributes.len(), lock.attributes.len());
+        assert!(cfg.attributes.contains_key("huge"));
+        assert!(cfg.attributes.contains_key("weird"));
+        // The genuine address attributes still round-trip exactly.
+        assert_eq!(cfg.get_string("bucket"), Some("b"));
+        assert_eq!(cfg.get_string("region"), Some("us-east-1"));
     }
 
     #[test]

--- a/carina-state/src/backends/mod.rs
+++ b/carina-state/src/backends/mod.rs
@@ -51,6 +51,49 @@ pub async fn resolve_backend(
     }
 }
 
+/// Resolve a backend, anchoring a local backend's relative state `path`
+/// (or the unset default) at `base_dir` instead of the process CWD.
+///
+/// `resolve_backend` / `create_backend` treat a local `path` as
+/// CWD-relative, which is correct only when the command is run from the
+/// project directory. Commands that accept an explicit directory
+/// argument (`carina init <dir>`, upstream `remote_state` resolution)
+/// must reach the state next to *that* directory's `.crn` files
+/// regardless of where the binary was invoked from — they use this.
+/// Remote backends carry their own absolute address and are delegated
+/// unchanged to `create_backend`.
+pub async fn resolve_backend_anchored(
+    backend_config: Option<&BackendConfig>,
+    base_dir: &std::path::Path,
+) -> BackendResult<Box<dyn StateBackend>> {
+    match backend_config {
+        Some(config) if config.is_local() => Ok(Box::new(LocalBackend::with_path(
+            anchored_local_path(config, base_dir),
+        ))),
+        Some(config) => create_backend(config).await,
+        None => Ok(Box::new(LocalBackend::with_path(
+            base_dir.join(LocalBackend::DEFAULT_STATE_FILE),
+        ))),
+    }
+}
+
+/// Resolve a local backend's state file path, anchoring a relative
+/// `path` (or the unset default) at `base_dir`.
+pub fn anchored_local_path(
+    config: &BackendConfig,
+    base_dir: &std::path::Path,
+) -> std::path::PathBuf {
+    let path = config
+        .get_string("path")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(LocalBackend::DEFAULT_STATE_FILE));
+    if path.is_absolute() {
+        path
+    } else {
+        base_dir.join(path)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -50,8 +50,11 @@ pub mod lock;
 pub mod state;
 
 // Re-export main types for convenience
-pub use backend::{BackendConfig, BackendError, BackendResult, StateBackend};
+pub use backend::{BackendConfig, BackendError, BackendResult, LOCAL_BACKEND_TYPE, StateBackend};
 pub use backend_lock::BackendLock;
-pub use backends::{LocalBackend, create_backend, create_local_backend, resolve_backend};
+pub use backends::{
+    LocalBackend, anchored_local_path, create_backend, create_local_backend, resolve_backend,
+    resolve_backend_anchored,
+};
 pub use lock::LockInfo;
 pub use state::{ResourceState, StateFile, check_and_migrate, check_and_migrate_bytes};

--- a/site/src/content/guides/state-management.md
+++ b/site/src/content/guides/state-management.md
@@ -68,6 +68,32 @@ carina state bucket-delete <bucket-name> --force
 
 This is a destructive operation that removes the bucket and all state history.
 
+## Moving state to a different backend
+
+<!-- derived-from ../reference/cli/init.md -->
+
+When you change the `backend` block — switching from local state to S3,
+or changing the `key` while reorganizing component directories — the
+state file must move with it. There is a single answer:
+
+```bash
+carina init --migrate-state
+```
+
+`init` compares the configured backend against the one recorded in
+`carina-backend.lock`. If they differ it copies the state from the old
+backend to the new one, verifies the copy, and rewrites the lock. A bare
+`carina init` (and any `plan`/`apply`/`destroy`) **refuses** when the
+backend changed, so you never silently abandon the old state — you have
+to opt in with `--migrate-state` (or revert the backend configuration).
+
+A local source is deleted after the verified copy; a remote source is
+kept as a recoverable backup. Add `--force` only when a *different*
+state already exists at the new backend and you intend to replace it.
+
+See the [`init` reference](/reference/cli/init/) for the full semantics
+and crash-recovery behavior.
+
 ## Importing existing resources
 
 To bring an existing cloud resource under Carina management, use the `import` block:

--- a/site/src/content/reference/cli/init.md
+++ b/site/src/content/reference/cli/init.md
@@ -4,6 +4,8 @@ title: init
 
 Resolve and download the provider plugins declared in `providers.crn`. Carina caches WASM plugin binaries locally and writes a lock file so subsequent runs use the same versions.
 
+`init` also owns the backend lock (`carina-backend.lock`). It records which backend the directory was last initialized against, and is the single command that migrates state when the configured backend changes.
+
 ## Usage
 
 ```bash
@@ -24,6 +26,44 @@ Require the lock file to match `providers.crn` exactly. Errors if any declared p
 
 `--upgrade` and `--locked` are mutually exclusive.
 
+### `--migrate-state`
+
+Migrate the state file when the configured backend differs from the one
+recorded in `carina-backend.lock`. This covers backend changes such as
+moving from local state to a remote backend, or changing the
+`backend s3 { key = ... }` value during a directory refactor.
+
+Without this flag, a backend change is a **hard error** — `carina init`
+refuses to proceed and points you at `--migrate-state`. This protects
+against accidentally editing `backend.crn` or checking out a branch with
+a different backend: adopting the new backend (and abandoning the old
+state) is never silent.
+
+With the flag, `init` reads the state from the locked (old) backend,
+writes it to the configured backend, and verifies the copy. It then
+rewrites `carina-backend.lock` to the new address — this is the commit
+point. The old source is only touched *after* the lock is rewritten, so
+an interrupted migration is always recoverable: a crash before the
+commit leaves the lock and the untouched source both describing the old
+backend (a re-run retries the whole migration), and a crash after the
+commit leaves the lock describing the new, verified state (a re-run is a
+no-op).
+
+- **local source** (local → remote, or a local → local path change such
+  as a directory rename): the old local state file is deleted after a
+  verified copy.
+- **remote source** (remote → remote): the old object is **kept** as a
+  recoverable backup; remove it manually once you have confirmed the new
+  backend.
+
+### `--force`
+
+When migrating, overwrite a target backend that already contains a
+*different* state (different lineage, or any resources). Without
+`--force`, a populated target aborts the migration loudly so a
+mistargeted backend cannot silently clobber live state. Has no effect
+without `--migrate-state`.
+
 ## Examples
 
 Download providers for the current directory:
@@ -42,4 +82,17 @@ Verify the lock file is up to date in CI:
 
 ```bash
 carina init --locked
+```
+
+Migrate state after changing the backend (e.g. a directory refactor that
+changes the `backend s3 { key }`):
+
+```bash
+carina init --migrate-state
+```
+
+Migrate and replace a stale state already present at the new backend:
+
+```bash
+carina init --migrate-state --force
 ```


### PR DESCRIPTION
Closes #3160

## What

Generalizes backend-state migration into `carina init`, per the issue's revised proposal (comment 2):

- **`carina init --migrate-state`** — when the configured backend differs from the address recorded in `carina-backend.lock`, copies state from the locked (old) backend to the configured one and rewrites the lock. Covers `local→remote`, `remote→remote`, and `local→local` (the directory-refactor case the issue describes for `carina-rs/infra`'s registry stack).
- **Bare `carina init` refuses on backend drift**, with an error naming `--migrate-state` (or reverting the config). Adopting a new backend and abandoning old state is never silent.
- **`--force`** overwrites a populated/different target; without it a populated target aborts loudly.
- **`carina state migrate` removed entirely** — the `local→remote` bootstrap case it covered is subsumed by the new path. No deprecation alias (project policy: no backward compat). `check_backend_lock`'s drift message now points at `carina init --migrate-state`.

## Scope

Implements **option 1** as agreed with the issue author: the command surface + safe single-process ordering. **Out of scope (deferred to a follow-up issue):** the full dual-backend distributed lock and the narrow half-migration recovery window from the issues first comment (tracked in #3162); the provider-resolution ordering coupling (tracked in #3163); `state mv-component`.

Note: `carina init`'s drift error offers migrate-or-revert only — there is no `init`-side "adopt and discard" (that lives behind `--reconfigure` on plan/apply via `check_backend_lock`). "Discard on init" is deliberately unsupported in this scope.

## Crash safety

The lock is rewritten **before** the source is touched (the commit point):

- Crash *before* commit → lock and untouched source both describe the old backend; a re-run retries the whole migration.
- Crash *after* commit → lock describes the new verified state; a re-run is a no-op.
- Local-source delete failure is a **non-fatal warning** (the migration already committed).

A typed `SourceDisposition` (`Deleted` / `KeptAsBackup` / `DeleteFailed`) drives the correct follow-up message per case (a kept remote backup vs. a failed local cleanup are distinct user situations).

## Refactor (via /simplify)

The local-backend relative-path anchoring was already duplicated twice in `plan.rs`. Rather than add a third copy for the migration path, it is extracted into shared `carina-state` helpers (`resolve_backend_anchored`, `anchored_local_path`, `BackendLock::for_config`, `LOCAL_BACKEND_TYPE` / `is_local`). Net effect: this change *reduces* duplication in pre-existing code.

A genuine pre-existing bug was fixed in passing: a relative local-backend `path` resolved against the process CWD, not the project dir — `carina init <dir>` invoked from elsewhere reached the wrong state file.

## Testing

- Unit: migration core (empty source, populated-target refuse/force, `to_state_config` totality incl. Duration/large-number/null, commit-before-source-removal regression).
- E2E (`init_migrate_state_e2e`): real `carina` binary, multi-file project (`main.crn` + `backend.crn`), exercising refuse-without-flag → migrate → re-lock no-op, and the `--force` path.
- Full workspace: 3463 tests + doctests + clippy + all 6 CI check scripts green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)