### PR TITLE
effect: flip Effect payloads to typestate structs (#3181 PR D)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1390,14 +1390,16 @@ pub async fn run_apply_from_plan(
     let plan_file: PlanFile =
         serde_json::from_str(&content).map_err(|e| format!("Failed to parse plan file: {}", e))?;
 
-    // Validate version compatibility. Plan-file version 2 added the
-    // upstream-state snapshot (#2303); older plans cannot guarantee the
-    // upstream values used during cascade re-resolution match what the
-    // plan was computed against, so they are rejected outright per the
+    // Validate version compatibility. Plan-file version 3 (carina#3181)
+    // changed the saved `Effect` payload shapes — managed effects carry
+    // `ManagedResource`, `Read` carries `DataSource`, neither serializes
+    // the legacy `kind` / `virtual_module` fields. Older plans
+    // (version 2 and below) deserialize into a different `Effect` shape
+    // and cannot be applied, so they are rejected outright per the
     // repo's no-backward-compat policy.
-    if plan_file.version != 2 {
+    if plan_file.version != 3 {
         return Err(AppError::Config(format!(
-            "Unsupported plan file version: {} (expected 2). \
+            "Unsupported plan file version: {} (expected 3). \
              Re-run 'carina plan' to produce a plan in the current format.",
             plan_file.version
         )));

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -578,7 +578,7 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
     plan.add(Effect::Replace {
         id: new_id.clone(),
         from: Box::new(State::existing(from_id.clone(), HashMap::new())),
-        to: sorted_resources[0].clone(),
+        to: sorted_resources[0].clone().try_into().unwrap(),
         directives: Directives::default(),
         changed_create_only: vec!["role_name".to_string(), "policy_name".to_string()],
         cascading_updates: vec![],
@@ -698,7 +698,7 @@ fn move_plus_update_keeps_post_update_attributes() {
     plan.add(Effect::Update {
         id: new_id.clone(),
         from: Box::new(State::existing(from_id.clone(), HashMap::new())),
-        to: sorted_resources[0].clone(),
+        to: sorted_resources[0].clone().try_into().unwrap(),
         changed_attributes: vec!["value".to_string()],
     });
     plan.add(Effect::Move {

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -122,7 +122,10 @@ fn build_plan_file<E>(
     ctx: &crate::wiring::PlanContext,
 ) -> Result<PlanFile, carina_core::value::SerializationError> {
     Ok(PlanFile {
-        version: 2,
+        // carina#3181 PR D: bumped 2→3 — Effect payloads are now typestate
+        // structs, so the saved-plan JSON shape changed (managed/data-source
+        // payloads no longer carry `kind` / `virtual_module`).
+        version: 3,
         carina_version: env!("CARGO_PKG_VERSION").to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
         source_path: path.display().to_string(),

--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -297,10 +297,10 @@ mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::executor::ProgressInfo;
-    use carina_core::resource::Resource;
+    use carina_core::resource::ManagedResource;
 
     fn dummy_create_effect() -> Effect {
-        Effect::Create(Resource::new("aws.s3.Bucket", "demo"))
+        Effect::Create(ManagedResource::new("aws.s3.Bucket", "demo"))
     }
 
     #[test]

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -345,7 +345,8 @@ async fn run_state_lookup(
 fn build_plan_from_state(state: &StateFile) -> Plan {
     let mut plan = Plan::new();
     for rs in &state.resources {
-        let mut resource = Resource::with_provider(
+        // carina#3181 PR D: `Effect::Read` carries a `DataSource`.
+        let mut resource = carina_core::resource::DataSource::with_provider(
             &rs.provider,
             &rs.resource_type,
             &rs.name,
@@ -364,7 +365,6 @@ fn build_plan_from_state(state: &StateFile) -> Plan {
             }
         }
 
-        resource.kind = carina_core::resource::ResourceKind::DataSource;
         plan.add(Effect::Read { resource });
     }
     plan
@@ -1283,9 +1283,9 @@ mod tests {
         let state = load_fixture_state();
         let plan = build_plan_from_state(&state);
 
-        let vpc_resource = plan.effects()[0].resource().unwrap();
-        assert!(vpc_resource.attributes.contains_key("cidr_block"));
-        assert!(vpc_resource.attributes.contains_key("vpc_id"));
+        let vpc_resource = plan.effects()[0].resource_like().unwrap();
+        assert!(vpc_resource.attributes().contains_key("cidr_block"));
+        assert!(vpc_resource.attributes().contains_key("vpc_id"));
     }
 
     #[test]
@@ -1301,10 +1301,10 @@ mod tests {
         let plan = build_plan_from_state(&state);
 
         // subnet depends on vpc
-        let subnet_resource = plan.effects()[1].resource().unwrap();
+        let subnet_resource = plan.effects()[1].resource_like().unwrap();
         assert_eq!(
-            subnet_resource.dependency_bindings,
-            std::collections::BTreeSet::from(["vpc".to_string()])
+            subnet_resource.dependency_bindings(),
+            &std::collections::BTreeSet::from(["vpc".to_string()])
         );
     }
 }

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -42,8 +42,8 @@ pub fn refresh_plan_separator(refreshed: bool) -> &'static str {
 }
 
 /// Check if a resource has a `let` binding (i.e., is not anonymous).
-fn has_binding(resource: &carina_core::resource::Resource) -> bool {
-    resource.binding.is_some()
+fn has_binding(resource: &dyn carina_core::resource::ResourceLike) -> bool {
+    resource.binding().is_some()
 }
 
 /// Format a compact resource identifier, showing either the binding name in quotes
@@ -53,7 +53,7 @@ fn has_binding(resource: &carina_core::resource::Resource) -> bool {
 /// `parent_binding` is the binding name of the parent in the tree, used to skip
 /// redundant ResourceRef hints.
 fn format_compact_name(
-    resource: &carina_core::resource::Resource,
+    resource: &dyn carina_core::resource::ResourceLike,
     name: &str,
     parent_binding: Option<&str>,
 ) -> String {
@@ -720,18 +720,9 @@ impl<'a> TreeRenderContext<'a> {
             if let Effect::Delete { binding, .. } = effect {
                 binding.clone()
             } else {
-                let resource = match effect {
-                    Effect::Create(r) => Some(r),
-                    Effect::Update { to, .. } => Some(to),
-                    Effect::Replace { to, .. } => Some(to),
-                    Effect::Read { resource } => Some(resource),
-                    Effect::Delete { .. }
-                    | Effect::Import { .. }
-                    | Effect::Remove { .. }
-                    | Effect::Move { .. }
-                    | Effect::Wait { .. } => None,
-                };
-                resource.and_then(|r| r.binding.clone())
+                effect
+                    .resource_like()
+                    .and_then(|r| r.binding().map(str::to_string))
             }
         };
 

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -2,10 +2,10 @@ use super::*;
 
 use carina_core::effect::{CascadingUpdate, Effect};
 use carina_core::plan::Plan;
-use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
 
-fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) -> Resource {
-    let mut r = Resource::new(resource_type, name);
+fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) -> ManagedResource {
+    let mut r = ManagedResource::new(resource_type, name);
     r.binding = Some(binding.to_string());
     for dep in deps {
         r.set_attr(
@@ -22,7 +22,7 @@ fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) 
 /// `.unwrap()` could theoretically panic if `dep_idx` were invalid.
 #[test]
 fn test_print_plan_with_external_dependency_does_not_panic() {
-    // Resource "b" depends on "a", but "a" is NOT in the plan.
+    // ManagedResource "b" depends on "a", but "a" is NOT in the plan.
     // This simulates an external/unresolved dependency.
     let b = make_resource("test.resource", "b", "b", &["a"]);
     let mut plan = Plan::new();
@@ -380,7 +380,7 @@ fn test_dependency_free_resource_nested_under_shallowest_referencing_resource() 
 /// Test that extract_compact_hint returns only the first non-parent ResourceRef hint.
 #[test]
 fn test_extract_compact_hint_resource_ref() {
-    let mut r = Resource::new("ec2.subnet_route_table_association", "hash123");
+    let mut r = ManagedResource::new("ec2.subnet_route_table_association", "hash123");
     r.set_attr(
         "route_table_id".to_string(),
         Value::resource_ref("public_rt".to_string(), "id".to_string(), vec![]),
@@ -398,7 +398,7 @@ fn test_extract_compact_hint_resource_ref() {
 /// Test that extract_compact_hint skips ResourceRef that matches parent binding.
 #[test]
 fn test_extract_compact_hint_skips_parent_ref() {
-    let mut r = Resource::new("ec2.subnet_route_table_association", "hash123");
+    let mut r = ManagedResource::new("ec2.subnet_route_table_association", "hash123");
     r.set_attr(
         "route_table_id".to_string(),
         Value::resource_ref("database_rt".to_string(), "id".to_string(), vec![]),
@@ -416,7 +416,7 @@ fn test_extract_compact_hint_skips_parent_ref() {
 /// Test that extract_compact_hint falls back to string values when no ResourceRef.
 #[test]
 fn test_extract_compact_hint_string_fallback() {
-    let mut r = Resource::new("ec2.route", "hash456");
+    let mut r = ManagedResource::new("ec2.route", "hash456");
     r.set_attr(
         "destination_cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
@@ -429,7 +429,7 @@ fn test_extract_compact_hint_string_fallback() {
 /// Test that extract_compact_hint returns None when no useful attributes.
 #[test]
 fn test_extract_compact_hint_none() {
-    let r = Resource::new("ec2.route", "hash789");
+    let r = ManagedResource::new("ec2.route", "hash789");
     let hint = extract_compact_hint(&r, None);
     assert_eq!(hint, None);
 }
@@ -437,7 +437,7 @@ fn test_extract_compact_hint_none() {
 /// Test that extract_compact_hint prefers string over ResourceRef.
 #[test]
 fn test_extract_compact_hint_prefers_string_over_resource_ref() {
-    let mut r = Resource::new("ec2.route", "hash_mixed");
+    let mut r = ManagedResource::new("ec2.route", "hash_mixed");
     r.set_attr(
         "destination".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
@@ -455,7 +455,7 @@ fn test_extract_compact_hint_prefers_string_over_resource_ref() {
 /// Test that extract_compact_hint shortens service_name values.
 #[test]
 fn test_extract_compact_hint_service_name_shortening() {
-    let mut r = Resource::new("ec2.vpc_endpoint", "hash_svc");
+    let mut r = ManagedResource::new("ec2.vpc_endpoint", "hash_svc");
     r.set_attr(
         "service_name".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -467,7 +467,7 @@ fn test_extract_compact_hint_service_name_shortening() {
     assert_eq!(hint, Some("service: ecr.dkr".to_string()));
 
     // Single service component
-    let mut r2 = Resource::new("ec2.vpc_endpoint", "hash_svc2");
+    let mut r2 = ManagedResource::new("ec2.vpc_endpoint", "hash_svc2");
     r2.set_attr(
         "service_name".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -482,7 +482,7 @@ fn test_extract_compact_hint_service_name_shortening() {
 /// Test that extract_compact_hint falls back to string when all ResourceRefs match parent.
 #[test]
 fn test_extract_compact_hint_all_refs_match_parent() {
-    let mut r = Resource::new("ec2.security_group_ingress", "hash_sg");
+    let mut r = ManagedResource::new("ec2.security_group_ingress", "hash_sg");
     r.set_attr(
         "group_id".to_string(),
         Value::resource_ref("endpoint_sg".to_string(), "id".to_string(), vec![]),
@@ -500,7 +500,7 @@ fn test_extract_compact_hint_all_refs_match_parent() {
 /// Test that extract_compact_hint prefers string over ResourceRef for vpc_endpoint.
 #[test]
 fn test_extract_compact_hint_prefers_string_for_vpc_endpoint() {
-    let mut r = Resource::new("ec2.vpc_endpoint", "hash_ep");
+    let mut r = ManagedResource::new("ec2.vpc_endpoint", "hash_ep");
     r.set_attr(
         "service_name".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -528,11 +528,11 @@ fn test_extract_compact_hint_prefers_string_for_vpc_endpoint() {
 /// Test that has_binding correctly detects bound vs anonymous resources.
 #[test]
 fn test_has_binding() {
-    let mut bound = Resource::new("ec2.Vpc", "vpc");
+    let mut bound = ManagedResource::new("ec2.Vpc", "vpc");
     bound.binding = Some("vpc".to_string());
     assert!(has_binding(&bound));
 
-    let anonymous = Resource::new("ec2.Vpc", "hash123");
+    let anonymous = ManagedResource::new("ec2.Vpc", "hash123");
     assert!(!has_binding(&anonymous));
 }
 
@@ -540,7 +540,7 @@ fn test_has_binding() {
 /// parenthesized hints for anonymous resources.
 #[test]
 fn test_format_compact_name_bound_resource() {
-    let mut r = Resource::new("ec2.Vpc", "vpc");
+    let mut r = ManagedResource::new("ec2.Vpc", "vpc");
     r.binding = Some("vpc".to_string());
     // For bound resources, should show name as plain identifier (no quotes)
     let result = format_compact_name(&r, "vpc", None);
@@ -553,7 +553,7 @@ fn test_format_compact_name_bound_resource() {
 
 #[test]
 fn test_format_compact_name_anonymous_with_hint() {
-    let mut r = Resource::new("ec2.subnet_route_table_association", "hash123");
+    let mut r = ManagedResource::new("ec2.subnet_route_table_association", "hash123");
     r.set_attr(
         "subnet_id".to_string(),
         Value::resource_ref("database_subnet_1a".to_string(), "id".to_string(), vec![]),
@@ -598,7 +598,7 @@ fn test_print_plan_compact_does_not_panic() {
 /// keys are not printed (attributes are hidden in compact mode).
 #[test]
 fn test_print_plan_compact_with_anonymous_resources() {
-    let mut anon = Resource::new("ec2.route", "hash_anon");
+    let mut anon = ManagedResource::new("ec2.route", "hash_anon");
     anon.set_attr(
         "destination_cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
@@ -628,7 +628,7 @@ fn test_print_plan_compact_with_anonymous_resources() {
 /// e.g., security_group_ids = [endpoint_sg.group_id] should produce "security_group: endpoint_sg"
 #[test]
 fn test_extract_compact_hint_list_containing_resource_ref() {
-    let mut r = Resource::new("ec2.vpc_endpoint", "hash_list_ref");
+    let mut r = ManagedResource::new("ec2.vpc_endpoint", "hash_list_ref");
     r.set_attr(
         "security_group_ids".to_string(),
         Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
@@ -649,7 +649,7 @@ fn test_extract_compact_hint_list_containing_resource_ref() {
 /// Test that extract_compact_hint skips List<ResourceRef> when ref matches parent.
 #[test]
 fn test_extract_compact_hint_list_ref_skips_parent() {
-    let mut r = Resource::new("ec2.vpc_endpoint", "hash_list_parent");
+    let mut r = ManagedResource::new("ec2.vpc_endpoint", "hash_list_parent");
     r.set_attr(
         "security_group_ids".to_string(),
         Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
@@ -680,7 +680,7 @@ fn test_shorten_attr_name_ids_suffix() {
 /// Test that extract_compact_hint resolves DSL enum identifiers.
 #[test]
 fn test_extract_compact_hint_resolves_dsl_enum() {
-    let mut r = Resource::new("ec2.Subnet", "hash_enum");
+    let mut r = ManagedResource::new("ec2.Subnet", "hash_enum");
     r.set_attr(
         "availability_zone".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -701,7 +701,7 @@ fn test_extract_compact_hint_resolves_dsl_enum() {
 /// Test that extract_compact_hint skips _-prefixed attributes.
 #[test]
 fn test_extract_compact_hint_skips_internal_attributes() {
-    let mut r = Resource::new("ec2.Vpc", "hash_internal");
+    let mut r = ManagedResource::new("ec2.Vpc", "hash_internal");
     r.binding = Some("vpc".to_string());
     r.set_attr(
         "_hash".to_string(),
@@ -724,7 +724,7 @@ fn test_cascading_update_shows_attribute_diffs() {
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         )]),
     );
-    let vpc_to = Resource::new("ec2.Vpc", "vpc")
+    let vpc_to = ManagedResource::new("ec2.Vpc", "vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -744,7 +744,7 @@ fn test_cascading_update_shows_attribute_diffs() {
             ),
         ]),
     );
-    let subnet_to = Resource::new("ec2.Subnet", "subnet")
+    let subnet_to = ManagedResource::new("ec2.Subnet", "subnet")
         .with_attribute(
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -807,7 +807,7 @@ fn test_format_cascading_update_attr_diff() {
                 ),
             ]),
         )),
-        to: Resource::new("ec2.Subnet", "subnet")
+        to: ManagedResource::new("ec2.Subnet", "subnet")
             .with_attribute(
                 "vpc_id",
                 Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -987,7 +987,7 @@ fn test_format_cascading_update_diff_excludes_non_ref_attributes() {
                 ),
             ]),
         )),
-        to: Resource::new("ec2.Subnet", "subnet")
+        to: ManagedResource::new("ec2.Subnet", "subnet")
             .with_attribute(
                 "vpc_id",
                 Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -1045,7 +1045,7 @@ fn test_format_cascading_update_diff_includes_list_with_ref() {
                 )])),
             )]),
         )),
-        to: Resource::new("ec2.Instance", "instance").with_attribute(
+        to: ManagedResource::new("ec2.Instance", "instance").with_attribute(
             "security_group_ids",
             Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
                 "sg".to_string(),
@@ -1204,7 +1204,7 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
     // SG: Create effect with RESOLVED ref (string instead of ResourceRef).
     // This is what happens after resolve_refs_with_state() runs:
     // vpc_id = vpc.vpc_id becomes vpc_id = "vpc-0123456789abcdef0"
-    let mut sg = Resource::new("ec2.SecurityGroup", "sg");
+    let mut sg = ManagedResource::new("ec2.SecurityGroup", "sg");
     sg.binding = Some("sg".to_string());
     // This is the resolved value — a plain string, NOT a ResourceRef
     sg.set_attr(
@@ -1289,7 +1289,7 @@ fn format_effect_delete_falls_back_to_id_name() {
 /// so the type/address boundary is visible in plan/apply output.
 #[test]
 fn format_effect_create_separates_type_and_name_with_space() {
-    let mut r = Resource::new("s3.Bucket", "state_bucket");
+    let mut r = ManagedResource::new("s3.Bucket", "state_bucket");
     r.id = ResourceId::with_provider("aws", "s3.Bucket", "state_bucket", None);
     let effect = Effect::Create(r);
     assert_eq!(format_effect(&effect), "Create aws.s3.Bucket state_bucket");
@@ -1298,7 +1298,7 @@ fn format_effect_create_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_update_separates_type_and_name_with_space() {
     let id = ResourceId::with_provider("awscc", "iam.Role", "bs.bootstrap.role", None);
-    let mut to = Resource::new("iam.Role", "bs.bootstrap.role");
+    let mut to = ManagedResource::new("iam.Role", "bs.bootstrap.role");
     to.id = id.clone();
     let effect = Effect::Update {
         id,
@@ -1320,7 +1320,7 @@ fn format_effect_update_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_replace_separates_type_and_name_with_space() {
     let id = ResourceId::with_provider("awscc", "ec2.Vpc", "vpc", None);
-    let mut to = Resource::new("ec2.Vpc", "vpc");
+    let mut to = ManagedResource::new("ec2.Vpc", "vpc");
     to.id = id.clone();
     let effect = Effect::Replace {
         id,

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -11,7 +11,8 @@ use carina_core::parser::{ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{
-    ConcreteValue, DeferredValue, Directives, Resource, ResourceId, State, Value,
+    ConcreteValue, DataSource, DeferredValue, Directives, ManagedResource, Resource, ResourceId,
+    State, Value,
 };
 use carina_core::schema::{ResourceSchema, SchemaRegistry};
 use carina_state::{BackendError, LockInfo, ResourceState, StateBackend, StateFile};
@@ -270,7 +271,7 @@ fn plan_file_serde_round_trip() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
+        ManagedResource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
         ),
@@ -302,7 +303,7 @@ fn plan_file_serde_round_trip() {
     }];
 
     let plan_file = PlanFile {
-        version: 2,
+        version: 3,
         carina_version: "0.1.0".to_string(),
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         source_path: "example.crn".to_string(),
@@ -348,7 +349,7 @@ fn plan_file_serde_round_trip() {
     let json = serde_json::to_string_pretty(&plan_file).unwrap();
     let deserialized: PlanFile = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(deserialized.version, 2);
+    assert_eq!(deserialized.version, 3);
     assert_eq!(deserialized.carina_version, "0.1.0");
     assert_eq!(deserialized.source_path, "example.crn");
     assert_eq!(deserialized.state_lineage, Some("test-lineage".to_string()));
@@ -579,7 +580,7 @@ fn test_detailed_exitcode_no_changes() {
 fn test_detailed_exitcode_with_changes() {
     // A plan with mutating effects means changes -- has_changes should be true
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "test")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "test")));
     let has_changes = plan.mutation_count() > 0;
     assert!(has_changes);
 }
@@ -589,7 +590,7 @@ fn test_detailed_exitcode_read_only_no_changes() {
     // A plan with only Read effects should NOT count as changes
     let mut plan = Plan::new();
     plan.add(Effect::Read {
-        resource: Resource::new("sts.caller_identity", "identity").with_read_only(true),
+        resource: DataSource::new("sts.caller_identity", "identity"),
     });
     let has_changes = plan.mutation_count() > 0;
     assert!(!has_changes);
@@ -1818,7 +1819,7 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
     plan.add(Effect::Replace {
         id: id.clone(),
         from: Box::new(old_state.clone()),
-        to: new_resource.clone(),
+        to: (new_resource.clone()).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1947,7 +1948,9 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc_unresolved.clone().with_binding("vpc"),
+        to: (vpc_unresolved.clone().with_binding("vpc"))
+            .try_into()
+            .unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1960,7 +1963,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     plan.add(Effect::Update {
         id: subnet_id.clone(),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: subnet_resolved.clone(), // Has stale "vpc-OLD" in vpc_id
+        to: subnet_resolved.clone().try_into().unwrap(), // Has stale "vpc-OLD" in vpc_id
         changed_attributes: vec!["cidr_block".to_string()],
     });
 
@@ -2778,7 +2781,9 @@ fn plan_file_serialization_redacts_secrets() {
         .with_attribute("master_password", secret_password.clone());
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource_with_secret.clone()));
+    plan.add(Effect::Create(
+        (resource_with_secret.clone()).try_into().unwrap(),
+    ));
 
     let mut state_attrs = HashMap::new();
     state_attrs.insert(
@@ -2793,7 +2798,7 @@ fn plan_file_serialization_redacts_secrets() {
 
     // Redact before building PlanFile (same as production code does)
     let plan_file = PlanFile {
-        version: 2,
+        version: 3,
         carina_version: "0.1.0".to_string(),
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         source_path: "example.crn".to_string(),

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -407,7 +407,7 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
         Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
     );
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(Effect::Create(resource.try_into().unwrap()));
 
     // Import block with the logical name (not the hash)
     let state_blocks = vec![StateBlock::Import {

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -315,8 +315,14 @@ pub fn find_failed_dependency(
     effect: &Effect,
     failed_bindings: &HashSet<String>,
 ) -> Option<String> {
-    let resource = effect.resource()?;
-    let deps = get_resource_dependencies(resource);
+    // carina#3181 PR D: `Effect` payloads are typestate structs, so the
+    // dependency set is assembled from the `ResourceLike` view (value
+    // refs + `dependency_bindings`) plus the effect's explicit
+    // `depends_on` edges — the same union `get_resource_dependencies`
+    // computes for a legacy `Resource`.
+    let resource = effect.resource_like()?;
+    let mut deps = get_resource_value_ref_dependencies(resource);
+    deps.extend(effect.explicit_dependencies());
     deps.into_iter().find(|dep| failed_bindings.contains(dep))
 }
 
@@ -345,7 +351,7 @@ pub fn find_failed_dependent<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{Directives, Resource, ResourceId, Value};
+    use crate::resource::{Directives, ManagedResource, Resource, ResourceId, Value};
 
     fn make_resource(binding: &str, deps: &[&str]) -> Resource {
         let mut r = Resource::new("test", binding);
@@ -487,7 +493,7 @@ mod tests {
     #[test]
     fn test_find_failed_dependency_direct() {
         let resource = make_resource("b", &["a"]);
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(ManagedResource::try_from(&resource).unwrap());
 
         let mut failed = HashSet::new();
         failed.insert("a".to_string());
@@ -499,7 +505,7 @@ mod tests {
     #[test]
     fn test_find_failed_dependency_none() {
         let resource = make_resource("b", &["a"]);
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(ManagedResource::try_from(&resource).unwrap());
 
         let failed: HashSet<String> = HashSet::new();
 
@@ -510,7 +516,7 @@ mod tests {
     #[test]
     fn test_find_failed_dependency_no_deps() {
         let resource = make_resource("a", &[]);
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(ManagedResource::try_from(&resource).unwrap());
 
         let mut failed = HashSet::new();
         failed.insert("x".to_string());
@@ -522,7 +528,7 @@ mod tests {
     #[test]
     fn test_find_failed_dependency_transitive_propagation() {
         let resource_c = make_resource("c", &["b"]);
-        let effect_c = Effect::Create(resource_c);
+        let effect_c = Effect::Create(ManagedResource::try_from(&resource_c).unwrap());
 
         let mut failed = HashSet::new();
         failed.insert("a".to_string());

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -367,17 +367,24 @@ pub fn build_detail_rows(
         return Vec::new();
     }
 
+    // carina#3181 PR D: `Effect` payloads are typestate structs; the
+    // row builders / schema lookup still take a legacy `&Resource`, so
+    // bridge through `Resource::from` at this display seam.
     match effect {
-        Effect::Create(r) => build_create_rows(r, registry, detail),
+        Effect::Create(r) => {
+            let r = crate::resource::Resource::from(r);
+            build_create_rows(&r, registry, detail)
+        }
         Effect::Update {
             from,
             to,
             changed_attributes,
             ..
         } => {
+            let to = crate::resource::Resource::from(to);
             let explicit = prev_explicit.and_then(|map| map.get(&to.id));
-            let schema = registry.and_then(|r| r.get_for(to));
-            build_update_rows(from, to, changed_attributes, schema, detail, explicit)
+            let schema = registry.and_then(|r| r.get_for(&to));
+            build_update_rows(from, &to, changed_attributes, schema, detail, explicit)
         }
         Effect::Replace {
             from,
@@ -388,11 +395,12 @@ pub fn build_detail_rows(
             cascade_ref_hints,
             ..
         } => {
+            let to = crate::resource::Resource::from(to);
             let explicit = prev_explicit.and_then(|map| map.get(&to.id));
-            let schema = registry.and_then(|r| r.get_for(to));
+            let schema = registry.and_then(|r| r.get_for(&to));
             build_replace_rows(
                 from,
-                to,
+                &to,
                 changed_create_only,
                 cascading_updates,
                 temporary_name,
@@ -403,7 +411,10 @@ pub fn build_detail_rows(
             )
         }
         Effect::Delete { id, .. } => build_delete_rows(id, delete_attributes),
-        Effect::Read { resource } => build_create_rows(resource, registry, detail),
+        Effect::Read { resource } => {
+            let resource = crate::resource::Resource::from(resource);
+            build_create_rows(&resource, registry, detail)
+        }
         Effect::Import { identifier, .. } => {
             vec![DetailRow::Attribute {
                 key: "id".to_string(),
@@ -1449,7 +1460,7 @@ mod tests {
     #[test]
     fn test_names_only_returns_empty() {
         let resource = Resource::new("s3.Bucket", "my-bucket");
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resource.try_into().unwrap());
         let rows = build_detail_rows(&effect, None, DetailLevel::NamesOnly, None, None);
         assert!(rows.is_empty());
     }
@@ -1465,7 +1476,7 @@ mod tests {
                 "region",
                 Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
             );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resource.try_into().unwrap());
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert_eq!(rows.len(), 2);
         assert!(matches!(&rows[0], DetailRow::Attribute { key, .. } if key == "bucket"));
@@ -1490,7 +1501,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("s3.Bucket", "my-bucket"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["versioning".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -1536,7 +1547,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("s3.Bucket", "my-bucket"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["versioning".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Full, None, None);
@@ -1590,7 +1601,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("s3.Bucket", "my-bucket"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["trigger_diff".to_string()],
         };
 
@@ -1681,7 +1692,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("s3.Bucket", "my-bucket"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["removed_attr".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -1702,7 +1713,7 @@ mod tests {
         );
         let resource = Resource::new("s3.Bucket", "my-bucket")
             .with_attribute("tags", Value::Concrete(ConcreteValue::Map(tags)));
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resource.try_into().unwrap());
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert_eq!(rows.len(), 1);
         match &rows[0] {
@@ -1767,7 +1778,7 @@ mod tests {
             "policy_document",
             Value::Concrete(ConcreteValue::Map(policy)),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resource.try_into().unwrap());
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         let entries = rows
             .iter()
@@ -1915,7 +1926,7 @@ mod tests {
         let effect = Effect::Replace {
             id: ResourceId::new("ec2.Vpc", "my-vpc"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             directives: crate::resource::Directives::default(),
             changed_create_only: vec!["cidr_block".to_string()],
             cascading_updates: vec![],
@@ -1983,7 +1994,7 @@ mod tests {
                 ConcreteValue::Map(entry),
             )])),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resource.try_into().unwrap());
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
 
         let pretty_value = rows.iter().find_map(|row| match row {
@@ -2009,7 +2020,7 @@ mod tests {
             "role_name",
             Value::Concrete(ConcreteValue::String("foo".to_string())),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resource.try_into().unwrap());
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert!(
             rows.iter().any(|row| matches!(
@@ -2035,7 +2046,7 @@ mod tests {
                 )),
             ])),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resource.try_into().unwrap());
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
 
         let pretty = rows.iter().find_map(|row| match row {
@@ -2061,7 +2072,7 @@ mod tests {
         // for empty lists, breaking the formatting-path uniformity.
         let resource = Resource::new("iam.Role", "test")
             .with_attribute("tags", Value::Concrete(ConcreteValue::List(vec![])));
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resource.try_into().unwrap());
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert!(
             rows.iter().any(|row| matches!(
@@ -2175,7 +2186,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("iam.Role", "r"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["policy".to_string()],
         };
         let registry = iam_policy_registry();
@@ -2224,7 +2235,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("iam.Role", "r"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["policy".to_string(), "description".to_string()],
         };
         let registry = iam_policy_registry();
@@ -2268,7 +2279,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("iam.Role", "r"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["policy".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -2308,7 +2319,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("iam.Role", "r"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["policy".to_string()],
         };
         let registry = iam_policy_registry();
@@ -2372,7 +2383,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("x.Thing", "t"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["modes".to_string()],
         };
         let rows = build_detail_rows(&effect, Some(&registry), DetailLevel::Explicit, None, None);
@@ -2412,7 +2423,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("iam.Role", "r"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["policy".to_string()],
         };
         let registry = iam_policy_registry();
@@ -2473,7 +2484,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("iam.Role", "r"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["policy".to_string(), "description".to_string()],
         };
         let registry = iam_policy_registry();
@@ -2564,7 +2575,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("x.Thing", "t"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["modes".to_string()],
         };
         let rows = build_detail_rows(&effect, Some(&registry), DetailLevel::Explicit, None, None);
@@ -2609,7 +2620,7 @@ mod tests {
         let effect = Effect::Update {
             id: ResourceId::new("x.Thing", "t"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             changed_attributes: vec!["modes".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -66,7 +66,7 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: (vpc.clone().with_binding("vpc")).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -166,7 +166,7 @@ fn cascade_skips_resources_already_in_plan() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone(),
+        to: (vpc.clone()).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -179,7 +179,7 @@ fn cascade_skips_resources_already_in_plan() {
     plan.add(Effect::Update {
         id: subnet_id.clone(),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: subnet.clone(),
+        to: (subnet.clone()).try_into().unwrap(),
         changed_attributes: vec!["cidr_block".to_string()],
     });
 
@@ -239,7 +239,7 @@ fn cascade_no_op_without_create_before_destroy() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone(),
+        to: (vpc.clone()).try_into().unwrap(),
         directives: Directives::default(), // create_before_destroy = false
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],
@@ -333,7 +333,7 @@ fn cascade_transitive_dependencies() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone(),
+        to: (vpc.clone()).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -414,7 +414,7 @@ fn cascade_anonymous_resource_dependent() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone(),
+        to: (vpc.clone()).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -526,7 +526,7 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: (vpc.clone().with_binding("vpc")).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -699,7 +699,7 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: (vpc.clone().with_binding("vpc")).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -712,7 +712,7 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     plan.add(Effect::Replace {
         id: subnet_id.clone(),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: subnet.clone().with_binding("subnet"),
+        to: (subnet.clone().with_binding("subnet")).try_into().unwrap(),
         directives: Directives::default(),
         changed_create_only: vec!["availability_zone".to_string()],
         cascading_updates: vec![],
@@ -846,7 +846,7 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: (vpc.clone().with_binding("vpc")).try_into().unwrap(),
         directives: Directives::default(), // create_before_destroy = false (user didn't set it)
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],
@@ -973,7 +973,7 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: (vpc.clone().with_binding("vpc")).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -986,7 +986,7 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
     plan.add(Effect::Update {
         id: subnet_id.clone(),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: subnet.clone().with_binding("subnet"),
+        to: (subnet.clone().with_binding("subnet")).try_into().unwrap(),
         changed_attributes: vec!["tags".to_string()],
     });
 
@@ -1100,7 +1100,7 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: (vpc.clone().with_binding("vpc")).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1230,7 +1230,7 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: (vpc.clone().with_binding("vpc")).try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1243,7 +1243,7 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
     plan.add(Effect::Update {
         id: subnet_id.clone(),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: subnet.clone().with_binding("subnet"),
+        to: (subnet.clone().with_binding("subnet")).try_into().unwrap(),
         changed_attributes: vec!["tags".to_string()],
     });
 

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -18,6 +18,20 @@ use crate::wait::predicate::{AttrPath, WaitPredicate};
 
 use super::{Diff, diff};
 
+/// Bridge a legacy [`Resource`] to a [`ManagedResource`] at the
+/// differ/effect seam (carina#3181 PR D).
+///
+/// `Effect::Create` / `Update` / `Replace` and `CascadingUpdate` carry
+/// `ManagedResource`, but the differ's internal pipeline (`diff()`,
+/// `cascade_dependent_updates`'s unresolved set) still works in legacy
+/// `Resource`. Every resource that reaches a managed effect has already
+/// been classified as managed upstream, so the conversion cannot fail —
+/// `expect` documents that invariant.
+fn to_managed(resource: &Resource) -> ManagedResource {
+    ManagedResource::try_from(resource)
+        .expect("differ produced a non-managed resource for a managed effect")
+}
+
 /// A pending merge operation: cascade-triggered create-only attributes to add to an existing effect.
 struct CascadeMerge {
     resource_id: ResourceId,
@@ -196,7 +210,7 @@ pub fn create_plan(
     // longer reachable from this loop (carina#3179).
     for ds in data_sources {
         plan.add(Effect::Read {
-            resource: Resource::from(ds),
+            resource: ds.clone(),
         });
     }
 
@@ -228,7 +242,11 @@ pub fn create_plan(
         );
 
         match d {
-            Diff::Create(r) => plan.add(Effect::Create(r)),
+            // carina#3181 PR D: `Effect` payloads are typestate structs.
+            // `diff()` runs on a managed resource, so the legacy
+            // `Resource` it returns is always managed — bridge it to
+            // `ManagedResource` at the differ/effect seam.
+            Diff::Create(r) => plan.add(Effect::Create(to_managed(&r))),
             Diff::Update {
                 id,
                 from,
@@ -272,7 +290,7 @@ pub fn create_plan(
                     plan.add(Effect::Update {
                         id,
                         from,
-                        to,
+                        to: to_managed(&to),
                         changed_attributes,
                     });
                 } else {
@@ -314,7 +332,7 @@ pub fn create_plan(
                     plan.add(Effect::Replace {
                         id,
                         from,
-                        to,
+                        to: to_managed(&to),
                         directives,
                         changed_create_only,
                         cascading_updates: vec![],
@@ -808,7 +826,7 @@ pub fn cascade_dependent_updates(
                         .push(CascadingUpdate {
                             id: unresolved.id.clone(),
                             from: Box::new(from),
-                            to: (*unresolved).clone(),
+                            to: to_managed(unresolved),
                         });
                 } else if unresolved.directives.prevent_destroy {
                     // Cascade would promote to Replace (destroy + recreate),
@@ -842,7 +860,7 @@ pub fn cascade_dependent_updates(
                     promoted_replaces.push(Effect::Replace {
                         id: unresolved.id.clone(),
                         from: Box::new(from),
-                        to: (*unresolved).clone(),
+                        to: to_managed(unresolved),
                         directives: unresolved.directives.clone(),
                         changed_create_only: create_only_refs,
                         cascading_updates: vec![],

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::resource::{Directives, Resource, ResourceId, State};
+use crate::resource::{DataSource, Directives, ManagedResource, ResourceId, ResourceLike, State};
 use crate::wait::predicate::WaitPredicate;
 
 /// Temporary name used during create-before-destroy replacement.
@@ -37,7 +37,7 @@ pub struct TemporaryName {
 pub struct CascadingUpdate {
     pub id: ResourceId,
     pub from: Box<State>,
-    pub to: Resource,
+    pub to: ManagedResource,
 }
 
 /// How an [`Effect::Wait`] obtains the cloud provider identifier its
@@ -82,16 +82,16 @@ pub enum WaitTarget {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Effect {
     /// Read the current state of a resource (data source)
-    Read { resource: Resource },
+    Read { resource: DataSource },
 
     /// Create a new resource
-    Create(Resource),
+    Create(ManagedResource),
 
     /// Update an existing resource
     Update {
         id: ResourceId,
         from: Box<State>,
-        to: Resource,
+        to: ManagedResource,
         /// Attribute names that changed (including removed attributes)
         changed_attributes: Vec<String>,
     },
@@ -100,7 +100,7 @@ pub enum Effect {
     Replace {
         id: ResourceId,
         from: Box<State>,
-        to: Resource,
+        to: ManagedResource,
         #[serde(default)]
         directives: Directives,
         /// Which create-only attributes forced the replacement
@@ -233,13 +233,13 @@ pub enum Effect {
 pub enum BasicEffect<'a> {
     Create {
         effect: &'a Effect,
-        resource: &'a Resource,
+        resource: &'a ManagedResource,
     },
     Update {
         effect: &'a Effect,
         id: &'a ResourceId,
         from: &'a State,
-        to: &'a Resource,
+        to: &'a ManagedResource,
         changed_attributes: &'a [String],
     },
     Delete {
@@ -284,8 +284,8 @@ impl Effect {
     ///
     /// ```compile_fail
     /// use carina_core::effect::{BasicEffect, Effect};
-    /// use carina_core::resource::Resource;
-    /// let effect = Effect::Create(Resource::new("test", "x"));
+    /// use carina_core::resource::ManagedResource;
+    /// let effect = Effect::Create(ManagedResource::new("test", "x"));
     /// // Was: a missed filter could pass a non-basic `&Effect` straight
     /// // into `execute_basic_effect` and trip `unreachable!()` at apply
     /// // time (carina#3164). The conversion no longer exists.
@@ -372,14 +372,57 @@ impl Effect {
         }
     }
 
-    /// Returns a reference to the resource for this effect, if it has one.
-    /// Delete, Import, Remove, Move, and Wait effects have no resource.
-    pub fn resource(&self) -> Option<&Resource> {
+    /// Returns a read-only [`ResourceLike`] view of the resource for this
+    /// effect, if it has one. Delete, Import, Remove, Move, and Wait
+    /// effects have no resource.
+    ///
+    /// carina#3181: the underlying payloads are typestate structs —
+    /// `Create`/`Update`/`Replace` carry a [`ManagedResource`], `Read`
+    /// carries a [`DataSource`]. Callers that need a concrete type match
+    /// the variant directly; this helper covers the shared
+    /// id/attributes/binding/dependency_bindings accessors.
+    pub fn resource_like(&self) -> Option<&dyn ResourceLike> {
         match self {
             Effect::Create(resource) => Some(resource),
             Effect::Update { to, .. } => Some(to),
             Effect::Replace { to, .. } => Some(to),
             Effect::Read { resource } => Some(resource),
+            Effect::Delete { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Move { .. }
+            | Effect::Wait { .. } => None,
+        }
+    }
+
+    /// Bridge this effect's resource to a legacy [`Resource`], if it has
+    /// one. carina#3181 PR D: the payloads are typestate structs, but a
+    /// few executor/display call sites still want a `Resource` — this
+    /// rebuilds one via the `From<&ManagedResource>` / `From<&DataSource>`
+    /// bridges. Removed once those call sites are typestate-aware.
+    pub fn resource_as_legacy(&self) -> Option<crate::resource::Resource> {
+        match self {
+            Effect::Create(resource) => Some(resource.into()),
+            Effect::Update { to, .. } => Some(to.into()),
+            Effect::Replace { to, .. } => Some(to.into()),
+            Effect::Read { resource } => Some(resource.into()),
+            Effect::Delete { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Move { .. }
+            | Effect::Wait { .. } => None,
+        }
+    }
+
+    /// Returns the `directives` block of this effect's resource, if it
+    /// has one. `Read` (data source) and the managed variants both carry
+    /// directives; state-only and `Wait` effects do not.
+    fn resource_directives(&self) -> Option<&Directives> {
+        match self {
+            Effect::Create(resource) => Some(&resource.directives),
+            Effect::Update { to, .. } => Some(&to.directives),
+            Effect::Replace { to, .. } => Some(&to.directives),
+            Effect::Read { resource } => Some(&resource.directives),
             Effect::Delete { .. }
             | Effect::Import { .. }
             | Effect::Remove { .. }
@@ -396,7 +439,8 @@ impl Effect {
         if let Effect::Wait { binding, .. } = self {
             return Some(binding.clone());
         }
-        self.resource().and_then(|r| r.binding.clone())
+        self.resource_like()
+            .and_then(|r| r.binding().map(str::to_string))
     }
 
     /// Returns the binding names this effect depends on **via explicit
@@ -413,8 +457,8 @@ impl Effect {
     /// State-only effects (Import, Remove, Move) return an empty set —
     /// they are scheduling primitives, not resource-state operations.
     pub fn explicit_dependencies(&self) -> HashSet<String> {
-        if let Some(res) = self.resource() {
-            return res.directives.depends_on.iter().cloned().collect();
+        if let Some(directives) = self.resource_directives() {
+            return directives.depends_on.iter().cloned().collect();
         }
         if let Effect::Delete {
             explicit_dependencies,
@@ -440,21 +484,21 @@ mod tests {
 
     #[test]
     fn read_is_not_mutating() {
-        let resource = Resource::new("test", "example").with_read_only(true);
+        let resource = DataSource::new("test", "example");
         let effect = Effect::Read { resource };
         assert!(!effect.is_mutating());
     }
 
     #[test]
     fn create_is_mutating() {
-        let resource = Resource::new("s3.Bucket", "my-bucket");
+        let resource = ManagedResource::new("s3.Bucket", "my-bucket");
         let effect = Effect::Create(resource);
         assert!(effect.is_mutating());
     }
 
     #[test]
     fn resource_id_returns_correct_id() {
-        let resource = Resource::new("s3.Bucket", "my-bucket").with_read_only(true);
+        let resource = DataSource::new("s3.Bucket", "my-bucket");
         let effect = Effect::Read {
             resource: resource.clone(),
         };
@@ -463,9 +507,9 @@ mod tests {
 
     #[test]
     fn resource_returns_some_for_create() {
-        let resource = Resource::new("s3.Bucket", "my-bucket");
+        let resource = ManagedResource::new("s3.Bucket", "my-bucket");
         let effect = Effect::Create(resource.clone());
-        assert_eq!(effect.resource().unwrap().id, resource.id);
+        assert_eq!(effect.resource_like().unwrap().id(), &resource.id);
     }
 
     #[test]
@@ -478,12 +522,12 @@ mod tests {
             dependencies: HashSet::new(),
             explicit_dependencies: std::collections::HashSet::new(),
         };
-        assert!(effect.resource().is_none());
+        assert!(effect.resource_like().is_none());
     }
 
     #[test]
     fn binding_name_returns_binding() {
-        let resource = Resource::new("test", "my_binding").with_binding("my_binding");
+        let resource = ManagedResource::new("test", "my_binding").with_binding("my_binding");
         let effect = Effect::Create(resource);
         assert_eq!(effect.binding_name(), Some("my_binding".to_string()));
     }
@@ -491,7 +535,7 @@ mod tests {
     #[test]
     fn binding_name_returns_none_without_binding() {
         use crate::resource::{ConcreteValue, Value};
-        let resource = Resource::new("test", "no_binding").with_attribute(
+        let resource = ManagedResource::new("test", "no_binding").with_attribute(
             "name",
             Value::Concrete(ConcreteValue::String("test".to_string())),
         );
@@ -505,9 +549,9 @@ mod tests {
         use std::collections::HashMap;
 
         let effects = vec![
-            Effect::Create(Resource::new("s3.Bucket", "my-bucket")),
+            Effect::Create(ManagedResource::new("s3.Bucket", "my-bucket")),
             Effect::Read {
-                resource: Resource::new("s3.Bucket", "existing").with_read_only(true),
+                resource: DataSource::new("s3.Bucket", "existing"),
             },
             Effect::Update {
                 id: ResourceId::new("s3.Bucket", "my-bucket"),
@@ -518,7 +562,7 @@ mod tests {
                         Value::Concrete(ConcreteValue::String("Disabled".to_string())),
                     )]),
                 )),
-                to: Resource::new("s3.Bucket", "my-bucket").with_attribute(
+                to: ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
                     "versioning",
                     Value::Concrete(ConcreteValue::String("Enabled".to_string())),
                 ),
@@ -533,13 +577,22 @@ mod tests {
                         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
                     )]),
                 )),
-                to: Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+                to: ManagedResource::new("ec2.Vpc", "my-vpc").with_attribute(
                     "cidr_block",
                     Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
                 ),
                 directives: Directives::default(),
                 changed_create_only: vec!["cidr_block".to_string()],
-                cascading_updates: vec![],
+                // carina#3181 PR D: cover `CascadingUpdate.to:
+                // ManagedResource` in the serde round-trip.
+                cascading_updates: vec![CascadingUpdate {
+                    id: ResourceId::new("ec2.Subnet", "my-subnet"),
+                    from: Box::new(State::not_found(ResourceId::new("ec2.Subnet", "my-subnet"))),
+                    to: ManagedResource::new("ec2.Subnet", "my-subnet").with_attribute(
+                        "vpc_id",
+                        Value::Concrete(ConcreteValue::String("vpc.id".to_string())),
+                    ),
+                }],
                 temporary_name: None,
                 cascade_ref_hints: vec![],
             },
@@ -563,7 +616,7 @@ mod tests {
     #[test]
     fn explicit_dependencies_derived_from_resource_directives() {
         use crate::resource::Directives;
-        let mut bucket = Resource::new("s3.Bucket", "b");
+        let mut bucket = ManagedResource::new("s3.Bucket", "b");
         bucket.directives = Directives {
             depends_on: vec!["role".to_string(), "kms".to_string()],
             ..Directives::default()
@@ -745,7 +798,7 @@ mod tests {
         let rid = ResourceId::new("test", "x");
 
         // Basic variants must narrow.
-        let create = Effect::Create(Resource::new("test", "x"));
+        let create = Effect::Create(ManagedResource::new("test", "x"));
         assert!(matches!(
             create.as_basic(),
             Some(BasicEffect::Create { .. })
@@ -754,7 +807,7 @@ mod tests {
         let update = Effect::Update {
             id: rid.clone(),
             from: Box::new(ResState::not_found(rid.clone())),
-            to: Resource::new("test", "x"),
+            to: ManagedResource::new("test", "x"),
             changed_attributes: vec![],
         };
         assert!(matches!(
@@ -780,12 +833,12 @@ mod tests {
         // inside `as_basic` is what catches it at compile time; this
         // test catches misclassification of an existing variant.
         let read = Effect::Read {
-            resource: Resource::new("test", "x"),
+            resource: DataSource::new("test", "x"),
         };
         let replace = Effect::Replace {
             id: rid.clone(),
             from: Box::new(ResState::not_found(rid.clone())),
-            to: Resource::new("test", "x"),
+            to: ManagedResource::new("test", "x"),
             directives: Directives::default(),
             changed_create_only: vec![],
             cascading_updates: vec![],

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -376,6 +376,10 @@ pub(super) async fn execute_basic_effect<'a>(
 
     match basic {
         BasicEffect::Create { resource, .. } => {
+            // carina#3181 PR D: `BasicEffect::Create.resource` is a
+            // `ManagedResource`; the executor's resolve/renormalize
+            // pipeline still works in legacy `Resource`, so bridge here.
+            let resource = &Resource::from(resource);
             let resolved = match resolve_resource(resource, bindings, pipeline).await {
                 Ok(r) => r,
                 Err(e) => {
@@ -436,6 +440,10 @@ pub(super) async fn execute_basic_effect<'a>(
             changed_attributes,
             ..
         } => {
+            // carina#3181 PR D: `BasicEffect::Update.to` is a
+            // `ManagedResource`; bridge to legacy `Resource` for the
+            // executor's resolve pipeline and the `unresolved` map.
+            let to = &Resource::from(to);
             let resolve_source = unresolved.get(id).unwrap_or(to);
             let resolved_to =
                 match resolve_resource_with_source(to, resolve_source, bindings, pipeline).await {

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -48,8 +48,8 @@ pub(super) fn build_dependency_map(
     let mut deps_of: HashMap<usize, HashSet<usize>> = HashMap::new();
     for (idx, effect) in effects.iter().enumerate() {
         let mut dep_indices = HashSet::new();
-        if let Some(resource) = effect.resource() {
-            resolver.collect_from_resource(resource, &mut dep_indices);
+        if let Some(resource) = effect.resource_as_legacy() {
+            resolver.collect_from_resource(&resource, &mut dep_indices);
             if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
                 resolver.collect_from_resource(unresolved, &mut dep_indices);
             }
@@ -369,13 +369,17 @@ pub(super) async fn execute_effects_sequential(
                             };
                             observer.on_event(&ExecutionEvent::EffectStarted { effect });
 
+                            // carina#3181 PR D: bridge the `ManagedResource`
+                            // payload to legacy `Resource` for `ReplaceContext`.
+                            let to = Resource::from(to);
+
                             execute_replace_parallel(
                                 provider,
                                 &ReplaceContext {
                                     effect,
                                     id,
                                     from,
-                                    to,
+                                    to: &to,
                                     directives,
                                     cascading_updates,
                                     temporary_name: temporary_name.as_ref(),
@@ -613,8 +617,8 @@ mod tests {
         );
 
         let effects = vec![
-            Effect::Create(role.clone()),
-            Effect::Create(role_policy.clone()),
+            Effect::Create(role.clone().try_into().unwrap()),
+            Effect::Create(role_policy.clone().try_into().unwrap()),
         ];
 
         let mut unresolved: HashMap<ResourceId, Resource> = HashMap::new();

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -28,7 +28,10 @@ pub(super) fn has_interdependent_replaces(effects: &[Effect]) -> bool {
 
     for effect in effects {
         if let Effect::Replace { to, .. } = effect {
-            for dep in get_resource_dependencies(to) {
+            // carina#3181 PR D: `Effect::Replace.to` is a
+            // `ManagedResource`; `get_resource_dependencies` still works
+            // in legacy `Resource` (it reads `directives.depends_on`).
+            for dep in get_resource_dependencies(&Resource::from(to)) {
                 if replace_bindings.contains(&dep) {
                     return true;
                 }
@@ -76,7 +79,7 @@ pub(super) fn topological_sort_replaces(
     for &idx in &replace_indices {
         let effect = &effects[idx];
         if let Effect::Replace { to, .. } = effect {
-            let dep_indices: Vec<usize> = get_resource_dependencies(to)
+            let dep_indices: Vec<usize> = get_resource_dependencies(&Resource::from(to))
                 .iter()
                 .filter(|b| replace_bindings.contains(b.as_str()))
                 .filter_map(|b| binding_to_idx.get(b))
@@ -158,8 +161,8 @@ pub(super) fn build_phase_dependency_map(
     for &idx in phase_indices {
         let mut dep_indices = HashSet::new();
         let effect = &effects[idx];
-        if let Some(resource) = effect.resource() {
-            resolver.collect_from_resource(resource, &mut dep_indices);
+        if let Some(resource) = effect.resource_as_legacy() {
+            resolver.collect_from_resource(&resource, &mut dep_indices);
             if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
                 resolver.collect_from_resource(unresolved, &mut dep_indices);
             }
@@ -574,6 +577,10 @@ pub(super) async fn execute_effects_phased(
                         let started = Instant::now();
                         observer.on_event(&ExecutionEvent::EffectStarted { effect });
 
+                        // carina#3181 PR D: bridge the `ManagedResource`
+                        // payload to legacy `Resource` for the executor's
+                        // resolve pipeline and the `unresolved` map.
+                        let to = &Resource::from(to);
                         let resolve_source = unresolved.get(&to.id).unwrap_or(to);
                         let resolved = match resolve_resource_with_source(
                             to,
@@ -624,7 +631,7 @@ pub(super) async fn execute_effects_phased(
                                 let mut cascade_states = Vec::new();
                                 for cascade in cascading_updates {
                                     let resolved_to = match resolve_resource(
-                                        &cascade.to,
+                                        &Resource::from(&cascade.to),
                                         &local_bindings,
                                         &pipeline,
                                     )
@@ -760,9 +767,12 @@ pub(super) async fn execute_effects_phased(
                 } => {
                     let effect = &effects[idx];
                     if let Effect::Replace { to, .. } = effect {
+                        // carina#3181 PR D: `resolved_attributes` lives on
+                        // the legacy `Resource`; bridge the `ManagedResource`.
+                        let to_legacy = Resource::from(to);
                         input.bindings.record_applied(
                             to.binding.as_deref(),
-                            &to.resolved_attributes(),
+                            &to_legacy.resolved_attributes(),
                             &state,
                         );
                     }
@@ -847,8 +857,8 @@ pub(super) async fn execute_effects_phased(
         for &idx in &delete_indices {
             let effect = &effects[idx];
             let mut dep_indices = HashSet::new();
-            if let Some(resource) = effect.resource() {
-                resolver.collect_from_resource(resource, &mut dep_indices);
+            if let Some(resource) = effect.resource_as_legacy() {
+                resolver.collect_from_resource(&resource, &mut dep_indices);
                 if let Some(unresolved) = input.unresolved_resources.get(effect.resource_id()) {
                     resolver.collect_from_resource(unresolved, &mut dep_indices);
                 }
@@ -1178,6 +1188,10 @@ pub(super) async fn execute_effects_phased(
                         in_flight.push(Box::pin(async move {
                             if let Effect::Replace { to, .. } = effect {
                                 let started = effect_started;
+                                // carina#3181 PR D: bridge the
+                                // `ManagedResource` payload to legacy
+                                // `Resource` for the resolve pipeline.
+                                let to = &Resource::from(to);
                                 let resolve_source = unresolved.get(&to.id).unwrap_or(to);
                                 let resolved = match resolve_resource_with_source(
                                     to,
@@ -1369,8 +1383,8 @@ mod tests {
         );
 
         let effects = vec![
-            Effect::Create(role.clone()),
-            Effect::Create(role_policy.clone()),
+            Effect::Create(role.clone().try_into().unwrap()),
+            Effect::Create(role_policy.clone().try_into().unwrap()),
         ];
         let phase_indices: Vec<usize> = vec![0, 1];
 
@@ -1422,7 +1436,10 @@ mod tests {
             Value::resource_ref("outer", "role_name", vec![]),
         );
 
-        let effects = vec![Effect::Create(role.clone()), Effect::Create(caller.clone())];
+        let effects = vec![
+            Effect::Create(role.clone().try_into().unwrap()),
+            Effect::Create(caller.clone().try_into().unwrap()),
+        ];
         let phase_indices: Vec<usize> = vec![0, 1];
 
         let mut unresolved: HashMap<ResourceId, Resource> = HashMap::new();
@@ -1462,7 +1479,7 @@ mod tests {
         let role_replace = Effect::Replace {
             id: role.id.clone(),
             from: Box::new(role_state),
-            to: role.clone(),
+            to: role.clone().try_into().unwrap(),
             directives: Directives::default(),
             changed_create_only: vec!["role_name".to_string()],
             cascading_updates: vec![],
@@ -1472,7 +1489,7 @@ mod tests {
         let bucket_replace = Effect::Replace {
             id: bucket.id.clone(),
             from: Box::new(bucket_state),
-            to: bucket.clone(),
+            to: bucket.clone().try_into().unwrap(),
             directives: Directives::default(),
             changed_create_only: vec!["bucket_name".to_string()],
             cascading_updates: vec![],

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -156,8 +156,12 @@ pub(super) async fn execute_cbd_replace_parallel(
             // Execute cascading updates
             let mut cascade_failed = false;
             for cascade in ctx.cascading_updates {
-                let resolved_to = match resolve_resource(&cascade.to, &local_bindings, ctx.pipeline)
-                    .await
+                let resolved_to = match resolve_resource(
+                    &crate::resource::Resource::from(&cascade.to),
+                    &local_bindings,
+                    ctx.pipeline,
+                )
+                .await
                 {
                     Ok(r) => r,
                     Err(e) => {

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -4,7 +4,9 @@ use crate::provider::{
     BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
     ReadRequest, UpdateRequest,
 };
-use crate::resource::{ConcreteValue, DeferredValue, Directives, Resource, Value};
+use crate::resource::{
+    ConcreteValue, DataSource, DeferredValue, Directives, ManagedResource, Resource, Value,
+};
 use parallel::{build_dependency_levels, build_dependency_map};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -376,8 +378,8 @@ impl ProviderFactory for AliasFactory {
 // Helper functions
 // -----------------------------------------------------------------------
 
-fn make_resource(binding: &str, deps: &[&str]) -> Resource {
-    let mut r = Resource::new("test", binding);
+fn make_resource(binding: &str, deps: &[&str]) -> ManagedResource {
+    let mut r = ManagedResource::new("test", binding);
     r.binding = Some(binding.to_string());
     for dep in deps {
         r.set_attr(
@@ -520,7 +522,7 @@ async fn test_apply_reapplies_enum_alias_stage() {
     let rid = resource.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(Effect::Create(resource.try_into().unwrap()));
     provider.push_create(Ok(ok_state(&rid)));
 
     let factories: Vec<Box<dyn ProviderFactory>> = vec![Box::new(AliasFactory)];
@@ -577,7 +579,7 @@ async fn test_apply_reapplies_enum_alias_stage_update_path() {
     plan.add(Effect::Update {
         id: rid.clone(),
         from: Box::new(from_state),
-        to: to_resource,
+        to: to_resource.try_into().unwrap(),
         changed_attributes: vec!["ip_protocol".to_string()],
     });
     provider.push_update(Ok(ok_state(&rid)));
@@ -631,7 +633,7 @@ async fn test_apply_reapplies_canonicalize_stage() {
     let rid = resource.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(Effect::Create(resource.try_into().unwrap()));
     provider.push_create(Ok(ok_state(&rid)));
 
     let input = ExecutionInput {
@@ -1016,7 +1018,7 @@ async fn test_cbd_creates_before_deletes() {
     plan.add(Effect::Replace {
         id: rid.clone(),
         from: Box::new(from),
-        to,
+        to: to.try_into().unwrap(),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1063,7 +1065,7 @@ async fn test_dbd_deletes_before_creates() {
     plan.add(Effect::Replace {
         id: rid.clone(),
         from: Box::new(from),
-        to,
+        to: to.try_into().unwrap(),
         directives: Directives::default(),
         changed_create_only: vec!["attr".to_string()],
         cascading_updates: vec![],
@@ -1126,7 +1128,7 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(vpc_from),
-        to: vpc_to,
+        to: vpc_to.try_into().unwrap(),
         directives: cbd_directives.clone(),
         changed_create_only: vec!["attr".to_string()],
         cascading_updates: vec![],
@@ -1136,7 +1138,7 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
     plan.add(Effect::Replace {
         id: subnet_id.clone(),
         from: Box::new(subnet_from),
-        to: subnet_to,
+        to: subnet_to.try_into().unwrap(),
         directives: cbd_directives,
         changed_create_only: vec!["attr".to_string()],
         cascading_updates: vec![],
@@ -1202,7 +1204,7 @@ async fn test_phased_noncbd_creates_after_deletes() {
     plan.add(Effect::Replace {
         id: vpc_id.clone(),
         from: Box::new(vpc_from),
-        to: vpc_to,
+        to: vpc_to.try_into().unwrap(),
         directives: dbd_directives.clone(),
         changed_create_only: vec!["attr".to_string()],
         cascading_updates: vec![],
@@ -1212,7 +1214,7 @@ async fn test_phased_noncbd_creates_after_deletes() {
     plan.add(Effect::Replace {
         id: subnet_id.clone(),
         from: Box::new(subnet_from),
-        to: subnet_to,
+        to: subnet_to.try_into().unwrap(),
         directives: dbd_directives,
         changed_create_only: vec!["attr".to_string()],
         cascading_updates: vec![],
@@ -1285,7 +1287,7 @@ async fn test_observer_events_emitted_correctly() {
 #[tokio::test]
 async fn test_read_effect_is_no_op() {
     let provider = MockProvider::new();
-    let resource = Resource::new("test", "data").with_read_only(true);
+    let resource = DataSource::new("test", "data");
 
     let mut plan = Plan::new();
     plan.add(Effect::Read { resource });
@@ -1523,12 +1525,12 @@ fn test_build_dependency_levels_transitive_ref_preserves_direct_dep() {
     rt.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc)); // idx 0
-    plan.add(Effect::Create(tgw)); // idx 1
-    plan.add(Effect::Create(subnet)); // idx 2
-    plan.add(Effect::Create(tgw_attach)); // idx 3
-    plan.add(Effect::Create(rt)); // idx 4
-    plan.add(Effect::Create(route)); // idx 5
+    plan.add(Effect::Create(vpc.try_into().unwrap())); // idx 0
+    plan.add(Effect::Create(tgw.try_into().unwrap())); // idx 1
+    plan.add(Effect::Create(subnet.try_into().unwrap())); // idx 2
+    plan.add(Effect::Create(tgw_attach.try_into().unwrap())); // idx 3
+    plan.add(Effect::Create(rt.try_into().unwrap())); // idx 4
+    plan.add(Effect::Create(route.try_into().unwrap())); // idx 5
 
     let levels = build_dependency_levels(plan.effects(), &HashMap::new());
 
@@ -1958,8 +1960,8 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     let subnet_id = subnet.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(subnet));
+    plan.add(Effect::Create(vpc.try_into().unwrap()));
+    plan.add(Effect::Create(subnet.try_into().unwrap()));
 
     // VPC create returns state with vpc_id
     let vpc_state = State::existing(
@@ -2137,7 +2139,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
     // tgw_b: Create (new resource)
     let mut tgw_b = Resource::new("test", "tgw_b");
     tgw_b.binding = Some("tgw_b".to_string());
-    plan.add(Effect::Create(tgw_b));
+    plan.add(Effect::Create(tgw_b.try_into().unwrap()));
 
     // tgw_a: Delete
     plan.add(Effect::Delete {
@@ -2153,7 +2155,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
     plan.add(Effect::Replace {
         id: attachment_id.clone(),
         from: Box::new(attachment_from),
-        to: attachment_to,
+        to: attachment_to.try_into().unwrap(),
         directives: cbd_directives,
         changed_create_only: vec!["transit_gateway_id".to_string()],
         cascading_updates: vec![],
@@ -2230,7 +2232,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
     // tgw_b: Create
     let mut tgw_b = Resource::new("test", "tgw_b");
     tgw_b.binding = Some("tgw_b".to_string());
-    plan.add(Effect::Create(tgw_b));
+    plan.add(Effect::Create(tgw_b.try_into().unwrap()));
 
     // tgw_a: Delete — binding is None (the key difference from the previous test)
     plan.add(Effect::Delete {
@@ -2246,7 +2248,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
     plan.add(Effect::Replace {
         id: attachment_id.clone(),
         from: Box::new(attachment_from),
-        to: attachment_to,
+        to: attachment_to.try_into().unwrap(),
         directives: cbd_directives,
         changed_create_only: vec!["transit_gateway_id".to_string()],
         cascading_updates: vec![],
@@ -2463,7 +2465,7 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
         interval: std::time::Duration::from_millis(1),
         explicit_dependencies: std::collections::HashSet::new(),
     });
-    plan.add(Effect::Create(dist));
+    plan.add(Effect::Create(dist.try_into().unwrap()));
 
     // create cert → PENDING; wait polls read → PENDING → ISSUED+arn.
     let mut create_attrs = HashMap::new();
@@ -2667,8 +2669,8 @@ async fn test_chained_index_then_field_unresolved_at_apply_fails_with_clear_erro
     let record_id = record.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
-    plan.add(Effect::Create(record));
+    plan.add(Effect::Create(cert.try_into().unwrap()));
+    plan.add(Effect::Create(record.try_into().unwrap()));
 
     // Mirror the AWS RequestCertificate read-back race: the DVO list
     // is populated asynchronously by ACM after RequestCertificate
@@ -2820,8 +2822,8 @@ async fn test_chained_index_then_nested_field_resolves_from_post_create_state() 
     let record_id = record.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
-    plan.add(Effect::Create(record));
+    plan.add(Effect::Create(cert.try_into().unwrap()));
+    plan.add(Effect::Create(record.try_into().unwrap()));
 
     // Cert create returns post-read state with DVO populated. Shape
     // mirrors what `read_acm_certificate` inserts after aws#295.
@@ -3054,7 +3056,7 @@ async fn wait_resolves_target_identifier_from_just_created_state() {
     let provider = IdentifierAwareProvider::new("cert-arn-real", created_state);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(Effect::Create(cert.try_into().unwrap()));
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
         target_id: cert_id.clone(),
@@ -3132,7 +3134,7 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
     plan.add(Effect::Replace {
         id: role_id.clone(),
         from: Box::new(role_from),
-        to: role_to,
+        to: role_to.try_into().unwrap(),
         directives: Directives::default(),
         changed_create_only: vec!["role_name".to_string()],
         cascading_updates: vec![],
@@ -3146,7 +3148,7 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
     plan.add(Effect::Replace {
         id: policy_new_id,
         from: Box::new(policy_from),
-        to: policy_to,
+        to: policy_to.try_into().unwrap(),
         directives: Directives::default(),
         changed_create_only: vec!["policy_name".to_string()],
         cascading_updates: vec![],

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -134,11 +134,15 @@ impl Plan {
                     return;
                 }
                 Effect::Update { id, .. } if id == resource_id => {
-                    // Take ownership of the Update fields and upgrade to Replace
-                    let old = std::mem::replace(
-                        effect,
-                        Effect::Create(crate::resource::Resource::new("", "")),
-                    );
+                    // Take ownership of the Update fields and upgrade to Replace.
+                    // The `Create` here is a throwaway placeholder overwritten
+                    // on the next line — carina#3181 PR D: `Effect::Create`
+                    // carries `ManagedResource`, so bridge a bare `Resource`.
+                    let placeholder = crate::resource::ManagedResource::try_from(
+                        &crate::resource::Resource::new("", ""),
+                    )
+                    .expect("bare Resource::new is always managed");
+                    let old = std::mem::replace(effect, Effect::Create(placeholder));
                     if let Effect::Update { id, from, to, .. } = old {
                         *effect = Effect::Replace {
                             id,
@@ -273,10 +277,10 @@ impl ModularPlan {
         // Extract module sources from effect resources
         for (idx, effect) in plan.effects().iter().enumerate() {
             let source = match effect {
-                Effect::Create(r) => Self::extract_source(r),
-                Effect::Update { to, .. } => Self::extract_source(to),
-                Effect::Replace { to, .. } => Self::extract_source(to),
-                Effect::Read { resource } => Self::extract_source(resource),
+                Effect::Create(r) => Self::extract_source(&r.module_source),
+                Effect::Update { to, .. } => Self::extract_source(&to.module_source),
+                Effect::Replace { to, .. } => Self::extract_source(&to.module_source),
+                Effect::Read { resource } => Self::extract_source(&resource.module_source),
                 Effect::Delete { .. }
                 | Effect::Import { .. }
                 | Effect::Remove { .. }
@@ -289,8 +293,8 @@ impl ModularPlan {
         modular
     }
 
-    fn extract_source(resource: &crate::resource::Resource) -> ModuleSource {
-        resource.module_source.clone().unwrap_or(ModuleSource::Root)
+    fn extract_source(module_source: &Option<ModuleSource>) -> ModuleSource {
+        module_source.clone().unwrap_or(ModuleSource::Root)
     }
 
     /// Get the source for an effect by index
@@ -450,7 +454,9 @@ mod tests {
         use std::time::Duration;
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("acm.Certificate", "cert")));
+        plan.add(Effect::Create(
+            Resource::new("acm.Certificate", "cert").try_into().unwrap(),
+        ));
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
@@ -472,8 +478,12 @@ mod tests {
     #[test]
     fn plan_summary() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+        plan.add(Effect::Create(
+            Resource::new("s3.Bucket", "a").try_into().unwrap(),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("s3.Bucket", "b").try_into().unwrap(),
+        ));
         plan.add(Effect::Delete {
             id: crate::resource::ResourceId::new("s3.Bucket", "c"),
             identifier: String::new(),
@@ -493,7 +503,9 @@ mod tests {
         let mut plan = Plan::new();
 
         // Root resource
-        plan.add(Effect::Create(Resource::new("vpc", "main")));
+        plan.add(Effect::Create(
+            Resource::new("vpc", "main").try_into().unwrap(),
+        ));
 
         // Module resource
         let module_resource =
@@ -501,7 +513,7 @@ mod tests {
                 name: "web_tier".to_string(),
                 instance: "web".to_string(),
             });
-        plan.add(Effect::Create(module_resource));
+        plan.add(Effect::Create(module_resource.try_into().unwrap()));
 
         let modular = ModularPlan::from_plan(plan);
 
@@ -520,8 +532,12 @@ mod tests {
         let mut plan = Plan::new();
 
         // Two root resources
-        plan.add(Effect::Create(Resource::new("vpc", "main")));
-        plan.add(Effect::Create(Resource::new("subnet", "public")));
+        plan.add(Effect::Create(
+            Resource::new("vpc", "main").try_into().unwrap(),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("subnet", "public").try_into().unwrap(),
+        ));
 
         // Module resource
         let module_resource =
@@ -529,7 +545,7 @@ mod tests {
                 name: "web_tier".to_string(),
                 instance: "web".to_string(),
             });
-        plan.add(Effect::Create(module_resource));
+        plan.add(Effect::Create(module_resource.try_into().unwrap()));
 
         let modular = ModularPlan::from_plan(plan);
         let groups = modular.group_by_module();
@@ -561,12 +577,12 @@ mod tests {
                 State::not_found(ResourceId::new("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
             ),
-            to: Resource::new("ec2.Subnet", "subnet"),
+            to: (Resource::new("ec2.Subnet", "subnet")).try_into().unwrap(),
         };
         plan.add(Effect::Replace {
             id: ResourceId::new("ec2.Vpc", "vpc"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             directives: Directives::default(),
             changed_create_only: vec!["cidr_block".to_string()],
             cascading_updates: vec![cascading],
@@ -597,12 +613,12 @@ mod tests {
                 State::not_found(ResourceId::new("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
             ),
-            to: Resource::new("ec2.Subnet", "subnet"),
+            to: (Resource::new("ec2.Subnet", "subnet")).try_into().unwrap(),
         };
         plan.add(Effect::Replace {
             id: ResourceId::new("ec2.Vpc", "vpc"),
             from: Box::new(from),
-            to,
+            to: to.try_into().unwrap(),
             directives: Directives::default(),
             changed_create_only: vec!["cidr_block".to_string()],
             cascading_updates: vec![cascading],
@@ -628,7 +644,9 @@ mod tests {
         use crate::resource::ResourceId;
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+        plan.add(Effect::Create(
+            Resource::new("s3.Bucket", "a").try_into().unwrap(),
+        ));
         plan.add(Effect::Delete {
             id: ResourceId::new("s3.Bucket", "b"),
             identifier: "b-id".to_string(),

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -9,7 +9,7 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::deps::get_resource_dependencies;
+use crate::deps::get_resource_value_ref_dependencies;
 use crate::effect::Effect;
 use crate::plan::Plan;
 use crate::resource::{ConcreteValue, DeferredValue, Value};
@@ -32,66 +32,79 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
     let mut effect_types: HashMap<usize, String> = HashMap::new();
 
     for (idx, effect) in plan.effects().iter().enumerate() {
-        let (resource, deps) = match effect {
-            Effect::Create(r) => (Some(r), get_resource_dependencies(r)),
-            Effect::Update { to, .. } => (Some(to), get_resource_dependencies(to)),
-            Effect::Replace { to, .. } => (Some(to), get_resource_dependencies(to)),
-            Effect::Read { resource } => (Some(resource), get_resource_dependencies(resource)),
-            Effect::Delete {
-                id,
-                binding,
-                dependencies,
-                ..
-            } => {
-                let deps = dependencies.clone();
-                if let Some(b) = binding {
-                    binding_to_effect.insert(b.clone(), idx);
-                    effect_bindings.insert(idx, b.clone());
-                } else {
+        let (resource, deps): (Option<&dyn crate::resource::ResourceLike>, HashSet<String>) =
+            match effect {
+                // carina#3181 PR D: `Create`/`Update`/`Replace`/`Read`
+                // all carry a typestate struct — reach them through the
+                // shared `ResourceLike` view, and assemble the dependency
+                // set from value refs + the effect's explicit depends_on.
+                Effect::Create(_)
+                | Effect::Update { .. }
+                | Effect::Replace { .. }
+                | Effect::Read { .. } => {
+                    let rl = effect.resource_like().expect("variant carries a resource");
+                    let mut deps = get_resource_value_ref_dependencies(rl);
+                    deps.extend(effect.explicit_dependencies());
+                    (Some(rl), deps)
+                }
+                Effect::Delete {
+                    id,
+                    binding,
+                    dependencies,
+                    ..
+                } => {
+                    let deps = dependencies.clone();
+                    if let Some(b) = binding {
+                        binding_to_effect.insert(b.clone(), idx);
+                        effect_bindings.insert(idx, b.clone());
+                    } else {
+                        let fallback = id.to_string();
+                        binding_to_effect.insert(fallback.clone(), idx);
+                        effect_bindings.insert(idx, fallback);
+                    }
+                    effect_types.insert(idx, id.resource_type.clone());
+                    effect_deps.insert(idx, deps);
+                    continue;
+                }
+                Effect::Import { id, .. } | Effect::Remove { id, .. } => {
                     let fallback = id.to_string();
                     binding_to_effect.insert(fallback.clone(), idx);
                     effect_bindings.insert(idx, fallback);
+                    effect_types.insert(idx, id.resource_type.clone());
+                    effect_deps.insert(idx, HashSet::new());
+                    continue;
                 }
-                effect_types.insert(idx, id.resource_type.clone());
-                effect_deps.insert(idx, deps);
-                continue;
-            }
-            Effect::Import { id, .. } | Effect::Remove { id, .. } => {
-                let fallback = id.to_string();
-                binding_to_effect.insert(fallback.clone(), idx);
-                effect_bindings.insert(idx, fallback);
-                effect_types.insert(idx, id.resource_type.clone());
-                effect_deps.insert(idx, HashSet::new());
-                continue;
-            }
-            Effect::Move { to, .. } => {
-                let fallback = to.to_string();
-                binding_to_effect.insert(fallback.clone(), idx);
-                effect_bindings.insert(idx, fallback);
-                effect_types.insert(idx, to.resource_type.clone());
-                effect_deps.insert(idx, HashSet::new());
-                continue;
-            }
-            Effect::Wait {
-                binding, target_id, ..
-            } => {
-                // The wait depends on its target binding so the tree
-                // shows the wait as a child of the resource it gates.
-                let mut deps = HashSet::new();
-                deps.insert(target_id.name_str().to_string());
-                binding_to_effect.insert(binding.clone(), idx);
-                effect_bindings.insert(idx, binding.clone());
-                effect_types.insert(idx, "wait".to_string());
-                effect_deps.insert(idx, deps);
-                continue;
-            }
-        };
+                Effect::Move { to, .. } => {
+                    let fallback = to.to_string();
+                    binding_to_effect.insert(fallback.clone(), idx);
+                    effect_bindings.insert(idx, fallback);
+                    effect_types.insert(idx, to.resource_type.clone());
+                    effect_deps.insert(idx, HashSet::new());
+                    continue;
+                }
+                Effect::Wait {
+                    binding, target_id, ..
+                } => {
+                    // The wait depends on its target binding so the tree
+                    // shows the wait as a child of the resource it gates.
+                    let mut deps = HashSet::new();
+                    deps.insert(target_id.name_str().to_string());
+                    binding_to_effect.insert(binding.clone(), idx);
+                    effect_bindings.insert(idx, binding.clone());
+                    effect_types.insert(idx, "wait".to_string());
+                    effect_deps.insert(idx, deps);
+                    continue;
+                }
+            };
 
         if let Some(r) = resource {
-            let binding = r.binding.clone().unwrap_or_else(|| r.id.to_string());
+            let binding = r
+                .binding()
+                .map(str::to_string)
+                .unwrap_or_else(|| r.id().to_string());
             binding_to_effect.insert(binding.clone(), idx);
             effect_bindings.insert(idx, binding);
-            effect_types.insert(idx, r.id.resource_type.clone());
+            effect_types.insert(idx, r.id().resource_type.clone());
         }
         effect_deps.insert(idx, deps);
     }
@@ -272,11 +285,11 @@ pub fn build_single_parent_tree(
 /// `parent_binding` is the binding name of the parent resource in the tree, used to
 /// skip ResourceRef attributes that redundantly reference the parent.
 pub fn extract_compact_hint(
-    resource: &crate::resource::Resource,
+    resource: &dyn crate::resource::ResourceLike,
     parent_binding: Option<&str>,
 ) -> Option<String> {
     let mut keys: Vec<_> = resource
-        .attributes
+        .attributes()
         .keys()
         .filter(|k| !k.starts_with('_'))
         .collect();
@@ -284,7 +297,7 @@ pub fn extract_compact_hint(
 
     // Priority 1: First distinguishing string attribute (most identifying)
     for key in &keys {
-        if let Some(Value::Concrete(ConcreteValue::String(s))) = resource.get_attr(key)
+        if let Some(Value::Concrete(ConcreteValue::String(s))) = resource.attributes().get(*key)
             && !s.is_empty()
         {
             let short_key = shorten_attr_name(key);
@@ -301,7 +314,7 @@ pub fn extract_compact_hint(
 
     // Priority 2: First non-parent ResourceRef attribute (direct or inside a List)
     for key in &keys {
-        match resource.get_attr(key) {
+        match resource.attributes().get(*key) {
             Some(Value::Deferred(DeferredValue::ResourceRef { path })) => {
                 if parent_binding == Some(path.binding()) {
                     continue;
@@ -369,8 +382,8 @@ mod tests {
         bucket.directives.depends_on = vec!["role".to_string()];
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(role));
-        plan.add(Effect::Create(bucket));
+        plan.add(Effect::Create(role.try_into().unwrap()));
+        plan.add(Effect::Create(bucket.try_into().unwrap()));
         let graph = build_dependency_graph(&plan);
 
         let bucket_idx = *graph

--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -56,6 +56,59 @@ pub struct DataSource {
     pub quoted_string_attrs: HashSet<String>,
 }
 
+impl DataSource {
+    /// Create a data source with an empty attribute map.
+    pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            id: ResourceId::new(resource_type, name),
+            attributes: IndexMap::new(),
+            directives: Directives::default(),
+            binding: None,
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: HashSet::new(),
+        }
+    }
+
+    /// Create a data source with a provider-qualified id.
+    pub fn with_provider(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        name: impl Into<String>,
+        provider_instance: Option<String>,
+    ) -> Self {
+        Self {
+            id: ResourceId::with_provider(provider, resource_type, name, provider_instance),
+            attributes: IndexMap::new(),
+            directives: Directives::default(),
+            binding: None,
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: HashSet::new(),
+        }
+    }
+
+    /// Get an attribute value by key.
+    pub fn get_attr(&self, key: &str) -> Option<&Value> {
+        self.attributes.get(key)
+    }
+
+    /// Set an attribute value.
+    pub fn set_attr(&mut self, key: impl Into<String>, value: Value) {
+        self.attributes.insert(key.into(), value);
+    }
+
+    pub fn with_attribute(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.attributes.insert(key.into(), value);
+        self
+    }
+
+    pub fn with_binding(mut self, binding: impl Into<String>) -> Self {
+        self.binding = Some(binding.into());
+        self
+    }
+}
+
 impl TryFrom<&Resource> for DataSource {
     type Error = ResourceKindMismatch;
 
@@ -75,6 +128,17 @@ impl TryFrom<&Resource> for DataSource {
                 actual: res.kind.label(),
             }),
         }
+    }
+}
+
+/// Owned-`Resource` convenience over [`TryFrom<&Resource>`]. Symmetric
+/// with the `ManagedResource` impl; removed with the other transitional
+/// bridges when #3181 inline-merges `Resource`.
+impl TryFrom<Resource> for DataSource {
+    type Error = ResourceKindMismatch;
+
+    fn try_from(res: Resource) -> Result<Self, Self::Error> {
+        Self::try_from(&res)
     }
 }
 

--- a/carina-core/src/resource/managed.rs
+++ b/carina-core/src/resource/managed.rs
@@ -9,6 +9,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 
 use super::{
     Directives, ModuleSource, Resource, ResourceId, ResourceKind, ResourceKindLabel,
@@ -20,25 +21,113 @@ use super::{
 /// Cf. [`VirtualResource`](super::VirtualResource) and
 /// [`DataSource`](super::DataSource) for the other two arms of the
 /// typestate split.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ManagedResource {
     pub id: ResourceId,
     /// Source-order preserving map of attribute name → expression.
     /// Fully resolvable at pre-apply (no deferred virtual-only refs).
     pub attributes: IndexMap<String, Value>,
     /// `directives` meta-argument block.
+    #[serde(default)]
     pub directives: Directives,
     /// Attribute prefixes (e.g. `bucket_name_prefix = "my-app-"`).
+    #[serde(default)]
     pub prefixes: HashMap<String, String>,
     /// Binding name from `let` bindings in DSL.
+    #[serde(default)]
     pub binding: Option<String>,
     /// Binding names of resources this resource depends on.
+    #[serde(default)]
     pub dependency_bindings: BTreeSet<String>,
     /// Module source info for resources that belong to a module.
+    #[serde(default)]
     pub module_source: Option<ModuleSource>,
     /// Parser-level: attributes whose value was written as a quoted
-    /// string literal (`attr = "..."`).
+    /// string literal (`attr = "..."`). Parse-time only; `#[serde(skip)]`
+    /// keeps it out of state — mirrors [`Resource::quoted_string_attrs`].
+    #[serde(default, skip)]
     pub quoted_string_attrs: HashSet<String>,
+}
+
+impl ManagedResource {
+    /// Create a managed resource with an empty attribute map.
+    pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            id: ResourceId::new(resource_type, name),
+            attributes: IndexMap::new(),
+            directives: Directives::default(),
+            prefixes: HashMap::new(),
+            binding: None,
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: HashSet::new(),
+        }
+    }
+
+    /// Create a managed resource with a provider-qualified id.
+    pub fn with_provider(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        name: impl Into<String>,
+        provider_instance: Option<String>,
+    ) -> Self {
+        Self {
+            id: ResourceId::with_provider(provider, resource_type, name, provider_instance),
+            attributes: IndexMap::new(),
+            directives: Directives::default(),
+            prefixes: HashMap::new(),
+            binding: None,
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: HashSet::new(),
+        }
+    }
+
+    /// Returns the attributes projected to a `HashMap<String, Value>`.
+    pub fn resolved_attributes(&self) -> HashMap<String, Value> {
+        super::attrs_to_hashmap(&self.attributes)
+    }
+
+    /// Get an attribute value by key.
+    pub fn get_attr(&self, key: &str) -> Option<&Value> {
+        self.attributes.get(key)
+    }
+
+    /// Get a mutable attribute value by key.
+    pub fn get_attr_mut(&mut self, key: &str) -> Option<&mut Value> {
+        self.attributes.get_mut(key)
+    }
+
+    /// Set an attribute value.
+    pub fn set_attr(&mut self, key: impl Into<String>, value: Value) {
+        self.attributes.insert(key.into(), value);
+    }
+
+    pub fn with_attribute(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.attributes.insert(key.into(), value);
+        self
+    }
+
+    /// Set attributes from a `HashMap<String, Value>`.
+    pub fn with_value_attributes(mut self, attrs: HashMap<String, Value>) -> Self {
+        self.attributes = attrs.into_iter().collect();
+        self
+    }
+
+    pub fn with_binding(mut self, binding: impl Into<String>) -> Self {
+        self.binding = Some(binding.into());
+        self
+    }
+
+    pub fn with_dependency_bindings(mut self, deps: BTreeSet<String>) -> Self {
+        self.dependency_bindings = deps;
+        self
+    }
+
+    pub fn with_module_source(mut self, source: ModuleSource) -> Self {
+        self.module_source = Some(source);
+        self
+    }
 }
 
 impl TryFrom<&Resource> for ManagedResource {
@@ -61,6 +150,18 @@ impl TryFrom<&Resource> for ManagedResource {
                 actual: res.kind.label(),
             }),
         }
+    }
+}
+
+/// Owned-`Resource` convenience over [`TryFrom<&Resource>`]. Lets call
+/// sites that hold an owned legacy `Resource` write `resource.try_into()`
+/// without an explicit borrow. Removed with the rest of the transitional
+/// bridges when #3181 inline-merges `Resource` into `ManagedResource`.
+impl TryFrom<Resource> for ManagedResource {
+    type Error = ResourceKindMismatch;
+
+    fn try_from(res: Resource) -> Result<Self, Self::Error> {
+        Self::try_from(&res)
     }
 }
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -721,6 +721,39 @@ pub fn redact_secrets_in_resource(
     })
 }
 
+/// Redact all secrets in a [`ManagedResource`](crate::resource::ManagedResource).
+///
+/// carina#3181 PR D: `Effect` payloads are typestate structs, so the
+/// redaction pass needs a typed entry point per arm.
+pub fn redact_secrets_in_managed(
+    resource: &crate::resource::ManagedResource,
+) -> Result<crate::resource::ManagedResource, SerializationError> {
+    let attributes: Result<_, _> = resource
+        .attributes
+        .iter()
+        .map(|(k, e)| redact_secrets_in_value(e).map(|rv| (k.clone(), rv)))
+        .collect();
+    Ok(crate::resource::ManagedResource {
+        attributes: attributes?,
+        ..resource.clone()
+    })
+}
+
+/// Redact all secrets in a [`DataSource`](crate::resource::DataSource).
+pub fn redact_secrets_in_data_source(
+    resource: &crate::resource::DataSource,
+) -> Result<crate::resource::DataSource, SerializationError> {
+    let attributes: Result<_, _> = resource
+        .attributes
+        .iter()
+        .map(|(k, e)| redact_secrets_in_value(e).map(|rv| (k.clone(), rv)))
+        .collect();
+    Ok(crate::resource::DataSource {
+        attributes: attributes?,
+        ..resource.clone()
+    })
+}
+
 /// Redact all secrets in a `State`, returning a new State with secrets replaced by hashes.
 pub fn redact_secrets_in_state(
     state: &crate::resource::State,
@@ -741,9 +774,9 @@ pub fn redact_secrets_in_effect(
     use crate::effect::Effect;
     Ok(match effect {
         Effect::Read { resource } => Effect::Read {
-            resource: redact_secrets_in_resource(resource)?,
+            resource: redact_secrets_in_data_source(resource)?,
         },
-        Effect::Create(resource) => Effect::Create(redact_secrets_in_resource(resource)?),
+        Effect::Create(resource) => Effect::Create(redact_secrets_in_managed(resource)?),
         Effect::Update {
             id,
             from,
@@ -752,7 +785,7 @@ pub fn redact_secrets_in_effect(
         } => Effect::Update {
             id: id.clone(),
             from: Box::new(redact_secrets_in_state(from)?),
-            to: redact_secrets_in_resource(to)?,
+            to: redact_secrets_in_managed(to)?,
             changed_attributes: changed_attributes.clone(),
         },
         Effect::Replace {
@@ -767,7 +800,7 @@ pub fn redact_secrets_in_effect(
         } => Effect::Replace {
             id: id.clone(),
             from: Box::new(redact_secrets_in_state(from)?),
-            to: redact_secrets_in_resource(to)?,
+            to: redact_secrets_in_managed(to)?,
             directives: directives.clone(),
             changed_create_only: changed_create_only.clone(),
             temporary_name: temporary_name.clone(),
@@ -778,7 +811,7 @@ pub fn redact_secrets_in_effect(
                     Ok::<_, SerializationError>(crate::effect::CascadingUpdate {
                         id: cu.id.clone(),
                         from: Box::new(redact_secrets_in_state(&cu.from)?),
-                        to: redact_secrets_in_resource(&cu.to)?,
+                        to: redact_secrets_in_managed(&cu.to)?,
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?,

--- a/carina-tui/src/app/mod.rs
+++ b/carina-tui/src/app/mod.rs
@@ -628,27 +628,19 @@ fn build_tree_structure(plan: &Plan, nodes: &mut [TreeNode]) {
 /// Shorten effect labels: strip provider prefix and use binding name or compact hint.
 fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
     for (idx, effect) in plan.effects().iter().enumerate() {
-        let resource = match effect {
-            Effect::Create(r) => Some(r),
-            Effect::Update { to, .. } => Some(to),
-            Effect::Replace { to, .. } => Some(to),
-            Effect::Read { resource } => Some(resource),
-            Effect::Delete { .. }
-            | Effect::Import { .. }
-            | Effect::Remove { .. }
-            | Effect::Move { .. }
-            | Effect::Wait { .. } => None,
-        };
+        // carina#3181 PR D: `Effect` payloads are typestate structs;
+        // reach them through the shared `ResourceLike` view.
+        let resource = effect.resource_like();
 
         if let Some(r) = resource {
-            let display_type = r.id.display_type();
-            let has_binding = r.binding.is_some();
+            let display_type = r.id().display_type();
+            let has_binding = r.binding().is_some();
 
             let name_part = if has_binding {
                 // For bound resources, show the binding name
-                r.binding
-                    .clone()
-                    .unwrap_or_else(|| r.id.name_str().to_string())
+                r.binding()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| r.id().name_str().to_string())
             } else {
                 // For anonymous resources, try to extract a compact hint
                 let parent_binding = nodes[idx].parent.and_then(|p_idx| {
@@ -656,23 +648,14 @@ fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
                     if let Effect::Delete { binding, .. } = p_effect {
                         return binding.clone();
                     }
-                    let p_resource = match p_effect {
-                        Effect::Create(r) => Some(r),
-                        Effect::Update { to, .. } => Some(to),
-                        Effect::Replace { to, .. } => Some(to),
-                        Effect::Read { resource } => Some(resource),
-                        Effect::Delete { .. }
-                        | Effect::Import { .. }
-                        | Effect::Remove { .. }
-                        | Effect::Move { .. }
-                        | Effect::Wait { .. } => None,
-                    };
-                    p_resource.and_then(|pr| pr.binding.clone())
+                    p_effect
+                        .resource_like()
+                        .and_then(|pr| pr.binding().map(str::to_string))
                 });
                 if let Some(hint) = extract_compact_hint(r, parent_binding.as_deref()) {
                     format!("({})", hint)
                 } else {
-                    r.id.name_str().to_string()
+                    r.id().name_str().to_string()
                 }
             };
 

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
 use carina_core::value::format_value;
 
 #[test]
@@ -13,7 +13,10 @@ fn app_from_empty_plan() {
 #[test]
 fn app_from_plan_with_effects() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
+    plan.add(Effect::Create(ManagedResource::new(
+        "s3.Bucket",
+        "my-bucket",
+    )));
     plan.add(Effect::Delete {
         id: ResourceId::new("s3.Bucket", "old-bucket"),
         identifier: "old-bucket-id".to_string(),
@@ -34,9 +37,9 @@ fn app_from_plan_with_effects() {
 #[test]
 fn navigation() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "c")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "c")));
 
     let mut app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.selected, 0);
@@ -76,7 +79,7 @@ fn update_effect_has_detail_rows() {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("s3.Bucket", "my-bucket").with_attribute(
+        to: ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
             "versioning",
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         ),
@@ -98,7 +101,7 @@ fn update_effect_has_detail_rows() {
 fn internal_attributes_filtered() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::new("s3.Bucket", "my-bucket")
+        ManagedResource::new("s3.Bucket", "my-bucket")
             .with_attribute(
                 "name",
                 Value::Concrete(ConcreteValue::String("test".to_string())),
@@ -155,7 +158,7 @@ fn replace_effect_symbols() {
     plan.add(Effect::Replace {
         id: ResourceId::new("ec2.Vpc", "my-vpc"),
         from: from.clone(),
-        to: Resource::new("ec2.Vpc", "my-vpc"),
+        to: ManagedResource::new("ec2.Vpc", "my-vpc"),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -170,7 +173,7 @@ fn replace_effect_symbols() {
     plan.add(Effect::Replace {
         id: ResourceId::new("ec2.Vpc", "my-vpc2"),
         from,
-        to: Resource::new("ec2.Vpc", "my-vpc2"),
+        to: ManagedResource::new("ec2.Vpc", "my-vpc2"),
         directives: Directives::default(),
         changed_create_only: vec!["cidr".to_string()],
         cascading_updates: vec![],
@@ -188,7 +191,7 @@ fn tree_structure_with_dependencies() {
     // Create a plan where subnet depends on vpc via ResourceRef
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::new("ec2.Vpc", "my-vpc")
+        ManagedResource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -196,7 +199,7 @@ fn tree_structure_with_dependencies() {
             ),
     ));
     plan.add(Effect::Create(
-        Resource::new("ec2.Subnet", "my-subnet")
+        ManagedResource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
                 "vpc_id",
@@ -221,7 +224,7 @@ fn tree_structure_with_dependencies() {
 fn selected_node_returns_correct_node() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::new("s3.Bucket", "my-bucket").with_attribute(
+        ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
             "name",
             Value::Concrete(ConcreteValue::String("test".to_string())),
         ),
@@ -237,7 +240,7 @@ fn selected_node_returns_correct_node() {
 #[test]
 fn toggle_focus_switches_panels() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     assert_eq!(app.focused_panel, FocusedPanel::Tree);
@@ -250,7 +253,7 @@ fn toggle_focus_switches_panels() {
 #[test]
 fn detail_scroll_up_down() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     assert_eq!(app.detail_scroll, 0);
@@ -270,8 +273,8 @@ fn detail_scroll_up_down() {
 #[test]
 fn detail_scroll_resets_on_navigation() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     app.detail_scroll = 5;
@@ -288,7 +291,7 @@ fn tree_scroll_cursor_moves_within_visible_area_before_scrolling() {
     // Create a plan with 10 items
     let mut plan = Plan::new();
     for i in 0..10 {
-        plan.add(Effect::Create(Resource::new(
+        plan.add(Effect::Create(ManagedResource::new(
             "s3.Bucket",
             format!("bucket-{}", i),
         )));
@@ -347,8 +350,8 @@ fn tree_scroll_cursor_moves_within_visible_area_before_scrolling() {
 fn tree_scroll_zero_height_does_not_scroll_on_move_down() {
     // When tree_area_height is 0 (before first render), move_down should not scroll
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.tree_area_height, 0);
 
@@ -361,7 +364,7 @@ fn tree_scroll_zero_height_does_not_scroll_on_move_down() {
 fn make_tree_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::new("ec2.Vpc", "my-vpc")
+        ManagedResource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -369,7 +372,7 @@ fn make_tree_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Create(
-        Resource::new("ec2.Subnet", "my-subnet")
+        ManagedResource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
                 "vpc_id",
@@ -377,7 +380,7 @@ fn make_tree_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Create(
-        Resource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
+        ManagedResource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
     ));
     plan
 }
@@ -561,13 +564,14 @@ fn tab_complete_matches_middle_of_word() {
 
 #[test]
 fn tab_complete_with_provider_prefix() {
-    // Resource types with provider prefix (e.g., "awscc.ec2.Vpc")
+    // ManagedResource types with provider prefix (e.g., "awscc.ec2.Vpc")
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
+        ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
     ));
     plan.add(Effect::Create(
-        Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None).with_binding("subnet"),
+        ManagedResource::with_provider("awscc", "ec2.Subnet", "my-subnet", None)
+            .with_binding("subnet"),
     ));
     let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
@@ -632,7 +636,7 @@ fn format_value_resolves_dsl_enum_identifiers() {
 fn create_effect_attributes_resolve_enum_values() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::new("ec2.vpc_endpoint", "my-endpoint")
+        ManagedResource::new("ec2.vpc_endpoint", "my-endpoint")
             .with_attribute(
                 "vpc_endpoint_type",
                 Value::Concrete(ConcreteValue::String(
@@ -685,7 +689,7 @@ fn move_suppressed_when_update_exists_for_same_target() {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("s3.Bucket", "new-name").with_attribute(
+        to: ManagedResource::new("s3.Bucket", "new-name").with_attribute(
             "versioning",
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         ),
@@ -716,7 +720,7 @@ fn move_suppressed_when_replace_exists_for_same_target() {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("ec2.Vpc", "new-vpc"),
+        to: ManagedResource::new("ec2.Vpc", "new-vpc"),
         directives: Directives::default(),
         changed_create_only: vec!["cidr".to_string()],
         cascading_updates: vec![],

--- a/carina-tui/src/lib.rs
+++ b/carina-tui/src/lib.rs
@@ -226,12 +226,12 @@ fn run_tui<A>(
 mod tests {
     use super::*;
     use carina_core::effect::Effect;
-    use carina_core::resource::Resource;
+    use carina_core::resource::ManagedResource;
 
     fn make_app() -> App {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+        plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
+        plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
         App::new(&plan, &SchemaRegistry::new())
     }
 
@@ -275,13 +275,13 @@ mod tests {
     fn make_search_app() -> App {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            Resource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
+            ManagedResource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
         ));
         plan.add(Effect::Create(
-            Resource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
+            ManagedResource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
         ));
         plan.add(Effect::Create(
-            Resource::new("ec2.Subnet", "my-subnet")
+            ManagedResource::new("ec2.Subnet", "my-subnet")
                 .with_binding("subnet")
                 .with_attribute(
                     "vpc_id",
@@ -483,14 +483,15 @@ mod tests {
     fn make_provider_prefixed_app() -> App {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
+            ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
         ));
         plan.add(Effect::Create(
-            Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None)
+            ManagedResource::with_provider("awscc", "ec2.Subnet", "my-subnet", None)
                 .with_binding("subnet"),
         ));
         plan.add(Effect::Create(
-            Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None).with_binding("bucket"),
+            ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None)
+                .with_binding("bucket"),
         ));
         App::new(&plan, &SchemaRegistry::new())
     }

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -10,7 +10,7 @@ use ratatui::backend::TestBackend;
 
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
-use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 
 use crate::app::App;
@@ -46,7 +46,7 @@ fn render_tui_with_schemas(
 fn build_all_create_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::new("ec2.Vpc", "my-vpc")
+        ManagedResource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -54,7 +54,7 @@ fn build_all_create_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Create(
-        Resource::new("ec2.RouteTable", "my-rt")
+        ManagedResource::new("ec2.RouteTable", "my-rt")
             .with_binding("rt")
             .with_attribute(
                 "vpc_id",
@@ -62,7 +62,7 @@ fn build_all_create_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Create(
-        Resource::new("ec2.Subnet", "my-subnet")
+        ManagedResource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
                 "cidr_block",
@@ -96,7 +96,7 @@ fn build_mixed_operations_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("ec2.Vpc", "my-vpc")
+        to: ManagedResource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -109,7 +109,7 @@ fn build_mixed_operations_plan() -> Plan {
         changed_attributes: vec!["enable_dns_support".to_string()],
     });
     plan.add(Effect::Create(
-        Resource::new("ec2.SecurityGroup", "my-sg")
+        ManagedResource::new("ec2.SecurityGroup", "my-sg")
             .with_binding("sg")
             .with_attribute(
                 "group_description",
@@ -190,7 +190,7 @@ fn build_map_key_diff_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("ec2.Vpc", "my-vpc")
+        to: ManagedResource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -235,7 +235,7 @@ fn snapshot_map_key_diff() {
 fn snapshot_create_with_schema() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        Resource::new("ec2.Vpc", "my-vpc")
+        ManagedResource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -361,7 +361,7 @@ fn build_moved_with_changes_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("ec2.Vpc", "new_vpc")
+        to: ManagedResource::new("ec2.Vpc", "new_vpc")
             .with_binding("new_vpc")
             .with_attribute(
                 "cidr_block",
@@ -381,7 +381,7 @@ fn build_moved_with_changes_plan() -> Plan {
         changed_attributes: vec!["tags".to_string()],
     });
     plan.add(Effect::Create(
-        Resource::new("ec2.Subnet", "my-subnet")
+        ManagedResource::new("ec2.Subnet", "my-subnet")
             .with_attribute(
                 "cidr_block",
                 Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),

--- a/carina-tui/src/ui/tree.rs
+++ b/carina-tui/src/ui/tree.rs
@@ -156,13 +156,16 @@ mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{ConcreteValue, Resource, Value};
+    use carina_core::resource::{ConcreteValue, ManagedResource, Value};
     use carina_core::schema::SchemaRegistry;
 
     #[test]
     fn tree_connector_root_has_no_prefix() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
+        plan.add(Effect::Create(ManagedResource::new(
+            "s3.Bucket",
+            "my-bucket",
+        )));
         let app = App::new(&plan, &SchemaRegistry::new());
         assert_eq!(build_tree_connector(0, &app), "");
     }
@@ -171,7 +174,7 @@ mod tests {
     fn tree_connector_single_child() {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            Resource::new("ec2.Vpc", "my-vpc")
+            ManagedResource::new("ec2.Vpc", "my-vpc")
                 .with_binding("vpc")
                 .with_attribute(
                     "cidr_block",
@@ -179,7 +182,7 @@ mod tests {
                 ),
         ));
         plan.add(Effect::Create(
-            Resource::new("ec2.Subnet", "my-subnet")
+            ManagedResource::new("ec2.Subnet", "my-subnet")
                 .with_binding("subnet")
                 .with_attribute(
                     "vpc_id",
@@ -197,10 +200,10 @@ mod tests {
     fn tree_connector_multiple_children() {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            Resource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
+            ManagedResource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
         ));
         plan.add(Effect::Create(
-            Resource::new("ec2.Subnet", "subnet-a")
+            ManagedResource::new("ec2.Subnet", "subnet-a")
                 .with_binding("subnet_a")
                 .with_attribute(
                     "vpc_id",
@@ -208,7 +211,7 @@ mod tests {
                 ),
         ));
         plan.add(Effect::Create(
-            Resource::new("ec2.Subnet", "subnet-b")
+            ManagedResource::new("ec2.Subnet", "subnet-b")
                 .with_binding("subnet_b")
                 .with_attribute(
                     "vpc_id",


### PR DESCRIPTION
## Summary

Fourth step of the carina#3181 5-PR series (A→E) that deletes the
`Resource::kind` discriminant.

The `Effect` enum payloads are now the typestate structs instead of the
legacy `Resource`:

- `Effect::Read.resource` — `Resource` → `DataSource`
- `Effect::Create` / `Update.to` / `Replace.to` — `Resource` → `ManagedResource`
- `CascadingUpdate.to` — `Resource` → `ManagedResource`
- `BasicEffect::{Create.resource, Update.to}` — `&Resource` → `&ManagedResource`

## API changes

- `Effect::resource()` → `resource_like()` (returns `&dyn ResourceLike`).
- New `Effect::resource_directives()` and `Effect::resource_as_legacy()`
  (an owned-`Resource` bridge) for consumers that still need directives
  or a legacy `Resource`.
- `ManagedResource` gains `Serialize`/`Deserialize` (PR A added them only
  to `DataSource`/`VirtualResource`).
- `ManagedResource` and `DataSource` gain constructor methods (`new`,
  `with_provider`, `with_attribute`, `with_binding`, `set_attr`,
  `get_attr`, `resolved_attributes`, …) mirroring `Resource`, plus an
  owned `TryFrom<Resource>` over the existing `TryFrom<&Resource>`.
- `value.rs` gains typed `redact_secrets_in_managed` /
  `redact_secrets_in_data_source` helpers.

## Design

- The differ produces effects via a new `to_managed()` bridge — `diff()`
  runs on a managed resource, so its legacy `Resource` result is always
  managed (`try_from().expect()`).
- The executor keeps working in legacy `Resource` internally and bridges
  typed structs → `Resource` via `Resource::from` only at the
  provider/resolver boundary (Codex-confirmed scope: `Diff`, provider
  requests, and the unresolved maps stay legacy `Resource` for now).
- `Effect` is carina-core/carina-cli only — `carina-provider-protocol`
  is unaffected.

## Saved-plan compatibility

`PlanFile.version` is bumped 2 → 3 — the saved-plan JSON payload shape
changed (managed/data-source payloads no longer serialize the legacy
`kind` / `virtual_module` fields). `apply --plan` rejects any version
other than 3, per the repo's no-backward-compat policy.

## Test plan

- [x] `cargo nextest run --workspace` — 3515 passed
- [x] `cargo test --workspace --doc` — `compile_fail` doctest still fails to compile
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] `make plan-fixtures`
- [x] `effect_serde_round_trip` extended to cover a non-empty
  `CascadingUpdate` so `CascadingUpdate.to: ManagedResource` round-trips.

Codex reviewed the implementation: no correctness bugs found.

Refs #3181

🤖 Generated with [Claude Code](https://claude.com/claude-code)