### PR TITLE
resolver: split into managed / virtual typed entry points (3/9 of #3169)

### DIFF
--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -26,6 +26,8 @@ pub mod plan;
 pub mod plan_tree;
 pub mod provider;
 pub mod resolver;
+#[cfg(test)]
+mod resolver_split_tests;
 pub mod resource;
 pub mod schema;
 pub mod upstream_exports;

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -9,8 +9,8 @@ use indexmap::IndexMap;
 
 use crate::binding_index::ResolvedBindings;
 use crate::resource::{
-    ConcreteValue, DeferredValue, InterpolationPart, Resource, ResourceId, State, Value,
-    contains_resource_ref, peel_secrets, rewrap_secrets,
+    ConcreteValue, DeferredValue, InterpolationPart, ManagedResource, Resource, ResourceId, State,
+    Value, VirtualResource, contains_resource_ref, peel_secrets, rewrap_secrets,
 };
 
 /// Resolve all ResourceRef values in resources using current state.
@@ -118,6 +118,92 @@ fn resolve_refs_inner(
             resolved_attrs.insert(key.clone(), final_value);
         }
         resource.attributes = resolved_attrs;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Typed resolver entry points (#3175 / typestate split)
+// ---------------------------------------------------------------------------
+
+/// Pre-apply path: resolve `ResourceRef` values across a slice of
+/// `ManagedResource`s.
+///
+/// Encodes the design-doc invariant ("`VirtualResource`s are never
+/// resolved against pre-apply state") at the type level: the slice
+/// type rejects virtuals at compile time. For virtuals, use
+/// [`resolve_virtual_refs_post_apply`] from `finalize_apply` (#3177).
+///
+/// # Scope limitation
+///
+/// Bindings are built from the managed slice alone — virtual bindings
+/// are **not** in the binding map. A managed attribute that references
+/// a virtual binding pre-apply (`managed_x.attr = ref some_module.role_arn`)
+/// will leave its ResourceRef un-resolved. The typestate split treats
+/// this as a non-case: in the migration target, managed inputs that
+/// depend on virtual outputs are routed via `wait` bindings or
+/// upstream-state passthroughs. If a real call site needs the
+/// mixed-bindings shape, prefer the legacy shim
+/// [`resolve_refs_with_state_and_remote`] until #3176 ships a typed
+/// constructor that accepts both slices.
+///
+/// Internally this currently round-trips through the legacy
+/// `&mut [Resource]` pipeline so behaviour matches
+/// [`resolve_refs_with_state_and_remote`] bit-for-bit when the inputs
+/// contain no managed→virtual references. The round-trip itself is
+/// removed once a managed-slice `ResolvedBindings` constructor lands;
+/// the `From<&ManagedResource> for Resource` bridge survives until
+/// #3181 inline-merges the two types.
+pub fn resolve_managed_refs_with_state_and_remote(
+    managed: &mut [ManagedResource],
+    current_states: &HashMap<ResourceId, State>,
+    remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    wait_aliases: &[crate::binding_index::WaitAliasSpec],
+) -> Result<(), String> {
+    let mut bridge: Vec<Resource> = managed.iter().map(Resource::from).collect();
+    resolve_refs_inner(
+        &mut bridge,
+        current_states,
+        remote_bindings,
+        wait_aliases,
+        false,
+    )?;
+    // Invariant: `resolve_refs_inner` mutates ONLY `attributes` and
+    // `dependency_bindings` on each `Resource` (lines 86-91 and 109-121).
+    // If that contract is broadened, extend the write-back below — the
+    // bridge silently drops any other mutation otherwise. Removed
+    // entirely once #3181 lands and the bridge goes away.
+    for (m, r) in managed.iter_mut().zip(bridge) {
+        m.attributes = r.attributes;
+        m.dependency_bindings = r.dependency_bindings;
+    }
+    Ok(())
+}
+
+/// Post-apply path: resolve `ResourceRef` values across a slice of
+/// `VirtualResource`s using a `ResolvedBindings` view that the caller
+/// has already built against the post-apply state.
+///
+/// Calling this against pre-apply state would re-introduce the
+/// #3169 exports-drift bug, so the caller is responsible for the
+/// post-apply ordering. The signature is structurally distinct from
+/// [`resolve_managed_refs_with_state_and_remote`] (takes a built
+/// bindings view, not the raw state inputs) to make accidental
+/// pre-apply use harder to write.
+///
+/// `dependency_bindings` is left untouched: virtual→managed edges are
+/// already recorded during the pre-apply pass, and the post-apply
+/// resolution only needs to materialise the attribute values.
+pub fn resolve_virtual_refs_post_apply(
+    virtuals: &mut [VirtualResource],
+    bindings: &ResolvedBindings,
+) -> Result<(), String> {
+    for v in virtuals.iter_mut() {
+        let mut resolved_attrs: IndexMap<String, Value> = IndexMap::new();
+        for (key, value) in &v.attributes {
+            resolved_attrs.insert(key.clone(), resolve_ref_value(value, bindings)?);
+        }
+        v.attributes = resolved_attrs;
     }
     Ok(())
 }

--- a/carina-core/src/resolver_split_tests.rs
+++ b/carina-core/src/resolver_split_tests.rs
@@ -1,0 +1,246 @@
+//! Tests for #3175: typed resolver entry points.
+//!
+//! - `resolve_managed_refs_with_state_and_remote(&mut [ManagedResource], ...)`
+//!   — pre-apply path, accepts only `ManagedResource` slices.
+//! - `resolve_virtual_refs_post_apply(&mut [VirtualResource], &ResolvedBindings)`
+//!   — post-apply path, takes a pre-built bindings view.
+//!
+//! Both are new entry points layered over the existing
+//! `resolve_refs_inner` logic; the legacy
+//! `resolve_refs_with_state_and_remote(&mut [Resource], …)` shim is
+//! unchanged.
+
+use std::collections::{BTreeSet, HashMap};
+
+use indexmap::IndexMap;
+
+use crate::binding_index::ResolvedBindings;
+use crate::resolver::{
+    resolve_managed_refs_with_state_and_remote, resolve_virtual_refs_post_apply,
+};
+use crate::resource::{
+    AccessPath, ConcreteValue, DeferredValue, ManagedResource, Resource, ResourceId, State, Value,
+    VirtualResource,
+};
+
+fn s(s: &str) -> Value {
+    Value::Concrete(ConcreteValue::String(s.into()))
+}
+
+fn ref_to(binding: &str, attr: &str) -> Value {
+    Value::Deferred(DeferredValue::ResourceRef {
+        path: AccessPath::new(binding, attr),
+    })
+}
+
+fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> ManagedResource {
+    let mut attributes = IndexMap::new();
+    for (k, v) in attrs {
+        attributes.insert((*k).into(), v.clone());
+    }
+    ManagedResource {
+        id: ResourceId::new("aws.s3.Bucket", binding),
+        attributes,
+        directives: Default::default(),
+        prefixes: HashMap::new(),
+        binding: Some(binding.into()),
+        dependency_bindings: BTreeSet::new(),
+        module_source: None,
+        quoted_string_attrs: Default::default(),
+    }
+}
+
+fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> VirtualResource {
+    let mut attributes = IndexMap::new();
+    for (k, v) in attrs {
+        attributes.insert((*k).into(), v.clone());
+    }
+    VirtualResource {
+        id: ResourceId::new("_virtual.module", binding),
+        attributes,
+        binding: Some(binding.into()),
+        dependency_bindings: BTreeSet::new(),
+        module_name: "m".into(),
+        instance: binding.into(),
+        quoted_string_attrs: Default::default(),
+    }
+}
+
+#[test]
+fn resolve_managed_refs_resolves_resource_ref_against_managed_sibling() {
+    // Two managed resources, `b` references `a.value`.
+    let a = make_managed("a", &[("value", s("hello"))]);
+    let b = make_managed("b", &[("dep", ref_to("a", "value"))]);
+    let mut managed = vec![a, b];
+
+    resolve_managed_refs_with_state_and_remote(&mut managed, &HashMap::new(), &HashMap::new(), &[])
+        .expect("resolve managed");
+
+    // After resolution `b.dep` should be the literal string from `a`.
+    let dep = managed[1].attributes.get("dep").expect("dep present");
+    assert_eq!(*dep, s("hello"), "expected resolved string, got {dep:?}");
+}
+
+#[test]
+fn resolve_managed_refs_records_dependency_bindings() {
+    let a = make_managed("a", &[("value", s("hello"))]);
+    let b = make_managed("b", &[("dep", ref_to("a", "value"))]);
+    let mut managed = vec![a, b];
+
+    resolve_managed_refs_with_state_and_remote(&mut managed, &HashMap::new(), &HashMap::new(), &[])
+        .expect("resolve managed");
+
+    assert!(
+        managed[1].dependency_bindings.contains("a"),
+        "expected dependency on `a`, got {:?}",
+        managed[1].dependency_bindings,
+    );
+}
+
+#[test]
+fn resolve_managed_refs_falls_through_state_attributes() {
+    // `b` references `a.value`, but `a` has no `value` attribute in
+    // its DSL — the resolved binding must come from `current_states`.
+    let a = make_managed("a", &[]);
+    let b = make_managed("b", &[("dep", ref_to("a", "value"))]);
+    let mut managed = vec![a, b];
+
+    let mut state_attrs: HashMap<String, Value> = HashMap::new();
+    state_attrs.insert("value".into(), s("from_state"));
+    let mut current_states = HashMap::new();
+    current_states.insert(
+        managed[0].id.clone(),
+        State::existing(managed[0].id.clone(), state_attrs),
+    );
+
+    resolve_managed_refs_with_state_and_remote(&mut managed, &current_states, &HashMap::new(), &[])
+        .expect("resolve managed");
+
+    let dep = managed[1].attributes.get("dep").expect("dep present");
+    assert_eq!(*dep, s("from_state"), "expected state value, got {dep:?}");
+}
+
+#[test]
+fn resolve_virtual_refs_post_apply_uses_provided_bindings() {
+    // Bindings built externally (#3177's job at apply time). Verify
+    // that the post-apply entry resolves `VirtualResource` refs
+    // against the supplied view.
+    let referenced = make_managed("a", &[("value", s("post_apply_value"))]);
+    let bindings = ResolvedBindings::from_resources_with_state(
+        &[Resource::from(&referenced)],
+        &HashMap::new(),
+        &HashMap::new(),
+        &[],
+    );
+
+    let mut virtuals = vec![make_virtual("v", &[("forwarded", ref_to("a", "value"))])];
+    resolve_virtual_refs_post_apply(&mut virtuals, &bindings).expect("resolve virtuals");
+
+    let forwarded = virtuals[0]
+        .attributes
+        .get("forwarded")
+        .expect("forwarded present");
+    assert_eq!(*forwarded, s("post_apply_value"));
+}
+
+#[test]
+fn resolve_virtual_refs_post_apply_picks_post_apply_value_not_pre_apply() {
+    // #3169 root cause: a virtual that references a managed Role
+    // gets the *pre-apply* ARN if resolution runs against the
+    // pre-apply state, and the *post-apply* ARN if it runs against
+    // the post-apply state. Verify the post-apply entry selects the
+    // post-apply value when handed the post-apply bindings view.
+    let role = make_managed("role", &[("arn", s("post_apply_arn"))]);
+    let post_apply_bindings = ResolvedBindings::from_resources_with_state(
+        &[Resource::from(&role)],
+        &HashMap::new(),
+        &HashMap::new(),
+        &[],
+    );
+
+    let mut virtuals = vec![make_virtual("rd", &[("role_arn", ref_to("role", "arn"))])];
+    resolve_virtual_refs_post_apply(&mut virtuals, &post_apply_bindings).expect("resolve virtuals");
+
+    let role_arn = virtuals[0]
+        .attributes
+        .get("role_arn")
+        .expect("role_arn present");
+    assert_eq!(
+        *role_arn,
+        s("post_apply_arn"),
+        "expected post-apply ARN, got {role_arn:?}",
+    );
+}
+
+#[test]
+fn resolve_virtual_refs_post_apply_leaves_non_ref_values_intact() {
+    // A literal attribute on a `VirtualResource` should be preserved
+    // verbatim by the post-apply pass.
+    let bindings =
+        ResolvedBindings::from_resources_with_state(&[], &HashMap::new(), &HashMap::new(), &[]);
+    let mut virtuals = vec![make_virtual("v", &[("literal", s("kept"))])];
+
+    resolve_virtual_refs_post_apply(&mut virtuals, &bindings).expect("resolve virtuals");
+
+    let literal = virtuals[0]
+        .attributes
+        .get("literal")
+        .expect("literal present");
+    assert_eq!(*literal, s("kept"));
+}
+
+#[test]
+fn resolve_managed_refs_with_empty_slice_is_ok() {
+    let mut managed: Vec<ManagedResource> = Vec::new();
+    resolve_managed_refs_with_state_and_remote(&mut managed, &HashMap::new(), &HashMap::new(), &[])
+        .expect("empty managed slice resolves cleanly");
+    assert!(managed.is_empty());
+}
+
+#[test]
+fn resolve_virtual_refs_post_apply_with_empty_slice_is_ok() {
+    let bindings =
+        ResolvedBindings::from_resources_with_state(&[], &HashMap::new(), &HashMap::new(), &[]);
+    let mut virtuals: Vec<VirtualResource> = Vec::new();
+    resolve_virtual_refs_post_apply(&mut virtuals, &bindings)
+        .expect("empty virtual slice resolves cleanly");
+    assert!(virtuals.is_empty());
+}
+
+#[test]
+fn resolve_managed_refs_legacy_shim_produces_identical_result() {
+    // Equivalence guard: feeding the same managed-only inputs through
+    // the new typed entry and the legacy `&mut [Resource]` shim must
+    // produce identical attributes.
+    let a_new = make_managed("a", &[("value", s("hi"))]);
+    let b_new = make_managed("b", &[("dep", ref_to("a", "value"))]);
+    let mut managed = vec![a_new.clone(), b_new.clone()];
+
+    resolve_managed_refs_with_state_and_remote(&mut managed, &HashMap::new(), &HashMap::new(), &[])
+        .expect("resolve managed");
+
+    let mut legacy: Vec<Resource> = vec![Resource::from(&a_new), Resource::from(&b_new)];
+    crate::resolver::resolve_refs_with_state_and_remote(
+        &mut legacy,
+        &HashMap::new(),
+        &HashMap::new(),
+        &[],
+    )
+    .expect("resolve legacy");
+
+    for (m, l) in managed.iter().zip(legacy.iter()) {
+        assert_eq!(
+            m.attributes, l.attributes,
+            "managed/legacy attribute divergence for {}",
+            m.id.name,
+        );
+        // `dependency_bindings` is the second mutation the legacy
+        // pipeline performs; the bridge's writeback contract names
+        // both fields, so the equivalence guard does too.
+        assert_eq!(
+            m.dependency_bindings, l.dependency_bindings,
+            "managed/legacy dependency_bindings divergence for {}",
+            m.id.name,
+        );
+    }
+}

--- a/carina-core/src/resource/managed.rs
+++ b/carina-core/src/resource/managed.rs
@@ -63,3 +63,23 @@ impl TryFrom<&Resource> for ManagedResource {
         }
     }
 }
+
+/// Transitional bridge — rebuild a legacy [`Resource`] from a
+/// `ManagedResource`. Co-located with the reverse `TryFrom<&Resource>`
+/// impl above so #3181 can remove both directions in one place when
+/// `Resource` is inline-merged into `ManagedResource`.
+impl From<&ManagedResource> for Resource {
+    fn from(m: &ManagedResource) -> Self {
+        Self {
+            id: m.id.clone(),
+            attributes: m.attributes.clone(),
+            kind: ResourceKind::Managed,
+            directives: m.directives.clone(),
+            prefixes: m.prefixes.clone(),
+            binding: m.binding.clone(),
+            dependency_bindings: m.dependency_bindings.clone(),
+            module_source: m.module_source.clone(),
+            quoted_string_attrs: m.quoted_string_attrs.clone(),
+        }
+    }
+}


### PR DESCRIPTION
Part 3/9 of the resource typestate split (#3169). Design PR #3172
(merged) covers the rationale; PRs #3183 (1/9) and #3184 (2/9) landed
the wrapper structs and `ResourceLike` trait.

## Summary

Two new typed resolver entry points in `carina-core/src/resolver.rs`,
layered over the existing `resolve_refs_inner` core:

- **`resolve_managed_refs_with_state_and_remote(&mut [ManagedResource], …)`**
  — pre-apply path. The slice type structurally rejects virtuals at
  compile time, encoding the design-doc invariant *"VirtualResource
  attributes are never resolved against pre-apply state"*.
- **`resolve_virtual_refs_post_apply(&mut [VirtualResource], &ResolvedBindings)`**
  — post-apply path. Takes a pre-built bindings view (the caller's
  responsibility, post-apply) and resolves each virtual's attributes
  against it. This is the entry #3177 will call from `finalize_apply`
  to fix #3169's exports drift.

Co-located in `resource/managed.rs`: a transitional
`From<&ManagedResource> for Resource` impl alongside the existing
`TryFrom<&Resource> for ManagedResource`, so #3181 can remove both
directions in one place.

## Why these signatures

- The pre-apply entry takes the raw `state` + `remote` + `wait_aliases`
  inputs (matches issue #3175's spec).
- The post-apply entry takes an already-built `ResolvedBindings` view
  rather than re-building. This is structurally distinct from the
  managed entry so accidental pre-apply use is harder to write.
- `dependency_bindings` is left untouched by the virtual entry: the
  pre-apply pass already recorded virtual→managed edges.

## Bridge writeback contract

The managed entry currently round-trips through the legacy
`&mut [Resource]` pipeline (via the new `From<&ManagedResource>`).
The bridge's writeback handles `attributes` and `dependency_bindings`
only — an inline `// Invariant:` comment names the exact lines in
`resolve_refs_inner` that mutate those fields, and the legacy-shim
equivalence test (`resolve_managed_refs_legacy_shim_produces_identical_result`)
asserts parity on both fields. The round-trip itself disappears once
a managed-slice `ResolvedBindings` constructor lands; the bridge
function survives until #3181 inline-merges the two types.

## Scope limitation (documented in code)

The managed entry builds bindings from the managed slice alone, so a
pre-apply managed attribute that references a *virtual* binding is
left un-resolved. The migration target routes such references via
`wait` bindings or upstream-state passthroughs; mixed-bindings
consumers should keep using the legacy
`resolve_refs_with_state_and_remote` shim until a typed
`ResolvedBindings::from_managed_with_state` constructor exists.

## Tests

9 new tests in `resolver_split_tests.rs`:

- happy path (managed→managed sibling, post-apply virtual→managed)
- `dependency_bindings` recording
- state-fallthrough (managed resolves via `current_states`)
- **#3169 regression marker**:
  `resolve_virtual_refs_post_apply_picks_post_apply_value_not_pre_apply`
  asserts post-apply value selection.
- literal preservation (virtual non-ref attribute round-trip)
- legacy-shim equivalence (attributes + dependency_bindings)
- empty-slice edge cases for both entries

## No behaviour change

The legacy `resolve_refs_with_state_and_remote(&mut [Resource], …)`
shim is byte-identical to main. Existing call sites
(`carina-cli/src/commands/apply/mod.rs`,
`carina-cli/src/wiring/mod.rs`, `carina-cli/src/fixture_plan.rs`, and
the workspace tests) continue to use it. Migration to the typed
entries lands in #3177 and later.

## Test plan

- [x] `cargo nextest run --workspace` — 3498 passed
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo build --release -p carina-core` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — all OK
- [x] 5-round self-review — clean (5 fixes applied across rounds 1-5)

Refs #3169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
