### PR TITLE
binding_index: split ResolvedBindings into managed/virtual constructors (4/9 of #3169)

### DIFF
--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -40,7 +40,7 @@
 //! ```
 
 use crate::parser::BindingName;
-use crate::resource::{Resource, ResourceId, State, Value};
+use crate::resource::{ManagedResource, Resource, ResourceId, State, Value, VirtualResource};
 use crate::schema::{ResourceSchema, SchemaRegistry};
 use std::collections::HashMap;
 
@@ -496,6 +496,76 @@ impl ResolvedBindings {
         }
 
         Self { by_name }
+    }
+
+    /// Typed pre-apply constructor (#3176): build the bindings view
+    /// from a `ManagedResource` slice plus the same `current_states`,
+    /// `remote_bindings`, and `wait_aliases` inputs that
+    /// [`Self::from_resources_with_state`] consumes.
+    ///
+    /// Encodes the typestate-split invariant at the input side:
+    /// virtuals cannot be passed here. The pre-apply binding view a
+    /// caller builds via this constructor is the *only* view a
+    /// pre-apply resolver should consult; virtuals layer in
+    /// post-apply via [`Self::add_virtual_resources`].
+    ///
+    /// Implementation is intentionally a shallow wrapper that
+    /// rebridges each `ManagedResource` to a `Resource` (via the
+    /// existing `From<&ManagedResource>` impl, transitional until
+    /// #3181) so the binding-construction logic stays in one place.
+    /// The bridge disappears once the legacy `Resource` IR is
+    /// retired.
+    pub fn from_managed_with_state(
+        managed: &[ManagedResource],
+        current_states: &HashMap<ResourceId, State>,
+        remote_bindings: &HashMap<String, HashMap<String, Value>>,
+        wait_aliases: &[WaitAliasSpec],
+    ) -> Self {
+        let bridge: Vec<Resource> = managed.iter().map(Resource::from).collect();
+        Self::from_resources_with_state(&bridge, current_states, remote_bindings, wait_aliases)
+    }
+
+    /// Typed post-apply layering (#3176): add virtual-resource
+    /// bindings onto an existing view.
+    ///
+    /// **Ordering contract**: must be called *after* the managed-side
+    /// bindings have been constructed, so any virtual whose
+    /// attributes contain a `ResourceRef` to a managed sibling
+    /// resolves against the up-to-date managed view. The caller is
+    /// responsible for that ordering; the function itself just
+    /// appends.
+    ///
+    /// Unlike `from_managed_with_state`, this entry does **not** merge
+    /// `current_states`: virtuals have no provider-side state to
+    /// merge. The virtual's own attribute map (as authored, after
+    /// `resolve_virtual_refs_post_apply` materialised any refs) is
+    /// recorded verbatim.
+    ///
+    /// Same-name collisions favour the virtual entry (it is inserted
+    /// last) — consistent with the design-doc rule that the
+    /// post-apply view is layered *on top of* the pre-apply view.
+    ///
+    /// Returns `Result<(), String>` to match the design-doc signature;
+    /// today the only failure mode (an ordering-precondition check)
+    /// is left to the caller, so this currently always returns
+    /// `Ok(())`. The Result shape lets future validation (e.g. a
+    /// hard error on a same-name collision when the post-apply layer
+    /// expects to merge rather than overwrite) be added without
+    /// breaking the signature.
+    pub fn add_virtual_resources(&mut self, virtuals: &[VirtualResource]) -> Result<(), String> {
+        for v in virtuals.iter() {
+            let Some(binding_name) = v.binding.as_ref() else {
+                continue;
+            };
+            self.by_name.insert(
+                binding_name.clone(),
+                ResolvedBinding {
+                    attributes: crate::resource::attrs_to_hashmap(&v.attributes),
+                    source: BindingValueSource::Local,
+                },
+            );
+        }
+        Ok(())
     }
 
     pub fn get(&self, name: &str) -> Option<&HashMap<String, Value>> {

--- a/carina-core/src/binding_index_split_tests.rs
+++ b/carina-core/src/binding_index_split_tests.rs
@@ -1,0 +1,198 @@
+//! Tests for #3176: typed `ResolvedBindings` constructors.
+//!
+//! - `ResolvedBindings::from_managed_with_state(&[ManagedResource], …)` —
+//!   pre-apply bindings from a managed slice plus current state.
+//! - `ResolvedBindings::add_virtual_resources(&mut self, &[VirtualResource])` —
+//!   layer virtual bindings on top, called only after managed bindings exist.
+//!
+//! The legacy `from_resources_with_state(&[Resource], …)` constructor is
+//! a thin shim over the two new entry points.
+
+use std::collections::{BTreeSet, HashMap};
+
+use indexmap::IndexMap;
+
+use crate::binding_index::ResolvedBindings;
+use crate::resource::{
+    ConcreteValue, ManagedResource, Resource, ResourceId, State, Value, VirtualResource,
+};
+
+fn s(s: &str) -> Value {
+    Value::Concrete(ConcreteValue::String(s.into()))
+}
+
+fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> ManagedResource {
+    let mut attributes = IndexMap::new();
+    for (k, v) in attrs {
+        attributes.insert((*k).into(), v.clone());
+    }
+    ManagedResource {
+        id: ResourceId::new("aws.s3.Bucket", binding),
+        attributes,
+        directives: Default::default(),
+        prefixes: HashMap::new(),
+        binding: Some(binding.into()),
+        dependency_bindings: BTreeSet::new(),
+        module_source: None,
+        quoted_string_attrs: Default::default(),
+    }
+}
+
+fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> VirtualResource {
+    let mut attributes = IndexMap::new();
+    for (k, v) in attrs {
+        attributes.insert((*k).into(), v.clone());
+    }
+    VirtualResource {
+        id: ResourceId::new("_virtual.module", binding),
+        attributes,
+        binding: Some(binding.into()),
+        dependency_bindings: BTreeSet::new(),
+        module_name: "m".into(),
+        instance: binding.into(),
+        quoted_string_attrs: Default::default(),
+    }
+}
+
+#[test]
+fn from_managed_with_state_records_dsl_attributes() {
+    let m = make_managed("a", &[("value", s("hello"))]);
+    let bindings =
+        ResolvedBindings::from_managed_with_state(&[m], &HashMap::new(), &HashMap::new(), &[]);
+    let view = bindings.get("a").expect("binding present");
+    assert_eq!(view.get("value"), Some(&s("hello")));
+}
+
+#[test]
+fn from_managed_with_state_merges_state_for_missing_dsl_keys() {
+    // DSL has `dsl_only`; state has `state_only` and the same `dsl_only`.
+    // DSL wins on collision (pre-apply: trust the DSL).
+    let m = make_managed("a", &[("dsl_only", s("from_dsl"))]);
+
+    let mut state_attrs: HashMap<String, Value> = HashMap::new();
+    state_attrs.insert("dsl_only".into(), s("from_state_should_be_ignored"));
+    state_attrs.insert("state_only".into(), s("from_state"));
+    let mut current_states = HashMap::new();
+    current_states.insert(m.id.clone(), State::existing(m.id.clone(), state_attrs));
+
+    let bindings =
+        ResolvedBindings::from_managed_with_state(&[m], &current_states, &HashMap::new(), &[]);
+    let view = bindings.get("a").expect("binding present");
+    assert_eq!(view.get("dsl_only"), Some(&s("from_dsl")));
+    assert_eq!(view.get("state_only"), Some(&s("from_state")));
+}
+
+#[test]
+fn from_managed_with_state_skips_resources_without_binding() {
+    let mut m = make_managed("a", &[("k", s("v"))]);
+    m.binding = None;
+    let bindings =
+        ResolvedBindings::from_managed_with_state(&[m], &HashMap::new(), &HashMap::new(), &[]);
+    assert!(bindings.get("a").is_none());
+}
+
+#[test]
+fn add_virtual_resources_layers_on_top_of_managed() {
+    let managed = make_managed("a", &[("value", s("from_managed"))]);
+    let mut bindings = ResolvedBindings::from_managed_with_state(
+        &[managed],
+        &HashMap::new(),
+        &HashMap::new(),
+        &[],
+    );
+    assert!(bindings.get("a").is_some());
+
+    let virt = make_virtual("v", &[("role_arn", s("post_apply_arn"))]);
+    bindings
+        .add_virtual_resources(&[virt])
+        .expect("add_virtual_resources");
+
+    // Both bindings present after layering.
+    assert!(bindings.get("a").is_some());
+    let v_view = bindings.get("v").expect("virtual binding present");
+    assert_eq!(v_view.get("role_arn"), Some(&s("post_apply_arn")));
+}
+
+#[test]
+fn add_virtual_resources_overwrites_same_name_managed_binding() {
+    // If a virtual happens to share a binding name with a managed one,
+    // add_virtual_resources lands later → the virtual wins. This is the
+    // "post-apply view layers on the pre-apply view" semantic.
+    let managed = make_managed("rd", &[("v", s("pre_apply"))]);
+    let mut bindings = ResolvedBindings::from_managed_with_state(
+        &[managed],
+        &HashMap::new(),
+        &HashMap::new(),
+        &[],
+    );
+    let virt = make_virtual("rd", &[("v", s("post_apply"))]);
+    bindings
+        .add_virtual_resources(&[virt])
+        .expect("add_virtual_resources");
+
+    let view = bindings.get("rd").expect("rd binding present");
+    assert_eq!(view.get("v"), Some(&s("post_apply")));
+}
+
+#[test]
+fn add_virtual_resources_skips_unbound() {
+    let mut virt = make_virtual("v", &[("k", s("x"))]);
+    virt.binding = None;
+    let mut bindings =
+        ResolvedBindings::from_managed_with_state(&[], &HashMap::new(), &HashMap::new(), &[]);
+    bindings
+        .add_virtual_resources(&[virt])
+        .expect("add_virtual_resources");
+    assert!(bindings.get("v").is_none());
+}
+
+#[test]
+fn legacy_constructor_equivalence_managed_plus_virtual() {
+    // Feeding the same inputs through the legacy `from_resources_with_state`
+    // (mixed Resource slice) and through the new managed+virtual pair
+    // must yield identical bindings views — same binding names, same
+    // attribute maps, same source kinds.
+    let managed = make_managed("a", &[("value", s("hello"))]);
+    let virt = make_virtual("v", &[("forwarded", s("via_virtual"))]);
+
+    // New typed path:
+    let mut typed = ResolvedBindings::from_managed_with_state(
+        std::slice::from_ref(&managed),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[],
+    );
+    typed
+        .add_virtual_resources(std::slice::from_ref(&virt))
+        .expect("add_virtual_resources");
+
+    // Legacy mixed-slice path:
+    let mixed: Vec<Resource> = vec![Resource::from(&managed), virtual_as_resource(&virt)];
+    let legacy =
+        ResolvedBindings::from_resources_with_state(&mixed, &HashMap::new(), &HashMap::new(), &[]);
+
+    assert_eq!(typed.get("a"), legacy.get("a"), "managed binding mismatch");
+    assert_eq!(typed.get("v"), legacy.get("v"), "virtual binding mismatch");
+}
+
+/// Reverse of [`From<&ManagedResource> for Resource`]: rebuild a
+/// `Resource` from a `VirtualResource` for the legacy-path equivalence
+/// test. Local to the test — production code lives behind the typed
+/// entry once #3177+ migrates the call sites.
+fn virtual_as_resource(v: &VirtualResource) -> Resource {
+    use crate::resource::ResourceKind;
+    Resource {
+        id: v.id.clone(),
+        attributes: v.attributes.clone(),
+        kind: ResourceKind::Virtual {
+            module_name: v.module_name.clone(),
+            instance: v.instance.clone(),
+        },
+        directives: Default::default(),
+        prefixes: HashMap::new(),
+        binding: v.binding.clone(),
+        dependency_bindings: v.dependency_bindings.clone(),
+        module_source: None,
+        quoted_string_attrs: v.quoted_string_attrs.clone(),
+    }
+}

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -3,6 +3,8 @@
 //! Core library for an infrastructure management tool that treats side effects as values
 
 pub mod binding_index;
+#[cfg(test)]
+mod binding_index_split_tests;
 pub mod builtins;
 pub mod config_loader;
 pub mod deps;


### PR DESCRIPTION
Part 4/9 of the resource typestate split (#3169). Design PR #3172
(merged) covers the rationale; PRs #3183 (1/9), #3184 (2/9), and
#3185 (3/9) landed the wrapper structs, `ResourceLike` trait, and
typed resolver entries.

## Summary

Splits `ResolvedBindings::from_resources_with_state(&[Resource], …)`
in `carina-core/src/binding_index.rs` into two typed entry points:

- **`from_managed_with_state(&[ManagedResource], …) → ResolvedBindings`**
  — pre-apply path. Builds the bindings view from a managed slice
  plus `current_states`, `remote_bindings`, and `wait_aliases`.
- **`add_virtual_resources(&mut self, &[VirtualResource]) → Result<(), String>`**
  — post-apply path. Layers virtual-resource bindings onto an
  existing view. Must be called *after* the managed-side bindings
  exist (API contract).

The legacy `from_resources_with_state` is byte-identical to main;
existing call sites continue to use it.

## Why these signatures

- The pre-apply entry mirrors the legacy signature so #3177 can swap
  call sites mechanically.
- The post-apply entry takes `&mut self` rather than a builder
  because the typical call site is one function in
  `state_writeback.rs` (per design doc) that wants to layer on top
  of an existing pre-apply view.
- `Result<(), String>` on `add_virtual_resources` matches the
  design-doc signature and reserves space for future validation
  (e.g. a hard error on same-name collisions when the post-apply
  layer expects to merge rather than overwrite).

## Semantics notes

- Same-name collisions between a managed and a virtual binding
  favour the virtual (last-write-wins via the underlying `HashMap`),
  matching the "post-apply view layers on top" rule.
- Virtuals have no provider state, so `add_virtual_resources` does
  not merge `current_states` — the virtual's authored attribute
  map (after `resolve_virtual_refs_post_apply` materialises any
  refs) is recorded verbatim.
- Unbound virtuals (no `binding`) are skipped, mirroring the
  legacy behaviour for unbound managed resources.

## Internal bridge

`from_managed_with_state` re-bridges each `ManagedResource` to a
legacy `Resource` via the `From<&ManagedResource>` impl that landed
in #3185 (`resource/managed.rs`), then delegates to the legacy
constructor. This avoids duplicating the binding-construction
logic during the staged migration; the bridge disappears in #3181
when `ManagedResource` inline-merges with `Resource`.

## Tests

7 new tests in `binding_index_split_tests.rs`:

- happy path: managed → bindings
- managed + state merge (DSL wins on collision)
- managed without `binding` is skipped
- virtual layering (`add_virtual_resources_layers_on_top_of_managed`)
- same-name collision (virtual wins)
- virtual without `binding` is skipped
- **legacy-shim equivalence**: the new typed path (managed +
  `add_virtual_resources`) and the legacy mixed-slice path produce
  identical binding views.

## No behaviour change

Legacy `from_resources_with_state` is untouched and all existing
call sites continue to use it. No call-site migration in this PR;
that lands in #3177 (the user-facing fix for #3169) and later
hardening PRs.

## Test plan

- [x] `cargo nextest run --workspace` — 3508 passed
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — all OK

Refs #3169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
