### PR TITLE
parser: add typed data_sources/virtual_resources slices to ParsedFile (#3181 PR A)

### DIFF
--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -727,6 +727,8 @@ fn test_find_state_bucket_resource_matching_type() {
                 Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
             ),
         ],
+        data_sources: vec![],
+        virtual_resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],
         module_calls: vec![],

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -328,6 +328,8 @@ pub(crate) fn merge_parsed_file<E>(target: &mut File<E>, source: File<E>) {
     let File {
         providers,
         resources,
+        data_sources,
+        virtual_resources,
         variables,
         uses,
         module_calls,
@@ -347,6 +349,8 @@ pub(crate) fn merge_parsed_file<E>(target: &mut File<E>, source: File<E>) {
 
     target.providers.extend(providers);
     target.resources.extend(resources);
+    target.data_sources.extend(data_sources);
+    target.virtual_resources.extend(virtual_resources);
     target.variables.extend(variables);
     target.uses.extend(uses);
     target.module_calls.extend(module_calls);

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -9,8 +9,8 @@ use crate::parser::{
     ArgumentParameter, BindingName, DeferredForExpression, ModuleCall, ParsedFile, WaitBinding,
 };
 use crate::resource::{
-    ConcreteValue, DeferredValue, Directives, Resource, ResourceId, ResourceKind, ResourceName,
-    Value,
+    ConcreteValue, DataSource, DeferredValue, Directives, Resource, ResourceId, ResourceKind,
+    ResourceName, Value, VirtualResource,
 };
 
 use super::error::ModuleError;
@@ -292,6 +292,23 @@ impl ModuleResolver<'_> {
             })
             .collect();
 
+        // carina#3181 PR A: project the expanded resources into the
+        // typed `data_sources` / `virtual_resources` slices in parallel
+        // with the legacy `resources` Vec. A module instance contributes
+        // both managed resources and exactly one `_virtual` attribute
+        // resource (built above); a module may also declare data
+        // sources. `expanded_resources` keeps every resource so current
+        // consumers are untouched; PR B migrates them onto the typed
+        // slices.
+        let data_sources: Vec<DataSource> = expanded_resources
+            .iter()
+            .filter_map(|r| r.try_into().ok())
+            .collect();
+        let virtual_resources: Vec<VirtualResource> = expanded_resources
+            .iter()
+            .filter_map(|r| r.try_into().ok())
+            .collect();
+
         // The contribution is a full `ParsedFile` built with an
         // **exhaustive struct literal** (no `..Default::default()`):
         // adding a `File<E>` field breaks this until someone decides
@@ -301,6 +318,8 @@ impl ModuleResolver<'_> {
         Ok(ParsedFile {
             // Populated from the module, instance-prefixed:
             resources: expanded_resources,
+            data_sources,
+            virtual_resources,
             wait_bindings: expanded_wait_bindings,
             deferred_for_expressions: expanded_deferred_for_expressions,
 

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -20,6 +20,8 @@ use crate::resource::{
 fn create_test_module() -> ParsedFile {
     ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![Resource {
             id: ResourceId::new("security_group", "sg"),
             attributes: {
@@ -137,6 +139,8 @@ fn test_substitute_arguments_nested() {
 fn create_test_module_with_anonymous_resource() -> ParsedFile {
     ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![Resource {
             id: ResourceId::with_provider("awscc", "iam.RolePolicy", "", None),
             attributes: {
@@ -279,6 +283,8 @@ fn test_expand_module_call() {
 fn create_module_with_named_provider_instance() -> ParsedFile {
     ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![Resource {
             id: ResourceId::with_provider("aws", "acm.Certificate", "cert", Some("us".to_string())),
             attributes: {
@@ -424,6 +430,8 @@ fn test_reconcile_anonymous_module_instances_preserves_provider_instance() {
 fn create_module_with_intra_refs() -> ParsedFile {
     ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![
             Resource {
                 id: ResourceId::new("ec2.Vpc", "main_vpc"),
@@ -586,6 +594,8 @@ fn create_module_with_attributes() -> ParsedFile {
 
     ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![Resource {
             id: ResourceId::new("security_group", "sg"),
             attributes: {
@@ -682,6 +692,54 @@ fn test_expand_module_call_creates_virtual_resource() {
             vec![]
         ))
     );
+}
+
+/// carina#3181 PR A: module-call expansion projects the synthetic
+/// virtual resource into the typed `virtual_resources` slice in
+/// parallel with the legacy `resources` Vec (duplicate storage during
+/// the typestate migration).
+#[test]
+fn test_expand_module_call_populates_virtual_resources_slice() {
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules
+            .insert("web_tier".to_string(), create_module_with_attributes());
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "web_tier".to_string(),
+        binding_name: Some("web".to_string()),
+        arguments: HashMap::new(),
+    };
+
+    let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
+
+    // Legacy mixed Vec still holds the managed + virtual resources.
+    assert_eq!(expanded.resources.len(), 2);
+
+    // The typed slice holds only the virtual resource, matching the
+    // corresponding legacy entry.
+    assert_eq!(expanded.virtual_resources.len(), 1);
+    assert_eq!(
+        expanded.virtual_resources[0].binding,
+        Some("web".to_string())
+    );
+    assert_eq!(expanded.virtual_resources[0].module_name, "web_tier");
+    assert_eq!(expanded.virtual_resources[0].instance, "web");
+    let legacy_virtual = expanded
+        .resources
+        .iter()
+        .find(|r| r.is_virtual())
+        .expect("legacy resources still contains the virtual resource");
+    assert_eq!(expanded.virtual_resources[0].id, legacy_virtual.id);
+    assert_eq!(
+        expanded.virtual_resources[0].attributes,
+        legacy_virtual.attributes
+    );
+
+    // This module declares no data sources.
+    assert!(expanded.data_sources.is_empty());
 }
 
 #[test]
@@ -1519,6 +1577,8 @@ fn create_module_with_interpolation() -> ParsedFile {
 
     ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![Resource {
             id: ResourceId::new("ec2.Vpc", "vpc"),
             attributes: {
@@ -1885,6 +1945,8 @@ fn create_module_with_port_validation() -> ParsedFile {
     use crate::parser::{CompareOp, ValidateExpr, ValidationBlock};
     ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],
@@ -2068,6 +2130,8 @@ fn test_argument_validation_no_message_uses_default() {
     use crate::parser::{CompareOp, ValidateExpr, ValidationBlock};
     let module = ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],
@@ -2131,6 +2195,8 @@ fn test_argument_validation_len_with_list() {
     use crate::parser::{CompareOp, ValidateExpr, ValidationBlock};
     let module = ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],
@@ -2216,6 +2282,8 @@ fn test_require_block_passes() {
     use crate::parser::{CompareOp, RequireBlock, ValidateExpr};
     let module = ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],
@@ -2297,6 +2365,8 @@ fn test_require_block_fails_with_not_expr() {
     use crate::parser::{RequireBlock, ValidateExpr};
     let module = ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],
@@ -2377,6 +2447,8 @@ fn test_require_block_len_function() {
     use crate::parser::{CompareOp, RequireBlock, ValidateExpr};
     let module = ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],
@@ -2466,6 +2538,8 @@ fn test_require_block_multiple_constraints() {
     use crate::parser::{CompareOp, RequireBlock, ValidateExpr};
     let module = ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],
@@ -3768,6 +3842,8 @@ let prod = outer {
 fn create_module_with_environment_union() -> ParsedFile {
     ParsedFile {
         providers: vec![],
+        data_sources: vec![],
+        virtual_resources: vec![],
         resources: vec![],
         variables: IndexMap::new(),
         uses: vec![],

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -7,7 +7,10 @@ use super::expressions::for_expr::ForBinding;
 use super::expressions::validate_expr::CompareOp;
 use super::util::snake_to_pascal;
 use crate::binding_index::IterableBindings;
-use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, UnknownReason, Value};
+use crate::resource::{
+    ConcreteValue, DataSource, DeferredValue, Resource, ResourceId, UnknownReason, Value,
+    VirtualResource,
+};
 use crate::version_constraint::VersionConstraint;
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
@@ -665,7 +668,27 @@ impl ExportParamLike for InferredExportParam {
 #[derive(Debug, Clone)]
 pub struct File<E> {
     pub providers: Vec<ProviderConfig>,
+    /// Heterogeneous resource collection (managed + virtual + data
+    /// source mixed), discriminated by `Resource::kind`.
+    ///
+    /// **Transitional (carina#3181 PR A):** the typestate split is
+    /// migrating consumers off this mixed `Vec` onto the typed
+    /// [`data_sources`](Self::data_sources) /
+    /// [`virtual_resources`](Self::virtual_resources) slices. While the
+    /// migration is in flight every resource is stored **twice**: once
+    /// here (legacy readers) and once in the matching typed slice. PR B
+    /// makes this field managed-only once all legacy readers are gone.
     pub resources: Vec<Resource>,
+    /// Read-only data-source resources (`read`-keyword resources).
+    ///
+    /// **Transitional (carina#3181 PR A):** populated in parallel with
+    /// `resources`; no consumer reads it yet (PR B migrates them).
+    pub data_sources: Vec<DataSource>,
+    /// Virtual resources synthesized by module-call expansion.
+    ///
+    /// **Transitional (carina#3181 PR A):** populated in parallel with
+    /// `resources`; no consumer reads it yet (PR B migrates them).
+    pub virtual_resources: Vec<VirtualResource>,
     pub variables: IndexMap<String, Value>,
     /// Module `use` statements
     pub uses: Vec<UseStatement>,
@@ -711,6 +734,8 @@ impl<E> Default for File<E> {
         Self {
             providers: Vec::new(),
             resources: Vec::new(),
+            data_sources: Vec::new(),
+            virtual_resources: Vec::new(),
             variables: IndexMap::new(),
             uses: Vec::new(),
             module_calls: Vec::new(),
@@ -748,6 +773,8 @@ impl<E> File<E> {
         let File {
             providers,
             resources,
+            data_sources,
+            virtual_resources,
             variables,
             uses,
             module_calls,
@@ -768,6 +795,8 @@ impl<E> File<E> {
         File {
             providers,
             resources,
+            data_sources,
+            virtual_resources,
             variables,
             uses,
             module_calls,

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -27,7 +27,7 @@ use super::resolve::{
     resolve_resource_refs,
 };
 use crate::eval_value::EvalValue;
-use crate::resource::{DeferredValue, Resource, Value};
+use crate::resource::{DataSource, DeferredValue, Resource, Value};
 use indexmap::IndexMap;
 use pest::Parser;
 
@@ -363,9 +363,21 @@ pub fn parse_with_seeded_bindings(
         })
         .collect();
 
+    // carina#3181 PR A: project the read-keyword resources into the
+    // typed `data_sources` slice in parallel with the legacy `resources`
+    // Vec. `resources` keeps every resource (managed + data source) so
+    // current consumers are untouched; PR B migrates them onto the typed
+    // slices and makes `resources` managed-only.
+    let data_sources: Vec<DataSource> =
+        resources.iter().filter_map(|r| r.try_into().ok()).collect();
+
     Ok(ParsedFile {
         providers,
         resources,
+        data_sources,
+        // Virtual resources are synthesized by module-call expansion,
+        // not the parser — left empty here, populated in `expander.rs`.
+        virtual_resources: Vec::new(),
         variables,
         uses,
         module_calls,

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -6423,6 +6423,51 @@ fn parse_let_discard_read_resource() {
     );
 }
 
+/// carina#3181 PR A: the parser projects `read`-keyword resources into
+/// the typed `data_sources` slice in parallel with the legacy
+/// `resources` Vec (duplicate storage during the typestate migration).
+#[test]
+fn parse_populates_data_sources_slice_in_parallel() {
+    let input = r#"
+        provider aws {
+            region = aws.Region.ap_northeast_1
+        }
+
+        let _ = read aws.sts.caller_identity {}
+
+        let bucket = aws.s3.Bucket {
+            bucket = "my-bucket"
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+
+    // Legacy mixed Vec still holds both resources.
+    assert_eq!(result.resources.len(), 2);
+
+    // The typed slice holds only the read-keyword resource, and its
+    // contents match the corresponding legacy entry.
+    assert_eq!(result.data_sources.len(), 1);
+    assert_eq!(
+        result.data_sources[0].id.resource_type,
+        "sts.caller_identity"
+    );
+    let legacy_data_source = result
+        .resources
+        .iter()
+        .find(|r| r.kind == crate::resource::ResourceKind::DataSource)
+        .expect("legacy resources still contains the data source");
+    assert_eq!(result.data_sources[0].id, legacy_data_source.id);
+    assert_eq!(
+        result.data_sources[0].attributes,
+        legacy_data_source.attributes
+    );
+
+    // The parser never synthesizes virtual resources — that is the
+    // module expander's job.
+    assert!(result.virtual_resources.is_empty());
+}
+
 #[test]
 fn parse_upstream_state_registers_binding() {
     // After parsing upstream_state, the binding should be registered so that

--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -11,6 +11,7 @@
 use std::collections::{BTreeSet, HashSet};
 
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 
 use super::{
     Directives, ModuleSource, Resource, ResourceId, ResourceKind, ResourceKindLabel,
@@ -30,22 +31,28 @@ use super::{
 ///     &d.prefixes
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DataSource {
     pub id: ResourceId,
     /// Source-order preserving map of attribute name → expression.
     pub attributes: IndexMap<String, Value>,
     /// `directives` meta-argument block — `depends_on` and
     /// `provider_instance` are meaningful for data sources too.
+    #[serde(default)]
     pub directives: Directives,
     /// Binding name from `let` bindings in DSL.
+    #[serde(default)]
     pub binding: Option<String>,
     /// Binding names this data source depends on.
+    #[serde(default)]
     pub dependency_bindings: BTreeSet<String>,
     /// Module source info for data sources from modules.
+    #[serde(default)]
     pub module_source: Option<ModuleSource>,
     /// Parser-level: attributes whose value was written as a quoted
-    /// string literal.
+    /// string literal. Parse-time only; `#[serde(skip)]` keeps it out
+    /// of state — mirrors [`Resource::quoted_string_attrs`].
+    #[serde(default, skip)]
     pub quoted_string_attrs: HashSet<String>,
 }
 

--- a/carina-core/src/resource/virtual_resource.rs
+++ b/carina-core/src/resource/virtual_resource.rs
@@ -17,6 +17,7 @@
 use std::collections::{BTreeSet, HashSet};
 
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 
 use super::{Resource, ResourceId, ResourceKind, ResourceKindLabel, ResourceKindMismatch, Value};
 
@@ -55,15 +56,17 @@ use super::{Resource, ResourceId, ResourceKind, ResourceKindLabel, ResourceKindM
 ///     &v.module_source
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VirtualResource {
     pub id: ResourceId,
     /// Attributes that may contain unresolved `ResourceRef` /
     /// `BindingRef` values. Resolution is deferred until post-apply.
     pub attributes: IndexMap<String, Value>,
     /// Binding name from `let` bindings in DSL.
+    #[serde(default)]
     pub binding: Option<String>,
     /// Binding names this virtual depends on.
+    #[serde(default)]
     pub dependency_bindings: BTreeSet<String>,
     /// Module name from the originating `ResourceKind::Virtual` tag
     /// (e.g. "web_tier"). Always set for virtuals — see #2516.
@@ -71,7 +74,9 @@ pub struct VirtualResource {
     /// Module instance binding name (e.g. "web").
     pub instance: String,
     /// Parser-level: attributes whose value was written as a quoted
-    /// string literal.
+    /// string literal. Parse-time only; `#[serde(skip)]` keeps it out
+    /// of state — mirrors [`Resource::quoted_string_attrs`].
+    #[serde(default, skip)]
     pub quoted_string_attrs: HashSet<String>,
 }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -7,6 +7,8 @@ fn empty_parsed() -> ParsedFile {
     ParsedFile {
         providers: Vec::new(),
         resources: Vec::new(),
+        data_sources: Vec::new(),
+        virtual_resources: Vec::new(),
         variables: IndexMap::new(),
         uses: Vec::new(),
         module_calls: Vec::new(),


### PR DESCRIPTION
## Summary

First step of the carina#3181 5-PR series (A→E) that deletes the
`Resource::kind` discriminant — the 9/9 final step of the #3169
resource typestate split.

`File<E>` (`ParsedFile`) now carries two **typed** resource slices
alongside the legacy heterogeneous `resources: Vec<Resource>`:

- `data_sources: Vec<DataSource>` — `read`-keyword resources
- `virtual_resources: Vec<VirtualResource>` — module-expansion virtuals

The parser populates `data_sources`, and the module expander populates
`virtual_resources`, **in parallel with** the legacy `resources` Vec.
This is deliberate duplicate storage: every resource is stored twice
while the typestate migration is in flight, so the diff cannot break
any of the ~247 consumers of `iter_all_resources` / `parsed.resources`.
PR B migrates those consumers onto the typed slices and makes
`resources` managed-only.

## Why a 5-PR series

Deleting `kind` outright forces splitting `ParsedFile.resources` into
typed slices, which changes `iter_all_resources`'s return type and
breaks ~247 consumer sites simultaneously — there is no intermediate
compiling state. The series keeps `kind` until the last PR and migrates
consumers first, so every PR compiles green and is independently
mergeable. PR A is the pure-addition enabler.

## Changes

- Add `data_sources` / `virtual_resources` fields to `File<E>`.
- Parser projects `read`-keyword resources into `data_sources`.
- Module expander projects the synthetic virtual into `virtual_resources`.
- `DataSource` / `VirtualResource` gain `Serialize` / `Deserialize`
  derives (needed once `Effect` payloads carry the typed structs in PR D).
- Thread the two new fields through the exhaustive `File<E>` struct
  literals: `map_export_params`, `merge_parsed_file`, `expand_module_call`.

## Test plan

- [x] `cargo nextest run --workspace` — 3512 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] `make plan-fixtures`
- [x] New tests: `parse_populates_data_sources_slice_in_parallel`,
  `test_expand_module_call_populates_virtual_resources_slice` — assert the
  typed slices match the legacy `resources` entries.

Refs #3181

🤖 Generated with [Claude Code](https://claude.com/claude-code)