### PR TITLE
resource: hoist virtual module data off ResourceKind discriminant (refs #3181)

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1190,10 +1190,11 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
     // an expanded sub-resource.
     let mut virtual_resource = Resource::new("_virtual", "github_actions_carina");
     virtual_resource.binding = Some("github_actions_carina".to_string());
-    virtual_resource.kind = ResourceKind::Virtual {
-        module_name: "github_module".to_string(),
-        instance: "github_actions_carina".to_string(),
-    };
+    virtual_resource.kind = ResourceKind::Virtual;
+    virtual_resource.virtual_module = Some((
+        "github_module".to_string(),
+        "github_actions_carina".to_string(),
+    ));
     virtual_resource.attributes.insert(
         "role_arn".to_string(),
         Value::Deferred(DeferredValue::ResourceRef {
@@ -1274,10 +1275,8 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
 
     let mut inner_virtual = Resource::new("_virtual", "outer.inner");
     inner_virtual.binding = Some("outer.inner".to_string());
-    inner_virtual.kind = ResourceKind::Virtual {
-        module_name: "inner_module".to_string(),
-        instance: "outer.inner".to_string(),
-    };
+    inner_virtual.kind = ResourceKind::Virtual;
+    inner_virtual.virtual_module = Some(("inner_module".to_string(), "outer.inner".to_string()));
     inner_virtual.attributes.insert(
         "role_arn".to_string(),
         Value::Deferred(DeferredValue::ResourceRef {
@@ -1287,10 +1286,8 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
 
     let mut outer_virtual = Resource::new("_virtual", "outer");
     outer_virtual.binding = Some("outer".to_string());
-    outer_virtual.kind = ResourceKind::Virtual {
-        module_name: "outer_module".to_string(),
-        instance: "outer".to_string(),
-    };
+    outer_virtual.kind = ResourceKind::Virtual;
+    outer_virtual.virtual_module = Some(("outer_module".to_string(), "outer".to_string()));
     outer_virtual.attributes.insert(
         "public_role_arn".to_string(),
         Value::Deferred(DeferredValue::ResourceRef {
@@ -1432,10 +1429,9 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
 
     let mut virtual_resource = Resource::new("_virtual", "carina_module");
     virtual_resource.binding = Some("carina_module".to_string());
-    virtual_resource.kind = ResourceKind::Virtual {
-        module_name: "carina_module".to_string(),
-        instance: "carina_module".to_string(),
-    };
+    virtual_resource.kind = ResourceKind::Virtual;
+    virtual_resource.virtual_module =
+        Some(("carina_module".to_string(), "carina_module".to_string()));
     virtual_resource.attributes.insert(
         "role_arn".to_string(),
         Value::Deferred(DeferredValue::ResourceRef {

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -201,7 +201,7 @@ pub(crate) fn resolve_exports(
     let mut managed: Vec<ManagedResource> = Vec::with_capacity(sorted_resources.len());
     for r in sorted_resources {
         match r.kind {
-            ResourceKind::Virtual { .. } => {
+            ResourceKind::Virtual => {
                 // Virtuals come from `pre_resolve_virtuals` below.
                 continue;
             }
@@ -619,6 +619,7 @@ pub(crate) fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceI
         dependency_bindings: rs.dependency_bindings.clone(),
         module_source: None,
         quoted_string_attrs: std::collections::HashSet::new(),
+        virtual_module: None,
     }
 }
 

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -306,7 +306,7 @@ fn apply_path_propagates_module_wait_binding() {
         .collect();
     let virtual_r = parsed.resources.iter().any(|r| {
         r.binding.as_deref() == Some("r")
-            && matches!(r.kind, carina_core::resource::ResourceKind::Virtual { .. })
+            && matches!(r.kind, carina_core::resource::ResourceKind::Virtual)
     });
     // This assertion encodes the hypothesis. If it FAILS showing
     // binding="r", we've found the apply-path root cause: the nested

--- a/carina-core/src/binding_index_split_tests.rs
+++ b/carina-core/src/binding_index_split_tests.rs
@@ -184,15 +184,13 @@ fn virtual_as_resource(v: &VirtualResource) -> Resource {
     Resource {
         id: v.id.clone(),
         attributes: v.attributes.clone(),
-        kind: ResourceKind::Virtual {
-            module_name: v.module_name.clone(),
-            instance: v.instance.clone(),
-        },
+        kind: ResourceKind::Virtual,
         directives: Default::default(),
         prefixes: HashMap::new(),
         binding: v.binding.clone(),
         dependency_bindings: v.dependency_bindings.clone(),
         module_source: None,
         quoted_string_attrs: v.quoted_string_attrs.clone(),
+        virtual_module: Some((v.module_name.clone(), v.instance.clone())),
     }
 }

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -392,6 +392,7 @@ pub fn create_plan(
                     dependency_bindings: BTreeSet::new(),
                     module_source: None,
                     quoted_string_attrs: std::collections::HashSet::new(),
+                    virtual_module: None,
                 };
                 get_resource_dependencies(&temp_resource)
             };

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1188,10 +1188,9 @@ fn prevent_destroy_collects_multiple_errors() {
 #[test]
 fn virtual_resources_are_skipped_in_plan() {
     // Virtual resources (module attribute containers) should not generate any effects
-    let mut virtual_resource = Resource::new("_virtual", "web").with_kind(ResourceKind::Virtual {
-        module_name: "web_tier".to_string(),
-        instance: "web".to_string(),
-    });
+    let mut virtual_resource = Resource::new("_virtual", "web").with_kind(ResourceKind::Virtual);
+
+    virtual_resource.virtual_module = Some(("web_tier".to_string(), "web".to_string()));
     virtual_resource.binding = Some("web".to_string());
     virtual_resource.set_attr(
         "security_group".to_string(),

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -598,10 +598,9 @@ mod tests {
 
         let mut virt = Resource::with_provider("_virtual", "_virtual", "bootstrap", None);
         virt.binding = Some("bootstrap".to_string());
-        virt.kind = ResourceKind::Virtual {
-            module_name: "github-oidc".to_string(),
-            instance: "bootstrap".to_string(),
-        };
+        virt.kind = ResourceKind::Virtual;
+
+        virt.virtual_module = Some(("github-oidc".to_string(), "bootstrap".to_string()));
         virt.set_attr(
             "role_name",
             Value::resource_ref("bootstrap.role", "role_name", vec![]),

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1352,10 +1352,9 @@ mod tests {
 
         let mut virt = Resource::with_provider("_virtual", "_virtual", "bootstrap", None);
         virt.binding = Some("bootstrap".to_string());
-        virt.kind = ResourceKind::Virtual {
-            module_name: "github-oidc".to_string(),
-            instance: "bootstrap".to_string(),
-        };
+        virt.kind = ResourceKind::Virtual;
+
+        virt.virtual_module = Some(("github-oidc".to_string(), "bootstrap".to_string()));
         // The virtual exposes `role_name = role.role_name`, which after intra-module
         // rewriting becomes `bootstrap.role.role_name`.
         virt.set_attr(
@@ -1399,10 +1398,9 @@ mod tests {
 
         let mut inner_virt = Resource::with_provider("_virtual", "_virtual", "outer.inner", None);
         inner_virt.binding = Some("outer.inner".to_string());
-        inner_virt.kind = ResourceKind::Virtual {
-            module_name: "inner-mod".to_string(),
-            instance: "outer.inner".to_string(),
-        };
+        inner_virt.kind = ResourceKind::Virtual;
+
+        inner_virt.virtual_module = Some(("inner-mod".to_string(), "outer.inner".to_string()));
         inner_virt.set_attr(
             "role_name",
             Value::resource_ref("outer.inner.role", "role_name", vec![]),
@@ -1410,10 +1408,9 @@ mod tests {
 
         let mut outer_virt = Resource::with_provider("_virtual", "_virtual", "outer", None);
         outer_virt.binding = Some("outer".to_string());
-        outer_virt.kind = ResourceKind::Virtual {
-            module_name: "outer-mod".to_string(),
-            instance: "outer".to_string(),
-        };
+        outer_virt.kind = ResourceKind::Virtual;
+
+        outer_virt.virtual_module = Some(("outer-mod".to_string(), "outer".to_string()));
         outer_virt.set_attr(
             "role_name",
             Value::resource_ref("outer.inner", "role_name", vec![]),

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -251,16 +251,14 @@ impl ModuleResolver<'_> {
             let virtual_resource = Resource {
                 id: ResourceId::new("_virtual", binding_name),
                 attributes: virtual_attrs,
-                kind: ResourceKind::Virtual {
-                    module_name: call.module_name.clone(),
-                    instance: instance_prefix.to_string(),
-                },
+                kind: ResourceKind::Virtual,
                 directives: Directives::default(),
                 prefixes: HashMap::new(),
                 binding: Some(binding_name.clone()),
                 dependency_bindings: BTreeSet::new(),
                 module_source: None,
                 quoted_string_attrs: std::collections::HashSet::new(),
+                virtual_module: Some((call.module_name.clone(), instance_prefix.to_string())),
             };
             expanded_resources.push(virtual_resource);
         }

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -47,6 +47,7 @@ fn create_test_module() -> ParsedFile {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: std::collections::HashSet::new(),
+            virtual_module: None,
         }],
         variables: IndexMap::new(),
         uses: vec![],
@@ -153,6 +154,7 @@ fn create_test_module_with_anonymous_resource() -> ParsedFile {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: std::collections::HashSet::new(),
+            virtual_module: None,
         }],
         variables: IndexMap::new(),
         uses: vec![],
@@ -297,6 +299,7 @@ fn create_module_with_named_provider_instance() -> ParsedFile {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: std::collections::HashSet::new(),
+            virtual_module: None,
         }],
         variables: IndexMap::new(),
         uses: vec![],
@@ -397,6 +400,7 @@ fn test_reconcile_anonymous_module_instances_preserves_provider_instance() {
             instance: current_prefix.clone(),
         }),
         quoted_string_attrs: std::collections::HashSet::new(),
+        virtual_module: None,
     }];
 
     let state_lookup = |_: &str, _: &str| vec![state_name.clone()];
@@ -440,6 +444,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
                 dependency_bindings: BTreeSet::new(),
                 module_source: None,
                 quoted_string_attrs: std::collections::HashSet::new(),
+                virtual_module: None,
             },
             Resource {
                 id: ResourceId::new("ec2.Subnet", "sub"),
@@ -458,6 +463,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
                 dependency_bindings: BTreeSet::new(),
                 module_source: None,
                 quoted_string_attrs: std::collections::HashSet::new(),
+                virtual_module: None,
             },
         ],
         variables: IndexMap::new(),
@@ -601,6 +607,7 @@ fn create_module_with_attributes() -> ParsedFile {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: std::collections::HashSet::new(),
+            virtual_module: None,
         }],
         variables: IndexMap::new(),
         uses: vec![],
@@ -657,13 +664,11 @@ fn test_expand_module_call_creates_virtual_resource() {
         .expect("Virtual resource should exist");
 
     assert_eq!(virtual_res.binding, Some("web".to_string()));
-    // Module info should be in the kind, not in attributes
+    // Module info should be in the virtual_module field, not in attributes
+    assert_eq!(virtual_res.kind, ResourceKind::Virtual);
     assert_eq!(
-        virtual_res.kind,
-        ResourceKind::Virtual {
-            module_name: "web_tier".to_string(),
-            instance: "web".to_string(),
-        }
+        virtual_res.virtual_module,
+        Some(("web_tier".to_string(), "web".to_string()))
     );
     assert!(!virtual_res.attributes.contains_key("_module"));
     assert!(!virtual_res.attributes.contains_key("_module_instance"));
@@ -1297,6 +1302,7 @@ fn test_expand_module_call_propagates_and_prefixes_wait_bindings() {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: std::collections::HashSet::new(),
+            virtual_module: None,
         });
         m.wait_bindings.push(WaitBinding {
             binding: "cert_issued".into(),
@@ -1547,6 +1553,7 @@ fn create_module_with_interpolation() -> ParsedFile {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: std::collections::HashSet::new(),
+            virtual_module: None,
         }],
         variables: IndexMap::new(),
         uses: vec![],
@@ -4004,6 +4011,7 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: std::collections::HashSet::new(),
+            virtual_module: None,
         });
         m.deferred_for_expressions.push(DeferredForExpression {
             file: None,
@@ -4040,6 +4048,7 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
                 dependency_bindings: BTreeSet::new(),
                 module_source: None,
                 quoted_string_attrs: std::collections::HashSet::new(),
+                virtual_module: None,
             },
         });
         m
@@ -4166,6 +4175,7 @@ fn deferred_for_iterable_binding_not_prefixed_when_not_module_internal() {
                 dependency_bindings: BTreeSet::new(),
                 module_source: None,
                 quoted_string_attrs: std::collections::HashSet::new(),
+                virtual_module: None,
             },
         });
         m

--- a/carina-core/src/parser/blocks/resource.rs
+++ b/carina-core/src/parser/blocks/resource.rs
@@ -69,6 +69,7 @@ pub(in crate::parser) fn parse_anonymous_resource(
         dependency_bindings: BTreeSet::new(),
         module_source: None,
         quoted_string_attrs,
+        virtual_module: None,
     })
 }
 
@@ -241,6 +242,7 @@ pub(crate) fn parse_resource_expr(
         dependency_bindings: BTreeSet::new(),
         module_source: None,
         quoted_string_attrs,
+        virtual_module: None,
     })
 }
 
@@ -298,6 +300,7 @@ pub(crate) fn parse_read_resource_expr(
         dependency_bindings: BTreeSet::new(),
         module_source: None,
         quoted_string_attrs,
+        virtual_module: None,
     })
 }
 

--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -93,6 +93,7 @@ impl From<&DataSource> for Resource {
             dependency_bindings: d.dependency_bindings.clone(),
             module_source: d.module_source.clone(),
             quoted_string_attrs: d.quoted_string_attrs.clone(),
+            virtual_module: None,
         }
     }
 }

--- a/carina-core/src/resource/managed.rs
+++ b/carina-core/src/resource/managed.rs
@@ -92,7 +92,7 @@ impl ManagedResource {
     /// `ManagedResource`.
     pub fn as_managed_view(r: &Resource) -> Self {
         debug_assert!(
-            !matches!(r.kind, ResourceKind::Virtual { .. }),
+            !matches!(r.kind, ResourceKind::Virtual),
             "as_managed_view called on Virtual; route via VirtualResource::try_from",
         );
         Self {
@@ -124,6 +124,7 @@ impl From<&ManagedResource> for Resource {
             dependency_bindings: m.dependency_bindings.clone(),
             module_source: m.module_source.clone(),
             quoted_string_attrs: m.quoted_string_attrs.clone(),
+            virtual_module: None,
         }
     }
 }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1599,7 +1599,14 @@ impl ModuleSource {
     }
 }
 
-/// Classification of a resource in the IR
+/// Classification of a resource in the IR.
+///
+/// Carina#3181 (step 2) flattened `Virtual { module_name, instance }`
+/// to a bare variant; the (`module_name`, `instance`) pair now lives on
+/// the [`Resource`] struct as `virtual_module: Option<(String, String)>`.
+/// The discriminator stays load-bearing while [`Effect`] payloads carry
+/// `Resource` (next step); both go away when the full inline-merge
+/// lands.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum ResourceKind {
     /// A managed infrastructure resource with full CRUD lifecycle.
@@ -1607,10 +1614,9 @@ pub enum ResourceKind {
     Managed,
     /// A virtual resource created by the module resolver to expose module attributes.
     /// Virtual resources are not sent to providers; they exist only in the IR.
-    Virtual {
-        module_name: String,
-        instance: String,
-    },
+    /// Pair with `Resource::virtual_module` for the originating module
+    /// data.
+    Virtual,
     /// A data source (read-only) that is queried but not managed
     DataSource,
 }
@@ -1668,6 +1674,13 @@ pub struct Resource {
     /// Parse-time only; `#[serde(skip)]` keeps it out of state.
     #[serde(default, skip)]
     pub quoted_string_attrs: HashSet<String>,
+    /// For virtual resources, the `(module_name, instance)` data
+    /// previously encoded in `ResourceKind::Virtual { module_name,
+    /// instance }`. Hoisted to a struct field so the discriminant
+    /// can be flattened to a plain enum (carina#3181 step 1). Only
+    /// `Some` when `kind == ResourceKind::Virtual`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub virtual_module: Option<(String, String)>,
 }
 
 impl Resource {
@@ -1682,6 +1695,7 @@ impl Resource {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: HashSet::new(),
+            virtual_module: None,
         }
     }
 
@@ -1701,6 +1715,7 @@ impl Resource {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: HashSet::new(),
+            virtual_module: None,
         }
     }
 
@@ -1779,7 +1794,7 @@ impl Resource {
     /// `attributes` values as a structured record. They should not be sent to
     /// providers for reading, creating, or updating.
     pub fn is_virtual(&self) -> bool {
-        matches!(self.kind, ResourceKind::Virtual { .. })
+        matches!(self.kind, ResourceKind::Virtual)
     }
 }
 

--- a/carina-core/src/resource/resource_like_tests.rs
+++ b/carina-core/src/resource/resource_like_tests.rs
@@ -15,12 +15,17 @@ fn sample_value(s: &str) -> Value {
 
 fn make_resource(kind: ResourceKind) -> Resource {
     let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
-    Resource::new("aws.s3.Bucket", "b")
+    let is_virtual = matches!(kind, ResourceKind::Virtual);
+    let mut res = Resource::new("aws.s3.Bucket", "b")
         .with_kind(kind)
         .with_attribute("k", sample_value("v"))
         .with_binding("b")
         .with_dependency_bindings(deps)
-        .with_module_source(ModuleSource::module("m", "inst"))
+        .with_module_source(ModuleSource::module("m", "inst"));
+    if is_virtual {
+        res.virtual_module = Some(("m".into(), "inst".into()));
+    }
+    res
 }
 
 fn assert_resource_like<R: ResourceLike>(
@@ -62,10 +67,7 @@ fn managed_resource_implements_resource_like() {
 
 #[test]
 fn virtual_resource_implements_resource_like() {
-    let res = make_resource(ResourceKind::Virtual {
-        module_name: "m".into(),
-        instance: "inst".into(),
-    });
+    let res = make_resource(ResourceKind::Virtual);
     let v = VirtualResource::try_from(&res).expect("Virtual → VirtualResource");
     let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
     let expected_id = v.id.clone();
@@ -90,10 +92,9 @@ fn binding_none_covers_all_arms() {
     let managed = ManagedResource::try_from(&res_managed).expect("Managed → ManagedResource");
     assert_eq!(<ManagedResource as ResourceLike>::binding(&managed), None);
 
-    let res_virt = Resource::new("aws.s3.Bucket", "b").with_kind(ResourceKind::Virtual {
-        module_name: "m".into(),
-        instance: "i".into(),
-    });
+    let mut res_virt = Resource::new("aws.s3.Bucket", "b").with_kind(ResourceKind::Virtual);
+
+    res_virt.virtual_module = Some(("m".into(), "i".into()));
     let v = VirtualResource::try_from(&res_virt).expect("Virtual → VirtualResource");
     assert_eq!(<VirtualResource as ResourceLike>::binding(&v), None);
 
@@ -114,10 +115,7 @@ fn resource_like_supports_generic_dispatch() {
     let managed = ManagedResource::try_from(&res).expect("Managed → ManagedResource");
     assert_eq!(first_attribute_key(&managed), Some(&"k".to_string()));
 
-    let virt_src = make_resource(ResourceKind::Virtual {
-        module_name: "m".into(),
-        instance: "inst".into(),
-    });
+    let virt_src = make_resource(ResourceKind::Virtual);
     let v = VirtualResource::try_from(&virt_src).expect("Virtual → VirtualResource");
     assert_eq!(first_attribute_key(&v), Some(&"k".to_string()));
 

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -767,10 +767,9 @@ fn state_dependency_bindings_dedup_on_duplicate_insert() {
 
 #[test]
 fn resource_typed_virtual_field() {
-    let resource = Resource::new("_virtual", "web").with_kind(ResourceKind::Virtual {
-        module_name: "web_tier".to_string(),
-        instance: "web".to_string(),
-    });
+    let mut resource = Resource::new("_virtual", "web").with_kind(ResourceKind::Virtual);
+
+    resource.virtual_module = Some(("web_tier".to_string(), "web".to_string()));
     assert!(resource.is_virtual());
     // _virtual should NOT be in attributes
     assert!(!resource.attributes.contains_key("_virtual"));
@@ -794,25 +793,21 @@ fn resource_kind_enum_managed_by_default() {
 
 #[test]
 fn resource_kind_enum_virtual_carries_module_info() {
-    let resource = Resource::new("_virtual", "web").with_kind(ResourceKind::Virtual {
-        module_name: "web_tier".to_string(),
-        instance: "web".to_string(),
-    });
+    let mut resource = Resource::new("_virtual", "web").with_kind(ResourceKind::Virtual);
+
+    resource.virtual_module = Some(("web_tier".to_string(), "web".to_string()));
     assert!(resource.is_virtual());
     assert!(!resource.is_data_source());
-    // Module info is in the kind, not in attributes
+    // Module info is in the virtual_module field, not in attributes
     assert!(!resource.attributes.contains_key("_module"));
     assert!(!resource.attributes.contains_key("_module_instance"));
-    // Can extract module info from the kind
-    match &resource.kind {
-        ResourceKind::Virtual {
-            module_name,
-            instance,
-        } => {
+    // Can extract module info from the virtual_module field
+    match &resource.virtual_module {
+        Some((module_name, instance)) => {
             assert_eq!(module_name, "web_tier");
             assert_eq!(instance, "web");
         }
-        _ => panic!("Expected Virtual kind"),
+        None => panic!("Expected virtual_module to be set"),
     }
 }
 

--- a/carina-core/src/resource/typestate_tests.rs
+++ b/carina-core/src/resource/typestate_tests.rs
@@ -22,6 +22,7 @@ fn sample_value(s: &str) -> Value {
 /// are written in-place after construction.
 fn make_resource(kind: ResourceKind) -> Resource {
     let deps: BTreeSet<String> = ["dep_binding".into()].into_iter().collect();
+    let is_virtual = matches!(kind, ResourceKind::Virtual);
 
     let mut res = Resource::new("aws.s3.Bucket", "b")
         .with_kind(kind)
@@ -29,6 +30,9 @@ fn make_resource(kind: ResourceKind) -> Resource {
         .with_binding("b")
         .with_dependency_bindings(deps)
         .with_module_source(ModuleSource::module("m", "inst"));
+    if is_virtual {
+        res.virtual_module = Some(("my_module".into(), "my_instance".into()));
+    }
 
     res.directives = Directives {
         force_delete: true,
@@ -57,10 +61,7 @@ fn managed_resource_carries_full_managed_field_set() {
 
 #[test]
 fn virtual_resource_flattens_module_name_and_instance_drops_directives_and_prefixes() {
-    let res = make_resource(ResourceKind::Virtual {
-        module_name: "my_module".into(),
-        instance: "my_instance".into(),
-    });
+    let res = make_resource(ResourceKind::Virtual);
     let v = VirtualResource::try_from(&res).expect("Virtual → VirtualResource");
 
     assert_eq!(v.id, res.id);
@@ -88,10 +89,7 @@ fn data_source_carries_directives_and_module_source_drops_prefixes() {
 
 #[test]
 fn try_from_rejects_kind_mismatch_for_managed() {
-    let virt = make_resource(ResourceKind::Virtual {
-        module_name: "m".into(),
-        instance: "i".into(),
-    });
+    let virt = make_resource(ResourceKind::Virtual);
     let err = ManagedResource::try_from(&virt).expect_err("Virtual must not convert to Managed");
     assert_eq!(err.expected, ResourceKindLabel::Managed);
     assert_eq!(err.actual, ResourceKindLabel::Virtual);
@@ -124,10 +122,7 @@ fn try_from_rejects_kind_mismatch_for_data_source() {
     assert_eq!(err.expected, ResourceKindLabel::DataSource);
     assert_eq!(err.actual, ResourceKindLabel::Managed);
 
-    let virt = make_resource(ResourceKind::Virtual {
-        module_name: "m".into(),
-        instance: "i".into(),
-    });
+    let virt = make_resource(ResourceKind::Virtual);
     let err = DataSource::try_from(&virt).expect_err("Virtual must not convert to DataSource");
     assert_eq!(err.expected, ResourceKindLabel::DataSource);
     assert_eq!(err.actual, ResourceKindLabel::Virtual);
@@ -156,14 +151,7 @@ fn resource_kind_label_display_round_trip() {
 #[test]
 fn resource_kind_projects_to_label_dropping_payload() {
     assert_eq!(ResourceKind::Managed.label(), ResourceKindLabel::Managed);
-    assert_eq!(
-        ResourceKind::Virtual {
-            module_name: "m".into(),
-            instance: "i".into(),
-        }
-        .label(),
-        ResourceKindLabel::Virtual,
-    );
+    assert_eq!(ResourceKind::Virtual.label(), ResourceKindLabel::Virtual,);
     assert_eq!(
         ResourceKind::DataSource.label(),
         ResourceKindLabel::DataSource,

--- a/carina-core/src/resource/virtual_resource.rs
+++ b/carina-core/src/resource/virtual_resource.rs
@@ -79,11 +79,8 @@ impl TryFrom<&Resource> for VirtualResource {
     type Error = ResourceKindMismatch;
 
     fn try_from(res: &Resource) -> Result<Self, Self::Error> {
-        match &res.kind {
-            ResourceKind::Virtual {
-                module_name,
-                instance,
-            } => Ok(Self {
+        match (&res.kind, &res.virtual_module) {
+            (ResourceKind::Virtual, Some((module_name, instance))) => Ok(Self {
                 id: res.id.clone(),
                 attributes: res.attributes.clone(),
                 binding: res.binding.clone(),
@@ -92,7 +89,13 @@ impl TryFrom<&Resource> for VirtualResource {
                 instance: instance.clone(),
                 quoted_string_attrs: res.quoted_string_attrs.clone(),
             }),
-            other => Err(ResourceKindMismatch {
+            (ResourceKind::Virtual, None) => Err(ResourceKindMismatch {
+                // Inconsistent: kind says Virtual but virtual_module is None.
+                // Treat as the kind label mismatch since the data is missing.
+                expected: ResourceKindLabel::Virtual,
+                actual: ResourceKindLabel::Virtual,
+            }),
+            (other, _) => Err(ResourceKindMismatch {
                 expected: ResourceKindLabel::Virtual,
                 actual: other.label(),
             }),

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -1329,10 +1329,12 @@ mod tests {
         // points at the inner role's schema attribute.
         let mut virt = crate::resource::Resource::new("_virtual", "github_actions_carina");
         virt.binding = Some("github_actions_carina".to_string());
-        virt.kind = ResourceKind::Virtual {
-            module_name: "github_module".to_string(),
-            instance: "github_actions_carina".to_string(),
-        };
+        virt.kind = ResourceKind::Virtual;
+
+        virt.virtual_module = Some((
+            "github_module".to_string(),
+            "github_actions_carina".to_string(),
+        ));
         virt.attributes.insert(
             "role_id".to_string(),
             Value::resource_ref(

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -3384,6 +3384,7 @@ mod tests {
             dependency_bindings: BTreeSet::new(),
             module_source: None,
             quoted_string_attrs: HashSet::new(),
+            virtual_module: None,
         }
     }
 


### PR DESCRIPTION
## Summary

First increment of the carina#3181 final typestate cleanup (tracker for the 9/9 step of carina#3169).

`ResourceKind::Virtual` previously carried `{ module_name, instance }` inside the enum discriminant. This PR flattens that to a bare `ResourceKind::Virtual` variant and hoists the pair to a new `Resource::virtual_module: Option<(String, String)>` field.

## Why

`#3181`'s end goal is to delete the `kind` field entirely and inline-merge `Resource` into `ManagedResource`. That deletion is blocked by the discriminant carrying associated data — the virtual module metadata has to live *somewhere* that isn't the kind tag before the tag can be removed. This PR does exactly that decoupling, as the first reviewable slice.

## Changes

- `ResourceKind::Virtual { module_name, instance }` → `ResourceKind::Virtual` (unit variant).
- New `Resource::virtual_module: Option<(String, String)>` field (`#[serde(default, skip_serializing_if = "Option::is_none")]` — managed/data-source resources never emit it, old saved plans deserialize unchanged).
- `module_resolver::expander` now writes `virtual_module` when minting virtual resources.
- `VirtualResource::try_from(&Resource)` reads `virtual_module` instead of the enum payload.
- Test fixtures and `make_resource` helpers updated to seed `virtual_module` for virtual-kind resources.

## Scope

This is **step 1 of a multi-PR sequence** for #3181. Remaining (follow-up PRs):

- Flip `Effect` payloads (`Create`/`Update`/`Replace` → `ManagedResource`, `Read` → `DataSource`).
- Split `ParsedFile.resources` into typed slices so the `kind` field can be deleted outright.
- Rename `Resource` → `ManagedResource`, delete the `kind` field, `ResourceKind` enum, and the transitional `From`/`split_resources_by_kind` bridges.

`#3181` stays open as the tracker; it closes when the final rename PR lands.

## Test plan

- [x] `cargo nextest run --workspace` — 3510 passed
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all pass

Refs #3181, #3169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
