### PR TITLE
apply: re-resolve virtual exports against post-apply state (5/9 of #3169, Closes #3169)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -299,8 +299,13 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
     // no source-side view of which exports the user intends — see the
     // `FinalizeApplyInput::export_params` doc-comment.
     if let Some(params) = input.export_params {
-        state.exports =
-            resolve_exports(params, input.sorted_resources, &state, input.wait_aliases)?;
+        state.exports = resolve_exports(
+            params,
+            input.sorted_resources,
+            input.pre_resolve_virtuals,
+            &state,
+            input.wait_aliases,
+        )?;
     }
 
     if let Some(lock) = input.lock {
@@ -353,11 +358,18 @@ pub(crate) async fn persist_exports_only(
     lock: Option<&LockInfo>,
     state_file: Option<StateFile>,
     sorted_resources: &[Resource],
+    pre_resolve_virtuals: &[carina_core::resource::VirtualResource],
     export_params: &[carina_core::parser::InferredExportParam],
     wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
-    let exports = resolve_exports(export_params, sorted_resources, &state, wait_aliases)?;
+    let exports = resolve_exports(
+        export_params,
+        sorted_resources,
+        pre_resolve_virtuals,
+        &state,
+        wait_aliases,
+    )?;
     state.exports = exports;
     if let Some(lk) = lock {
         save_state_locked(backend, lk, &mut state).await?;
@@ -1077,6 +1089,20 @@ async fn run_apply_locked(
         ctx.schemas(),
     );
 
+    // Snapshot each virtual resource's *pre-resolve* attributes
+    // (still carrying `ResourceRef`s) before the head-of-pipeline
+    // `resolve_refs_with_state_and_remote` call below replaces them
+    // with pre-apply concrete values. `finalize_apply`'s export
+    // resolution needs this snapshot to re-resolve virtuals against
+    // the post-apply state — see #3169 / #3177. Without it, every
+    // virtual ref is frozen at the pre-apply value and `state.exports`
+    // captures stale data after any Replace on a referenced managed
+    // resource.
+    let pre_resolve_virtuals: Vec<carina_core::resource::VirtualResource> = sorted_resources
+        .iter()
+        .filter_map(|r| carina_core::resource::VirtualResource::try_from(r).ok())
+        .collect();
+
     // Resolve references and enum identifiers, then create initial plan for display
     let mut resources_for_plan = sorted_resources.clone();
     resolve_refs_with_state_and_remote(
@@ -1191,11 +1217,22 @@ async fn run_apply_locked(
             )
             .cyan()
         );
+        // No-op apply path: virtuals were never resolved (no head-of-
+        // pipeline pass ran), so `sorted_resources` still carries
+        // the authored `ResourceRef` snapshots. Pull pre-resolve
+        // virtuals straight from it — same shape `resolve_exports`
+        // expects from the post-apply path.
+        let pre_resolve_virtuals_noop: Vec<carina_core::resource::VirtualResource> =
+            sorted_resources
+                .iter()
+                .filter_map(|r| carina_core::resource::VirtualResource::try_from(r).ok())
+                .collect();
         persist_exports_only(
             backend,
             lock,
             state_file,
             &sorted_resources,
+            &pre_resolve_virtuals_noop,
             &parsed.export_params,
             &wait_aliases,
         )
@@ -1301,6 +1338,7 @@ async fn run_apply_locked(
         schemas,
         export_params: Some(&parsed.export_params),
         wait_aliases: &wait_aliases,
+        pre_resolve_virtuals: &pre_resolve_virtuals,
     })
     .await?;
 
@@ -1641,6 +1679,10 @@ async fn run_apply_from_plan_locked(
         // the field is required; pass the reconstructed aliases so the
         // value is correct if a future plan file persists export_params.
         wait_aliases: &wait_aliases,
+        // Same rationale as `export_params: None`: no export
+        // resolution runs from the `apply --plan` path, so no
+        // pre-resolve virtual snapshot is needed.
+        pre_resolve_virtuals: &[],
     })
     .await?;
 

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1137,7 +1137,7 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     registry_prod.binding = Some("registry_prod".to_string());
     let sorted_resources = vec![registry_prod];
 
-    let exports = resolve_exports(&export_params, &sorted_resources, &state, &[]).unwrap();
+    let exports = resolve_exports(&export_params, &sorted_resources, &[], &state, &[]).unwrap();
 
     assert_eq!(
         exports.get("account_id"),
@@ -1201,6 +1201,10 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
         }),
     );
     let sorted_resources = vec![role_resource, virtual_resource];
+    let pre_resolve_virtuals: Vec<carina_core::resource::VirtualResource> = sorted_resources
+        .iter()
+        .filter_map(|r| carina_core::resource::VirtualResource::try_from(r).ok())
+        .collect();
 
     let export_params = vec![ExportParameter {
         name: "role_arn".to_string(),
@@ -1210,7 +1214,14 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
         })),
     }];
 
-    let exports = resolve_exports(&export_params, &sorted_resources, &state, &[]).unwrap();
+    let exports = resolve_exports(
+        &export_params,
+        &sorted_resources,
+        &pre_resolve_virtuals,
+        &state,
+        &[],
+    )
+    .unwrap();
 
     assert_eq!(
         exports.get("role_arn"),
@@ -1297,7 +1308,18 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
         })),
     }];
 
-    let exports = resolve_exports(&export_params, &sorted_resources, &state, &[]).unwrap();
+    let pre_resolve_virtuals: Vec<carina_core::resource::VirtualResource> = sorted_resources
+        .iter()
+        .filter_map(|r| carina_core::resource::VirtualResource::try_from(r).ok())
+        .collect();
+    let exports = resolve_exports(
+        &export_params,
+        &sorted_resources,
+        &pre_resolve_virtuals,
+        &state,
+        &[],
+    )
+    .unwrap();
 
     assert_eq!(
         exports.get("role_arn"),
@@ -1306,6 +1328,174 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
         )),
         "two-hop module-call chain must resolve through both virtuals, got: {:?}",
         exports
+    );
+}
+
+#[test]
+fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
+    // #3169 root-cause regression test (carina-rs/infra PR #64 drift).
+    //
+    // **The bug** (pre-#3177): the apply path's head-of-pipeline
+    // call to `resolve_refs_with_state_and_remote(&mut
+    // resources_for_plan, &pre_apply_current_states, …)` collapses
+    // every `ResourceRef` — including the ones inside a
+    // `VirtualResource`'s `attributes` — into the pre-apply
+    // concrete value (here: OLD_ARN). The virtual's `role_arn`
+    // attribute thus becomes a frozen string snapshot of the
+    // pre-apply state. Later in `finalize_apply`, the resource
+    // graph is sent into `resolve_exports`, which feeds the
+    // virtual's stale `role_arn` into `state.exports` — even
+    // though the writeback wrote the new ARN into
+    // `state.resources[role].arn`. So `state.exports.role_arn` and
+    // `state.resources[role].arn` disagree, with exports holding
+    // the old ARN.
+    //
+    // **The fix** (#3177): `apply/mod.rs` snapshots every virtual
+    // *before* the head-of-pipeline `ResourceRef` collapse — that
+    // snapshot still carries the authored `ref role.arn`. It
+    // threads that pre-resolve snapshot into `finalize_apply` →
+    // `resolve_exports`, which uses it (instead of the mutated
+    // `sorted_resources`) to build a fresh post-apply
+    // `ResolvedBindings` view via the typestate-split API
+    // (`from_managed_with_state` + `resolve_virtual_refs_post_apply`
+    // + `add_virtual_resources`). Exports then resolve against the
+    // post-apply view.
+    //
+    // **The test** mirrors that production pipeline: it (1)
+    // constructs the same managed + virtual graph, (2) takes a
+    // pre-resolve snapshot of the virtual, (3) runs the head-of-
+    // pipeline resolver against a *pre-apply* `current_states`
+    // (OLD_ARN), then (4) feeds the pre-resolve snapshot and the
+    // resolved working slice into `resolve_exports` along with a
+    // *post-apply* `StateFile` (NEW_ARN). The assertion checks the
+    // export ends up at NEW_ARN.
+    //
+    // Without the #3177 fix, `resolve_exports` would consult the
+    // mutated virtual's stale concrete attribute and return
+    // OLD_ARN. With the fix in place, the pre-resolve snapshot
+    // kicks in and re-resolves against the post-apply state.
+    use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
+    use carina_core::resolver::resolve_refs_with_state_and_remote;
+    use carina_core::resource::{
+        AccessPath, ConcreteValue, DeferredValue, ResourceId, ResourceKind, State as ResourceState,
+        Value, VirtualResource,
+    };
+    use carina_state::StateFile;
+    use std::collections::HashMap;
+
+    let pre_apply_arn = "arn:aws:iam::123456789012:role/role-OLD";
+    let post_apply_arn = "arn:aws:iam::123456789012:role/role-NEW";
+
+    // Step (a): post-apply `StateFile` — what `state.resources`
+    // looks like after the writeback wrote the new ARN. This is
+    // what `resolve_exports` sees as its `state` argument.
+    let post_apply_state_file = {
+        let json = serde_json::json!({
+            "version": 5,
+            "serial": 2,
+            "lineage": "test",
+            "carina_version": "0.4.0",
+            "resources": [
+                {
+                    "resource_type": "iam.Role",
+                    "name": "carina_role",
+                    "identifier": "carina-role-NEW",
+                    "provider": "awscc",
+                    "binding": "role",
+                    "attributes": { "arn": post_apply_arn }
+                }
+            ]
+        });
+        serde_json::from_value::<StateFile>(json).unwrap()
+    };
+
+    // Step (b): pre-apply `current_states` — what the head-of-
+    // pipeline resolver sees. Holds the OLD ARN, so the pre-apply
+    // pass freezes virtual `role_arn` to OLD_ARN.
+    let pre_apply_current_states: HashMap<ResourceId, ResourceState> = {
+        let id = ResourceId::with_provider("awscc", "iam.Role", "carina_role", None);
+        let mut attrs: HashMap<String, Value> = HashMap::new();
+        attrs.insert(
+            "arn".to_string(),
+            Value::Concrete(ConcreteValue::String(pre_apply_arn.to_string())),
+        );
+        let mut m = HashMap::new();
+        m.insert(id.clone(), ResourceState::existing(id, attrs));
+        m
+    };
+
+    // Build the authored resource graph: a managed `role` (DSL
+    // does not inline `arn` — provider returns it) and a virtual
+    // module-call binding that references `role.arn`.
+    let mut role_managed = Resource::with_provider("awscc", "iam.Role", "carina_role", None);
+    role_managed.binding = Some("role".to_string());
+
+    let mut virtual_resource = Resource::new("_virtual", "carina_module");
+    virtual_resource.binding = Some("carina_module".to_string());
+    virtual_resource.kind = ResourceKind::Virtual {
+        module_name: "carina_module".to_string(),
+        instance: "carina_module".to_string(),
+    };
+    virtual_resource.attributes.insert(
+        "role_arn".to_string(),
+        Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new("role", "arn"),
+        }),
+    );
+
+    let mut sorted_resources = vec![role_managed, virtual_resource];
+
+    // Step (c): pre-resolve snapshot — same `apply/mod.rs` does
+    // before the head-of-pipeline resolver runs.
+    let pre_resolve_virtuals: Vec<VirtualResource> = sorted_resources
+        .iter()
+        .filter_map(|r| VirtualResource::try_from(r).ok())
+        .collect();
+
+    // Step (d): head-of-pipeline resolver. After this call,
+    // `sorted_resources[1].attributes["role_arn"]` is
+    // `Value::Concrete(String(OLD_ARN))` — the bug-class state.
+    resolve_refs_with_state_and_remote(
+        &mut sorted_resources,
+        &pre_apply_current_states,
+        &HashMap::new(),
+        &[],
+    )
+    .unwrap();
+
+    // Sanity-check the bug condition is in place before the fix
+    // runs: the virtual now carries the stale OLD_ARN inline.
+    assert_eq!(
+        sorted_resources[1].attributes.get("role_arn"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            pre_apply_arn.to_string()
+        ))),
+        "head-of-pipeline must have frozen virtual.role_arn to pre-apply OLD_ARN",
+    );
+
+    let export_params = vec![ExportParameter {
+        name: "role_arn".to_string(),
+        type_expr: TypeExpr::Unknown,
+        value: Some(Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new("carina_module", "role_arn"),
+        })),
+    }];
+
+    let exports = resolve_exports(
+        &export_params,
+        &sorted_resources,
+        &pre_resolve_virtuals,
+        &post_apply_state_file,
+        &[],
+    )
+    .unwrap();
+
+    assert_eq!(
+        exports.get("role_arn"),
+        Some(&serde_json::Value::String(post_apply_arn.to_string())),
+        "exports.role_arn must be the POST-apply ARN ({post_apply_arn}) — \
+         the value carried by state.resources, NOT a pre-apply snapshot. \
+         Got: {exports:?}",
     );
 }
 

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -89,6 +89,26 @@ pub(crate) struct FinalizeApplyInput<'a> {
     /// (paired with `export_params: None`, so no export resolution
     /// runs there anyway).
     pub wait_aliases: &'a [carina_core::binding_index::WaitAliasSpec],
+    /// Pre-resolve snapshot of every `VirtualResource` in the
+    /// configuration: each one carries its **authored**
+    /// `ResourceRef` attribute values (e.g. `role_arn = role.arn`),
+    /// not the pre-apply-resolved concrete values.
+    ///
+    /// `apply` mutates a working copy of `sorted_resources`
+    /// in-place via `resolve_refs_with_state_and_remote` at the head
+    /// of the pipeline, which collapses every `ResourceRef` —
+    /// including the ones inside virtual `attributes` — into
+    /// pre-apply concrete values. By the time `finalize_apply`
+    /// runs, the resolved copy holds the *pre-apply* values, and a
+    /// post-apply re-resolve has nothing to chase.
+    ///
+    /// This field carries the unresolved snapshot taken **before**
+    /// that head-of-pipeline pass, so the export-resolution path
+    /// (#3169 / #3177) can re-resolve virtuals against the
+    /// post-apply state. Empty for the `apply --plan` path, where
+    /// `export_params` is also `None` and no export resolution
+    /// runs.
+    pub pre_resolve_virtuals: &'a [carina_core::resource::VirtualResource],
 }
 
 /// Resolve export expressions using bindings built from applied state.
@@ -101,22 +121,49 @@ pub(crate) struct FinalizeApplyInput<'a> {
 /// bindings — a downstream `exports { x = my_module_call.attr }` then
 /// fails with `unresolved reference my_module_call.attr` even though
 /// `carina plan` rendered the value cleanly. Issue #2479.
+///
+/// # Post-apply virtual re-resolution (#3169)
+///
+/// Before #3177 this function fed `sorted_resources` directly into
+/// `from_resources_with_state`. That captured each virtual's
+/// **pre-apply** attribute snapshot — for a virtual whose
+/// `attributes.role_arn = role.arn` and a managed `role` that was
+/// `Replace`d during apply, the pre-apply `role.arn` was the
+/// *old* ARN. The writeback path then wrote that stale ARN into
+/// `state.exports`, even though `state.resources[role].attributes.arn`
+/// already held the new ARN. Issue #3169.
+///
+/// The fix splits `sorted_resources` by kind and re-resolves virtual
+/// attributes against the post-apply view before exports use them:
+///
+/// 1. Build `post_apply_states` from `state.resources` (managed
+///    resources' applied attributes).
+/// 2. Split `sorted_resources` into a managed view (Managed +
+///    DataSource collapsed via [`ManagedResource::as_managed_view`])
+///    and a virtual view ([`VirtualResource::try_from`]).
+/// 3. Build the bindings view from the managed slice via
+///    [`ResolvedBindings::from_managed_with_state`] (#3176).
+/// 4. Re-resolve each virtual's `ResourceRef`s against that view via
+///    [`resolve_virtual_refs_post_apply`] (#3175), so a virtual that
+///    references a Replaced managed gets the *post*-replace value.
+/// 5. Layer the re-resolved virtuals onto the bindings view via
+///    `add_virtual_resources` (#3176).
+/// 6. Resolve export expressions against the combined view.
 pub(crate) fn resolve_exports(
     export_params: &[carina_core::parser::InferredExportParam],
     sorted_resources: &[Resource],
+    pre_resolve_virtuals: &[carina_core::resource::VirtualResource],
     state: &StateFile,
     wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
-) -> Result<HashMap<String, serde_json::Value>, carina_core::value::SerializationError> {
+) -> Result<HashMap<String, serde_json::Value>, AppError> {
     use carina_core::binding_index::ResolvedBindings;
-    use carina_core::resource::Value;
+    use carina_core::resolver::resolve_virtual_refs_post_apply;
+    use carina_core::resource::{ManagedResource, ResourceKind, Value};
 
-    // `from_resources_with_state` merges DSL-side attributes
-    // (`sorted_resources`, including `ResourceKind::Virtual` synthesised
-    // by module-call expansion) with provider-returned post-apply
-    // attributes (`current_states`, derived from `state.resources`).
-    // Same merge order the planner uses, so plan and writeback resolve
-    // identically.
-    let current_states = state
+    // Step 1: rebuild post-apply `current_states` from
+    // `state.resources` (the writeback already wrote the post-apply
+    // attribute values into the StateFile).
+    let post_apply_states = state
         .resources
         .iter()
         .map(|rs| {
@@ -139,13 +186,61 @@ pub(crate) fn resolve_exports(
             )
         })
         .collect::<HashMap<_, _>>();
-    let bindings = ResolvedBindings::from_resources_with_state(
-        sorted_resources,
-        &current_states,
+
+    // Step 2: extract the managed view from `sorted_resources`.
+    // `sorted_resources` carries the *resolved* working copy that
+    // the apply pipeline mutated — its virtual entries have already
+    // had `ResourceRef`s collapsed to pre-apply concrete values, so
+    // we ignore them here and pull virtuals from
+    // `pre_resolve_virtuals` instead. DataSources are collapsed
+    // onto a `ManagedResource` view because the binding index only
+    // cares about (binding name, attribute map, state merge) —
+    // DataSources share that shape with managed resources. See
+    // `ManagedResource::as_managed_view` for the rationale and the
+    // `Virtual must not pass through here` invariant.
+    let mut managed: Vec<ManagedResource> = Vec::with_capacity(sorted_resources.len());
+    for r in sorted_resources {
+        match r.kind {
+            ResourceKind::Virtual { .. } => {
+                // Virtuals come from `pre_resolve_virtuals` below.
+                continue;
+            }
+            ResourceKind::Managed | ResourceKind::DataSource => {
+                managed.push(ManagedResource::as_managed_view(r));
+            }
+        }
+    }
+
+    // Virtuals: fresh clone of the **pre-resolve** snapshot. Their
+    // attributes still carry `ResourceRef`s, so the post-apply
+    // resolver below can pick up the post-apply state values for
+    // any managed sibling that was Replaced during apply
+    // (#3169 / #3177).
+    let mut virtuals: Vec<carina_core::resource::VirtualResource> = pre_resolve_virtuals.to_vec();
+
+    // Step 3: build the bindings view from the managed slice plus
+    // post-apply states. Wait aliases land at the end of construction
+    // and snapshot whatever binding the alias targets (carina#3085).
+    let mut bindings = ResolvedBindings::from_managed_with_state(
+        &managed,
+        &post_apply_states,
         &HashMap::new(),
         wait_aliases,
     );
 
+    // Step 4: re-resolve each virtual's attributes against the
+    // post-apply bindings view. After this, a virtual's
+    // `role_arn = role.arn` no longer holds the pre-apply
+    // `ResourceRef`; it holds the post-apply concrete value.
+    resolve_virtual_refs_post_apply(&mut virtuals, &bindings)?;
+
+    // Step 5: layer the re-resolved virtuals onto the bindings view.
+    // Now `exports { foo = some_module.role_arn }` resolves against
+    // a binding whose `role_arn` is the post-apply value.
+    bindings.add_virtual_resources(&virtuals)?;
+
+    // Step 6: resolve the export expressions against the combined
+    // view.
     let mut exports = HashMap::new();
     for param in export_params {
         if let Some(ref value) = param.value {

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -798,9 +798,19 @@ pub(crate) async fn run_state_refresh_locked(
             .iter()
             .map(carina_core::binding_index::WaitAliasSpec::from)
             .collect();
+        // State refresh path: `sorted_resources` has not been
+        // mutated by a head-of-pipeline resolver pass, so its
+        // virtuals still carry the authored `ResourceRef` snapshots
+        // and we can lift them straight out for `resolve_exports`'s
+        // post-apply re-resolution (#3169 / #3177).
+        let pre_resolve_virtuals: Vec<carina_core::resource::VirtualResource> = sorted_resources
+            .iter()
+            .filter_map(|r| carina_core::resource::VirtualResource::try_from(r).ok())
+            .collect();
         state.exports = crate::commands::shared::state_writeback::resolve_exports(
             &parsed.export_params,
             &sorted_resources,
+            &pre_resolve_virtuals,
             &state,
             &wait_aliases,
         )?;

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1483,6 +1483,7 @@ async fn lock_released_on_write_state_failure() {
         schemas: &SchemaRegistry::new(),
         export_params: Some(&[]),
         wait_aliases: &[],
+        pre_resolve_virtuals: &[],
     })
     .await;
 
@@ -1617,6 +1618,7 @@ async fn finalize_apply_uses_write_state_locked() {
         schemas: &SchemaRegistry::new(),
         export_params: Some(&[]),
         wait_aliases: &[],
+        pre_resolve_virtuals: &[],
     })
     .await;
 
@@ -2207,6 +2209,7 @@ async fn finalize_apply_without_lock_uses_write_state() {
         schemas: &SchemaRegistry::new(),
         export_params: Some(&[]),
         wait_aliases: &[],
+        pre_resolve_virtuals: &[],
     })
     .await;
 
@@ -2891,6 +2894,7 @@ async fn persist_exports_only_clears_state_exports_when_params_empty() {
         &[],
         &[],
         &[],
+        &[],
     )
     .await;
 
@@ -2928,6 +2932,7 @@ async fn persist_exports_only_writes_state_with_new_exports() {
         &backend,
         Some(&lock),
         Some(StateFile::new()),
+        &[],
         &[],
         &export_params,
         &[],
@@ -2994,6 +2999,7 @@ async fn finalize_apply_clears_state_exports_when_params_empty() {
         schemas: &SchemaRegistry::new(),
         export_params: Some(&[]),
         wait_aliases: &[],
+        pre_resolve_virtuals: &[],
     })
     .await;
 
@@ -3050,6 +3056,7 @@ async fn finalize_apply_preserves_state_exports_when_params_none() {
         schemas: &SchemaRegistry::new(),
         export_params: None,
         wait_aliases: &[],
+        pre_resolve_virtuals: &[],
     })
     .await;
 

--- a/carina-core/src/resource/managed.rs
+++ b/carina-core/src/resource/managed.rs
@@ -64,6 +64,50 @@ impl TryFrom<&Resource> for ManagedResource {
     }
 }
 
+impl ManagedResource {
+    /// Project a legacy [`Resource`] onto a `ManagedResource` view
+    /// **regardless of `kind`**, discarding the discriminant.
+    ///
+    /// Unlike the strict [`TryFrom<&Resource>`] impl above, this
+    /// helper does not check `kind`. It exists for one specific
+    /// caller (`carina-cli`'s `resolve_exports`) where the
+    /// bindings-index construction needs to treat
+    /// `ResourceKind::DataSource` as having the same attribute /
+    /// state shape as a managed resource: the binding index only
+    /// indexes by `binding` name + attribute map, and DataSources
+    /// participate in that lookup just like Managed resources do.
+    /// Routing both through the same `ManagedResource` view keeps
+    /// the binding-index API single-typed without forcing the
+    /// caller to spread `match kind` across the bridge.
+    ///
+    /// `Virtual` resources must **not** be passed here — the
+    /// caller has already split them out (the typestate invariant
+    /// that virtuals are post-apply-only forbids them participating
+    /// in the pre-apply / managed binding view). Passing a virtual
+    /// drops it to a Managed view, which would re-introduce the
+    /// class of bug #3169 fixed. Callers that observe a virtual
+    /// must route it through [`VirtualResource::try_from`] instead.
+    ///
+    /// Removed when #3181 inline-merges `Resource` into
+    /// `ManagedResource`.
+    pub fn as_managed_view(r: &Resource) -> Self {
+        debug_assert!(
+            !matches!(r.kind, ResourceKind::Virtual { .. }),
+            "as_managed_view called on Virtual; route via VirtualResource::try_from",
+        );
+        Self {
+            id: r.id.clone(),
+            attributes: r.attributes.clone(),
+            directives: r.directives.clone(),
+            prefixes: r.prefixes.clone(),
+            binding: r.binding.clone(),
+            dependency_bindings: r.dependency_bindings.clone(),
+            module_source: r.module_source.clone(),
+            quoted_string_attrs: r.quoted_string_attrs.clone(),
+        }
+    }
+}
+
 /// Transitional bridge — rebuild a legacy [`Resource`] from a
 /// `ManagedResource`. Co-located with the reverse `TryFrom<&Resource>`
 /// impl above so #3181 can remove both directions in one place when


### PR DESCRIPTION
**This is the user-facing fix for #3169.** Closes #3169.

Part 5/9 of the resource typestate split (#3169). Design PR #3172
(merged) covers the rationale; PRs #3183, #3184, #3185, #3186
(1/9 → 4/9) landed the wrapper structs, `ResourceLike` trait,
typed resolver entries, and typed `ResolvedBindings` constructors
this PR consumes.

## Root cause

`carina-cli/src/commands/apply/mod.rs::run_apply_locked` calls
`resolve_refs_with_state_and_remote` at line 1082 against the
**pre-apply** `current_states`. That pass collapses every
`ResourceRef` — including the ones inside a `VirtualResource`'s
`attributes` — into the pre-apply concrete value. A virtual whose
`attributes.role_arn = role.arn` ends up with
`role_arn = Concrete(String("OLD_ARN"))` inline on the in-memory
resource graph.

Effects execute, the real `role` resource's `arn` is applied, and
`build_state_after_apply` correctly writes the new ARN to
`state.resources[role].attributes.arn`. But the virtual's
attributes are never re-resolved, so when `finalize_apply` runs
`resolve_exports`, it reads `OLD_ARN` from the virtual's stale
attribute and writes it into `state.exports`. The exports row
disagrees with `state.resources[role]`. Issue #3169.

## Fix

Snapshot each `VirtualResource` **before** the head-of-pipeline
`ResourceRef` collapse runs, thread the snapshot through
`FinalizeApplyInput`, and use it (not the mutated
`sorted_resources`) when rebuilding the post-apply bindings view
inside `resolve_exports`. The pre-resolve snapshot still carries
`ResourceRef`s, so the typestate-split API
(`ResolvedBindings::from_managed_with_state` (#3176) →
`resolve_virtual_refs_post_apply` (#3175) →
`add_virtual_resources` (#3176)) can re-resolve them against the
post-apply state derived from `state.resources`. Exports then
resolve against the combined view.

This is the user-visible payoff of the typestate split — the
previous mixed-kind `from_resources_with_state` entry made it
impossible to re-resolve only the virtual subset against the
post-apply view. Now the split surface enables the natural fix.

## Surface changes

- `FinalizeApplyInput` gains
  `pre_resolve_virtuals: &'a [VirtualResource]`. Source-driven
  apply paths pass the snapshot taken at `apply/mod.rs:1081`;
  the `apply --plan` path (no export resolution) passes `&[]`.
- `resolve_exports` signature gains `pre_resolve_virtuals` and
  changes its error from `SerializationError` to `AppError`
  (so `String` errors from the new resolver entries flow
  through cleanly via `From<String> for AppError`).
- `persist_exports_only` gains `pre_resolve_virtuals` for the
  no-op apply path. State refresh (`state.rs:801`) and the
  no-op apply paths derive the snapshot from `sorted_resources`
  directly because those paths never run the head-of-pipeline
  resolver.
- `ManagedResource::as_managed_view(&Resource)` is added in
  `carina-core/src/resource/managed.rs` — a kind-agnostic lossy
  view used by the bindings-index construction to collapse
  `Managed` + `DataSource` onto a single shape. A
  `debug_assert!` rejects a Virtual to keep the typestate
  invariant explicit. Doc-comment explains the rationale
  (bindings only care about binding-name + attribute map,
  which Managed and DataSource share).

## Regression test

`resolve_exports_picks_post_apply_role_arn_after_replace_3169`
in `carina-cli/src/commands/apply/tests.rs` mirrors the
production pipeline:

1. Build a pre-apply `current_states` with `OLD_ARN`.
2. Snapshot the virtual *before* the head-of-pipeline resolver.
3. Run `resolve_refs_with_state_and_remote` against the
   pre-apply `current_states` to freeze the virtual's `role_arn`
   to `OLD_ARN` inline (sanity-asserted with an inline
   `assert_eq!` that confirms the bug condition is in place).
4. Run `resolve_exports` with the pre-resolve snapshot, the
   resolved `sorted_resources`, and a post-apply `StateFile`
   carrying `NEW_ARN`.
5. Assert the export ends up at `NEW_ARN`.

**Verified non-vacuous**: temporarily switching the function
back to pulling virtuals from `sorted_resources` (the pre-#3177
shape) makes this test fail loudly with
`OLD_ARN` in `exports.role_arn`. The test bites pre-fix code.

## Test plan

- [x] `cargo nextest run --workspace` — 3509 passed
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — all OK
- [x] Stress-tested: reverting `resolve_exports` to read virtuals
  from `sorted_resources` causes the new #3169 regression test
  to FAIL with `OLD_ARN`; restoring the fix makes it PASS.

Refs #3169.
Closes #3169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
