### PR TITLE
resource: delete as_managed_view, inline get_for kind dispatch (refs #3181)

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -139,7 +139,7 @@ pub(crate) struct FinalizeApplyInput<'a> {
 /// 1. Build `post_apply_states` from `state.resources` (managed
 ///    resources' applied attributes).
 /// 2. Split `sorted_resources` into a managed view (Managed +
-///    DataSource collapsed via [`ManagedResource::as_managed_view`])
+///    DataSource collapsed onto `ManagedResource` by field projection)
 ///    and a virtual view ([`VirtualResource::try_from`]).
 /// 3. Build the bindings view from the managed slice via
 ///    [`ResolvedBindings::from_managed_with_state`] (#3176).
@@ -196,8 +196,8 @@ pub(crate) fn resolve_exports(
     // onto a `ManagedResource` view because the binding index only
     // cares about (binding name, attribute map, state merge) —
     // DataSources share that shape with managed resources. See
-    // `ManagedResource::as_managed_view` for the rationale and the
-    // `Virtual must not pass through here` invariant.
+    // The `Virtual must not pass through here` invariant holds because
+    // the `match` routes `Virtual` to its own branch above.
     let mut managed: Vec<ManagedResource> = Vec::with_capacity(sorted_resources.len());
     for r in sorted_resources {
         match r.kind {
@@ -206,7 +206,20 @@ pub(crate) fn resolve_exports(
                 continue;
             }
             ResourceKind::Managed | ResourceKind::DataSource => {
-                managed.push(ManagedResource::as_managed_view(r));
+                // DataSources are collapsed onto a `ManagedResource`
+                // view: the binding index only cares about
+                // (binding name, attribute map, state merge), a shape
+                // DataSources share with managed resources.
+                managed.push(ManagedResource {
+                    id: r.id.clone(),
+                    attributes: r.attributes.clone(),
+                    directives: r.directives.clone(),
+                    prefixes: r.prefixes.clone(),
+                    binding: r.binding.clone(),
+                    dependency_bindings: r.dependency_bindings.clone(),
+                    module_source: r.module_source.clone(),
+                    quoted_string_attrs: r.quoted_string_attrs.clone(),
+                });
             }
         }
     }

--- a/carina-core/src/resource/managed.rs
+++ b/carina-core/src/resource/managed.rs
@@ -64,50 +64,6 @@ impl TryFrom<&Resource> for ManagedResource {
     }
 }
 
-impl ManagedResource {
-    /// Project a legacy [`Resource`] onto a `ManagedResource` view
-    /// **regardless of `kind`**, discarding the discriminant.
-    ///
-    /// Unlike the strict [`TryFrom<&Resource>`] impl above, this
-    /// helper does not check `kind`. It exists for one specific
-    /// caller (`carina-cli`'s `resolve_exports`) where the
-    /// bindings-index construction needs to treat
-    /// `ResourceKind::DataSource` as having the same attribute /
-    /// state shape as a managed resource: the binding index only
-    /// indexes by `binding` name + attribute map, and DataSources
-    /// participate in that lookup just like Managed resources do.
-    /// Routing both through the same `ManagedResource` view keeps
-    /// the binding-index API single-typed without forcing the
-    /// caller to spread `match kind` across the bridge.
-    ///
-    /// `Virtual` resources must **not** be passed here — the
-    /// caller has already split them out (the typestate invariant
-    /// that virtuals are post-apply-only forbids them participating
-    /// in the pre-apply / managed binding view). Passing a virtual
-    /// drops it to a Managed view, which would re-introduce the
-    /// class of bug #3169 fixed. Callers that observe a virtual
-    /// must route it through [`VirtualResource::try_from`] instead.
-    ///
-    /// Removed when #3181 inline-merges `Resource` into
-    /// `ManagedResource`.
-    pub fn as_managed_view(r: &Resource) -> Self {
-        debug_assert!(
-            !matches!(r.kind, ResourceKind::Virtual),
-            "as_managed_view called on Virtual; route via VirtualResource::try_from",
-        );
-        Self {
-            id: r.id.clone(),
-            attributes: r.attributes.clone(),
-            directives: r.directives.clone(),
-            prefixes: r.prefixes.clone(),
-            binding: r.binding.clone(),
-            dependency_bindings: r.dependency_bindings.clone(),
-            module_source: r.module_source.clone(),
-            quoted_string_attrs: r.quoted_string_attrs.clone(),
-        }
-    }
-}
-
 /// Transitional bridge — rebuild a legacy [`Resource`] from a
 /// `ManagedResource`. Co-located with the reverse `TryFrom<&Resource>`
 /// impl above so #3181 can remove both directions in one place when

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -3336,10 +3336,9 @@ impl SchemaRegistry {
     /// `Managed` entry for normal resources and the `DataSource` entry for
     /// `read`-keyword resources (`ResourceKind::DataSource`).
     pub fn get_for(&self, resource: &crate::resource::Resource) -> Option<&ResourceSchema> {
-        let kind = if resource.is_data_source() {
-            SchemaKind::DataSource
-        } else {
-            SchemaKind::Managed
+        let kind = match resource.kind {
+            crate::resource::ResourceKind::DataSource => SchemaKind::DataSource,
+            _ => SchemaKind::Managed,
         };
         self.get(&resource.id.provider, &resource.id.resource_type, kind)
     }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -331,7 +331,7 @@ impl DiagnosticEngine {
                 if let Some(schema) = &schema {
                     // Check data source without `read` keyword
                     if schema.is_data_source()
-                        && !resource.is_data_source()
+                        && carina_core::resource::DataSource::try_from(resource).is_err()
                         && let Some((line, col)) = self.find_resource_type_position(
                             doc,
                             provider,


### PR DESCRIPTION
## Summary

Second increment toward carina#3181. Removes the `ManagedResource::as_managed_view` transitional helper now that its sole production caller can field-project directly, and inlines the `kind` dispatch in `SchemaRegistry::get_for` so the `Resource::is_data_source()` accessor is no longer needed there.

## Changes

- Delete `ManagedResource::as_managed_view` — its one production caller (`state_writeback`'s managed-view collapse) now constructs `ManagedResource` by direct field projection, with the `Virtual must not pass here` invariant upheld by the enclosing `match` arm.
- `SchemaRegistry::get_for` matches `resource.kind` directly instead of going through `Resource::is_data_source()`.
- `carina-lsp` data-source diagnostic uses `DataSource::try_from(resource).is_err()` instead of `!resource.is_data_source()`.

## Scope

Incremental cleanup on the path to deleting the `kind` field. The field itself, the `ResourceKind` enum, and the `Resource`→`ManagedResource` inline-merge remain — those require restructuring `ParsedFile.resources` from a heterogeneous `Vec<Resource>` into typed slices (parser-phase change touching ~247 consumer sites + the saved-plan wire format), tracked under #3181.

## Test plan

- [x] `cargo nextest run --workspace` — 3510 passed
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all pass

Refs #3181, #3169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
