### PR TITLE
core: TypeIdentity::assignable_to directional subsumption (closes #3218)

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1377,11 +1377,16 @@ impl AttributeType {
     /// Rules (first match wins):
     /// 1. Union sink: OK if source is assignable to any member.
     /// 2. Union source: OK iff source is assignable to sink for every member.
-    /// 3. Custom→Custom with both `identity: Some` that are not the
-    ///    [`TypeIdentity::same_type`]: NG. Per-axis identity equality —
-    ///    an empty axis on either side is the wider type, so the
-    ///    generic `aws.Arn` stays assignable against `aws.iam.Role.Arn`
-    ///    while `aws.Region` and `gcp.Region` are rejected.
+    /// 3. Custom→Custom with both `identity: Some` where the source's
+    ///    identity is not [`TypeIdentity::assignable_to`] the sink's:
+    ///    NG. Directional per-axis subsumption — an empty axis on the
+    ///    **sink** widens (any source matches), but an empty axis on
+    ///    the **source** against a populated sink is rejected (no
+    ///    evidence). So `aws.iam.Role.Arn` flows into `aws.Arn` (sink
+    ///    is wider) but `aws.Arn` does not flow into `aws.iam.Role.Arn`
+    ///    (source has no Role-specific evidence). `aws.Region` and
+    ///    `gcp.Region` are rejected both ways (populated providers
+    ///    differ). Closes carina#3218.
     /// 4. Custom→Custom: check pattern (pat-1 literal equality) and length
     ///    containment (source ⊆ sink), then recurse on base.
     /// 5. Custom source → non-Custom sink: recurse on `source.base`.
@@ -1428,7 +1433,7 @@ impl AttributeType {
                     identity: Some(k_id),
                     ..
                 },
-            ) if !s_id.same_type(k_id) => false,
+            ) if !s_id.assignable_to(k_id) => false,
             // Anonymous source → identified sink has no proof of identity.
             (
                 Custom { identity: None, .. },

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2737,9 +2737,11 @@ fn assignable_rejects_same_kind_across_providers() {
 
 /// The generic provider-scoped `aws.Arn` (no service/resource segments)
 /// stays assignable against a more specific `aws.iam.Role.Arn`: an
-/// empty `segments` axis is the wider type, not a wildcard mismatch.
+/// `segments` is **directional**: an empty `segments` source carries
+/// no evidence of satisfying a populated `segments` sink. Closes
+/// carina#3218.
 #[test]
-fn assignable_allows_generic_arn_against_specific_arn() {
+fn assignable_specific_arn_flows_into_generic_arn() {
     let mk = |segments: &[&str]| AttributeType::Custom {
         identity: Some(TypeIdentity::new(Some("aws"), segments.to_vec(), "Arn")),
         base: Box::new(AttributeType::String),
@@ -2751,12 +2753,47 @@ fn assignable_allows_generic_arn_against_specific_arn() {
     };
     let generic = mk(&[]);
     let role_arn = mk(&["iam", "Role"]);
-    assert!(generic.is_assignable_to(&role_arn));
+
+    // Specific → generic: narrower source satisfies wider sink.
     assert!(role_arn.is_assignable_to(&generic));
 
-    // …but two specific ARNs with different service/resource differ.
+    // Generic → specific: the empty-segments source carries no
+    // evidence of being an IAM Role ARN. Must be rejected.
+    assert!(!generic.is_assignable_to(&role_arn));
+
+    // …and two specific ARNs with different service/resource differ.
     let cert_arn = mk(&["acm", "Certificate"]);
     assert!(!role_arn.is_assignable_to(&cert_arn));
+    assert!(!cert_arn.is_assignable_to(&role_arn));
+}
+
+/// Directional per-axis subsumption: source missing a populated sink
+/// axis (provider or segments) is rejected; sink missing a populated
+/// source axis is accepted (widening).
+#[test]
+fn assignable_identity_axis_directionality() {
+    let mk = |provider: Option<&str>, segments: &[&str]| AttributeType::Custom {
+        identity: Some(TypeIdentity::new(provider, segments.to_vec(), "Arn")),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: noop_validator(),
+        namespace: None,
+        to_dsl: None,
+    };
+
+    // provider: None source → Some sink rejected
+    let bare = mk(None, &[]);
+    let scoped = mk(Some("aws"), &[]);
+    assert!(!bare.is_assignable_to(&scoped));
+    // The reverse (sink None) is the widening case and is accepted.
+    assert!(scoped.is_assignable_to(&bare));
+
+    // segments: [] source → ["iam", "Role"] sink rejected
+    let generic = mk(Some("aws"), &[]);
+    let role = mk(Some("aws"), &["iam", "Role"]);
+    assert!(!generic.is_assignable_to(&role));
+    assert!(role.is_assignable_to(&generic));
 }
 
 #[test]

--- a/carina-core/src/schema/type_identity.rs
+++ b/carina-core/src/schema/type_identity.rs
@@ -147,6 +147,57 @@ impl TypeIdentity {
         }
         true
     }
+
+    /// Whether a value of `self`'s type can be assigned into a sink of
+    /// `other`'s type — **directional** per-axis subsumption.
+    ///
+    /// Unlike [`same_type`](Self::same_type), which is symmetric and
+    /// answers "do these denote the same type?", this method asks
+    /// "does the source carry enough provenance to satisfy the sink?".
+    /// The two rules are deliberately separate (see carina#3218): the
+    /// symmetric equivalence is correct for display and schema-registry
+    /// lookup, but the assignment check inside
+    /// [`AttributeType::is_assignable_to`] needs the directional shape.
+    ///
+    /// Rules, per-axis:
+    ///
+    /// - `kind` must match (the `kind` axis is never empty).
+    /// - `provider`: if the sink populates it (`Some(_)`), the source
+    ///   must populate it with the same value. A sink `None` (the
+    ///   provider-agnostic kind) accepts any provider on the source —
+    ///   widening is OK, narrowing is not.
+    /// - `segments`: if the sink populates `segments`, the source must
+    ///   carry **the same** segments. An empty source `segments` on a
+    ///   populated sink is rejected — the source carries no segment
+    ///   evidence that it satisfies the sink's resource scope (mirror
+    ///   of the existing "anonymous source → semantic sink" rule on
+    ///   `Custom.identity` itself). An empty sink `segments` accepts
+    ///   any source (the sink does not distinguish at this axis).
+    ///
+    /// This yields:
+    /// - `aws.iam.Role.Arn` (source) → `aws.Arn` (sink): **accepted**
+    ///   (narrower → wider on the segments axis).
+    /// - `aws.Arn` (source) → `aws.iam.Role.Arn` (sink): **rejected**
+    ///   (the empty `segments` source carries no evidence of being an
+    ///   IAM Role ARN).
+    /// - `aws.iam.Role.Arn` ↔ `aws.acm.Certificate.Arn`: rejected both
+    ///   ways (populated segments differ).
+    /// - `aws.Region` ↔ `gcp.Region`: rejected both ways (populated
+    ///   providers differ).
+    pub fn assignable_to(&self, sink: &TypeIdentity) -> bool {
+        if self.kind != sink.kind {
+            return false;
+        }
+        if let Some(sink_provider) = &sink.provider
+            && self.provider.as_deref() != Some(sink_provider.as_str())
+        {
+            return false;
+        }
+        if !sink.segments.is_empty() && self.segments != sink.segments {
+            return false;
+        }
+        true
+    }
 }
 
 impl fmt::Display for TypeIdentity {
@@ -264,6 +315,49 @@ mod tests {
         for s in ["aws.iam.Role.Arn", "aws.VpcId", "Ipv4Cidr"] {
             assert_eq!(TypeIdentity::from_dotted(s).to_string(), s);
         }
+    }
+
+    #[test]
+    fn assignable_to_is_directional_on_segments() {
+        let generic = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn");
+        let role = TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn");
+        // narrower (populated segments) → wider (empty segments): OK
+        assert!(role.assignable_to(&generic));
+        // wider (empty segments) → narrower (populated segments): NG
+        assert!(!generic.assignable_to(&role));
+    }
+
+    #[test]
+    fn assignable_to_is_directional_on_provider() {
+        let bare = TypeIdentity::bare("Arn");
+        let scoped = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn");
+        // narrower (Some provider) → wider (None provider): OK
+        assert!(scoped.assignable_to(&bare));
+        // wider (None provider) → narrower (Some provider): NG
+        assert!(!bare.assignable_to(&scoped));
+    }
+
+    #[test]
+    fn assignable_to_rejects_distinct_populated_axes() {
+        // aws.Region vs gcp.Region: providers differ → both directions NG.
+        let aws_region = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region");
+        let gcp_region = TypeIdentity::new(Some("gcp"), Vec::<String>::new(), "Region");
+        assert!(!aws_region.assignable_to(&gcp_region));
+        assert!(!gcp_region.assignable_to(&aws_region));
+
+        // aws.iam.Role.Arn vs aws.acm.Certificate.Arn: segments differ.
+        let role = TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn");
+        let cert = TypeIdentity::new(Some("aws"), ["acm", "Certificate"], "Arn");
+        assert!(!role.assignable_to(&cert));
+        assert!(!cert.assignable_to(&role));
+    }
+
+    #[test]
+    fn assignable_to_kind_must_match() {
+        let arn = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn");
+        let vpc_id = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "VpcId");
+        assert!(!arn.assignable_to(&vpc_id));
+        assert!(!vpc_id.assignable_to(&arn));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3218.

S2 (#3204) introduced the structured `TypeIdentity` but conflated two distinct comparisons into one `same_type`:

- **type identity** — symmetric, "are these the same type?"
- **assignment subsumption** — directional, "does the source carry enough provenance for the sink?"

`is_assignable_to`'s Custom→Custom arm used `same_type` as if it were directional. Because `same_type` treats empty axes as the wider type symmetrically, the generic `aws.Arn` flowed into specific `aws.iam.Role.Arn` sinks with no Role-specific evidence — the segments-axis soundness hole the structured identity was supposed to close (issue #3218 describes the audit that surfaced this).

## Fix

Split the two:

- `same_type` — kept, symmetric. Still correct for display / schema-registry lookup / "are these the same type?".
- `assignable_to(source, sink)` — new, **directional** per-axis subsumption:
  - `kind` must match.
  - `provider`: sink `Some(_)` requires source same `Some(_)`. Sink `None` accepts any source (widening OK).
  - `segments`: sink non-empty requires source equal segments. Sink empty accepts any source.

`is_assignable_to` rule 3 now calls `assignable_to` instead of `same_type`.

## Test updates

- Pre-existing `assignable_allows_generic_arn_against_specific_arn` asserted **symmetric** generic ↔ specific (both directions OK). Renamed to `assignable_specific_arn_flows_into_generic_arn` and flipped: asserts the specific→generic direction OK and explicitly rejects the reverse.
- New `assignable_identity_axis_directionality` covers per-axis asymmetry on `provider` and `segments`.
- New unit tests on `TypeIdentity::assignable_to` itself: directional on segments, directional on provider, rejects distinct populated axes, kind must match.

## Verification

- `cargo nextest run --workspace --all-features`: 3517 passed (+5 over main; new directional tests).
- `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -D warnings`: green.

## Blast-radius note

The aws / awscc provider crates (carina-rs/carina-provider-aws, carina-rs/carina-provider-awscc) define a generic `aws.Arn` and various specific `aws.<service>.<Resource>.Arn`. With this fix, code paths that fed a value typed as `aws.Arn` into a sink expecting `aws.iam.Role.Arn` start failing at validate-time — which is exactly the soundness restoration this PR intends. Any such call sites need either a more specific identity at the source or an explicit cast at the sink; that audit lives downstream (provider rev bump PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
