### PR TITLE
resource: introduce ResourceLike trait (2/9 of #3169)

### DIFF
--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1837,12 +1837,17 @@ mod tests;
 #[cfg(test)]
 mod typestate_tests;
 
+#[cfg(test)]
+mod resource_like_tests;
+
 pub mod data_source;
 pub mod managed;
+pub mod resource_like;
 pub mod virtual_resource;
 
 pub use data_source::DataSource;
 pub use managed::ManagedResource;
+pub use resource_like::ResourceLike;
 pub use virtual_resource::VirtualResource;
 
 /// Type-level label for the three resource arms.

--- a/carina-core/src/resource/resource_like.rs
+++ b/carina-core/src/resource/resource_like.rs
@@ -1,0 +1,112 @@
+//! Shared read-only accessor trait across the resource typestate
+//! arms (#3174).
+//!
+//! Lets read-only consumers — plan tree builders, formatters,
+//! diagnostics — stay generic over the three sibling types
+//! ([`Resource`](super::Resource), [`ManagedResource`](super::ManagedResource),
+//! [`VirtualResource`](super::VirtualResource),
+//! [`DataSource`](super::DataSource)). Write-side callers (resolver,
+//! effect-executor, writeback) continue to take a concrete type and
+//! benefit from the typed dispatch.
+
+use std::collections::BTreeSet;
+
+use indexmap::IndexMap;
+
+use super::{DataSource, ManagedResource, Resource, ResourceId, Value, VirtualResource};
+
+/// Read-only accessors shared by all four resource representations.
+///
+/// Object-safe: `&dyn ResourceLike` is a legal type.
+pub trait ResourceLike {
+    /// Stable identifier of this resource.
+    fn id(&self) -> &ResourceId;
+
+    /// Source-order preserving attribute map.
+    fn attributes(&self) -> &IndexMap<String, Value>;
+
+    /// `let` binding name if any.
+    fn binding(&self) -> Option<&str>;
+
+    /// Binding names this resource depends on.
+    fn dependency_bindings(&self) -> &BTreeSet<String>;
+}
+
+/// Blanket impl so a `&T` where `T: ResourceLike` is itself
+/// `ResourceLike`. Lets generic callers — `fn f<R: ResourceLike>(r: R)` —
+/// accept both an owned receiver and a borrowed one without forcing
+/// every downstream site to spell `?Sized` bounds.
+impl<T: ResourceLike + ?Sized> ResourceLike for &T {
+    fn id(&self) -> &ResourceId {
+        (**self).id()
+    }
+    fn attributes(&self) -> &IndexMap<String, Value> {
+        (**self).attributes()
+    }
+    fn binding(&self) -> Option<&str> {
+        (**self).binding()
+    }
+    fn dependency_bindings(&self) -> &BTreeSet<String> {
+        (**self).dependency_bindings()
+    }
+}
+
+impl ResourceLike for Resource {
+    fn id(&self) -> &ResourceId {
+        &self.id
+    }
+    fn attributes(&self) -> &IndexMap<String, Value> {
+        &self.attributes
+    }
+    fn binding(&self) -> Option<&str> {
+        self.binding.as_deref()
+    }
+    fn dependency_bindings(&self) -> &BTreeSet<String> {
+        &self.dependency_bindings
+    }
+}
+
+impl ResourceLike for ManagedResource {
+    fn id(&self) -> &ResourceId {
+        &self.id
+    }
+    fn attributes(&self) -> &IndexMap<String, Value> {
+        &self.attributes
+    }
+    fn binding(&self) -> Option<&str> {
+        self.binding.as_deref()
+    }
+    fn dependency_bindings(&self) -> &BTreeSet<String> {
+        &self.dependency_bindings
+    }
+}
+
+impl ResourceLike for VirtualResource {
+    fn id(&self) -> &ResourceId {
+        &self.id
+    }
+    fn attributes(&self) -> &IndexMap<String, Value> {
+        &self.attributes
+    }
+    fn binding(&self) -> Option<&str> {
+        self.binding.as_deref()
+    }
+    fn dependency_bindings(&self) -> &BTreeSet<String> {
+        &self.dependency_bindings
+    }
+}
+
+impl ResourceLike for DataSource {
+    fn id(&self) -> &ResourceId {
+        &self.id
+    }
+    fn attributes(&self) -> &IndexMap<String, Value> {
+        &self.attributes
+    }
+    fn binding(&self) -> Option<&str> {
+        self.binding.as_deref()
+    }
+    fn dependency_bindings(&self) -> &BTreeSet<String> {
+        &self.dependency_bindings
+    }
+}

--- a/carina-core/src/resource/resource_like_tests.rs
+++ b/carina-core/src/resource/resource_like_tests.rs
@@ -1,0 +1,154 @@
+//! Tests for #3174: `ResourceLike` trait — shared read-only
+//! accessors implemented for `Resource`, `ManagedResource`,
+//! `VirtualResource`, and `DataSource`.
+
+use std::collections::BTreeSet;
+
+use crate::resource::{
+    ConcreteValue, DataSource, ManagedResource, ModuleSource, Resource, ResourceId, ResourceKind,
+    ResourceLike, Value, VirtualResource,
+};
+
+fn sample_value(s: &str) -> Value {
+    Value::Concrete(ConcreteValue::String(s.into()))
+}
+
+fn make_resource(kind: ResourceKind) -> Resource {
+    let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
+    Resource::new("aws.s3.Bucket", "b")
+        .with_kind(kind)
+        .with_attribute("k", sample_value("v"))
+        .with_binding("b")
+        .with_dependency_bindings(deps)
+        .with_module_source(ModuleSource::module("m", "inst"))
+}
+
+fn assert_resource_like<R: ResourceLike>(
+    r: &R,
+    expected_id: &ResourceId,
+    expected_attr_key: &str,
+    expected_binding: Option<&str>,
+    expected_deps: &BTreeSet<String>,
+) {
+    assert_eq!(r.id(), expected_id, "id() mismatch");
+    assert!(
+        r.attributes().contains_key(expected_attr_key),
+        "attributes() missing key {expected_attr_key}",
+    );
+    assert_eq!(r.binding(), expected_binding, "binding() mismatch");
+    assert_eq!(
+        r.dependency_bindings(),
+        expected_deps,
+        "dependency_bindings() mismatch",
+    );
+}
+
+#[test]
+fn resource_implements_resource_like() {
+    let res = make_resource(ResourceKind::Managed);
+    let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
+    let expected_id = res.id.clone();
+    assert_resource_like(&res, &expected_id, "k", Some("b"), &deps);
+}
+
+#[test]
+fn managed_resource_implements_resource_like() {
+    let res = make_resource(ResourceKind::Managed);
+    let managed = ManagedResource::try_from(&res).expect("Managed → ManagedResource");
+    let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
+    let expected_id = managed.id.clone();
+    assert_resource_like(&managed, &expected_id, "k", Some("b"), &deps);
+}
+
+#[test]
+fn virtual_resource_implements_resource_like() {
+    let res = make_resource(ResourceKind::Virtual {
+        module_name: "m".into(),
+        instance: "inst".into(),
+    });
+    let v = VirtualResource::try_from(&res).expect("Virtual → VirtualResource");
+    let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
+    let expected_id = v.id.clone();
+    assert_resource_like(&v, &expected_id, "k", Some("b"), &deps);
+}
+
+#[test]
+fn data_source_implements_resource_like() {
+    let res = make_resource(ResourceKind::DataSource);
+    let ds = DataSource::try_from(&res).expect("DataSource → DataSource");
+    let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
+    let expected_id = ds.id.clone();
+    assert_resource_like(&ds, &expected_id, "k", Some("b"), &deps);
+}
+
+#[test]
+fn binding_none_covers_all_arms() {
+    // Resource::new() leaves binding = None by default.
+    let res_managed = Resource::new("aws.s3.Bucket", "b").with_kind(ResourceKind::Managed);
+    assert_eq!(<Resource as ResourceLike>::binding(&res_managed), None);
+
+    let managed = ManagedResource::try_from(&res_managed).expect("Managed → ManagedResource");
+    assert_eq!(<ManagedResource as ResourceLike>::binding(&managed), None);
+
+    let res_virt = Resource::new("aws.s3.Bucket", "b").with_kind(ResourceKind::Virtual {
+        module_name: "m".into(),
+        instance: "i".into(),
+    });
+    let v = VirtualResource::try_from(&res_virt).expect("Virtual → VirtualResource");
+    assert_eq!(<VirtualResource as ResourceLike>::binding(&v), None);
+
+    let res_ds = Resource::new("aws.s3.Bucket", "b").with_kind(ResourceKind::DataSource);
+    let ds = DataSource::try_from(&res_ds).expect("DataSource → DataSource");
+    assert_eq!(<DataSource as ResourceLike>::binding(&ds), None);
+}
+
+#[test]
+fn resource_like_supports_generic_dispatch() {
+    fn first_attribute_key<R: ResourceLike>(r: &R) -> Option<&String> {
+        r.attributes().keys().next()
+    }
+
+    let res = make_resource(ResourceKind::Managed);
+    assert_eq!(first_attribute_key(&res), Some(&"k".to_string()));
+
+    let managed = ManagedResource::try_from(&res).expect("Managed → ManagedResource");
+    assert_eq!(first_attribute_key(&managed), Some(&"k".to_string()));
+
+    let virt_src = make_resource(ResourceKind::Virtual {
+        module_name: "m".into(),
+        instance: "inst".into(),
+    });
+    let v = VirtualResource::try_from(&virt_src).expect("Virtual → VirtualResource");
+    assert_eq!(first_attribute_key(&v), Some(&"k".to_string()));
+
+    let ds_src = make_resource(ResourceKind::DataSource);
+    let ds = DataSource::try_from(&ds_src).expect("DataSource → DataSource");
+    assert_eq!(first_attribute_key(&ds), Some(&"k".to_string()));
+}
+
+#[test]
+fn resource_like_is_object_safe() {
+    // Using `&dyn ResourceLike` here would force the trait to be
+    // object-safe. Read-only accessors with `&self` returning
+    // borrowed data satisfy object-safety; lock that in.
+    let res = make_resource(ResourceKind::Managed);
+    let dyn_ref: &dyn ResourceLike = &res;
+    assert_eq!(dyn_ref.binding(), Some("b"));
+    let _ = dyn_ref.attributes();
+}
+
+#[test]
+fn blanket_impl_makes_references_resource_like() {
+    // A `&T` where `T: ResourceLike` is itself `ResourceLike` via
+    // the blanket impl. Generic callers can take either by value or
+    // by reference.
+    fn ensure_resource_like<R: ResourceLike>(r: R) -> Option<String> {
+        r.binding().map(str::to_owned)
+    }
+
+    let res = make_resource(ResourceKind::Managed);
+    assert_eq!(ensure_resource_like(&res), Some("b".into()));
+
+    let managed = ManagedResource::try_from(&res).expect("Managed → ManagedResource");
+    assert_eq!(ensure_resource_like(&managed), Some("b".into()));
+}


### PR DESCRIPTION
Part 2/9 of the resource typestate split (#3169). Design PR #3172
(merged) covers the rationale; PR #3183 (1/9) landed the wrapper
structs themselves.

## Summary

- New `ResourceLike` trait in `carina-core/src/resource/resource_like.rs`
  exposing the four read-only accessors shared across the typestate
  arms: `id() -> &ResourceId`, `attributes() -> &IndexMap<String, Value>`,
  `binding() -> Option<&str>`, `dependency_bindings() -> &BTreeSet<String>`.
- Implementations for `Resource` (back-compat shim), `ManagedResource`,
  `VirtualResource`, and `DataSource`.
- Blanket impl `impl<T: ResourceLike + ?Sized> ResourceLike for &T` so
  a generic `fn f<R: ResourceLike>(r: R)` accepts both owned and
  borrowed receivers (and the `?Sized` makes `&dyn ResourceLike`
  itself implement `ResourceLike`).

## Why a trait

Read-only consumers — plan tree builders, formatters, diagnostics —
can stay generic over the four representations. Write-side callers
(resolver, executor, writeback) continue to take a concrete type and
benefit from the typed dispatch. The migration plan is staged: this
PR ships the trait; subsequent PRs in the series (#3175-#3181) wire
consumers to it and eventually merge `Resource` into `ManagedResource`.

## Object-safety

Object-safety is asserted by a runtime test (`&dyn ResourceLike = &res;`),
so any future addition of a non-object-safe method (generic `Self`,
async, etc.) trips CI rather than silently breaking the dyn path.

## Tests

8 tests in `resource_like_tests.rs`:

- 4× per-arm identity test (each impl returns the expected fields)
- `binding_none_covers_all_arms` — None case is symmetric across the
  four arms.
- `resource_like_is_object_safe` — compile-time guard via
  `&dyn ResourceLike`.
- `resource_like_supports_generic_dispatch` — generic dispatch over
  all four arms.
- `blanket_impl_makes_references_resource_like` — references receive
  the trait via the blanket impl.

## No behaviour change

Only a new trait and its impls. Existing call sites are untouched;
mod.rs is append-only (5 lines).

## Test plan

- [x] `cargo nextest run --workspace` — 3492 passed
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — all OK
- [x] 5-round self-review — only a rustfmt fix in Round 5; otherwise clean

Refs #3169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
