### PR TITLE
parser: make File::resources managed-only (#3181 PR C)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -813,7 +813,12 @@ async fn run_apply_locked(
     // source (e.g. `let cert`) is a normal top-level resource already
     // here and refreshed by phase 1, only the loop's generated children
     // are added later.
-    let mut sorted_resources = sort_resources_by_dependencies(&parsed.resources)?;
+    // carina#3181: `parsed.resources` is managed-only; rebuild the mixed
+    // legacy view (managed + virtual + data source) for the dependency
+    // sort and the StringEnum-lift passes below so data sources still
+    // reach `split_resources_by_kind` / `create_plan`.
+    let all_top_level_resources = parsed.legacy_top_level_resources();
+    let mut sorted_resources = sort_resources_by_dependencies(&all_top_level_resources)?;
 
     // Build state-file-derived maps up front so anonymous → let-bound
     // rename transfer (#1685) can run between refresh phases 1 and 2.
@@ -827,7 +832,7 @@ async fn run_apply_locked(
     // desired against un-lifted saved state. Same seam as the plan path.
     carina_core::utils::lift_saved_state_string_enums(
         &mut saved_attrs,
-        &parsed.resources,
+        &all_top_level_resources,
         ctx.schemas(),
     );
     let mut prev_explicit = state_file
@@ -1088,7 +1093,7 @@ async fn run_apply_locked(
     // populated `current_states` by here.
     carina_core::utils::lift_current_state_string_enums(
         &mut current_states,
-        &parsed.resources,
+        &all_top_level_resources,
         ctx.schemas(),
     );
 

--- a/carina-cli/src/commands/lint.rs
+++ b/carina-cli/src/commands/lint.rs
@@ -59,8 +59,11 @@ pub fn run_lint(path: &Path, provider_context: &ProviderContext) -> Result<(), A
     // and build a map of attr_name -> block_name for lint suggestions
     let mut all_list_struct_attrs: HashSet<String> = HashSet::new();
     let mut block_name_suggestions: HashMap<String, String> = HashMap::new();
-    for resource in &parsed.resources {
-        if let Some(schema) = schemas.get_for(resource) {
+    // carina#3181: walk every top-level resource — managed and data
+    // source schemas can both carry List<Struct> attributes. Virtuals
+    // have no schema, so `get_for` returns `None` for them.
+    for rref in parsed.iter_top_level_resources() {
+        if let Some(schema) = schemas.get_for(rref.as_legacy_resource().as_ref()) {
             all_list_struct_attrs.extend(list_struct_attr_names(schema));
             for (attr_name, attr_schema) in &schema.attributes {
                 if let Some(bn) = &attr_schema.block_name {

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -326,10 +326,13 @@ pub fn validate_and_resolve_errors_with_factories(
             parsed,
             &argument_names,
         ));
+        // carina#3181: `parsed.resources` is managed-only; rebuild the
+        // mixed legacy view so attribute params can ref-type-check
+        // against `read` (data-source) bindings too.
         errors.extend(validate_attribute_param_ref_types_with_ctx(
             &ctx,
             &parsed.attribute_params,
-            &parsed.resources,
+            &parsed.legacy_top_level_resources(),
         ));
         if !errors.is_empty() {
             return errors;
@@ -344,9 +347,11 @@ pub fn validate_and_resolve_errors_with_factories(
         ) {
             errors.extend(split_validation_message(&msg));
         }
+        // carina#3181: rebuild the mixed legacy view so exports can
+        // ref-type-check against `read` (data-source) bindings too.
         if let Err(msg) = carina_core::validation::validate_export_param_ref_types(
             &parsed.export_params,
-            &parsed.resources,
+            &parsed.legacy_top_level_resources(),
             ctx.schemas(),
         ) {
             errors.extend(split_validation_message(&msg));

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -92,7 +92,11 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         reconcile_anonymous_identifiers_with_ctx(&wiring, &mut parsed.resources, sf);
     }
 
-    let sorted_resources = sort_resources_by_dependencies(&parsed.resources).unwrap();
+    // carina#3181: `parsed.resources` is managed-only; rebuild the mixed
+    // legacy view so data sources still reach `split_resources_by_kind` /
+    // `create_plan`.
+    let all_top_level_resources = parsed.legacy_top_level_resources();
+    let sorted_resources = sort_resources_by_dependencies(&all_top_level_resources).unwrap();
 
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
     if let Some(sf) = state_file.as_ref() {

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -299,12 +299,15 @@ where
     E: carina_core::parser::ExportParamLike,
 {
     let mut errors = Vec::new();
-    for resource in &parsed.resources {
-        for (attr_name, value) in &resource.attributes {
+    // carina#3181: walk every top-level resource — managed, data source,
+    // virtual — so an empty interpolation in a `read` resource's
+    // attribute is still caught.
+    for rref in parsed.iter_top_level_resources() {
+        for (attr_name, value) in rref.attributes() {
             if value_contains_empty_interpolation(value) {
                 errors.push(AppError::Validation(format!(
                     "{}: attribute `{}`: empty interpolation `${{}}` — fill in the expression or remove it",
-                    resource.id, attr_name
+                    rref.id(), attr_name
                 )));
             }
         }
@@ -871,9 +874,12 @@ pub fn validate_module_attribute_param_types<E>(
         if module_parsed.attribute_params.is_empty() {
             continue;
         }
+        // carina#3181: rebuild the mixed legacy view so an imported
+        // module's attribute params can ref-type-check against its
+        // `read` (data-source) bindings too.
         if let Err(joined) = validation::validate_attribute_param_ref_types(
             &module_parsed.attribute_params,
-            &module_parsed.resources,
+            &module_parsed.legacy_top_level_resources(),
             ctx.schemas(),
         ) {
             // Preserve the module-path prefix the legacy wrapper emitted
@@ -1360,8 +1366,12 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // pre-expansion set (the loop's iterable source — e.g. `let cert` —
     // is a normal top-level resource already here and refreshed by the
     // normal phase-1 pass; only the loop's generated children are added).
+    // carina#3181: `parsed.resources` is managed-only; rebuild the mixed
+    // legacy view (managed + virtual + data source) so data sources
+    // still reach `split_resources_by_kind` / `create_plan` below.
+    let all_top_level_resources = parsed.legacy_top_level_resources();
     let mut sorted_resources =
-        sort_resources_by_dependencies(&parsed.resources).map_err(AppError::Validation)?;
+        sort_resources_by_dependencies(&all_top_level_resources).map_err(AppError::Validation)?;
 
     // Select appropriate Provider based on configuration
     let provider = get_provider_with_ctx(&ctx, parsed, base_dir).await?;
@@ -1387,7 +1397,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // carina-state stays schema-free; the registry only exists here.
     carina_core::utils::lift_saved_state_string_enums(
         &mut saved_attrs,
-        &parsed.resources,
+        &all_top_level_resources,
         ctx.schemas(),
     );
     let mut prev_explicit = state_file
@@ -1735,7 +1745,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // resolver / differ consume it.
     carina_core::utils::lift_current_state_string_enums(
         &mut current_states,
-        &parsed.resources,
+        &all_top_level_resources,
         ctx.schemas(),
     );
     resolve_refs_for_plan(

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -35,7 +35,7 @@
 //! ```ignore
 //! let index = BindingIndex::from_parsed(&parsed, &registry);
 //! if let Some(entry) = index.get("vpc") {
-//!     // entry.resource and entry.schema are both available
+//!     // entry.schema is the resolved schema for the binding
 //! }
 //! ```
 
@@ -44,12 +44,11 @@ use crate::resource::{ManagedResource, Resource, ResourceId, State, Value, Virtu
 use crate::schema::{ResourceSchema, SchemaRegistry};
 use std::collections::HashMap;
 
-/// One entry in the binding index. Both fields are non-`Option` because the
+/// One entry in the binding index. `schema` is non-`Option` because the
 /// builder skips bindings whose schema cannot be resolved — callers never
 /// have to defend against half-populated entries.
 #[derive(Debug)]
 pub struct BindingEntry<'a> {
-    pub resource: &'a Resource,
     pub schema: &'a ResourceSchema,
 }
 
@@ -83,24 +82,30 @@ impl<'a> BindingIndex<'a> {
     ) -> Self {
         let mut entries = HashMap::new();
         let mut known_names = std::collections::HashSet::new();
-        // Walk top-level resources only. The parser auto-generates a
-        // synthetic `binding` for anonymous for-body templates (used for
-        // resource address derivation), but those names are an internal
-        // detail — they were never visible to validation's binding map
-        // pre-#2231 and surfacing them here would be an unintended
-        // behaviour change for ResourceRef lookups. The LSP and
-        // validation both still walk `iter_all_resources` *separately*
-        // for their own checks; only the binding-name table is scoped to
-        // top-level here.
-        for resource in &parsed.resources {
-            let Some(binding_name) = resource.binding.as_ref() else {
+        // Walk top-level resources only — managed resources, data
+        // sources, and virtuals (carina#3181: `iter_top_level_resources`
+        // chains the typed slices and excludes deferred for-body
+        // templates). The parser auto-generates a synthetic `binding` for
+        // anonymous for-body templates (used for resource address
+        // derivation), but those names are an internal detail — they were
+        // never visible to validation's binding map pre-#2231 and
+        // surfacing them here would be an unintended behaviour change for
+        // ResourceRef lookups. The LSP and validation both still walk
+        // `iter_all_resources` *separately* for their own checks; only
+        // the binding-name table is scoped to top-level here.
+        for rref in parsed.iter_top_level_resources() {
+            let Some(binding_name) = rref.binding() else {
                 continue;
             };
-            known_names.insert(binding_name.clone());
-            let Some(schema) = registry.get_for(resource) else {
+            known_names.insert(binding_name.to_string());
+            // `get_for` is not yet typestate-aware — bridge through the
+            // legacy `Resource` shape. A virtual resource has no schema,
+            // so it stays in `known_names` but gets no `entries` row,
+            // matching the prior "known binding, schema absent" surface.
+            let Some(schema) = registry.get_for(&rref.as_legacy_resource()) else {
                 continue;
             };
-            entries.insert(binding_name.clone(), BindingEntry { resource, schema });
+            entries.insert(binding_name.to_string(), BindingEntry { schema });
         }
         Self {
             entries,
@@ -231,8 +236,14 @@ impl BindingNameSet {
     pub fn from_parsed<E>(parsed: &crate::parser::File<E>) -> Self {
         let mut by_name: HashMap<String, BindingNameKind> = HashMap::new();
 
-        for resource in &parsed.resources {
-            if let Some(name) = resource.binding.as_deref() {
+        // carina#3181: walk the typed top-level slices — managed
+        // resources, data sources, and virtuals all register a
+        // `Resource`-kind binding name (a data source declared as
+        // `let x = read ...` is addressable by `ResourceRef`, and a
+        // virtual binding was a `Resource`-kind name before the
+        // typestate split too).
+        for rref in parsed.iter_top_level_resources() {
+            if let Some(name) = rref.binding() {
                 by_name
                     .entry(name.to_string())
                     .or_insert(BindingNameKind::Resource);
@@ -727,8 +738,30 @@ let vpc = aws.ec2.Vpc {
         let index = BindingIndex::from_parsed(&parsed, &registry);
         let entry = index.get("vpc").expect("vpc binding present");
         assert_eq!(entry.schema.resource_type, "ec2.Vpc");
-        assert_eq!(entry.resource.binding.as_deref(), Some("vpc"));
+        assert!(index.is_declared("vpc"));
         assert_eq!(index.len(), 1);
+    }
+
+    /// carina#3181 PR C: `read` (data-source) bindings must appear in the
+    /// `BindingIndex` — `from_parsed` walks the typed `data_sources`
+    /// slice, not just managed `resources`.
+    #[test]
+    fn build_indexes_data_source_binding() {
+        let src = r#"
+let existing = read aws.ec2.Vpc {
+    name = "v"
+}
+"#;
+        let parsed = parse(src, &Default::default()).expect("parse");
+        let mut registry = SchemaRegistry::new();
+        registry.insert("aws", vpc_schema().as_data_source());
+
+        let index = BindingIndex::from_parsed(&parsed, &registry);
+        let entry = index
+            .get("existing")
+            .expect("data-source binding present in index");
+        assert_eq!(entry.schema.resource_type, "ec2.Vpc");
+        assert!(index.is_declared("existing"));
     }
 
     #[test]

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -103,12 +103,17 @@ fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
 /// before reference resolution. Keeping the depends_on edges out of that
 /// snapshot is what lets the validation pass tell a redundant edge apart
 /// from a depends_on-only edge.
-pub fn get_resource_value_ref_dependencies(resource: &Resource) -> HashSet<String> {
+///
+/// Takes `&dyn ResourceLike` so the resolver can compute the snapshot for
+/// both managed [`Resource`]s and [`DataSource`]s (carina#3181).
+pub fn get_resource_value_ref_dependencies(
+    resource: &dyn crate::resource::ResourceLike,
+) -> HashSet<String> {
     let mut deps = HashSet::new();
-    for value in resource.attributes.values() {
+    for value in resource.attributes().values() {
         collect_dependencies(value, &mut deps);
     }
-    for name in &resource.dependency_bindings {
+    for name in resource.dependency_bindings() {
         deps.insert(name.clone());
     }
     deps

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -292,22 +292,24 @@ impl ModuleResolver<'_> {
             })
             .collect();
 
-        // carina#3181 PR A: project the expanded resources into the
-        // typed `data_sources` / `virtual_resources` slices in parallel
-        // with the legacy `resources` Vec. A module instance contributes
-        // both managed resources and exactly one `_virtual` attribute
-        // resource (built above); a module may also declare data
-        // sources. `expanded_resources` keeps every resource so current
-        // consumers are untouched; PR B migrates them onto the typed
-        // slices.
-        let data_sources: Vec<DataSource> = expanded_resources
-            .iter()
-            .filter_map(|r| r.try_into().ok())
-            .collect();
-        let virtual_resources: Vec<VirtualResource> = expanded_resources
-            .iter()
-            .filter_map(|r| r.try_into().ok())
-            .collect();
+        // carina#3181 PR C: partition the expanded resources into the
+        // managed-only `resources` Vec and the typed `data_sources` /
+        // `virtual_resources` slices. A module instance contributes
+        // managed resources, exactly one `_virtual` attribute resource
+        // (built above), and possibly data sources — each lands in
+        // exactly one slice.
+        let mut managed_resources: Vec<Resource> = Vec::new();
+        let mut data_sources: Vec<DataSource> = Vec::new();
+        let mut virtual_resources: Vec<VirtualResource> = Vec::new();
+        for resource in expanded_resources {
+            if let Ok(ds) = DataSource::try_from(&resource) {
+                data_sources.push(ds);
+            } else if let Ok(vr) = VirtualResource::try_from(&resource) {
+                virtual_resources.push(vr);
+            } else {
+                managed_resources.push(resource);
+            }
+        }
 
         // The contribution is a full `ParsedFile` built with an
         // **exhaustive struct literal** (no `..Default::default()`):
@@ -317,7 +319,7 @@ impl ModuleResolver<'_> {
         // reason — never silently absent (the carina#3126 fix).
         Ok(ParsedFile {
             // Populated from the module, instance-prefixed:
-            resources: expanded_resources,
+            resources: managed_resources,
             data_sources,
             virtual_resources,
             wait_bindings: expanded_wait_bindings,

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -660,32 +660,23 @@ fn test_expand_module_call_creates_virtual_resource() {
         arguments: HashMap::new(),
     };
 
-    let expanded = resolver
-        .expand_module_call(&call, "web", None)
-        .unwrap()
-        .resources;
-    // 1 real resource + 1 virtual resource
-    assert_eq!(expanded.len(), 2);
-
-    // Find the virtual resource
-    let virtual_res = expanded
-        .iter()
-        .find(|r| r.is_virtual())
-        .expect("Virtual resource should exist");
+    let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
+    // carina#3181 PR C: `resources` is managed-only — 1 real resource.
+    assert_eq!(expanded.resources.len(), 1);
+    // The virtual resource lives in the typed `virtual_resources` slice.
+    assert_eq!(expanded.virtual_resources.len(), 1);
+    let virtual_res = &expanded.virtual_resources[0];
 
     assert_eq!(virtual_res.binding, Some("web".to_string()));
-    // Module info should be in the virtual_module field, not in attributes
-    assert_eq!(virtual_res.kind, ResourceKind::Virtual);
-    assert_eq!(
-        virtual_res.virtual_module,
-        Some(("web_tier".to_string(), "web".to_string()))
-    );
+    // Module info lives in the flattened module_name / instance fields.
+    assert_eq!(virtual_res.module_name, "web_tier");
+    assert_eq!(virtual_res.instance, "web");
     assert!(!virtual_res.attributes.contains_key("_module"));
     assert!(!virtual_res.attributes.contains_key("_module_instance"));
     // The security_group attribute should be a rewritten ResourceRef
     // pointing to the dot-path binding (web.sg)
     assert_eq!(
-        virtual_res.get_attr("security_group"),
+        virtual_res.attributes.get("security_group"),
         Some(&Value::resource_ref(
             "web.sg".to_string(),
             "id".to_string(),
@@ -694,10 +685,10 @@ fn test_expand_module_call_creates_virtual_resource() {
     );
 }
 
-/// carina#3181 PR A: module-call expansion projects the synthetic
-/// virtual resource into the typed `virtual_resources` slice in
-/// parallel with the legacy `resources` Vec (duplicate storage during
-/// the typestate migration).
+/// carina#3181 PR C: module-call expansion partitions the expanded
+/// resources into the managed-only `resources` Vec and the typed
+/// `virtual_resources` / `data_sources` slices — each resource lands in
+/// exactly one slice.
 #[test]
 fn test_expand_module_call_populates_virtual_resources_slice() {
     let resolver = {
@@ -715,11 +706,11 @@ fn test_expand_module_call_populates_virtual_resources_slice() {
 
     let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
 
-    // Legacy mixed Vec still holds the managed + virtual resources.
-    assert_eq!(expanded.resources.len(), 2);
+    // `resources` is managed-only — the synthetic virtual is NOT here.
+    assert_eq!(expanded.resources.len(), 1);
+    assert!(!expanded.resources.iter().any(|r| r.is_virtual()));
 
-    // The typed slice holds only the virtual resource, matching the
-    // corresponding legacy entry.
+    // The virtual resource lives only in the typed slice.
     assert_eq!(expanded.virtual_resources.len(), 1);
     assert_eq!(
         expanded.virtual_resources[0].binding,
@@ -727,16 +718,6 @@ fn test_expand_module_call_populates_virtual_resources_slice() {
     );
     assert_eq!(expanded.virtual_resources[0].module_name, "web_tier");
     assert_eq!(expanded.virtual_resources[0].instance, "web");
-    let legacy_virtual = expanded
-        .resources
-        .iter()
-        .find(|r| r.is_virtual())
-        .expect("legacy resources still contains the virtual resource");
-    assert_eq!(expanded.virtual_resources[0].id, legacy_virtual.id);
-    assert_eq!(
-        expanded.virtual_resources[0].attributes,
-        legacy_virtual.attributes
-    );
 
     // This module declares no data sources.
     assert!(expanded.data_sources.is_empty());
@@ -1450,19 +1431,17 @@ fn test_module_virtual_resource_dot_path_refs() {
         arguments: HashMap::new(),
     };
 
-    let expanded = resolver
-        .expand_module_call(&call, "web", None)
-        .unwrap()
-        .resources;
+    let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
 
+    // carina#3181 PR C: the virtual resource lives in the typed slice.
     let virtual_res = expanded
-        .iter()
-        .find(|r| r.is_virtual())
+        .virtual_resources
+        .first()
         .expect("Virtual resource should exist");
 
     // The security_group attribute should reference dot-notation binding
     assert_eq!(
-        virtual_res.get_attr("security_group"),
+        virtual_res.attributes.get("security_group"),
         Some(&Value::resource_ref(
             "web.sg".to_string(),
             "id".to_string(),

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -956,17 +956,14 @@ impl<E> File<E> {
     /// `notes/specs/2026-04-19-unify-resource-walk-design.md` for the
     /// rationale.
     ///
-    /// **carina#3181 PR B:** the managed arm filters `self.resources` to
-    /// `ResourceKind::Managed` rows. While the typestate migration is in
-    /// flight `resources` still holds virtual + data-source rows too (the
-    /// PR A duplicate storage); the filter keeps each resource yielded
-    /// exactly once — virtuals and data sources come from their typed
-    /// slices instead. PR C makes `resources` managed-only and drops the
-    /// filter.
+    /// **carina#3181 PR C:** `self.resources` is now managed-only — the
+    /// parser, module expander, and deferred-for expansion write each
+    /// resource into exactly one of `resources` / `data_sources` /
+    /// `virtual_resources`. The iterator chains the three typed slices
+    /// plus the deferred for-expression templates.
     pub fn iter_all_resources(&self) -> impl Iterator<Item = ResourceRef<'_>> {
         self.resources
             .iter()
-            .filter(|r| matches!(r.kind, ResourceKind::Managed))
             .map(ResourceRef::Managed)
             .chain(self.virtual_resources.iter().map(ResourceRef::Virtual))
             .chain(self.data_sources.iter().map(ResourceRef::DataSource))
@@ -978,6 +975,44 @@ impl<E> File<E> {
                         deferred: d,
                     }),
             )
+    }
+
+    /// Iterate the top-level resources — managed, virtual, and data
+    /// source — as typed [`ResourceRef`]s, **excluding** deferred
+    /// for-expression templates.
+    ///
+    /// Use this over [`iter_all_resources`](Self::iter_all_resources)
+    /// when a consumer needs only the concrete top-level declarations
+    /// (binding-name collection, dependency sorting) and a for-body
+    /// template would be a spurious entry.
+    pub fn iter_top_level_resources(&self) -> impl Iterator<Item = ResourceRef<'_>> {
+        self.resources
+            .iter()
+            .map(ResourceRef::Managed)
+            .chain(self.virtual_resources.iter().map(ResourceRef::Virtual))
+            .chain(self.data_sources.iter().map(ResourceRef::DataSource))
+    }
+
+    /// Rebuild a single legacy `Vec<Resource>` of every top-level
+    /// resource — managed rows verbatim, data sources and virtuals
+    /// bridged back via `From<&DataSource>` / `From<&VirtualResource>`.
+    ///
+    /// **carina#3181 transitional (PR C):** `resources` is managed-only,
+    /// but several legacy APIs — `sort_resources_by_dependencies`,
+    /// `differ::split_resources_by_kind`, the resolver — still take a
+    /// mixed `&[Resource]`. This helper produces that mixed view without
+    /// reintroducing duplicate storage. Removed once those APIs are
+    /// typestate-aware. The order is managed → virtual → data source;
+    /// callers that care about ordering (dependency sort) re-sort
+    /// topologically anyway.
+    pub fn legacy_top_level_resources(&self) -> Vec<Resource> {
+        let mut out = Vec::with_capacity(
+            self.resources.len() + self.virtual_resources.len() + self.data_sources.len(),
+        );
+        out.extend(self.resources.iter().cloned());
+        out.extend(self.virtual_resources.iter().map(Resource::from));
+        out.extend(self.data_sources.iter().map(Resource::from));
+        out
     }
 
     /// Find a resource by resource type and name attribute value
@@ -1137,20 +1172,18 @@ impl<E> File<E> {
             self.deferred_for_expressions.remove(idx);
         }
 
-        // carina#3181 PR A/B duplicate-storage invariant: every resource
-        // lives both in the legacy `resources` Vec and in its typed slice.
-        // Expansion happens after the parser's initial projection, so
-        // project the freshly expanded for-body resources into the typed
-        // slices here too — otherwise an expanded `read` for-body would be
-        // dropped by `iter_all_resources`'s managed-only filter.
-        for resource in &expanded_resources {
-            if let Ok(ds) = DataSource::try_from(resource) {
+        // carina#3181 PR C: `resources` is managed-only. Partition the
+        // freshly expanded for-body resources — managed rows into
+        // `resources`, `read` rows into `data_sources` — so an expanded
+        // data-source for-body lands in the right typed slice. (A
+        // for-body cannot synthesize a virtual resource.)
+        for resource in expanded_resources {
+            if let Ok(ds) = DataSource::try_from(&resource) {
                 self.data_sources.push(ds);
-            } else if let Ok(vr) = VirtualResource::try_from(resource) {
-                self.virtual_resources.push(vr);
+            } else {
+                self.resources.push(resource);
             }
         }
-        self.resources.extend(expanded_resources);
         self.warnings.extend(new_warnings);
     }
 }

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -363,13 +363,19 @@ pub fn parse_with_seeded_bindings(
         })
         .collect();
 
-    // carina#3181 PR A: project the read-keyword resources into the
-    // typed `data_sources` slice in parallel with the legacy `resources`
-    // Vec. `resources` keeps every resource (managed + data source) so
-    // current consumers are untouched; PR B migrates them onto the typed
-    // slices and makes `resources` managed-only.
-    let data_sources: Vec<DataSource> =
-        resources.iter().filter_map(|r| r.try_into().ok()).collect();
+    // carina#3181 PR C: `resources` is now managed-only. Partition the
+    // parsed resources — `read`-keyword resources move into the typed
+    // `data_sources` slice, managed resources stay in `resources`. The
+    // parser never synthesizes virtual resources (that is the module
+    // expander's job), so `virtual_resources` is empty here.
+    let mut data_sources: Vec<DataSource> = Vec::new();
+    resources.retain(|r| match DataSource::try_from(r) {
+        Ok(ds) => {
+            data_sources.push(ds);
+            false
+        }
+        Err(_) => true,
+    });
 
     Ok(ParsedFile {
         providers,

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -7,9 +7,58 @@ use super::ast::{AttributeParameter, ExportParameter, ModuleCall, ParsedFile};
 use super::error::{ParseError, undefined_identifier_error};
 use super::static_eval::is_static_value;
 use crate::eval_value::EvalValue;
-use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
+use crate::resource::{ConcreteValue, DataSource, DeferredValue, Resource, ResourceLike, Value};
 use indexmap::IndexMap;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
+
+/// Mutable pre-apply traversal — the resolver mutates `attributes` and
+/// `dependency_bindings` of every resource whose references are resolved
+/// **before** apply: managed [`Resource`]s and [`DataSource`]s.
+///
+/// `VirtualResource` is excluded on purpose — a virtual resource's
+/// attributes may carry refs whose resolution is deferred to the
+/// post-apply path, so the pre-apply resolver must never rewrite them
+/// (carina#3181; see the `virtual_resource.rs` module doc).
+trait PreApplyResourceMut: ResourceLike {
+    fn attributes_mut(&mut self) -> &mut IndexMap<String, Value>;
+    fn dependency_bindings_mut(&mut self) -> &mut BTreeSet<String>;
+}
+
+impl PreApplyResourceMut for Resource {
+    fn attributes_mut(&mut self) -> &mut IndexMap<String, Value> {
+        &mut self.attributes
+    }
+    fn dependency_bindings_mut(&mut self) -> &mut BTreeSet<String> {
+        &mut self.dependency_bindings
+    }
+}
+
+impl PreApplyResourceMut for DataSource {
+    fn attributes_mut(&mut self) -> &mut IndexMap<String, Value> {
+        &mut self.attributes
+    }
+    fn dependency_bindings_mut(&mut self) -> &mut BTreeSet<String> {
+        &mut self.dependency_bindings
+    }
+}
+
+/// Mutable iterator over the pre-apply resolvable resources — managed
+/// resources then data sources (carina#3181). Used by the resolver to
+/// rewrite refs in place across both typed slices in one walk.
+fn iter_pre_apply_resources_mut(
+    parsed: &mut ParsedFile,
+) -> impl Iterator<Item = &mut dyn PreApplyResourceMut> + '_ {
+    parsed
+        .resources
+        .iter_mut()
+        .map(|r| r as &mut dyn PreApplyResourceMut)
+        .chain(
+            parsed
+                .data_sources
+                .iter_mut()
+                .map(|d| d as &mut dyn PreApplyResourceMut),
+        )
+}
 
 /// Resolve forward references after the full binding set is known.
 ///
@@ -141,21 +190,29 @@ pub fn resolve_resource_refs_with_config(
     // Save dependency bindings before resolution may change ResourceRef binding names.
     // This preserves direct dependencies that would be lost by recursive resolution
     // (e.g., tgw_attach.transit_gateway_id resolves to tgw.id, losing the tgw_attach dep).
-    for resource in &mut parsed.resources {
-        let deps = crate::deps::get_resource_value_ref_dependencies(resource);
+    //
+    // carina#3181: walk managed resources *and* data sources — a data
+    // source's attributes can carry refs too, and `parsed.resources` is
+    // now managed-only.
+    for resource in iter_pre_apply_resources_mut(parsed) {
+        let deps = crate::deps::get_resource_value_ref_dependencies(&*resource);
         if !deps.is_empty() {
-            resource.dependency_bindings = deps.into_iter().collect();
+            *resource.dependency_bindings_mut() = deps.into_iter().collect();
         }
     }
 
-    // Build a map of binding_name -> attributes for quick lookup
+    // Build a map of binding_name -> attributes for quick lookup. Walk
+    // every top-level resource (managed, data source, virtual) so a
+    // `ResourceRef` to any binding resolves. `binding_map` only needs
+    // key-based lookup, not source order, so the inner map stays a plain
+    // `HashMap`.
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
-    for resource in &parsed.resources {
-        if let Some(ref binding_name) = resource.binding {
-            // `binding_map` only needs key-based lookup, not source order
-            // (callers consume it via `.get(name)` for ResourceRef
-            // resolution), so the inner map stays `HashMap`.
-            binding_map.insert(binding_name.clone(), resource.resolved_attributes());
+    for rref in parsed.iter_top_level_resources() {
+        if let Some(binding_name) = rref.binding() {
+            binding_map.insert(
+                binding_name.to_string(),
+                rref.as_legacy_resource().resolved_attributes(),
+            );
         }
     }
 
@@ -200,15 +257,19 @@ pub fn resolve_resource_refs_with_config(
 
     // Resolve references in each resource. Keep `IndexMap` to preserve
     // the user's source order through resolution (#2222).
-    for resource in &mut parsed.resources {
+    //
+    // carina#3181: managed resources and data sources both go through
+    // pre-apply ref resolution; `VirtualResource` is excluded — its refs
+    // are resolved on the post-apply path.
+    for resource in iter_pre_apply_resources_mut(parsed) {
         let mut resolved_attrs: IndexMap<String, Value> = IndexMap::new();
 
-        for (key, expr) in &resource.attributes {
+        for (key, expr) in resource.attributes().iter() {
             let resolved = resolve_value_with_config(expr, &binding_map, &fn_ctx)?;
             resolved_attrs.insert(key.clone(), resolved);
         }
 
-        resource.attributes = resolved_attrs;
+        *resource.attributes_mut() = resolved_attrs;
     }
 
     // Resolve top-level `let v = ...` bindings that contain
@@ -230,10 +291,14 @@ pub fn resolve_resource_refs_with_config(
     // During per-file parsing, "binding.attribute" strings from sibling files
     // remain as Value::Concrete(ConcreteValue::String). Convert them to ResourceRef now that the full
     // binding map is available.
+    // carina#3181: include data sources and virtuals — a sibling-file
+    // export can forward-reference any top-level binding.
     let resource_bindings: HashMap<String, Resource> = parsed
-        .resources
-        .iter()
-        .filter_map(|r| r.binding.as_ref().map(|b| (b.clone(), r.clone())))
+        .iter_top_level_resources()
+        .filter_map(|rref| {
+            rref.binding()
+                .map(|b| (b.to_string(), rref.as_legacy_resource().into_owned()))
+        })
         .collect();
     for export_param in &mut parsed.export_params {
         if let Some(value) = export_param.value.take() {
@@ -266,7 +331,13 @@ pub fn resolve_resource_refs_with_config(
 /// to rebuild a borrowed view per call).
 pub fn collect_known_bindings_merged(parsed: &ParsedFile) -> std::collections::HashSet<&str> {
     let mut known: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    known.extend(parsed.resources.iter().filter_map(|r| r.binding.as_deref())); // allow: direct — parser-internal, pre-expansion
+    // carina#3181: walk the typed top-level slices — managed resources,
+    // data sources, and virtuals all contribute a binding name in scope.
+    known.extend(
+        parsed
+            .iter_top_level_resources()
+            .filter_map(|r| r.binding()),
+    );
     known.extend(parsed.arguments.iter().map(|a| a.name.as_str()));
     known.extend(
         parsed
@@ -334,8 +405,14 @@ pub fn check_identifier_scope(parsed: &ParsedFile) -> Vec<ParseError> {
 /// validation to pay for both.
 pub fn check_provider_instance_routing(parsed: &ParsedFile) -> Vec<ParseError> {
     let mut errors = Vec::new();
-    for resource in &parsed.resources {
-        match &resource.directives.provider_instance {
+    // carina#3181: walk the typed top-level slices. `directives()` is
+    // `None` for the virtual arm (no `directives` on a synthetic node),
+    // which routes to the `None` match arm — and a virtual's `id` has an
+    // empty provider, so it is skipped there, matching prior behaviour.
+    for rref in parsed.iter_top_level_resources() {
+        let id = rref.id();
+        let provider_instance = rref.directives().and_then(|d| d.provider_instance.as_ref());
+        match provider_instance {
             Some(binding) => {
                 let Some(instance) = parsed
                     .providers
@@ -352,16 +429,13 @@ pub fn check_provider_instance_routing(parsed: &ParsedFile) -> Vec<ParseError> {
                     });
                     continue;
                 };
-                if instance.name != resource.id.provider {
+                if instance.name != id.provider {
                     errors.push(ParseError::InvalidExpression {
                         line: 0,
                         message: format!(
                             "directives.provider: instance `{binding}` has kind \
                              `{}`, but resource `{}.{}` requires kind `{}`",
-                            instance.name,
-                            resource.id.provider,
-                            resource.id.resource_type,
-                            resource.id.provider,
+                            instance.name, id.provider, id.resource_type, id.provider,
                         ),
                     });
                 }
@@ -369,7 +443,7 @@ pub fn check_provider_instance_routing(parsed: &ParsedFile) -> Vec<ParseError> {
             None => {
                 // Mock / synthetic resources (no provider prefix) have no
                 // kind to route by; skip them.
-                if resource.id.provider.is_empty() {
+                if id.provider.is_empty() {
                     continue;
                 }
                 let (kind_has_any, kind_has_default) =
@@ -377,7 +451,7 @@ pub fn check_provider_instance_routing(parsed: &ParsedFile) -> Vec<ParseError> {
                         .providers
                         .iter()
                         .fold((false, false), |(any, def), p| {
-                            let matches = p.name == resource.id.provider;
+                            let matches = p.name == id.provider;
                             (any || matches, def || (matches && p.is_default))
                         });
                 if !kind_has_any {
@@ -392,10 +466,7 @@ pub fn check_provider_instance_routing(parsed: &ParsedFile) -> Vec<ParseError> {
                              attributes to the top-level `provider {}` \
                              block, or set `directives {{ provider = \
                              <instance> }}` explicitly.",
-                            resource.id.provider,
-                            resource.id.resource_type,
-                            resource.id.provider,
-                            resource.id.provider,
+                            id.provider, id.resource_type, id.provider, id.provider,
                         ),
                     });
                 }
@@ -422,8 +493,12 @@ fn accumulate_undefined_reference_errors(
         });
     };
 
-    for resource in &parsed.resources {
-        for value in resource.attributes.values() {
+    // carina#3181: walk the typed top-level slices (managed, virtual,
+    // data source) — `parsed.resources` is managed-only now. Deferred
+    // for-expression templates are handled by
+    // `accumulate_deferred_iterable_errors`, so they are excluded here.
+    for rref in parsed.iter_top_level_resources() {
+        for value in rref.attributes().values() {
             check(value);
         }
     }
@@ -656,9 +731,16 @@ pub fn resolve_provider_unresolved_attributes<E>(
     config: &ProviderContext,
 ) -> Result<(), ParseError> {
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
-    for resource in &parsed.resources {
-        if let Some(ref binding_name) = resource.binding {
-            binding_map.insert(binding_name.clone(), resource.resolved_attributes());
+    // carina#3181: walk every top-level resource — managed, data source,
+    // and virtual. This runs after module expansion, so virtual resources
+    // exist and a provider attr like `default_tags = mod.tags` resolves
+    // through the module-call virtual.
+    for rref in parsed.iter_top_level_resources() {
+        if let Some(binding_name) = rref.binding() {
+            binding_map.insert(
+                binding_name.to_string(),
+                rref.as_legacy_resource().resolved_attributes(),
+            );
         }
     }
     for arg in &parsed.arguments {

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -86,11 +86,9 @@ fn iter_all_resources_yields_direct_then_deferred() {
     assert!(matches!(items[1].context(), ResourceContext::Deferred(_)));
 }
 
-/// carina#3181 PR B: `iter_all_resources` yields each resource exactly
-/// once with the correct typed arm. While `resources` still holds
-/// data-source rows too (PR A duplicate storage), the managed-only
-/// filter must keep a `read` resource from being double-counted as both
-/// `Managed` and `DataSource`.
+/// carina#3181: `iter_all_resources` yields each resource exactly once
+/// with the correct typed arm — a managed resource as `Managed`, a
+/// `read` resource as `DataSource` — chaining the typed slices.
 #[test]
 fn iter_all_resources_classifies_managed_and_data_source_arms() {
     let src = r#"
@@ -126,6 +124,42 @@ fn iter_all_resources_classifies_managed_and_data_source_arms() {
         data_sources[0].kind(),
         crate::resource::ResourceKind::DataSource
     );
+}
+
+/// carina#3181 PR C: `legacy_top_level_resources` rebuilds the mixed
+/// `Vec<Resource>` from the typed slices — every kind present, each with
+/// the correct `ResourceKind` discriminant — for legacy `&[Resource]`
+/// APIs (`sort_resources_by_dependencies`, `split_resources_by_kind`).
+#[test]
+fn legacy_top_level_resources_rebuilds_mixed_vec() {
+    let src = r#"
+        provider aws {
+            region = aws.Region.ap_northeast_1
+        }
+        let bucket = aws.s3.Bucket {
+            bucket = "my-bucket"
+        }
+        let _ = read aws.sts.caller_identity {}
+    "#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+
+    // `resources` is managed-only, `data_sources` holds the read.
+    assert_eq!(parsed.resources.len(), 1); // allow: direct — fixture test inspection
+    assert_eq!(parsed.data_sources.len(), 1);
+
+    // The rebuilt legacy view holds both, each with the right kind.
+    let legacy = parsed.legacy_top_level_resources();
+    assert_eq!(legacy.len(), 2);
+    let managed = legacy
+        .iter()
+        .find(|r| r.kind == crate::resource::ResourceKind::Managed)
+        .expect("managed resource in legacy view");
+    let data_source = legacy
+        .iter()
+        .find(|r| r.kind == crate::resource::ResourceKind::DataSource)
+        .expect("data source in legacy view");
+    assert_eq!(managed.id.resource_type, "s3.Bucket");
+    assert_eq!(data_source.id.resource_type, "sts.caller_identity");
 }
 
 #[test]
@@ -1292,19 +1326,20 @@ fn parse_read_resource_expr() {
     "#;
 
     let result = parse(input, &ProviderContext::default()).unwrap();
-    assert_eq!(result.resources.len(), 1);
+    // carina#3181 PR C: the `read` resource lands in `data_sources`.
+    assert!(result.resources.is_empty());
+    assert_eq!(result.data_sources.len(), 1);
 
-    let resource = &result.resources[0];
-    assert_eq!(resource.id.resource_type, "s3_bucket");
-    assert_eq!(resource.id.name_str(), "existing"); // binding name becomes the resource ID
-    assert!(resource.is_data_source());
+    let data_source = &result.data_sources[0];
+    assert_eq!(data_source.id.resource_type, "s3_bucket");
+    assert_eq!(data_source.id.name_str(), "existing"); // binding name becomes the resource ID
 }
 
 #[test]
 fn parse_read_resource_does_not_inject_data_source_attribute() {
-    // Regression test for #2224: `kind == DataSource` is the only
-    // record that a `read` block produces a data source — there must
-    // be no `_data_source` key shadowing it in the attribute map.
+    // Regression test for #2224: a `read` block produces a data source
+    // — there must be no `_data_source` key shadowing it in the
+    // attribute map. carina#3181 PR C: it lands in `data_sources`.
     let input = r#"
         let existing = read aws.s3_bucket {
             name = "my-bucket"
@@ -1312,11 +1347,11 @@ fn parse_read_resource_does_not_inject_data_source_attribute() {
         }
     "#;
     let result = parse(input, &ProviderContext::default()).unwrap();
-    let resource = &result.resources[0];
-    assert!(resource.is_data_source());
-    assert!(resource.attributes.contains_key("name"));
-    assert!(resource.attributes.contains_key("region"));
-    assert!(!resource.attributes.contains_key("_data_source"));
+    assert!(result.resources.is_empty());
+    let data_source = &result.data_sources[0];
+    assert!(data_source.attributes.contains_key("name"));
+    assert!(data_source.attributes.contains_key("region"));
+    assert!(!data_source.attributes.contains_key("_data_source"));
 }
 
 #[test]
@@ -1330,7 +1365,8 @@ fn parse_read_resource_without_name_uses_binding() {
     let result = parse(input, &ProviderContext::default());
     assert!(result.is_ok());
     let parsed = result.unwrap();
-    assert_eq!(parsed.resources[0].id.name_str(), "existing"); // binding name
+    // carina#3181 PR C: `read` resources live in the `data_sources` slice.
+    assert_eq!(parsed.data_sources[0].id.name_str(), "existing"); // binding name
 }
 
 #[test]
@@ -1348,15 +1384,14 @@ fn parse_read_with_regular_resources() {
     "#;
 
     let result = parse(input, &ProviderContext::default()).unwrap();
-    assert_eq!(result.resources.len(), 2);
 
-    // First resource is read-only (data source)
-    assert!(result.resources[0].is_data_source());
-    assert_eq!(result.resources[0].id.name_str(), "existing_bucket"); // binding name
+    // carina#3181 PR C: the data source and the managed resource land
+    // in separate typed slices.
+    assert_eq!(result.data_sources.len(), 1);
+    assert_eq!(result.data_sources[0].id.name_str(), "existing_bucket"); // binding name
 
-    // Second resource is a regular resource
-    assert!(!result.resources[1].is_data_source());
-    assert_eq!(result.resources[1].id.name_str(), "new_bucket"); // binding name
+    assert_eq!(result.resources.len(), 1);
+    assert_eq!(result.resources[0].id.name_str(), "new_bucket"); // binding name
 }
 
 #[test]
@@ -6461,19 +6496,21 @@ fn parse_let_discard_read_resource() {
     "#;
 
     let result = parse(input, &ProviderContext::default()).unwrap();
-    assert_eq!(result.resources.len(), 1);
-    assert_eq!(result.resources[0].id.resource_type, "sts.caller_identity");
+    // carina#3181 PR C: `resources` is managed-only — the `read`
+    // resource lives in the typed `data_sources` slice.
+    assert!(result.resources.is_empty());
+    assert_eq!(result.data_sources.len(), 1);
     assert_eq!(
-        result.resources[0].kind,
-        crate::resource::ResourceKind::DataSource
+        result.data_sources[0].id.resource_type,
+        "sts.caller_identity"
     );
 }
 
-/// carina#3181 PR A: the parser projects `read`-keyword resources into
-/// the typed `data_sources` slice in parallel with the legacy
-/// `resources` Vec (duplicate storage during the typestate migration).
+/// carina#3181 PR C: the parser partitions resources into the
+/// managed-only `resources` Vec and the typed `data_sources` slice —
+/// each resource lands in exactly one slice.
 #[test]
-fn parse_populates_data_sources_slice_in_parallel() {
+fn parse_partitions_managed_and_data_source_slices() {
     let input = r#"
         provider aws {
             region = aws.Region.ap_northeast_1
@@ -6488,25 +6525,15 @@ fn parse_populates_data_sources_slice_in_parallel() {
 
     let result = parse(input, &ProviderContext::default()).unwrap();
 
-    // Legacy mixed Vec still holds both resources.
-    assert_eq!(result.resources.len(), 2);
+    // `resources` is managed-only — just the bucket.
+    assert_eq!(result.resources.len(), 1);
+    assert_eq!(result.resources[0].id.resource_type, "s3.Bucket");
 
-    // The typed slice holds only the read-keyword resource, and its
-    // contents match the corresponding legacy entry.
+    // The data source lives only in the typed `data_sources` slice.
     assert_eq!(result.data_sources.len(), 1);
     assert_eq!(
         result.data_sources[0].id.resource_type,
         "sts.caller_identity"
-    );
-    let legacy_data_source = result
-        .resources
-        .iter()
-        .find(|r| r.kind == crate::resource::ResourceKind::DataSource)
-        .expect("legacy resources still contains the data source");
-    assert_eq!(result.data_sources[0].id, legacy_data_source.id);
-    assert_eq!(
-        result.data_sources[0].attributes,
-        legacy_data_source.attributes
     );
 
     // The parser never synthesizes virtual resources — that is the

--- a/carina-core/src/validation/depends_on.rs
+++ b/carina-core/src/validation/depends_on.rs
@@ -209,7 +209,12 @@ pub fn validate_depends_on<E>(parsed: &File<E>) -> Vec<DependsOnDiagnostic> {
     // (early-return at top), so a cycle here is at least *touched* by
     // depends_on — but the cycle itself may go through value refs only.
     // Don't claim attribution; just report the cycle.
-    if let Err(msg) = sort_resources_by_dependencies(&parsed.resources) {
+    //
+    // carina#3181: `parsed.resources` is managed-only now, so rebuild the
+    // mixed legacy view (managed + virtual + data source) — the cycle
+    // graph must see every top-level resource.
+    let all_resources = parsed.legacy_top_level_resources();
+    if let Err(msg) = sort_resources_by_dependencies(&all_resources) {
         diags.push(DependsOnDiagnostic::error(msg));
     }
 

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -139,7 +139,11 @@ pub type InferenceBindings = HashMap<String, InferenceBinding>;
 /// over [`bindings_from_parts`] for the common case of having a parsed
 /// file in hand.
 pub fn bindings_from_parsed(parsed: &crate::parser::ParsedFile) -> InferenceBindings {
-    let mut out = bindings_from_parts(&parsed.resources, &parsed.upstream_states);
+    // carina#3181: `parsed.resources` is managed-only; rebuild the mixed
+    // legacy view so `bindings_from_parts` still sees data-source and
+    // (post-expansion) virtual rows and classifies each correctly.
+    let all_resources = parsed.legacy_top_level_resources();
+    let mut out = bindings_from_parts(&all_resources, &parsed.upstream_states);
     // Pre-expansion (load_configuration), `parsed.resources` does not
     // yet hold the `Virtual` resources that `expand_module_call`
     // synthesises for each module-call binding. Register the binding

--- a/carina-core/src/validation/wait.rs
+++ b/carina-core/src/validation/wait.rs
@@ -12,6 +12,7 @@
 //! error surfaces via the regular parser diagnostic path.
 
 use crate::parser::File;
+use crate::resource::ResourceKind;
 use crate::schema::{SchemaKind, SchemaRegistry};
 
 /// A wait-construct diagnostic.
@@ -37,20 +38,24 @@ pub fn validate_wait_bindings<E>(
     }
     let mut out: Vec<WaitDiagnostic> = Vec::new();
 
-    // Build binding → (provider, resource_type) lookup once.
-    let mut by_binding: std::collections::HashMap<String, (String, String)> =
+    // Build binding → (provider, resource_type, kind) lookup once.
+    // carina#3181: walk the typed top-level slices so a data-source
+    // target (`let x = read ...`) is still found, and carry its kind so
+    // the schema lookup below uses the matching `SchemaKind`.
+    let mut by_binding: std::collections::HashMap<String, (String, String, ResourceKind)> =
         std::collections::HashMap::new();
-    for r in &parsed.resources {
-        if let Some(b) = &r.binding {
+    for rref in parsed.iter_top_level_resources() {
+        if let Some(b) = rref.binding() {
+            let id = rref.id();
             by_binding.insert(
-                b.clone(),
-                (r.id.provider.clone(), r.id.resource_type.clone()),
+                b.to_string(),
+                (id.provider.clone(), id.resource_type.clone(), rref.kind()),
             );
         }
     }
 
     for wb in &parsed.wait_bindings {
-        let Some((provider, resource_type)) = by_binding.get(wb.target.as_str()) else {
+        let Some((provider, resource_type, kind)) = by_binding.get(wb.target.as_str()) else {
             out.push(WaitDiagnostic {
                 message: format!(
                     "wait `{}`: target binding `{}` is not a known resource",
@@ -68,7 +73,14 @@ pub fn validate_wait_bindings<E>(
         let Some(attr_name) = wb.until_predicate.lhs_segments.get(1) else {
             continue;
         };
-        let Some(schema) = schemas.get(provider, resource_type, SchemaKind::Managed) else {
+        // Virtual resources have no schema — skip the attr check (the
+        // target was still "found", matching pre-typestate behaviour).
+        let schema_kind = match kind {
+            ResourceKind::Managed => SchemaKind::Managed,
+            ResourceKind::DataSource => SchemaKind::DataSource,
+            ResourceKind::Virtual => continue,
+        };
+        let Some(schema) = schemas.get(provider, resource_type, schema_kind) else {
             // No schema for this resource type — skip the attr check.
             // The user already gets a separate "unknown resource type"
             // diagnostic from the upstream identifier-scope pass.


### PR DESCRIPTION
## Summary

Third step of the carina#3181 5-PR series (A→E) that deletes the
`Resource::kind` discriminant.

`File::resources` now holds **only managed resources** — the PR A/B
duplicate storage is gone. The parser writes `read`-keyword resources
into `data_sources`, the module expander writes virtuals into
`virtual_resources`, and `expand_deferred_for_expressions` partitions
expanded for-body resources the same way. `iter_all_resources` drops its
managed-only filter and just chains the three typed slices.

## Consumer migration

Every reader of the mixed `parsed.resources` is migrated so data sources
and virtuals are not silently dropped:

- **`BindingIndex` / `BindingNameSet`** walk `iter_top_level_resources`
  so `read` (data-source) and virtual bindings stay in scope.
  `BindingEntry` drops its unused `resource` field — only `schema` was
  ever read in production.
- **The config-loader resolution pass** —
  `resolve_resource_refs_with_config`, `collect_known_bindings_merged`,
  `check_identifier_scope`, `check_provider_instance_routing`,
  `resolve_provider_unresolved_attributes` — walks managed resources
  *and* data sources via a new private `PreApplyResourceMut` traversal.
  A data source's attributes still get ResourceRef resolution,
  dependency-binding snapshots, and identifier-scope checks. Virtuals
  are excluded from the mutable resolver (their refs resolve post-apply).
- **`validate_wait_bindings`** carries each target's kind and looks the
  schema up with the matching `SchemaKind`.
- **`validate_depends_on`'s cycle sort, `bindings_from_parsed`, and the
  carina-cli plan/apply/destroy paths** rebuild the mixed legacy view via
  the new `File::legacy_top_level_resources()` bridge before calling
  `sort_resources_by_dependencies` / `split_resources_by_kind` — so data
  sources still reach the differ as `Effect::Read`.

`get_resource_value_ref_dependencies` now takes `&dyn ResourceLike` so
it works for both managed resources and data sources.

`reconcile_*` / `apply_name_overrides` / `state refresh` lift passes /
`destroy` ordering stay managed-only — data sources carry no prefixes,
name overrides, or destroy semantics.

## New `File` helpers

- `iter_top_level_resources` — typed `ResourceRef` iterator, excludes
  deferred for-expression templates.
- `legacy_top_level_resources` — rebuilds a mixed `Vec<Resource>` for
  legacy `&[Resource]` APIs; removed once those are typestate-aware.

## Design

The resolution-pass design was reviewed with Codex: making `resources`
managed-only would have silently dropped data-source ResourceRef
resolution / scope checks. The `PreApplyResourceMut` traversal is the
type-safe fix — managed resources and data sources are mutated through
one walk; virtuals are statically excluded.

## Test plan

- [x] `cargo nextest run --workspace` — 3515 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] `make plan-fixtures`
- [x] New tests: `build_indexes_data_source_binding` (data-source
  binding reaches `BindingIndex`), `legacy_top_level_resources_rebuilds_mixed_vec`,
  `parse_partitions_managed_and_data_source_slices`.

Refs #3181

🤖 Generated with [Claude Code](https://claude.com/claude-code)