### PR TITLE
core/protocol/lsp: drop namespace fields, introduce CustomEnum variant (closes #3222)

### DIFF
--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -254,7 +254,10 @@ fn enum_schemas() -> SchemaRegistry {
     let mode = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
-        namespace: Some("test.r".to_string()),
+        identity: Some(carina_core::schema::string_enum_identity(
+            "Mode",
+            Some("test.r"),
+        )),
         dsl_aliases: vec![],
     };
     single_schema_map(
@@ -350,13 +353,10 @@ fn region_schemas() -> SchemaRegistry {
         s.replace('-', "_")
     }
 
-    let region_custom = AttributeType::Custom {
-        identity: Some(carina_core::schema::TypeIdentity::bare("Region")),
+    let region_custom = AttributeType::CustomEnum {
+        identity: carina_core::schema::string_enum_identity("Region", Some("test")),
         base: Box::new(AttributeType::String),
-        pattern: None,
-        length: None,
         validate: legacy_validator(validate_region),
-        namespace: Some("test".to_string()),
         to_dsl: Some(to_dsl),
     };
 
@@ -851,8 +851,6 @@ fn wasm_style_vpc_schema() -> ResourceSchema {
         length: None,
         base: Box::new(AttributeType::String),
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     ResourceSchema::new("ec2.security_group")
         .attribute(AttributeSchema::new(
@@ -943,8 +941,6 @@ fn wasm_style_subnet_schema() -> ResourceSchema {
         length: None,
         base: Box::new(AttributeType::String),
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     ResourceSchema::new("ec2.subnet").attribute(AttributeSchema::new(
         "vpc_ids",
@@ -1058,8 +1054,6 @@ fn vpc_id_custom_type_2358() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(vpc_id_validate_2358),
-        namespace: None,
-        to_dsl: None,
     }
 }
 

--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -46,7 +46,10 @@ fn invalid_enum_variant_namespaced_display() {
             AttributeType::StringEnum {
                 name: "VersioningStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Suspended".to_string()],
-                namespace: Some("aws.s3.Bucket".to_string()),
+                identity: Some(carina_core::schema::string_enum_identity(
+                    "VersioningStatus",
+                    Some("aws.s3.Bucket"),
+                )),
                 dsl_aliases: vec![],
             },
         )
@@ -75,7 +78,7 @@ fn invalid_enum_variant_bare_display() {
     let t = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     };
     let err = t
@@ -92,7 +95,10 @@ fn invalid_enum_variant_with_dsl_aliases_display() {
     let t = AttributeType::StringEnum {
         name: "VersioningStatus".to_string(),
         values: vec!["Enabled".to_string(), "Suspended".to_string()],
-        namespace: Some("aws.s3.Bucket".to_string()),
+        identity: Some(carina_core::schema::string_enum_identity(
+            "VersioningStatus",
+            Some("aws.s3.Bucket"),
+        )),
         dsl_aliases: vec![
             ("Enabled".to_string(), "enabled".to_string()),
             ("Suspended".to_string(), "suspended".to_string()),
@@ -114,7 +120,10 @@ fn string_literal_expected_enum_string_enum_display() {
             AttributeType::StringEnum {
                 name: "TargetType".to_string(),
                 values: vec!["AWS_ACCOUNT".to_string(), "GROUP".to_string()],
-                namespace: Some("awscc.sso.Assignment".to_string()),
+                identity: Some(carina_core::schema::string_enum_identity(
+                    "TargetType",
+                    Some("awscc.sso.Assignment"),
+                )),
                 dsl_aliases: vec![],
             },
         )
@@ -142,21 +151,14 @@ fn string_literal_expected_enum_custom_namespaced_display() {
     let schema = ResourceSchema::new("test.r.mode_holder").attribute(
         AttributeSchema::new(
             "mode",
-            AttributeType::Custom {
+            AttributeType::CustomEnum {
                 // Structured identity matching the legacy `namespace: "test.r"`
                 // shorthand prefix: provider=test, segments=[r], kind=Mode.
                 // The dotted display is `test.r.Mode`, which is the prefix
                 // `expand_enum_shorthand` now derives from `identity`.
-                identity: Some(carina_core::schema::TypeIdentity::new(
-                    Some("test"),
-                    ["r"],
-                    "Mode",
-                )),
+                identity: carina_core::schema::TypeIdentity::new(Some("test"), ["r"], "Mode"),
                 base: Box::new(AttributeType::String),
-                pattern: None,
-                length: None,
                 validate: legacy_validator(validate_mode),
-                namespace: Some("test.r".to_string()),
                 to_dsl: None,
             },
         )

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -2089,7 +2089,7 @@ mod tests {
         let effect = AttributeType::StringEnum {
             name: "Effect".to_string(),
             values: vec!["Allow".to_string(), "Deny".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![
                 ("Allow".to_string(), "allow".to_string()),
                 ("Deny".to_string(), "deny".to_string()),
@@ -2098,7 +2098,7 @@ mod tests {
         let version = AttributeType::StringEnum {
             name: "Version".to_string(),
             values: vec!["2012-10-17".to_string(), "2008-10-17".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![
                 ("2012-10-17".to_string(), "2012_10_17".to_string()),
                 ("2008-10-17".to_string(), "2008_10_17".to_string()),
@@ -2343,7 +2343,7 @@ mod tests {
         let enum_t = AttributeType::StringEnum {
             name: "Mode".to_string(),
             values: vec!["On".to_string(), "Off".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![
                 ("On".to_string(), "on".to_string()),
                 ("Off".to_string(), "off".to_string()),
@@ -2513,7 +2513,7 @@ mod tests {
         let mode = AttributeType::StringEnum {
             name: "Mode".to_string(),
             values: vec!["Allow".to_string(), "Deny".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![
                 ("Allow".to_string(), "allow".to_string()),
                 ("Deny".to_string(), "deny".to_string()),

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -113,8 +113,6 @@ fn type_aware_custom_delegates_to_base() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(type_aware_equal(
         &Value::Concrete(ConcreteValue::Int(8080)),
@@ -244,7 +242,10 @@ fn type_aware_string_enum_namespaced_vs_raw() {
             "AES256".to_string(),
             "aws:kms:dsse".to_string(),
         ],
-        namespace: Some("awscc.s3.Bucket".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "ServerSideEncryptionByDefaultSseAlgorithm",
+            Some("awscc.s3.Bucket"),
+        )),
         dsl_aliases: vec![],
     };
 
@@ -303,7 +304,7 @@ fn type_aware_struct_ignores_default_string_enum_empty() {
                 AttributeType::StringEnum {
                     name: "Status".to_string(),
                     values: vec!["Active".to_string(), "Inactive".to_string()],
-                    namespace: None,
+                    identity: None,
                     dsl_aliases: vec![],
                 },
             ),
@@ -350,8 +351,6 @@ fn type_aware_struct_ignores_default_custom_type() {
                     pattern: None,
                     length: None,
                     validate: noop_validator(),
-                    namespace: None,
-                    to_dsl: None,
                 },
             ),
         ],
@@ -1030,8 +1029,6 @@ fn union_string_or_list_through_custom_wrapper() {
         pattern: None,
         length: None,
         validate: std::sync::Arc::new(|_| Ok(())),
-        namespace: None,
-        to_dsl: None,
     };
     let a = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
     let b = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
@@ -1159,7 +1156,10 @@ fn carina3122_cloudfront_allowed_methods_set_is_no_change_via_pipeline() {
     let method_enum = |name: &str, values: &[&str]| AttributeType::StringEnum {
         name: name.to_string(),
         values: values.iter().map(|s| s.to_string()).collect(),
-        namespace: Some("awscc.cloudfront.Distribution".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            name,
+            Some("awscc.cloudfront.Distribution"),
+        )),
         dsl_aliases: values
             .iter()
             .map(|s| (s.to_string(), s.to_lowercase()))
@@ -1405,7 +1405,10 @@ fn carina3122_cloudfront_allowed_methods_ordered_list_does_change_via_pipeline()
     let method_enum = |name: &str, values: &[&str]| AttributeType::StringEnum {
         name: name.to_string(),
         values: values.iter().map(|s| s.to_string()).collect(),
-        namespace: Some("awscc.cloudfront.Distribution".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            name,
+            Some("awscc.cloudfront.Distribution"),
+        )),
         dsl_aliases: values
             .iter()
             .map(|s| (s.to_string(), s.to_lowercase()))

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -1034,7 +1034,10 @@ fn diff_no_change_for_struct_list_with_saved_state_egress_rules() {
                         "-1".to_string(),
                         "all".to_string(),
                     ],
-                    namespace: Some("awscc.ec2.SecurityGroup".to_string()),
+                    identity: Some(crate::schema::string_enum_identity(
+                        "IpProtocol",
+                        Some("awscc.ec2.SecurityGroup"),
+                    )),
                     dsl_aliases: vec![("-1".to_string(), "all".to_string())],
                 },
             ),
@@ -1361,7 +1364,10 @@ fn diff_no_change_for_compound_word_dsl_alias() {
                     "BucketOwnerPreferred".to_string(),
                     "ObjectWriter".to_string(),
                 ],
-                namespace: Some("aws.s3.BucketOwnershipControls".to_string()),
+                identity: Some(crate::schema::string_enum_identity(
+                    "ObjectOwnership",
+                    Some("aws.s3.BucketOwnershipControls"),
+                )),
                 dsl_aliases: vec![
                     (
                         "BucketOwnerEnforced".to_string(),

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -176,6 +176,23 @@ fn walk_custom_lookup(
                 });
             }
         }
+        AttributeType::CustomEnum { identity, .. } => {
+            // CustomEnum carries a mandatory identity; the lookup
+            // path is otherwise identical to the structural Custom
+            // arm above. (The split exists only at the validate /
+            // diagnostic level — at the registry lookup level the
+            // two variants behave the same way.)
+            if let Err(e) = lookup(identity, value) {
+                let message = match e {
+                    TypeError::ValidationFailed { message } => message,
+                    other => other.to_string(),
+                };
+                errors.push(TypeError::ResourceValidationFailed {
+                    message,
+                    attribute: Some(attr_name.to_string()),
+                });
+            }
+        }
         AttributeType::List { inner, .. } => {
             if let Value::Concrete(ConcreteValue::List(items)) = value {
                 for item in items {
@@ -237,9 +254,13 @@ fn walk_custom_lookup(
     }
 }
 
-pub type StringEnumParts<'a> = (&'a str, &'a [String], Option<&'a str>, DslMap<'a>);
+pub type StringEnumParts<'a> = (&'a str, &'a [String], Option<&'a TypeIdentity>, DslMap<'a>);
 
-pub type NamespacedEnumParts<'a> = (&'a str, &'a str, DslMap<'a>);
+/// `(kind, dotted_prefix, dsl_map)` for an enum-shaped type — either a
+/// `StringEnum` with an `identity` or a `CustomEnum`. The dotted
+/// prefix is freshly composed from the `TypeIdentity`, so this tuple
+/// carries an owned `String` rather than a borrowed slice.
+pub type NamespacedEnumParts<'a> = (&'a str, String, DslMap<'a>);
 
 /// API-canonical → DSL-spelling mapping carried by a `StringEnum`
 /// (data) or a `Custom` (closure). Both sources answer the same
@@ -393,7 +414,7 @@ pub enum AttributeType {
     /// (`75min`, `1h`, `30s`); internally a `std::time::Duration`.
     /// Serialised as integer seconds at every value-tree boundary.
     Duration,
-    /// String enum with optional namespace-aware DSL syntax support.
+    /// String enum with namespace-aware DSL syntax support.
     ///
     /// `dsl_aliases` is a list of `(api, dsl)` pairs that map a canonical
     /// (API) value to the DSL spelling, for every value where the two
@@ -406,13 +427,31 @@ pub enum AttributeType {
     /// because `fn` pointers are not serializable, so provider plugins
     /// silently lost their alias map and validation rejected legitimate
     /// DSL spellings (carina#2831, awscc#199, aws#247).
+    ///
+    /// The legacy `namespace: Option<String>` field was replaced by
+    /// `identity: Option<TypeIdentity>` in carina#3222
+    /// (S2.5c-followup); the dotted prefix is now derived from the
+    /// structure (`identity.dotted_prefix()`) rather than carried as
+    /// a separate string.
     StringEnum {
         name: String,
         values: Vec<String>,
-        namespace: Option<String>,
+        /// Structured identity. `Some(_)` when the enum has a provider
+        /// scope (the namespaced shorthand path); `None` for a bare
+        /// enum without a namespace (legacy / built-in shape).
+        identity: Option<TypeIdentity>,
         dsl_aliases: Vec<(String, String)>,
     },
-    /// Custom type (with validation function)
+    /// Structurally-validated custom type — values carry their own
+    /// format (e.g. `arn:aws:s3:::bucket-name`, `vpc-12345678`) and
+    /// reach the validator verbatim. Distinct from [`AttributeType::CustomEnum`],
+    /// which gates the value through `expand_enum_shorthand` first.
+    ///
+    /// The split was introduced in carina#3222 (S2.5c-followup) so the
+    /// enum-shorthand vs structural divide is a compile-time fact
+    /// rather than a runtime `namespace.is_some()` check — the
+    /// carina#3216 class of mis-expansion (`aws.Arn.arn:aws:s3:...`)
+    /// is structurally impossible under this shape.
     Custom {
         /// `Some(identity)` when this type carries a structured type
         /// identity (e.g. `aws.iam.Role.Arn`, `aws.VpcId`). `None` when
@@ -430,9 +469,22 @@ pub enum AttributeType {
         /// Optional length bounds (min, max).
         length: Option<(Option<u64>, Option<u64>)>,
         validate: CustomValidator,
-        /// Namespace for resolving shorthand enum values (e.g., "aws.vpc")
-        /// When set, allows `dedicated` to be resolved to `aws.vpc.InstanceTenancy.dedicated`
-        namespace: Option<String>,
+    },
+    /// Enum-shaped custom type — values are written in namespaced
+    /// shorthand (`us_east_1`, `dedicated`, `us_east_1a`) and flow
+    /// through `expand_enum_shorthand` to a fully-qualified form
+    /// (`aws.Region.us_east_1`, …) before reaching the validator.
+    ///
+    /// Sibling of [`AttributeType::Custom`]; both replace the older
+    /// single `Custom` variant whose `namespace.is_some()` flag
+    /// distinguished the two cases at runtime. Identity is mandatory
+    /// here — without one there is no namespace to expand into.
+    CustomEnum {
+        /// Structured identity. Always populated (unlike `Custom`):
+        /// the namespace expansion needs the dotted prefix.
+        identity: TypeIdentity,
+        base: Box<AttributeType>,
+        validate: CustomValidator,
         /// Optional callback to normalize AWS values to DSL format.
         /// For example, availability_zone uses `|s| s.replace('-', "_")` to convert
         /// "ap-northeast-1a" to "ap_northeast_1a" for DSL identifier form.
@@ -477,13 +529,13 @@ impl fmt::Debug for AttributeType {
             AttributeType::StringEnum {
                 name,
                 values,
-                namespace,
+                identity,
                 dsl_aliases,
             } => f
                 .debug_struct("StringEnum")
                 .field("name", name)
                 .field("values", values)
-                .field("namespace", namespace)
+                .field("identity", identity)
                 .field("dsl_aliases", dsl_aliases)
                 .finish(),
             AttributeType::Custom {
@@ -491,8 +543,6 @@ impl fmt::Debug for AttributeType {
                 base,
                 pattern,
                 length,
-                namespace,
-                to_dsl,
                 validate: _,
             } => f
                 .debug_struct("Custom")
@@ -500,7 +550,17 @@ impl fmt::Debug for AttributeType {
                 .field("base", base)
                 .field("pattern", pattern)
                 .field("length", length)
-                .field("namespace", namespace)
+                .field("validate", &"<closure>")
+                .finish(),
+            AttributeType::CustomEnum {
+                identity,
+                base,
+                to_dsl,
+                validate: _,
+            } => f
+                .debug_struct("CustomEnum")
+                .field("identity", identity)
+                .field("base", base)
                 .field("to_dsl", to_dsl)
                 .field("validate", &"<closure>")
                 .finish(),
@@ -648,12 +708,12 @@ impl AttributeType {
             AttributeType::StringEnum {
                 name,
                 values,
-                namespace,
+                identity,
                 dsl_aliases,
             } => Some((
                 name,
                 values,
-                namespace.as_deref(),
+                identity.as_ref(),
                 DslMap::Aliases(dsl_aliases),
             )),
             _ => None,
@@ -664,16 +724,23 @@ impl AttributeType {
         match self {
             AttributeType::StringEnum {
                 name,
-                namespace: Some(namespace),
+                identity: Some(id),
                 dsl_aliases,
                 ..
-            } => Some((name, namespace, DslMap::Aliases(dsl_aliases))),
-            AttributeType::Custom {
-                identity: Some(id),
-                namespace: Some(namespace),
-                to_dsl,
-                ..
-            } => Some((&id.kind, namespace, DslMap::Closure(*to_dsl))),
+            } => {
+                let prefix = id.dotted_prefix()?;
+                Some((name, prefix, DslMap::Aliases(dsl_aliases)))
+            }
+            AttributeType::CustomEnum {
+                identity, to_dsl, ..
+            } => {
+                // `CustomEnum` always carries an identity with a
+                // populated provider axis; if `dotted_prefix` is `None`
+                // the identity is malformed and we treat the type as
+                // non-namespaced (the pre-#3222 `namespace: None` case).
+                let prefix = identity.dotted_prefix()?;
+                Some((&identity.kind, prefix, DslMap::Closure(*to_dsl)))
+            }
             _ => None,
         }
     }
@@ -708,17 +775,18 @@ impl AttributeType {
         if let AttributeType::StringEnum {
             name,
             values,
-            namespace,
+            identity,
             dsl_aliases,
         } = self
             && let Some(binding) = bare_binding_name(value)
             && enum_alias_collides_with(binding, values, dsl_aliases)
         {
+            let prefix = identity.as_ref().and_then(|id| id.dotted_prefix());
             return Err(TypeError::ValidationFailed {
                 message: enum_binding_collision_message(
                     binding,
                     name,
-                    namespace.as_deref(),
+                    prefix.as_deref(),
                     values,
                     dsl_aliases,
                 ),
@@ -734,6 +802,7 @@ impl AttributeType {
         match self {
             AttributeType::StringEnum { .. } => self.validate_string_enum(value),
             AttributeType::Custom { .. } => self.validate_custom(value),
+            AttributeType::CustomEnum { .. } => self.validate_custom_enum(value),
             AttributeType::List { .. } => self.validate_list(value),
             AttributeType::Map { .. } => self.validate_map(value),
             AttributeType::Struct { .. } => self.validate_struct(value),
@@ -940,12 +1009,19 @@ impl AttributeType {
         let AttributeType::StringEnum {
             name,
             values,
-            namespace,
+            identity,
             dsl_aliases,
         } = self
         else {
             unreachable!("validate_string_enum called on non-StringEnum");
         };
+
+        // Dotted `{provider}.{segments...}` prefix derived from the
+        // structured identity, mirroring the pre-#3222
+        // `namespace.as_deref()` shape (which was a flat string
+        // carried alongside `name`).
+        let prefix = identity.as_ref().and_then(|id| id.dotted_prefix());
+        let prefix_ref = prefix.as_deref();
 
         // Phase 4 of carina#2986: enum attributes accept only DSL
         // identifiers (`ConcreteValue::EnumIdentifier`), never quoted
@@ -958,12 +1034,8 @@ impl AttributeType {
         if let ConcreteValueRef::String(s) = value {
             let mut expected: Vec<ExpectedEnumVariant> = Vec::new();
             let mut push = |variant_value: &str, is_alias: bool| {
-                let entry = ExpectedEnumVariant::from_namespaced(
-                    namespace.as_deref(),
-                    name,
-                    variant_value,
-                    is_alias,
-                );
+                let entry =
+                    ExpectedEnumVariant::from_namespaced(prefix_ref, name, variant_value, is_alias);
                 if !expected.contains(&entry) {
                     expected.push(entry);
                 }
@@ -985,11 +1057,13 @@ impl AttributeType {
             });
         }
 
-        // Build a structured identity from the legacy `name + namespace`
-        // pair so the shorthand-expansion helper can reuse the same
-        // `TypeIdentity`-keyed projection as `Custom`.
-        let identity = string_enum_identity(name, namespace.as_deref());
-        let resolved_value = Self::resolve_enum_input(&identity, value);
+        // `identity` is the structured form; fall back to a bare
+        // identity for `StringEnum`s without a provider scope so the
+        // shorthand-expansion helper still has something to key on.
+        let owned_identity = identity
+            .clone()
+            .unwrap_or_else(|| TypeIdentity::bare(name.as_str()));
+        let resolved_value = Self::resolve_enum_input(&owned_identity, value);
         // Capture the user's original input for diagnostics. The parser
         // emits `ConcreteValue::EnumIdentifier` for bare identifier short
         // forms (`dedicated`) and dotted forms (`aws.s3.Bucket.VersioningStatus.Enabled`).
@@ -1018,7 +1092,10 @@ impl AttributeType {
             // `{namespace}.{name}.{variant}`. This rejects malformed
             // inputs like double-namespaced values while still allowing
             // enum values that themselves contain dots (e.g., "ipsec.1").
-            if !direct_match && let Some(ns) = namespace.as_deref() {
+            if !direct_match
+                && let Some(ns) = prefix_ref
+                && let Some(id) = identity.as_ref()
+            {
                 let expected_prefix = format!("{}.{}.", ns, name);
                 let prefix_matches =
                     s.starts_with(&expected_prefix) && &s[expected_prefix.len()..] == variant;
@@ -1026,8 +1103,7 @@ impl AttributeType {
                     // Fall back to strict namespace validation, which
                     // produces a clear error for the common bare form.
                     let user_form = user_input.unwrap_or(s.as_str());
-                    let identity = string_enum_identity(name, Some(ns));
-                    validate_enum_namespace(s, &identity).map_err(|message| {
+                    validate_enum_namespace(s, id).map_err(|message| {
                         TypeError::ValidationFailed {
                             message: format!("Invalid {} '{}': {}", name, user_form, message),
                         }
@@ -1063,7 +1139,7 @@ impl AttributeType {
                 let mut expected: Vec<ExpectedEnumVariant> = Vec::new();
                 let mut push = |variant_value: &str, is_alias: bool| {
                     let entry = ExpectedEnumVariant::from_namespaced(
-                        namespace.as_deref(),
+                        prefix_ref,
                         name,
                         variant_value,
                         is_alias,
@@ -1095,42 +1171,44 @@ impl AttributeType {
         }
     }
 
-    /// Validate against a `Custom` variant by delegating to its `validate`
-    /// closure after expanding any enum-shorthand identifier in `value`.
+    /// Validate against a `Custom` variant by delegating to its
+    /// `validate` closure on the raw value.
+    ///
+    /// Pre-carina#3222 this function also handled enum-shaped Customs
+    /// (gated on `namespace.is_some()`); those are now
+    /// [`AttributeType::CustomEnum`] and dispatched separately by
+    /// [`Self::validate_custom_enum`], so the enum-shorthand gate is
+    /// gone — the structurally-validated arm is the only thing left.
     ///
     /// Phase 2 of RFC #2972: takes [`ConcreteValueRef`]. The deferred-skip
     /// guard for `Value::Deferred(DeferredValue::ResourceRef)`/`Value::Deferred(DeferredValue::Interpolation)` is gone —
     /// the dispatcher filters them out in [`Self::validate`].
     fn validate_custom(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
-        let AttributeType::Custom {
-            validate,
-            identity,
-            namespace,
-            ..
-        } = self
-        else {
+        let AttributeType::Custom { validate, .. } = self else {
             unreachable!("validate_custom called on non-Custom");
         };
+        validate(&value.to_owned_value())
+    }
 
-        // `Custom.namespace.is_some()` is the load-bearing flag that
-        // distinguishes enum-shaped Customs (`aws.Region`,
-        // `aws.AvailabilityZone.ZoneName` — values written in the
-        // namespaced shorthand `dedicated`, `us_east_1a`) from
-        // structurally-validated Customs (`aws.Arn`,
-        // `aws.ec2.Vpc.Id` — values that already carry their own
-        // format like `arn:aws:s3:...` or `vpc-12345678`). Only the
-        // enum-shaped arm should pass the value through
-        // `expand_enum_shorthand`; the structural arm hands the raw
-        // text to the validator. See carina#3215 follow-up: the
-        // `namespace` field stays for now as the enum-marker; folding
-        // it into the structured identity is S2.5b's job.
-        let bare = TypeIdentity::bare("");
-        let id_for_resolve = identity.as_ref().unwrap_or(&bare);
-        let resolved_value = if namespace.is_some() {
-            Self::resolve_enum_input(id_for_resolve, value)
-        } else {
-            value.to_owned_value()
+    /// Validate against a `CustomEnum` variant: expand the namespaced
+    /// shorthand using the structured identity, then delegate to the
+    /// `validate` closure on the resolved value.
+    ///
+    /// Sibling of [`Self::validate_custom`]; the split was introduced
+    /// in carina#3222 so the enum-shorthand vs structural divide is a
+    /// type-level fact rather than a runtime `namespace.is_some()`
+    /// check. The carina#3216 class of mis-expansion (`aws.Arn`
+    /// values being silently rewritten into `aws.Arn.arn:aws:s3:...`)
+    /// is structurally impossible here because structural `Custom`
+    /// cannot reach this dispatch.
+    fn validate_custom_enum(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
+        let AttributeType::CustomEnum {
+            validate, identity, ..
+        } = self
+        else {
+            unreachable!("validate_custom_enum called on non-CustomEnum");
         };
+        let resolved_value = Self::resolve_enum_input(identity, value);
         validate(&resolved_value)
     }
 
@@ -1343,6 +1421,11 @@ impl AttributeType {
                 length,
                 ..
             } => custom_display_name(identity.as_ref(), pattern.as_deref(), length.as_ref()),
+            AttributeType::CustomEnum { identity, .. } => {
+                // CustomEnum carries no pattern/length — the value form
+                // is a namespaced enum, fully described by its identity.
+                custom_display_name(Some(identity), None, None)
+            }
             AttributeType::List { inner, .. } => format!("List<{}>", inner.type_name()),
             AttributeType::Map { value: inner, .. } => format!("Map<{}>", inner.type_name()),
             AttributeType::Struct { name, .. } => format!("Struct({})", name),
@@ -1474,15 +1557,23 @@ impl AttributeType {
     }
 }
 
-/// Build a structured [`TypeIdentity`] from a `StringEnum`'s
-/// `name + namespace` pair.
+/// Build a structured [`TypeIdentity`] from a `(name, namespace)`
+/// pair — the inverse of [`TypeIdentity::dotted_prefix`].
 ///
-/// The legacy `namespace` field is a dot-joined string of
-/// `provider.<segments...>`; this helper splits it back so the
-/// shorthand-expansion helper can derive the dotted prefix from the
-/// structure rather than parsing a flat string. Once `StringEnum`
-/// itself carries a `TypeIdentity`, this function disappears.
-fn string_enum_identity(name: &str, namespace: Option<&str>) -> TypeIdentity {
+/// `namespace` is a dot-joined `provider.<segments...>` string of the
+/// shape providers used to carry on the pre-#3222 `Custom.namespace` /
+/// `StringEnum.namespace` field. The provider segment is the head and
+/// every following segment goes into `segments`; `name` becomes the
+/// `kind`. A bare `name` with no namespace yields
+/// `TypeIdentity::bare(name)`.
+///
+/// Kept as a public helper because provider repositories
+/// (`carina-aws-types`, `carina-provider-{aws,awscc}`) still build
+/// `StringEnum.identity` / `CustomEnum.identity` from the same dotted
+/// inputs their codegen has carried for years; expressing that as
+/// "the inverse of `dotted_prefix`" is clearer than re-splitting at
+/// every call site.
+pub fn string_enum_identity(name: &str, namespace: Option<&str>) -> TypeIdentity {
     match namespace {
         Some(ns) if !ns.is_empty() => {
             let mut parts = ns.split('.');
@@ -1732,25 +1823,25 @@ fn reshape_for_string_literal(
         return tagged.into_string_literal_diagnostic();
     }
 
-    // Namespaced Custom: manually build the shape-mismatch diagnostic from
+    // CustomEnum: manually build the shape-mismatch diagnostic from
     // the semantic name. `ValidationFailed` has no attribute slot so
     // `with_attribute` is a no-op; we thread the attribute name in
     // explicitly. `expected` stays empty — custom validators don't
     // enumerate variants — and the original validator message rides on
     // `extra_message` so its detail (which often lists valid forms)
     // stays visible without polluting the structured candidates list.
-    if let AttributeType::Custom {
-        identity: Some(id),
-        namespace: Some(_),
-        ..
-    } = attr_type
+    //
+    // Pre-#3222 this matched on `Custom { namespace: Some(_), .. }`
+    // — the runtime enum-marker form. The shape moved to a sibling
+    // variant, so the match is now structural.
+    if let AttributeType::CustomEnum { identity, .. } = attr_type
         && let Value::Concrete(ConcreteValue::String(typed)) = value
         && let TypeError::ValidationFailed { message } = &tagged
     {
         return TypeError::StringLiteralExpectedEnum {
             user_typed: typed.clone(),
             attribute: Some(attr_name.to_string()),
-            type_name: id.kind.clone(),
+            type_name: identity.kind.clone(),
             expected: Vec::new(),
             extra_message: Some(message.clone()),
         };
@@ -2967,8 +3058,6 @@ pub mod types {
                     Err("Expected integer".to_string())
                 }
             }),
-            namespace: None,
-            to_dsl: None,
         }
     }
 
@@ -2986,8 +3075,6 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
-            namespace: None,
-            to_dsl: None,
         }
     }
 
@@ -3005,8 +3092,6 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
-            namespace: None,
-            to_dsl: None,
         }
     }
 
@@ -3024,8 +3109,6 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
-            namespace: None,
-            to_dsl: None,
         }
     }
 
@@ -3043,8 +3126,6 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
-            namespace: None,
-            to_dsl: None,
         }
     }
 
@@ -3071,8 +3152,6 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
-            namespace: None,
-            to_dsl: None,
         }
     }
 }

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -48,7 +48,10 @@ fn validate_string_enum_type() {
     let t = AttributeType::StringEnum {
         name: "AddressFamily".to_string(),
         values: vec!["IPv4".to_string(), "IPv6".to_string()],
-        namespace: Some("awscc.ec2.ipam_pool".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "AddressFamily",
+            Some("awscc.ec2.ipam_pool"),
+        )),
         dsl_aliases: vec![],
     };
     assert!(
@@ -87,7 +90,10 @@ fn validate_string_enum_rejects_quoted_string_literal() {
     let t = AttributeType::StringEnum {
         name: "AddressFamily".to_string(),
         values: vec!["IPv4".to_string(), "IPv6".to_string()],
-        namespace: Some("awscc.ec2.ipam_pool".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "AddressFamily",
+            Some("awscc.ec2.ipam_pool"),
+        )),
         dsl_aliases: vec![],
     };
     let err = t
@@ -104,7 +110,10 @@ fn string_enum_type_name_uses_declared_name() {
     let t = AttributeType::StringEnum {
         name: "VersioningStatus".to_string(),
         values: vec!["Enabled".to_string(), "Suspended".to_string()],
-        namespace: Some("aws.s3.Bucket".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "VersioningStatus",
+            Some("aws.s3.Bucket"),
+        )),
         dsl_aliases: vec![],
     };
     assert_eq!(t.type_name(), "VersioningStatus");
@@ -121,7 +130,10 @@ fn validate_string_enum_accepts_dsl_alias() {
             "icmpv6".to_string(),
             "-1".to_string(),
         ],
-        namespace: Some("awscc.ec2.SecurityGroup".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "IpProtocol",
+            Some("awscc.ec2.SecurityGroup"),
+        )),
         dsl_aliases: vec![("-1".to_string(), "all".to_string())],
     };
     // Canonical "-1" is rewritten to DSL "all" — the DSL surface must
@@ -171,7 +183,7 @@ fn validate_string_enum_all_without_dsl_aliases_requires_explicit_variant() {
             "icmpv6".to_string(),
             "-1".to_string(),
         ],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     };
     // Without "all" in values and no dsl_aliases entry mapping to "all", it is rejected
@@ -194,7 +206,7 @@ fn validate_string_enum_all_without_dsl_aliases_requires_explicit_variant() {
             "-1".to_string(),
             "all".to_string(),
         ],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     };
     assert!(
@@ -213,7 +225,10 @@ fn validate_string_enum_accepts_values_with_dots() {
     let t = AttributeType::StringEnum {
         name: "Type".to_string(),
         values: vec!["ipsec.1".to_string()],
-        namespace: Some("awscc.ec2.vpn_gateway".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "Type",
+            Some("awscc.ec2.vpn_gateway"),
+        )),
         dsl_aliases: vec![],
     };
     // Bare identifier with dot should match directly (carried as
@@ -254,7 +269,10 @@ fn invalid_enum_error_preserves_user_typed_string_literal() {
     let t = AttributeType::StringEnum {
         name: "TargetType".to_string(),
         values: vec!["AWS_ACCOUNT".to_string()],
-        namespace: Some("awscc.sso.Assignment".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "TargetType",
+            Some("awscc.sso.Assignment"),
+        )),
         dsl_aliases: vec![],
     };
     let err = t
@@ -280,7 +298,10 @@ fn invalid_enum_error_names_the_enum_type_and_fully_qualified_variants() {
     let t = AttributeType::StringEnum {
         name: "TargetType".to_string(),
         values: vec!["AWS_ACCOUNT".to_string()],
-        namespace: Some("awscc.sso.Assignment".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "TargetType",
+            Some("awscc.sso.Assignment"),
+        )),
         dsl_aliases: vec![],
     };
     let err = t
@@ -307,7 +328,10 @@ fn with_attribute_adds_attribute_name_to_enum_error() {
     let t = AttributeType::StringEnum {
         name: "TargetType".to_string(),
         values: vec!["AWS_ACCOUNT".to_string()],
-        namespace: Some("awscc.sso.Assignment".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "TargetType",
+            Some("awscc.sso.Assignment"),
+        )),
         dsl_aliases: vec![],
     };
     // String-literal path (strict-mode rejection): rendered as
@@ -375,7 +399,10 @@ fn schema_validate_wraps_enum_error_with_attribute_name() {
             AttributeType::StringEnum {
                 name: "TargetType".to_string(),
                 values: vec!["AWS_ACCOUNT".to_string()],
-                namespace: Some("awscc.sso.Assignment".to_string()),
+                identity: Some(crate::schema::string_enum_identity(
+                    "TargetType",
+                    Some("awscc.sso.Assignment"),
+                )),
                 dsl_aliases: vec![],
             },
         )
@@ -505,7 +532,10 @@ fn schema_validate_with_origins_emits_string_literal_diagnostic_for_quoted_enum(
             AttributeType::StringEnum {
                 name: "TargetType".to_string(),
                 values: vec!["AWS_ACCOUNT".to_string()],
-                namespace: Some("awscc.sso.Assignment".to_string()),
+                identity: Some(crate::schema::string_enum_identity(
+                    "TargetType",
+                    Some("awscc.sso.Assignment"),
+                )),
                 dsl_aliases: vec![],
             },
         )
@@ -554,7 +584,10 @@ fn schema_validate_with_origins_leaves_valid_values_alone() {
             AttributeType::StringEnum {
                 name: "TargetType".to_string(),
                 values: vec!["AWS_ACCOUNT".to_string()],
-                namespace: Some("awscc.sso.Assignment".to_string()),
+                identity: Some(crate::schema::string_enum_identity(
+                    "TargetType",
+                    Some("awscc.sso.Assignment"),
+                )),
                 dsl_aliases: vec![],
             },
         )
@@ -591,13 +624,10 @@ fn schema_validate_with_origins_reshapes_custom_namespaced_type() {
     let schema = ResourceSchema::new("test.r.mode_holder").attribute(
         AttributeSchema::new(
             "mode",
-            AttributeType::Custom {
-                identity: Some(TypeIdentity::bare("Mode")),
+            AttributeType::CustomEnum {
+                identity: crate::schema::string_enum_identity("Mode", Some("test.r")),
                 base: Box::new(AttributeType::String),
-                pattern: None,
-                length: None,
                 validate: legacy_validator(validate_mode),
-                namespace: Some("test.r".to_string()),
                 to_dsl: None,
             },
         )
@@ -634,7 +664,7 @@ fn invalid_enum_error_without_namespace_uses_bare_variants() {
     let t = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     };
     let err = t
@@ -661,7 +691,10 @@ fn invalid_enum_error_preserves_bare_identifier_form() {
     let t = AttributeType::StringEnum {
         name: "TargetType".to_string(),
         values: vec!["AWS_ACCOUNT".to_string()],
-        namespace: Some("awscc.sso.Assignment".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "TargetType",
+            Some("awscc.sso.Assignment"),
+        )),
         dsl_aliases: vec![],
     };
     let input = "awscc.sso.Assignment.TargetType.NOT_REAL".to_string();
@@ -684,7 +717,10 @@ fn validate_string_enum_rejects_double_namespace() {
             "dedicated".to_string(),
             "host".to_string(),
         ],
-        namespace: Some("awscc.ec2.Vpc".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "InstanceTenancy",
+            Some("awscc.ec2.Vpc"),
+        )),
         dsl_aliases: vec![],
     };
     // Double-namespace must be rejected
@@ -1780,8 +1816,6 @@ fn validate_union_type() {
                 Err("Expected string".to_string())
             }
         }),
-        namespace: None,
-        to_dsl: None,
     };
     let type_b = AttributeType::Custom {
         identity: Some(TypeIdentity::bare("TypeB")),
@@ -1799,8 +1833,6 @@ fn validate_union_type() {
                 Err("Expected string".to_string())
             }
         }),
-        namespace: None,
-        to_dsl: None,
     };
 
     let union_type = AttributeType::Union(vec![type_a, type_b]);
@@ -1886,8 +1918,6 @@ fn union_type_name() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     let type_b = AttributeType::Custom {
         identity: Some(TypeIdentity::bare("TypeB")),
@@ -1895,8 +1925,6 @@ fn union_type_name() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
 
     let union_type = AttributeType::Union(vec![type_a, type_b]);
@@ -1911,8 +1939,6 @@ fn union_accepts_type_name() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     let type_b = AttributeType::Custom {
         identity: Some(TypeIdentity::bare("TypeB")),
@@ -1920,8 +1946,6 @@ fn union_accepts_type_name() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
 
     let union_type = AttributeType::Union(vec![type_a, type_b]);
@@ -2657,8 +2681,6 @@ fn make_custom(name: &str, base: AttributeType) -> AttributeType {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     }
 }
 
@@ -2669,8 +2691,6 @@ fn make_custom_anon_pattern(pattern: &str) -> AttributeType {
         pattern: Some(pattern.to_string()),
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     }
 }
 
@@ -2681,8 +2701,6 @@ fn make_custom_anon_len(min: u64, max: u64) -> AttributeType {
         pattern: None,
         length: Some((Some(min), Some(max))),
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     }
 }
 
@@ -2726,8 +2744,6 @@ fn assignable_rejects_same_kind_across_providers() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     let aws_region = provider_custom("aws");
     let gcp_region = provider_custom("gcp");
@@ -2748,8 +2764,6 @@ fn assignable_specific_arn_flows_into_generic_arn() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     let generic = mk(&[]);
     let role_arn = mk(&["iam", "Role"]);
@@ -2778,8 +2792,6 @@ fn assignable_identity_axis_directionality() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
 
     // provider: None source → Some sink rejected
@@ -2806,8 +2818,6 @@ fn assignable_narrow_to_anonymous_unconstrained_sink() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(account.is_assignable_to(&anon));
 }
@@ -2859,8 +2869,6 @@ fn assignable_union_source_requires_all_members_assignable() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     let both_ok = AttributeType::Union(vec![vpc.clone(), vpc.clone()]);
     assert!(both_ok.is_assignable_to(&vpc));
@@ -2885,8 +2893,6 @@ fn semantic_custom_assigns_to_anonymous_unconstrained_sink() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(vpc.is_assignable_to(&anon));
     // Reverse: anon has no proof it's a VpcId → NG.
@@ -2925,8 +2931,6 @@ fn make_custom_anon_pattern_and_len(
         pattern: pattern.map(str::to_string),
         length,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     }
 }
 
@@ -3036,8 +3040,6 @@ fn custom_carries_semantic_name_pattern_length() {
         pattern: Some("^vpc-[a-f0-9]+$".to_string()),
         length: Some((Some(8), Some(21))),
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     match t {
         AttributeType::Custom {
@@ -3062,8 +3064,6 @@ fn custom_type_name_anonymous_pattern_only() {
         pattern: Some("^foo$".to_string()),
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert_eq!(t.type_name(), "String(pattern)");
 }
@@ -3076,8 +3076,6 @@ fn custom_type_name_anonymous_length_only() {
         pattern: None,
         length: Some((Some(1), Some(64))),
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert_eq!(t.type_name(), "String(len: 1..=64)");
 }
@@ -3090,8 +3088,6 @@ fn custom_type_name_anonymous_pattern_and_length() {
         pattern: Some("^.*$".to_string()),
         length: Some((Some(1), Some(64))),
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert_eq!(t.type_name(), "String(pattern, len: 1..=64)");
 }
@@ -3440,7 +3436,10 @@ fn expected_includes_to_dsl_aliases_with_alias_flag() {
     let t = AttributeType::StringEnum {
         name: "VersioningStatus".to_string(),
         values: vec!["Enabled".to_string(), "Suspended".to_string()],
-        namespace: Some("aws.s3.Bucket".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "VersioningStatus",
+            Some("aws.s3.Bucket"),
+        )),
         dsl_aliases: vec![
             ("Enabled".to_string(), "enabled".to_string()),
             ("Suspended".to_string(), "suspended".to_string()),
@@ -3500,13 +3499,10 @@ fn custom_namespaced_string_literal_routes_validator_text_to_extra_message() {
     let schema = ResourceSchema::new("test.r.mode_holder").attribute(
         AttributeSchema::new(
             "mode",
-            AttributeType::Custom {
-                identity: Some(TypeIdentity::bare("Mode")),
+            AttributeType::CustomEnum {
+                identity: crate::schema::string_enum_identity("Mode", Some("test.r")),
                 base: Box::new(AttributeType::String),
-                pattern: None,
-                length: None,
                 validate: legacy_validator(validate_mode),
-                namespace: Some("test.r".to_string()),
                 to_dsl: None,
             },
         )
@@ -3612,7 +3608,7 @@ fn union_string_vs_string_enum_picks_enum_error_for_string_input() {
         AttributeType::StringEnum {
             name: "Mode".to_string(),
             values: vec!["fast".to_string(), "slow".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![],
         },
     ]);
@@ -3685,8 +3681,6 @@ fn union_string_vs_custom_picks_custom_error_for_string_input() {
             pattern: None,
             length: None,
             validate: legacy_validator(must_be_arn),
-            namespace: None,
-            to_dsl: None,
         },
     ]);
     let err = union_type
@@ -3753,8 +3747,6 @@ fn union_custom_with_int_base_picks_custom_error_for_int_input() {
             pattern: None,
             length: None,
             validate: legacy_validator(must_be_positive),
-            namespace: None,
-            to_dsl: None,
         },
         AttributeType::Bool,
     ]);
@@ -3829,8 +3821,6 @@ fn custom_validator_can_capture_external_state() {
                 got: other.type_name(),
             }),
         }),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(
         attr.validate(&Value::Concrete(ConcreteValue::String(
@@ -3878,8 +3868,6 @@ fn custom_validator_returns_structured_type_error_directly() {
                 got: other.type_name(),
             }),
         }),
-        namespace: None,
-        to_dsl: None,
     };
     let err = attr
         .validate(&Value::Concrete(ConcreteValue::String(
@@ -4009,10 +3997,8 @@ fn walk_custom_lookup_skips_value_unknown() {
         base: Box::new(AttributeType::String),
         validate: always_fail,
         identity: Some(TypeIdentity::bare("vpc_id")),
-        namespace: None,
         pattern: None,
         length: None,
-        to_dsl: None,
     };
 
     let mut errors = Vec::new();
@@ -4053,10 +4039,8 @@ fn union_walk_custom_lookup_succeeds_when_any_member_accepts() {
         base: Box::new(AttributeType::String),
         validate: validator(|_v: &Value| Ok(())),
         identity: Some(TypeIdentity::bare(name)),
-        namespace: None,
         pattern: None,
         length: None,
-        to_dsl: None,
     };
     let union = AttributeType::Union(vec![custom("ok_arm"), custom("fail_arm")]);
 
@@ -4094,10 +4078,8 @@ fn union_walk_custom_lookup_emits_smallest_error_set_when_all_fail() {
         base: Box::new(AttributeType::String),
         validate: validator(|_v: &Value| Ok(())),
         identity: Some(TypeIdentity::bare(name)),
-        namespace: None,
         pattern: None,
         length: None,
-        to_dsl: None,
     };
     let union = AttributeType::Union(vec![custom("a"), custom("b")]);
 
@@ -4191,7 +4173,10 @@ fn dsl_aliases_validator_accepts_dsl_spellings_only() {
             "BucketOwnerPreferred".to_string(),
             "BucketOwnerEnforced".to_string(),
         ],
-        namespace: Some("awscc.s3.Bucket".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "ObjectOwnership",
+            Some("awscc.s3.Bucket"),
+        )),
         dsl_aliases: vec![
             ("ObjectWriter".to_string(), "object_writer".to_string()),
             (
@@ -4277,7 +4262,10 @@ fn enum_without_dsl_aliases_accepts_api_spelling_as_before() {
             "REJECT".to_string(),
             "ALL".to_string(),
         ],
-        namespace: Some("aws.ec2.FlowLog".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "TrafficType",
+            Some("aws.ec2.FlowLog"),
+        )),
         dsl_aliases: vec![],
     };
     assert!(
@@ -4297,7 +4285,10 @@ fn dsl_aliases_diagnostic_tags_alias_entries_distinct_from_canonical() {
     let t = AttributeType::StringEnum {
         name: "VersioningStatus".to_string(),
         values: vec!["Enabled".to_string(), "Suspended".to_string()],
-        namespace: Some("aws.s3.Bucket".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "VersioningStatus",
+            Some("aws.s3.Bucket"),
+        )),
         dsl_aliases: vec![
             ("Enabled".to_string(), "enabled".to_string()),
             ("Suspended".to_string(), "suspended".to_string()),
@@ -4338,7 +4329,10 @@ fn dsl_aliases_empty_keeps_api_only_validation() {
     let t = AttributeType::StringEnum {
         name: "Status".to_string(),
         values: vec!["active".to_string(), "inactive".to_string()],
-        namespace: Some("test.r".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "Status",
+            Some("test.r"),
+        )),
         dsl_aliases: vec![],
     };
     assert!(
@@ -4379,7 +4373,10 @@ mod string_enum_binding_collision {
                 "Subnet".to_string(),
                 "VPC".to_string(),
             ],
-            namespace: Some("awscc.ec2.FlowLog".to_string()),
+            identity: Some(crate::schema::string_enum_identity(
+                "ResourceType",
+                Some("awscc.ec2.FlowLog"),
+            )),
             dsl_aliases: vec![
                 (
                     "NetworkInterface".to_string(),
@@ -4598,7 +4595,10 @@ fn condition_operator_map(value: AttributeType) -> AttributeType {
                 "string_not_equals".to_string(),
                 "arn_like".to_string(),
             ],
-            namespace: Some("aws.iam.ConditionOperator".to_string()),
+            identity: Some(crate::schema::string_enum_identity(
+                "ConditionOperator",
+                Some("aws.iam.ConditionOperator"),
+            )),
             dsl_aliases: vec![],
         }),
         value: Box::new(value),
@@ -4634,7 +4634,10 @@ fn validate_map_with_string_enum_key_accepts_dsl_alias_spelling() {
         key: Box::new(AttributeType::StringEnum {
             name: "IpProtocol".to_string(),
             values: vec!["tcp".to_string(), "-1".to_string()],
-            namespace: Some("awscc.ec2.SecurityGroup".to_string()),
+            identity: Some(crate::schema::string_enum_identity(
+                "IpProtocol",
+                Some("awscc.ec2.SecurityGroup"),
+            )),
             dsl_aliases: vec![("-1".to_string(), "all".to_string())],
         }),
         value: Box::new(AttributeType::String),
@@ -4683,7 +4686,10 @@ fn lift_state_string_enums_to_identifiers_fixes_awscc251() {
     let version_enum = AttributeType::StringEnum {
         name: "Version".to_string(),
         values: vec!["2012-10-17".to_string(), "2008-10-17".to_string()],
-        namespace: Some("aws.iam.PolicyDocument".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "Version",
+            Some("aws.iam.PolicyDocument"),
+        )),
         dsl_aliases: vec![
             ("2012-10-17".to_string(), "2012_10_17".to_string()),
             ("2008-10-17".to_string(), "2008_10_17".to_string()),
@@ -4692,7 +4698,10 @@ fn lift_state_string_enums_to_identifiers_fixes_awscc251() {
     let effect_enum = AttributeType::StringEnum {
         name: "Effect".to_string(),
         values: vec!["Allow".to_string(), "Deny".to_string()],
-        namespace: Some("aws.iam.PolicyDocument".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "Effect",
+            Some("aws.iam.PolicyDocument"),
+        )),
         dsl_aliases: vec![
             ("Allow".to_string(), "allow".to_string()),
             ("Deny".to_string(), "deny".to_string()),
@@ -4799,7 +4808,10 @@ fn lift_state_string_enums_is_idempotent_and_preserves_invalid() {
     let version_enum = AttributeType::StringEnum {
         name: "Version".to_string(),
         values: vec!["2012-10-17".to_string()],
-        namespace: Some("aws.iam.PolicyDocument".to_string()),
+        identity: Some(crate::schema::string_enum_identity(
+            "Version",
+            Some("aws.iam.PolicyDocument"),
+        )),
         dsl_aliases: vec![("2012-10-17".to_string(), "2012_10_17".to_string())],
     };
     let policy_struct = AttributeType::Struct {

--- a/carina-core/src/schema/type_identity.rs
+++ b/carina-core/src/schema/type_identity.rs
@@ -198,6 +198,28 @@ impl TypeIdentity {
         }
         true
     }
+
+    /// The dotted form of `provider + segments`, without the trailing
+    /// `kind`. Returns `None` when the identity has no provider axis
+    /// (a bare type — there is no namespace prefix to render).
+    ///
+    /// `aws.iam.Role.Arn` ⇒ `Some("aws.iam.Role")`.
+    /// `aws.Arn` ⇒ `Some("aws")`.
+    /// `Ipv4Cidr` ⇒ `None`.
+    ///
+    /// Replaces the load-bearing string lookups against the
+    /// pre-carina#3222 `Custom.namespace` / `StringEnum.namespace`
+    /// fields. Where the legacy field was `Some(prefix)`, the prefix
+    /// is the value this returns; where it was `None`, this returns
+    /// `None`.
+    pub fn dotted_prefix(&self) -> Option<String> {
+        let provider = self.provider.as_deref()?;
+        if self.segments.is_empty() {
+            Some(provider.to_string())
+        } else {
+            Some(format!("{}.{}", provider, self.segments.join(".")))
+        }
+    }
 }
 
 impl fmt::Display for TypeIdentity {
@@ -358,6 +380,21 @@ mod tests {
         let vpc_id = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "VpcId");
         assert!(!arn.assignable_to(&vpc_id));
         assert!(!vpc_id.assignable_to(&arn));
+    }
+
+    #[test]
+    fn dotted_prefix_drops_kind_and_handles_bare_identity() {
+        // Provider + segments + kind → `provider.segments...`.
+        let role_arn = TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn");
+        assert_eq!(role_arn.dotted_prefix().as_deref(), Some("aws.iam.Role"));
+
+        // Provider + kind only → just the provider.
+        let generic_arn = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn");
+        assert_eq!(generic_arn.dotted_prefix().as_deref(), Some("aws"));
+
+        // No provider axis → no prefix to render.
+        let bare = TypeIdentity::bare("Ipv4Cidr");
+        assert_eq!(bare.dotted_prefix(), None);
     }
 
     #[test]

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -2106,14 +2106,10 @@ mod tests {
                 pattern: None,
                 length: None,
                 validate: noop_validator(),
-                namespace: None,
-                to_dsl: None,
             }),
             pattern: None,
             length: None,
             validate: noop_validator(),
-            namespace: None,
-            to_dsl: None,
         };
         let schemas = schema_with_attr("name", kms_arn);
         let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
@@ -2161,8 +2157,6 @@ mod tests {
             pattern: None,
             length: None,
             validate: noop_validator(),
-            namespace: None,
-            to_dsl: None,
         };
         let schemas = schema_with_attr("name", aws_account_id);
         let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -667,7 +667,7 @@ pub fn resolve_enum_value(value: &Value, parts: &NamespacedEnumParts<'_>) -> Opt
 /// let status_enum = AttributeType::StringEnum {
 ///     name: "VersioningStatus".to_string(),
 ///     values: vec!["Enabled".to_string(), "Suspended".to_string()],
-///     namespace: Some("aws.s3.Bucket".to_string()),
+///     identity: Some(carina_core::schema::string_enum_identity("VersioningStatus", Some("aws.s3.Bucket"))),
 ///     dsl_aliases: vec![],
 /// };
 /// let config = AttributeType::Struct {
@@ -2022,7 +2022,10 @@ mod tests {
             AttributeType::StringEnum {
                 name: "VersioningStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Suspended".to_string()],
-                namespace: Some("aws.s3.Bucket".to_string()),
+                identity: Some(crate::schema::string_enum_identity(
+                    "VersioningStatus",
+                    Some("aws.s3.Bucket"),
+                )),
                 dsl_aliases: vec![],
             }
         }
@@ -2047,7 +2050,10 @@ mod tests {
             let aliased = AttributeType::StringEnum {
                 name: "Effect".to_string(),
                 values: vec!["Allow".to_string(), "Deny".to_string()],
-                namespace: Some("aws.iam.PolicyDocument".to_string()),
+                identity: Some(crate::schema::string_enum_identity(
+                    "Effect",
+                    Some("aws.iam.PolicyDocument"),
+                )),
                 dsl_aliases: vec![
                     ("Allow".to_string(), "allow".to_string()),
                     ("Deny".to_string(), "deny".to_string()),
@@ -2250,7 +2256,10 @@ mod tests {
             let aliased = AttributeType::StringEnum {
                 name: "VersioningStatus".to_string(),
                 values: vec!["Enabled".to_string()],
-                namespace: Some("aws.s3.Bucket".to_string()),
+                identity: Some(crate::schema::string_enum_identity(
+                    "VersioningStatus",
+                    Some("aws.s3.Bucket"),
+                )),
                 dsl_aliases: vec![("Enabled".to_string(), "enabled".to_string())],
             };
             let resolved = resolve_enum_value_recursive(&s("Enabled"), &aliased).unwrap();
@@ -2377,7 +2386,10 @@ mod tests {
         let version_enum = AttributeType::StringEnum {
             name: "Version".to_string(),
             values: vec!["2012-10-17".to_string()],
-            namespace: Some("aws.iam.PolicyDocument".to_string()),
+            identity: Some(crate::schema::string_enum_identity(
+                "Version",
+                Some("aws.iam.PolicyDocument"),
+            )),
             dsl_aliases: vec![("2012-10-17".to_string(), "2012_10_17".to_string())],
         };
         let policy_struct = AttributeType::Struct {
@@ -2447,7 +2459,10 @@ mod tests {
         let version_enum = AttributeType::StringEnum {
             name: "Version".to_string(),
             values: vec!["2012-10-17".to_string()],
-            namespace: Some("aws.iam.PolicyDocument".to_string()),
+            identity: Some(crate::schema::string_enum_identity(
+                "Version",
+                Some("aws.iam.PolicyDocument"),
+            )),
             dsl_aliases: vec![("2012-10-17".to_string(), "2012_10_17".to_string())],
         };
         let policy_struct = AttributeType::Struct {

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -604,6 +604,18 @@ fn attribute_type_to_type_expr(attr_type: &AttributeType) -> TypeExpr {
             None => TypeExpr::Simple(crate::parser::pascal_to_snake(&id.kind)),
         },
         AttributeType::Custom { base, .. } => attribute_type_to_type_expr(base),
+        // CustomEnum's identity is mandatory and always provider-
+        // scoped (an enum-shorthand needs the dotted prefix), so the
+        // bare-identity / fall-through-to-base arms above do not
+        // apply.
+        AttributeType::CustomEnum { identity, .. } => match &identity.provider {
+            Some(provider) => TypeExpr::SchemaType {
+                provider: provider.clone(),
+                path: identity.segments.join("."),
+                type_name: identity.kind.clone(),
+            },
+            None => TypeExpr::Simple(crate::parser::pascal_to_snake(&identity.kind)),
+        },
         AttributeType::StringEnum { .. } => TypeExpr::String,
         AttributeType::List { inner, .. } => {
             TypeExpr::List(Box::new(attribute_type_to_type_expr(inner)))
@@ -747,8 +759,6 @@ mod tests {
             length: None,
             base: Box::new(AttributeType::String),
             validate: legacy_validator(noop),
-            namespace: None,
-            to_dsl: None,
         }
     }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1399,8 +1399,6 @@ fn is_type_expr_compatible_unknown_rejects_custom_receiver() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Unknown,
@@ -1420,8 +1418,6 @@ fn is_type_expr_compatible_string_rejects_custom_with_semantic_name() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(
         !is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
@@ -1445,8 +1441,6 @@ fn is_type_expr_compatible_string_accepts_custom_without_semantic_name() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(
         is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
@@ -1472,8 +1466,6 @@ fn is_type_expr_compatible_string_rejects_union_containing_specific_custom() {
             length: None,
             base: Box::new(AttributeType::String),
             validate: legacy_validator(noop),
-            namespace: None,
-            to_dsl: None,
         },
     ]);
     assert!(
@@ -1497,8 +1489,6 @@ fn is_type_expr_compatible_string_rejects_union_of_only_specific_customs() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
-        namespace: None,
-        to_dsl: None,
     };
     let schema = AttributeType::Union(vec![mk("VpcId"), mk("SubnetId")]);
     assert!(
@@ -1517,7 +1507,7 @@ fn is_type_expr_compatible_string_accepts_union_of_only_strings() {
         AttributeType::StringEnum {
             name: "Mode".to_string(),
             values: vec!["A".to_string(), "B".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![],
         },
     ]);
@@ -1542,8 +1532,6 @@ fn is_type_expr_compatible_simple_vpcid_accepts_custom_vpcid() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
-        namespace: None,
-        to_dsl: None,
     };
     // Parser normalizes `: VpcId` to TypeExpr::Simple("vpc_id") (snake).
     let expr = TypeExpr::Simple("vpc_id".to_string());
@@ -1616,8 +1604,6 @@ fn attribute_param_ref_type_mismatch_detected() {
             pattern: None,
             length: None,
             validate: noop_validator(),
-            namespace: None,
-            to_dsl: None,
         },
     ));
 
@@ -1770,14 +1756,10 @@ fn type_compat_subtype_accepted() {
             pattern: None,
             length: None,
             validate: noop_validator(),
-            namespace: None,
-            to_dsl: None,
         }),
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("arn".to_string()),
@@ -1796,14 +1778,10 @@ fn type_compat_sibling_rejected() {
             pattern: None,
             length: None,
             validate: noop_validator(),
-            namespace: None,
-            to_dsl: None,
         }),
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("kms_key_arn".to_string()),
@@ -1822,14 +1800,10 @@ fn type_compat_resource_id_subtype() {
             pattern: None,
             length: None,
             validate: noop_validator(),
-            namespace: None,
-            to_dsl: None,
         }),
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("aws_resource_id".to_string()),
@@ -1848,14 +1822,10 @@ fn type_compat_resource_id_siblings_rejected() {
             pattern: None,
             length: None,
             validate: noop_validator(),
-            namespace: None,
-            to_dsl: None,
         }),
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("vpc_id".to_string()),
@@ -1871,8 +1841,6 @@ fn type_compat_exact_match() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("arn".to_string()),
@@ -2005,8 +1973,6 @@ fn type_compat_simple_rejected_when_union_has_string_shaped_peer() {
         pattern: None,
         length: None,
         validate: noop_validator(),
-        namespace: None,
-        to_dsl: None,
     };
     let with_custom = AttributeType::Union(vec![AttributeType::String, arn]);
     assert!(!is_type_expr_compatible_with_schema(
@@ -2018,7 +1984,7 @@ fn type_compat_simple_rejected_when_union_has_string_shaped_peer() {
         AttributeType::StringEnum {
             name: "Status".to_string(),
             values: vec!["enabled".to_string(), "disabled".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![],
         },
     ]);
@@ -2379,7 +2345,7 @@ fn enum_membership_violation_in_for_body_is_flagged() {
                 AttributeType::StringEnum {
                     name: "Mode".to_string(),
                     values: vec!["on".to_string(), "off".to_string()],
-                    namespace: None,
+                    identity: None,
                     dsl_aliases: vec![],
                 },
             )],
@@ -2414,7 +2380,7 @@ fn mode_schema() -> SchemaRegistry {
                 AttributeType::StringEnum {
                     name: "Mode".to_string(),
                     values: vec!["fast".to_string(), "slow".to_string()],
-                    namespace: Some("test.r".to_string()),
+                    identity: Some(crate::schema::string_enum_identity("Mode", Some("test.r"))),
                     dsl_aliases: vec![],
                 },
             )],

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -3245,8 +3245,6 @@ mod tests {
             pattern: None,
             length: None,
             validate: std::sync::Arc::new(|_| Ok(())),
-            namespace: None,
-            to_dsl: None,
         };
         let v = Value::Concrete(ConcreteValue::String("x".to_string()));
         let canon = canonicalize_with_type(v, &t);

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -179,7 +179,7 @@ fn list_string_enum_completions() {
     let list_enum = AttributeType::list(AttributeType::StringEnum {
         name: "Protocol".to_string(),
         values: vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string()],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     });
 
@@ -196,7 +196,7 @@ fn list_string_enum_completions() {
         &AttributeType::list(AttributeType::StringEnum {
             name: "Protocol".to_string(),
             values: vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![],
         }),
         None,
@@ -244,7 +244,7 @@ fn union_completions_include_member_types() {
             AttributeType::StringEnum {
                 name: "Mode".to_string(),
                 values: vec!["active".to_string(), "passive".to_string()],
-                namespace: None,
+                identity: None,
                 dsl_aliases: vec![],
             },
             AttributeType::Bool,
@@ -1089,7 +1089,7 @@ fn map_key_completions_from_string_enum_key_type() {
         AttributeType::StringEnum {
             name: "ConditionOperator".to_string(),
             values: condition_keys.clone(),
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![],
         },
         AttributeType::map(AttributeType::String),
@@ -2704,8 +2704,6 @@ fn exports_map_value_offers_matching_resource_refs() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
-        namespace: None,
-        to_dsl: None,
     };
     let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
@@ -2789,8 +2787,6 @@ fn exports_map_value_multiple_entries_returns_refs() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
-        namespace: None,
-        to_dsl: None,
     };
     let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
@@ -2847,8 +2843,6 @@ fn exports_map_value_includes_bindings_from_sibling_files() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
-        namespace: None,
-        to_dsl: None,
     };
     let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
@@ -2905,8 +2899,6 @@ fn custom_type_value_ref_includes_sibling_file_bindings() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
-        namespace: None,
-        to_dsl: None,
     };
     let account_schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id.clone()));
@@ -3006,8 +2998,6 @@ fn binding_dot_completion_resolves_sibling_file_binding() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
-        namespace: None,
-        to_dsl: None,
     };
     let account_schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id.clone()));
@@ -3242,8 +3232,6 @@ fn upstream_state_string_export_not_offered_to_specific_custom_receiver() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
-        namespace: None,
-        to_dsl: None,
     };
     let schema = ResourceSchema::new("ec2.SecurityGroup")
         .attribute(AttributeSchema::new("vpc_id", vpc_id_type));

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -151,7 +151,7 @@ pub(super) fn test_provider_with_enum_and_regions() -> CompletionProvider {
     let status_enum = AttributeType::StringEnum {
         name: "VersioningStatus".to_string(),
         values: vec!["Enabled".to_string(), "Suspended".to_string()],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     };
     let schema = ResourceSchema::new("s3.Bucket")
@@ -184,7 +184,7 @@ pub(super) fn test_provider_with_nameless_enum() -> CompletionProvider {
     let status_enum = AttributeType::StringEnum {
         name: "VersioningStatus".to_string(),
         values: vec!["Enabled".to_string(), "Suspended".to_string()],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     };
 
@@ -223,8 +223,6 @@ pub(super) fn test_provider_with_vpc_and_security_group() -> CompletionProvider 
         pattern: None,
         length: None,
         validate: legacy_validator(noop_validate),
-        namespace: None,
-        to_dsl: None,
     };
     let vpc = ResourceSchema::new("ec2.Vpc")
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
@@ -252,13 +250,14 @@ pub(super) fn test_provider_with_custom_semantic_attr() -> CompletionProvider {
         pattern: None,
         length: None,
         validate: legacy_validator(noop_validate),
-        namespace: None,
-        to_dsl: None,
     };
     let principal_type = AttributeType::StringEnum {
         name: "PrincipalType".to_string(),
         values: vec!["GROUP".to_string(), "USER".to_string()],
-        namespace: Some("awscc.sso.Assignment".to_string()),
+        identity: Some(carina_core::schema::string_enum_identity(
+            "PrincipalType",
+            Some("awscc.sso.Assignment"),
+        )),
         dsl_aliases: vec![],
     };
     let schema = ResourceSchema::new("sso.Assignment")

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -998,8 +998,6 @@ fn type_expr_to_attribute_type(
             pattern: None,
             length: None,
             validate: legacy_validator(noop),
-            namespace: None,
-            to_dsl: None,
         }),
         parser::TypeExpr::List(inner) => {
             type_expr_to_attribute_type(inner).map(AttributeType::list)

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -555,11 +555,16 @@ impl CompletionProvider {
             AttributeType::StringEnum {
                 name,
                 values,
-                namespace,
+                identity,
                 dsl_aliases,
             } => {
-                // Use explicit namespace if available, otherwise derive from resource_type
-                let effective_ns = namespace.as_deref().or(if !name.is_empty() {
+                // Derive the dotted prefix from the structured
+                // identity. Fall back to the surrounding resource
+                // type when the enum has no provider scope of its
+                // own — this matches the pre-#3222 `namespace`
+                // fallback rule for bare enums.
+                let id_prefix = identity.as_ref().and_then(|id| id.dotted_prefix());
+                let effective_ns = id_prefix.as_deref().or(if !name.is_empty() {
                     resource_type
                 } else {
                     None
@@ -1948,8 +1953,10 @@ fn return_type_fits(ret: builtins::BuiltinReturnType, attr_type: &AttributeType)
         // Custom types carry a semantic meaning (Cidr, AwsAccountId, Arn,
         // …) that built-ins don't declare. Not even `Any` fits — we need
         // a semantic return annotation before a built-in can be suggested
-        // here.
-        AttributeType::Custom { .. } => false,
+        // here. CustomEnum (carina#3222) is even more specific — the
+        // value must be a namespaced enum identifier, which no built-in
+        // can synthesise.
+        AttributeType::Custom { .. } | AttributeType::CustomEnum { .. } => false,
         // Float, Duration, and Struct attributes — no matching built-in today.
         AttributeType::Float => false,
         AttributeType::Duration => false,
@@ -2010,8 +2017,6 @@ fn parse_exports_type_text(text: &str) -> Option<AttributeType> {
                 pattern: None,
                 length: None,
                 validate: legacy_validator(noop_validate),
-                namespace: None,
-                to_dsl: None,
             })
         }
         _ => None,

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -553,7 +553,6 @@ impl DiagnosticEngine {
                                     carina_core::schema::AttributeType::Custom {
                                         identity,
                                         validate,
-                                        namespace,
                                         ..
                                     },
                                     value,
@@ -568,61 +567,77 @@ impl DiagnosticEngine {
                                     ) {
                                         None
                                     } else {
-                                        let bare = carina_core::schema::TypeIdentity::bare("");
-                                        let id_for_resolve = identity.as_ref().unwrap_or(&bare);
-                                        let kind = id_for_resolve.kind.as_str();
-                                        // `Custom.namespace.is_some()` marks enum-shaped Customs
-                                        // (`aws.Region`, `aws.AvailabilityZone.ZoneName`) whose
-                                        // values are written in the namespaced shorthand
-                                        // (`dedicated`, `us_east_1a`). Structurally-validated
-                                        // Customs (`aws.Arn`, `aws.ec2.Vpc.Id`) carry their own
-                                        // format and must reach the validator verbatim — see
-                                        // carina#3215 follow-up.
-                                        let resolved_value = if namespace.is_some() {
-                                            carina_core::utils::expand_enum_shorthand(
-                                                value,
-                                                id_for_resolve,
-                                            )
-                                        } else {
-                                            value.clone()
-                                        };
-
-                                        // Run the schema-attached validator first; for WASM-plugin
-                                        // types it is a noop, so fall back to the provider-context
-                                        // lookup which reaches the factory's `validate_custom_type`.
+                                        // Structural Custom: values reach the validator
+                                        // verbatim. CustomEnum has its own arm below — the
+                                        // pre-#3222 `namespace.is_some()` gate is now a
+                                        // type-level split.
                                         let lookup = carina_core::parser::provider_context_lookup(
                                             &self.provider_context,
                                         );
+                                        validate(value)
+                                            .err()
+                                            .or_else(|| {
+                                                identity
+                                                    .as_ref()
+                                                    .and_then(|id| lookup(id, value).err())
+                                            })
+                                            .map(|inner_err| inner_err.to_string())
+                                    }
+                                }
+                                (
+                                    carina_core::schema::AttributeType::CustomEnum {
+                                        identity,
+                                        validate,
+                                        ..
+                                    },
+                                    value,
+                                ) => {
+                                    if matches!(
+                                        value,
+                                        carina_core::resource::Value::Deferred(
+                                            carina_core::resource::DeferredValue::Unknown(_)
+                                        )
+                                    ) {
+                                        None
+                                    } else {
+                                        // Enum-shaped Custom: expand the namespaced
+                                        // shorthand before validating. The pre-#3222
+                                        // gate (`Custom.namespace.is_some()`) is
+                                        // structurally captured by this arm — values for
+                                        // structural `Custom` never reach here, so the
+                                        // carina#3216 class of mis-expansion is impossible.
+                                        let resolved_value =
+                                            carina_core::utils::expand_enum_shorthand(
+                                                value, identity,
+                                            );
+                                        let lookup = carina_core::parser::provider_context_lookup(
+                                            &self.provider_context,
+                                        );
+                                        let kind = identity.kind.as_str();
                                         validate(&resolved_value)
-                                        .err()
-                                        .or_else(|| {
-                                            identity
-                                                .as_ref()
-                                                .and_then(|id| lookup(id, &resolved_value).err())
-                                        })
-                                        .map(|inner_err| {
-                                        // For namespaced Custom types (enum-like), mirror
-                                        // the CLI shape-mismatch diagnostic when the user
-                                        // wrote a quoted string literal. The validator
-                                        // returns a structured `TypeError`; render it as a
-                                        // string when wrapping for the LSP message. See #2094.
-                                        let inner_msg = inner_err.to_string();
-                                        if namespace.is_some()
-                                            && matches!(value, Value::Concrete(ConcreteValue::String(s)) if !s.contains('.'))
-                                            && resource_quoted_string_attrs.contains(attr_name)
-                                        {
-                                            let typed = match value {
-                                                Value::Concrete(ConcreteValue::String(s)) => s.as_str(),
-                                                _ => "",
-                                            };
-                                            format!(
-                                                "'{}' ({}) expects an enum identifier, got a string literal \"{}\". {}",
-                                                attr_name, kind, typed, inner_msg
-                                            )
-                                        } else {
-                                            inner_msg
-                                        }
-                                    })
+                                            .err()
+                                            .or_else(|| lookup(identity, &resolved_value).err())
+                                            .map(|inner_err| {
+                                                // Mirror the CLI shape-mismatch
+                                                // diagnostic when the user wrote a
+                                                // quoted string literal on an enum-
+                                                // shaped Custom. See #2094.
+                                                let inner_msg = inner_err.to_string();
+                                                if matches!(value, Value::Concrete(ConcreteValue::String(s)) if !s.contains('.'))
+                                                    && resource_quoted_string_attrs.contains(attr_name)
+                                                {
+                                                    let typed = match value {
+                                                        Value::Concrete(ConcreteValue::String(s)) => s.as_str(),
+                                                        _ => "",
+                                                    };
+                                                    format!(
+                                                        "'{}' ({}) expects an enum identifier, got a string literal \"{}\". {}",
+                                                        attr_name, kind, typed, inner_msg
+                                                    )
+                                                } else {
+                                                    inner_msg
+                                                }
+                                            })
                                     }
                                 }
                                 // String type - check for bare resource binding

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -267,7 +267,7 @@ fn list_item_type_validation() {
     let list_enum = AttributeType::list(AttributeType::StringEnum {
         name: "Protocol".to_string(),
         values: vec!["tcp".to_string(), "udp".to_string()],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     });
 
@@ -353,7 +353,7 @@ fn union_static_value_validated() {
                 AttributeType::StringEnum {
                     name: "Mode".to_string(),
                     values: vec!["active".to_string(), "passive".to_string()],
-                    namespace: None,
+                    identity: None,
                     dsl_aliases: vec![],
                 },
                 AttributeType::Int,
@@ -406,7 +406,7 @@ fn union_valid_static_value_no_warning() {
                 AttributeType::StringEnum {
                     name: "Mode".to_string(),
                     values: vec!["active".to_string(), "passive".to_string()],
-                    namespace: None,
+                    identity: None,
                     dsl_aliases: vec![],
                 },
                 AttributeType::Int,
@@ -452,7 +452,7 @@ fn union_valid_int_value_no_warning() {
                 AttributeType::StringEnum {
                     name: "Mode".to_string(),
                     values: vec!["active".to_string(), "passive".to_string()],
-                    namespace: None,
+                    identity: None,
                     dsl_aliases: vec![],
                 },
                 AttributeType::Int,
@@ -1303,13 +1303,10 @@ fn resource_ref_type_check_helper_regression() {
         .attribute(AttributeSchema::new("name", AttributeType::String))
         .attribute(AttributeSchema::new(
             "my_id",
-            AttributeType::Custom {
-                identity: Some(carina_core::schema::TypeIdentity::bare("MyId")),
+            AttributeType::CustomEnum {
+                identity: carina_core::schema::string_enum_identity("MyId", Some("test")),
                 base: Box::new(AttributeType::String),
-                pattern: None,
-                length: None,
                 validate: legacy_validator(dummy_validate),
-                namespace: Some("test".to_string()),
                 to_dsl: None,
             },
         ));
@@ -1325,19 +1322,16 @@ fn resource_ref_type_check_helper_regression() {
             AttributeType::StringEnum {
                 name: "Status".to_string(),
                 values: vec!["active".to_string(), "inactive".to_string()],
-                namespace: None,
+                identity: None,
                 dsl_aliases: vec![],
             },
         ))
         .attribute(AttributeSchema::new(
             "custom_attr",
-            AttributeType::Custom {
-                identity: Some(carina_core::schema::TypeIdentity::bare("MyId")),
+            AttributeType::CustomEnum {
+                identity: carina_core::schema::string_enum_identity("MyId", Some("test")),
                 base: Box::new(AttributeType::String),
-                pattern: None,
-                length: None,
                 validate: legacy_validator(dummy_validate),
-                namespace: Some("test".to_string()),
                 to_dsl: None,
             },
         ));
@@ -1684,7 +1678,7 @@ fn map_key_validation_warns_on_invalid_key() {
         AttributeType::StringEnum {
             name: "ConditionOperator".to_string(),
             values: vec!["string_equals".to_string(), "string_like".to_string()],
-            namespace: None,
+            identity: None,
             dsl_aliases: vec![],
         },
         AttributeType::map(AttributeType::String),
@@ -1773,13 +1767,15 @@ fn distinct_semantic_customs_are_rejected() {
         .attribute(AttributeSchema::new(
             "account_id",
             AttributeType::Custom {
-                identity: Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
+                identity: Some(carina_core::schema::TypeIdentity::new(
+                    Some("aws"),
+                    Vec::<String>::new(),
+                    "AwsAccountId",
+                )),
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
                 validate: legacy_validator(validate_account_id),
-                namespace: Some("aws".to_string()),
-                to_dsl: None,
             },
         ));
 
@@ -1787,13 +1783,15 @@ fn distinct_semantic_customs_are_rejected() {
     let target_schema = ResourceSchema::new("sso.Assignment").attribute(AttributeSchema::new(
         "target_id",
         AttributeType::Custom {
-            identity: Some(carina_core::schema::TypeIdentity::bare("TargetId")),
+            identity: Some(carina_core::schema::TypeIdentity::new(
+                Some("awscc"),
+                Vec::<String>::new(),
+                "TargetId",
+            )),
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
             validate: legacy_validator(validate_target_id),
-            namespace: Some("awscc".to_string()),
-            to_dsl: None,
         },
     ));
 
@@ -1846,8 +1844,6 @@ fn exports_cross_file_ref_no_false_positive() {
             )),
             _ => Err("expected string".to_string()),
         }),
-        namespace: None,
-        to_dsl: None,
     };
     let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", aws_account_id_type));

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -77,7 +77,7 @@ pub(super) fn test_engine_with_enum_attr() -> DiagnosticEngine {
     let mode_enum = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     };
 
@@ -104,7 +104,10 @@ pub(super) fn test_engine_with_namespaced_enum_attr() -> DiagnosticEngine {
     let mode_enum = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
-        namespace: Some("test.r".to_string()),
+        identity: Some(carina_core::schema::string_enum_identity(
+            "Mode",
+            Some("test.r"),
+        )),
         dsl_aliases: vec![],
     };
 
@@ -138,13 +141,10 @@ pub(super) fn test_engine_with_custom_namespaced_attr() -> DiagnosticEngine {
         }
     }
 
-    let mode_custom = AttributeType::Custom {
-        identity: Some(carina_core::schema::TypeIdentity::bare("Mode")),
+    let mode_custom = AttributeType::CustomEnum {
+        identity: carina_core::schema::string_enum_identity("Mode", Some("test.r")),
         base: Box::new(AttributeType::String),
-        pattern: None,
-        length: None,
         validate: legacy_validator(validate_mode),
-        namespace: Some("test.r".to_string()),
         to_dsl: None,
     };
 

--- a/carina-lsp/tests/e2e_typecheck.rs
+++ b/carina-lsp/tests/e2e_typecheck.rs
@@ -42,7 +42,10 @@ fn enum_schemas() -> SchemaRegistry {
     let mode = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
-        namespace: Some("test.r".to_string()),
+        identity: Some(carina_core::schema::string_enum_identity(
+            "Mode",
+            Some("test.r"),
+        )),
         dsl_aliases: vec![],
     };
     single_schema_map(
@@ -135,13 +138,10 @@ fn region_schemas() -> SchemaRegistry {
         s.replace('-', "_")
     }
 
-    let region_custom = AttributeType::Custom {
-        identity: Some(carina_core::schema::TypeIdentity::bare("Region")),
+    let region_custom = AttributeType::CustomEnum {
+        identity: carina_core::schema::string_enum_identity("Region", Some("test")),
         base: Box::new(AttributeType::String),
-        pattern: None,
-        length: None,
         validate: legacy_validator(validate_region),
-        namespace: Some("test".to_string()),
         to_dsl: Some(to_dsl),
     };
 

--- a/carina-lsp/tests/lsp_enum_code_action.rs
+++ b/carina-lsp/tests/lsp_enum_code_action.rs
@@ -25,7 +25,10 @@ fn versioning_schema() -> SchemaRegistry {
     let versioning = AttributeType::StringEnum {
         name: "VersioningStatus".to_string(),
         values: vec!["Enabled".to_string(), "Suspended".to_string()],
-        namespace: Some("aws.s3.Bucket".to_string()),
+        identity: Some(carina_core::schema::string_enum_identity(
+            "VersioningStatus",
+            Some("aws.s3.Bucket"),
+        )),
         dsl_aliases: vec![
             ("Enabled".to_string(), "enabled".to_string()),
             ("Suspended".to_string(), "suspended".to_string()),
@@ -172,7 +175,7 @@ fn bare_mode_schema() -> SchemaRegistry {
     let mode = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
-        namespace: None,
+        identity: None,
         dsl_aliases: vec![],
     };
     let mut schemas = SchemaRegistry::new();

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -712,7 +712,16 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
         } => CoreAttributeType::StringEnum {
             name: name.clone(),
             values: values.clone(),
-            namespace: namespace.clone(),
+            // Lift the wire-form flat dotted prefix into the
+            // structured `TypeIdentity` the core schema now carries
+            // (carina#3222). The pre-#3222 core form mirrored the
+            // wire form one-to-one; with the split, the wire form
+            // remains flat while the core form is structural — the
+            // boundary cost lives here.
+            identity: namespace
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|ns| carina_core::schema::string_enum_identity(name, Some(ns))),
             dsl_aliases: dsl_aliases.clone(),
         },
         proto::AttributeType::List { inner, ordered } => CoreAttributeType::List {
@@ -730,11 +739,7 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
         proto::AttributeType::Union { members } => {
             CoreAttributeType::Union(members.iter().map(proto_attr_type_to_core).collect())
         }
-        proto::AttributeType::Custom {
-            name,
-            base,
-            namespace,
-        } => CoreAttributeType::Custom {
+        proto::AttributeType::Custom { name, base } => CoreAttributeType::Custom {
             identity: if name.is_empty() {
                 None
             } else {
@@ -744,7 +749,21 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             pattern: None,
             length: None,
             validate: noop_validator(), // Validation is handled via ProviderContext.validators
-            namespace: namespace.clone(),
+        },
+        proto::AttributeType::CustomEnum {
+            name,
+            base,
+            namespace,
+        } => CoreAttributeType::CustomEnum {
+            // CustomEnum requires a populated identity (the
+            // shorthand expansion needs the dotted prefix);
+            // `string_enum_identity` is the inverse of
+            // `TypeIdentity::dotted_prefix` and recovers the
+            // structured form from the wire's flat `namespace + name`
+            // shape.
+            identity: carina_core::schema::string_enum_identity(name, Some(namespace.as_str())),
+            base: Box::new(proto_attr_type_to_core(base)),
+            validate: noop_validator(), // Validation is handled via ProviderContext.validators
             to_dsl: None,
         },
     }

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -367,6 +367,15 @@ pub enum AttributeType {
         /// DSL namespace prefix for enum validation (e.g., `"awscc"`).
         /// When present, values may be written as
         /// `{namespace}.{name}.{value}` in the DSL.
+        ///
+        /// Carried as a flat dotted string over the JSON wire form;
+        /// the host reconstructs the structured
+        /// [`carina_core::schema::TypeIdentity`] via
+        /// `string_enum_identity(name, namespace.as_deref())` when
+        /// projecting back into the core schema. Pre-#3222 the core
+        /// `StringEnum` carried the same flat string; with #3222 the
+        /// core form carries a structured identity but the wire form
+        /// stays flat — splitting the boundary cost in one place.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         namespace: Option<String>,
         /// API-canonical -> DSL spelling pairs, for every value where the
@@ -400,16 +409,32 @@ pub enum AttributeType {
     Union {
         members: Vec<AttributeType>,
     },
-    /// Custom type with a name and base type. The validation function is
-    /// resolved on the host side; the protocol only carries the type name
-    /// and underlying base type.
+    /// Structurally-validated custom type: values carry their own
+    /// format (`arn:aws:s3:::bucket-name`, `vpc-12345678`) and reach
+    /// the host-side validator verbatim. Sibling of
+    /// [`AttributeType::CustomEnum`].
+    ///
+    /// The pre-#3222 wire shape carried a single `Custom` variant
+    /// with a runtime `namespace: Option<String>` flag distinguishing
+    /// enum-shaped vs structural; the variant split makes that a
+    /// type-level fact (see the corresponding split in
+    /// `carina_core::schema::AttributeType`).
     #[serde(rename = "custom")]
     Custom {
         name: String,
         base: Box<AttributeType>,
-        /// Optional namespace for enum-style validation
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        namespace: Option<String>,
+    },
+    /// Enum-shaped custom type: values are written as namespaced
+    /// shorthand and expanded host-side via `expand_enum_shorthand`
+    /// before the validator runs. `namespace` is the dotted prefix
+    /// (`"aws"`, `"awscc.s3.Bucket"`) — the host reconstructs the
+    /// structured [`carina_core::schema::TypeIdentity`] from
+    /// `(name, namespace)`.
+    #[serde(rename = "custom_enum")]
+    CustomEnum {
+        name: String,
+        base: Box<AttributeType>,
+        namespace: String,
     },
 }
 


### PR DESCRIPTION
## Summary

Implementation of carina#3222 per the design landed in carina#3226 (Option A — `CustomEnum` variant).

Removes `Custom.namespace: Option<String>` and `StringEnum.namespace: Option<String>` — the last surviving piece of the pre-`TypeIdentity` flat-string representation. The field's content was fully derivable from the structured identity; its *presence* (the enum-marker the S2.5a hotfix carina#3216 leans on) is now a type-level fact via a new `AttributeType::CustomEnum` variant.

The carina#3216 class of mis-expansion (`aws.Arn` values being silently rewritten into `aws.Arn.arn:aws:s3:...`) becomes compile-time impossible: only `CustomEnum`-typed sinks can reach `expand_enum_shorthand`; structurally-validated `Custom`s no longer have the runtime gate that could be flipped wrong.

## Changes

### Core schema (`carina-core/src/schema/mod.rs`)
- `AttributeType::Custom`: drops `namespace`, `to_dsl` fields. Remaining fields (`identity`, `base`, `pattern`, `length`, `validate`) describe a structurally-validated Custom — values carry their own format (ARN, VpcId, ipv4 CIDR, …) and reach the validator verbatim.
- `AttributeType::CustomEnum` (new): `identity` (mandatory — namespaced shorthand needs a dotted prefix), `base`, `validate`, `to_dsl`. The dispatcher routes here through a new `validate_custom_enum` that runs `expand_enum_shorthand` before the validator.
- `AttributeType::StringEnum`: `namespace: Option<String>` replaced by `identity: Option<TypeIdentity>`. The few call sites that still need a flat dotted prefix derive it via `TypeIdentity::dotted_prefix()` on demand.
- New `TypeIdentity::dotted_prefix()`: the inverse direction of `Display` — `provider + segments` without the trailing `kind`. Returns `None` for bare identities.
- `string_enum_identity(name, namespace)` is made `pub` so provider repositories and the protocol→core converter can lift the legacy `(name, dotted_namespace)` shape into the structured identity.
- Pattern-match sites (`walk_custom_lookup`, `type_name`, `attribute_type_to_type_expr`, the diagnostic reshape helper) grow a structural `CustomEnum` arm.

### Wire shape (`carina-provider-protocol/src/types.rs`)
- `Custom { name, base, namespace }` → `Custom { name, base }`.
- New `CustomEnum { name, base, namespace }` carrying the dotted prefix as a flat string over the JSON wire form.
- `StringEnum.namespace` stays on the wire as a flat string. The host lifts it into the structured identity at the boundary (`carina-plugin-host/src/wasm_convert.rs::proto_attr_type_to_core`) — so the boundary cost is concentrated in one converter rather than spread across the JSON contract.

### LSP (`carina-lsp`)
- `completion/values.rs`: `StringEnum` effective prefix is `identity.dotted_prefix()`, falling back to the surrounding resource type for bare enums (the pre-#3222 fallback rule).
- `diagnostics/mod.rs`: the `validate_custom` mirror splits into two arms — `Custom` runs the validator on the raw value; `CustomEnum` expands first. The shape-mismatch diagnostic reshape lives with the enum-shaped arm.

### Tests
~140 construction sites across `carina-core`, `carina-lsp`, and `carina-cli` integration tests migrated. Three patterns:

- `Custom { namespace: None, to_dsl: None, .. }` → drop both fields.
- `Custom { namespace: Some(\"...\"), to_dsl: ..., .. }` → migrate to `CustomEnum { identity, base, validate, to_dsl }`.
- `StringEnum { namespace: Some(\"...\"), .. }` → `StringEnum { identity: Some(string_enum_identity(name, Some(\"...\"))), .. }`.

## Verify

Run from the worktree at `bf86a0e9`:

- `cargo nextest run --workspace --all-features`: **3526/3526 pass**.
- `cargo test --workspace --doc`: pass.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo build --release --workspace`: clean.
- `scripts/check-*.sh`: all pass.

## Provider follow-ups

Provider repositories (carina-provider-aws / carina-provider-awscc) cannot compile against this `carina-core` until their `Custom { namespace: ... }` sites are migrated. Two follow-up PRs land immediately after this merges; each bumps the core pin and walks the per-repo construction sites:

- carina-provider-aws: 71 sites in `carina-aws-types/src/lib.rs` and the provider crate's `factory.rs` / `convert.rs` / `schemas/types.rs` / `main.rs`.
- carina-provider-awscc: 145 sites including the `src/bin/codegen.rs` template that regenerates the per-resource schema files.

Closes #3222. Sub-issue of carina-rs/carina#2807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)