### PR TITLE
core: structured TypeIdentity replacing flat semantic_name (S2 of #2807)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -133,12 +133,14 @@ fn enrich_provider_context(
     ProviderContext {
         decryptor: None,
         validators: carina_core::provider::collect_custom_type_validators(schemas),
-        custom_type_validator: Some(Box::new(move |type_name: &str, value: &str| {
-            for factory in factories.iter() {
-                factory.validate_custom_type(type_name, value)?;
-            }
-            Ok(())
-        })),
+        custom_type_validator: Some(Box::new(
+            move |identity: &carina_core::schema::TypeIdentity, value: &str| {
+                for factory in factories.iter() {
+                    factory.validate_custom_type(identity, value)?;
+                }
+                Ok(())
+            },
+        )),
         schema_types: Default::default(),
     }
 }

--- a/carina-cli/tests/deferred_populate_validate_e2e.rs
+++ b/carina-cli/tests/deferred_populate_validate_e2e.rs
@@ -37,7 +37,11 @@ impl ProviderFactory for DeferredPopulateTestFactory {
     fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
         Ok(())
     }
-    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+    fn validate_custom_type(
+        &self,
+        _type_name: &carina_core::schema::TypeIdentity,
+        _value: &str,
+    ) -> Result<(), String> {
         Ok(())
     }
     fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -351,7 +351,7 @@ fn region_schemas() -> SchemaRegistry {
     }
 
     let region_custom = AttributeType::Custom {
-        semantic_name: Some("Region".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("Region")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -807,10 +807,14 @@ impl ProviderFactory for WasmStyleProviderFactory {
     fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
         Ok(())
     }
-    fn validate_custom_type(&self, type_name: &str, value: &str) -> Result<(), String> {
-        // Mirror awscc's `prefixed` validator family: vpc_id must start
+    fn validate_custom_type(
+        &self,
+        identity: &carina_core::schema::TypeIdentity,
+        value: &str,
+    ) -> Result<(), String> {
+        // Mirror awscc's `prefixed` validator family: VpcId must start
         // with "vpc-".
-        if type_name == "vpc_id" && !value.starts_with("vpc-") {
+        if identity.kind == "VpcId" && !value.starts_with("vpc-") {
             return Err(format!(
                 "Invalid vpc_id '{}': must start with 'vpc-'",
                 value
@@ -842,7 +846,7 @@ impl ProviderFactory for WasmStyleProviderFactory {
 
 fn wasm_style_vpc_schema() -> ResourceSchema {
     let vpc_id_type = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("VpcId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -934,7 +938,7 @@ awsccmock.ec2.security_group {
 
 fn wasm_style_subnet_schema() -> ResourceSchema {
     let vpc_id_type = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("VpcId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -1022,12 +1026,12 @@ awsccmock.ec2.subnet {
 // Scenario: generic-String → specific Custom downcast (#2358)
 //
 // `vpc_id: String = main.vpc_id` declares a `String`-typed export of a
-// value whose actual type is `Custom { semantic_name: VpcId }`. The
+// value whose actual type is `Custom { identity: VpcId }`. The
 // declaration drops the specific identity, so any downstream consumer
 // receives `String` and can no longer be type-checked against a
 // `Custom { VpcId }` receiver. Validation, LSP diagnostics, and
 // completion must all reject the unsafe direction (`TypeExpr::String`
-// against a Custom-with-`semantic_name` receiver) while keeping the
+// against a Custom-with-`identity` receiver) while keeping the
 // safe direction (specific Custom export → same Custom receiver) and
 // literal-value assignment (`vpc_id = 'vpc-12345678'`) working.
 // ============================================================================
@@ -1049,7 +1053,7 @@ fn vpc_id_validate_2358(v: &Value) -> Result<(), String> {
 
 fn vpc_id_custom_type_2358() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("VpcId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),

--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -143,7 +143,7 @@ fn string_literal_expected_enum_custom_namespaced_display() {
         AttributeSchema::new(
             "mode",
             AttributeType::Custom {
-                semantic_name: Some("Mode".to_string()),
+                identity: Some(carina_core::schema::TypeIdentity::bare("Mode")),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,

--- a/carina-cli/tests/validate_deferred_for_enumeration_e2e.rs
+++ b/carina-cli/tests/validate_deferred_for_enumeration_e2e.rs
@@ -48,7 +48,11 @@ impl ProviderFactory for ForTestFactory {
     fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
         Ok(())
     }
-    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+    fn validate_custom_type(
+        &self,
+        _type_name: &carina_core::schema::TypeIdentity,
+        _value: &str,
+    ) -> Result<(), String> {
         Ok(())
     }
     fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -59,7 +59,11 @@ impl ProviderFactory for AwsStub {
     fn validate_config(&self, _a: &IndexMap<String, Value>) -> Result<(), String> {
         Ok(())
     }
-    fn validate_custom_type(&self, _t: &str, _v: &str) -> Result<(), String> {
+    fn validate_custom_type(
+        &self,
+        _t: &carina_core::schema::TypeIdentity,
+        _v: &str,
+    ) -> Result<(), String> {
         Ok(())
     }
     fn extract_region(&self, _a: &IndexMap<String, Value>) -> String {

--- a/carina-cli/tests/wait_validate_e2e.rs
+++ b/carina-cli/tests/wait_validate_e2e.rs
@@ -40,7 +40,11 @@ impl ProviderFactory for WaitTestFactory {
     fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
         Ok(())
     }
-    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+    fn validate_custom_type(
+        &self,
+        _type_name: &carina_core::schema::TypeIdentity,
+        _value: &str,
+    ) -> Result<(), String> {
         Ok(())
     }
     fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::resource::{ConcreteValue, DeferredValue, Value};
-use crate::schema::noop_validator;
+use crate::schema::{TypeIdentity, noop_validator};
 use indexmap::IndexMap;
 
 #[test]
@@ -108,7 +108,7 @@ fn type_aware_union_numeric() {
 #[test]
 fn type_aware_custom_delegates_to_base() {
     let custom_type = AttributeType::Custom {
-        semantic_name: Some("Port".to_string()),
+        identity: Some(TypeIdentity::bare("Port")),
         base: Box::new(AttributeType::Float),
         pattern: None,
         length: None,
@@ -345,7 +345,7 @@ fn type_aware_struct_ignores_default_custom_type() {
             StructField::new(
                 "port",
                 AttributeType::Custom {
-                    semantic_name: Some("Port".to_string()),
+                    identity: Some(TypeIdentity::bare("Port")),
                     base: Box::new(AttributeType::Int),
                     pattern: None,
                     length: None,
@@ -1025,7 +1025,7 @@ fn union_string_or_list_through_custom_wrapper() {
     // the comparator delegates `Custom { base, .. }` to its `base`.
     let inner = string_or_list_of_strings_type();
     let custom = AttributeType::Custom {
-        semantic_name: Some("PolicyConditionValue".to_string()),
+        identity: Some(TypeIdentity::bare("PolicyConditionValue")),
         base: Box::new(inner),
         pattern: None,
         length: None,

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -16,6 +16,7 @@ use crate::parser::{ArgumentParameter, ModuleCall, ParsedFile, ProviderContext, 
 use crate::resource::{
     ConcreteValue, DeferredValue, Directives, ManagedResource, ResourceId, Value,
 };
+use crate::schema::TypeIdentity;
 
 fn create_test_module() -> ParsedFile {
     ParsedFile {
@@ -2662,9 +2663,9 @@ fn test_argument_type_custom_validator() {
     use crate::parser::ValidatorFn;
 
     // Create a ProviderContext with a custom "arn" validator
-    let mut validators: HashMap<String, ValidatorFn> = HashMap::new();
+    let mut validators: HashMap<TypeIdentity, ValidatorFn> = HashMap::new();
     validators.insert(
-        "arn".to_string(),
+        TypeIdentity::bare("Arn"),
         Box::new(|s: &str| {
             if s.starts_with("arn:") {
                 Ok(())
@@ -2737,9 +2738,9 @@ fn test_argument_type_custom_validator() {
 fn test_argument_type_list_of_custom_type() {
     use crate::parser::ValidatorFn;
 
-    let mut validators: HashMap<String, ValidatorFn> = HashMap::new();
+    let mut validators: HashMap<TypeIdentity, ValidatorFn> = HashMap::new();
     validators.insert(
-        "arn".to_string(),
+        TypeIdentity::bare("Arn"),
         Box::new(|s: &str| {
             if s.starts_with("arn:") {
                 Ok(())

--- a/carina-core/src/module_resolver/typecheck.rs
+++ b/carina-core/src/module_resolver/typecheck.rs
@@ -166,10 +166,14 @@ pub(super) fn check_type_match(
                     | Value::Deferred(DeferredValue::ResourceRef { .. })
             ) {
                 TypeCheckResult::Mismatch
-            } else if let Err(e) = validate_custom_type(name, value, config) {
-                TypeCheckResult::ValidationError(e)
             } else {
-                TypeCheckResult::Ok
+                let identity =
+                    crate::schema::TypeIdentity::bare(crate::parser::snake_to_pascal(name));
+                if let Err(e) = validate_custom_type(&identity, value, config) {
+                    TypeCheckResult::ValidationError(e)
+                } else {
+                    TypeCheckResult::Ok
+                }
             }
         }
         // Resource type refs and schema types: accept strings (validated elsewhere)

--- a/carina-core/src/parser/config.rs
+++ b/carina-core/src/parser/config.rs
@@ -5,6 +5,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::schema::TypeIdentity;
+
 /// Signature for a custom type validator function.
 ///
 /// Takes a string value and returns `Ok(())` if valid, or `Err(message)` if invalid.
@@ -12,9 +14,12 @@ pub type ValidatorFn = Box<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
 
 /// Signature for a factory-based custom type validator.
 ///
-/// Takes `(type_name, value)` and returns `Ok(())` if valid or unknown,
-/// or `Err(message)` if invalid.
-pub type CustomTypeValidatorFn = Box<dyn Fn(&str, &str) -> Result<(), String> + Send + Sync>;
+/// Takes `(identity, value)` and returns `Ok(())` if valid or unknown,
+/// or `Err(message)` if invalid. The identity is structured so the
+/// factory (e.g. a WASM provider) resolves the exact provider-scoped
+/// type instead of splitting a flat name string.
+pub type CustomTypeValidatorFn =
+    Box<dyn Fn(&TypeIdentity, &str) -> Result<(), String> + Send + Sync>;
 
 /// Signature for a decryptor function.
 ///
@@ -30,8 +35,10 @@ pub type DecryptorFn = Box<dyn Fn(&str, Option<&str>) -> Result<String, String> 
 pub struct ProviderContext {
     /// Optional decryptor for the `decrypt()` built-in function.
     pub decryptor: Option<DecryptorFn>,
-    /// Custom type validators keyed by type name (e.g., "arn", "availability_zone").
-    pub validators: HashMap<String, ValidatorFn>,
+    /// Custom type validators keyed by structured [`TypeIdentity`], so
+    /// two providers' same-named custom types resolve to distinct
+    /// validators instead of colliding first-wins.
+    pub validators: HashMap<TypeIdentity, ValidatorFn>,
     /// Factory-based custom type validator that calls through to provider factories
     /// (e.g., WASM plugins) for types not covered by `validators`.
     pub custom_type_validator: Option<CustomTypeValidatorFn>,

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -6,12 +6,13 @@ use super::ast::{FnParam, TypeExpr, UserFunction, UserFunctionBody};
 use super::context::{ParseContext, next_pair};
 use super::error::{ParseError, ParseWarning};
 use super::types::parse_type_expr;
-use super::util::{pascal_to_snake, value_type_name};
+use super::util::{snake_to_pascal, value_type_name};
 use super::{ProviderContext, Rule, parse_expression};
 use crate::eval_value::EvalValue;
 use crate::resource::{ConcreteValue, DeferredValue, Value};
 use crate::schema::{
-    validate_ipv4_address, validate_ipv4_cidr, validate_ipv6_address, validate_ipv6_cidr,
+    TypeIdentity, validate_ipv4_address, validate_ipv4_cidr, validate_ipv6_address,
+    validate_ipv6_cidr,
 };
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -194,53 +195,57 @@ pub(super) fn prepare_user_function_call<'cfg>(
 
 /// Adapter that turns a [`ProviderContext`] into the
 /// [`crate::schema::CustomTypeLookup`] shape consumed by the schema-walk
-/// validator. PascalCase semantic names (e.g. `VpcId`) are normalized to
-/// snake_case (`vpc_id`) before lookup, then [`validate_custom_type`]
-/// runs the registered validator chain. The returned closure may be
-/// hoisted out of any per-resource loop — it borrows the context only.
+/// validator. The lookup is keyed on a structured [`TypeIdentity`], so
+/// [`validate_custom_type`] runs the registered validator chain against
+/// the exact provider-scoped identity — no flat-string normalization.
+/// The returned closure may be hoisted out of any per-resource loop —
+/// it borrows the context only.
 pub fn provider_context_lookup(
     ctx: &ProviderContext,
-) -> impl Fn(&str, &Value) -> Result<(), crate::schema::TypeError> + use<'_> {
-    move |type_name, value| {
-        let key = pascal_to_snake(type_name);
-        validate_custom_type(&key, value, ctx)
+) -> impl Fn(&TypeIdentity, &Value) -> Result<(), crate::schema::TypeError> + use<'_> {
+    move |identity, value| {
+        validate_custom_type(identity, value, ctx)
             .map_err(|message| crate::schema::TypeError::ValidationFailed { message })
     }
 }
 
-/// Validate a value against a custom type (ipv4_cidr, ipv4_address, etc.).
-/// Returns Ok(()) if the value passes validation or cannot be validated statically
-/// (e.g., ResourceRef, FunctionCall, Interpolation are deferred).
+/// Validate a value against a custom type (`Ipv4Cidr`, `Ipv4Address`, …).
+/// Returns Ok(()) if the value passes validation or cannot be validated
+/// statically (e.g., ResourceRef, FunctionCall, Interpolation are
+/// deferred).
 ///
-/// Checks built-in validators first, then falls back to custom validators
-/// registered in the [`ProviderContext`].
+/// Checks built-in validators first (matched on the identity's `kind`),
+/// then falls back to custom validators registered in the
+/// [`ProviderContext`], keyed by the full structured [`TypeIdentity`].
 pub fn validate_custom_type(
-    type_name: &str,
+    identity: &TypeIdentity,
     value: &Value,
     config: &ProviderContext,
 ) -> Result<(), String> {
-    match (type_name, value) {
+    // Built-in DSL custom types carry no provider axis — match on `kind`.
+    let builtin = identity.provider.is_none() && identity.segments.is_empty();
+    match (builtin.then_some(identity.kind.as_str()), value) {
         (
-            "ipv4_cidr",
+            Some("Ipv4Cidr"),
             Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
         ) => validate_ipv4_cidr(s),
         (
-            "ipv4_address",
+            Some("Ipv4Address"),
             Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
         ) => validate_ipv4_address(s),
         (
-            "ipv6_cidr",
+            Some("Ipv6Cidr"),
             Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
         ) => validate_ipv6_cidr(s),
         (
-            "ipv6_address",
+            Some("Ipv6Address"),
             Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
         ) => validate_ipv6_address(s),
         (_, Value::Deferred(DeferredValue::ResourceRef { .. })) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::FunctionCall { .. })) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::Interpolation(_))) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::Unknown(_))) => Ok(()), // resolved at upstream apply
-        (name, Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s))) => {
+        (_, Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s))) => {
             // Both `String` (quoted-literal source) and `EnumIdentifier`
             // (bare or namespaced identifier source) are accepted: this
             // lookup runs from `walk_custom_lookup`, which is reached
@@ -249,20 +254,22 @@ pub fn validate_custom_type(
             // quoted literals on namespaced Custom types happens in the
             // LSP / CLI surface code (carina#2986 Phase 4), not here —
             // this fallback validator just needs the textual payload.
-            // Check custom validators from config (schema-extracted)
-            if let Some(validator) = config.validators.get(name) {
+            // Check custom validators from config (schema-extracted),
+            // keyed by the full structured identity so two providers'
+            // same-named types do not collide.
+            if let Some(validator) = config.validators.get(identity) {
                 validator(s)?;
             }
             // Fall back to factory-based validator (e.g., WASM providers)
             if let Some(ref factory_validator) = config.custom_type_validator {
-                factory_validator(name, s)
+                factory_validator(identity, s)
             } else {
                 Ok(())
             }
         }
         (_, value) => Err(format!(
             "expected {}, got {}",
-            type_name,
+            identity,
             value_type_name(value)
         )),
     }
@@ -305,8 +312,11 @@ fn check_fn_arg_type(
             ) {
                 false
             } else {
-                // Validate the actual value against the custom type
-                if let Err(e) = validate_custom_type(name, value, ctx.config) {
+                // `Simple` annotations name a built-in DSL custom type
+                // (snake-cased, e.g. `ipv4_cidr`); project it onto a
+                // bare, provider-agnostic identity.
+                let identity = TypeIdentity::bare(snake_to_pascal(name));
+                if let Err(e) = validate_custom_type(&identity, value, ctx.config) {
                     return Err(ParseError::UserFunctionError(format!(
                         "function '{fn_name}': parameter '{param_name}' type '{name}' validation failed: {e}"
                     )));
@@ -337,7 +347,11 @@ fn check_fn_arg_type(
             true
         }
         // Schema types (awscc.ec2.VpcId, etc.) are string subtypes with provider validators
-        TypeExpr::SchemaType { type_name, .. } => {
+        TypeExpr::SchemaType {
+            provider,
+            path,
+            type_name,
+        } => {
             if !matches!(
                 value,
                 Value::Concrete(ConcreteValue::String(_))
@@ -346,9 +360,8 @@ fn check_fn_arg_type(
             ) {
                 false
             } else {
-                // Convert PascalCase type_name to snake_case for validator lookup
-                let validator_key = pascal_to_snake(type_name);
-                if let Err(e) = validate_custom_type(&validator_key, value, ctx.config) {
+                let identity = TypeIdentity::from_schema_type(provider, path, type_name);
+                if let Err(e) = validate_custom_type(&identity, value, ctx.config) {
                     return Err(ParseError::UserFunctionError(format!(
                         "function '{fn_name}': parameter '{param_name}' type '{type_expr}' validation failed: {e}"
                     )));
@@ -429,7 +442,8 @@ fn check_fn_return_type(
             ) {
                 false
             } else {
-                if let Err(e) = validate_custom_type(name, value, config) {
+                let identity = TypeIdentity::bare(snake_to_pascal(name));
+                if let Err(e) = validate_custom_type(&identity, value, config) {
                     return Err(ParseError::UserFunctionError(format!(
                         "function '{fn_name}': return type '{name}' validation failed: {e}"
                     )));
@@ -440,7 +454,11 @@ fn check_fn_return_type(
         // Resource type refs: not applicable for value functions
         TypeExpr::Ref(_) => true,
         // Schema types: validate returned value against the provider validator
-        TypeExpr::SchemaType { type_name, .. } => {
+        TypeExpr::SchemaType {
+            provider,
+            path,
+            type_name,
+        } => {
             if !matches!(
                 value,
                 Value::Concrete(ConcreteValue::String(_))
@@ -449,8 +467,8 @@ fn check_fn_return_type(
             ) {
                 false
             } else {
-                let validator_key = pascal_to_snake(type_name);
-                if let Err(e) = validate_custom_type(&validator_key, value, config) {
+                let identity = TypeIdentity::from_schema_type(provider, path, type_name);
+                if let Err(e) = validate_custom_type(&identity, value, config) {
                     return Err(ParseError::UserFunctionError(format!(
                         "function '{fn_name}': return type '{type_name}' validation failed: {e}"
                     )));

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::binding_index::IterableBindings;
 use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, ManagedResource, Value};
+use crate::schema::TypeIdentity;
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
@@ -6296,9 +6297,9 @@ fn parse_custom_validator_accepts_valid() {
     // Test validate_custom_type directly with a type name that has no built-in
     // handler. Built-in types (cidr, ipv4_address, etc.) are matched first in
     // validate_custom_type, so custom validators only apply to other type names.
-    let mut validators: HashMap<String, ValidatorFn> = HashMap::new();
+    let mut validators: HashMap<TypeIdentity, ValidatorFn> = HashMap::new();
     validators.insert(
-        "custom_type".to_string(),
+        TypeIdentity::bare("CustomType"),
         Box::new(|s: &str| {
             if s.starts_with("valid-") {
                 Ok(())
@@ -6315,7 +6316,7 @@ fn parse_custom_validator_accepts_valid() {
     };
 
     let result = validate_custom_type(
-        "custom_type",
+        &TypeIdentity::bare("CustomType"),
         &Value::Concrete(ConcreteValue::String("valid-data".to_string())),
         &config,
     );
@@ -6323,7 +6324,7 @@ fn parse_custom_validator_accepts_valid() {
 
     // Unknown type with no custom validator should also pass (permissive)
     let result = validate_custom_type(
-        "unknown_type",
+        &TypeIdentity::bare("UnknownType"),
         &Value::Concrete(ConcreteValue::String("anything".to_string())),
         &config,
     );
@@ -6337,9 +6338,9 @@ fn parse_custom_validator_rejects_invalid() {
     // The "arn" type is accepted by the grammar as identifier. But it fails to parse.
     // Use "cidr" which is known to work in grammar. Register a custom stricter validator.
     // Actually, let's test validate_custom_type directly to avoid grammar issues.
-    let mut validators: HashMap<String, ValidatorFn> = HashMap::new();
+    let mut validators: HashMap<TypeIdentity, ValidatorFn> = HashMap::new();
     validators.insert(
-        "custom_type".to_string(),
+        TypeIdentity::bare("CustomType"),
         Box::new(|s: &str| {
             if s.starts_with("valid-") {
                 Ok(())
@@ -6358,14 +6359,14 @@ fn parse_custom_validator_rejects_invalid() {
     // Test validate_custom_type directly since the grammar may not accept
     // arbitrary type names. This verifies the custom validator is called.
     let valid_result = validate_custom_type(
-        "custom_type",
+        &TypeIdentity::bare("CustomType"),
         &Value::Concrete(ConcreteValue::String("valid-data".to_string())),
         &config,
     );
     assert!(valid_result.is_ok());
 
     let invalid_result = validate_custom_type(
-        "custom_type",
+        &TypeIdentity::bare("CustomType"),
         &Value::Concrete(ConcreteValue::String("invalid".to_string())),
         &config,
     );

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -12,7 +12,7 @@ use std::pin::Pin;
 use crate::resource::{
     ConcreteValue, DataSource, Directives, ManagedResource, ResourceId, State, Value,
 };
-use crate::schema::SchemaRegistry;
+use crate::schema::{SchemaRegistry, TypeIdentity};
 
 /// Contextual metadata attached to every [`ProviderError`] variant.
 ///
@@ -820,7 +820,11 @@ pub trait ProviderFactory: Send + Sync {
     /// Validate a value against a provider-defined custom type.
     /// Returns `Ok(())` if the value is valid or the type is unknown to this provider.
     /// Returns `Err(message)` if the value is invalid for the given type.
-    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+    ///
+    /// `identity` is the structured [`TypeIdentity`] of the type, so a
+    /// provider resolves the exact provider-scoped type instead of
+    /// splitting a flat name string.
+    fn validate_custom_type(&self, _identity: &TypeIdentity, _value: &str) -> Result<(), String> {
         Ok(())
     }
 
@@ -930,8 +934,8 @@ pub fn collect_schemas(factories: &[Box<dyn ProviderFactory>]) -> SchemaRegistry
 /// for populating `ProviderContext.validators`.
 pub fn collect_custom_type_validators(
     registry: &SchemaRegistry,
-) -> HashMap<String, crate::parser::ValidatorFn> {
-    let mut validators: HashMap<String, crate::parser::ValidatorFn> = HashMap::new();
+) -> HashMap<TypeIdentity, crate::parser::ValidatorFn> {
+    let mut validators: HashMap<TypeIdentity, crate::parser::ValidatorFn> = HashMap::new();
 
     for (_provider, _resource_type, _kind, schema) in registry.iter() {
         for attr_schema in schema.attributes.values() {
@@ -942,11 +946,12 @@ pub fn collect_custom_type_validators(
     validators
 }
 
-/// Collect custom type names from a registry without allocating validators.
+/// Collect custom type identities from a registry without allocating
+/// validators.
 ///
-/// Cheaper than `collect_custom_type_validators` when only the type names
-/// are needed (e.g., for LSP completions).
-pub fn collect_custom_type_names(registry: &SchemaRegistry) -> Vec<String> {
+/// Cheaper than `collect_custom_type_validators` when only the
+/// identities are needed (e.g., for LSP completions).
+pub fn collect_custom_type_names(registry: &SchemaRegistry) -> Vec<TypeIdentity> {
     let mut names = std::collections::HashSet::new();
 
     for (_provider, _resource_type, _kind, schema) in registry.iter() {
@@ -961,18 +966,17 @@ pub fn collect_custom_type_names(registry: &SchemaRegistry) -> Vec<String> {
 /// Recursively extract Custom type validators from an AttributeType.
 fn collect_validators_from_type(
     attr_type: &crate::schema::AttributeType,
-    validators: &mut HashMap<String, crate::parser::ValidatorFn>,
+    validators: &mut HashMap<TypeIdentity, crate::parser::ValidatorFn>,
 ) {
     use crate::schema::AttributeType;
 
     match attr_type {
         AttributeType::Custom {
-            semantic_name: Some(name),
+            identity: Some(id),
             validate,
             ..
         } => {
-            let snake_name = crate::parser::pascal_to_snake(name);
-            validators.entry(snake_name).or_insert_with(|| {
+            validators.entry(id.clone()).or_insert_with(|| {
                 let validate_fn = validate.clone();
                 Box::new(move |s: &str| {
                     validate_fn(&crate::resource::Value::Concrete(
@@ -982,10 +986,7 @@ fn collect_validators_from_type(
                 })
             });
         }
-        AttributeType::Custom {
-            semantic_name: None,
-            ..
-        } => {}
+        AttributeType::Custom { identity: None, .. } => {}
         AttributeType::List { inner, .. } => {
             collect_validators_from_type(inner, validators);
         }
@@ -1007,24 +1008,21 @@ fn collect_validators_from_type(
     }
 }
 
-/// Recursively collect Custom type names from an AttributeType (names only, no closures).
+/// Recursively collect Custom type identities from an AttributeType
+/// (identities only, no closures).
 fn collect_type_names_from_type(
     attr_type: &crate::schema::AttributeType,
-    names: &mut std::collections::HashSet<String>,
+    names: &mut std::collections::HashSet<TypeIdentity>,
 ) {
     use crate::schema::AttributeType;
 
     match attr_type {
         AttributeType::Custom {
-            semantic_name: Some(name),
-            ..
+            identity: Some(id), ..
         } => {
-            names.insert(crate::parser::pascal_to_snake(name));
+            names.insert(id.clone());
         }
-        AttributeType::Custom {
-            semantic_name: None,
-            ..
-        } => {}
+        AttributeType::Custom { identity: None, .. } => {}
         AttributeType::List { inner, .. } => {
             collect_type_names_from_type(inner, names);
         }

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -13,6 +13,9 @@ use crate::resource::{ConcreteValue, ConcreteValueRef, DeferredValue, ManagedRes
 use crate::utils::{extract_enum_value_with_values, validate_enum_namespace};
 use crate::value::format_value_with_key;
 
+mod type_identity;
+pub use type_identity::TypeIdentity;
+
 /// Type alias for resource validator functions
 pub type ResourceValidator = fn(&HashMap<String, Value>) -> Result<(), Vec<TypeError>>;
 
@@ -52,17 +55,17 @@ pub fn noop_validator() -> CustomValidator {
     validator(|_| Ok(()))
 }
 
-/// External validator looked up by `AttributeType::Custom.semantic_name`
+/// External validator looked up by `AttributeType::Custom.identity`
 /// at validation time. Used to bridge to provider-supplied validators
 /// (the `ProviderContext.validators` map and WASM factory's
 /// `validate_custom_type`) that the schema itself cannot carry across
 /// the WASM boundary — see #2354.
 ///
-/// Implementors normalize the type name as needed (typically PascalCase
-/// → snake_case via `parser::pascal_to_snake`) before looking up the
-/// real validator.
+/// The lookup is keyed on a structured [`TypeIdentity`], not a flat
+/// type-name string, so two providers' same-named custom types resolve
+/// to distinct validators instead of colliding first-wins.
 pub type CustomTypeLookup<'a> =
-    &'a (dyn Fn(&str, &Value) -> Result<(), TypeError> + Send + Sync + 'a);
+    &'a (dyn Fn(&TypeIdentity, &Value) -> Result<(), TypeError> + Send + Sync + 'a);
 
 /// A [`CustomTypeLookup`] that approves every value. Pass to
 /// `validate_with_origins_and_lookup` from contexts that have no
@@ -154,9 +157,9 @@ fn walk_custom_lookup(
         return;
     }
     match attr_type {
-        AttributeType::Custom { semantic_name, .. } => {
-            if let Some(name) = semantic_name
-                && let Err(e) = lookup(name, value)
+        AttributeType::Custom { identity, .. } => {
+            if let Some(id) = identity
+                && let Err(e) = lookup(id, value)
             {
                 // Re-wrap as `ResourceValidationFailed` so the attribute
                 // slot survives. `with_attribute` only enriches the two
@@ -411,10 +414,16 @@ pub enum AttributeType {
     },
     /// Custom type (with validation function)
     Custom {
-        /// Some(name) when this type carries a semantic identity (e.g. "VpcId",
-        /// "AwsAccountId"). None when this is a generic string/int pattern type
-        /// synthesized by codegen for a property without a named semantic.
-        semantic_name: Option<String>,
+        /// `Some(identity)` when this type carries a structured type
+        /// identity (e.g. `aws.iam.Role.Arn`, `aws.VpcId`). `None` when
+        /// this is a generic string/int pattern type synthesized by
+        /// codegen for a property without a named semantic.
+        ///
+        /// Replaces the former flat `semantic_name: Option<String>`:
+        /// keying identity on discrete `provider + segments + kind`
+        /// axes keeps two providers' same-named types distinct. See
+        /// [`TypeIdentity`].
+        identity: Option<TypeIdentity>,
         base: Box<AttributeType>,
         /// Optional regex pattern constraint (for structural comparison).
         pattern: Option<String>,
@@ -478,7 +487,7 @@ impl fmt::Debug for AttributeType {
                 .field("dsl_aliases", dsl_aliases)
                 .finish(),
             AttributeType::Custom {
-                semantic_name,
+                identity,
                 base,
                 pattern,
                 length,
@@ -487,7 +496,7 @@ impl fmt::Debug for AttributeType {
                 validate: _,
             } => f
                 .debug_struct("Custom")
-                .field("semantic_name", semantic_name)
+                .field("identity", identity)
                 .field("base", base)
                 .field("pattern", pattern)
                 .field("length", length)
@@ -664,11 +673,11 @@ impl AttributeType {
                 ..
             } => Some((name, namespace, DslMap::Aliases(dsl_aliases))),
             AttributeType::Custom {
-                semantic_name: Some(name),
+                identity: Some(id),
                 namespace: Some(namespace),
                 to_dsl,
                 ..
-            } => Some((name, namespace, DslMap::Closure(*to_dsl))),
+            } => Some((&id.kind, namespace, DslMap::Closure(*to_dsl))),
             _ => None,
         }
     }
@@ -1094,7 +1103,7 @@ impl AttributeType {
     fn validate_custom(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
         let AttributeType::Custom {
             validate,
-            semantic_name,
+            identity,
             namespace,
             ..
         } = self
@@ -1102,7 +1111,7 @@ impl AttributeType {
             unreachable!("validate_custom called on non-Custom");
         };
 
-        let name_for_resolve = semantic_name.as_deref().unwrap_or("");
+        let name_for_resolve = identity.as_ref().map(|id| id.kind.as_str()).unwrap_or("");
         let resolved_value =
             Self::resolve_enum_input(name_for_resolve, namespace.as_deref(), value);
         validate(&resolved_value)
@@ -1312,15 +1321,11 @@ impl AttributeType {
             AttributeType::Duration => "Duration".to_string(),
             AttributeType::StringEnum { name, .. } => name.clone(),
             AttributeType::Custom {
-                semantic_name,
+                identity,
                 pattern,
                 length,
                 ..
-            } => custom_display_name(
-                semantic_name.as_deref(),
-                pattern.as_deref(),
-                length.as_ref(),
-            ),
+            } => custom_display_name(identity.as_ref(), pattern.as_deref(), length.as_ref()),
             AttributeType::List { inner, .. } => format!("List<{}>", inner.type_name()),
             AttributeType::Map { value: inner, .. } => format!("Map<{}>", inner.type_name()),
             AttributeType::Struct { name, .. } => format!("Struct({})", name),
@@ -1355,12 +1360,16 @@ impl AttributeType {
     /// Rules (first match wins):
     /// 1. Union sink: OK if source is assignable to any member.
     /// 2. Union source: OK iff source is assignable to sink for every member.
-    /// 3. Custom→Custom with both `semantic_name: Some` and names differ: NG.
+    /// 3. Custom→Custom with both `identity: Some` that are not the
+    ///    [`TypeIdentity::same_type`]: NG. Per-axis identity equality —
+    ///    an empty axis on either side is the wider type, so the
+    ///    generic `aws.Arn` stays assignable against `aws.iam.Role.Arn`
+    ///    while `aws.Region` and `gcp.Region` are rejected.
     /// 4. Custom→Custom: check pattern (pat-1 literal equality) and length
     ///    containment (source ⊆ sink), then recurse on base.
     /// 5. Custom source → non-Custom sink: recurse on `source.base`.
     /// 6. non-Custom source → Custom sink: NG (source has no proof of
-    ///    satisfying the sink's semantic/pattern/length).
+    ///    satisfying the sink's identity/pattern/length).
     /// 7. Otherwise: same primitive type names.
     ///
     /// # Conservative pattern/length policy
@@ -1395,23 +1404,19 @@ impl AttributeType {
         match (self, sink) {
             (
                 Custom {
-                    semantic_name: Some(s_name),
+                    identity: Some(s_id),
                     ..
                 },
                 Custom {
-                    semantic_name: Some(k_name),
+                    identity: Some(k_id),
                     ..
                 },
-            ) if s_name != k_name => false,
-            // Anonymous source → semantic sink has no proof of identity.
+            ) if !s_id.same_type(k_id) => false,
+            // Anonymous source → identified sink has no proof of identity.
             (
+                Custom { identity: None, .. },
                 Custom {
-                    semantic_name: None,
-                    ..
-                },
-                Custom {
-                    semantic_name: Some(_),
-                    ..
+                    identity: Some(_), ..
                 },
             ) => false,
             (
@@ -1609,12 +1614,12 @@ impl fmt::Display for AttributeType {
 }
 
 fn custom_display_name(
-    semantic_name: Option<&str>,
+    identity: Option<&TypeIdentity>,
     pattern: Option<&str>,
     length: Option<&(Option<u64>, Option<u64>)>,
 ) -> String {
-    if let Some(n) = semantic_name {
-        return n.to_string();
+    if let Some(id) = identity {
+        return id.to_string();
     }
     let mut s = String::from("String");
     let has_pattern = pattern.is_some();
@@ -1689,7 +1694,7 @@ fn reshape_for_string_literal(
     // `extra_message` so its detail (which often lists valid forms)
     // stays visible without polluting the structured candidates list.
     if let AttributeType::Custom {
-        semantic_name: Some(name),
+        identity: Some(id),
         namespace: Some(_),
         ..
     } = attr_type
@@ -1699,7 +1704,7 @@ fn reshape_for_string_literal(
         return TypeError::StringLiteralExpectedEnum {
             user_typed: typed.clone(),
             attribute: Some(attr_name.to_string()),
-            type_name: name.clone(),
+            type_name: id.kind.clone(),
             expected: Vec::new(),
             extra_message: Some(message.clone()),
         };
@@ -2901,7 +2906,7 @@ pub mod types {
     /// Positive integer type
     pub fn positive_int() -> AttributeType {
         AttributeType::Custom {
-            semantic_name: Some("PositiveInt".to_string()),
+            identity: Some(TypeIdentity::bare("PositiveInt")),
             base: Box::new(AttributeType::Int),
             pattern: None,
             length: None,
@@ -2924,7 +2929,7 @@ pub mod types {
     /// IPv4 CIDR block type (e.g., "10.0.0.0/16")
     pub fn ipv4_cidr() -> AttributeType {
         AttributeType::Custom {
-            semantic_name: Some("Ipv4Cidr".to_string()),
+            identity: Some(TypeIdentity::bare("Ipv4Cidr")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -2943,7 +2948,7 @@ pub mod types {
     /// IPv4 address type (e.g., "10.0.1.5", "192.168.0.1")
     pub fn ipv4_address() -> AttributeType {
         AttributeType::Custom {
-            semantic_name: Some("Ipv4Address".to_string()),
+            identity: Some(TypeIdentity::bare("Ipv4Address")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -2962,7 +2967,7 @@ pub mod types {
     /// IPv6 address type (e.g., "2001:db8::1", "::1")
     pub fn ipv6_address() -> AttributeType {
         AttributeType::Custom {
-            semantic_name: Some("Ipv6Address".to_string()),
+            identity: Some(TypeIdentity::bare("Ipv6Address")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -2981,7 +2986,7 @@ pub mod types {
     /// IPv6 CIDR block type (e.g., "2001:db8::/32", "::/0")
     pub fn ipv6_cidr() -> AttributeType {
         AttributeType::Custom {
-            semantic_name: Some("Ipv6Cidr".to_string()),
+            identity: Some(TypeIdentity::bare("Ipv6Cidr")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -3009,7 +3014,7 @@ pub mod types {
     /// contains at least one dot with non-empty labels.
     pub fn email() -> AttributeType {
         AttributeType::Custom {
-            semantic_name: Some("Email".to_string()),
+            identity: Some(TypeIdentity::bare("Email")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -592,7 +592,7 @@ fn schema_validate_with_origins_reshapes_custom_namespaced_type() {
         AttributeSchema::new(
             "mode",
             AttributeType::Custom {
-                semantic_name: Some("Mode".to_string()),
+                identity: Some(TypeIdentity::bare("Mode")),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
@@ -1765,7 +1765,7 @@ fn exclusive_required_multiple_groups() {
 fn validate_union_type() {
     // Create two Custom types that validate different prefixes
     let type_a = AttributeType::Custom {
-        semantic_name: Some("TypeA".to_string()),
+        identity: Some(TypeIdentity::bare("TypeA")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -1784,7 +1784,7 @@ fn validate_union_type() {
         to_dsl: None,
     };
     let type_b = AttributeType::Custom {
-        semantic_name: Some("TypeB".to_string()),
+        identity: Some(TypeIdentity::bare("TypeB")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -1881,7 +1881,7 @@ fn union_struct_unknown_field_shows_specific_error() {
 #[test]
 fn union_type_name() {
     let type_a = AttributeType::Custom {
-        semantic_name: Some("TypeA".to_string()),
+        identity: Some(TypeIdentity::bare("TypeA")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -1890,7 +1890,7 @@ fn union_type_name() {
         to_dsl: None,
     };
     let type_b = AttributeType::Custom {
-        semantic_name: Some("TypeB".to_string()),
+        identity: Some(TypeIdentity::bare("TypeB")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -1906,7 +1906,7 @@ fn union_type_name() {
 #[test]
 fn union_accepts_type_name() {
     let type_a = AttributeType::Custom {
-        semantic_name: Some("TypeA".to_string()),
+        identity: Some(TypeIdentity::bare("TypeA")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -1915,7 +1915,7 @@ fn union_accepts_type_name() {
         to_dsl: None,
     };
     let type_b = AttributeType::Custom {
-        semantic_name: Some("TypeB".to_string()),
+        identity: Some(TypeIdentity::bare("TypeB")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2652,7 +2652,7 @@ fn validate_skips_internal_attributes() {
 
 fn make_custom(name: &str, base: AttributeType) -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some(name.to_string()),
+        identity: Some(TypeIdentity::bare(name)),
         base: Box::new(base),
         pattern: None,
         length: None,
@@ -2664,7 +2664,7 @@ fn make_custom(name: &str, base: AttributeType) -> AttributeType {
 
 fn make_custom_anon_pattern(pattern: &str) -> AttributeType {
     AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: Some(pattern.to_string()),
         length: None,
@@ -2676,7 +2676,7 @@ fn make_custom_anon_pattern(pattern: &str) -> AttributeType {
 
 fn make_custom_anon_len(min: u64, max: u64) -> AttributeType {
     AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: None,
         length: Some((Some(min), Some(max))),
@@ -2709,12 +2709,62 @@ fn assignable_allows_same_semantic_name() {
     assert!(a.is_assignable_to(&b));
 }
 
+/// carina#2807: two providers exposing a same-named custom type
+/// (`aws.Region` vs `gcp.Region`, different formats) must be distinct
+/// types. Before the structured `TypeIdentity`, a flat `semantic_name`
+/// string made them collide — `is_assignable_to` would treat them as
+/// the same type because the strings were equal.
+#[test]
+fn assignable_rejects_same_kind_across_providers() {
+    let provider_custom = |provider: &str| AttributeType::Custom {
+        identity: Some(TypeIdentity::new(
+            Some(provider),
+            Vec::<String>::new(),
+            "Region",
+        )),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: noop_validator(),
+        namespace: None,
+        to_dsl: None,
+    };
+    let aws_region = provider_custom("aws");
+    let gcp_region = provider_custom("gcp");
+    assert!(!aws_region.is_assignable_to(&gcp_region));
+    assert!(!gcp_region.is_assignable_to(&aws_region));
+}
+
+/// The generic provider-scoped `aws.Arn` (no service/resource segments)
+/// stays assignable against a more specific `aws.iam.Role.Arn`: an
+/// empty `segments` axis is the wider type, not a wildcard mismatch.
+#[test]
+fn assignable_allows_generic_arn_against_specific_arn() {
+    let mk = |segments: &[&str]| AttributeType::Custom {
+        identity: Some(TypeIdentity::new(Some("aws"), segments.to_vec(), "Arn")),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: noop_validator(),
+        namespace: None,
+        to_dsl: None,
+    };
+    let generic = mk(&[]);
+    let role_arn = mk(&["iam", "Role"]);
+    assert!(generic.is_assignable_to(&role_arn));
+    assert!(role_arn.is_assignable_to(&generic));
+
+    // …but two specific ARNs with different service/resource differ.
+    let cert_arn = mk(&["acm", "Certificate"]);
+    assert!(!role_arn.is_assignable_to(&cert_arn));
+}
+
 #[test]
 fn assignable_narrow_to_anonymous_unconstrained_sink() {
     // Semantic source with no pattern assigns to fully-anonymous unconstrained sink.
     let account = make_custom("AwsAccountId", AttributeType::String);
     let anon = AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2767,7 +2817,7 @@ fn assignable_union_source_requires_all_members_assignable() {
     // All members of source must be assignable to sink.
     let vpc = make_custom("VpcId", AttributeType::String);
     let anon_any = AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2793,7 +2843,7 @@ fn semantic_custom_assigns_to_anonymous_unconstrained_sink() {
     // which asserted VpcId <-> SubnetId were symmetric-compatible.
     let vpc = make_custom("VpcId", AttributeType::String);
     let anon = AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2833,7 +2883,7 @@ fn make_custom_anon_pattern_and_len(
     length: Option<(Option<u64>, Option<u64>)>,
 ) -> AttributeType {
     AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: pattern.map(str::to_string),
         length,
@@ -2944,7 +2994,7 @@ fn assignable_anon_length_both_none_compatible() {
 #[test]
 fn custom_carries_semantic_name_pattern_length() {
     let t = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(TypeIdentity::bare("VpcId")),
         base: Box::new(AttributeType::String),
         pattern: Some("^vpc-[a-f0-9]+$".to_string()),
         length: Some((Some(8), Some(21))),
@@ -2954,12 +3004,12 @@ fn custom_carries_semantic_name_pattern_length() {
     };
     match t {
         AttributeType::Custom {
-            semantic_name,
+            identity,
             pattern,
             length,
             ..
         } => {
-            assert_eq!(semantic_name.as_deref(), Some("VpcId"));
+            assert_eq!(identity.as_ref().map(|id| id.kind.as_str()), Some("VpcId"));
             assert_eq!(pattern.as_deref(), Some("^vpc-[a-f0-9]+$"));
             assert_eq!(length, Some((Some(8), Some(21))));
         }
@@ -2970,7 +3020,7 @@ fn custom_carries_semantic_name_pattern_length() {
 #[test]
 fn custom_type_name_anonymous_pattern_only() {
     let t = AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: Some("^foo$".to_string()),
         length: None,
@@ -2984,7 +3034,7 @@ fn custom_type_name_anonymous_pattern_only() {
 #[test]
 fn custom_type_name_anonymous_length_only() {
     let t = AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: None,
         length: Some((Some(1), Some(64))),
@@ -2998,7 +3048,7 @@ fn custom_type_name_anonymous_length_only() {
 #[test]
 fn custom_type_name_anonymous_pattern_and_length() {
     let t = AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         base: Box::new(AttributeType::String),
         pattern: Some("^.*$".to_string()),
         length: Some((Some(1), Some(64))),
@@ -3041,14 +3091,10 @@ fn validate_email_function_directly() {
 fn validate_email_type() {
     let t = types::email();
 
-    // Type identity: Custom with semantic_name "Email" and String base
+    // Type identity: Custom with kind "Email" and String base
     match &t {
-        AttributeType::Custom {
-            semantic_name,
-            base,
-            ..
-        } => {
-            assert_eq!(semantic_name.as_deref(), Some("Email"));
+        AttributeType::Custom { identity, base, .. } => {
+            assert_eq!(identity.as_ref().map(|id| id.kind.as_str()), Some("Email"));
             assert!(matches!(**base, AttributeType::String));
         }
         other => panic!("Expected AttributeType::Custom, got: {:?}", other),
@@ -3418,7 +3464,7 @@ fn custom_namespaced_string_literal_routes_validator_text_to_extra_message() {
         AttributeSchema::new(
             "mode",
             AttributeType::Custom {
-                semantic_name: Some("Mode".to_string()),
+                identity: Some(TypeIdentity::bare("Mode")),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
@@ -3597,7 +3643,7 @@ fn union_string_vs_custom_picks_custom_error_for_string_input() {
     let union_type = AttributeType::Union(vec![
         AttributeType::Int,
         AttributeType::Custom {
-            semantic_name: Some("Arn".to_string()),
+            identity: Some(TypeIdentity::bare("Arn")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -3665,7 +3711,7 @@ fn union_custom_with_int_base_picks_custom_error_for_int_input() {
     // is the `Custom` one.
     let union_type = AttributeType::Union(vec![
         AttributeType::Custom {
-            semantic_name: Some("PositiveInt".to_string()),
+            identity: Some(TypeIdentity::bare("PositiveInt")),
             base: Box::new(AttributeType::Int),
             pattern: None,
             length: None,
@@ -3732,7 +3778,7 @@ fn custom_validator_can_capture_external_state() {
     // #2217 (closure-capable Custom validator).
     let allowed_region = "ap-northeast-1".to_string();
     let attr = AttributeType::Custom {
-        semantic_name: Some("Region".to_string()),
+        identity: Some(TypeIdentity::bare("Region")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -3775,7 +3821,7 @@ fn custom_validator_returns_structured_type_error_directly() {
     // This is what unlocks LSP code-action quick-fixes for Custom-typed
     // attributes (see #2220 / #2309 for the structured-error path).
     let attr = AttributeType::Custom {
-        semantic_name: Some("Mode".to_string()),
+        identity: Some(TypeIdentity::bare("Mode")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -3925,7 +3971,7 @@ fn walk_custom_lookup_skips_value_unknown() {
     let custom_type = AttributeType::Custom {
         base: Box::new(AttributeType::String),
         validate: always_fail,
-        semantic_name: Some("vpc_id".to_string()),
+        identity: Some(TypeIdentity::bare("vpc_id")),
         namespace: None,
         pattern: None,
         length: None,
@@ -3969,7 +4015,7 @@ fn union_walk_custom_lookup_succeeds_when_any_member_accepts() {
     let custom = |name: &str| AttributeType::Custom {
         base: Box::new(AttributeType::String),
         validate: validator(|_v: &Value| Ok(())),
-        semantic_name: Some(name.to_string()),
+        identity: Some(TypeIdentity::bare(name)),
         namespace: None,
         pattern: None,
         length: None,
@@ -3977,12 +4023,12 @@ fn union_walk_custom_lookup_succeeds_when_any_member_accepts() {
     };
     let union = AttributeType::Union(vec![custom("ok_arm"), custom("fail_arm")]);
 
-    let lookup = |name: &str, _v: &Value| -> Result<(), TypeError> {
-        if name == "ok_arm" {
+    let lookup = |id: &TypeIdentity, _v: &Value| -> Result<(), TypeError> {
+        if id.kind == "ok_arm" {
             Ok(())
         } else {
             Err(TypeError::ValidationFailed {
-                message: format!("{name} rejects"),
+                message: format!("{} rejects", id.kind),
             })
         }
     };
@@ -4010,7 +4056,7 @@ fn union_walk_custom_lookup_emits_smallest_error_set_when_all_fail() {
     let custom = |name: &str| AttributeType::Custom {
         base: Box::new(AttributeType::String),
         validate: validator(|_v: &Value| Ok(())),
-        semantic_name: Some(name.to_string()),
+        identity: Some(TypeIdentity::bare(name)),
         namespace: None,
         pattern: None,
         length: None,
@@ -4018,9 +4064,9 @@ fn union_walk_custom_lookup_emits_smallest_error_set_when_all_fail() {
     };
     let union = AttributeType::Union(vec![custom("a"), custom("b")]);
 
-    let lookup = |name: &str, _v: &Value| -> Result<(), TypeError> {
+    let lookup = |id: &TypeIdentity, _v: &Value| -> Result<(), TypeError> {
         Err(TypeError::ValidationFailed {
-            message: format!("{name} rejects"),
+            message: format!("{} rejects", id.kind),
         })
     };
 
@@ -4050,11 +4096,11 @@ fn union_walk_custom_lookup_cidr_accepts_ipv4_when_lookup_routes_correctly() {
     // rejection through anyway. This is the awscc#217 reproduction.
     let cidr = AttributeType::Union(vec![types::ipv4_cidr(), types::ipv6_cidr()]);
 
-    let lookup = |name: &str, value: &Value| -> Result<(), TypeError> {
+    let lookup = |id: &TypeIdentity, value: &Value| -> Result<(), TypeError> {
         let Value::Concrete(ConcreteValue::String(s)) = value else {
             return Ok(());
         };
-        match name {
+        match id.kind.as_str() {
             "Ipv4Cidr" => {
                 validate_ipv4_cidr(s).map_err(|message| TypeError::ValidationFailed { message })
             }

--- a/carina-core/src/schema/type_identity.rs
+++ b/carina-core/src/schema/type_identity.rs
@@ -1,0 +1,281 @@
+//! Structured identity of a provider-defined custom type.
+//!
+//! Replaces the flat `semantic_name: Option<String>` that
+//! `AttributeType::Custom` previously carried. A flat string conflated
+//! the type-identity key with the display name and had no provider
+//! axis, so two providers exposing a same-named type (`aws.Region` vs a
+//! future `gcp.Region`, different formats) collided: the type system
+//! treated them as the same type because their `semantic_name` strings
+//! were equal.
+//!
+//! [`TypeIdentity`] keys identity on discrete axes —
+//! `provider + segments + kind`. Identity equality is **per-axis**: two
+//! identities denote the same type iff every *populated* axis is equal.
+//! An empty axis (`provider: None`, or an empty `segments`) means "not
+//! distinguished on this axis" — a wider type, higher in the base
+//! chain — not a wildcard.
+//!
+//! The dotted display form (`aws.iam.Role.Arn`) is *derived* from the
+//! structure via [`Display`]; it is never the source of truth and is
+//! never parsed back into axes.
+//!
+//! See `notes/specs/2026-05-16-semantic-name-redesign-design.md`.
+
+use std::fmt;
+
+/// Structured identity of an `AttributeType::Custom`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct TypeIdentity {
+    /// Provider segment, e.g. `Some("aws")`. `None` when the type
+    /// carries no provider axis — a truly provider-agnostic wrapper
+    /// (e.g. the built-in `Ipv4Cidr`). A `None` provider is *wider*
+    /// than any `Some`: it does not distinguish on the provider axis.
+    pub provider: Option<String>,
+    /// Service / resource segments between the provider and the kind,
+    /// e.g. `["iam", "Role"]` for `aws.iam.Role.Arn`. Empty for a
+    /// provider-scoped but resource-agnostic type such as the generic
+    /// `aws.Arn`.
+    pub segments: Vec<String>,
+    /// The type's own name, e.g. `"Arn"`, `"VpcId"`, `"Region"`.
+    pub kind: String,
+}
+
+impl TypeIdentity {
+    /// Construct an identity from its three axes.
+    pub fn new(
+        provider: Option<impl Into<String>>,
+        segments: impl IntoIterator<Item = impl Into<String>>,
+        kind: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: provider.map(Into::into),
+            segments: segments.into_iter().map(Into::into).collect(),
+            kind: kind.into(),
+        }
+    }
+
+    /// A provider-agnostic identity carrying only a `kind` — no provider
+    /// axis, no service/resource segments. Used for the built-in DSL
+    /// custom types (`Ipv4Cidr`, `Email`, …) that are not owned by any
+    /// provider.
+    pub fn bare(kind: impl Into<String>) -> Self {
+        Self {
+            provider: None,
+            segments: Vec::new(),
+            kind: kind.into(),
+        }
+    }
+
+    /// Parse a dotted identity string produced by a provider's
+    /// serialized schema (`carina-provider-protocol`).
+    ///
+    /// This is the one place a dotted string is turned back into the
+    /// structure — the schema-transport JSON channel, distinct from the
+    /// WIT boundary which already carries the structured record. The
+    /// classification rule mirrors the parser's `Ref`-vs-`SchemaType`
+    /// split: a name with a provider segment and a PascalCase tail
+    /// (`aws.iam.Role.Arn`, `aws.VpcId`) parses to a provider-scoped
+    /// identity; a bare PascalCase name (`VpcId`, `Ipv4Cidr`) — what a
+    /// not-yet-migrated provider still emits — parses to a bare,
+    /// provider-agnostic identity.
+    pub fn from_dotted(name: &str) -> Self {
+        match name.split_once('.') {
+            // `provider.<rest...>.Kind` — at least one provider segment
+            // plus a kind.
+            Some((provider, rest)) => {
+                let mut parts: Vec<&str> = rest.split('.').collect();
+                let kind = parts.pop().unwrap_or(rest);
+                Self {
+                    provider: Some(provider.to_string()),
+                    segments: parts.into_iter().map(String::from).collect(),
+                    kind: kind.to_string(),
+                }
+            }
+            // Bare name — no provider axis.
+            None => Self::bare(name),
+        }
+    }
+
+    /// Build an identity from a `TypeExpr::SchemaType`'s three parts.
+    ///
+    /// `provider` is the provider segment, `path` the dotted
+    /// service/resource path (`"ec2"` or `"iam.Role"`, possibly empty),
+    /// and `kind` the PascalCase type name. Used to project a parsed
+    /// dotted type annotation onto the structured identity it denotes.
+    pub fn from_schema_type(provider: &str, path: &str, kind: &str) -> Self {
+        let segments = if path.is_empty() {
+            Vec::new()
+        } else {
+            path.split('.').map(String::from).collect()
+        };
+        Self {
+            provider: Some(provider.to_string()),
+            segments,
+            kind: kind.to_string(),
+        }
+    }
+
+    /// Whether two identities denote the **same type**.
+    ///
+    /// Equality is per-axis over *populated* axes only:
+    ///
+    /// - `kind` must always match (the `kind` axis is never empty).
+    /// - `provider` must match when **both** sides populate it. If
+    ///   either side has `provider: None`, the provider axis is not
+    ///   distinguished — `None` is the wider type.
+    /// - `segments` must match when **both** sides are non-empty. An
+    ///   empty `segments` on either side is the wider type.
+    ///
+    /// This yields the required distinctions: `aws.iam.Role.Arn` and
+    /// `aws.acm.Certificate.Arn` differ (segments differ), `aws.Region`
+    /// and `gcp.Region` differ (provider differs), while the generic
+    /// `aws.Arn` stays assignable against a more specific `aws.*.Arn`.
+    pub fn same_type(&self, other: &TypeIdentity) -> bool {
+        if self.kind != other.kind {
+            return false;
+        }
+        if let (Some(a), Some(b)) = (&self.provider, &other.provider)
+            && a != b
+        {
+            return false;
+        }
+        if !self.segments.is_empty()
+            && !other.segments.is_empty()
+            && self.segments != other.segments
+        {
+            return false;
+        }
+        true
+    }
+}
+
+impl fmt::Display for TypeIdentity {
+    /// Dotted form: `provider.seg.seg.kind`, omitting empty axes.
+    /// `aws.iam.Role.Arn`, `aws.Arn`, or a bare `Ipv4Cidr`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(provider) = &self.provider {
+            write!(f, "{}.", provider)?;
+        }
+        for seg in &self.segments {
+            write!(f, "{}.", seg)?;
+        }
+        write!(f, "{}", self.kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_identity_has_no_provider_or_segments() {
+        let id = TypeIdentity::bare("Ipv4Cidr");
+        assert_eq!(id.provider, None);
+        assert!(id.segments.is_empty());
+        assert_eq!(id.kind, "Ipv4Cidr");
+    }
+
+    #[test]
+    fn display_renders_dotted_form() {
+        let role_arn = TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn");
+        assert_eq!(role_arn.to_string(), "aws.iam.Role.Arn");
+
+        let generic_arn = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn");
+        assert_eq!(generic_arn.to_string(), "aws.Arn");
+
+        let bare = TypeIdentity::bare("Ipv4Cidr");
+        assert_eq!(bare.to_string(), "Ipv4Cidr");
+    }
+
+    #[test]
+    fn same_provider_same_kind_different_segments_are_distinct() {
+        // The headline disambiguation: aws.iam.Role.Arn != aws.acm.Certificate.Arn.
+        let role_arn = TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn");
+        let cert_arn = TypeIdentity::new(Some("aws"), ["acm", "Certificate"], "Arn");
+        assert!(!role_arn.same_type(&cert_arn));
+        assert!(!cert_arn.same_type(&role_arn));
+    }
+
+    #[test]
+    fn same_kind_different_provider_are_distinct() {
+        // The motivating collision: aws.Region != gcp.Region.
+        let aws_region = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region");
+        let gcp_region = TypeIdentity::new(Some("gcp"), Vec::<String>::new(), "Region");
+        assert!(!aws_region.same_type(&gcp_region));
+        assert!(!gcp_region.same_type(&aws_region));
+    }
+
+    #[test]
+    fn empty_provider_axis_is_not_distinguished() {
+        // A None provider is the wider type — it does not distinguish
+        // on the provider axis, so it matches either side.
+        let bare_arn = TypeIdentity::bare("Arn");
+        let aws_arn = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn");
+        assert!(bare_arn.same_type(&aws_arn));
+        assert!(aws_arn.same_type(&bare_arn));
+    }
+
+    #[test]
+    fn empty_segments_axis_is_not_distinguished() {
+        // Generic aws.Arn (no segments) is wider than aws.iam.Role.Arn.
+        let generic_arn = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn");
+        let role_arn = TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn");
+        assert!(generic_arn.same_type(&role_arn));
+        assert!(role_arn.same_type(&generic_arn));
+    }
+
+    #[test]
+    fn different_kind_is_always_distinct() {
+        let arn = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn");
+        let vpc_id = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "VpcId");
+        assert!(!arn.same_type(&vpc_id));
+    }
+
+    #[test]
+    fn identical_identities_are_same_type() {
+        let a = TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn");
+        let b = TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn");
+        assert!(a.same_type(&b));
+    }
+
+    #[test]
+    fn from_dotted_parses_provider_scoped_and_bare_names() {
+        // Fully specified: provider + service/resource + kind.
+        let role_arn = TypeIdentity::from_dotted("aws.iam.Role.Arn");
+        assert_eq!(role_arn.provider.as_deref(), Some("aws"));
+        assert_eq!(role_arn.segments, vec!["iam", "Role"]);
+        assert_eq!(role_arn.kind, "Arn");
+
+        // Provider + kind, no service/resource segments.
+        let aws_vpc_id = TypeIdentity::from_dotted("aws.VpcId");
+        assert_eq!(aws_vpc_id.provider.as_deref(), Some("aws"));
+        assert!(aws_vpc_id.segments.is_empty());
+        assert_eq!(aws_vpc_id.kind, "VpcId");
+
+        // Bare name — a not-yet-migrated provider's flat spelling.
+        let bare = TypeIdentity::from_dotted("VpcId");
+        assert_eq!(bare.provider, None);
+        assert!(bare.segments.is_empty());
+        assert_eq!(bare.kind, "VpcId");
+    }
+
+    #[test]
+    fn from_dotted_round_trips_through_display() {
+        for s in ["aws.iam.Role.Arn", "aws.VpcId", "Ipv4Cidr"] {
+            assert_eq!(TypeIdentity::from_dotted(s).to_string(), s);
+        }
+    }
+
+    #[test]
+    fn from_schema_type_builds_provider_scoped_identity() {
+        let id = TypeIdentity::from_schema_type("awscc", "ec2", "VpcId");
+        assert_eq!(id.provider.as_deref(), Some("awscc"));
+        assert_eq!(id.segments, vec!["ec2"]);
+        assert_eq!(id.kind, "VpcId");
+
+        // Empty path → no service/resource segments.
+        let no_path = TypeIdentity::from_schema_type("aws", "", "Arn");
+        assert!(no_path.segments.is_empty());
+        assert_eq!(no_path.to_string(), "aws.Arn");
+    }
+}

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -731,7 +731,7 @@ fn check_resource_ref_at_position(
     // strict compat check above accepts `Simple(name) → String` /
     // `Union<plain Strings>` directly via subtyping (#2643), so this
     // fallback only handles the receivers it doesn't yet cover —
-    // `Custom { semantic_name: None }`-shaped wrappers and
+    // `Custom { identity: None }`-shaped wrappers and
     // `StringEnum` receivers — and the non-`Simple` string-shaped
     // values (e.g. `SchemaType` / scalar `String` literal) the
     // strict path also doesn't recognise. The reverse direction
@@ -2086,7 +2086,7 @@ mod tests {
         // Consumer attribute is `Custom { name: "KmsKeyArn", base: Arn }`;
         // export declares plain `TypeExpr::Simple("arn")`. The type checker
         // walks Custom's base chain, so `arn` accepts `KmsKeyArn`.
-        use crate::schema::{AttributeType, noop_validator};
+        use crate::schema::{AttributeType, TypeIdentity, noop_validator};
         let parsed = parse_project_with_provider(
             r#"
                 let orgs = upstream_state { source = "../organizations" }
@@ -2099,9 +2099,9 @@ mod tests {
         let exports =
             mk_typed_exports(&[("orgs", &[("key_arn", TypeExpr::Simple("arn".to_string()))])]);
         let kms_arn = AttributeType::Custom {
-            semantic_name: Some("KmsKeyArn".to_string()),
+            identity: Some(TypeIdentity::bare("KmsKeyArn")),
             base: Box::new(AttributeType::Custom {
-                semantic_name: Some("Arn".to_string()),
+                identity: Some(TypeIdentity::bare("Arn")),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
@@ -2135,7 +2135,7 @@ mod tests {
         // narrowing the comparison fires `map(AwsAccountId)` against the
         // receiver and (when the receiver is anything but a compatible map)
         // false-flags the position. Issue #2447.
-        use crate::schema::{AttributeType, noop_validator};
+        use crate::schema::{AttributeType, TypeIdentity, noop_validator};
         let parsed = parse_project_with_provider(
             r#"
                 let orgs = upstream_state { source = "../organizations" }
@@ -2156,7 +2156,7 @@ mod tests {
         // compares against `String` and fails. With narrowing,
         // `AwsAccountId` (Custom over String) is accepted.
         let aws_account_id = AttributeType::Custom {
-            semantic_name: Some("AwsAccountId".to_string()),
+            identity: Some(TypeIdentity::bare("AwsAccountId")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -574,10 +574,13 @@ fn descend_struct_field<'a>(
 /// recursive descent into `List`/`Map`/`Struct` schema receivers.
 ///
 /// Notable mappings:
-/// - `Custom { semantic_name: Some(name), .. }` → `TypeExpr::Simple(snake)`
-///   so the predicate's existing `Simple(name)` arm matches by
+/// - `Custom { identity: Some(id), .. }` with a provider axis →
+///   `TypeExpr::SchemaType` (the same structured form the parser
+///   produces for a dotted `awscc.ec2.VpcId` annotation). A bare,
+///   provider-agnostic identity → `TypeExpr::Simple(snake)` so the
+///   predicate's existing `Simple(name)` arm matches by
 ///   pascal_to_snake equality.
-/// - `Custom { semantic_name: None, .. }` → falls through to the base
+/// - `Custom { identity: None, .. }` → falls through to the base
 ///   type; an anonymous Custom is structurally a wrapper and carries
 ///   no identity to project.
 /// - `StringEnum` → `TypeExpr::String` (an enum value is still a
@@ -591,9 +594,15 @@ fn attribute_type_to_type_expr(attr_type: &AttributeType) -> TypeExpr {
         AttributeType::Bool => TypeExpr::Bool,
         AttributeType::Duration => TypeExpr::Duration,
         AttributeType::Custom {
-            semantic_name: Some(name),
-            ..
-        } => TypeExpr::Simple(crate::parser::pascal_to_snake(name)),
+            identity: Some(id), ..
+        } => match &id.provider {
+            Some(provider) => TypeExpr::SchemaType {
+                provider: provider.clone(),
+                path: id.segments.join("."),
+                type_name: id.kind.clone(),
+            },
+            None => TypeExpr::Simple(crate::parser::pascal_to_snake(&id.kind)),
+        },
         AttributeType::Custom { base, .. } => attribute_type_to_type_expr(base),
         AttributeType::StringEnum { .. } => TypeExpr::String,
         AttributeType::List { inner, .. } => {
@@ -723,7 +732,8 @@ mod tests {
     use super::*;
     use crate::resource::AccessPath;
     use crate::schema::{
-        AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, legacy_validator,
+        AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, TypeIdentity,
+        legacy_validator,
     };
 
     fn noop(_v: &Value) -> Result<(), String> {
@@ -732,7 +742,7 @@ mod tests {
 
     fn vpc_id_custom() -> AttributeType {
         AttributeType::Custom {
-            semantic_name: Some("VpcId".to_string()),
+            identity: Some(TypeIdentity::bare("VpcId")),
             pattern: None,
             length: None,
             base: Box::new(AttributeType::String),

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -621,14 +621,14 @@ fn is_plain_string_or_string_union(attr_type: &AttributeType) -> bool {
 
 /// Recursive check used by the `TypeExpr::String` arm of
 /// `is_type_expr_compatible_with_schema`: returns `true` when
-/// `attr_type` carries a `Custom { semantic_name: Some(_) }` either at
+/// `attr_type` carries a `Custom { identity: Some(_) }` either at
 /// the top level or anywhere inside a `Union`. A schema attribute that
 /// names a specific identity (`VpcId`, `Arn`, …) cannot accept a value
 /// known only as `String`. Issue #2358.
 ///
 /// Scope:
-/// - Looks at the outer `semantic_name` only — does **not** walk
-///   `Custom.base` chains. Real provider schemas keep `semantic_name`
+/// - Looks at the outer `identity` only — does **not** walk
+///   `Custom.base` chains. Real provider schemas keep `identity`
 ///   on the outer wrapper, so an anonymous `Custom` wrapping a
 ///   specific `Custom` does not occur in practice. If a future schema
 ///   introduces that shape, this helper would need to walk the base
@@ -637,13 +637,12 @@ fn is_plain_string_or_string_union(attr_type: &AttributeType) -> bool {
 ///   schemas currently express every named-identity Custom as a
 ///   `String`-base wrapper, so `TypeExpr::Int/Bool/Float` arms have
 ///   no analogous strictness. If a future schema adds e.g. a
-///   `Custom { semantic_name: "Port", base: Int }`, those arms will
+///   `Custom { identity: "Port", base: Int }`, those arms will
 ///   also need to consult this helper (or a sibling).
 fn attr_type_demands_specific_custom(attr_type: &AttributeType) -> bool {
     match attr_type {
         AttributeType::Custom {
-            semantic_name: Some(_),
-            ..
+            identity: Some(_), ..
         } => true,
         AttributeType::Union(types) => types.iter().any(attr_type_demands_specific_custom),
         _ => false,
@@ -958,7 +957,10 @@ pub fn validate_type_expr_value(
         return None;
     }
     match (type_expr, value) {
-        (TypeExpr::Simple(name), _) => validate_custom_type(name, value, config).err(),
+        (TypeExpr::Simple(name), _) => {
+            let identity = crate::schema::TypeIdentity::bare(crate::parser::snake_to_pascal(name));
+            validate_custom_type(&identity, value, config).err()
+        }
         (TypeExpr::List(inner), Value::Concrete(ConcreteValue::List(items))) => {
             for (i, item) in items.iter().enumerate() {
                 if let Some(e) = validate_type_expr_value(inner, item, config) {

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::parser::{ParsedFile, ProviderContext};
 use crate::resource::ManagedResource;
-use crate::schema::{ResourceSchema, SchemaRegistry, noop_validator};
+use crate::schema::{ResourceSchema, SchemaRegistry, TypeIdentity, noop_validator};
 
 fn empty_parsed() -> ParsedFile {
     ParsedFile {
@@ -30,9 +30,9 @@ fn empty_parsed() -> ParsedFile {
 fn context_with_iam_policy_arn_validator() -> ProviderContext {
     use crate::parser::ValidatorFn;
 
-    let mut validators: HashMap<String, ValidatorFn> = HashMap::new();
+    let mut validators: HashMap<TypeIdentity, ValidatorFn> = HashMap::new();
     validators.insert(
-        "iam_policy_arn".to_string(),
+        TypeIdentity::bare("IamPolicyArn"),
         Box::new(|s: &str| {
             if s.starts_with("arn:aws:iam::") {
                 Ok(())
@@ -1394,7 +1394,7 @@ fn is_type_expr_compatible_unknown_rejects_custom_receiver() {
         Ok(())
     }
     let custom = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(TypeIdentity::bare("VpcId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -1415,7 +1415,7 @@ fn is_type_expr_compatible_string_rejects_custom_with_semantic_name() {
         Ok(())
     }
     let schema = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(TypeIdentity::bare("VpcId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -1440,7 +1440,7 @@ fn is_type_expr_compatible_string_accepts_custom_without_semantic_name() {
         Ok(())
     }
     let schema = AttributeType::Custom {
-        semantic_name: None,
+        identity: None,
         pattern: Some("^.+$".to_string()),
         length: None,
         base: Box::new(AttributeType::String),
@@ -1467,7 +1467,7 @@ fn is_type_expr_compatible_string_rejects_union_containing_specific_custom() {
     let schema = AttributeType::Union(vec![
         AttributeType::String,
         AttributeType::Custom {
-            semantic_name: Some("VpcId".to_string()),
+            identity: Some(TypeIdentity::bare("VpcId")),
             pattern: None,
             length: None,
             base: Box::new(AttributeType::String),
@@ -1492,7 +1492,7 @@ fn is_type_expr_compatible_string_rejects_union_of_only_specific_customs() {
         Ok(())
     }
     let mk = |name: &str| AttributeType::Custom {
-        semantic_name: Some(name.to_string()),
+        identity: Some(TypeIdentity::bare(name)),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -1537,7 +1537,7 @@ fn is_type_expr_compatible_simple_vpcid_accepts_custom_vpcid() {
         Ok(())
     }
     let schema = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(TypeIdentity::bare("VpcId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -1611,7 +1611,7 @@ fn attribute_param_ref_type_mismatch_detected() {
     role_schema = role_schema.attribute(AttributeSchema::new(
         "arn",
         AttributeType::Custom {
-            semantic_name: Some("IamRoleArn".to_string()),
+            identity: Some(TypeIdentity::bare("IamRoleArn")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -1763,9 +1763,9 @@ fn validate_export_params_rejects_type_mismatch() {
 fn type_compat_subtype_accepted() {
     // arn accepts KmsKeyArn (subtype via base chain: KmsKeyArn → Arn)
     let kms_key_arn = AttributeType::Custom {
-        semantic_name: Some("KmsKeyArn".to_string()),
+        identity: Some(TypeIdentity::bare("KmsKeyArn")),
         base: Box::new(AttributeType::Custom {
-            semantic_name: Some("Arn".to_string()),
+            identity: Some(TypeIdentity::bare("Arn")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -1789,9 +1789,9 @@ fn type_compat_subtype_accepted() {
 fn type_compat_sibling_rejected() {
     // kms_key_arn rejects IamRoleArn (sibling: IamRoleArn → Arn, not KmsKeyArn)
     let iam_role_arn = AttributeType::Custom {
-        semantic_name: Some("IamRoleArn".to_string()),
+        identity: Some(TypeIdentity::bare("IamRoleArn")),
         base: Box::new(AttributeType::Custom {
-            semantic_name: Some("Arn".to_string()),
+            identity: Some(TypeIdentity::bare("Arn")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -1815,9 +1815,9 @@ fn type_compat_sibling_rejected() {
 fn type_compat_resource_id_subtype() {
     // aws_resource_id accepts VpcId (subtype)
     let vpc_id = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(TypeIdentity::bare("VpcId")),
         base: Box::new(AttributeType::Custom {
-            semantic_name: Some("AwsResourceId".to_string()),
+            identity: Some(TypeIdentity::bare("AwsResourceId")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -1841,9 +1841,9 @@ fn type_compat_resource_id_subtype() {
 fn type_compat_resource_id_siblings_rejected() {
     // vpc_id rejects SubnetId (sibling)
     let subnet_id = AttributeType::Custom {
-        semantic_name: Some("SubnetId".to_string()),
+        identity: Some(TypeIdentity::bare("SubnetId")),
         base: Box::new(AttributeType::Custom {
-            semantic_name: Some("AwsResourceId".to_string()),
+            identity: Some(TypeIdentity::bare("AwsResourceId")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -1866,7 +1866,7 @@ fn type_compat_resource_id_siblings_rejected() {
 #[test]
 fn type_compat_exact_match() {
     let arn = AttributeType::Custom {
-        semantic_name: Some("Arn".to_string()),
+        identity: Some(TypeIdentity::bare("Arn")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2000,7 +2000,7 @@ fn type_compat_simple_rejected_when_union_has_no_plain_string() {
 #[test]
 fn type_compat_simple_rejected_when_union_has_string_shaped_peer() {
     let arn = AttributeType::Custom {
-        semantic_name: Some("Arn".to_string()),
+        identity: Some(TypeIdentity::bare("Arn")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -3237,9 +3237,10 @@ mod tests {
 
     #[test]
     fn canonicalize_through_custom_wrapper() {
+        use crate::schema::TypeIdentity;
         // Custom wrappers must be transparent for type matching.
         let t = AttributeType::Custom {
-            semantic_name: Some("PolicyConditionValue".to_string()),
+            identity: Some(TypeIdentity::bare("PolicyConditionValue")),
             base: Box::new(string_or_list_of_strings()),
             pattern: None,
             length: None,

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -65,8 +65,14 @@ impl ProviderState {
             .iter()
             .flat_map(|f| f.config_completions().remove("region").unwrap_or_default())
             .collect();
-        // Extract custom type names from provider schemas for completion
-        let custom_type_names = provider_mod::collect_custom_type_names(&schemas);
+        // Extract custom type names from provider schemas for completion.
+        // The structured identities render to their dotted display form
+        // (`aws.iam.Role.Arn`, `Ipv4Cidr`), which is also the spelling a
+        // user writes in a type annotation.
+        let custom_type_names: Vec<String> = provider_mod::collect_custom_type_names(&schemas)
+            .iter()
+            .map(|id| id.to_string())
+            .collect();
         let factories_arc = Arc::new(factories);
         Self {
             diagnostic_engine: DiagnosticEngine::new(

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2673,7 +2673,7 @@ fn exports_map_value_offers_matching_resource_refs() {
         Ok(())
     }
     let account_id = AttributeType::Custom {
-        semantic_name: Some("AwsAccountId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2758,7 +2758,7 @@ fn exports_map_value_multiple_entries_returns_refs() {
         Ok(())
     }
     let account_id = AttributeType::Custom {
-        semantic_name: Some("AwsAccountId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2816,7 +2816,7 @@ fn exports_map_value_includes_bindings_from_sibling_files() {
         Ok(())
     }
     let account_id = AttributeType::Custom {
-        semantic_name: Some("AwsAccountId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2874,7 +2874,7 @@ fn custom_type_value_ref_includes_sibling_file_bindings() {
         Ok(())
     }
     let account_id = AttributeType::Custom {
-        semantic_name: Some("AwsAccountId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -2975,7 +2975,7 @@ fn binding_dot_completion_resolves_sibling_file_binding() {
         Ok(())
     }
     let account_id = AttributeType::Custom {
-        semantic_name: Some("AwsAccountId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -3211,7 +3211,7 @@ fn upstream_state_string_export_not_offered_to_specific_custom_receiver() {
         Ok(())
     }
     let vpc_id_type = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("VpcId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -4104,7 +4104,7 @@ awscc.ec2.SecurityGroup {
 #[test]
 fn value_position_filters_generic_string_arg_against_specific_custom_target() {
     // Motivating case from #2640's report: `vpc_id` is a
-    // `Custom { semantic_name: Some("VpcId"), base: String }`. A
+    // `Custom { identity: Some(carina_core::schema::TypeIdentity::bare("VpcId")), base: String }`. A
     // generic-`String` argument cannot satisfy that — the receiver
     // names a specific identity, and any `String` value would erase
     // that proof. Conversely, an argument typed `vpc_id` (Simple) is

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -218,7 +218,7 @@ pub(super) fn test_provider_with_vpc_and_security_group() -> CompletionProvider 
         Ok(())
     }
     let vpc_id_custom = AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("VpcId")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
@@ -247,7 +247,7 @@ pub(super) fn test_provider_with_custom_semantic_attr() -> CompletionProvider {
         Ok(())
     }
     let account_id = AttributeType::Custom {
-        semantic_name: Some("aws_account_id".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("aws_account_id")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -991,7 +991,9 @@ fn type_expr_to_attribute_type(
         parser::TypeExpr::Float => Some(AttributeType::Float),
         parser::TypeExpr::Duration => Some(AttributeType::Duration),
         parser::TypeExpr::Simple(name) => Some(AttributeType::Custom {
-            semantic_name: Some(parser::snake_to_pascal(name)),
+            identity: Some(carina_core::schema::TypeIdentity::bare(
+                parser::snake_to_pascal(name),
+            )),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -519,13 +519,13 @@ impl CompletionProvider {
         }
     }
 
-    /// Extract the Custom type name from an AttributeType, if it is a Custom type.
+    /// Extract the Custom type's kind name from an AttributeType, if it
+    /// is a Custom type with a structured identity.
     fn extract_custom_type_name(attr_type: &AttributeType) -> Option<&str> {
         match attr_type {
             AttributeType::Custom {
-                semantic_name: Some(name),
-                ..
-            } => Some(name),
+                identity: Some(id), ..
+            } => Some(&id.kind),
             _ => None,
         }
     }
@@ -605,13 +605,11 @@ impl CompletionProvider {
                 },
             ],
             AttributeType::Custom {
-                semantic_name: Some(name),
-                ..
-            } if name == "Cidr" || name == "Ipv4Cidr" => self.cidr_completions(),
+                identity: Some(id), ..
+            } if id.kind == "Cidr" || id.kind == "Ipv4Cidr" => self.cidr_completions(),
             AttributeType::Custom {
-                semantic_name: Some(name),
-                ..
-            } if name == "Ipv6Cidr" => self.ipv6_cidr_completions(),
+                identity: Some(id), ..
+            } if id.kind == "Ipv6Cidr" => self.ipv6_cidr_completions(),
             // Generic ARN snippet only for the bare `Arn` type. Specific
             // ARN families (`IamRoleArn`, `IamPolicyArn`,
             // `IamOidcProviderArn`, `KmsKeyArn`, …) already have shape
@@ -622,15 +620,14 @@ impl CompletionProvider {
             // the per-type formats are useful enough to justify the
             // surface. See #2621.
             AttributeType::Custom {
-                semantic_name: Some(name),
-                ..
-            } if name == "Arn" => self.arn_completions(),
+                identity: Some(id), ..
+            } if id.kind == "Arn" => self.arn_completions(),
             AttributeType::Custom {
-                semantic_name: Some(name),
+                identity: Some(id),
                 namespace,
                 ..
-            } if name == "AvailabilityZone" => {
-                self.availability_zone_completions(namespace.as_deref().unwrap_or(""), name)
+            } if id.kind == "AvailabilityZone" => {
+                self.availability_zone_completions(namespace.as_deref().unwrap_or(""), &id.kind)
             }
             // List(non-Struct): delegate to inner type completions
             AttributeType::List { inner, .. } => self.completions_for_type(inner, resource_type),
@@ -1978,13 +1975,12 @@ fn parse_exports_type_text(text: &str) -> Option<AttributeType> {
         "Float" => Some(AttributeType::Float),
         "Bool" => Some(AttributeType::Bool),
         // Custom types also ship in PascalCase now (e.g. `AwsAccountId`,
-        // `Ipv4Cidr`). Carry the PascalCase form as `semantic_name` and
-        // canonicalise the internal key to snake_case.
+        // `Ipv4Cidr`). Carry the PascalCase form as a bare identity.
         name if name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
             && name.chars().all(|c| c.is_ascii_alphanumeric()) =>
         {
             Some(AttributeType::Custom {
-                semantic_name: Some(name.to_string()),
+                identity: Some(carina_core::schema::TypeIdentity::bare(name)),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1510,7 +1510,12 @@ impl DiagnosticEngine {
                 if builtin.contains(&name.as_str()) {
                     return None;
                 }
-                if self.provider_context.validators.contains_key(name) {
+                // `Simple` annotations name a built-in custom type; key
+                // the validator lookup on the bare structured identity.
+                let identity = carina_core::schema::TypeIdentity::bare(
+                    carina_core::parser::snake_to_pascal(name),
+                );
+                if self.provider_context.validators.contains_key(&identity) {
                     return None;
                 }
                 Some(format!("Unknown type '{name}'."))

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -78,12 +78,14 @@ impl DiagnosticEngine {
         let provider_context = carina_core::parser::ProviderContext {
             decryptor: None,
             validators: carina_core::provider::collect_custom_type_validators(&schemas),
-            custom_type_validator: Some(Box::new(move |type_name: &str, value: &str| {
-                for factory in factories_clone.iter() {
-                    factory.validate_custom_type(type_name, value)?;
-                }
-                Ok(())
-            })),
+            custom_type_validator: Some(Box::new(
+                move |identity: &carina_core::schema::TypeIdentity, value: &str| {
+                    for factory in factories_clone.iter() {
+                        factory.validate_custom_type(identity, value)?;
+                    }
+                    Ok(())
+                },
+            )),
             schema_types: Default::default(),
         };
         Self {
@@ -549,7 +551,7 @@ impl DiagnosticEngine {
                                 }
                                 (
                                     carina_core::schema::AttributeType::Custom {
-                                        semantic_name,
+                                        identity,
                                         validate,
                                         namespace,
                                         ..
@@ -566,13 +568,16 @@ impl DiagnosticEngine {
                                     ) {
                                         None
                                     } else {
-                                        let name = semantic_name.as_deref().unwrap_or("");
+                                        let kind = identity
+                                            .as_ref()
+                                            .map(|id| id.kind.as_str())
+                                            .unwrap_or("");
                                         // Handle bare/shorthand enum identifiers by expanding to full namespace format.
                                         // These are String values like "dedicated" or "InstanceTenancy.dedicated".
                                         let resolved_value =
                                             carina_core::utils::expand_enum_shorthand(
                                                 value,
-                                                name,
+                                                kind,
                                                 namespace.as_deref(),
                                             );
 
@@ -585,9 +590,9 @@ impl DiagnosticEngine {
                                         validate(&resolved_value)
                                         .err()
                                         .or_else(|| {
-                                            (!name.is_empty())
-                                                .then(|| lookup(name, &resolved_value).err())
-                                                .flatten()
+                                            identity
+                                                .as_ref()
+                                                .and_then(|id| lookup(id, &resolved_value).err())
                                         })
                                         .map(|inner_err| {
                                         // For namespaced Custom types (enum-like), mirror
@@ -606,7 +611,7 @@ impl DiagnosticEngine {
                                             };
                                             format!(
                                                 "'{}' ({}) expects an enum identifier, got a string literal \"{}\". {}",
-                                                attr_name, name, typed, inner_msg
+                                                attr_name, kind, typed, inner_msg
                                             )
                                         } else {
                                             inner_msg

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1304,7 +1304,7 @@ fn resource_ref_type_check_helper_regression() {
         .attribute(AttributeSchema::new(
             "my_id",
             AttributeType::Custom {
-                semantic_name: Some("MyId".to_string()),
+                identity: Some(carina_core::schema::TypeIdentity::bare("MyId")),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
@@ -1332,7 +1332,7 @@ fn resource_ref_type_check_helper_regression() {
         .attribute(AttributeSchema::new(
             "custom_attr",
             AttributeType::Custom {
-                semantic_name: Some("MyId".to_string()),
+                identity: Some(carina_core::schema::TypeIdentity::bare("MyId")),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
@@ -1773,7 +1773,7 @@ fn distinct_semantic_customs_are_rejected() {
         .attribute(AttributeSchema::new(
             "account_id",
             AttributeType::Custom {
-                semantic_name: Some("AwsAccountId".to_string()),
+                identity: Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
@@ -1787,7 +1787,7 @@ fn distinct_semantic_customs_are_rejected() {
     let target_schema = ResourceSchema::new("sso.Assignment").attribute(AttributeSchema::new(
         "target_id",
         AttributeType::Custom {
-            semantic_name: Some("TargetId".to_string()),
+            identity: Some(carina_core::schema::TypeIdentity::bare("TargetId")),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
@@ -1830,7 +1830,7 @@ fn exports_cross_file_ref_no_false_positive() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
     let aws_account_id_type = AttributeType::Custom {
-        semantic_name: Some("AwsAccountId".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -139,7 +139,7 @@ pub(super) fn test_engine_with_custom_namespaced_attr() -> DiagnosticEngine {
     }
 
     let mode_custom = AttributeType::Custom {
-        semantic_name: Some("Mode".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("Mode")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,

--- a/carina-lsp/tests/e2e_typecheck.rs
+++ b/carina-lsp/tests/e2e_typecheck.rs
@@ -136,7 +136,7 @@ fn region_schemas() -> SchemaRegistry {
     }
 
     let region_custom = AttributeType::Custom {
-        semantic_name: Some("Region".to_string()),
+        identity: Some(carina_core::schema::TypeIdentity::bare("Region")),
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -555,6 +555,22 @@ pub fn wit_to_core_patch_op(op: &wit::PatchOp) -> CorePatchOp {
     }
 }
 
+/// Convert a host-side [`carina_core::schema::TypeIdentity`] to the
+/// WIT [`wit::TypeIdentity`] record.
+///
+/// The WIT record has no `option` provider field; an absent provider
+/// axis is encoded as an empty string (see the `type-identity` record
+/// doc in `provider.wit`).
+pub fn core_type_identity_to_wit(
+    identity: &carina_core::schema::TypeIdentity,
+) -> wit::TypeIdentity {
+    wit::TypeIdentity {
+        provider: identity.provider.clone().unwrap_or_default(),
+        segments: identity.segments.clone(),
+        kind: identity.kind.clone(),
+    }
+}
+
 /// Deserialize JSON to (name, display_name, version) tuple from ProviderInfo.
 pub fn json_to_provider_info(json: &str) -> (String, String, String) {
     if let Ok(info) = serde_json::from_str::<proto::ProviderInfo>(json) {
@@ -719,10 +735,10 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             base,
             namespace,
         } => CoreAttributeType::Custom {
-            semantic_name: if name.is_empty() {
+            identity: if name.is_empty() {
                 None
             } else {
-                Some(name.clone())
+                Some(carina_core::schema::TypeIdentity::from_dotted(name))
             },
             base: Box::new(proto_attr_type_to_core(base)),
             pattern: None,

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -25,7 +25,7 @@ use carina_core::provider::{
     ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
 };
 use carina_core::resource::{DataSource, ManagedResource, ResourceId, State, Value};
-use carina_core::schema::{CompletionValue, ResourceSchema};
+use carina_core::schema::{CompletionValue, ResourceSchema, TypeIdentity};
 use carina_core::value::SerializationError;
 
 use crate::wasm_bindings::CarinaProvider;
@@ -527,18 +527,18 @@ impl WasmBindings {
     async fn call_validate_custom_type(
         &self,
         store: &mut Store<HostState>,
-        type_name: &str,
+        identity: &wit_types::TypeIdentity,
         value: &str,
     ) -> wasmtime::Result<Result<(), wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
-                    .call_validate_custom_type(store, type_name, value)
+                    .call_validate_custom_type(store, identity, value)
                     .await
             }
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
-                    .call_validate_custom_type(store, type_name, value)
+                    .call_validate_custom_type(store, identity, value)
                     .await
             }
         }
@@ -1422,14 +1422,15 @@ impl ProviderFactory for WasmProviderFactory {
         })
     }
 
-    fn validate_custom_type(&self, type_name: &str, value: &str) -> Result<(), String> {
+    fn validate_custom_type(&self, identity: &TypeIdentity, value: &str) -> Result<(), String> {
+        let wit_identity = wasm_convert::core_type_identity_to_wit(identity);
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let mut guard = self.init_instance.lock().await;
                 let (ref mut store, ref bindings) = *guard;
                 store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
                 bindings
-                    .call_validate_custom_type(store, type_name, value)
+                    .call_validate_custom_type(store, &wit_identity, value)
                     .await
                     .map_err(|e| format!("Failed to call validate_custom_type(): {e}"))?
                     .map_err(|e| {

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -155,7 +155,11 @@ pub trait CarinaProvider {
     /// Validate a value against a provider-defined custom type.
     /// Returns `Ok(())` if the value is valid or the type is unknown.
     /// Returns `Err(message)` if the value is invalid for the given type.
-    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+    ///
+    /// `identity` is the structured [`TypeIdentity`] of the type, so a
+    /// provider matches on the discrete axes instead of splitting a
+    /// flat name string.
+    fn validate_custom_type(&self, _identity: &TypeIdentity, _value: &str) -> Result<(), String> {
         Ok(())
     }
 

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -115,6 +115,16 @@ macro_rules! export_provider {
                 }
             }
 
+            fn wit_to_proto_type_identity(
+                ty: &wit_types::TypeIdentity,
+            ) -> proto::TypeIdentity {
+                proto::TypeIdentity {
+                    provider: ty.provider.clone(),
+                    segments: ty.segments.clone(),
+                    kind: ty.kind.clone(),
+                }
+            }
+
             fn proto_to_wit_resource_id(id: &proto::ResourceId) -> wit_types::ResourceId {
                 wit_types::ResourceId {
                     provider: id.provider.clone(),
@@ -453,13 +463,13 @@ macro_rules! export_provider {
                 }
 
                 fn validate_custom_type(
-                    type_name: String,
+                    ty: wit_types::TypeIdentity,
                     value: String,
                 ) -> Result<(), wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     $crate::CarinaProvider::validate_custom_type(
                         &*provider,
-                        &type_name,
+                        &wit_to_proto_type_identity(&ty),
                         &value,
                     )
                     .map_err(validate_string_to_provider_error)
@@ -583,6 +593,16 @@ macro_rules! export_provider {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
                     name: id.name.clone(),
+                }
+            }
+
+            fn wit_to_proto_type_identity(
+                ty: &wit_types::TypeIdentity,
+            ) -> proto::TypeIdentity {
+                proto::TypeIdentity {
+                    provider: ty.provider.clone(),
+                    segments: ty.segments.clone(),
+                    kind: ty.kind.clone(),
                 }
             }
 
@@ -926,13 +946,13 @@ macro_rules! export_provider {
                 }
 
                 fn validate_custom_type(
-                    type_name: String,
+                    ty: wit_types::TypeIdentity,
                     value: String,
                 ) -> Result<(), wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     $crate::CarinaProvider::validate_custom_type(
                         &*provider,
-                        &type_name,
+                        &wit_to_proto_type_identity(&ty),
                         &value,
                     )
                     .map_err(validate_string_to_provider_error)

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -17,6 +17,19 @@ pub struct ResourceId {
     pub name: String,
 }
 
+/// Structured identity of a provider-defined custom type.
+///
+/// Mirrors `carina_core::schema::TypeIdentity` and the WIT
+/// `type-identity` record. Keyed on discrete `provider + segments +
+/// kind` axes so two providers' same-named custom types stay distinct.
+/// An empty `provider` string denotes a provider-agnostic type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TypeIdentity {
+    pub provider: String,
+    pub segments: Vec<String>,
+    pub kind: String,
+}
+
 /// Mirrors `carina_core::resource::Value`.
 ///
 /// Only includes variants that can cross the process boundary.


### PR DESCRIPTION
## Summary

Sub-issue **S2** of #2807 — the structured provider-scoped type-identity
redesign. Design doc:
`notes/specs/2026-05-16-semantic-name-redesign-design.md`.
Depends on the WIT contract change in S1 (carina-plugin-wit#16, merged).

Replaces the flat `semantic_name: Option<String>` on
`AttributeType::Custom` with a structured `TypeIdentity` keyed on
discrete `provider + segments + kind` axes.

## Why

A flat `semantic_name` string conflated the type-identity key with the
display name and had no provider axis. Two providers exposing a
same-named custom type — `aws.Region` vs a future `gcp.Region`, with
different value formats — collided: the type system treated them as the
same type because the strings were equal. Latent only because every
provider today is AWS; it becomes a real type-safety hole the moment a
second provider lands.

`TypeIdentity::same_type` compares **per-axis**: an empty axis is the
*wider* type, not a wildcard. So the generic `aws.Arn` stays assignable
against `aws.iam.Role.Arn`, while `aws.Region` / `gcp.Region` and
`aws.iam.Role.Arn` / `aws.acm.Certificate.Arn` are distinct.

## Changes

The string round-trip is removed across every boundary that carried it:

- `is_assignable_to` rule 3 compares `TypeIdentity::same_type` instead
  of raw `semantic_name` string inequality.
- `ProviderContext.validators` and `collect_custom_type_validators` are
  keyed by `TypeIdentity` — two providers' same-named validators no
  longer collide first-wins (the original #2807 bug).
- `CustomTypeLookup`, the `Provider` / `ProviderFactory` / SDK
  `CarinaProvider` `validate_custom_type` methods, and the
  `custom_type_validator` closure all take `&TypeIdentity`.
- `validation/inference.rs` projects `Custom { identity }` to
  `TypeExpr::SchemaType` (provider-scoped) or `TypeExpr::Simple` (bare),
  unifying the schema-side identity with the parser's input-side
  `SchemaType`.
- WIT submodule bumped to the S1 commit; the host converts
  `TypeIdentity` to the `type-identity` record; the SDK guest binding
  converts the WIT record to `proto::TypeIdentity`.
- `carina-provider-protocol` gains a `TypeIdentity` type mirroring the
  core and WIT shapes.

The protocol's `AttributeType::Custom.name` stays a string on the wire;
the host parses it via `TypeIdentity::from_dotted` (dotted name →
provider-scoped, bare name → provider-agnostic), so a provider that has
not yet migrated still works, and S3/S4 enable full provider scoping by
emitting dotted names.

## Verification

- `cargo nextest run --workspace`: 3509 passed (incl. new
  `TypeIdentity` and cross-provider collision tests).
- `cargo test --workspace --doc`, `cargo clippy --workspace
  --all-targets -D warnings`, all `scripts/check-*.sh`: green.
- `cargo build --release --workspace`: green.
- `cargo build -p carina-provider-mock --target wasm32-wasip2`: green
  (the CI step that produces the host's WASM test fixture).

## Scope notes

`Custom.namespace` (enum-shorthand resolution) is intentionally left as
a separate field; folding it into `TypeIdentity` is follow-up work once
the provider copies are migrated. Next in the chain: S3
(carina-provider-aws#314), S4 (carina-provider-awscc#252).

🤖 Generated with [Claude Code](https://claude.com/claude-code)