### PR TITLE
core: restore Custom.to_dsl for state-normalization closures (follow-up to #3222)

### DIFF
--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -851,6 +851,7 @@ fn wasm_style_vpc_schema() -> ResourceSchema {
         length: None,
         base: Box::new(AttributeType::String),
         validate: noop_validator(),
+        to_dsl: None,
     };
     ResourceSchema::new("ec2.security_group")
         .attribute(AttributeSchema::new(
@@ -941,6 +942,7 @@ fn wasm_style_subnet_schema() -> ResourceSchema {
         length: None,
         base: Box::new(AttributeType::String),
         validate: noop_validator(),
+        to_dsl: None,
     };
     ResourceSchema::new("ec2.subnet").attribute(AttributeSchema::new(
         "vpc_ids",
@@ -1054,6 +1056,7 @@ fn vpc_id_custom_type_2358() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(vpc_id_validate_2358),
+        to_dsl: None,
     }
 }
 

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -113,6 +113,7 @@ fn type_aware_custom_delegates_to_base() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert!(type_aware_equal(
         &Value::Concrete(ConcreteValue::Int(8080)),
@@ -351,6 +352,7 @@ fn type_aware_struct_ignores_default_custom_type() {
                     pattern: None,
                     length: None,
                     validate: noop_validator(),
+                    to_dsl: None,
                 },
             ),
         ],
@@ -1029,6 +1031,7 @@ fn union_string_or_list_through_custom_wrapper() {
         pattern: None,
         length: None,
         validate: std::sync::Arc::new(|_| Ok(())),
+        to_dsl: None,
     };
     let a = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
     let b = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -469,6 +469,18 @@ pub enum AttributeType {
         /// Optional length bounds (min, max).
         length: Option<(Option<u64>, Option<u64>)>,
         validate: CustomValidator,
+        /// Optional value-level normalization callback applied when
+        /// the provider reads a state value back from the SDK. For
+        /// example, `route53.hosted_zone.name` arrives with a trailing
+        /// `.` that the DSL form does not carry — the closure strips
+        /// it so the differ does not report a phantom diff.
+        ///
+        /// Distinct from [`AttributeType::CustomEnum`]'s `to_dsl`,
+        /// which expands the *DSL spelling* of enum variants. Here
+        /// the closure is a generic state→DSL normalizer.
+        /// `Option<fn>` because closures cannot cross the WASM
+        /// boundary; structural normalization is host-side only.
+        to_dsl: Option<fn(&str) -> String>,
     },
     /// Enum-shaped custom type — values are written in namespaced
     /// shorthand (`us_east_1`, `dedicated`, `us_east_1a`) and flow
@@ -543,6 +555,7 @@ impl fmt::Debug for AttributeType {
                 base,
                 pattern,
                 length,
+                to_dsl,
                 validate: _,
             } => f
                 .debug_struct("Custom")
@@ -550,6 +563,7 @@ impl fmt::Debug for AttributeType {
                 .field("base", base)
                 .field("pattern", pattern)
                 .field("length", length)
+                .field("to_dsl", to_dsl)
                 .field("validate", &"<closure>")
                 .finish(),
             AttributeType::CustomEnum {
@@ -3058,6 +3072,7 @@ pub mod types {
                     Err("Expected integer".to_string())
                 }
             }),
+            to_dsl: None,
         }
     }
 
@@ -3075,6 +3090,7 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
+            to_dsl: None,
         }
     }
 
@@ -3092,6 +3108,7 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
+            to_dsl: None,
         }
     }
 
@@ -3109,6 +3126,7 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
+            to_dsl: None,
         }
     }
 
@@ -3126,6 +3144,7 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
+            to_dsl: None,
         }
     }
 
@@ -3152,6 +3171,7 @@ pub mod types {
                     Err("Expected string".to_string())
                 }
             }),
+            to_dsl: None,
         }
     }
 }

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -1816,6 +1816,8 @@ fn validate_union_type() {
                 Err("Expected string".to_string())
             }
         }),
+
+        to_dsl: None,
     };
     let type_b = AttributeType::Custom {
         identity: Some(TypeIdentity::bare("TypeB")),
@@ -1833,6 +1835,8 @@ fn validate_union_type() {
                 Err("Expected string".to_string())
             }
         }),
+
+        to_dsl: None,
     };
 
     let union_type = AttributeType::Union(vec![type_a, type_b]);
@@ -1918,6 +1922,7 @@ fn union_type_name() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     let type_b = AttributeType::Custom {
         identity: Some(TypeIdentity::bare("TypeB")),
@@ -1925,6 +1930,7 @@ fn union_type_name() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
 
     let union_type = AttributeType::Union(vec![type_a, type_b]);
@@ -1939,6 +1945,7 @@ fn union_accepts_type_name() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     let type_b = AttributeType::Custom {
         identity: Some(TypeIdentity::bare("TypeB")),
@@ -1946,6 +1953,7 @@ fn union_accepts_type_name() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
 
     let union_type = AttributeType::Union(vec![type_a, type_b]);
@@ -2681,6 +2689,7 @@ fn make_custom(name: &str, base: AttributeType) -> AttributeType {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     }
 }
 
@@ -2691,6 +2700,7 @@ fn make_custom_anon_pattern(pattern: &str) -> AttributeType {
         pattern: Some(pattern.to_string()),
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     }
 }
 
@@ -2701,6 +2711,7 @@ fn make_custom_anon_len(min: u64, max: u64) -> AttributeType {
         pattern: None,
         length: Some((Some(min), Some(max))),
         validate: noop_validator(),
+        to_dsl: None,
     }
 }
 
@@ -2744,6 +2755,7 @@ fn assignable_rejects_same_kind_across_providers() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     let aws_region = provider_custom("aws");
     let gcp_region = provider_custom("gcp");
@@ -2764,6 +2776,7 @@ fn assignable_specific_arn_flows_into_generic_arn() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     let generic = mk(&[]);
     let role_arn = mk(&["iam", "Role"]);
@@ -2792,6 +2805,7 @@ fn assignable_identity_axis_directionality() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
 
     // provider: None source → Some sink rejected
@@ -2818,6 +2832,7 @@ fn assignable_narrow_to_anonymous_unconstrained_sink() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert!(account.is_assignable_to(&anon));
 }
@@ -2869,6 +2884,7 @@ fn assignable_union_source_requires_all_members_assignable() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     let both_ok = AttributeType::Union(vec![vpc.clone(), vpc.clone()]);
     assert!(both_ok.is_assignable_to(&vpc));
@@ -2893,6 +2909,7 @@ fn semantic_custom_assigns_to_anonymous_unconstrained_sink() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert!(vpc.is_assignable_to(&anon));
     // Reverse: anon has no proof it's a VpcId → NG.
@@ -2931,6 +2948,7 @@ fn make_custom_anon_pattern_and_len(
         pattern: pattern.map(str::to_string),
         length,
         validate: noop_validator(),
+        to_dsl: None,
     }
 }
 
@@ -3040,6 +3058,7 @@ fn custom_carries_semantic_name_pattern_length() {
         pattern: Some("^vpc-[a-f0-9]+$".to_string()),
         length: Some((Some(8), Some(21))),
         validate: noop_validator(),
+        to_dsl: None,
     };
     match t {
         AttributeType::Custom {
@@ -3064,6 +3083,7 @@ fn custom_type_name_anonymous_pattern_only() {
         pattern: Some("^foo$".to_string()),
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert_eq!(t.type_name(), "String(pattern)");
 }
@@ -3076,6 +3096,7 @@ fn custom_type_name_anonymous_length_only() {
         pattern: None,
         length: Some((Some(1), Some(64))),
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert_eq!(t.type_name(), "String(len: 1..=64)");
 }
@@ -3088,6 +3109,7 @@ fn custom_type_name_anonymous_pattern_and_length() {
         pattern: Some("^.*$".to_string()),
         length: Some((Some(1), Some(64))),
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert_eq!(t.type_name(), "String(pattern, len: 1..=64)");
 }
@@ -3681,6 +3703,7 @@ fn union_string_vs_custom_picks_custom_error_for_string_input() {
             pattern: None,
             length: None,
             validate: legacy_validator(must_be_arn),
+            to_dsl: None,
         },
     ]);
     let err = union_type
@@ -3747,6 +3770,7 @@ fn union_custom_with_int_base_picks_custom_error_for_int_input() {
             pattern: None,
             length: None,
             validate: legacy_validator(must_be_positive),
+            to_dsl: None,
         },
         AttributeType::Bool,
     ]);
@@ -3821,6 +3845,8 @@ fn custom_validator_can_capture_external_state() {
                 got: other.type_name(),
             }),
         }),
+
+        to_dsl: None,
     };
     assert!(
         attr.validate(&Value::Concrete(ConcreteValue::String(
@@ -3868,6 +3894,8 @@ fn custom_validator_returns_structured_type_error_directly() {
                 got: other.type_name(),
             }),
         }),
+
+        to_dsl: None,
     };
     let err = attr
         .validate(&Value::Concrete(ConcreteValue::String(
@@ -3999,6 +4027,7 @@ fn walk_custom_lookup_skips_value_unknown() {
         identity: Some(TypeIdentity::bare("vpc_id")),
         pattern: None,
         length: None,
+        to_dsl: None,
     };
 
     let mut errors = Vec::new();
@@ -4041,6 +4070,7 @@ fn union_walk_custom_lookup_succeeds_when_any_member_accepts() {
         identity: Some(TypeIdentity::bare(name)),
         pattern: None,
         length: None,
+        to_dsl: None,
     };
     let union = AttributeType::Union(vec![custom("ok_arm"), custom("fail_arm")]);
 
@@ -4080,6 +4110,7 @@ fn union_walk_custom_lookup_emits_smallest_error_set_when_all_fail() {
         identity: Some(TypeIdentity::bare(name)),
         pattern: None,
         length: None,
+        to_dsl: None,
     };
     let union = AttributeType::Union(vec![custom("a"), custom("b")]);
 

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -2106,10 +2106,12 @@ mod tests {
                 pattern: None,
                 length: None,
                 validate: noop_validator(),
+                to_dsl: None,
             }),
             pattern: None,
             length: None,
             validate: noop_validator(),
+            to_dsl: None,
         };
         let schemas = schema_with_attr("name", kms_arn);
         let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
@@ -2157,6 +2159,7 @@ mod tests {
             pattern: None,
             length: None,
             validate: noop_validator(),
+            to_dsl: None,
         };
         let schemas = schema_with_attr("name", aws_account_id);
         let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -759,6 +759,7 @@ mod tests {
             length: None,
             base: Box::new(AttributeType::String),
             validate: legacy_validator(noop),
+            to_dsl: None,
         }
     }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1399,6 +1399,7 @@ fn is_type_expr_compatible_unknown_rejects_custom_receiver() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
+        to_dsl: None,
     };
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Unknown,
@@ -1418,6 +1419,7 @@ fn is_type_expr_compatible_string_rejects_custom_with_semantic_name() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
+        to_dsl: None,
     };
     assert!(
         !is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
@@ -1441,6 +1443,7 @@ fn is_type_expr_compatible_string_accepts_custom_without_semantic_name() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
+        to_dsl: None,
     };
     assert!(
         is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
@@ -1466,6 +1469,7 @@ fn is_type_expr_compatible_string_rejects_union_containing_specific_custom() {
             length: None,
             base: Box::new(AttributeType::String),
             validate: legacy_validator(noop),
+            to_dsl: None,
         },
     ]);
     assert!(
@@ -1489,6 +1493,7 @@ fn is_type_expr_compatible_string_rejects_union_of_only_specific_customs() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
+        to_dsl: None,
     };
     let schema = AttributeType::Union(vec![mk("VpcId"), mk("SubnetId")]);
     assert!(
@@ -1532,6 +1537,7 @@ fn is_type_expr_compatible_simple_vpcid_accepts_custom_vpcid() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
+        to_dsl: None,
     };
     // Parser normalizes `: VpcId` to TypeExpr::Simple("vpc_id") (snake).
     let expr = TypeExpr::Simple("vpc_id".to_string());
@@ -1604,6 +1610,7 @@ fn attribute_param_ref_type_mismatch_detected() {
             pattern: None,
             length: None,
             validate: noop_validator(),
+            to_dsl: None,
         },
     ));
 
@@ -1756,10 +1763,12 @@ fn type_compat_subtype_accepted() {
             pattern: None,
             length: None,
             validate: noop_validator(),
+            to_dsl: None,
         }),
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("arn".to_string()),
@@ -1778,10 +1787,12 @@ fn type_compat_sibling_rejected() {
             pattern: None,
             length: None,
             validate: noop_validator(),
+            to_dsl: None,
         }),
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("kms_key_arn".to_string()),
@@ -1800,10 +1811,12 @@ fn type_compat_resource_id_subtype() {
             pattern: None,
             length: None,
             validate: noop_validator(),
+            to_dsl: None,
         }),
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("aws_resource_id".to_string()),
@@ -1822,10 +1835,12 @@ fn type_compat_resource_id_siblings_rejected() {
             pattern: None,
             length: None,
             validate: noop_validator(),
+            to_dsl: None,
         }),
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("vpc_id".to_string()),
@@ -1841,6 +1856,7 @@ fn type_compat_exact_match() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("arn".to_string()),
@@ -1973,6 +1989,7 @@ fn type_compat_simple_rejected_when_union_has_string_shaped_peer() {
         pattern: None,
         length: None,
         validate: noop_validator(),
+        to_dsl: None,
     };
     let with_custom = AttributeType::Union(vec![AttributeType::String, arn]);
     assert!(!is_type_expr_compatible_with_schema(

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -3245,6 +3245,7 @@ mod tests {
             pattern: None,
             length: None,
             validate: std::sync::Arc::new(|_| Ok(())),
+            to_dsl: None,
         };
         let v = Value::Concrete(ConcreteValue::String("x".to_string()));
         let canon = canonicalize_with_type(v, &t);

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2704,6 +2704,7 @@ fn exports_map_value_offers_matching_resource_refs() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
+        to_dsl: None,
     };
     let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
@@ -2787,6 +2788,7 @@ fn exports_map_value_multiple_entries_returns_refs() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
+        to_dsl: None,
     };
     let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
@@ -2843,6 +2845,7 @@ fn exports_map_value_includes_bindings_from_sibling_files() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
+        to_dsl: None,
     };
     let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
@@ -2899,6 +2902,7 @@ fn custom_type_value_ref_includes_sibling_file_bindings() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
+        to_dsl: None,
     };
     let account_schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id.clone()));
@@ -2998,6 +3002,7 @@ fn binding_dot_completion_resolves_sibling_file_binding() {
         pattern: None,
         length: None,
         validate: legacy_validator(validate_noop),
+        to_dsl: None,
     };
     let account_schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id.clone()));
@@ -3232,6 +3237,7 @@ fn upstream_state_string_export_not_offered_to_specific_custom_receiver() {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(noop),
+        to_dsl: None,
     };
     let schema = ResourceSchema::new("ec2.SecurityGroup")
         .attribute(AttributeSchema::new("vpc_id", vpc_id_type));

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -223,6 +223,7 @@ pub(super) fn test_provider_with_vpc_and_security_group() -> CompletionProvider 
         pattern: None,
         length: None,
         validate: legacy_validator(noop_validate),
+        to_dsl: None,
     };
     let vpc = ResourceSchema::new("ec2.Vpc")
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
@@ -250,6 +251,7 @@ pub(super) fn test_provider_with_custom_semantic_attr() -> CompletionProvider {
         pattern: None,
         length: None,
         validate: legacy_validator(noop_validate),
+        to_dsl: None,
     };
     let principal_type = AttributeType::StringEnum {
         name: "PrincipalType".to_string(),

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -998,6 +998,7 @@ fn type_expr_to_attribute_type(
             pattern: None,
             length: None,
             validate: legacy_validator(noop),
+            to_dsl: None,
         }),
         parser::TypeExpr::List(inner) => {
             type_expr_to_attribute_type(inner).map(AttributeType::list)

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -2017,6 +2017,7 @@ fn parse_exports_type_text(text: &str) -> Option<AttributeType> {
                 pattern: None,
                 length: None,
                 validate: legacy_validator(noop_validate),
+                to_dsl: None,
             })
         }
         _ => None,

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1776,6 +1776,7 @@ fn distinct_semantic_customs_are_rejected() {
                 pattern: None,
                 length: None,
                 validate: legacy_validator(validate_account_id),
+                to_dsl: None,
             },
         ));
 
@@ -1792,6 +1793,7 @@ fn distinct_semantic_customs_are_rejected() {
             pattern: None,
             length: None,
             validate: legacy_validator(validate_target_id),
+            to_dsl: None,
         },
     ));
 
@@ -1844,6 +1846,7 @@ fn exports_cross_file_ref_no_false_positive() {
             )),
             _ => Err("expected string".to_string()),
         }),
+        to_dsl: None,
     };
     let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", aws_account_id_type));

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -749,6 +749,11 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             pattern: None,
             length: None,
             validate: noop_validator(), // Validation is handled via ProviderContext.validators
+            // `to_dsl` is a `fn` pointer that does not survive the
+            // WASM-component boundary; host-side normalization for
+            // plugin-provided types is registered separately, so this
+            // arm always sees `None` after the proto→core lift.
+            to_dsl: None,
         },
         proto::AttributeType::CustomEnum {
             name,


### PR DESCRIPTION
## Summary

Restores `to_dsl: Option<fn(&str) -> String>` on `AttributeType::Custom` as a structural normalization hook, distinct from `CustomEnum.to_dsl` (which expands enum-shorthand). Follow-up to carina#3228.

## What went wrong in #3228

PR #3228 moved `to_dsl` from `Custom` to the new `CustomEnum` variant — modelling it as part of the enum-shorthand pipeline. That conflated two distinct uses of the field:

1. **Enum-shorthand expansion** on `CustomEnum` — `aws.Region` accepts `ap_northeast_1` and converts to `ap-northeast-1` host-side via `to_dsl`. ✓ correctly modelled.
2. **State-level value normalization** on `Custom` — `route53.hosted_zone.name` arrives from the SDK with a trailing `.` that the DSL form does not carry, and the differ would phantom-diff without a strip-trailing-dot closure. The pre-#3228 schema declared this as `Custom { to_dsl: Some(|s| s.strip_suffix('.')...), namespace: None }`.

When the carina-provider-awscc bump PR tried to land, it hit 3 sites of the second pattern (`src/provider/conversion.rs:128`, `src/provider/conversion.rs:1726`, `src/schemas/generated/route53/hosted_zone.rs:125`) that no longer have anywhere to express the closure.

## Fix

Add `to_dsl` back to `Custom` with explicit doc-comment about the separation from `CustomEnum.to_dsl`. The two are distinct hooks for distinct stages of the value pipeline:

- `Custom.to_dsl(s)` — applied when the provider reads state back from the SDK. Generic value normalizer.
- `CustomEnum.to_dsl(s)` — applied to the API spelling of enum variants so DSL spellings round-trip.

The original carina#3222 promise — making the enum-shorthand vs structural divide a *type-level* fact — is unaffected. `CustomEnum` remains the only variant that drives `expand_enum_shorthand`; the carina#3216 class of bug is still compile-time impossible.

## Changes

- `carina-core/src/schema/mod.rs`: re-add `to_dsl: Option<fn(&str) -> String>` to `Custom`; doc comment clarifies the split from `CustomEnum.to_dsl`. Debug derivation updated.
- 7 structural-`Custom` test constructors and `walk_custom_lookup` test sites across `carina-core` and `carina-lsp` add explicit `to_dsl: None`.
- `carina-plugin-host/src/wasm_convert.rs`: the WIT `Custom`→core lift sets `to_dsl: None` (the `fn` cannot cross the WASM boundary, so host-side normalization for plugin types is registered separately).

No code outside this repo needs `to_dsl: Some(...)` on a structural Custom *except* carina-provider-awscc (the 3 sites listed above); that PR follows immediately.

## Verify

- `cargo nextest run --workspace --all-features`: **3526/3526 pass**.
- `cargo test --workspace --doc`: pass.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `scripts/check-*.sh`: all pass.

Unblocks the carina-provider-awscc #3222 bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)