### PR TITLE
feat: add proto::AttributeType::Duration so providers can declare Duration fields

### DIFF
--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -671,6 +671,7 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
         proto::AttributeType::Int => CoreAttributeType::Int,
         proto::AttributeType::Float => CoreAttributeType::Float,
         proto::AttributeType::Bool => CoreAttributeType::Bool,
+        proto::AttributeType::Duration => CoreAttributeType::Duration,
         proto::AttributeType::StringEnum {
             values,
             name,
@@ -1446,6 +1447,22 @@ mod tests {
             }
             other => panic!("expected List, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn json_to_attribute_types_decodes_duration() {
+        // Acceptance for carina#3166: providers that declare a
+        // Duration-typed schema attribute via `provider_config_attribute_types`
+        // (e.g. assume_role.duration in aws#342 / awscc#260) must
+        // round-trip through `{"type":"Duration"}` to
+        // `CoreAttributeType::Duration` so the host's type checker
+        // accepts `duration = 30min` against that declaration.
+        let json = r#"{"timeout":{"type":"Duration"}}"#;
+        let types = json_to_attribute_types(json);
+        assert!(matches!(
+            types.get("timeout"),
+            Some(CoreAttributeType::Duration)
+        ));
     }
 
     #[test]

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -340,6 +340,12 @@ pub enum AttributeType {
     Int,
     Float,
     Bool,
+    /// Time duration. Authored in the DSL as a literal like `30min`,
+    /// `1h`, or `15s` (`duration_literal` in the grammar); reaches the
+    /// provider across the WIT boundary as integer seconds. Lets
+    /// providers declare Duration-typed schema attributes so the
+    /// host-side type checker accepts the literal form (carina#3166).
+    Duration,
     #[serde(rename = "string_enum")]
     StringEnum {
         values: Vec<String>,
@@ -467,6 +473,20 @@ mod tests {
         let json = serde_json::to_string(&attr).unwrap();
         let back: AttributeType = serde_json::from_str(&json).unwrap();
         assert_eq!(json, serde_json::to_string(&back).unwrap());
+    }
+
+    #[test]
+    fn duration_attribute_type_serializes_as_duration_tag() {
+        // Providers serialize this via serde_json across the WIT
+        // boundary; the host must reconstruct it from the
+        // `{"type": "Duration"}` form. Pinning the wire shape is the
+        // only thing that keeps the cross-boundary contract stable
+        // (carina#3166).
+        let attr = AttributeType::Duration;
+        let json = serde_json::to_string(&attr).unwrap();
+        assert_eq!(json, r#"{"type":"Duration"}"#);
+        let back: AttributeType = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, AttributeType::Duration));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `proto::AttributeType::Duration` variant (no fields). Serializes as `{\"type\":\"Duration\"}`.
- Add the corresponding arm in `carina-plugin-host/src/wasm_convert.rs::proto_attr_type_to_core` mapping it to `CoreAttributeType::Duration`.
- Two unit tests: serde round-trip in `carina-provider-protocol` and `json_to_attribute_types` decode in `carina-plugin-host`.

## Why

carina-core already has `AttributeType::Duration` and `ConcreteValue::Duration(std::time::Duration)`, and the DSL grammar (`carina.pest::duration_literal`) supports literals like `30min` / `1h` / `15s`. But the protocol-level enum has been missing the `Duration` variant, so WASM-component providers cannot declare a Duration-typed schema attribute via `provider_config_attribute_types()`.

Concrete blocker: carina-rs/carina-provider-aws#342 and carina-rs/carina-provider-awscc#260 both want `assume_role.duration = 30min` at provider-config level. Without this PR, those providers would have to either declare `String` (forcing DSL users to spell `\"30m\"` and ship a humantime parser per provider) or `Int` (losing the semantic literal form). With this PR, they can declare `Duration` and the host's type checker accepts the existing `30min` literal directly.

## What is **not** in this PR

- The "inbound re-typing" follow-up flagged at `wasm_convert.rs:60-76`. `ConcreteValue::Duration` still crosses the WIT boundary as `IntVal(seconds)` and is read by providers as `Int`. The schema-aware reconstruction of `Int → Duration` on the inbound side stays a deferred follow-up; the assume_role use case does not require it (provider only needs the integer seconds at init time).
- Any provider-side change. aws#342 / awscc#260 are sibling PRs that will pin this commit once it lands.

## Test plan

- [x] `cargo nextest run --workspace` — 3467 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check-*.sh` — all five pass
- [x] New `duration_attribute_type_serializes_as_duration_tag` round-trips `{\"type\":\"Duration\"}` ↔ `AttributeType::Duration`.
- [x] New `json_to_attribute_types_decodes_duration` decodes `{\"timeout\":{\"type\":\"Duration\"}}` into `CoreAttributeType::Duration`.
- [x] 5-round self-review: all rounds clean, HIGH confidence.

Closes #3166

🤖 Generated with [Claude Code](https://claude.com/claude-code)