### PR TITLE
differ: migrate create_plan / cascade_dependent_updates to typed slices (#3179)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1133,8 +1133,11 @@ async fn run_apply_locked(
         .map(|sf| sf.build_directives())
         .unwrap_or_default();
     let schemas = ctx.schemas();
+    let (managed_for_plan, data_sources_for_plan) =
+        carina_core::differ::split_resources_by_kind(&resources_for_plan);
     let mut plan = create_plan(
-        &resources_for_plan,
+        &managed_for_plan,
+        &data_sources_for_plan,
         &current_states,
         &directives_map,
         schemas,
@@ -1146,7 +1149,9 @@ async fn run_apply_locked(
 
     // Populate cascading updates for create_before_destroy Replace effects.
     // Uses unresolved resources (sorted_resources) so dependents retain ResourceRef values.
-    cascade_dependent_updates(&mut plan, &sorted_resources, &current_states, schemas);
+    let (unresolved_managed, _unresolved_ds) =
+        carina_core::differ::split_resources_by_kind(&sorted_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed, &current_states, schemas);
 
     // Add state block effects (import/removed/moved) to the plan
     crate::wiring::add_state_block_effects(

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -214,8 +214,11 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &state_file,
     );
 
+    let (managed_for_plan, data_sources_for_plan) =
+        carina_core::differ::split_resources_by_kind(&resources);
     let mut plan = create_plan(
-        &resources,
+        &managed_for_plan,
+        &data_sources_for_plan,
         &current_states,
         &directives_map,
         wiring.schemas(),
@@ -225,9 +228,11 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &parsed.wait_bindings,
     );
 
+    let (unresolved_managed, _unresolved_ds) =
+        carina_core::differ::split_resources_by_kind(&sorted_resources);
     cascade_dependent_updates(
         &mut plan,
-        &sorted_resources,
+        &unresolved_managed,
         &current_states,
         wiring.schemas(),
     );

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1345,8 +1345,10 @@ fn orphaned_state_resource_produces_delete_effect() {
     let saved_attrs = state_file.build_saved_attrs();
     let prev_explicit = state_file.build_explicit();
 
+    let (managed___, data_sources___) = carina_core::differ::split_resources_by_kind(&desired);
     let plan = create_plan(
-        &desired,
+        &managed___,
+        &data_sources___,
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -2304,8 +2306,10 @@ fn orphaned_resource_deleted_externally_should_not_produce_delete_effect() {
     let saved_attrs = state_file.build_saved_attrs();
     let prev_explicit = state_file.build_explicit();
 
+    let (managed___, data_sources___) = carina_core::differ::split_resources_by_kind(&desired);
     let plan = create_plan(
-        &desired,
+        &managed___,
+        &data_sources___,
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -2389,8 +2393,10 @@ fn refresh_false_uses_cached_state_from_state_file() {
     let saved_attrs = state_file.build_saved_attrs();
     let prev_explicit = state_file.build_explicit();
 
+    let (managed___, data_sources___) = carina_core::differ::split_resources_by_kind(&desired);
     let plan = create_plan(
-        &desired,
+        &managed___,
+        &data_sources___,
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -2436,8 +2442,10 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
     let saved_attrs = state_file.build_saved_attrs();
     let prev_explicit = state_file.build_explicit();
 
+    let (managed___, data_sources___) = carina_core::differ::split_resources_by_kind(&desired);
     let plan = create_plan(
-        &desired,
+        &managed___,
+        &data_sources___,
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -2481,8 +2489,10 @@ fn refresh_false_without_state_file_treats_resources_as_new() {
         current_states.insert(res.id.clone(), State::not_found(res.id.clone()));
     }
 
+    let (managed___, data_sources___) = carina_core::differ::split_resources_by_kind(&desired);
     let plan = create_plan(
-        &desired,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1770,8 +1770,11 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         .as_ref()
         .map(|sf| sf.build_directives())
         .unwrap_or_default();
+    let (managed_for_plan, data_sources_for_plan) =
+        carina_core::differ::split_resources_by_kind(&resources);
     let mut plan = create_plan(
-        &resources,
+        &managed_for_plan,
+        &data_sources_for_plan,
         &current_states,
         &directives_map,
         ctx.schemas(),
@@ -1784,7 +1787,14 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // Populate cascading updates for Replace effects with create_before_destroy.
     // Uses unresolved resources (sorted_resources) so dependent Update effects
     // retain ResourceRef values for re-resolution at apply time.
-    cascade_dependent_updates(&mut plan, &sorted_resources, &current_states, ctx.schemas());
+    let (unresolved_managed, _unresolved_ds) =
+        carina_core::differ::split_resources_by_kind(&sorted_resources);
+    cascade_dependent_updates(
+        &mut plan,
+        &unresolved_managed,
+        &current_states,
+        ctx.schemas(),
+    );
 
     // Add state block effects (import/removed/moved) to the plan
     add_state_block_effects(

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -192,8 +192,11 @@ fn test_normalize_state_prevents_false_enum_diff() {
     let saved_attrs = HashMap::new();
     let prev_explicit = HashMap::new();
     let orphan_deps = HashMap::new();
+    let (managed___, data_sources___) =
+        carina_core::differ::split_resources_by_kind(&resources_without);
     let plan_without = create_plan(
-        &resources_without,
+        &managed___,
+        &data_sources___,
         &current_states,
         &directives_map,
         &schemas,
@@ -210,8 +213,11 @@ fn test_normalize_state_prevents_false_enum_diff() {
     // After normalize_state, state values match desired values → no diff
     normalize_state_with_ctx(&ctx, &mut current_states);
     let resources_with = vec![resource];
+    let (managed_w___, data_sources_w___) =
+        carina_core::differ::split_resources_by_kind(&resources_with);
     let plan_with = create_plan(
-        &resources_with,
+        &managed_w___,
+        &data_sources_w___,
         &current_states,
         &directives_map,
         &schemas,
@@ -301,8 +307,11 @@ fn test_merge_default_tags_prevents_false_diff() {
     let directives_map: HashMap<ResourceId, Directives> = HashMap::new();
     let saved_attrs = HashMap::new();
     let orphan_deps = HashMap::new();
+    let (managed___, data_sources___) =
+        carina_core::differ::split_resources_by_kind(&resources_without);
     let plan_without = create_plan(
-        &resources_without,
+        &managed___,
+        &data_sources___,
         &current_states,
         &directives_map,
         &schemas,
@@ -330,8 +339,11 @@ fn test_merge_default_tags_prevents_false_diff() {
     rt.block_on(router.merge_default_tags(&mut resources_with, &default_tags, &schemas));
 
     // After merging, desired now has tags matching state → no diff
+    let (managed_w___, data_sources_w___) =
+        carina_core::differ::split_resources_by_kind(&resources_with);
     let plan_with = create_plan(
-        &resources_with,
+        &managed_w___,
+        &data_sources_w___,
         &current_states,
         &directives_map,
         &schemas,

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -398,8 +398,11 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
         )
         .await;
 
+    let (managed___, data_sources___) =
+        carina_core::differ::split_resources_by_kind(&resources_for_plan);
     let plan = create_plan(
-        &resources_for_plan,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         ctx.schemas(),

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -79,7 +79,9 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
 
     // Apply cascade
     let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // Verify the Replace effect now has a cascading update for the subnet
     let effects = plan.effects();
@@ -182,7 +184,9 @@ fn cascade_skips_resources_already_in_plan() {
     });
 
     let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // The Replace should have NO cascading updates since subnet already has an Update
     if let Effect::Replace {
@@ -244,7 +248,9 @@ fn cascade_no_op_without_create_before_destroy() {
     });
 
     let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     if let Effect::Replace {
         cascading_updates, ..
@@ -339,7 +345,9 @@ fn cascade_transitive_dependencies() {
     });
 
     let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // Only subnet directly depends on VPC, so only subnet gets cascading update
     // Instance depends on subnet, not VPC directly
@@ -418,7 +426,9 @@ fn cascade_anonymous_resource_dependent() {
     });
 
     let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     if let Effect::Replace {
         cascading_updates, ..
@@ -528,7 +538,9 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
     });
 
     // Apply cascade with schemas so it can detect create-only attributes
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // After cascading, the subnet should appear as a separate Replace effect in the plan,
     // NOT as a CascadingUpdate inside the VPC's Replace effect.
@@ -709,7 +721,9 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     });
 
     // Apply cascade
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // After cascading, the subnet Replace should have BOTH availability_zone AND vpc_id
     // in changed_create_only, because vpc_id is a create-only ref to the replaced VPC.
@@ -842,7 +856,9 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
 
     // Apply cascade — this should auto-detect that VPC has dependents and
     // promote it to create_before_destroy
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // The VPC Replace should now have create_before_destroy = true
     // because the subnet references it
@@ -975,7 +991,9 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
     });
 
     // Apply cascade
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // After cascading, the subnet should be UPGRADED from Update to Replace,
     // because vpc_id is a create-only attribute referencing the replaced VPC.
@@ -1094,7 +1112,9 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
     });
 
     // Apply cascade
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // The subnet should NOT be promoted to Replace because it has prevent_destroy.
     // Instead, a PlanError should be generated.
@@ -1228,7 +1248,9 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
     });
 
     // Apply cascade
-    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+    let (unresolved_managed___, _ds___) =
+        crate::differ::split_resources_by_kind(&unresolved_resources);
+    cascade_dependent_updates(&mut plan, &unresolved_managed___, &current_states, &schemas);
 
     // The subnet should NOT be upgraded to Replace because it has prevent_destroy.
     // A PlanError should be generated instead.

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -74,8 +74,10 @@ fn create_plan_from_resources() {
         State::existing(ResourceId::new("bucket", "existing-bucket"), attrs),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -103,8 +105,10 @@ fn create_plan_with_read_only_resource() {
     ];
 
     let current_states = HashMap::new();
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -207,8 +211,10 @@ fn create_plan_detects_orphaned_resources_for_deletion() {
         State::existing(ResourceId::new("bucket", "orphaned-bucket"), orphan_attrs),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&desired);
     let plan = create_plan(
-        &desired,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -257,8 +263,10 @@ fn read_only_resource_always_generates_read_effect() {
         State::existing(ResourceId::new("bucket", "existing-bucket"), attrs),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -328,8 +336,10 @@ fn replace_when_create_only_attr_changed() {
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -383,8 +393,10 @@ fn normal_update_when_non_create_only_attr_changed() {
             )),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -451,8 +463,10 @@ fn replace_when_schema_force_replace() {
             .force_replace(),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -512,8 +526,10 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
             )),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -565,8 +581,10 @@ fn replace_carries_create_before_destroy_directives() {
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -686,8 +704,10 @@ fn replace_with_provider_prefixed_schema_key() {
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -955,8 +975,10 @@ fn orphan_delete_preserves_binding_and_dependencies() {
         State::existing(ResourceId::new("subnet", "my-subnet"), orphan_attrs),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&desired);
     let plan = create_plan(
-        &desired,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),

--- a/carina-core/src/differ/mod.rs
+++ b/carina-core/src/differ/mod.rs
@@ -98,6 +98,34 @@ pub fn diff(
     }
 }
 
+/// Split a legacy `[Resource]` mix into the typed slices that
+/// [`create_plan`] now requires (carina#3179).
+///
+/// Virtuals are dropped — they are post-apply attribute containers and
+/// never participate in differ logic. Used by tests and other callers
+/// that still hold an unsorted `Vec<Resource>` while wiring/parser
+/// migration to typed inputs proceeds.
+pub fn split_resources_by_kind(
+    resources: &[Resource],
+) -> (
+    Vec<crate::resource::ManagedResource>,
+    Vec<crate::resource::DataSource>,
+) {
+    let mut managed = Vec::new();
+    let mut data_sources = Vec::new();
+    for r in resources {
+        if let Ok(ds) = crate::resource::DataSource::try_from(r) {
+            data_sources.push(ds);
+        } else if let Ok(m) = crate::resource::ManagedResource::try_from(r) {
+            managed.push(m);
+        }
+        // Virtuals are silently dropped by both `TryFrom` impls
+        // returning `Err(ResourceKindMismatch)`; the post-apply-only
+        // typestate invariant means they have no role here.
+    }
+    (managed, data_sources)
+}
+
 #[cfg(test)]
 mod cascade_tests;
 #[cfg(test)]

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -8,7 +8,8 @@ use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
 use crate::resource::{
-    ConcreteValue, DeferredValue, Directives, Resource, ResourceId, ResourceKind, State, Value,
+    ConcreteValue, DataSource, DeferredValue, Directives, ManagedResource, Resource, ResourceId,
+    ResourceKind, State, Value,
 };
 use crate::schema::{
     ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
@@ -143,9 +144,36 @@ fn generate_temporary_name(
 /// the user never wrote, refs awscc#206) and to detect attribute
 /// removals: if a top-level key was previously in the user's desired
 /// state but is now absent, it means the user intentionally removed it.
+///
+/// # Typestate invariants
+///
+/// Virtuals are intentionally not an input. The compile-fail doctest
+/// below pins that — passing a [`VirtualResource`](crate::resource::VirtualResource)
+/// slice must fail to type-check, so the post-apply-only virtual class
+/// (carina#3169) cannot accidentally reach pre-apply differ logic.
+///
+/// ```compile_fail
+/// use std::collections::{BTreeSet, HashMap};
+/// use carina_core::differ::create_plan;
+/// use carina_core::resource::VirtualResource;
+/// use carina_core::schema::SchemaRegistry;
+/// let virtuals: Vec<VirtualResource> = vec![];
+/// let _ = create_plan(
+///     &virtuals,
+///     &[],
+///     &HashMap::new(),
+///     &HashMap::new(),
+///     &SchemaRegistry::default(),
+///     &HashMap::new(),
+///     &HashMap::new(),
+///     &HashMap::new(),
+///     &[],
+/// );
+/// ```
 #[allow(clippy::too_many_arguments)]
 pub fn create_plan(
-    desired: &[Resource],
+    managed: &[ManagedResource],
+    data_sources: &[DataSource],
     current_states: &HashMap<ResourceId, State>,
     directives_map: &HashMap<ResourceId, Directives>,
     registry: &SchemaRegistry,
@@ -156,23 +184,29 @@ pub fn create_plan(
 ) -> Plan {
     let mut plan = Plan::new();
 
-    let desired_ids: std::collections::HashSet<&ResourceId> =
-        desired.iter().map(|r| &r.id).collect();
+    let desired_ids: std::collections::HashSet<&ResourceId> = managed
+        .iter()
+        .map(|r| &r.id)
+        .chain(data_sources.iter().map(|r| &r.id))
+        .collect();
 
-    for resource in desired {
-        // Skip virtual resources (module attribute containers)
-        if resource.is_virtual() {
-            continue;
-        }
+    // Data sources only generate Read effects; the typestate split
+    // routes them through their own slice so the legacy
+    // `if resource.is_data_source() { continue; }` runtime guard is no
+    // longer reachable from this loop (carina#3179).
+    for ds in data_sources {
+        plan.add(Effect::Read {
+            resource: Resource::from(ds),
+        });
+    }
 
-        // Data sources (read-only resources) only generate Read effects
-        if resource.is_data_source() {
-            plan.add(Effect::Read {
-                resource: resource.clone(),
-            });
-            continue;
-        }
-
+    for managed_res in managed {
+        // Bridge to the legacy `Resource` shape at the differ/effect
+        // seam. `Effect::Create | Update | Replace | Delete` still
+        // carries `Resource` over the saved-plan and provider WIT
+        // wire formats; flipping those payloads is deferred to a
+        // later cleanup (see #3181 design non-goals).
+        let resource: Resource = Resource::from(managed_res);
         let current = current_states
             .get(&resource.id)
             .cloned()
@@ -186,7 +220,7 @@ pub fn create_plan(
             SchemaKind::Managed,
         );
         let d = diff(
-            resource,
+            &resource,
             &current,
             saved,
             prev_explicit_for_resource,
@@ -305,7 +339,7 @@ pub fn create_plan(
                     .unwrap_or_default();
                 let directives = resource.directives.clone();
                 let binding = resource.binding.clone();
-                let dependencies = get_resource_dependencies(resource);
+                let dependencies = get_resource_dependencies(&resource);
                 let explicit_dependencies =
                     resource.directives.depends_on.iter().cloned().collect();
                 plan.add(Effect::Delete {
@@ -385,11 +419,33 @@ pub fn create_plan(
     // wait is skipped with a plan-level error so downstream resources
     // referencing the wait binding still fail loudly.
     for wb in wait_bindings {
-        let resolved = desired
+        // Wait targets resolve over managed + data-source bindings.
+        // Virtuals are post-apply attribute containers and don't carry
+        // `until`-pollable state, so excluding them (by construction
+        // via the typed-slice split) matches the runtime invariant.
+        let resolved = managed
             .iter()
             .find(|r| r.binding.as_deref() == Some(wb.target.as_str()))
-            .or_else(|| desired.iter().find(|r| r.id.name.as_str() == wb.target));
-        let Some(target_resource) = resolved else {
+            .map(|r| r.id.clone())
+            .or_else(|| {
+                data_sources
+                    .iter()
+                    .find(|r| r.binding.as_deref() == Some(wb.target.as_str()))
+                    .map(|r| r.id.clone())
+            })
+            .or_else(|| {
+                managed
+                    .iter()
+                    .find(|r| r.id.name.as_str() == wb.target)
+                    .map(|r| r.id.clone())
+            })
+            .or_else(|| {
+                data_sources
+                    .iter()
+                    .find(|r| r.id.name.as_str() == wb.target)
+                    .map(|r| r.id.clone())
+            });
+        let Some(target_id_resolved) = resolved else {
             plan.add_error(PlanError {
                 resource_id: ResourceId::new("__wait", wb.binding.as_str()),
                 message: format!(
@@ -412,13 +468,27 @@ pub fn create_plan(
         // (carina#3101). A genuinely pending consumer change still
         // produces the wait + its dependency edge (carina#3085 /
         // carina#3061 behavior preserved).
-        let gates_a_pending_change = desired.iter().any(|r| {
-            get_resource_dependencies(r).contains(wb.binding.as_str())
-                && plan
-                    .effects()
+        let gates_a_pending_change =
+            managed
+                .iter()
+                .map(|m| (&m.id, Resource::from(m)))
+                .any(|(id, r)| {
+                    get_resource_dependencies(&r).contains(wb.binding.as_str())
+                        && plan
+                            .effects()
+                            .iter()
+                            .any(|e| e.resource_id() == id && e.is_mutating())
+                })
+                || data_sources
                     .iter()
-                    .any(|e| e.resource_id() == &r.id && e.is_mutating())
-        });
+                    .map(|d| (&d.id, Resource::from(d)))
+                    .any(|(id, r)| {
+                        get_resource_dependencies(&r).contains(wb.binding.as_str())
+                            && plan
+                                .effects()
+                                .iter()
+                                .any(|e| e.resource_id() == id && e.is_mutating())
+                    });
         if !gates_a_pending_change {
             continue;
         }
@@ -432,7 +502,7 @@ pub fn create_plan(
             attr,
             value: wb.until_predicate.rhs.clone(),
         };
-        let target_id = target_resource.id.clone();
+        let target_id = target_id_resolved;
         // The target's identifier is only known at plan time if it
         // already exists in state. When the target is created/updated
         // in this same run it has no prior state, so the executor must
@@ -497,15 +567,22 @@ pub fn create_plan(
 /// `registry` provides attribute metadata to detect create-only attributes.
 pub fn cascade_dependent_updates(
     plan: &mut Plan,
-    unresolved_resources: &[Resource],
+    unresolved_managed: &[ManagedResource],
     current_states: &HashMap<ResourceId, State>,
     registry: &SchemaRegistry,
 ) {
+    // Bridge to legacy `Resource` once. `get_resource_dependencies` and
+    // the per-attribute `ResourceRef` walks downstream still consume
+    // `&Resource`; flipping them is out of scope for the differ-only
+    // pass that this function lives in (carina#3179).
+    let unresolved_resources: Vec<Resource> =
+        unresolved_managed.iter().map(Resource::from).collect();
+
     // Build binding/key -> unresolved resource mapping.
     // Uses the same key logic as the dependent lookup below so anonymous resources
     // (without _binding) are also found.
     let mut binding_to_unresolved: HashMap<String, &Resource> = HashMap::new();
-    for resource in unresolved_resources {
+    for resource in &unresolved_resources {
         let key = resource
             .binding
             .clone()
@@ -537,7 +614,7 @@ pub fn cascade_dependent_updates(
             .collect();
 
         if !all_replace_bindings.is_empty() {
-            for resource in unresolved_resources {
+            for resource in &unresolved_resources {
                 let deps = get_resource_dependencies(resource);
                 for dep in &deps {
                     if let Some(resource_id) = all_replace_bindings.get(dep) {
@@ -576,7 +653,7 @@ pub fn cascade_dependent_updates(
 
     // For each unresolved resource, check if it depends on a replaced binding.
     // Resources already in the plan are handled separately below.
-    for resource in unresolved_resources {
+    for resource in &unresolved_resources {
         if planned_ids.contains(&resource.id) {
             continue;
         }
@@ -599,7 +676,7 @@ pub fn cascade_dependent_updates(
     // attributes need to be merged into their existing effects.
     let mut merge_operations: Vec<CascadeMerge> = Vec::new();
 
-    for resource in unresolved_resources {
+    for resource in &unresolved_resources {
         if !planned_ids.contains(&resource.id) {
             continue;
         }

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -61,8 +61,10 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
             .with_name_attribute("bucket_name"),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -146,8 +148,10 @@ fn create_before_destroy_generates_temporary_name_with_can_rename() {
             .with_name_attribute("log_group_name"),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -213,8 +217,10 @@ fn no_temporary_name_without_create_before_destroy() {
             .with_name_attribute("bucket_name"),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -283,8 +289,10 @@ fn no_temporary_name_when_name_prefix_is_used() {
             .with_name_attribute("bucket_name"),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -337,8 +345,10 @@ fn no_temporary_name_without_name_attribute_in_schema() {
         // No name_attribute set
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -405,8 +415,10 @@ fn no_temporary_name_when_name_attribute_changes() {
             .with_name_attribute("bucket_name"),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -672,8 +684,10 @@ fn create_plan_detects_attribute_removal() {
         explicit_top_level(&["region", "tags"]),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -738,8 +752,10 @@ fn create_plan_filters_non_removable_attribute_removal() {
             )),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -807,8 +823,10 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
             .attribute(AttributeSchema::new("region", AttributeType::String).non_removable()),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -882,7 +900,8 @@ fn prevent_destroy_blocks_delete_for_orphaned_resource() {
     );
 
     let plan = create_plan(
-        &[], // no desired resources
+        &[],
+        &[],
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -945,8 +964,10 @@ fn prevent_destroy_blocks_replace() {
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -999,8 +1020,10 @@ fn prevent_destroy_does_not_block_update() {
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
     );
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1037,8 +1060,10 @@ fn prevent_destroy_does_not_block_create() {
 
     let resources = vec![resource];
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &HashMap::new(), // no current states (resource doesn't exist)
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1078,7 +1103,8 @@ fn without_prevent_destroy_delete_works_normally() {
     );
 
     let plan = create_plan(
-        &[], // no desired resources
+        &[],
+        &[],
         &current_states,
         &HashMap::new(), // no directives (default = prevent_destroy: false)
         &SchemaRegistry::new(),
@@ -1141,6 +1167,7 @@ fn prevent_destroy_collects_multiple_errors() {
 
     let plan = create_plan(
         &[],
+        &[],
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -1178,8 +1205,10 @@ fn virtual_resources_are_skipped_in_plan() {
 
     let resources = vec![virtual_resource, real_resource];
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &HashMap::new(),
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1228,8 +1257,10 @@ fn wait_binding_lowers_to_wait_effect() {
         line: 1,
     };
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &HashMap::new(),
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1313,8 +1344,10 @@ fn wait_uses_schema_default_timeout_when_omitted() {
         line: 1,
     };
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &HashMap::new(),
         &HashMap::new(),
         &schemas,
@@ -1356,8 +1389,10 @@ fn wait_with_unknown_target_emits_plan_error() {
         line: 1,
     };
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &HashMap::new(),
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1420,8 +1455,10 @@ fn wait_omitted_when_all_consumers_unchanged() {
         line: 1,
     };
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1470,8 +1507,10 @@ fn wait_emitted_when_a_consumer_has_a_pending_change() {
         line: 1,
     };
 
+    let (managed___, data_sources___) = crate::differ::split_resources_by_kind(&resources);
     let plan = create_plan(
-        &resources,
+        &managed___,
+        &data_sources___,
         &HashMap::new(),
         &HashMap::new(),
         &SchemaRegistry::new(),

--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -70,3 +70,29 @@ impl TryFrom<&Resource> for DataSource {
         }
     }
 }
+
+/// Transitional bridge — rebuild a legacy [`Resource`] from a
+/// `DataSource`. Symmetric with [`From<&ManagedResource> for Resource`]
+/// in `managed.rs`; removed alongside it when #3181 inline-merges
+/// `Resource` into the typestate structs.
+///
+/// `prefixes` is reconstructed empty — `DataSource` drops the field as a
+/// compile-time invariant (auto-generated names do not apply to
+/// read-only lookups), and a `Resource` synthesized from a `DataSource`
+/// only flows into `Effect::Read { resource }` whose downstream
+/// consumers (executor read path) do not read `prefixes`.
+impl From<&DataSource> for Resource {
+    fn from(d: &DataSource) -> Self {
+        Self {
+            id: d.id.clone(),
+            attributes: d.attributes.clone(),
+            kind: ResourceKind::DataSource,
+            directives: d.directives.clone(),
+            prefixes: std::collections::HashMap::new(),
+            binding: d.binding.clone(),
+            dependency_bindings: d.dependency_bindings.clone(),
+            module_source: d.module_source.clone(),
+            quoted_string_attrs: d.quoted_string_attrs.clone(),
+        }
+    }
+}

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -221,8 +221,11 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
     .expect("resolve_refs should succeed");
 
     let registry = SchemaRegistry::new();
+    let (managed___, data_sources___) =
+        carina_core::differ::split_resources_by_kind(&resources_for_plan);
     let plan = create_plan(
-        &resources_for_plan,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &registry,
@@ -348,8 +351,11 @@ async fn nested_module_wait_binding_survives_two_expansions() {
     .expect("resolve_refs should succeed");
 
     let registry = SchemaRegistry::new();
+    let (managed___, data_sources___) =
+        carina_core::differ::split_resources_by_kind(&resources_for_plan);
     let plan = create_plan(
-        &resources_for_plan,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &registry,
@@ -488,8 +494,11 @@ async fn carina3085_distribution_wait_ref_resolves_no_phantom_via_real_pipeline(
 
     // ---- The dependency edge is intact: Effect::Wait still emitted.
     let registry = SchemaRegistry::new();
+    let (managed___, data_sources___) =
+        carina_core::differ::split_resources_by_kind(&resources_for_plan);
     let plan = create_plan(
-        &resources_for_plan,
+        &managed___,
+        &data_sources___,
         &current_states,
         &HashMap::new(),
         &registry,


### PR DESCRIPTION
## Summary

Part 7 of the carina#3169 typestate split (design PR #3172). Routes the differ surface to typed inputs:

- `create_plan(managed: &[ManagedResource], data_sources: &[DataSource], ...)`
- `cascade_dependent_updates(plan, unresolved_managed: &[ManagedResource], ...)`

The two remaining runtime guards in `carina-core/src/differ/plan.rs` — `if resource.is_virtual() { continue; }` and `if resource.is_data_source() { ... Read; continue; }` — are gone. The compiler now refuses to feed virtuals through the differ at all. The data-source branch is no longer reachable from the managed loop; data sources iterate through their own slice.

The plan-tree display operates on `Effect`s and never read those guards, so the issue's "plan-tree builders" scope reduces to the differ-only migration.

## Wire format / scope

`Effect::{Create,Update,Replace,Read,Delete}` payloads still carry `Resource` — saved-plan format (`carina plan --out`) and the provider WIT protocol both serialize that shape, and the design doc lists those as out-of-scope for the typestate split. Each typed iteration therefore bridges back to `Resource` at the effect-construction seam via:

- existing `From<&ManagedResource> for Resource` (managed.rs)
- new `From<&DataSource> for Resource` (data_source.rs)

This keeps the wire format byte-identical with `main`; saved-plan snapshot tests and `make plan-fixtures` outputs are unchanged.

## Compile-fail invariant

A `compile_fail` doctest on `create_plan` pins the typestate invariant — passing `&[VirtualResource]` must fail to type-check:

```
test carina-core/src/differ/plan.rs - differ::plan::create_plan (line 154) - compile fail ... ok
```

## Caller-side helper

A workspace-level `differ::split_resources_by_kind(&[Resource]) -> (Vec<ManagedResource>, Vec<DataSource>)` routes the remaining `Vec<Resource>` callers (wiring/plan, apply, fixtures, tests) onto the typed inputs without spreading kind-routing logic across every call site. Virtuals are silently dropped (the post-apply-only invariant means they have no role in the differ).

`#3180` picks up the wiring / destroy / validation / data-source filter `is_virtual()` / `is_data_source()` migrations that live outside `differ/`.

## Test plan

- [x] `cargo nextest run --workspace` — 3510 passed, 0 failed
- [x] `cargo test --workspace --doc` — including the new compile-fail doctest
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all pass
- [x] `make plan-fixtures` — plan output unchanged

Refs #3169. Closes #3179. Leaves #3180 / #3181 open for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
