### PR TITLE
resource: introduce ManagedResource / VirtualResource / DataSource wrappers (1/9 of #3169)

### DIFF
--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -1,0 +1,72 @@
+//! `DataSource` — a read-only resource that is queried but not
+//! managed.
+//!
+//! Part of the resource typestate split (#3169). A `DataSource`
+//! carries the same fields as a [`ManagedResource`](super::ManagedResource)
+//! minus `prefixes` (auto-generated names do not apply to read-only
+//! lookups). `directives` is retained because `depends_on` and
+//! `provider_instance` are still meaningful when ordering reads
+//! against other resources.
+
+use std::collections::{BTreeSet, HashSet};
+
+use indexmap::IndexMap;
+
+use super::{
+    Directives, ModuleSource, Resource, ResourceId, ResourceKind, ResourceKindLabel,
+    ResourceKindMismatch, Value,
+};
+
+/// A read-only resource (data source).
+///
+/// # Dropped fields (compile-time invariants)
+///
+/// `prefixes` is dropped (auto-generated names do not apply to
+/// read-only lookups):
+///
+/// ```compile_fail
+/// use carina_core::resource::DataSource;
+/// fn _f(d: &DataSource) -> &std::collections::HashMap<String, String> {
+///     &d.prefixes
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct DataSource {
+    pub id: ResourceId,
+    /// Source-order preserving map of attribute name → expression.
+    pub attributes: IndexMap<String, Value>,
+    /// `directives` meta-argument block — `depends_on` and
+    /// `provider_instance` are meaningful for data sources too.
+    pub directives: Directives,
+    /// Binding name from `let` bindings in DSL.
+    pub binding: Option<String>,
+    /// Binding names this data source depends on.
+    pub dependency_bindings: BTreeSet<String>,
+    /// Module source info for data sources from modules.
+    pub module_source: Option<ModuleSource>,
+    /// Parser-level: attributes whose value was written as a quoted
+    /// string literal.
+    pub quoted_string_attrs: HashSet<String>,
+}
+
+impl TryFrom<&Resource> for DataSource {
+    type Error = ResourceKindMismatch;
+
+    fn try_from(res: &Resource) -> Result<Self, Self::Error> {
+        match res.kind {
+            ResourceKind::DataSource => Ok(Self {
+                id: res.id.clone(),
+                attributes: res.attributes.clone(),
+                directives: res.directives.clone(),
+                binding: res.binding.clone(),
+                dependency_bindings: res.dependency_bindings.clone(),
+                module_source: res.module_source.clone(),
+                quoted_string_attrs: res.quoted_string_attrs.clone(),
+            }),
+            _ => Err(ResourceKindMismatch {
+                expected: ResourceKindLabel::DataSource,
+                actual: res.kind.label(),
+            }),
+        }
+    }
+}

--- a/carina-core/src/resource/managed.rs
+++ b/carina-core/src/resource/managed.rs
@@ -1,0 +1,65 @@
+//! `ManagedResource` — a managed infrastructure resource with full
+//! CRUD lifecycle.
+//!
+//! Part of the resource typestate split (#3169). Carries only the
+//! fields meaningful for a managed lifecycle: identifier, attributes,
+//! Carina-side directives, attribute prefixes, binding metadata,
+//! module source, and the parser-level `quoted_string_attrs` bit.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use indexmap::IndexMap;
+
+use super::{
+    Directives, ModuleSource, Resource, ResourceId, ResourceKind, ResourceKindLabel,
+    ResourceKindMismatch, Value,
+};
+
+/// A managed infrastructure resource.
+///
+/// Cf. [`VirtualResource`](super::VirtualResource) and
+/// [`DataSource`](super::DataSource) for the other two arms of the
+/// typestate split.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ManagedResource {
+    pub id: ResourceId,
+    /// Source-order preserving map of attribute name → expression.
+    /// Fully resolvable at pre-apply (no deferred virtual-only refs).
+    pub attributes: IndexMap<String, Value>,
+    /// `directives` meta-argument block.
+    pub directives: Directives,
+    /// Attribute prefixes (e.g. `bucket_name_prefix = "my-app-"`).
+    pub prefixes: HashMap<String, String>,
+    /// Binding name from `let` bindings in DSL.
+    pub binding: Option<String>,
+    /// Binding names of resources this resource depends on.
+    pub dependency_bindings: BTreeSet<String>,
+    /// Module source info for resources that belong to a module.
+    pub module_source: Option<ModuleSource>,
+    /// Parser-level: attributes whose value was written as a quoted
+    /// string literal (`attr = "..."`).
+    pub quoted_string_attrs: HashSet<String>,
+}
+
+impl TryFrom<&Resource> for ManagedResource {
+    type Error = ResourceKindMismatch;
+
+    fn try_from(res: &Resource) -> Result<Self, Self::Error> {
+        match res.kind {
+            ResourceKind::Managed => Ok(Self {
+                id: res.id.clone(),
+                attributes: res.attributes.clone(),
+                directives: res.directives.clone(),
+                prefixes: res.prefixes.clone(),
+                binding: res.binding.clone(),
+                dependency_bindings: res.dependency_bindings.clone(),
+                module_source: res.module_source.clone(),
+                quoted_string_attrs: res.quoted_string_attrs.clone(),
+            }),
+            _ => Err(ResourceKindMismatch {
+                expected: ResourceKindLabel::Managed,
+                actual: res.kind.label(),
+            }),
+        }
+    }
+}

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1833,3 +1833,59 @@ impl State {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod typestate_tests;
+
+pub mod data_source;
+pub mod managed;
+pub mod virtual_resource;
+
+pub use data_source::DataSource;
+pub use managed::ManagedResource;
+pub use virtual_resource::VirtualResource;
+
+/// Type-level label for the three resource arms.
+///
+/// Used by [`ResourceKindMismatch`] (the `TryFrom<&Resource>` error)
+/// and [`ResourceKind::label`]. Encoding the label as an enum — rather
+/// than a `&'static str` — means a typo in any `expected:` / `actual:`
+/// initializer is a compile error, not a runtime mismatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResourceKindLabel {
+    Managed,
+    Virtual,
+    DataSource,
+}
+
+impl std::fmt::Display for ResourceKindLabel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Managed => "Managed",
+            Self::Virtual => "Virtual",
+            Self::DataSource => "DataSource",
+        })
+    }
+}
+
+impl ResourceKind {
+    /// Project this kind onto its `ResourceKindLabel`, discarding any
+    /// payload (`module_name` / `instance` for `Virtual`).
+    pub fn label(&self) -> ResourceKindLabel {
+        match self {
+            Self::Managed => ResourceKindLabel::Managed,
+            Self::Virtual { .. } => ResourceKindLabel::Virtual,
+            Self::DataSource => ResourceKindLabel::DataSource,
+        }
+    }
+}
+
+/// Error returned by `TryFrom<&Resource>` impls on
+/// [`ManagedResource`], [`VirtualResource`], and [`DataSource`] when
+/// the source `Resource`'s `kind` does not match the requested target.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("expected {expected} resource, got {actual}")]
+pub struct ResourceKindMismatch {
+    pub expected: ResourceKindLabel,
+    pub actual: ResourceKindLabel,
+}

--- a/carina-core/src/resource/typestate_tests.rs
+++ b/carina-core/src/resource/typestate_tests.rs
@@ -1,0 +1,185 @@
+//! Tests for #3173: typed wrappers `ManagedResource`, `VirtualResource`,
+//! and `DataSource`, plus their `TryFrom<&Resource>` conversions.
+//!
+//! No behaviour change — these tests exercise the new types and the
+//! fallible conversion from the legacy `Resource` shape.
+
+use std::collections::BTreeSet;
+
+use crate::resource::{
+    ConcreteValue, DataSource, Directives, ManagedResource, ModuleSource, Resource, ResourceKind,
+    ResourceKindLabel, ResourceKindMismatch, Value, VirtualResource,
+};
+
+fn sample_value(s: &str) -> Value {
+    Value::Concrete(ConcreteValue::String(s.into()))
+}
+
+/// Build a fully-populated `Resource` of the requested kind.
+///
+/// Fields that have a builder (`with_*`) are set through it. The two
+/// without a builder (`directives`, `prefixes`, `quoted_string_attrs`)
+/// are written in-place after construction.
+fn make_resource(kind: ResourceKind) -> Resource {
+    let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
+
+    let mut res = Resource::new("aws.s3.Bucket", "b")
+        .with_kind(kind)
+        .with_attribute("k", sample_value("v"))
+        .with_binding("b")
+        .with_dependency_bindings(deps)
+        .with_module_source(ModuleSource::module("m", "inst"));
+
+    res.directives = Directives {
+        force_delete: true,
+        ..Directives::default()
+    };
+    res.prefixes.insert("k".into(), "pfx-".into());
+    res.quoted_string_attrs.insert("k".into());
+
+    res
+}
+
+#[test]
+fn managed_resource_carries_full_managed_field_set() {
+    let res = make_resource(ResourceKind::Managed);
+    let managed = ManagedResource::try_from(&res).expect("Managed → ManagedResource");
+
+    assert_eq!(managed.id, res.id);
+    assert_eq!(managed.attributes, res.attributes);
+    assert_eq!(managed.directives, res.directives);
+    assert_eq!(managed.prefixes, res.prefixes);
+    assert_eq!(managed.binding, res.binding);
+    assert_eq!(managed.dependency_bindings, res.dependency_bindings);
+    assert_eq!(managed.module_source, res.module_source);
+    assert_eq!(managed.quoted_string_attrs, res.quoted_string_attrs);
+}
+
+#[test]
+fn virtual_resource_flattens_module_name_and_instance_drops_directives_and_prefixes() {
+    let res = make_resource(ResourceKind::Virtual {
+        module_name: "my_module".into(),
+        instance: "my_instance".into(),
+    });
+    let v = VirtualResource::try_from(&res).expect("Virtual → VirtualResource");
+
+    assert_eq!(v.id, res.id);
+    assert_eq!(v.attributes, res.attributes);
+    assert_eq!(v.binding, res.binding);
+    assert_eq!(v.dependency_bindings, res.dependency_bindings);
+    assert_eq!(v.module_name, "my_module");
+    assert_eq!(v.instance, "my_instance");
+    assert_eq!(v.quoted_string_attrs, res.quoted_string_attrs);
+}
+
+#[test]
+fn data_source_carries_directives_and_module_source_drops_prefixes() {
+    let res = make_resource(ResourceKind::DataSource);
+    let ds = DataSource::try_from(&res).expect("DataSource → DataSource");
+
+    assert_eq!(ds.id, res.id);
+    assert_eq!(ds.attributes, res.attributes);
+    assert_eq!(ds.directives, res.directives);
+    assert_eq!(ds.binding, res.binding);
+    assert_eq!(ds.dependency_bindings, res.dependency_bindings);
+    assert_eq!(ds.module_source, res.module_source);
+    assert_eq!(ds.quoted_string_attrs, res.quoted_string_attrs);
+}
+
+#[test]
+fn try_from_rejects_kind_mismatch_for_managed() {
+    let virt = make_resource(ResourceKind::Virtual {
+        module_name: "m".into(),
+        instance: "i".into(),
+    });
+    let err = ManagedResource::try_from(&virt).expect_err("Virtual must not convert to Managed");
+    assert_eq!(err.expected, ResourceKindLabel::Managed);
+    assert_eq!(err.actual, ResourceKindLabel::Virtual);
+
+    let ds = make_resource(ResourceKind::DataSource);
+    let err = ManagedResource::try_from(&ds).expect_err("DataSource must not convert to Managed");
+    assert_eq!(err.expected, ResourceKindLabel::Managed);
+    assert_eq!(err.actual, ResourceKindLabel::DataSource);
+}
+
+#[test]
+fn try_from_rejects_kind_mismatch_for_virtual() {
+    let managed = make_resource(ResourceKind::Managed);
+    let err = VirtualResource::try_from(&managed)
+        .expect_err("Managed must not convert to VirtualResource");
+    assert_eq!(err.expected, ResourceKindLabel::Virtual);
+    assert_eq!(err.actual, ResourceKindLabel::Managed);
+
+    let ds = make_resource(ResourceKind::DataSource);
+    let err =
+        VirtualResource::try_from(&ds).expect_err("DataSource must not convert to VirtualResource");
+    assert_eq!(err.expected, ResourceKindLabel::Virtual);
+    assert_eq!(err.actual, ResourceKindLabel::DataSource);
+}
+
+#[test]
+fn try_from_rejects_kind_mismatch_for_data_source() {
+    let managed = make_resource(ResourceKind::Managed);
+    let err = DataSource::try_from(&managed).expect_err("Managed must not convert to DataSource");
+    assert_eq!(err.expected, ResourceKindLabel::DataSource);
+    assert_eq!(err.actual, ResourceKindLabel::Managed);
+
+    let virt = make_resource(ResourceKind::Virtual {
+        module_name: "m".into(),
+        instance: "i".into(),
+    });
+    let err = DataSource::try_from(&virt).expect_err("Virtual must not convert to DataSource");
+    assert_eq!(err.expected, ResourceKindLabel::DataSource);
+    assert_eq!(err.actual, ResourceKindLabel::Virtual);
+}
+
+#[test]
+fn kind_mismatch_error_formats_with_both_sides() {
+    let err = ResourceKindMismatch {
+        expected: ResourceKindLabel::Managed,
+        actual: ResourceKindLabel::Virtual,
+    };
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("Managed") && msg.contains("Virtual"),
+        "error message should name both sides, got: {msg}"
+    );
+}
+
+#[test]
+fn resource_kind_label_display_round_trip() {
+    assert_eq!(format!("{}", ResourceKindLabel::Managed), "Managed");
+    assert_eq!(format!("{}", ResourceKindLabel::Virtual), "Virtual");
+    assert_eq!(format!("{}", ResourceKindLabel::DataSource), "DataSource");
+}
+
+#[test]
+fn resource_kind_projects_to_label_dropping_payload() {
+    assert_eq!(ResourceKind::Managed.label(), ResourceKindLabel::Managed);
+    assert_eq!(
+        ResourceKind::Virtual {
+            module_name: "m".into(),
+            instance: "i".into(),
+        }
+        .label(),
+        ResourceKindLabel::Virtual,
+    );
+    assert_eq!(
+        ResourceKind::DataSource.label(),
+        ResourceKindLabel::DataSource,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time invariant guards
+// ---------------------------------------------------------------------------
+//
+// The point of the typestate split is that fields meaningful only to
+// one arm cannot be accessed on a wrong arm. Encoding that invariant
+// at runtime would require runtime checks — but with separate structs
+// each arm carries only its own fields. The `compile_fail` doctests
+// pinning these invariants live on the public structs themselves
+// (`VirtualResource` and `DataSource`); if someone re-adds `prefixes`
+// (or any other dropped field) to either type, those doctests start
+// compiling and CI fails. Keep this comment as the index pointing at
+// where the guards actually live.

--- a/carina-core/src/resource/virtual_resource.rs
+++ b/carina-core/src/resource/virtual_resource.rs
@@ -1,0 +1,101 @@
+//! `VirtualResource` — a synthetic IR node created by the module
+//! resolver to expose module `attributes` values.
+//!
+//! Part of the resource typestate split (#3169). Virtual resources
+//! are not sent to providers; they exist only in the IR. Their
+//! `attributes` may contain unresolved `ResourceRef` / `BindingRef`
+//! values whose resolution is **deferred to the post-apply path**.
+//! The typestate split encodes that invariant: a `VirtualResource`
+//! is never accepted by the pre-apply resolver.
+//!
+//! Unlike [`ManagedResource`](super::ManagedResource), this struct
+//! does not carry `directives` (no `prevent_destroy` applies to a
+//! synthetic node) or `prefixes` (no auto-generated names on a
+//! non-provider resource). `module_source` is flattened to
+//! `module_name` + `instance` — those are always set for virtuals.
+
+use std::collections::{BTreeSet, HashSet};
+
+use indexmap::IndexMap;
+
+use super::{Resource, ResourceId, ResourceKind, ResourceKindLabel, ResourceKindMismatch, Value};
+
+/// A virtual resource created by module-call expansion.
+///
+/// # Dropped fields (compile-time invariants)
+///
+/// These guards pin the design-doc invariants for #3169. If any of
+/// these fields is re-added, the corresponding doctest compiles and
+/// CI fails — re-read the design doc before doing so.
+///
+/// `prefixes` is dropped (no auto-generated names on a synthetic node):
+///
+/// ```compile_fail
+/// use carina_core::resource::VirtualResource;
+/// fn _f(v: &VirtualResource) -> &std::collections::HashMap<String, String> {
+///     &v.prefixes
+/// }
+/// ```
+///
+/// `directives` is dropped (no `prevent_destroy` applies to a synthetic node):
+///
+/// ```compile_fail
+/// use carina_core::resource::VirtualResource;
+/// fn _f(v: &VirtualResource) -> &carina_core::resource::Directives {
+///     &v.directives
+/// }
+/// ```
+///
+/// `module_source` is dropped — module metadata is flattened into
+/// `module_name` + `instance`:
+///
+/// ```compile_fail
+/// use carina_core::resource::VirtualResource;
+/// fn _f(v: &VirtualResource) -> &Option<carina_core::resource::ModuleSource> {
+///     &v.module_source
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct VirtualResource {
+    pub id: ResourceId,
+    /// Attributes that may contain unresolved `ResourceRef` /
+    /// `BindingRef` values. Resolution is deferred until post-apply.
+    pub attributes: IndexMap<String, Value>,
+    /// Binding name from `let` bindings in DSL.
+    pub binding: Option<String>,
+    /// Binding names this virtual depends on.
+    pub dependency_bindings: BTreeSet<String>,
+    /// Module name from the originating `ResourceKind::Virtual` tag
+    /// (e.g. "web_tier"). Always set for virtuals — see #2516.
+    pub module_name: String,
+    /// Module instance binding name (e.g. "web").
+    pub instance: String,
+    /// Parser-level: attributes whose value was written as a quoted
+    /// string literal.
+    pub quoted_string_attrs: HashSet<String>,
+}
+
+impl TryFrom<&Resource> for VirtualResource {
+    type Error = ResourceKindMismatch;
+
+    fn try_from(res: &Resource) -> Result<Self, Self::Error> {
+        match &res.kind {
+            ResourceKind::Virtual {
+                module_name,
+                instance,
+            } => Ok(Self {
+                id: res.id.clone(),
+                attributes: res.attributes.clone(),
+                binding: res.binding.clone(),
+                dependency_bindings: res.dependency_bindings.clone(),
+                module_name: module_name.clone(),
+                instance: instance.clone(),
+                quoted_string_attrs: res.quoted_string_attrs.clone(),
+            }),
+            other => Err(ResourceKindMismatch {
+                expected: ResourceKindLabel::Virtual,
+                actual: other.label(),
+            }),
+        }
+    }
+}


### PR DESCRIPTION
Part 1/9 of the resource typestate split (#3169). Adds typed wrapper
structs alongside the existing `Resource`, each carrying only the
fields meaningful for its lifecycle. Design PR #3172 (merged) covers
the rationale and the 9-step decomposition.

## Summary

- `ManagedResource` — full CRUD lifecycle; mirrors `Resource` minus
  the `kind` discriminant.
- `VirtualResource` — synthetic module-call IR node. Drops
  `directives`, `prefixes`, and `module_source`; flattens
  `ResourceKind::Virtual { module_name, instance }` into direct
  fields (per design doc §Three sibling types).
- `DataSource` — read-only resource. Drops `prefixes`; keeps
  `directives` (`depends_on` / `provider_instance` apply to reads
  too).
- `TryFrom<&Resource>` for each wrapper, fallible by kind, returning
  `ResourceKindMismatch { expected, actual }`.
- `ResourceKindLabel` enum + `ResourceKind::label()` projector — used
  by `ResourceKindMismatch` so any typo in a `TryFrom` impl is a
  compile error instead of a runtime mismatch.

## Compile-time invariants pinned by doctests

The design-doc invariants ("VirtualResource has no prefixes /
directives / module_source"; "DataSource has no prefixes") are
asserted by `compile_fail` doctests on the public struct docs (4
total). A future contributor re-adding any dropped field fails CI
rather than silently widening the type.

## Notes for reviewers

- **File name `virtual_resource.rs`** (not `virtual.rs` as the design
  doc spells it) — `virtual` is a Rust reserved keyword and
  `mod r#virtual;` would pollute every consumer with raw-identifier
  syntax. The public symbol `VirtualResource` matches the design doc.
- **`ResourceKindLabel` / `ResourceKind::label()`** are not in the
  issue body verbatim, but they are tightly coupled to the
  `TryFrom` error type the issue requires; using `&'static str`
  labels here would forfeit the type-safety win (memory rule:
  "type safety over runtime checks").
- **No behaviour change.** `carina-core/src/resource/mod.rs` is
  append-only — no existing call site is touched.

## Test plan

- [x] `cargo nextest run --workspace` — 3484 passed
- [x] `cargo test --workspace --doc` — 18 passed (incl. 6
      `compile_fail` doctests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — all OK
- [x] 5-round self-review — clean

Refs #3169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)