### PR TITLE
executor: migrate DepResolver to typed virtual slice (6/9 of #3169)

### DIFF
--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -35,6 +35,25 @@ pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
     deps
 }
 
+/// Dependency-binding collection for a [`VirtualResource`](crate::resource::VirtualResource).
+///
+/// `VirtualResource` has no `directives` field — synthetic IR nodes
+/// never carry `depends_on`. The collection therefore reduces to
+/// "attributes' ResourceRefs ∪ `dependency_bindings`", which is the
+/// same first-two-thirds of [`get_resource_dependencies`].
+pub fn get_virtual_resource_dependencies(
+    virt: &crate::resource::VirtualResource,
+) -> HashSet<String> {
+    let mut deps = HashSet::new();
+    for value in virt.attributes.values() {
+        collect_dependencies(value, &mut deps);
+    }
+    for name in &virt.dependency_bindings {
+        deps.insert(name.clone());
+    }
+    deps
+}
+
 /// Recursively collect resource reference dependencies from a value.
 ///
 /// Both attribute references (`vpc.vpc_id`) and bare-binding refs
@@ -341,6 +360,44 @@ mod tests {
         let deps = get_resource_dependencies(&resource);
         assert!(deps.contains("b"));
         assert!(deps.contains("c"));
+        assert_eq!(deps.len(), 2);
+    }
+
+    #[test]
+    fn test_get_virtual_resource_dependencies_collects_attrs_and_deps() {
+        use crate::resource::VirtualResource;
+        use indexmap::IndexMap;
+        use std::collections::BTreeSet;
+
+        // Build a virtual whose attributes carry a ResourceRef and
+        // whose `dependency_bindings` carries a separate entry.
+        // Both must end up in the merged set.
+        let mut attributes = IndexMap::new();
+        attributes.insert(
+            "role_arn".to_string(),
+            Value::resource_ref("role".to_string(), "arn", vec![]),
+        );
+        let mut dep_bindings = BTreeSet::new();
+        dep_bindings.insert("explicit_dep".to_string());
+        let virt = VirtualResource {
+            id: ResourceId::new("_virtual.module", "v"),
+            attributes,
+            binding: Some("v".to_string()),
+            dependency_bindings: dep_bindings,
+            module_name: "m".to_string(),
+            instance: "v".to_string(),
+            quoted_string_attrs: Default::default(),
+        };
+
+        let deps = get_virtual_resource_dependencies(&virt);
+        assert!(
+            deps.contains("role"),
+            "expected attribute ResourceRef binding `role`, got {deps:?}",
+        );
+        assert!(
+            deps.contains("explicit_dep"),
+            "expected pre-recorded dependency `explicit_dep`, got {deps:?}",
+        );
         assert_eq!(deps.len(), 2);
     }
 

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -170,11 +170,24 @@ pub(super) fn build_phase_dependency_map(
 }
 
 /// Resolve binding-name dependencies to the effect indices they reach,
-/// expanding any [`ResourceKind::Virtual`] proxy bindings transparently
+/// expanding any [`VirtualResource`] proxy bindings transparently
 /// through their own attribute references (#2543).
+///
+/// `virtuals_by_binding` now holds only virtuals (typestate-split
+/// #3178): the previous mixed `HashMap<&str, &Resource>` plus a
+/// runtime `matches!(res.kind, Virtual { .. })` check is replaced
+/// by a slice of one type. A binding being present in
+/// `virtuals_by_binding` *is* the "this is a virtual" condition; no
+/// runtime kind probe is needed.
 pub(super) struct DepResolver<'a> {
     binding_to_idx: &'a HashMap<String, usize>,
-    binding_to_resource: HashMap<&'a str, &'a Resource>,
+    /// Virtual resources owned by the resolver, keyed by their
+    /// `binding` name. Owned rather than `&'a VirtualResource`
+    /// because `VirtualResource::try_from(&Resource)` returns an
+    /// owned wrapper — keeping a borrow would force a
+    /// self-referential struct. The clone cost is bounded by the
+    /// number of virtuals in the config (typically small).
+    virtuals_by_binding: HashMap<String, crate::resource::VirtualResource>,
     /// `Some` filters output indices to those in the phase; `None` retains
     /// every reachable index.
     phase_set: Option<&'a HashSet<usize>>,
@@ -186,13 +199,33 @@ impl<'a> DepResolver<'a> {
         unresolved_resources: &'a HashMap<ResourceId, Resource>,
         phase_set: Option<&'a HashSet<usize>>,
     ) -> Self {
-        let binding_to_resource = unresolved_resources
-            .values()
-            .filter_map(|r| r.binding.as_deref().map(|b| (b, r)))
-            .collect();
+        // Project the mixed `unresolved_resources` map to a
+        // virtual-only `virtuals_by_binding` view via
+        // `VirtualResource::try_from`. Managed / DataSource arms
+        // fail the conversion and are silently filtered — that is
+        // the typestate-split equivalent of the legacy
+        // `matches!(res.kind, Virtual { .. })` check inside
+        // `expand`.
+        //
+        // The legacy code recorded all kinds in
+        // `binding_to_resource` and gated virtual-expansion on a
+        // runtime kind check at lookup time. Restricting the map
+        // to virtuals at construction time keeps the observable
+        // behaviour identical (only virtuals were ever traversed
+        // by the legacy gate) and removes the runtime probe.
+        let virtuals_by_binding: HashMap<String, crate::resource::VirtualResource> =
+            unresolved_resources
+                .values()
+                .filter_map(|r| {
+                    let binding = r.binding.clone()?;
+                    crate::resource::VirtualResource::try_from(r)
+                        .ok()
+                        .map(|v| (binding, v))
+                })
+                .collect();
         Self {
             binding_to_idx,
-            binding_to_resource,
+            virtuals_by_binding,
             phase_set,
         }
     }
@@ -207,7 +240,15 @@ impl<'a> DepResolver<'a> {
         }
     }
 
-    fn expand(&self, binding: &'a str, out: &mut HashSet<usize>, visited: &mut HashSet<&'a str>) {
+    /// Recursive dependency walk. The `'b` lifetime is bound to the
+    /// `&self` borrow at the call site so the borrowed keys live
+    /// inside the resolver (`virtuals_by_binding` / `binding_to_idx`).
+    fn expand<'b>(
+        &'b self,
+        binding: &'b str,
+        out: &mut HashSet<usize>,
+        visited: &mut HashSet<&'b str>,
+    ) {
         if !visited.insert(binding) {
             return;
         }
@@ -217,24 +258,23 @@ impl<'a> DepResolver<'a> {
             }
             return;
         }
-        // No Effect for this binding. If it's a Virtual resource (a module's
-        // attributes-block proxy), follow the references in its own attributes
-        // to the underlying resources the module exposes.
-        let Some(res) = self.binding_to_resource.get(binding) else {
+        // No effect for this binding. If it names a `VirtualResource`
+        // (a module's attributes-block proxy), follow the
+        // references in its own attributes to the underlying
+        // resources the module exposes. The typed map answers
+        // "is this a virtual?" by presence — no `matches!` probe.
+        let Some(virt) = self.virtuals_by_binding.get(binding) else {
             return;
         };
-        if !matches!(res.kind, crate::resource::ResourceKind::Virtual { .. }) {
-            return;
-        }
-        // `get_resource_dependencies` returns owned `String`s, but the
-        // visit set borrows from this resolver's keys to avoid per-binding
-        // allocation. Re-borrow each inner binding from the
-        // `binding_to_resource` / `binding_to_idx` keys so the borrow lifetime
-        // matches `'a`.
-        for inner in get_resource_dependencies(res) {
-            let key: &'a str =
-                if let Some((k, _)) = self.binding_to_resource.get_key_value(inner.as_str()) {
-                    k
+        // `get_virtual_resource_dependencies` returns owned `String`s,
+        // but the visit set borrows from this resolver's keys to
+        // avoid per-binding allocation. Re-borrow each inner
+        // binding from the resolver's own keys so the borrow
+        // lifetime matches `'b` (the `&self` borrow lifetime).
+        for inner in crate::deps::get_virtual_resource_dependencies(virt) {
+            let key: &'b str =
+                if let Some((k, _)) = self.virtuals_by_binding.get_key_value(inner.as_str()) {
+                    k.as_str()
                 } else if let Some((k, _)) = self.binding_to_idx.get_key_value(inner.as_str()) {
                     k.as_str()
                 } else {


### PR DESCRIPTION
Part 6/9 of the resource typestate split (#3169). Design PR #3172
(merged) covers the rationale; PRs #3183-#3187 (1/9 → 5/9) landed
the wrapper structs, `ResourceLike` trait, typed resolver entries,
typed `ResolvedBindings` constructors, and the #3169 fix this
series existed to enable.

## Summary

Removes the last `matches!(res.kind, ResourceKind::Virtual { .. })`
runtime probe from `executor/phased.rs`, replacing it with a
typed `HashMap<String, VirtualResource>` keyed by binding name.
A binding being present in the map *is* the "this is a virtual"
condition.

- `DepResolver` switches from a mixed `binding_to_resource:
  HashMap<&str, &Resource>` (all kinds) plus a runtime
  `matches!` gate to a `virtuals_by_binding: HashMap<String,
  VirtualResource>` constructed via `VirtualResource::try_from`.
  Managed and DataSource arms fail the conversion and are
  filtered out — exactly the resources the legacy gate skipped.
- `expand` walks dependencies through the typed map; the
  presence check (`get(binding)`) doubles as the kind check.
- `get_virtual_resource_dependencies(&VirtualResource)` is added
  to `carina-core/src/deps.rs` as the typed sibling of
  `get_resource_dependencies`. The virtual variant omits
  `directives.depends_on` because `VirtualResource` has no
  `directives` field (synthetic IR nodes never carry
  `depends_on`).

## Lifetime change

`DepResolver::expand` was `fn expand(&self, binding: &'a str, …,
visited: &mut HashSet<&'a str>)` — the borrowed keys came from
the legacy `HashMap<&'a str, &'a Resource>`. With ownership
moved into `virtuals_by_binding: HashMap<String, VirtualResource>`
the recursive walk now reborrows keys at the `&self` lifetime
(`'b`), tightening the relationship without forcing a
self-referential struct.

## Scope note: parallel.rs

The issue body lists `parallel.rs`'s "virtual proxy construction"
as a migration target, but the only `ResourceKind::Virtual`
construction in `parallel.rs` lives in a `#[cfg(test)] mod tests`
fixture; production code never builds a virtual there. This PR
is therefore scoped to `phased.rs`. The commit message
documents the reasoning so a reader of the typestate-split log
can confirm the scope decision.

## Test plan

- [x] `cargo nextest run --workspace` — 3509 passed (existing
      `build_dependency_map_follows_virtual_module_binding` test
      exercises the typed traversal path)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — all OK
- [x] `test_get_virtual_resource_dependencies_collects_attrs_and_deps`
      added in `deps.rs` to cover the new helper.

No behaviour change.

Refs #3169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
