### PR TITLE
lsp/docs: emit new {provider}.{segments...}.{kind}.{value} form for AZ completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ let app_subnet = aws.subnet {
   name              = 'app-subnet'
   vpc_id            = existing_vpc.id
   cidr_block        = '10.0.100.0/24'
-  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+  availability_zone = aws.AvailabilityZone.ZoneName.ap_northeast_1a
 }
 ```
 

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -464,7 +464,7 @@ pub trait ProviderNormalizer: Send + Sync {
     ///
     /// Converts raw values in current state (e.g., `"ap-northeast-1a"`) to
     /// the same DSL enum format that `normalize_desired` produces
-    /// (e.g., `"awscc.ec2.Subnet.AvailabilityZone.ap_northeast_1a"`).
+    /// (e.g., `"awscc.AvailabilityZone.ZoneName.ap_northeast_1a"`).
     /// This prevents false diffs when state stores raw AWS values but
     /// desired state has been normalized.
     /// Providers without enum types return [`ready_noop`].

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2,12 +2,31 @@ use super::*;
 use tower_lsp::lsp_types::{InsertTextFormat, TextEdit};
 
 #[test]
-#[ignore = "requires provider schemas"]
 fn availability_zone_completions_use_dynamic_prefix() {
-    let provider = test_provider();
+    use carina_core::schema::TypeIdentity;
 
-    // availability_zone_completions should use the namespace and type_name to build the prefix
-    let completions = provider.availability_zone_completions("awscc", "AvailabilityZone");
+    // Self-contained: hand-built region data lets this test exercise the
+    // emitter without depending on a real provider factory's
+    // `region_completions_data`. The prior #[ignore] guard skipped the
+    // test in CI; the migration to the structured `TypeIdentity` makes
+    // it easy enough to wire region data inline.
+    let region_completions: Vec<CompletionValue> = vec![CompletionValue {
+        value: "awscc.Region.ap_northeast_1".to_string(),
+        description: "Asia Pacific (Tokyo)".to_string(),
+    }];
+    let provider = CompletionProvider::new(
+        Arc::new(SchemaRegistry::new()),
+        vec!["awscc".to_string()],
+        region_completions,
+        vec![],
+    );
+
+    // S2.5a/b: AZ identity is `{provider}.AvailabilityZone.ZoneName`,
+    // with `"AvailabilityZone"` living in `segments` and `"ZoneName"` /
+    // `"ZoneId"` as the kind. Labels follow the unified value form
+    // `{provider}.{segments...}.{kind}.{value}`.
+    let identity = TypeIdentity::new(Some("awscc"), ["AvailabilityZone"], "ZoneName");
+    let completions = provider.availability_zone_completions(&identity);
 
     // Should have completions
     assert!(
@@ -15,25 +34,32 @@ fn availability_zone_completions_use_dynamic_prefix() {
         "Should generate AZ completions from region data"
     );
 
-    // All completions should use the dynamic prefix
+    // All completions should use the dynamic prefix derived from the
+    // structured identity — never the legacy 3-part form.
     for item in &completions {
         assert!(
-            item.label.starts_with("awscc.AvailabilityZone."),
-            "Label should start with 'awscc.AvailabilityZone.', got: {}",
+            item.label.starts_with("awscc.AvailabilityZone.ZoneName."),
+            "Label should start with 'awscc.AvailabilityZone.ZoneName.', got: {}",
+            item.label
+        );
+        // Guard against the legacy 3-part form leaking back.
+        assert!(
+            !item.label.starts_with("awscc.AvailabilityZone.ap_"),
+            "Label must not use the legacy `{{provider}}.AvailabilityZone.{{value}}` form, got: {}",
             item.label
         );
     }
 
-    // Should include specific regions from the factory data
+    // Should include specific regions from the inline region data
     let has_tokyo = completions
         .iter()
-        .any(|c| c.label == "awscc.AvailabilityZone.ap_northeast_1a");
+        .any(|c| c.label == "awscc.AvailabilityZone.ZoneName.ap_northeast_1a");
     assert!(has_tokyo, "Should include Tokyo region AZs");
 
     // Detail should include region display name
     let tokyo_a = completions
         .iter()
-        .find(|c| c.label == "awscc.AvailabilityZone.ap_northeast_1a")
+        .find(|c| c.label == "awscc.AvailabilityZone.ZoneName.ap_northeast_1a")
         .unwrap();
     assert_eq!(
         tokyo_a.detail.as_deref(),

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -8,7 +8,7 @@ use tower_lsp::lsp_types::{
 
 use carina_core::builtins;
 use carina_core::parser::snake_to_pascal;
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::{AttributeType, TypeIdentity, legacy_validator};
 
 use super::{CompletionProvider, DslSource};
 
@@ -622,12 +622,18 @@ impl CompletionProvider {
             AttributeType::Custom {
                 identity: Some(id), ..
             } if id.kind == "Arn" => self.arn_completions(),
+            // AvailabilityZone is split into two distinct types post-S2.5:
+            // `aws.AvailabilityZone.ZoneName` and `aws.AvailabilityZone.ZoneId`.
+            // The `kind` axis is `"ZoneName"` / `"ZoneId"`; `"AvailabilityZone"`
+            // lives in `segments`. We surface AZ-letter completions only for
+            // zone-name typed sinks — zone-id values look like `usw2-az1` and
+            // are not derivable from region code + letter.
             AttributeType::Custom {
-                identity: Some(id),
-                namespace,
-                ..
-            } if id.kind == "AvailabilityZone" => {
-                self.availability_zone_completions(namespace.as_deref().unwrap_or(""), &id.kind)
+                identity: Some(id), ..
+            } if id.kind == "ZoneName"
+                && id.segments.first().map(String::as_str) == Some("AvailabilityZone") =>
+            {
+                self.availability_zone_completions(id)
             }
             // List(non-Struct): delegate to inner type completions
             AttributeType::List { inner, .. } => self.completions_for_type(inner, resource_type),
@@ -1647,19 +1653,27 @@ impl CompletionProvider {
         basic.chain(generic).chain(custom).chain(resource).collect()
     }
 
+    /// Emit completion items for an availability-zone typed sink, in the
+    /// unified value form `{provider}.{segments...}.{kind}.{az}` derived
+    /// straight from the [`TypeIdentity`] (S2.5a/b convention — see
+    /// `notes/specs/2026-05-16-semantic-name-redesign-design.md`).
+    ///
+    /// For `aws.AvailabilityZone.ZoneName` (identity: provider=`aws`,
+    /// segments=`["AvailabilityZone"]`, kind=`"ZoneName"`) the emitted
+    /// labels look like `aws.AvailabilityZone.ZoneName.us_east_1a`.
     pub(super) fn availability_zone_completions(
         &self,
-        namespace: &str,
-        type_name: &str,
+        identity: &TypeIdentity,
     ) -> Vec<CompletionItem> {
-        let prefix = if namespace.is_empty() {
-            type_name.to_string()
-        } else {
-            format!("{}.{}", namespace, type_name)
+        // Region prefix is derived from the same provider axis as the
+        // sink identity, so the AZ candidates align with the regions the
+        // provider actually exposes. A bare (provider: None) AZ identity
+        // — should one ever appear — falls back to the unqualified
+        // `Region.` prefix.
+        let region_prefix = match identity.provider.as_deref() {
+            Some(p) => format!("{}.Region.", p),
+            None => "Region.".to_string(),
         };
-
-        // Build region display names from region_completions_data, filtered by namespace
-        let region_prefix = format!("{}.Region.", namespace);
         let region_names: std::collections::HashMap<String, String> = self
             .region_completions_data
             .iter()
@@ -1687,7 +1701,10 @@ impl CompletionProvider {
         for (region_code, region_name) in &region_names {
             for &zone_letter in &zone_letters {
                 let az = format!("{}{}", region_code, zone_letter);
-                let label = format!("{}.{}", prefix, az);
+                // Identity's Display impl renders the dotted type form
+                // (`aws.AvailabilityZone.ZoneName`); the value form
+                // simply appends the bare value as the trailing segment.
+                let label = format!("{}.{}", identity, az);
                 let detail = format!("{} Zone {}", region_name, zone_letter);
                 completions.push(CompletionItem {
                     label: label.clone(),
@@ -1714,10 +1731,18 @@ impl CompletionProvider {
         match namespace {
             Some(ns) => {
                 // Offer the fully-qualified form
-                // `<namespace>.<TypeName>.<Variant>`. The bare tail alone
-                // used to leak into sibling-attribute popups via the
-                // generic identifier pool; the qualified form is always
-                // valid and unambiguous.
+                // `<namespace>.<TypeName>.<Variant>`. With `namespace`
+                // carrying the dotted `{provider}.{segments...}` prefix
+                // (e.g. `"aws.s3.Bucket"`) and `type_name` the enum's
+                // kind (e.g. `"VersioningStatus"`), this composes the
+                // unified `{provider}.{segments...}.{kind}.{value}`
+                // value form established by S2.5a/b. Cases with no
+                // segments (e.g. `aws.Region`) render as
+                // `aws.Region.<v>` — still the new form, since `segments`
+                // is allowed to be empty. The bare tail alone used to
+                // leak into sibling-attribute popups via the generic
+                // identifier pool; the qualified form is always valid
+                // and unambiguous.
                 values
                     .iter()
                     .map(|value| {


### PR DESCRIPTION
## Summary

Sub-issue of carina-rs/carina#2807. Closes #3223.

After the structured `TypeIdentity` migration (S2.5a/b/d — PRs #3215, #3217, #3221), the LSP value-completion path for AvailabilityZone still emitted the legacy 3-part form `{provider}.AvailabilityZone.{value}`. Worse, the match arm at `carina-lsp/src/completion/values.rs:629` was keyed on `id.kind == "AvailabilityZone"`, but the migrated identity now stores `"AvailabilityZone"` in `segments` with `kind = "ZoneName"` / `"ZoneId"`. The arm never fired and AZ completion was effectively dead code.

This PR brings LSP completion and README in line with the unified value form `{provider}.{segments...}.{kind}.{value}` that S2.5a/b established for enum shorthand expansion.

## Changes

### `carina-lsp/src/completion/values.rs`
- `availability_zone_completions` now takes `&TypeIdentity` and uses its `Display` impl as the value prefix. Result: `aws.AvailabilityZone.ZoneName.us_east_1a` (4-part), no more 3-part legacy form.
- The match arm now fires on `kind == "ZoneName" && segments[0] == "AvailabilityZone"`. Zone-id sinks get no letter-based completions because their values look like `usw2-az1` and are not derivable from region code + letter.
- `string_enum_completions` already composes the same shape from its `{namespace}.{type_name}.{value}` triple. Added a comment spelling out the alignment with the S2.5a/b convention.

### Tests
- `carina-lsp/src/completion/tests/extended.rs`: the AZ test was previously `#[ignore]`-d for "requires provider schemas". Rewired it with inline region data so it actually runs in CI, plus an extra guard against the legacy 3-part form leaking back.

### Docs
- `README.md` L161: `aws.AvailabilityZone.ap_northeast_1a` → `aws.AvailabilityZone.ZoneName.ap_northeast_1a`.
- `carina-core/src/provider.rs`: `ProviderNormalizer::normalize_state` doc-comment example moves from the stale `awscc.ec2.Subnet.AvailabilityZone.<v>` shape to `awscc.AvailabilityZone.ZoneName.<v>`.

## Verify

- `cargo nextest run --workspace --all-features` — 3524 / 3524 pass (was 3523 + 1 ignored AZ test; now AZ test runs).
- `cargo test --workspace --doc` — all doctests pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `scripts/check-*.sh` — all pass.

## Notes

- `convert_enum_value` / `is_dsl_enum_format` in `carina-core/src/utils.rs` already accept both the 3-part and 4-part forms via `NamespacedId::parse`, so consumers downstream of LSP emit (plan display, parser normalization, etc.) continue to handle both shapes during the transition.
- `Region` typed sinks already emit the new form via `string_enum_completions` (`provider=aws`, `segments=[]`, `kind=Region` → `aws.Region.<v>`); no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)