### PR TITLE
parser: yield typed ResourceRef from iter_all_resources (#3181 PR B)

### DIFF
--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -8,7 +8,7 @@ use carina_core::config_loader::{
     find_crn_files_in_dir, get_base_dir, load_configuration_with_config,
 };
 use carina_core::lint::find_duplicate_attrs;
-use carina_core::parser::{File, ProviderContext, ResourceContext, UpstreamState};
+use carina_core::parser::{File, ProviderContext, ResourceRef, UpstreamState};
 use carina_core::resource::{ResourceId, ResourceName};
 
 use super::validate_and_resolve_errors;
@@ -223,18 +223,23 @@ impl std::fmt::Display for ValidatedEntry<'_> {
 fn validated_entries<E>(parsed: &File<E>) -> Vec<ValidatedEntry<'_>> {
     parsed
         .iter_all_resources()
-        .map(|(ctx, resource)| match ctx {
-            ResourceContext::Direct => match resource.id.name {
-                ResourceName::Bound(_) => ValidatedEntry::Resolved(&resource.id),
-                ResourceName::Pending => ValidatedEntry::PendingDirect(&resource.id),
-            },
-            ResourceContext::Deferred(d) => ValidatedEntry::DeferredLoop {
+        .map(|rref| match rref {
+            ResourceRef::Deferred { deferred: d, .. } => ValidatedEntry::DeferredLoop {
                 resource_type: &d.resource_type,
                 binding_name: &d.binding_name,
                 header: &d.header,
                 file: d.file.as_deref(),
                 line: d.line,
             },
+            // Managed / Virtual / DataSource — all direct, classified
+            // by whether the id has a resolved name.
+            other => {
+                let id = other.id();
+                match id.name {
+                    ResourceName::Bound(_) => ValidatedEntry::Resolved(id),
+                    ResourceName::Pending => ValidatedEntry::PendingDirect(id),
+                }
+            }
         })
         .collect()
 }

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -8,8 +8,8 @@ use super::expressions::validate_expr::CompareOp;
 use super::util::snake_to_pascal;
 use crate::binding_index::IterableBindings;
 use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, Resource, ResourceId, UnknownReason, Value,
-    VirtualResource,
+    ConcreteValue, DataSource, DeferredValue, Directives, Resource, ResourceId, ResourceKind,
+    ResourceLike, UnknownReason, Value, VirtualResource,
 };
 use crate::version_constraint::VersionConstraint;
 use indexmap::IndexMap;
@@ -58,6 +58,136 @@ pub struct DeferredForExpression {
 pub enum ResourceContext<'a> {
     Direct,
     Deferred(&'a DeferredForExpression),
+}
+
+/// A resource yielded by [`File::iter_all_resources`], discriminated by
+/// its typestate arm.
+///
+/// Part of the carina#3181 resource typestate split. The three typed
+/// arms borrow from `File`'s typed slices ([`File::resources`] managed
+/// rows, [`File::virtual_resources`], [`File::data_sources`]); the
+/// `Deferred` arm is a `for`-expression template body that still lives
+/// as a legacy [`Resource`] in [`File::deferred_for_expressions`].
+///
+/// Read-only consumers reach the shared accessors via
+/// [`ResourceRef::as_resource_like`] (or the `id` / `attributes` /
+/// `binding` passthroughs); callers that still branch on the kind use
+/// [`ResourceRef::kind`].
+#[derive(Debug, Clone, Copy)]
+pub enum ResourceRef<'a> {
+    /// A top-level managed resource.
+    Managed(&'a Resource),
+    /// A top-level virtual resource (module-expansion synthetic node).
+    Virtual(&'a VirtualResource),
+    /// A top-level data source (`read`-keyword resource).
+    DataSource(&'a DataSource),
+    /// The template body of a deferred `for` expression. Still a legacy
+    /// [`Resource`]; classify with [`ResourceRef::kind`] if needed.
+    Deferred {
+        resource: &'a Resource,
+        deferred: &'a DeferredForExpression,
+    },
+}
+
+impl<'a> ResourceRef<'a> {
+    /// View as the shared read-only trait — covers `id` / `attributes` /
+    /// `binding` / `dependency_bindings` for every arm.
+    pub fn as_resource_like(&self) -> &dyn ResourceLike {
+        match self {
+            ResourceRef::Managed(r) => *r,
+            ResourceRef::Virtual(v) => *v,
+            ResourceRef::DataSource(d) => *d,
+            ResourceRef::Deferred { resource, .. } => *resource,
+        }
+    }
+
+    /// Stable identifier of this resource.
+    pub fn id(&self) -> &'a ResourceId {
+        match self {
+            ResourceRef::Managed(r) => &r.id,
+            ResourceRef::Virtual(v) => &v.id,
+            ResourceRef::DataSource(d) => &d.id,
+            ResourceRef::Deferred { resource, .. } => &resource.id,
+        }
+    }
+
+    /// Source-order preserving attribute map.
+    pub fn attributes(&self) -> &'a IndexMap<String, Value> {
+        match self {
+            ResourceRef::Managed(r) => &r.attributes,
+            ResourceRef::Virtual(v) => &v.attributes,
+            ResourceRef::DataSource(d) => &d.attributes,
+            ResourceRef::Deferred { resource, .. } => &resource.attributes,
+        }
+    }
+
+    /// `let` binding name if any.
+    pub fn binding(&self) -> Option<&'a str> {
+        match self {
+            ResourceRef::Managed(r) => r.binding.as_deref(),
+            ResourceRef::Virtual(v) => v.binding.as_deref(),
+            ResourceRef::DataSource(d) => d.binding.as_deref(),
+            ResourceRef::Deferred { resource, .. } => resource.binding.as_deref(),
+        }
+    }
+
+    /// Classification of this resource. The `Deferred` arm reports the
+    /// template body's own `kind`.
+    pub fn kind(&self) -> ResourceKind {
+        match self {
+            ResourceRef::Managed(_) => ResourceKind::Managed,
+            ResourceRef::Virtual(_) => ResourceKind::Virtual,
+            ResourceRef::DataSource(_) => ResourceKind::DataSource,
+            ResourceRef::Deferred { resource, .. } => resource.kind.clone(),
+        }
+    }
+
+    /// `directives` meta-argument block. [`VirtualResource`] drops the
+    /// field (no `prevent_destroy` on a synthetic node) — returns `None`
+    /// for the `Virtual` arm.
+    pub fn directives(&self) -> Option<&'a Directives> {
+        match self {
+            ResourceRef::Managed(r) => Some(&r.directives),
+            ResourceRef::Virtual(_) => None,
+            ResourceRef::DataSource(d) => Some(&d.directives),
+            ResourceRef::Deferred { resource, .. } => Some(&resource.directives),
+        }
+    }
+
+    /// Parser-level set of attributes written as quoted string literals.
+    pub fn quoted_string_attrs(&self) -> &'a HashSet<String> {
+        match self {
+            ResourceRef::Managed(r) => &r.quoted_string_attrs,
+            ResourceRef::Virtual(v) => &v.quoted_string_attrs,
+            ResourceRef::DataSource(d) => &d.quoted_string_attrs,
+            ResourceRef::Deferred { resource, .. } => &resource.quoted_string_attrs,
+        }
+    }
+
+    /// The [`ResourceContext`] an old `iter_all_resources` caller would
+    /// have seen — `Deferred` for a for-expression template, `Direct`
+    /// otherwise.
+    pub fn context(&self) -> ResourceContext<'a> {
+        match self {
+            ResourceRef::Deferred { deferred, .. } => ResourceContext::Deferred(deferred),
+            _ => ResourceContext::Direct,
+        }
+    }
+
+    /// Bridge to the legacy [`Resource`] shape for APIs not yet
+    /// typestate-aware (`SchemaRegistry::get_for`,
+    /// `Resource::resolved_attributes`). Borrows for the `Managed` /
+    /// `Deferred` arms; rebuilds via the `From<&VirtualResource>` /
+    /// `From<&DataSource>` bridges for the other two. Removed in #3181
+    /// PR E alongside those bridges.
+    pub fn as_legacy_resource(&self) -> std::borrow::Cow<'a, Resource> {
+        match self {
+            ResourceRef::Managed(r) => std::borrow::Cow::Borrowed(r),
+            ResourceRef::Deferred { resource, .. } => std::borrow::Cow::Borrowed(resource),
+            ResourceRef::Virtual(v) => std::borrow::Cow::Owned(Resource::from(*v)),
+            ResourceRef::DataSource(d) => std::borrow::Cow::Owned(Resource::from(*d)),
+        }
+    }
 }
 
 /// Resource type path for typed references (e.g., aws.vpc, aws.security_group)
@@ -815,23 +945,38 @@ impl<E> File<E> {
         }
     }
 
-    /// Iterate every resource reachable from the parsed file — both
-    /// top-level `resources` and the `template_resource` of each deferred
-    /// for-expression — tagged with its origin context.
+    /// Iterate every resource reachable from the parsed file — the
+    /// top-level managed resources, virtual resources, data sources, and
+    /// the `template_resource` of each deferred for-expression — each
+    /// wrapped in a typed [`ResourceRef`].
     ///
     /// Per-attribute checkers (type, enum, required, ref validity, etc.)
     /// should prefer this over `self.resources.iter()` so they stay in sync
     /// with for-body code. See
     /// `notes/specs/2026-04-19-unify-resource-walk-design.md` for the
     /// rationale.
-    pub fn iter_all_resources(&self) -> impl Iterator<Item = (ResourceContext<'_>, &Resource)> {
+    ///
+    /// **carina#3181 PR B:** the managed arm filters `self.resources` to
+    /// `ResourceKind::Managed` rows. While the typestate migration is in
+    /// flight `resources` still holds virtual + data-source rows too (the
+    /// PR A duplicate storage); the filter keeps each resource yielded
+    /// exactly once — virtuals and data sources come from their typed
+    /// slices instead. PR C makes `resources` managed-only and drops the
+    /// filter.
+    pub fn iter_all_resources(&self) -> impl Iterator<Item = ResourceRef<'_>> {
         self.resources
             .iter()
-            .map(|r| (ResourceContext::Direct, r))
+            .filter(|r| matches!(r.kind, ResourceKind::Managed))
+            .map(ResourceRef::Managed)
+            .chain(self.virtual_resources.iter().map(ResourceRef::Virtual))
+            .chain(self.data_sources.iter().map(ResourceRef::DataSource))
             .chain(
                 self.deferred_for_expressions
                     .iter()
-                    .map(|d| (ResourceContext::Deferred(d), &d.template_resource)),
+                    .map(|d| ResourceRef::Deferred {
+                        resource: &d.template_resource,
+                        deferred: d,
+                    }),
             )
     }
 
@@ -992,6 +1137,19 @@ impl<E> File<E> {
             self.deferred_for_expressions.remove(idx);
         }
 
+        // carina#3181 PR A/B duplicate-storage invariant: every resource
+        // lives both in the legacy `resources` Vec and in its typed slice.
+        // Expansion happens after the parser's initial projection, so
+        // project the freshly expanded for-body resources into the typed
+        // slices here too — otherwise an expanded `read` for-body would be
+        // dropped by `iter_all_resources`'s managed-only filter.
+        for resource in &expanded_resources {
+            if let Ok(ds) = DataSource::try_from(resource) {
+                self.data_sources.push(ds);
+            } else if let Ok(vr) = VirtualResource::try_from(resource) {
+                self.virtual_resources.push(vr);
+            }
+        }
         self.resources.extend(expanded_resources);
         self.warnings.extend(new_warnings);
     }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -19,9 +19,9 @@ mod util;
 pub use ast::{
     ArgumentParameter, AttributeParameter, BackendConfig, BindingName, DeferredForExpression,
     ExportParamLike, ExportParameter, File, FnParam, InferredExportParam, InferredFile, ModuleCall,
-    ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock, ResourceContext, ResourceTypePath,
-    StateBlock, TypeExpr, UntilPredicateAst, UpstreamState, UseStatement, UserFunction,
-    UserFunctionBody, ValidateExpr, ValidationBlock, WaitBinding,
+    ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock, ResourceContext, ResourceRef,
+    ResourceTypePath, StateBlock, TypeExpr, UntilPredicateAst, UpstreamState, UseStatement,
+    UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock, WaitBinding,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub(crate) use entry::parse_with_seeded_bindings;

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -71,15 +71,61 @@ fn iter_all_resources_yields_direct_then_deferred() {
     let items: Vec<_> = parsed.iter_all_resources().collect();
     assert_eq!(items.len(), 2, "expected one direct + one deferred");
 
-    assert!(matches!(items[0].0, ResourceContext::Direct));
+    // The direct managed resource comes first.
+    assert!(matches!(items[0], ResourceRef::Managed(_)));
+    assert!(matches!(items[0].context(), ResourceContext::Direct));
     assert_eq!(
-        items[0].1.get_attr("name"),
+        items[0].attributes().get("name"),
         Some(&Value::Concrete(ConcreteValue::String(
             "direct".to_string()
         )))
     );
 
-    assert!(matches!(items[1].0, ResourceContext::Deferred(_)));
+    // The for-expression template body comes last as a Deferred arm.
+    assert!(matches!(items[1], ResourceRef::Deferred { .. }));
+    assert!(matches!(items[1].context(), ResourceContext::Deferred(_)));
+}
+
+/// carina#3181 PR B: `iter_all_resources` yields each resource exactly
+/// once with the correct typed arm. While `resources` still holds
+/// data-source rows too (PR A duplicate storage), the managed-only
+/// filter must keep a `read` resource from being double-counted as both
+/// `Managed` and `DataSource`.
+#[test]
+fn iter_all_resources_classifies_managed_and_data_source_arms() {
+    let src = r#"
+        provider aws {
+            region = aws.Region.ap_northeast_1
+        }
+        let bucket = aws.s3.Bucket {
+            bucket = "my-bucket"
+        }
+        let _ = read aws.sts.caller_identity {}
+    "#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+
+    let items: Vec<_> = parsed.iter_all_resources().collect();
+    // Exactly one managed + one data source — the `read` resource must
+    // NOT also appear as a `Managed` arm.
+    assert_eq!(items.len(), 2, "expected one managed + one data source");
+
+    let managed: Vec<_> = items
+        .iter()
+        .filter(|r| matches!(r, ResourceRef::Managed(_)))
+        .collect();
+    let data_sources: Vec<_> = items
+        .iter()
+        .filter(|r| matches!(r, ResourceRef::DataSource(_)))
+        .collect();
+    assert_eq!(managed.len(), 1);
+    assert_eq!(data_sources.len(), 1);
+    assert_eq!(managed[0].id().resource_type, "s3.Bucket");
+    assert_eq!(data_sources[0].id().resource_type, "sts.caller_identity");
+    assert_eq!(managed[0].kind(), crate::resource::ResourceKind::Managed);
+    assert_eq!(
+        data_sources[0].kind(),
+        crate::resource::ResourceKind::DataSource
+    );
 }
 
 #[test]

--- a/carina-core/src/resource/virtual_resource.rs
+++ b/carina-core/src/resource/virtual_resource.rs
@@ -107,3 +107,30 @@ impl TryFrom<&Resource> for VirtualResource {
         }
     }
 }
+
+/// Transitional bridge — rebuild a legacy [`Resource`] from a
+/// `VirtualResource`. Symmetric with [`From<&ManagedResource> for Resource`]
+/// in `managed.rs` and [`From<&DataSource> for Resource`] in
+/// `data_source.rs`; removed alongside them when #3181 inline-merges
+/// `Resource` into the typestate structs.
+///
+/// `directives` / `prefixes` are reconstructed empty — `VirtualResource`
+/// drops both fields as compile-time invariants (no `prevent_destroy` and
+/// no auto-generated names apply to a synthetic node). The flattened
+/// `module_name` + `instance` pair is restored into `virtual_module`.
+impl From<&VirtualResource> for Resource {
+    fn from(v: &VirtualResource) -> Self {
+        Self {
+            id: v.id.clone(),
+            attributes: v.attributes.clone(),
+            kind: ResourceKind::Virtual,
+            directives: super::Directives::default(),
+            prefixes: std::collections::HashMap::new(),
+            binding: v.binding.clone(),
+            dependency_bindings: v.dependency_bindings.clone(),
+            module_source: None,
+            quoted_string_attrs: v.quoted_string_attrs.clone(),
+            virtual_module: Some((v.module_name.clone(), v.instance.clone())),
+        }
+    }
+}

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::config_loader::{find_crn_files_in_dir, parse_directory};
-use crate::parser::{ProviderContext, ResourceContext, TypeExpr, UpstreamState};
+use crate::parser::{ProviderContext, ResourceContext, ResourceRef, TypeExpr, UpstreamState};
 use crate::resource::{ConcreteValue, DeferredValue, Subscript, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
@@ -285,35 +285,35 @@ pub fn resolve_upstream_exports_with_schemas(
 /// `for-body` prefix when the resource is a deferred-for template.
 /// Three checks emit the same string; centralized here so a future
 /// tweak to the wording lands in one place.
-fn resource_attr_location(
-    ctx: ResourceContext<'_>,
-    resource: &crate::resource::Resource,
-    attr_name: &str,
-) -> String {
-    match ctx {
-        ResourceContext::Direct => format!("{} attribute `{}`", resource.id, attr_name),
-        ResourceContext::Deferred(d) => format!(
-            "for-body `{}` {} attribute `{}`",
-            d.header, resource.id, attr_name
-        ),
+fn resource_attr_location(rref: ResourceRef<'_>, attr_name: &str) -> String {
+    match rref.context() {
+        ResourceContext::Direct => format!("{} attribute `{}`", rref.id(), attr_name),
+        ResourceContext::Deferred(d) => {
+            format!(
+                "for-body `{}` {} attribute `{}`",
+                d.header,
+                rref.id(),
+                attr_name
+            )
+        }
     }
 }
 
-/// Walk every resource attribute in the project (Direct + deferred-for
-/// templates), yielding `(ResourceContext, &Resource, attr_name, &Value)`
-/// for each non-internal attribute (skips `_*` keys). Used by all three
-/// upstream-ref checks; centralized so the iter_all_resources walk and
-/// the `_*` skip are written once.
+/// Walk every resource attribute in the project (managed, virtual, data
+/// source, and deferred-for templates), yielding
+/// `(ResourceRef, attr_name, &Value)` for each non-internal attribute
+/// (skips `_*` keys). Used by all upstream-ref checks; centralized so the
+/// `iter_all_resources` walk and the `_*` skip are written once.
 fn for_each_resource_attr<E, F>(parsed: &crate::parser::File<E>, mut f: F)
 where
-    F: FnMut(ResourceContext<'_>, &crate::resource::Resource, &str, &Value),
+    F: FnMut(ResourceRef<'_>, &str, &Value),
 {
-    for (ctx, resource) in parsed.iter_all_resources() {
-        for (attr_name, value) in resource.attributes.iter() {
+    for rref in parsed.iter_all_resources() {
+        for (attr_name, value) in rref.attributes().iter() {
             if attr_name.starts_with('_') {
                 continue;
             }
-            f(ctx, resource, attr_name, value);
+            f(rref, attr_name, value);
         }
     }
 }
@@ -430,8 +430,8 @@ pub fn check_upstream_state_field_references<E: crate::parser::ExportParamLike>(
         // one walk via `iter_all_resources` (helper). Location strings
         // use the `ResourceContext::Deferred` branch to mention the for
         // header so users can tell body errors from top-level ones.
-        for_each_resource_attr(parsed, |ctx, resource, attr_name, value| {
-            check(value, &resource_attr_location(ctx, resource, attr_name));
+        for_each_resource_attr(parsed, |rref, attr_name, value| {
+            check(value, &resource_attr_location(rref, attr_name));
         });
         for_each_non_resource_value(parsed, NonResourceScope::All, |value, location| {
             check(value, location);
@@ -536,14 +536,15 @@ pub fn check_upstream_state_field_types<E>(
     registry: &SchemaRegistry,
 ) -> Vec<UpstreamTypeError> {
     let mut errors: Vec<UpstreamTypeError> = Vec::new();
-    for_each_resource_attr(parsed, |ctx, resource, attr_name, value| {
-        let Some(schema) = registry.get_for(resource) else {
+    for_each_resource_attr(parsed, |rref, attr_name, value| {
+        let resource = rref.as_legacy_resource();
+        let Some(schema) = registry.get_for(resource.as_ref()) else {
             return;
         };
         let Some(attr_schema) = schema.attributes.get(attr_name) else {
             return;
         };
-        let location = resource_attr_location(ctx, resource, attr_name);
+        let location = resource_attr_location(rref, attr_name);
         check_ref_against_type(
             value,
             &attr_schema.attr_type,
@@ -1020,11 +1021,11 @@ pub fn check_upstream_state_attribute_access_shapes<E: crate::parser::ExportPara
     exports: &UpstreamExports,
 ) -> Vec<UpstreamAttributeAccessShapeError> {
     let mut errors: Vec<UpstreamAttributeAccessShapeError> = Vec::new();
-    for_each_resource_attr(parsed, |ctx, resource, attr_name, value| {
+    for_each_resource_attr(parsed, |rref, attr_name, value| {
         visit_attribute_access(
             value,
             exports,
-            &resource_attr_location(ctx, resource, attr_name),
+            &resource_attr_location(rref, attr_name),
             &mut errors,
         );
     });
@@ -1184,11 +1185,11 @@ pub fn check_upstream_state_subscript_shapes<E: crate::parser::ExportParamLike>(
     exports: &UpstreamExports,
 ) -> Vec<UpstreamSubscriptShapeError> {
     let mut errors: Vec<UpstreamSubscriptShapeError> = Vec::new();
-    for_each_resource_attr(parsed, |ctx, resource, attr_name, value| {
+    for_each_resource_attr(parsed, |rref, attr_name, value| {
         visit_subscript_access(
             value,
             exports,
-            &resource_attr_location(ctx, resource, attr_name),
+            &resource_attr_location(rref, attr_name),
             &mut errors,
         );
     });

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -73,11 +73,12 @@ pub fn validate_deferred_populate_refs<E>(
     // Walks both top-level resources and for-expression bodies so a
     // chained ref inside a `for` body still finds its target binding.
     let mut by_binding: HashMap<String, (String, String)> = HashMap::new();
-    for (_, r) in parsed.iter_all_resources() {
-        if let Some(b) = &r.binding {
+    for rref in parsed.iter_all_resources() {
+        if let Some(b) = rref.binding() {
+            let id = rref.id();
             by_binding.insert(
-                b.clone(),
-                (r.id.provider.clone(), r.id.resource_type.clone()),
+                b.to_string(),
+                (id.provider.clone(), id.resource_type.clone()),
             );
         }
     }
@@ -95,12 +96,12 @@ pub fn validate_deferred_populate_refs<E>(
         .collect();
 
     let mut out: Vec<DeferredPopulateDiagnostic> = Vec::new();
-    for (_, r) in parsed.iter_all_resources() {
-        for (key, value) in &r.attributes {
+    for rref in parsed.iter_all_resources() {
+        for (key, value) in rref.attributes() {
             collect_unsynchronized_refs(
                 value,
                 key,
-                r.binding.as_deref(),
+                rref.binding(),
                 &by_binding,
                 &synchronized,
                 schemas,

--- a/carina-core/src/validation/depends_on.rs
+++ b/carina-core/src/validation/depends_on.rs
@@ -14,8 +14,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::deps::sort_resources_by_dependencies;
-use crate::parser::File;
-use crate::resource::{Resource, ResourceKind};
+use crate::parser::{File, ResourceRef};
+use crate::resource::ResourceKind;
 use crate::validation::{collect_dot_notation_refs, collect_resource_refs};
 
 /// Severity of a depends_on diagnostic.
@@ -73,6 +73,15 @@ impl DependsOnDiagnostic {
     }
 }
 
+/// The `directives.depends_on` list of a resource, or an empty slice.
+///
+/// `VirtualResource` carries no directives — [`ResourceRef::directives`]
+/// is `None` for that arm, treated here as an empty `depends_on` list.
+fn depends_on_of<'a>(rref: ResourceRef<'a>) -> &'a [String] {
+    rref.directives()
+        .map_or(&[][..], |d| d.depends_on.as_slice())
+}
+
 /// Run all depends_on checks against a parsed file. Returns the full
 /// list of diagnostics (errors + warnings); callers decide how to surface
 /// them.
@@ -83,16 +92,16 @@ pub fn validate_depends_on<E>(parsed: &File<E>) -> Vec<DependsOnDiagnostic> {
     // (per the carina-core "directory-scoped, never single-file" rule).
     if parsed
         .iter_all_resources()
-        .all(|(_, r)| r.directives.depends_on.is_empty())
+        .all(|rref| depends_on_of(rref).is_empty())
     {
         return Vec::new();
     }
 
     let mut diags = Vec::new();
 
-    let bindings_by_name: HashMap<&str, &Resource> = parsed
+    let bindings_by_name: HashMap<&str, ResourceRef<'_>> = parsed
         .iter_all_resources()
-        .filter_map(|(_, r)| r.binding.as_deref().map(|n| (n, r)))
+        .filter_map(|rref| rref.binding().map(|n| (n, rref)))
         .collect();
     let upstream_names: HashSet<&str> = parsed
         .upstream_states
@@ -100,27 +109,28 @@ pub fn validate_depends_on<E>(parsed: &File<E>) -> Vec<DependsOnDiagnostic> {
         .map(|us| us.binding.as_str())
         .collect();
 
-    for (_, resource) in parsed.iter_all_resources() {
-        if resource.directives.depends_on.is_empty() {
+    for resource in parsed.iter_all_resources() {
+        let depends_on = depends_on_of(resource);
+        if depends_on.is_empty() {
             continue;
         }
         // `self_name` is only needed for self-reference detection; an
         // anonymous resource cannot self-reference (no name to point
         // back to), so an unbound resource just gets the other checks.
-        let self_name = resource.binding.as_deref().unwrap_or("(anonymous)");
+        let self_name = resource.binding().unwrap_or("(anonymous)");
 
         let mut value_ref_deps: HashSet<String> = HashSet::new();
-        for value in resource.attributes.values() {
+        for value in resource.attributes().values() {
             collect_resource_refs(value, &mut value_ref_deps);
             collect_dot_notation_refs(value, &mut value_ref_deps);
         }
-        for name in &resource.dependency_bindings {
+        for name in resource.as_resource_like().dependency_bindings() {
             value_ref_deps.insert(name.clone());
         }
 
         let mut seen: HashSet<&str> = HashSet::new();
         let mut duplicate_warned: HashSet<&str> = HashSet::new();
-        for dep_name in &resource.directives.depends_on {
+        for dep_name in depends_on {
             if !seen.insert(dep_name.as_str()) {
                 if duplicate_warned.insert(dep_name.as_str()) {
                     diags.push(
@@ -169,7 +179,7 @@ pub fn validate_depends_on<E>(parsed: &File<E>) -> Vec<DependsOnDiagnostic> {
                 continue;
             };
 
-            if matches!(target.kind, ResourceKind::DataSource) {
+            if matches!(target.kind(), ResourceKind::DataSource) {
                 diags.push(
                     DependsOnDiagnostic::error(format!(
                         "directives.depends_on on '{}': data sources cannot be \

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use indexmap::IndexMap;
 
 use crate::binding_index::BindingIndex;
-use crate::parser::{ModuleCall, ProviderContext, TypeExpr, validate_custom_type};
+use crate::parser::{ModuleCall, ProviderContext, ResourceRef, TypeExpr, validate_custom_type};
 use crate::provider::ProviderFactory;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
@@ -39,30 +39,32 @@ pub fn validate_resources<E>(
     let mut all_errors = Vec::new();
     let lookup = crate::parser::provider_context_lookup(provider_context);
 
-    // Classify per kind via typed wrappers instead of runtime
-    // `is_virtual()` / `is_data_source()` calls (carina#3180). Virtuals
-    // are post-apply attribute containers and have no schema to
-    // validate against, so they are silently filtered. Managed and
-    // data sources route to the same schema-lookup body but render
-    // different kind-mismatch diagnostics when the registry entry of
-    // the *opposite* kind exists.
-    use crate::resource::{DataSource, ManagedResource, VirtualResource};
+    // Classify per kind via the typed `ResourceRef` arms instead of
+    // runtime `is_virtual()` / `is_data_source()` calls (carina#3180 /
+    // #3181). Virtuals are post-apply attribute containers and have no
+    // schema to validate against, so they are silently filtered. Managed
+    // and data sources route to the same schema-lookup body but render
+    // different kind-mismatch diagnostics when the registry entry of the
+    // *opposite* kind exists.
     enum ValidatableKind {
         Managed,
         DataSource,
     }
-    for (_ctx, resource) in parsed.iter_all_resources() {
-        if VirtualResource::try_from(resource).is_ok() {
-            continue;
-        }
-        let kind = if DataSource::try_from(resource).is_ok() {
-            ValidatableKind::DataSource
-        } else if ManagedResource::try_from(resource).is_ok() {
-            ValidatableKind::Managed
-        } else {
-            // Unknown kind — shouldn't happen, but keep the loop total.
-            continue;
+    for rref in parsed.iter_all_resources() {
+        let kind = match rref {
+            ResourceRef::Virtual(_) => continue,
+            ResourceRef::DataSource(_) => ValidatableKind::DataSource,
+            ResourceRef::Managed(_) => ValidatableKind::Managed,
+            // A deferred for-expression template body classifies by its
+            // own `kind` — same as the legacy `try_from` ladder did.
+            ResourceRef::Deferred { resource, .. } => match resource.kind {
+                crate::resource::ResourceKind::Virtual => continue,
+                crate::resource::ResourceKind::DataSource => ValidatableKind::DataSource,
+                crate::resource::ResourceKind::Managed => ValidatableKind::Managed,
+            },
         };
+        let resource = rref.as_legacy_resource();
+        let resource = resource.as_ref();
 
         match registry.get_for(resource) {
             Some(schema) => {
@@ -140,12 +142,13 @@ pub fn validate_resource_ref_types<E>(
     // (#2231).
     let bindings = BindingIndex::from_parsed(parsed, registry);
 
-    for (_ctx, resource) in parsed.iter_all_resources() {
-        let Some(schema) = registry.get_for(resource) else {
+    for rref in parsed.iter_all_resources() {
+        let resource = rref.as_legacy_resource();
+        let Some(schema) = registry.get_for(resource.as_ref()) else {
             continue;
         };
 
-        for (attr_name, attr_value) in &resource.attributes {
+        for (attr_name, attr_value) in rref.attributes() {
             if attr_name.starts_with('_') {
                 continue;
             }
@@ -791,12 +794,12 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     // Walk top-level and for-body resources so bindings declared inside a
     // `for` template are also tracked.
     let mut defined_bindings: Vec<String> = Vec::new();
-    for (_ctx, resource) in parsed.iter_all_resources() {
-        if let Some(ref binding_name) = resource.binding {
+    for rref in parsed.iter_all_resources() {
+        if let Some(binding_name) = rref.binding() {
             if binding_name == "_" {
                 continue;
             }
-            defined_bindings.push(binding_name.clone());
+            defined_bindings.push(binding_name.to_string());
         }
     }
 
@@ -817,15 +820,17 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     // string form survives, so a reference nested in
     // `principals = [binding.attr]` would otherwise be missed.
     let mut referenced: HashSet<String> = HashSet::new();
-    for (_ctx, resource) in parsed.iter_all_resources() {
-        for (attr_name, value) in &resource.attributes {
+    for rref in parsed.iter_all_resources() {
+        for (attr_name, value) in rref.attributes() {
             if attr_name.starts_with('_') {
                 continue;
             }
             collect_resource_refs(value, &mut referenced);
             collect_dot_notation_refs(value, &mut referenced);
         }
-        for dep in &resource.directives.depends_on {
+        // `VirtualResource` has no directives — `directives()` is `None`
+        // for that arm, so the depends_on walk is simply skipped.
+        for dep in rref.directives().into_iter().flat_map(|d| &d.depends_on) {
             referenced.insert(dep.clone());
         }
     }

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1021,9 +1021,9 @@ impl DiagnosticEngine {
         // Collect defined binding names from parsed resources, including
         // bindings declared inside for-body templates.
         let mut defined_bindings: HashSet<String> = HashSet::new();
-        for (_ctx, resource) in parsed.iter_all_resources() {
-            if let Some(ref binding_name) = resource.binding {
-                defined_bindings.insert(binding_name.clone());
+        for rref in parsed.iter_all_resources() {
+            if let Some(binding_name) = rref.binding() {
+                defined_bindings.insert(binding_name.to_string());
             }
         }
 
@@ -1637,8 +1637,8 @@ impl DiagnosticEngine {
             (None, None) => parsed.user_functions.keys().cloned().collect(),
         };
 
-        for (_ctx, resource) in parsed.iter_all_resources() {
-            for value in resource.attributes.values() {
+        for rref in parsed.iter_all_resources() {
+            for value in rref.attributes().values() {
                 self.collect_unknown_function_diagnostics(doc, value, &user_fns, &mut diagnostics);
             }
         }
@@ -1755,8 +1755,8 @@ impl DiagnosticEngine {
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
-        for (_ctx, resource) in parsed.iter_all_resources() {
-            for (attr_name, attr_value) in &resource.attributes {
+        for rref in parsed.iter_all_resources() {
+            for (attr_name, attr_value) in rref.attributes() {
                 if attr_name.starts_with('_') {
                     continue;
                 }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -12,7 +12,7 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
 use crate::document::Document;
 use crate::position;
-use carina_core::parser::{ParseError, ParsedFile};
+use carina_core::parser::{ParseError, ParsedFile, ResourceRef};
 use carina_core::provider::ProviderFactory;
 use carina_core::resource::{ConcreteValue, DeferredValue, Value};
 use carina_core::schema::{ResourceSchema, SchemaRegistry};
@@ -248,7 +248,13 @@ impl DiagnosticEngine {
 
             // Check resource types — include for-body template resources so
             // attribute/type/enum validation fires inside `for` loops too.
-            for (ctx, resource) in parsed.iter_all_resources() {
+            for rref in parsed.iter_all_resources() {
+                let ctx = rref.context();
+                // Bridge to the legacy `Resource` shape — `get_for`,
+                // `resolved_attributes`, and the id/attribute reads below
+                // are not yet typestate-aware (carina#3181 PR B).
+                let resource = rref.as_legacy_resource();
+                let resource = resource.as_ref();
                 let provider = &resource.id.provider;
                 let full_resource_type = format!("{}.{}", provider, resource.id.resource_type);
                 // Source-range hint for attribute position lookups. Without
@@ -331,7 +337,7 @@ impl DiagnosticEngine {
                 if let Some(schema) = &schema {
                     // Check data source without `read` keyword
                     if schema.is_data_source()
-                        && carina_core::resource::DataSource::try_from(resource).is_err()
+                        && !matches!(rref, ResourceRef::DataSource(_))
                         && let Some((line, col)) = self.find_resource_type_position(
                             doc,
                             provider,
@@ -825,7 +831,7 @@ impl DiagnosticEngine {
                 Some(merged) => {
                     let current_file_bindings: HashSet<String> = parsed
                         .iter_all_resources()
-                        .filter_map(|(_, r)| r.binding.clone())
+                        .filter_map(|rref| rref.binding().map(str::to_string))
                         .collect();
                     carina_core::validation::check_unused_bindings(merged)
                         .into_iter()


### PR DESCRIPTION
## Summary

Second step of the carina#3181 5-PR series (A→E) that deletes the
`Resource::kind` discriminant.

`File::iter_all_resources` now yields a typed `ResourceRef<'a>` enum
instead of an untyped `(ResourceContext, &Resource)` tuple:

- `Managed(&Resource)` — top-level managed resources
- `Virtual(&VirtualResource)` — module-expansion synthetic nodes
- `DataSource(&DataSource)` — `read`-keyword resources
- `Deferred { resource, deferred }` — for-expression template bodies

The iterator chains the three typed slices `File` carries (added in
PR A) rather than just the legacy mixed `resources` Vec. This is the
type-safe replacement for the `kind` discriminant: callers that used to
branch on `resource.kind` now match `ResourceRef` arms, each carrying a
concrete typestate struct.

## API

`ResourceRef` exposes:
- `id` / `attributes` / `binding` / `as_resource_like` — the common
  read-only accessors (`ResourceLike`)
- `kind` / `directives` / `quoted_string_attrs` — for callers that still
  need them (`directives` returns `Option` since `VirtualResource` drops
  the field)
- `context` — the legacy `ResourceContext` for callers that branch on
  Direct vs Deferred
- `as_legacy_resource` — a `Cow<Resource>` bridge for APIs not yet
  typestate-aware (`SchemaRegistry::get_for`, `Resource::resolved_attributes`)

## Changes

- Define `ResourceRef<'a>` + accessors in `carina-core/src/parser/ast.rs`.
- Rewrite `iter_all_resources` to chain the typed slices; the managed
  arm filters `resources` to `ResourceKind::Managed` so each resource is
  yielded exactly once while `resources` still holds the PR A duplicate
  rows.
- Migrate all ~16 `iter_all_resources` callers across carina-core,
  carina-cli, carina-lsp.
- `validate_resources` and the LSP data-source diagnostic replace their
  `TryFrom<&Resource>` classification ladders with `ResourceRef` arm
  matches.
- `expand_deferred_for_expressions` projects newly expanded for-body
  resources into the typed slices too, preserving the duplicate-storage
  invariant.
- Add `From<&VirtualResource> for Resource`, symmetric with the existing
  managed / data-source bridges.

## Scope note

Making `resources` managed-only is deferred to PR C: `binding_index`,
`wait`, and the differ still read `parsed.resources` directly and must
migrate to the typed slices first, or data-source bindings would be
silently dropped.

## Test plan

- [x] `cargo nextest run --workspace` — 3513 passed
- [x] `cargo test --workspace --doc` — `compile_fail` doctests still fail to compile
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] `make plan-fixtures`
- [x] New test `iter_all_resources_classifies_managed_and_data_source_arms`
  asserts each resource is yielded once with the correct typed arm.

Refs #3181

🤖 Generated with [Claude Code](https://claude.com/claude-code)