### PR TITLE
carina-state: test S3 backend against an in-process AWS mock (winterbaume)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,8 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "carina-core",
  "chrono",
  "hostname",
@@ -990,6 +992,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "winterbaume-core",
+ "winterbaume-s3",
 ]
 
 [[package]]
@@ -3234,6 +3238,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -5526,6 +5540,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winterbaume-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9135da905ed2cbe0f7464134bf88feb0e1b1f3ce3315536805b4505db6abd4"
+dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "http 1.4.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "winterbaume-s3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48730964f4f607ae4739f90d75ab295dac32d06f2ed95892e5ad902748c0be59"
+dependencies = [
+ "bytes",
+ "chrono",
+ "http 1.4.0",
+ "md-5",
+ "quick-xml",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "winterbaume-core",
 ]
 
 [[package]]

--- a/carina-state/Cargo.toml
+++ b/carina-state/Cargo.toml
@@ -26,3 +26,13 @@ hostname = "0.4"
 [dev-dependencies]
 indexmap = "2"
 tempfile = "3"
+# In-process AWS service emulator: the S3 backend's integration tests
+# inject a winterbaume-backed S3 client and exercise the StateBackend
+# I/O path with no real AWS and no external process (#3203).
+winterbaume-core = "0.2"
+winterbaume-s3 = "0.2"
+# Lets the s3.rs unit tests build a real HTTP response (with a status
+# code) so the HTTP-status-based not-found classifier can be exercised
+# directly.
+aws-smithy-runtime-api = { version = "1", features = ["http-1x"] }
+aws-smithy-types = "1"

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -65,14 +65,42 @@ impl S3Backend {
         let region = resolve_region(config.get_string("region"), sdk_region.as_deref())?;
         let client = build_s3_client(&region).await;
 
-        Ok(Self {
+        Ok(Self::from_client(
             client,
             bucket,
             key,
             region,
             encrypt,
             auto_create,
-        })
+        ))
+    }
+
+    /// Construct an `S3Backend` over a caller-supplied `aws_sdk_s3::Client`.
+    ///
+    /// `from_config` is the production entry point — it resolves the
+    /// region and builds the SDK client itself. This constructor exists
+    /// so a test can inject a client wired to an in-process AWS mock
+    /// (`winterbaume`, library mode) and exercise the `StateBackend` I/O
+    /// path with no real AWS and no external process (#3203). It does
+    /// not touch the AWS SDK config chain; the `region` argument is used
+    /// verbatim (it still drives the `create_bucket` location
+    /// constraint).
+    pub fn from_client(
+        client: Client,
+        bucket: String,
+        key: String,
+        region: String,
+        encrypt: bool,
+        auto_create: bool,
+    ) -> Self {
+        Self {
+            client,
+            bucket,
+            key,
+            region,
+            encrypt,
+            auto_create,
+        }
     }
 
     /// Get the lock file key (state key + ".lock")
@@ -544,14 +572,23 @@ where
         .is_some_and(|service_err| is_conditional_write_conflict_code(service_err.code()))
 }
 
-fn is_head_bucket_not_found(err: &HeadBucketError) -> bool {
-    err.is_not_found()
-}
-
-fn is_missing_head_bucket_response<R>(
-    err: &aws_sdk_s3::error::SdkError<HeadBucketError, R>,
-) -> bool {
-    err.as_service_error().is_some_and(is_head_bucket_not_found)
+/// Returns `true` if a `HeadBucket` error means the bucket is absent.
+///
+/// `HeadBucket` is an HTTP `HEAD` request, so an absent bucket is a 404
+/// with no response body — the SDK cannot always resolve that into the
+/// typed `HeadBucketError::NotFound` variant and may leave it
+/// `Unhandled`. The HTTP status is therefore the reliable signal: a 404
+/// is a missing bucket regardless of how the SDK classified it. This is
+/// the same approach as `is_not_found_error` (used for `GetObject`),
+/// which also keys off `raw_response().status()`.
+///
+/// When no raw response is attached at all — a connection/dispatch
+/// failure rather than a service response — there is no evidence the
+/// bucket was reported absent, so this returns `false` and `bucket_exists`
+/// surfaces the underlying error.
+fn is_missing_head_bucket_response(err: &aws_sdk_s3::error::SdkError<HeadBucketError>) -> bool {
+    err.raw_response()
+        .is_some_and(|raw| raw.status().as_u16() == 404)
 }
 
 #[cfg(test)]
@@ -664,30 +701,56 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_is_head_bucket_not_found_for_not_found_error() {
-        let err = HeadBucketError::NotFound(aws_sdk_s3::types::error::NotFound::builder().build());
-        assert!(is_head_bucket_not_found(&err));
+    /// Build a `HeadBucket` raw HTTP response with the given status, so
+    /// the HTTP-status-based classifier can be exercised without a live
+    /// SDK call.
+    fn head_bucket_http_response(status: u16) -> aws_smithy_runtime_api::http::Response {
+        aws_smithy_runtime_api::http::Response::new(
+            status.try_into().unwrap(),
+            aws_smithy_types::body::SdkBody::empty(),
+        )
     }
 
     #[test]
-    fn test_is_head_bucket_not_found_rejects_other_service_errors() {
-        let err = HeadBucketError::generic(ErrorMetadata::builder().code("AccessDenied").build());
-        assert!(!is_head_bucket_not_found(&err));
-    }
-
-    #[test]
-    fn test_is_missing_head_bucket_response_for_not_found_service_error() {
+    fn test_is_missing_head_bucket_response_for_typed_not_found_with_404() {
+        // The SDK resolved the 404 into the typed NotFound variant.
         let err = SdkError::service_error(
             HeadBucketError::NotFound(aws_sdk_s3::types::error::NotFound::builder().build()),
-            (),
+            head_bucket_http_response(404),
         );
         assert!(is_missing_head_bucket_response(&err));
     }
 
     #[test]
-    fn test_is_missing_head_bucket_response_rejects_non_service_404s() {
-        let err = SdkError::response_error("not found response", ());
+    fn test_is_missing_head_bucket_response_for_unhandled_404() {
+        // The SDK left the 404 as an Unhandled error — e.g. when the
+        // response carries an error body the typed parser does not
+        // expect (this is exactly what an in-process S3 mock can emit).
+        // The HTTP status must still classify it as a missing bucket.
+        let err = SdkError::service_error(
+            HeadBucketError::generic(ErrorMetadata::builder().code("NoSuchBucket").build()),
+            head_bucket_http_response(404),
+        );
+        assert!(is_missing_head_bucket_response(&err));
+    }
+
+    #[test]
+    fn test_is_missing_head_bucket_response_rejects_non_404_status() {
+        // A 403 (e.g. AccessDenied) is not a missing bucket.
+        let err = SdkError::service_error(
+            HeadBucketError::generic(ErrorMetadata::builder().code("AccessDenied").build()),
+            head_bucket_http_response(403),
+        );
+        assert!(!is_missing_head_bucket_response(&err));
+    }
+
+    #[test]
+    fn test_is_missing_head_bucket_response_rejects_error_without_raw_response() {
+        // A construction/dispatch failure carries no HTTP response, so
+        // there is no evidence the bucket is absent — this must not be
+        // classified as a missing bucket.
+        let err: SdkError<HeadBucketError> =
+            SdkError::construction_failure("no raw response attached");
         assert!(!is_missing_head_bucket_response(&err));
     }
 

--- a/carina-state/tests/s3_backend_winterbaume.rs
+++ b/carina-state/tests/s3_backend_winterbaume.rs
@@ -1,0 +1,267 @@
+//! Integration tests for the S3 state backend against an in-process
+//! AWS mock (`winterbaume`, library mode).
+//!
+//! `winterbaume` is injected directly as the `aws-sdk-rust` HTTP client
+//! via `MockAws::sdk_config`, so these tests exercise the real
+//! `StateBackend` I/O path (`aws-sdk-s3` request construction, response
+//! parsing, error classification) with no network I/O and no external
+//! process.
+//!
+//! Scope note (#3203): `winterbaume-s3` 0.2 parses the S3 conditional
+//! write headers (`If-None-Match` / `If-Match`) but does not enforce
+//! them — there is no `PreconditionFailed` path — so the lock-contention
+//! and conditional-write-conflict paths cannot be covered here. See the
+//! issue and #3205 for the follow-up. These tests cover what the mock
+//! honors faithfully: state write/read, bucket auto-create, and
+//! single-holder lock acquire/release.
+
+use aws_sdk_s3::Client;
+use carina_state::backends::S3Backend;
+use carina_state::{StateBackend, StateFile};
+use winterbaume_core::MockAws;
+use winterbaume_s3::S3Service;
+
+const TEST_REGION: &str = "us-east-1";
+const TEST_BUCKET: &str = "carina-state-test-bucket";
+const TEST_KEY: &str = "carina.state.json";
+
+/// Build an `aws_sdk_s3::Client` wired to a fresh in-process winterbaume
+/// S3 service. Each call gets an isolated mock with empty state.
+async fn mock_s3_client() -> Client {
+    let mock = MockAws::builder().with_service(S3Service::new()).build();
+    let sdk_config = mock.sdk_config(TEST_REGION).await;
+    Client::new(&sdk_config)
+}
+
+/// Build an `S3Backend` over a winterbaume-backed client. `encrypt` is
+/// disabled because the mock does not need server-side encryption and
+/// leaving it on only adds a header the mock ignores.
+async fn mock_backend() -> S3Backend {
+    S3Backend::from_client(
+        mock_s3_client().await,
+        TEST_BUCKET.to_string(),
+        TEST_KEY.to_string(),
+        TEST_REGION.to_string(),
+        false, // encrypt
+        true,  // auto_create
+    )
+}
+
+#[tokio::test]
+async fn init_auto_creates_bucket_and_seeds_empty_state() {
+    let backend = mock_backend().await;
+
+    // The bucket does not exist yet.
+    assert!(
+        !backend.bucket_exists().await.unwrap(),
+        "bucket should not exist before init",
+    );
+
+    // init() auto-creates the bucket and seeds an empty state file.
+    backend.init().await.unwrap();
+
+    assert!(
+        backend.bucket_exists().await.unwrap(),
+        "bucket should exist after init",
+    );
+
+    let state = backend
+        .read_state()
+        .await
+        .unwrap()
+        .expect("init should seed a state file");
+    assert_eq!(
+        state.version,
+        StateFile::CURRENT_VERSION,
+        "seeded state should be the current format version",
+    );
+    assert_eq!(state.serial, 0, "seeded state should start at serial 0");
+    assert!(
+        state.resources.is_empty(),
+        "seeded state should have no resources",
+    );
+}
+
+#[tokio::test]
+async fn write_then_read_state_round_trips() {
+    let backend = mock_backend().await;
+    backend.init().await.unwrap();
+
+    // Use a state that carries a resource entry, not just scalar header
+    // fields — a serde regression that dropped `resources` would survive
+    // a header-only round-trip but is caught here.
+    let mut written = StateFile::with_managed_state_bucket(
+        "aws",
+        "s3.Bucket",
+        "aws_s3_bucket_a3f2b1c8",
+        "my-state-bucket",
+    );
+    written.increment_serial();
+    written.increment_serial();
+    assert_eq!(
+        written.resources.len(),
+        1,
+        "precondition: the written state carries one resource",
+    );
+
+    backend.write_state(&written).await.unwrap();
+
+    let read_back = backend
+        .read_state()
+        .await
+        .unwrap()
+        .expect("state written above should be readable");
+    // `StateFile` has no `PartialEq`; compare the fields that prove the
+    // bytes round-tripped through S3 unchanged. `lineage` is preserved
+    // (not regenerated) so it pins identity across the write/read.
+    assert_eq!(read_back.serial, written.serial, "serial must round-trip");
+    assert_eq!(
+        read_back.lineage, written.lineage,
+        "lineage must round-trip unchanged",
+    );
+    assert_eq!(
+        read_back.version, written.version,
+        "version must round-trip",
+    );
+    assert_eq!(
+        read_back.resources.len(),
+        1,
+        "the resource entry must survive the write/read round-trip",
+    );
+    // Assert every non-trivial field of the resource: a serde regression
+    // that dropped any one of `attributes` (a JSON map), `identifier`
+    // (an `Option`), or `protected` (a `bool`) would survive a
+    // name/type-only check but is caught here.
+    let written_res = &written.resources[0];
+    let read_res = &read_back.resources[0];
+    assert_eq!(
+        read_res.name, written_res.name,
+        "the round-tripped resource must keep its name",
+    );
+    assert_eq!(
+        read_res.resource_type, written_res.resource_type,
+        "the round-tripped resource must keep its type",
+    );
+    assert_eq!(
+        read_res.identifier, written_res.identifier,
+        "the round-tripped resource must keep its identifier",
+    );
+    assert_eq!(
+        read_res.attributes, written_res.attributes,
+        "the round-tripped resource must keep its attributes map",
+    );
+    assert_eq!(
+        read_res.protected, written_res.protected,
+        "the round-tripped resource must keep its protected flag",
+    );
+}
+
+#[tokio::test]
+async fn read_state_returns_none_when_object_absent() {
+    let backend = mock_backend().await;
+    // Create the bucket but never write a state object.
+    backend.create_bucket().await.unwrap();
+
+    let state = backend.read_state().await.unwrap();
+    assert!(
+        state.is_none(),
+        "read_state on an absent object must return None, not error",
+    );
+}
+
+#[tokio::test]
+async fn acquire_then_release_lock_round_trips() {
+    // Covers the single-holder lock mechanics: write the lock object,
+    // read it back to verify ownership on release, then delete it. It
+    // does *not* cover contention — `winterbaume-s3` 0.2 does not enforce
+    // the `If-None-Match` conditional header, so a second `acquire_lock`
+    // would succeed instead of conflicting. The contention path is
+    // tracked separately (#3203 Notes / follow-up #3205).
+    let backend = mock_backend().await;
+    backend.init().await.unwrap();
+
+    // No lock held: acquire writes the lock object and succeeds.
+    let lock = backend.acquire_lock("apply").await.unwrap();
+
+    // Release verifies ownership via a read, then deletes the object.
+    backend.release_lock(&lock).await.unwrap();
+
+    // A second release must fail: the lock object was deleted, so the
+    // ownership read finds nothing. This is the assertion that proves
+    // `release_lock` actually removed the object (it does not depend on
+    // the conditional-write header winterbaume ignores).
+    let err = backend
+        .release_lock(&lock)
+        .await
+        .expect_err("releasing an already-released lock must fail");
+    assert!(
+        matches!(err, carina_state::BackendError::LockNotFound(_)),
+        "expected LockNotFound after the lock object was deleted, got: {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn write_state_locked_succeeds_for_held_lock() {
+    let backend = mock_backend().await;
+    backend.init().await.unwrap();
+
+    let lock = backend.acquire_lock("apply").await.unwrap();
+
+    let mut state = StateFile::new();
+    state.increment_serial();
+    backend.write_state_locked(&state, &lock).await.unwrap();
+
+    let read_back = backend.read_state().await.unwrap().unwrap();
+    assert_eq!(
+        read_back.lineage, state.lineage,
+        "locked write must persist the state we passed in",
+    );
+    assert_eq!(read_back.serial, state.serial);
+
+    backend.release_lock(&lock).await.unwrap();
+}
+
+#[tokio::test]
+async fn write_state_locked_rejects_write_when_lock_not_held() {
+    // The negative half of the lock gate: once the lock object is gone,
+    // `write_state_locked` must refuse to write. Without this case
+    // `write_state_locked_succeeds_for_held_lock` would still pass even
+    // if the ownership check were bypassed entirely.
+    let backend = mock_backend().await;
+    backend.init().await.unwrap();
+
+    let lock = backend.acquire_lock("apply").await.unwrap();
+    backend.release_lock(&lock).await.unwrap();
+
+    let mut state = StateFile::new();
+    state.increment_serial();
+    let err = backend
+        .write_state_locked(&state, &lock)
+        .await
+        .expect_err("write_state_locked must fail when the lock is no longer held");
+    assert!(
+        matches!(err, carina_state::BackendError::LockNotHeld(_)),
+        "expected LockNotHeld when the lock object is absent, got: {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn init_without_auto_create_errors_on_missing_bucket() {
+    let backend = S3Backend::from_client(
+        mock_s3_client().await,
+        TEST_BUCKET.to_string(),
+        TEST_KEY.to_string(),
+        TEST_REGION.to_string(),
+        false, // encrypt
+        false, // auto_create disabled
+    );
+
+    let err = backend
+        .init()
+        .await
+        .expect_err("init must fail when the bucket is absent and auto_create is off");
+    assert!(
+        matches!(&err, carina_state::BackendError::BucketNotFound(b) if b == TEST_BUCKET),
+        "expected BucketNotFound({TEST_BUCKET}), got: {err:?}",
+    );
+}


### PR DESCRIPTION
Closes #3203

## Summary

The S3 state backend (`carina-state/src/backends/s3.rs`) talks to AWS via `aws-sdk-s3` directly. Only its pure helper functions were unit tested; the actual `StateBackend` I/O path — state put/get, locking, bucket auto-create — required real AWS and was untested.

This PR makes that path testable in-process, with no real AWS and no external process, using [`winterbaume`](https://github.com/moriyoshi/winterbaume) (an in-process AWS service emulator) in library mode.

## Changes

- **`S3Backend::from_client`** — a new `pub` constructor that accepts a caller-supplied `aws_sdk_s3::Client`. `from_config` (the production entry point) now delegates to it; its behavior is unchanged (same fields, same order, same region/client resolution).
- **`winterbaume-core` / `winterbaume-s3`** added as dev-dependencies. `MockAws` is injected directly as the `aws-sdk-rust` HTTP client — no network I/O, no `AWS_ENDPOINT_URL`, no external process.
- **Integration tests** (`carina-state/tests/s3_backend_winterbaume.rs`, 7 tests, ~0.06s): state write/read round-trip (carrying a real resource entry, so a serde regression dropping `resources` is caught), bucket auto-create, single-holder lock acquire/release, and the held / not-held gate on `write_state_locked`.

## Bug found and fixed

Testing against the mock surfaced a real bug. `is_missing_head_bucket_response` only recognised a 404 that the SDK had resolved into the typed `HeadBucketError::NotFound` variant. `HeadBucket` is an HTTP `HEAD` request, so an absent bucket is a body-less 404 — the SDK can leave it `Unhandled`. Fixed to key off the HTTP status code, matching the sibling `is_not_found_error` used for `GetObject`. This makes the classifier robust against real AWS and the mock alike.

## Scope

Lock-contention and conditional-write-conflict coverage is deferred: `winterbaume-s3` 0.2 parses but does not enforce the S3 conditional headers (`If-None-Match` / `If-Match`), so those paths cannot be exercised against it. The test file documents this, and the follow-up is tracked in #3205.

## Verification

- `cargo nextest run -p carina-state` — 122 passed
- `cargo test -p carina-state --doc` — passed
- `cargo clippy -p carina-state --all-targets -- -D warnings` — clean
- `scripts/check-*.sh` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)