### PR TITLE
fix(s2.5a): skip enum shorthand expansion when Custom.namespace is None

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1111,10 +1111,25 @@ impl AttributeType {
             unreachable!("validate_custom called on non-Custom");
         };
 
-        let _ = namespace; // superseded by `identity`; kept as a field for now (FIXME: remove `Custom.namespace`)
+        // `Custom.namespace.is_some()` is the load-bearing flag that
+        // distinguishes enum-shaped Customs (`aws.Region`,
+        // `aws.AvailabilityZone.ZoneName` — values written in the
+        // namespaced shorthand `dedicated`, `us_east_1a`) from
+        // structurally-validated Customs (`aws.Arn`,
+        // `aws.ec2.Vpc.Id` — values that already carry their own
+        // format like `arn:aws:s3:...` or `vpc-12345678`). Only the
+        // enum-shaped arm should pass the value through
+        // `expand_enum_shorthand`; the structural arm hands the raw
+        // text to the validator. See carina#3215 follow-up: the
+        // `namespace` field stays for now as the enum-marker; folding
+        // it into the structured identity is S2.5b's job.
         let bare = TypeIdentity::bare("");
         let id_for_resolve = identity.as_ref().unwrap_or(&bare);
-        let resolved_value = Self::resolve_enum_input(id_for_resolve, value);
+        let resolved_value = if namespace.is_some() {
+            Self::resolve_enum_input(id_for_resolve, value)
+        } else {
+            value.to_owned_value()
+        };
         validate(&resolved_value)
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -568,17 +568,24 @@ impl DiagnosticEngine {
                                     ) {
                                         None
                                     } else {
-                                        let _ = namespace; // superseded by structured `identity` (see carina-core::utils::expand_enum_shorthand)
                                         let bare = carina_core::schema::TypeIdentity::bare("");
                                         let id_for_resolve = identity.as_ref().unwrap_or(&bare);
                                         let kind = id_for_resolve.kind.as_str();
-                                        // Handle bare/shorthand enum identifiers by expanding to full namespace format.
-                                        // These are String values like "dedicated" or "InstanceTenancy.dedicated".
-                                        let resolved_value =
+                                        // `Custom.namespace.is_some()` marks enum-shaped Customs
+                                        // (`aws.Region`, `aws.AvailabilityZone.ZoneName`) whose
+                                        // values are written in the namespaced shorthand
+                                        // (`dedicated`, `us_east_1a`). Structurally-validated
+                                        // Customs (`aws.Arn`, `aws.ec2.Vpc.Id`) carry their own
+                                        // format and must reach the validator verbatim — see
+                                        // carina#3215 follow-up.
+                                        let resolved_value = if namespace.is_some() {
                                             carina_core::utils::expand_enum_shorthand(
                                                 value,
                                                 id_for_resolve,
-                                            );
+                                            )
+                                        } else {
+                                            value.clone()
+                                        };
 
                                         // Run the schema-attached validator first; for WASM-plugin
                                         // types it is a noop, so fall back to the provider-context


### PR DESCRIPTION
## Summary

Hotfix follow-up to S2.5a (#3215).

S2.5a made `expand_enum_shorthand` unconditionally expand bare values
whenever the identity carried a provider axis. That broke
structurally-validated `Custom` types: `arn()` carries identity
`aws.Arn` (provider = aws), so `'arn:aws:s3:::my-bucket'` (no dots in
the value) was rewritten to `'aws.Arn.arn:aws:s3:::my-bucket'` before
hitting `validate_arn`, which then rejects the prefixed form. The
failure showed up in S3 (carina-rs/carina-provider-aws#314) the moment
its `arn_type_with_value` test was re-run against the new core.

## Why the bug existed

`Custom.namespace: Option<String>` is the load-bearing flag that
distinguishes:

- **Enum-shaped Customs** (`aws.Region`, `aws.AvailabilityZone.ZoneName`)
  — values are written in the namespaced shorthand (`dedicated`,
  `us_east_1a`) and must be expanded to the full
  `provider.<segments>.<kind>.<value>` form before validation.
- **Structurally-validated Customs** (`aws.Arn`, `aws.ec2.Vpc.Id`) —
  values already carry their own format (`arn:aws:s3:...`,
  `vpc-12345678`) and must reach the validator verbatim.

Before S2.5a, the helper keyed the expansion on `namespace: Some(_)`,
which kept these two arms separate. S2.5a moved the projection onto
`TypeIdentity` (correct) but lost the `namespace.is_some()` gate
(missed) — the two are independent meanings even though the field
itself looks redundant once identities are structured.

## Fix

Reintroduce the `namespace.is_some()` gate at the two callers (the
core `validate_custom` and the LSP `expand_enum_shorthand` site). The
identity-keyed prefix derivation S2.5a fixed stays intact for the
enum-shaped arm (so the `AvailabilityZone.ZoneName` shorthand still
expands correctly). Structural Customs pass through unchanged.

## Why not drop the namespace field outright

Folding the enum-marker meaning into the structured identity (e.g. a
`CustomEnum` variant or an `enum_shorthand: bool` flag) is the right
long-term fix, but it touches every `Custom` construction site in
carina-core + both provider `carina-aws-types` copies. That belongs to
S2.5b (already on the issue tracker as carina#2807 sub-issue), not
this hotfix. Keeping the gate on `namespace.is_some()` for now lets S3
and S4 land first and gives S2.5b a clean canvas.

## Verification

- `cargo nextest run --workspace --all-features`: 3512 passed (same
  count as S2.5a — the regression that surfaced was outside this
  workspace's test set, lives in `carina-provider-aws::tests::validate_arn_type_with_value`).
- `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -D warnings`,
  `bash scripts/check-*.sh`: green.
- Reproduction confirmed locally in the S3 worktree
  (carina-provider-aws#314) — `arn` / `aws_resource_id` /
  `availability_zone_id` tests fail before this fix, pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)