### PR TITLE
fix: type-narrow execute_basic_effect via BasicEffect (Closes #3164)

### DIFF
--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -207,7 +207,128 @@ pub enum Effect {
     },
 }
 
+/// A type-level narrowing of [`Effect`] to the variants the basic
+/// executor (`execute_basic_effect`) actually handles: `Create`,
+/// `Update`, and `Delete`.
+///
+/// The basic executor was previously typed on `&Effect` and used a
+/// `_ => unreachable!("execute_basic_effect called with non-basic
+/// effect")` arm to reject `Replace`/`Read`/`Import`/`Remove`/`Move`/
+/// `Wait`. Callers' filters were the *only* thing keeping non-basic
+/// effects out; a single missed filter (#3164) panicked apply at
+/// runtime and left the state lock acquired.
+///
+/// `BasicEffect` makes that contract live in the type system instead.
+/// The only way to obtain one is [`Effect::as_basic`], which returns
+/// `None` for every non-basic variant. `execute_basic_effect` takes
+/// `BasicEffect<'a>` directly and exhaustively matches its three arms —
+/// no `unreachable!()` is needed, and adding a new `Effect` variant
+/// won't compile until the call sites decide whether the variant is
+/// "basic" or routed elsewhere.
+///
+/// Variants borrow from the source `&'a Effect` so the basic executor
+/// can still forward the original effect into `ExecutionEvent::*`
+/// observer calls.
+#[derive(Debug)]
+pub enum BasicEffect<'a> {
+    Create {
+        effect: &'a Effect,
+        resource: &'a Resource,
+    },
+    Update {
+        effect: &'a Effect,
+        id: &'a ResourceId,
+        from: &'a State,
+        to: &'a Resource,
+        changed_attributes: &'a [String],
+    },
+    Delete {
+        effect: &'a Effect,
+        id: &'a ResourceId,
+        identifier: &'a str,
+        directives: &'a Directives,
+    },
+}
+
+impl<'a> BasicEffect<'a> {
+    /// Returns the source `&Effect` this `BasicEffect` was narrowed
+    /// from. Used by `execute_basic_effect` to forward the original
+    /// effect to `ExecutionEvent::*` observer calls without storing it
+    /// twice.
+    pub fn as_effect(&self) -> &'a Effect {
+        match *self {
+            BasicEffect::Create { effect, .. }
+            | BasicEffect::Update { effect, .. }
+            | BasicEffect::Delete { effect, .. } => effect,
+        }
+    }
+}
+
 impl Effect {
+    /// Narrow this effect to a [`BasicEffect`] if it is one of the
+    /// variants the basic executor handles (`Create`, `Update`,
+    /// `Delete`). Returns `None` for `Replace`, `Read`, `Import`,
+    /// `Remove`, `Move`, and `Wait` — those route through other
+    /// executor paths or are state-only (applied by the CLI's
+    /// `execute_state_only_effects` step).
+    ///
+    /// This is the *only* way to construct a `BasicEffect`, so the
+    /// basic executor's "this is a Create/Update/Delete" contract
+    /// lives in the type system rather than in caller-side filters.
+    /// See [`BasicEffect`] for the rationale (#3164).
+    ///
+    /// Guard: `BasicEffect` has no `From<&Effect>` or other public
+    /// constructor — callers must route through `as_basic()` and
+    /// handle the `None` case. A bare `&Effect` does not coerce to
+    /// `BasicEffect`:
+    ///
+    /// ```compile_fail
+    /// use carina_core::effect::{BasicEffect, Effect};
+    /// use carina_core::resource::Resource;
+    /// let effect = Effect::Create(Resource::new("test", "x"));
+    /// // Was: a missed filter could pass a non-basic `&Effect` straight
+    /// // into `execute_basic_effect` and trip `unreachable!()` at apply
+    /// // time (carina#3164). The conversion no longer exists.
+    /// let _: BasicEffect = (&effect).into();
+    /// ```
+    pub fn as_basic(&self) -> Option<BasicEffect<'_>> {
+        match self {
+            Effect::Create(resource) => Some(BasicEffect::Create {
+                effect: self,
+                resource,
+            }),
+            Effect::Update {
+                id,
+                from,
+                to,
+                changed_attributes,
+            } => Some(BasicEffect::Update {
+                effect: self,
+                id,
+                from,
+                to,
+                changed_attributes,
+            }),
+            Effect::Delete {
+                id,
+                identifier,
+                directives,
+                ..
+            } => Some(BasicEffect::Delete {
+                effect: self,
+                id,
+                identifier,
+                directives,
+            }),
+            Effect::Replace { .. }
+            | Effect::Read { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Move { .. }
+            | Effect::Wait { .. } => None,
+        }
+    }
+
     /// Returns the kind of Effect as a string (for display)
     pub fn kind(&self) -> &'static str {
         match self {
@@ -610,5 +731,105 @@ mod tests {
         );
         let decoded: Effect = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, original);
+    }
+
+    /// `as_basic()` must return `Some` for the three variants the
+    /// basic executor handles, and `None` for every other variant.
+    /// This is the carina#3164 type-level contract: filters used to
+    /// be caller-side, and a missed filter (Move slipping into Phase
+    /// 1 of the phased executor) panicked apply.
+    #[test]
+    fn as_basic_narrows_to_create_update_and_delete_only() {
+        use crate::resource::State as ResState;
+
+        let rid = ResourceId::new("test", "x");
+
+        // Basic variants must narrow.
+        let create = Effect::Create(Resource::new("test", "x"));
+        assert!(matches!(
+            create.as_basic(),
+            Some(BasicEffect::Create { .. })
+        ));
+
+        let update = Effect::Update {
+            id: rid.clone(),
+            from: Box::new(ResState::not_found(rid.clone())),
+            to: Resource::new("test", "x"),
+            changed_attributes: vec![],
+        };
+        assert!(matches!(
+            update.as_basic(),
+            Some(BasicEffect::Update { .. })
+        ));
+
+        let delete = Effect::Delete {
+            id: rid.clone(),
+            identifier: "x-1".to_string(),
+            directives: Directives::default(),
+            binding: None,
+            dependencies: HashSet::new(),
+            explicit_dependencies: HashSet::new(),
+        };
+        assert!(matches!(
+            delete.as_basic(),
+            Some(BasicEffect::Delete { .. })
+        ));
+
+        // Non-basic variants must not. If a new variant is added and
+        // someone forgets to extend `as_basic`, the exhaustive match
+        // inside `as_basic` is what catches it at compile time; this
+        // test catches misclassification of an existing variant.
+        let read = Effect::Read {
+            resource: Resource::new("test", "x"),
+        };
+        let replace = Effect::Replace {
+            id: rid.clone(),
+            from: Box::new(ResState::not_found(rid.clone())),
+            to: Resource::new("test", "x"),
+            directives: Directives::default(),
+            changed_create_only: vec![],
+            cascading_updates: vec![],
+            temporary_name: None,
+            cascade_ref_hints: vec![],
+        };
+        let import = Effect::Import {
+            id: rid.clone(),
+            identifier: "x-1".to_string(),
+        };
+        let remove = Effect::Remove { id: rid.clone() };
+        let mov = Effect::Move {
+            from: rid.clone(),
+            to: ResourceId::new("test", "y"),
+        };
+        let wait = Effect::Wait {
+            binding: "w".to_string(),
+            target_id: rid.clone(),
+            target: WaitTarget::ResolvedAtApply,
+            until: WaitPredicate::Equals {
+                attr: crate::wait::predicate::AttrPath {
+                    segments: vec!["status".to_string()],
+                },
+                value: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(
+                    "ready".to_string(),
+                )),
+            },
+            until_surface: "status == 'ready'".to_string(),
+            timeout: std::time::Duration::from_secs(60),
+            interval: std::time::Duration::from_secs(1),
+            explicit_dependencies: HashSet::new(),
+        };
+        for (label, e) in [
+            ("Read", read),
+            ("Replace", replace),
+            ("Import", import),
+            ("Remove", remove),
+            ("Move", mov),
+            ("Wait", wait),
+        ] {
+            assert!(
+                e.as_basic().is_none(),
+                "{label} must not narrow to BasicEffect"
+            );
+        }
     }
 }

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use crate::binding_index::ResolvedBindings;
-use crate::effect::Effect;
+use crate::effect::{BasicEffect, Effect};
 use crate::provider::{
     CreateRequest, DeleteRequest, Provider, ProviderNormalizer, ReadRequest, UpdateRequest,
     build_update_patch,
@@ -343,14 +343,19 @@ pub(super) struct BasicEffectCtx<'a> {
 
 /// Execute a single Create, Update, or Delete effect.
 ///
-/// This helper encapsulates the shared dispatch logic: increment progress counter,
-/// record start time, emit EffectStarted, resolve resource, call provider, and
-/// emit EffectSucceeded/EffectFailed. Returns a `BasicEffectResult` that callers
-/// map to their path-specific result types.
+/// Takes a [`BasicEffect`] — a type-level narrowing of `Effect` to the
+/// three variants this function actually handles. Non-basic variants
+/// (`Replace`/`Read`/`Import`/`Remove`/`Move`/`Wait`) cannot reach this
+/// function because [`Effect::as_basic`] is the only constructor and
+/// returns `None` for them. This contract used to live in caller-side
+/// filters with an `unreachable!()` backstop; a missed filter
+/// (carina#3164) panicked apply with `execute_basic_effect called
+/// with non-basic effect`. The type now enforces it.
 ///
-/// Panics if called with a Replace, Read, Import, Remove, or Move effect.
+/// Returns a `BasicEffectResult` that callers map to their path-specific
+/// result types.
 pub(super) async fn execute_basic_effect<'a>(
-    effect: &'a Effect,
+    basic: BasicEffect<'a>,
     ctx: &BasicEffectCtx<'a>,
     observer: &'a dyn ExecutionObserver,
 ) -> BasicEffectResult {
@@ -366,10 +371,11 @@ pub(super) async fn execute_basic_effect<'a>(
         completed: c,
         total,
     };
+    let effect = basic.as_effect();
     observer.on_event(&ExecutionEvent::EffectStarted { effect });
 
-    match effect {
-        Effect::Create(resource) => {
+    match basic {
+        BasicEffect::Create { resource, .. } => {
             let resolved = match resolve_resource(resource, bindings, pipeline).await {
                 Ok(r) => r,
                 Err(e) => {
@@ -423,11 +429,12 @@ pub(super) async fn execute_basic_effect<'a>(
                 }
             }
         }
-        Effect::Update {
+        BasicEffect::Update {
             id,
             from,
             to,
             changed_attributes,
+            ..
         } => {
             let resolve_source = unresolved.get(id).unwrap_or(to);
             let resolved_to =
@@ -457,7 +464,7 @@ pub(super) async fn execute_basic_effect<'a>(
             // Without this, the patch would omit the changed
             // reference value and the provider would never be told
             // to update it.
-            let mut effective_changed: Vec<String> = changed_attributes.clone();
+            let mut effective_changed: Vec<String> = changed_attributes.to_vec();
             for (key, new_value) in &resolved_to.attributes {
                 if effective_changed.iter().any(|k| k == key) {
                     continue;
@@ -468,7 +475,7 @@ pub(super) async fn execute_basic_effect<'a>(
             }
             let patch = build_update_patch(&effective_changed, &resolved_to, from);
             let request = UpdateRequest {
-                from: (**from).clone(),
+                from: from.clone(),
                 patch,
             };
             match provider.update(id, identifier, request).await {
@@ -501,7 +508,7 @@ pub(super) async fn execute_basic_effect<'a>(
                 }
             }
         }
-        Effect::Delete {
+        BasicEffect::Delete {
             id,
             identifier,
             directives,
@@ -537,11 +544,10 @@ pub(super) async fn execute_basic_effect<'a>(
                 });
                 BasicEffectResult::Failure {
                     binding: None,
-                    refresh: Some((id.clone(), identifier.clone())),
+                    refresh: Some((id.clone(), identifier.to_string())),
                 }
             }
         },
-        _ => unreachable!("execute_basic_effect called with non-basic effect"),
     }
 }
 

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -322,120 +322,133 @@ pub(super) async fn execute_effects_sequential(
             let completed_ref = &completed;
 
             in_flight.push(async move {
-                let result = match effect {
-                    Effect::Create(_) | Effect::Update { .. } | Effect::Delete { .. } => {
-                        SingleEffectResult::Basic(
-                            execute_basic_effect(
-                                effect,
-                                &BasicEffectCtx {
-                                    provider,
-                                    bindings: &binding_snapshot,
-                                    unresolved,
-                                    pipeline: &pipeline,
-                                    completed: completed_ref,
-                                    total,
-                                },
-                                observer,
-                            )
-                            .await,
-                        )
-                    }
-                    Effect::Replace {
-                        id,
-                        from,
-                        to,
-                        directives,
-                        cascading_updates,
-                        temporary_name,
-                        ..
-                    } => {
-                        let c = completed_ref.fetch_add(1, Ordering::Relaxed) + 1;
-                        let started = Instant::now();
-                        let progress = ProgressInfo {
-                            completed: c,
-                            total,
-                        };
-                        observer.on_event(&ExecutionEvent::EffectStarted { effect });
-
-                        execute_replace_parallel(
-                            provider,
-                            &ReplaceContext {
-                                effect,
-                                id,
-                                from,
-                                to,
-                                directives,
-                                cascading_updates,
-                                temporary_name: temporary_name.as_ref(),
+                let result = match effect.as_basic() {
+                    // `BasicEffect` is the type-level contract for
+                    // `execute_basic_effect`: any Create/Update/Delete
+                    // narrows here, and any non-basic variant falls
+                    // through to the `None` arm so it can't accidentally
+                    // be dispatched (carina#3164). The compiler enforces
+                    // exhaustiveness on the outer `match effect { ... }`
+                    // below.
+                    Some(basic) => SingleEffectResult::Basic(
+                        execute_basic_effect(
+                            basic,
+                            &BasicEffectCtx {
+                                provider,
                                 bindings: &binding_snapshot,
                                 unresolved,
                                 pipeline: &pipeline,
-                                started,
-                                progress,
+                                completed: completed_ref,
+                                total,
                             },
                             observer,
                         )
-                        .await
-                    }
-                    Effect::Read { .. } => SingleEffectResult::ReadNoOp,
-                    // State operations are handled separately during apply
-                    Effect::Import { .. } | Effect::Remove { .. } | Effect::Move { .. } => {
-                        SingleEffectResult::ReadNoOp
-                    }
-                    Effect::Wait {
-                        binding,
-                        target_id,
-                        until,
-                        timeout,
-                        interval,
-                        ..
-                    } => {
-                        let c = completed_ref.fetch_add(1, Ordering::Relaxed) + 1;
-                        let started = Instant::now();
-                        observer.on_event(&ExecutionEvent::EffectStarted { effect });
-                        let progress = ProgressInfo {
-                            completed: c,
-                            total,
-                        };
-                        match super::wait::execute_wait_effect(
-                            provider,
+                        .await,
+                    ),
+                    None => match effect {
+                        Effect::Create(_) | Effect::Update { .. } | Effect::Delete { .. } => {
+                            // `as_basic()` returns `Some` for exactly these
+                            // three variants; they're handled by the `Some`
+                            // arm above.
+                            unreachable!("Create/Update/Delete are narrowed by as_basic()")
+                        }
+                        Effect::Replace {
+                            id,
+                            from,
+                            to,
+                            directives,
+                            cascading_updates,
+                            temporary_name,
+                            ..
+                        } => {
+                            let c = completed_ref.fetch_add(1, Ordering::Relaxed) + 1;
+                            let started = Instant::now();
+                            let progress = ProgressInfo {
+                                completed: c,
+                                total,
+                            };
+                            observer.on_event(&ExecutionEvent::EffectStarted { effect });
+
+                            execute_replace_parallel(
+                                provider,
+                                &ReplaceContext {
+                                    effect,
+                                    id,
+                                    from,
+                                    to,
+                                    directives,
+                                    cascading_updates,
+                                    temporary_name: temporary_name.as_ref(),
+                                    bindings: &binding_snapshot,
+                                    unresolved,
+                                    pipeline: &pipeline,
+                                    started,
+                                    progress,
+                                },
+                                observer,
+                            )
+                            .await
+                        }
+                        Effect::Read { .. } => SingleEffectResult::ReadNoOp,
+                        // State operations are handled separately during apply
+                        Effect::Import { .. } | Effect::Remove { .. } | Effect::Move { .. } => {
+                            SingleEffectResult::ReadNoOp
+                        }
+                        Effect::Wait {
+                            binding,
                             target_id,
-                            wait_identifier.as_deref(),
                             until,
-                            *timeout,
-                            *interval,
-                        )
-                        .await
-                        {
-                            Ok(state) => {
-                                observer.on_event(&ExecutionEvent::EffectSucceeded {
-                                    effect,
-                                    state: Some(&state),
-                                    duration: started.elapsed(),
-                                    progress,
-                                });
-                                SingleEffectResult::Wait {
-                                    success: true,
-                                    binding: binding.clone(),
-                                    target_state: Some(state),
+                            timeout,
+                            interval,
+                            ..
+                        } => {
+                            let c = completed_ref.fetch_add(1, Ordering::Relaxed) + 1;
+                            let started = Instant::now();
+                            observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                            let progress = ProgressInfo {
+                                completed: c,
+                                total,
+                            };
+                            match super::wait::execute_wait_effect(
+                                provider,
+                                target_id,
+                                wait_identifier.as_deref(),
+                                until,
+                                *timeout,
+                                *interval,
+                            )
+                            .await
+                            {
+                                Ok(state) => {
+                                    observer.on_event(&ExecutionEvent::EffectSucceeded {
+                                        effect,
+                                        state: Some(&state),
+                                        duration: started.elapsed(),
+                                        progress,
+                                    });
+                                    SingleEffectResult::Wait {
+                                        success: true,
+                                        binding: binding.clone(),
+                                        target_state: Some(state),
+                                    }
                                 }
-                            }
-                            Err(e) => {
-                                let err_msg = e.to_string();
-                                observer.on_event(&ExecutionEvent::EffectFailed {
-                                    effect,
-                                    error: &err_msg,
-                                    duration: started.elapsed(),
-                                    progress,
-                                });
-                                SingleEffectResult::Wait {
-                                    success: false,
-                                    binding: binding.clone(),
-                                    target_state: None,
+                                Err(e) => {
+                                    let err_msg = e.to_string();
+                                    observer.on_event(&ExecutionEvent::EffectFailed {
+                                        effect,
+                                        error: &err_msg,
+                                        duration: started.elapsed(),
+                                        progress,
+                                    });
+                                    SingleEffectResult::Wait {
+                                        success: false,
+                                        binding: binding.clone(),
+                                        target_state: None,
+                                    }
                                 }
                             }
                         }
-                    }
+                    },
                 };
                 (idx, result)
             });

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -371,6 +371,24 @@ pub(super) async fn execute_effects_phased(
                     continue;
                 }
 
+                // Phase 1 only dispatches `Create`/`Update`/`Delete` to
+                // `execute_basic_effect`. State-only effects (`Move`/
+                // `Import`/`Remove`) and `Wait` are routed elsewhere
+                // (the CLI's `execute_state_only_effects` step, or the
+                // sequential path's Wait branch). The previous
+                // `&Effect` signature let them slip through and trip an
+                // `unreachable!()` (carina#3164); narrowing via
+                // `as_basic()` makes the contract type-level. The
+                // outer `phase1_indices` filter still excludes
+                // `Replace` and `Read` so they reach their dedicated
+                // phases; everything else that isn't basic ends up
+                // here and is silently skipped from the basic
+                // executor's point of view.
+                let Some(basic_effect) = effect.as_basic() else {
+                    completed_indices.insert(idx);
+                    continue;
+                };
+
                 let binding_snapshot = input.bindings.clone();
                 let unresolved = &input.unresolved_resources;
                 let pipeline = RenormalizePipeline {
@@ -382,7 +400,7 @@ pub(super) async fn execute_effects_phased(
 
                 in_flight.push(async move {
                     let basic = execute_basic_effect(
-                        effect,
+                        basic_effect,
                         &BasicEffectCtx {
                             provider,
                             bindings: &binding_snapshot,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -3102,3 +3102,82 @@ async fn wait_resolves_target_identifier_from_just_created_state() {
         provider.read_identifiers()
     );
 }
+
+/// Regression for carina#3164: a plan that mixes `Effect::Move` with
+/// interdependent `Effect::Replace` effects must not panic. The
+/// phased executor's Phase 1 was filtering only `Replace` and `Read`,
+/// so state-only `Move` effects were dispatched into
+/// `execute_basic_effect` and tripped its `unreachable!()` arm.
+/// Move effects are state-only and must be skipped by the runtime
+/// executor — the CLI's `execute_state_only_effects` step applies them
+/// to state.
+#[tokio::test]
+async fn test_phased_move_with_interdependent_replace_does_not_panic() {
+    let provider = MockProvider::new();
+
+    let role_id = ResourceId::new("test", "role");
+    let policy_old_id = ResourceId::new("test", "policy_old");
+    let policy_new_id = ResourceId::new("test", "policy_new");
+
+    let role_from = State::existing(role_id.clone(), HashMap::new()).with_identifier("role-old");
+    let mut role_to = Resource::new("test", "role");
+    role_to.binding = Some("role".to_string());
+
+    let policy_from =
+        State::existing(policy_new_id.clone(), HashMap::new()).with_identifier("policy-old");
+    let mut policy_to = Resource::new("test", "policy_new");
+    policy_to.dependency_bindings = std::collections::BTreeSet::from(["role".to_string()]);
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: role_id.clone(),
+        from: Box::new(role_from),
+        to: role_to,
+        directives: Directives::default(),
+        changed_create_only: vec!["role_name".to_string()],
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+    plan.add(Effect::Move {
+        from: policy_old_id,
+        to: policy_new_id.clone(),
+    });
+    plan.add(Effect::Replace {
+        id: policy_new_id,
+        from: Box::new(policy_from),
+        to: policy_to,
+        directives: Directives::default(),
+        changed_create_only: vec!["policy_name".to_string()],
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+
+    provider.push_delete(Ok(()));
+    provider.push_create(Ok(ok_state(&role_id)));
+    provider.push_delete(Ok(()));
+    provider.push_create(Ok(ok_state(&ResourceId::new("test", "policy_new"))));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+
+    assert_eq!(
+        result.failure_count, 0,
+        "Replace effects must succeed; Move must be skipped, not dispatched to execute_basic_effect"
+    );
+    assert_eq!(
+        result.success_count, 2,
+        "two Replace effects should be counted as successes; Move is state-only and handled by the CLI"
+    );
+}


### PR DESCRIPTION
## Summary

- The runtime executor's basic dispatch (`execute_basic_effect`) used to take `&Effect` and reject non-basic variants at runtime with `unreachable!("execute_basic_effect called with non-basic effect")`. Caller-side filters in `phased.rs`/`parallel.rs` were the only thing keeping `Replace`/`Read`/`Import`/`Remove`/`Move`/`Wait` out.
- A missed filter in `phased.rs` Phase 1 (excluded only `Replace`/`Read`) panicked `carina apply` whenever a plan mixed `Move` with interdependent `Replace` effects, leaving the state lock acquired.
- This PR moves the contract into the type system: new `BasicEffect<'a>` enum carries only `Create`/`Update`/`Delete`, constructed exclusively via `Effect::as_basic() -> Option<BasicEffect<'_>>`. `execute_basic_effect` takes `BasicEffect` directly and exhaustively matches three arms. Adding a new `Effect` variant won't compile until `as_basic()` is extended.

## Why a type-level fix and not a one-line filter

The same class of bug (apply executor mis-routing a non-basic effect) has shown up before (#3145 references it). A caller-side filter would patch this instance but leave the next missed filter free to trip the same `unreachable!()`. Lifting the contract into a newtype means a future contributor either narrows through `as_basic()` (and handles the `None`) or doesn't compile.

## Regression coverage

- `executor::tests::test_phased_move_with_interdependent_replace_does_not_panic` reproduces the issue's `Role` replace + `RolePolicy` `Move` + `RolePolicy` replace scenario through the phased path. Fails on `main` with the same `unreachable!()` panic the issue reports.
- `effect::tests::as_basic_narrows_to_create_update_and_delete_only` asserts `as_basic()` is `Some` only for `Create`/`Update`/`Delete` and `None` for every other variant.
- `compile_fail` doctest on `Effect::as_basic` proves there is no `From<&Effect> for BasicEffect` (or other public bypass). A future impl that would reopen the panic-prone door flips `cargo test --doc` red.

## Test plan

- [x] `cargo nextest run --workspace` (3465 passed, +1 vs main for the new test)
- [x] `cargo test --workspace --doc` (incl. the new `compile_fail` doctest)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] Regression test fails on `main` (panic), passes on this branch

Closes #3164