### PR TITLE
core: enum shorthand keyed on structured TypeIdentity (S2.5a)

### DIFF
--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -143,7 +143,15 @@ fn string_literal_expected_enum_custom_namespaced_display() {
         AttributeSchema::new(
             "mode",
             AttributeType::Custom {
-                identity: Some(carina_core::schema::TypeIdentity::bare("Mode")),
+                // Structured identity matching the legacy `namespace: "test.r"`
+                // shorthand prefix: provider=test, segments=[r], kind=Mode.
+                // The dotted display is `test.r.Mode`, which is the prefix
+                // `expand_enum_shorthand` now derives from `identity`.
+                identity: Some(carina_core::schema::TypeIdentity::new(
+                    Some("test"),
+                    ["r"],
+                    "Mode",
+                )),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -638,13 +638,9 @@ impl AttributeType {
     /// Phase 2 of RFC #2972: the pre-Phase-2 `ResourceRef` short-circuit
     /// is gone — deferred values are filtered by the dispatcher in
     /// [`Self::validate`] and cannot reach this path.
-    fn resolve_enum_input(
-        name: &str,
-        namespace: Option<&str>,
-        value: ConcreteValueRef<'_>,
-    ) -> Value {
+    fn resolve_enum_input(identity: &TypeIdentity, value: ConcreteValueRef<'_>) -> Value {
         let owned = value.to_owned_value();
-        crate::utils::expand_enum_shorthand(&owned, name, namespace)
+        crate::utils::expand_enum_shorthand(&owned, identity)
     }
 
     pub fn string_enum_parts(&self) -> Option<StringEnumParts<'_>> {
@@ -989,7 +985,11 @@ impl AttributeType {
             });
         }
 
-        let resolved_value = Self::resolve_enum_input(name, namespace.as_deref(), value);
+        // Build a structured identity from the legacy `name + namespace`
+        // pair so the shorthand-expansion helper can reuse the same
+        // `TypeIdentity`-keyed projection as `Custom`.
+        let identity = string_enum_identity(name, namespace.as_deref());
+        let resolved_value = Self::resolve_enum_input(&identity, value);
         // Capture the user's original input for diagnostics. The parser
         // emits `ConcreteValue::EnumIdentifier` for bare identifier short
         // forms (`dedicated`) and dotted forms (`aws.s3.Bucket.VersioningStatus.Enabled`).
@@ -1111,9 +1111,10 @@ impl AttributeType {
             unreachable!("validate_custom called on non-Custom");
         };
 
-        let name_for_resolve = identity.as_ref().map(|id| id.kind.as_str()).unwrap_or("");
-        let resolved_value =
-            Self::resolve_enum_input(name_for_resolve, namespace.as_deref(), value);
+        let _ = namespace; // superseded by `identity`; kept as a field for now (FIXME: remove `Custom.namespace`)
+        let bare = TypeIdentity::bare("");
+        let id_for_resolve = identity.as_ref().unwrap_or(&bare);
+        let resolved_value = Self::resolve_enum_input(id_for_resolve, value);
         validate(&resolved_value)
     }
 
@@ -1449,6 +1450,30 @@ impl AttributeType {
             (_non_custom, Custom { .. }) => false,
             (a, b) => a.type_name() == b.type_name(),
         }
+    }
+}
+
+/// Build a structured [`TypeIdentity`] from a `StringEnum`'s
+/// `name + namespace` pair.
+///
+/// The legacy `namespace` field is a dot-joined string of
+/// `provider.<segments...>`; this helper splits it back so the
+/// shorthand-expansion helper can derive the dotted prefix from the
+/// structure rather than parsing a flat string. Once `StringEnum`
+/// itself carries a `TypeIdentity`, this function disappears.
+fn string_enum_identity(name: &str, namespace: Option<&str>) -> TypeIdentity {
+    match namespace {
+        Some(ns) if !ns.is_empty() => {
+            let mut parts = ns.split('.');
+            let provider = parts.next().map(String::from);
+            let segments: Vec<String> = parts.map(String::from).collect();
+            TypeIdentity {
+                provider,
+                segments,
+                kind: name.to_string(),
+            }
+        }
+        _ => TypeIdentity::bare(name),
     }
 }
 

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -247,15 +247,12 @@ pub fn expand_enum_shorthand(value: &Value, identity: &crate::schema::TypeIdenti
         Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.as_str()),
         _ => None,
     };
-    // The legacy `name` argument used to be the enum type name —
-    // typically the last service/resource segment (or the kind if
-    // segments are empty). We still need it to recognise the
-    // `TypeName.value` 2-part shorthand below.
-    let enum_type_name: &str = identity
-        .segments
-        .last()
-        .map(String::as_str)
-        .unwrap_or(&identity.kind);
+    // The kind is the type's own name and matches the leading
+    // `TypeName` of the 2-part `TypeName.value` shorthand:
+    // `InstanceTenancy.dedicated` against a Custom whose kind is
+    // `InstanceTenancy`, or `ZoneName.us_east_1a` against the
+    // zone-name AvailabilityZone type.
+    let enum_type_name: &str = &identity.kind;
     match text_form {
         Some(s) if !s.contains('.') => {
             if identity.provider.is_some() {

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -205,18 +205,28 @@ fn is_intermediate_segment(s: &str) -> bool {
 
 /// Expand a user-written enum value into its fully-qualified DSL form.
 ///
+/// `identity` is the structured [`crate::schema::TypeIdentity`] of the
+/// receiving attribute; the expanded form is the identity's dotted
+/// display followed by the value — `aws.iam.Role.Arn.<v>` for a
+/// fully-segmented identity, `aws.Region.<v>` for a bare-segment one,
+/// `aws.AvailabilityZone.ZoneName.<v>` for the segments + kind case
+/// users now write. The 2-part `TypeName.member` shorthand is
+/// recognised when `TypeName` matches the identity's enum type name
+/// (its last segment, or the kind if segments are empty).
+///
 /// Accepts the three input shapes the DSL allows for `StringEnum` and
 /// enum-like `Custom` attributes:
 ///
-/// - bare member (`dedicated`) → `<namespace>.<name>.dedicated`
+/// - bare member (`dedicated`) → `{identity}.dedicated`
 /// - `TypeName.member` shorthand (`InstanceTenancy.dedicated`) →
-///   `<namespace>.<name>.dedicated`, only when `TypeName == name`
-/// - any other input (already-qualified, foreign type name, missing
-///   namespace, non-string) → returned unchanged
+///   `{identity}.dedicated`, only when the type name matches the
+///   identity's enum type name
+/// - any other input (already-qualified, foreign type name, identity
+///   with no provider axis, non-string) → returned unchanged
 ///
 /// Used by both `AttributeType::resolve_value` and the LSP diagnostic
 /// pipeline so the two paths cannot drift.
-pub fn expand_enum_shorthand(value: &Value, name: &str, namespace: Option<&str>) -> Value {
+pub fn expand_enum_shorthand(value: &Value, identity: &crate::schema::TypeIdentity) -> Value {
     // Phase 4 of carina#2986: `EnumIdentifier` carries the same textual
     // payload as `String` (only the source-shape tag differs) and goes
     // through the same namespace expansion. The result is materialized as
@@ -226,28 +236,43 @@ pub fn expand_enum_shorthand(value: &Value, name: &str, namespace: Option<&str>)
     // `Value::Concrete(ConcreteValue::String)` arm. The `EnumIdentifier`
     // distinction is a parser-level signal used for strict shape
     // enforcement at the validator entry, not a wire-level form.
+    //
+    // The expanded form is the dotted display of the structured
+    // identity followed by the value: `{provider}.{segments...}.{kind}.{value}`
+    // — same shape as the type's `TypeIdentity::Display`. For a bare
+    // identity with no provider axis the shorthand passes through
+    // unchanged (no namespace to prefix).
     let text_form: Option<&str> = match value {
         Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
         Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.as_str()),
         _ => None,
     };
+    // The legacy `name` argument used to be the enum type name —
+    // typically the last service/resource segment (or the kind if
+    // segments are empty). We still need it to recognise the
+    // `TypeName.value` 2-part shorthand below.
+    let enum_type_name: &str = identity
+        .segments
+        .last()
+        .map(String::as_str)
+        .unwrap_or(&identity.kind);
     match text_form {
-        Some(s) if !s.contains('.') => match namespace {
-            Some(ns) => Value::Concrete(ConcreteValue::String(format!("{}.{}.{}", ns, name, s))),
-            None => Value::Concrete(ConcreteValue::String(s.to_string())),
-        },
+        Some(s) if !s.contains('.') => {
+            if identity.provider.is_some() {
+                Value::Concrete(ConcreteValue::String(format!("{}.{}", identity, s)))
+            } else {
+                Value::Concrete(ConcreteValue::String(s.to_string()))
+            }
+        }
         Some(s) => {
             if let Some(NamespacedId::TypeQualified {
                 type_name: ident,
                 value: member,
             }) = NamespacedId::parse(s)
-                && let Some(ns) = namespace
-                && ident == name
+                && identity.provider.is_some()
+                && ident == enum_type_name
             {
-                Value::Concrete(ConcreteValue::String(format!(
-                    "{}.{}.{}",
-                    ns, ident, member
-                )))
+                Value::Concrete(ConcreteValue::String(format!("{}.{}", identity, member)))
             } else {
                 Value::Concrete(ConcreteValue::String(s.to_string()))
             }
@@ -1688,31 +1713,30 @@ mod tests {
     // function must keep on both sides.
     #[test]
     fn expand_enum_shorthand_table() {
-        // (input, name, namespace, expected_output_string_or_passthrough)
-        // `None` for namespace means "no namespace" — bare and 2-part inputs
-        // pass through unchanged.
-        let cases: &[(Value, &str, Option<&str>, Value)] = &[
-            // bare member + namespace → fully qualified
+        use crate::schema::TypeIdentity;
+        // (input, identity, expected_output)
+        // A bare identity (no provider axis) passes shorthand through;
+        // a provider-scoped identity expands bare/2-part inputs into the
+        // full `{identity}.{value}` form.
+        let cases: &[(Value, TypeIdentity, Value)] = &[
+            // bare member + provider-scoped identity → fully qualified
             (
                 Value::Concrete(ConcreteValue::String("dedicated".into())),
-                "InstanceTenancy",
-                Some("awscc.ec2.Vpc"),
+                TypeIdentity::new(Some("awscc"), ["ec2", "Vpc"], "InstanceTenancy"),
                 Value::Concrete(ConcreteValue::String(
                     "awscc.ec2.Vpc.InstanceTenancy.dedicated".into(),
                 )),
             ),
-            // bare member, no namespace → passthrough
+            // bare member, bare identity → passthrough
             (
                 Value::Concrete(ConcreteValue::String("dedicated".into())),
-                "InstanceTenancy",
-                None,
+                TypeIdentity::bare("InstanceTenancy"),
                 Value::Concrete(ConcreteValue::String("dedicated".into())),
             ),
-            // TypeName.member matching `name` → fully qualified
+            // TypeName.member matching the enum type name → fully qualified
             (
                 Value::Concrete(ConcreteValue::String("InstanceTenancy.dedicated".into())),
-                "InstanceTenancy",
-                Some("awscc.ec2.Vpc"),
+                TypeIdentity::new(Some("awscc"), ["ec2", "Vpc"], "InstanceTenancy"),
                 Value::Concrete(ConcreteValue::String(
                     "awscc.ec2.Vpc.InstanceTenancy.dedicated".into(),
                 )),
@@ -1720,8 +1744,7 @@ mod tests {
             // TypeName.member with foreign type name → passthrough
             (
                 Value::Concrete(ConcreteValue::String("Tenancy.dedicated".into())),
-                "InstanceTenancy",
-                Some("awscc.ec2.Vpc"),
+                TypeIdentity::new(Some("awscc"), ["ec2", "Vpc"], "InstanceTenancy"),
                 Value::Concrete(ConcreteValue::String("Tenancy.dedicated".into())),
             ),
             // Already-fully-qualified → passthrough (parser returns
@@ -1730,8 +1753,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::String(
                     "awscc.ec2.Vpc.InstanceTenancy.dedicated".into(),
                 )),
-                "InstanceTenancy",
-                Some("awscc.ec2.Vpc"),
+                TypeIdentity::new(Some("awscc"), ["ec2", "Vpc"], "InstanceTenancy"),
                 Value::Concrete(ConcreteValue::String(
                     "awscc.ec2.Vpc.InstanceTenancy.dedicated".into(),
                 )),
@@ -1739,21 +1761,29 @@ mod tests {
             // Lowercase first segment → not a TypeName; passthrough
             (
                 Value::Concrete(ConcreteValue::String("instanceTenancy.dedicated".into())),
-                "InstanceTenancy",
-                Some("awscc.ec2.Vpc"),
+                TypeIdentity::new(Some("awscc"), ["ec2", "Vpc"], "InstanceTenancy"),
                 Value::Concrete(ConcreteValue::String("instanceTenancy.dedicated".into())),
             ),
             // Non-string → passthrough
             (
                 Value::Concrete(ConcreteValue::Bool(true)),
-                "Whatever",
-                Some("aws"),
+                TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Whatever"),
                 Value::Concrete(ConcreteValue::Bool(true)),
             ),
+            // Provider-scoped identity with `segments` (typical S2.5 form
+            // — `aws.AvailabilityZone.ZoneName.us_east_1a`): bare value
+            // expands into the full dotted form including the kind.
+            (
+                Value::Concrete(ConcreteValue::String("us_east_1a".into())),
+                TypeIdentity::new(Some("aws"), ["AvailabilityZone"], "ZoneName"),
+                Value::Concrete(ConcreteValue::String(
+                    "aws.AvailabilityZone.ZoneName.us_east_1a".into(),
+                )),
+            ),
         ];
-        for (input, name, ns, expected) in cases {
-            let actual = expand_enum_shorthand(input, name, *ns);
-            assert_eq!(actual, *expected, "input={input:?} name={name:?} ns={ns:?}",);
+        for (input, identity, expected) in cases {
+            let actual = expand_enum_shorthand(input, identity);
+            assert_eq!(actual, *expected, "input={input:?} identity={identity:?}",);
         }
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -568,17 +568,16 @@ impl DiagnosticEngine {
                                     ) {
                                         None
                                     } else {
-                                        let kind = identity
-                                            .as_ref()
-                                            .map(|id| id.kind.as_str())
-                                            .unwrap_or("");
+                                        let _ = namespace; // superseded by structured `identity` (see carina-core::utils::expand_enum_shorthand)
+                                        let bare = carina_core::schema::TypeIdentity::bare("");
+                                        let id_for_resolve = identity.as_ref().unwrap_or(&bare);
+                                        let kind = id_for_resolve.kind.as_str();
                                         // Handle bare/shorthand enum identifiers by expanding to full namespace format.
                                         // These are String values like "dedicated" or "InstanceTenancy.dedicated".
                                         let resolved_value =
                                             carina_core::utils::expand_enum_shorthand(
                                                 value,
-                                                kind,
-                                                namespace.as_deref(),
+                                                id_for_resolve,
                                             );
 
                                         // Run the schema-attached validator first; for WASM-plugin


### PR DESCRIPTION
## Summary

Follow-up to S2 (#3204). S2 lifted the schema-side type identity onto a
structured `TypeIdentity`, but kept `expand_enum_shorthand` and the
related `resolve_enum_input` path parameterised on the legacy
`(name: &str, namespace: Option<&str>)` pair. The two diverge as soon
as a `Custom` type splits its `kind` from its enum type name —
`aws.AvailabilityZone` (zone-name form) carries `kind = "ZoneName"`,
but the enum type name remains `AvailabilityZone`. Passing the kind
through to the shorthand helper produced bogus prefixes like
`aws.ZoneName.us_east_1a` and validation failed.

This PR re-keys the shorthand expansion on `&TypeIdentity` so the
schema-side and user-facing name spaces coincide:

- `expand_enum_shorthand` takes `&TypeIdentity` and derives the dotted
  prefix from the identity's `Display`. For `aws.AvailabilityZone`
  (`provider="aws", segments=["AvailabilityZone"], kind="ZoneName"`),
  bare `us_east_1a` expands to `aws.AvailabilityZone.ZoneName.us_east_1a`
  — the same name space the type itself lives in.
- The enum type name (used to recognise the `TypeName.member` 2-part
  shorthand) is derived as `segments.last()` if segments are non-empty,
  otherwise the `kind`. This fixes the kind/enum-type-name conflation
  S2 missed.
- `Custom.validate` feeds the identity directly to
  `resolve_enum_input`. The `StringEnum` arm reconstructs a
  `TypeIdentity` via a small `string_enum_identity` helper so both
  arms share the identity-keyed projection.

A provider-agnostic identity (no provider axis) still passes the
shorthand through unchanged, matching the previous `namespace: None`
behaviour.

## Why now

This is the bug that surfaced when S3 (carina-rs/carina-provider-aws#314)
migrated `availability_zone()` to a structured identity with
`kind = "ZoneName"`: the existing validators that recognised
`aws.AvailabilityZone.us_east_1a` started rejecting it because the
shorthand expansion was using the kind in place of the enum type name.

## Scope

Bounded refactor of three call sites in carina-core / carina-lsp:

- `carina-core/src/utils.rs` — `expand_enum_shorthand` and its tests
- `carina-core/src/schema/mod.rs` — `resolve_enum_input`,
  `validate_custom`, the `string_enum_identity` helper, the
  `StringEnum`-validation arm
- `carina-lsp/src/diagnostics/mod.rs` — the LSP caller

`Custom.namespace` and `StringEnum.namespace` are intentionally left as
distinct fields for this PR; folding them into `TypeIdentity` is
follow-up work scoped to a separate PR.

## Verification

- `cargo nextest run --workspace`: 3512 passed (+3 over S2; new
  AvailabilityZone shorthand case added to the `expand_enum_shorthand`
  table test).
- `cargo test --workspace --doc`, `cargo clippy --workspace
  --all-targets -D warnings`, `bash scripts/check-*.sh`: green.
- `cargo build -p carina-provider-mock --target wasm32-wasip2`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)