### PR TITLE
carina-cli: test the KMS decryptor against an in-process AWS mock (winterbaume)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +36,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -792,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -858,6 +882,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower-lsp",
+ "winterbaume-core",
+ "winterbaume-kms",
 ]
 
 [[package]]
@@ -1457,7 +1483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1468,7 +1494,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1479,7 +1505,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1696,7 +1732,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1791,7 +1827,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2022,6 +2058,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,7 +2086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2459,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -2935,6 +2981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,7 +3045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3011,6 +3063,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -3125,6 +3187,18 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3272,8 +3346,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3283,7 +3367,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3296,12 +3390,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3343,6 +3446,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -3915,7 +4031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4520,6 +4636,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -5563,6 +5689,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "winterbaume-kms"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad02ac483c8a27015ef8857d6d859adbeee4c57a7c45a6e2043a1411978d71bf"
+dependencies = [
+ "aes-gcm",
+ "base64",
+ "bytes",
+ "chrono",
+ "hmac",
+ "http 1.4.0",
+ "rand 0.9.4",
+ "rcgen",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "winterbaume-core",
+]
+
+[[package]]
 name = "winterbaume-s3"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5812,6 +5962,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -60,3 +60,9 @@ portable-pty = "0.8"
 regex-lite = "0.1"
 tempfile = "3"
 tower-lsp = "0.20"
+# In-process AWS service emulator: the KMS decryptor's integration test
+# injects a winterbaume-backed KMS client and exercises the real
+# base64 → KMS:Decrypt → UTF-8 path with no real AWS and no external
+# process (#3227, follow-up to #3206).
+winterbaume-core = "0.2"
+winterbaume-kms = "0.2"

--- a/carina-cli/src/kms.rs
+++ b/carina-cli/src/kms.rs
@@ -1,0 +1,85 @@
+//! AWS KMS decryptor for the DSL `decrypt(...)` built-in.
+//!
+//! The parser's `ProviderContext.decryptor` is an
+//! `Option<Box<dyn Fn(&str, Option<&str>) -> Result<String, String> + Send + Sync>>`.
+//! `create_provider_context` in `carina-cli`'s `main` builds and
+//! installs the production decryptor; this module owns the per-call
+//! logic (base64 decode → `KMS:Decrypt` → response unwrap → UTF-8
+//! decode) so a test can drive it with a mock `aws_sdk_kms::Client`
+//! (see `carina-cli/tests/kms_decryptor_winterbaume.rs`, #3227).
+//!
+//! Two entry points share [`decrypt_one`]:
+//!
+//! - [`build_kms_decryptor`] (test seam): takes an already-built KMS
+//!   client and returns a [`DecryptorFn`] that wraps it. Used by the
+//!   integration test against `winterbaume`.
+//! - `create_provider_context` in `main.rs` (production): keeps the
+//!   `static OnceCell<aws_sdk_kms::Client>` it has always had so the
+//!   real binary still loads SDK config lazily on the first
+//!   `decrypt()` call. Its closure resolves the cell and then calls
+//!   [`decrypt_one`] with the result.
+
+use aws_sdk_kms::Client;
+use aws_sdk_kms::primitives::Blob;
+use base64::Engine;
+use carina_core::parser::DecryptorFn;
+
+/// Decrypt a single base64-encoded ciphertext using the given client.
+///
+/// All errors are prefixed with `decrypt():` so users see which DSL
+/// built-in failed.
+// Note: `pub` (not `pub(crate)`) because `carina-cli` exposes both a
+// library (`lib.rs`) and a binary (`main.rs`), which cargo treats as
+// distinct crates — the binary's `main.rs` imports this as an external
+// crate (`carina_cli::kms::decrypt_one`), so `pub(crate)` would hide it.
+pub async fn decrypt_one(
+    client: &Client,
+    ciphertext: &str,
+    key: Option<&str>,
+) -> Result<String, String> {
+    let blob = base64::engine::general_purpose::STANDARD
+        .decode(ciphertext)
+        .map_err(|e| format!("decrypt(): invalid base64 ciphertext: {e}"))?;
+
+    let mut req = client.decrypt().ciphertext_blob(Blob::new(blob));
+    if let Some(k) = key {
+        req = req.key_id(k);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("decrypt(): KMS decrypt failed: {e}"))?;
+
+    let plaintext = resp
+        .plaintext()
+        .ok_or_else(|| "decrypt(): KMS response contained no plaintext".to_string())?;
+
+    String::from_utf8(plaintext.as_ref().to_vec())
+        .map_err(|e| format!("decrypt(): decrypted value is not valid UTF-8: {e}"))
+}
+
+/// Build a [`DecryptorFn`] backed by the given KMS client.
+///
+/// The returned closure uses `tokio::task::block_in_place` +
+/// `Handle::current().block_on(...)` so it can be invoked
+/// synchronously from inside parser evaluation.
+///
+/// # Panics
+///
+/// The returned closure panics if invoked outside a multi-threaded
+/// tokio runtime: `tokio::task::block_in_place` panics on the
+/// `current_thread` runtime and `Handle::current()` panics off any
+/// runtime. Production calls go through `#[tokio::main]` (multi-thread
+/// by default); tests must use `#[tokio::test(flavor = "multi_thread")]`.
+pub fn build_kms_decryptor(client: Client) -> DecryptorFn {
+    Box::new(move |ciphertext, key| {
+        let ciphertext = ciphertext.to_string();
+        let key = key.map(|k| k.to_string());
+        let client = client.clone();
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(async move { decrypt_one(&client, &ciphertext, key.as_deref()).await })
+        })
+    })
+}

--- a/carina-cli/src/lib.rs
+++ b/carina-cli/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cursor;
 pub mod display;
 pub mod error;
 pub mod fixture_plan;
+pub mod kms;
 pub mod signal;
 pub mod wiring;
 

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -4,7 +4,6 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{CompleteEnv, Shell, generate};
 use colored::Colorize;
 
-use base64::Engine;
 use carina_cli::DetailLevel;
 use carina_cli::commands;
 use carina_cli::commands::apply::{run_apply, run_apply_from_plan};
@@ -250,8 +249,14 @@ enum SkillsCommands {
 /// Create the parser configuration with AWS KMS decryptor.
 ///
 /// Uses the tokio runtime to call KMS synchronously from within the parse-time
-/// builtin evaluation. AWS credentials are loaded from the default chain
-/// (environment variables, profiles, instance metadata, etc.).
+/// builtin evaluation. AWS credentials are loaded lazily on the first
+/// `decrypt()` call from the default chain (environment variables, profiles,
+/// instance metadata, etc.) and cached in a process-wide `OnceCell` so the
+/// SDK is never initialised for commands that do not use `decrypt()`.
+///
+/// The per-call body (base64 → `KMS:Decrypt` → UTF-8) lives in
+/// [`carina_cli::kms::decrypt_one`] so an integration test can drive it
+/// with a mock client (#3227).
 fn create_provider_context() -> carina_core::parser::ProviderContext {
     static KMS_CLIENT: tokio::sync::OnceCell<aws_sdk_kms::Client> =
         tokio::sync::OnceCell::const_new();
@@ -260,7 +265,6 @@ fn create_provider_context() -> carina_core::parser::ProviderContext {
         decryptor: Some(Box::new(|ciphertext, key| {
             let ciphertext = ciphertext.to_string();
             let key = key.map(|k| k.to_string());
-
             tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(async {
                     let client = KMS_CLIENT
@@ -271,29 +275,7 @@ fn create_provider_context() -> carina_core::parser::ProviderContext {
                             aws_sdk_kms::Client::new(&config)
                         })
                         .await;
-
-                    let blob = base64::engine::general_purpose::STANDARD
-                        .decode(&ciphertext)
-                        .map_err(|e| format!("decrypt(): invalid base64 ciphertext: {e}"))?;
-
-                    let mut req = client
-                        .decrypt()
-                        .ciphertext_blob(aws_sdk_kms::primitives::Blob::new(blob));
-                    if let Some(k) = key {
-                        req = req.key_id(k);
-                    }
-
-                    let resp = req
-                        .send()
-                        .await
-                        .map_err(|e| format!("decrypt(): KMS decrypt failed: {e}"))?;
-
-                    let plaintext = resp.plaintext().ok_or_else(|| {
-                        "decrypt(): KMS response contained no plaintext".to_string()
-                    })?;
-
-                    String::from_utf8(plaintext.as_ref().to_vec())
-                        .map_err(|e| format!("decrypt(): decrypted value is not valid UTF-8: {e}"))
+                    carina_cli::kms::decrypt_one(client, &ciphertext, key.as_deref()).await
                 })
             })
         })),

--- a/carina-cli/tests/kms_decryptor_winterbaume.rs
+++ b/carina-cli/tests/kms_decryptor_winterbaume.rs
@@ -1,0 +1,122 @@
+//! Integration tests for `carina-cli`'s KMS decryptor against an
+//! in-process AWS mock (`winterbaume`, library mode).
+//!
+//! The decryptor is the closure `create_provider_context` builds for
+//! `ProviderContext.decryptor` — it powers the DSL `decrypt("…")`
+//! built-in by calling AWS KMS. `carina-core`'s
+//! `parse_decrypt_uses_config_decryptor` already proves the parser
+//! invokes whatever decryptor it is given, but the decryptor *that
+//! carina-cli actually ships* (the one that talks to KMS) has had no
+//! coverage. These tests fill that gap by injecting a winterbaume-backed
+//! `aws_sdk_kms::Client` into `build_kms_decryptor` and exercising the
+//! real base64 → `KMS:Decrypt` → UTF-8 path with no real AWS and no
+//! external process (#3227).
+//!
+//! Scope note: `decrypt_one`'s `Some(key)` branch (the optional
+//! `KeyId` argument) is not covered here. Real AWS validates `KeyId`
+//! against the ciphertext header and returns `IncorrectKeyException`
+//! on mismatch (per the `KMS:Decrypt` API docs), but `winterbaume-kms`
+//! 0.2 ignores the request-side `KeyId` and resolves the key from the
+//! ciphertext header alone — so a key-mismatch test would silently
+//! succeed and a key-match test would also succeed if the branch were
+//! reduced to a no-op. Neither shape is evidence. Tracked in
+//! winterbaume issue moriyoshi/winterbaume#5.
+
+use aws_sdk_kms::Client;
+use aws_sdk_kms::primitives::Blob;
+use base64::Engine;
+use carina_cli::kms::build_kms_decryptor;
+use winterbaume_core::MockAws;
+use winterbaume_kms::KmsService;
+
+const TEST_REGION: &str = "us-east-1";
+const TEST_PLAINTEXT: &[u8] = b"hello carina kms decryptor";
+
+/// Build an `aws_sdk_kms::Client` wired to a fresh in-process winterbaume
+/// KMS service. Each call gets an isolated mock with empty state.
+async fn mock_kms_client() -> Client {
+    let mock = MockAws::builder().with_service(KmsService::new()).build();
+    let sdk_config = mock.sdk_config(TEST_REGION).await;
+    Client::new(&sdk_config)
+}
+
+/// Create a key in the mock and encrypt `plaintext` with it, returning
+/// the base64-encoded ciphertext blob the way carina's `decrypt(...)`
+/// built-in receives it from the user (`.crn` literals are already
+/// base64-encoded).
+async fn seed_ciphertext_base64(client: &Client, plaintext: &[u8]) -> String {
+    let key = client
+        .create_key()
+        .send()
+        .await
+        .expect("create_key should succeed");
+    let key_id = key.key_metadata().unwrap().key_id();
+
+    let resp = client
+        .encrypt()
+        .key_id(key_id)
+        .plaintext(Blob::new(plaintext.to_vec()))
+        .send()
+        .await
+        .expect("encrypt should succeed");
+    let ciphertext = resp
+        .ciphertext_blob()
+        .expect("encrypt response should carry a ciphertext blob");
+
+    base64::engine::general_purpose::STANDARD.encode(ciphertext.as_ref())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decryptor_round_trips_base64_ciphertext_through_kms() {
+    let client = mock_kms_client().await;
+    let ciphertext_b64 = seed_ciphertext_base64(&client, TEST_PLAINTEXT).await;
+
+    let decryptor = build_kms_decryptor(client);
+
+    let plaintext = decryptor(&ciphertext_b64, None).expect("decryptor must succeed");
+    assert_eq!(
+        plaintext.as_bytes(),
+        TEST_PLAINTEXT,
+        "decryptor must return the original plaintext bytes",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decryptor_rejects_invalid_base64_with_named_error() {
+    // Base64 decoding happens before any KMS call, so an invalid blob
+    // surfaces as a base64-flavoured error string. This asserts the
+    // error shape (`decrypt():` prefix + `base64` mention); it does not
+    // independently observe that the KMS client was never invoked —
+    // that follows from `decrypt_one`'s straight-line code (decode → send).
+    let client = mock_kms_client().await;
+    let decryptor = build_kms_decryptor(client);
+
+    let err = decryptor("not%%%base64!", None)
+        .expect_err("invalid base64 must surface as a decryptor error");
+    assert!(
+        err.starts_with("decrypt():"),
+        "error message must be prefixed with the `decrypt():` builtin label, got: {err}",
+    );
+    assert!(
+        err.contains("base64"),
+        "error message must mention base64, got: {err}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decryptor_surfaces_kms_failure_for_valid_base64_garbage() {
+    // A blob that is syntactically valid base64 but is not a real KMS
+    // ciphertext reaches the KMS:Decrypt call and is rejected there.
+    // This is the path the happy-path test cannot isolate — it proves
+    // the closure actually invokes the SDK rather than short-circuiting.
+    let client = mock_kms_client().await;
+    let garbage_b64 = base64::engine::general_purpose::STANDARD.encode(b"not a real ciphertext");
+    let decryptor = build_kms_decryptor(client);
+
+    let err = decryptor(&garbage_b64, None)
+        .expect_err("KMS must reject a non-ciphertext blob even though base64 parses");
+    assert!(
+        err.starts_with("decrypt(): KMS decrypt failed:"),
+        "error message must be prefixed with the `decrypt(): KMS decrypt failed:` label, got: {err}",
+    );
+}


### PR DESCRIPTION
Closes #3227

## Summary

The DSL `decrypt("…")` built-in calls AWS KMS via the closure `create_provider_context` builds for `ProviderContext.decryptor`. `carina-core`'s `parse_decrypt_uses_config_decryptor` proves the parser invokes whatever decryptor it is given against a mock — but the decryptor *that carina-cli actually ships* (the one that talks to KMS) had **zero coverage**.

This PR applies PR #3206's pattern (extract a client-injection seam, inject a winterbaume-backed client, run in-process with no real AWS) to that decryptor.

## Changes

- **`carina-cli/src/kms.rs`** — new module owning the per-call body of the decryptor. Two pub items:
  - `pub async fn decrypt_one(client, ciphertext, key)` — base64 → KMS:Decrypt → UTF-8.
  - `pub fn build_kms_decryptor(client) -> DecryptorFn` — wraps a client into a complete `DecryptorFn`. Test seam.
- **`carina-cli/src/main.rs::create_provider_context`** — refactored to delegate the inline body to `decrypt_one` while keeping the `static OnceCell<aws_sdk_kms::Client>` lazy SDK init. Commands that never call `decrypt()` still skip the SDK config load.
- **`winterbaume-core` / `winterbaume-kms`** added as dev-dependencies.
- **Integration test** (`carina-cli/tests/kms_decryptor_winterbaume.rs`, 3 tests, ~0.04s): happy-path round-trip, invalid-base64, and valid-base64-but-garbage-ciphertext (KMS reject) — the three distinct arms of `decrypt_one`.

The `pub` (not `pub(crate)`) on `decrypt_one` is deliberate: cargo treats `carina-cli`'s `[[bin]] carina` and its lib as separate crates, so `main.rs` imports it as `carina_cli::kms::decrypt_one`. A comment documents the constraint.

## Scope (deferred)

`decrypt_one`'s `Some(key)` branch (the optional `KeyId` argument) is not covered. Real AWS validates `KeyId` against the ciphertext header and returns `IncorrectKeyException` on mismatch, but `winterbaume-kms` 0.2 ignores the request-side `KeyId` and resolves the key from the ciphertext header alone — so a key-mismatch test would silently succeed against the mock. The test file documents this and references the upstream bug report at moriyoshi/winterbaume#5.

## Verification

- `cargo nextest run -p carina-cli` — 482 passed, 27 skipped
- `cargo test -p carina-cli --doc` — clean
- `cargo clippy -p carina-cli --all-targets -- -D warnings` — clean
- `scripts/check-*.sh` — all 5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)