### PR TITLE
fix: resolve upstream_state refs in provider config (#3182)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -791,11 +791,12 @@ async fn run_apply_locked(
     }
     apply_name_overrides(&mut parsed.resources, &state_file);
 
-    // Select appropriate Provider based on configuration
-    let provider = get_provider_with_ctx(ctx, parsed, base_dir).await?;
-
     // Upstream state bindings are loaded up front so refs that target
-    // `upstream_state` blocks can be resolved during refresh (#1683).
+    // `upstream_state` blocks can be resolved during refresh (#1683) and
+    // so that provider configuration refs (`assume_role.role_arn =
+    // upstream.arn`) can be substituted before `create_provider` crosses
+    // the WASM boundary (carina#3182). Order matters: load upstream
+    // first, then resolve, then build the provider.
     let mut cycle_guard = super::plan::seed_cycle_guard(base_dir);
     let remote_bindings = super::plan::load_upstream_states(
         &parsed.upstream_states,
@@ -805,6 +806,18 @@ async fn run_apply_locked(
         super::plan::UpstreamMissingStatePolicy::Strict,
     )
     .await?;
+
+    // carina#3182: substitute upstream/binding refs inside
+    // `provider.attributes` before they reach `create_provider`.
+    carina_core::parser::resolve_provider_attributes_with_remote(
+        parsed,
+        &remote_bindings,
+        provider_context,
+    )
+    .map_err(|e| AppError::Config(format!("Provider attribute resolution error: {}", e)))?;
+
+    // Select appropriate Provider based on configuration
+    let provider = get_provider_with_ctx(ctx, parsed, base_dir).await?;
 
     // carina#3132: `sorted_resources` is `mut` because deferred-for
     // expansion now runs post-refresh (after phase-2, below) via the

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -467,6 +467,18 @@ pub async fn run_plan(
     )
     .await?;
 
+    // carina#3182: substitute `upstream.<attr>` and other binding refs
+    // inside `provider.attributes` (e.g. `assume_role.role_arn`) before
+    // the provider attributes cross the WASM boundary in
+    // `create_provider`. Parse leaves these refs in place; only here
+    // (post-`load_upstream_states`) do we have the upstream values.
+    carina_core::parser::resolve_provider_attributes_with_remote(
+        &mut parsed,
+        &remote_bindings,
+        provider_context,
+    )
+    .map_err(|e| AppError::Config(format!("Provider attribute resolution error: {}", e)))?;
+
     // carina#3132: deferred-for expansion runs inside
     // `create_plan_from_parsed_with_upstream` (post-refresh), which also
     // prints post-expansion warnings and returns the still-unresolved

--- a/carina-cli/tests/provider_upstream_state_e2e.rs
+++ b/carina-cli/tests/provider_upstream_state_e2e.rs
@@ -1,0 +1,156 @@
+//! Integration tests for carina#3182 — `upstream_state` references
+//! inside `provider { ... }` configuration.
+//!
+//! Before the fix, the planner rejected
+//! `provider aws { assume_role = { role_arn = upstream.arn } }` with
+//! `cannot serialize at WASM provider boundary: unresolved reference
+//! <binding>.<attr>` because `provider.attributes` was never substituted
+//! with the upstream's loaded values. The fix runs
+//! [`carina_core::parser::resolve_provider_attributes_with_remote`] right
+//! after `load_upstream_states` (plan/apply) and skips serializing
+//! still-deferred provider attributes at validate time.
+//!
+//! These tests follow the directory-scoped rule: each fixture is a
+//! `tempfile::tempdir()` mirroring the real `infra/aws/management/...`
+//! shape, with the downstream's configuration split across `backend.crn`,
+//! `upstream.crn`, `providers.crn`, and `main.crn` so the merged-file
+//! resolver path is exercised end-to-end.
+
+use std::fs;
+use std::path::Path;
+
+use carina_core::config_loader::load_configuration;
+use carina_core::parser::{ProviderContext, resolve_provider_attributes_with_remote};
+use carina_core::resource::{ConcreteValue, DeferredValue, Value};
+
+/// Write a minimal upstream directory that exports `delegation_writer_role_arn`.
+fn write_upstream(dir: &Path) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join("main.crn"),
+        r#"backend local { path = "carina.state.json" }
+exports {
+  delegation_writer_role_arn: String = "arn:aws:iam::412038850359:role/carina-route53-delegation-writer"
+}
+"#,
+    )
+    .unwrap();
+}
+
+/// Write a downstream directory whose `providers.crn` consumes the
+/// upstream value through a provider-level `assume_role`. Splits the
+/// configuration across multiple `.crn` files (the directory-scoped
+/// convention) so the test exercises the merged-file resolver path.
+fn write_downstream(dir: &Path, upstream_rel: &str) {
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join("backend.crn"),
+        r#"backend local { path = "carina.state.json" }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("upstream.crn"),
+        format!(
+            r#"let mgmt = upstream_state {{ source = "{upstream_rel}" }}
+"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        dir.join("providers.crn"),
+        r#"let management = provider aws {
+  region = "ap-northeast-1"
+  assume_role = {
+    role_arn = mgmt.delegation_writer_role_arn
+    session_name = "carina-test"
+  }
+}
+"#,
+    )
+    .unwrap();
+    // A no-op resource file keeps the shape close to real infra layouts.
+    fs::write(
+        dir.join("main.crn"),
+        r#"exports { region: String = "ap-northeast-1" }
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn provider_attributes_resolve_upstream_state_refs_post_load() {
+    // The acceptance case from the issue body: the downstream uses the
+    // upstream's exported role ARN inside `provider aws { assume_role }`.
+    // After parse, the ref is still deferred; after
+    // `resolve_provider_attributes_with_remote` with the upstream's loaded
+    // bindings it must be a concrete string ready for WASM serialization.
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("mgmt");
+    let downstream = tmp.path().join("env");
+    write_upstream(&upstream);
+    write_downstream(&downstream, "../mgmt");
+
+    let mut config = load_configuration(&downstream).expect("load_configuration");
+
+    // Sanity: pre-resolve, the ref survives nested inside `assume_role`.
+    let pc_pre = config
+        .parsed
+        .providers
+        .iter()
+        .find(|p| p.name == "aws")
+        .expect("aws provider present");
+    let assume_pre = pc_pre.attributes.get("assume_role").unwrap();
+    match assume_pre {
+        Value::Concrete(ConcreteValue::Map(m)) => match m.get("role_arn").unwrap() {
+            Value::Deferred(DeferredValue::ResourceRef { path }) => {
+                assert_eq!(path.binding(), "mgmt");
+            }
+            other => panic!("expected deferred role_arn pre-resolve, got: {other:?}"),
+        },
+        other => panic!("expected Map for assume_role, got: {other:?}"),
+    }
+
+    // Simulate `load_upstream_states`'s output (binding → attr → value).
+    let mut mgmt_attrs = std::collections::HashMap::new();
+    mgmt_attrs.insert(
+        "delegation_writer_role_arn".to_string(),
+        Value::Concrete(ConcreteValue::String(
+            "arn:aws:iam::412038850359:role/carina-route53-delegation-writer".to_string(),
+        )),
+    );
+    let mut remote = std::collections::HashMap::new();
+    remote.insert("mgmt".to_string(), mgmt_attrs);
+
+    resolve_provider_attributes_with_remote(
+        &mut config.parsed,
+        &remote,
+        &ProviderContext::default(),
+    )
+    .expect("resolve must succeed");
+
+    let pc = config
+        .parsed
+        .providers
+        .iter()
+        .find(|p| p.name == "aws")
+        .expect("aws provider present");
+    let assume = pc.attributes.get("assume_role").unwrap();
+    let Value::Concrete(ConcreteValue::Map(m)) = assume else {
+        panic!("expected Map for assume_role post-resolve, got: {assume:?}");
+    };
+    assert_eq!(
+        m.get("role_arn"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "arn:aws:iam::412038850359:role/carina-route53-delegation-writer".to_string()
+        ))),
+        "role_arn must be substituted from the upstream binding; got: {m:?}",
+    );
+    assert_eq!(
+        m.get("session_name"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "carina-test".to_string()
+        ))),
+        "literal sibling must be preserved post-resolve",
+    );
+}

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -32,7 +32,8 @@ pub(crate) use functions::evaluate_user_function;
 pub use functions::{provider_context_lookup, validate_custom_type};
 pub use resolve::{
     check_identifier_scope, check_provider_instance_routing, collect_known_bindings_merged,
-    finalize_provider_configs, resolve_provider_unresolved_attributes, resolve_resource_refs,
+    finalize_provider_configs, resolve_provider_attributes_with_remote,
+    resolve_provider_unresolved_attributes, resolve_resource_refs,
     resolve_resource_refs_with_config,
 };
 pub use types::parse_type_expr_str;

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -774,6 +774,52 @@ pub fn resolve_provider_unresolved_attributes<E>(
     Ok(())
 }
 
+/// Resolve `ResourceRef` values inside provider blocks' `attributes`
+/// against a binding map built from `parsed`'s resources and `remote_bindings`
+/// (the values fetched by `load_upstream_states` at plan/apply time).
+///
+/// This is the plan/apply-time counterpart to
+/// [`resolve_provider_unresolved_attributes`], which only touches the
+/// parse-time `unresolved_attributes` bucket (default_tags etc.). The
+/// regular `provider.attributes` map can contain refs nested inside
+/// struct literals — `assume_role = { role_arn = upstream.arn }` is the
+/// motivating case (carina#3182) — and those refs need to be substituted
+/// before the attributes cross the WASM provider boundary in
+/// `create_provider`.
+///
+/// Refs whose binding is unknown (neither a top-level resource nor an
+/// upstream binding) are left in place so the caller can decide whether
+/// that is a fatal error or expected (validate path tolerates it; the
+/// post-resolution WASM boundary rejects it on plan/apply).
+pub fn resolve_provider_attributes_with_remote<E>(
+    parsed: &mut super::File<E>,
+    remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    config: &ProviderContext,
+) -> Result<(), ParseError> {
+    let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+    for rref in parsed.iter_top_level_resources() {
+        if let Some(binding_name) = rref.binding() {
+            binding_map.insert(binding_name.to_string(), rref.resolved_attributes());
+        }
+    }
+    for (binding, attrs) in remote_bindings {
+        binding_map.insert(binding.clone(), attrs.clone());
+    }
+
+    let mut fn_ctx = super::ParseContext::new(config);
+    fn_ctx.user_functions = parsed.user_functions.clone();
+
+    for provider in &mut parsed.providers {
+        let mut resolved: IndexMap<String, Value> = IndexMap::new();
+        for (key, expr) in &provider.attributes {
+            let r = resolve_value_with_config(expr, &binding_map, &fn_ctx)?;
+            resolved.insert(key.clone(), r);
+        }
+        provider.attributes = resolved;
+    }
+    Ok(())
+}
+
 /// Drain `ProviderConfig.unresolved_attributes` and promote resolved
 /// well-known attributes into their typed fields. Run **after**
 /// [`resolve_resource_refs`] (and, for module-call deferrals,

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2671,6 +2671,117 @@ fn finalize_provider_configs_rejects_non_map_default_tags() {
 }
 
 #[test]
+fn resolve_provider_attributes_with_remote_substitutes_upstream_refs() {
+    // carina#3182: a ResourceRef nested inside provider attributes
+    // (e.g. `assume_role = { role_arn = upstream.arn }`) must be
+    // substituted from `remote_bindings` before the attributes cross
+    // the WASM provider boundary.
+    use crate::parser::resolve_provider_attributes_with_remote;
+
+    let input = r#"
+        let mgmt = upstream_state { source = "../mgmt" }
+
+        provider aws {
+          source = "github.com/carina-rs/carina-provider-aws"
+          revision = "main"
+          region = "ap-northeast-1"
+          assume_role = {
+            role_arn = mgmt.role_arn
+            session_name = "downstream"
+          }
+        }
+    "#;
+
+    let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+
+    // Pre-check: the ref survives parsing nested inside the assume_role map.
+    let pre = parsed.providers[0].attributes.get("assume_role").unwrap();
+    match pre {
+        Value::Concrete(ConcreteValue::Map(m)) => match m.get("role_arn").unwrap() {
+            Value::Deferred(DeferredValue::ResourceRef { path }) => {
+                assert_eq!(path.binding(), "mgmt");
+                assert_eq!(path.attribute(), "role_arn");
+            }
+            other => panic!("expected ResourceRef pre-resolve, got: {other:?}"),
+        },
+        other => panic!("expected Map for assume_role, got: {other:?}"),
+    }
+
+    // Build a `remote_bindings` shape mirroring what `load_upstream_states`
+    // produces at plan/apply time.
+    let mut mgmt_attrs: HashMap<String, Value> = HashMap::new();
+    mgmt_attrs.insert(
+        "role_arn".to_string(),
+        Value::Concrete(ConcreteValue::String(
+            "arn:aws:iam::123456789012:role/writer".to_string(),
+        )),
+    );
+    let mut remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
+    remote.insert("mgmt".to_string(), mgmt_attrs);
+
+    resolve_provider_attributes_with_remote(&mut parsed, &remote, &ProviderContext::default())
+        .expect("resolve must succeed");
+
+    let assume_role = parsed.providers[0].attributes.get("assume_role").unwrap();
+    let Value::Concrete(ConcreteValue::Map(m)) = assume_role else {
+        panic!("expected Map for assume_role post-resolve, got: {assume_role:?}");
+    };
+    assert_eq!(
+        m.get("role_arn"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "arn:aws:iam::123456789012:role/writer".to_string()
+        ))),
+        "role_arn must be substituted from remote_bindings; got: {m:?}",
+    );
+    assert_eq!(
+        m.get("session_name"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "downstream".to_string()
+        ))),
+        "literal sibling must be preserved",
+    );
+}
+
+#[test]
+fn resolve_provider_attributes_with_remote_leaves_unknown_refs_alone() {
+    // When `remote_bindings` does not name the binding referenced from
+    // provider attributes, the ref must be left in place (the caller —
+    // validate vs plan/apply — decides whether to error). The resolver
+    // itself must not panic or invent a value.
+    use crate::parser::resolve_provider_attributes_with_remote;
+
+    let input = r#"
+        let mgmt = upstream_state { source = "../mgmt" }
+
+        provider aws {
+          source = "github.com/carina-rs/carina-provider-aws"
+          revision = "main"
+          region = "ap-northeast-1"
+          assume_role = {
+            role_arn = mgmt.role_arn
+          }
+        }
+    "#;
+
+    let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+    let empty: HashMap<String, HashMap<String, Value>> = HashMap::new();
+
+    resolve_provider_attributes_with_remote(&mut parsed, &empty, &ProviderContext::default())
+        .expect("resolve must not error on missing binding");
+
+    let assume_role = parsed.providers[0].attributes.get("assume_role").unwrap();
+    let Value::Concrete(ConcreteValue::Map(m)) = assume_role else {
+        panic!("expected Map for assume_role, got: {assume_role:?}");
+    };
+    match m.get("role_arn").unwrap() {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            assert_eq!(path.binding(), "mgmt");
+        }
+        other => panic!("expected ResourceRef preserved, got: {other:?}"),
+    }
+}
+
+#[test]
 fn provider_config_carries_unresolved_attributes_field() {
     use crate::parser::ast::ProviderConfig;
     use indexmap::IndexMap;

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -685,6 +685,30 @@ pub fn validate_no_provider_in_module<E>(parsed: &crate::parser::File<E>) -> Res
     Ok(())
 }
 
+/// Returns `true` if `value` contains any deferred sub-value that the
+/// WASM provider boundary would reject (ResourceRef, BindingRef,
+/// Interpolation, FunctionCall, Unknown). Used by
+/// [`validate_provider_config`] to skip the plugin-side `validate_config`
+/// call for attributes whose refs cannot be substituted at validate
+/// time. `Secret` is transparent — its inner value is unwrapped because
+/// the secret wrapper survives WASM serialization but the inner value
+/// must still be checked. carina#3182.
+pub(crate) fn value_contains_unresolved_ref(value: &Value) -> bool {
+    match value {
+        Value::Deferred(DeferredValue::ResourceRef { .. })
+        | Value::Deferred(DeferredValue::BindingRef { .. })
+        | Value::Deferred(DeferredValue::Interpolation(_))
+        | Value::Deferred(DeferredValue::FunctionCall { .. })
+        | Value::Deferred(DeferredValue::Unknown(_)) => true,
+        Value::Deferred(DeferredValue::Secret(inner)) => value_contains_unresolved_ref(inner),
+        Value::Concrete(ConcreteValue::List(items)) => {
+            items.iter().any(value_contains_unresolved_ref)
+        }
+        Value::Concrete(ConcreteValue::Map(map)) => map.values().any(value_contains_unresolved_ref),
+        Value::Concrete(_) => false,
+    }
+}
+
 /// Validate provider configuration attributes.
 ///
 /// Runs host-side type-level validation using
@@ -693,6 +717,17 @@ pub fn validate_no_provider_in_module<E>(parsed: &crate::parser::File<E>) -> Res
 /// provider-specific semantic checks. Keeping format validation
 /// (namespace structure, enum membership) on the host side means fixes
 /// in `carina-core` take effect without rebuilding provider binaries.
+///
+/// Attributes containing unresolved references (e.g.
+/// `assume_role = { role_arn = upstream.arn }` at validate time, before
+/// plan/apply has fetched upstream state) are passed through host-side
+/// type validation — `AttributeType::validate` is deferred-aware and
+/// no-ops on `Value::Deferred` — but **excluded from the plugin-side
+/// `validate_config` call**, because the WASM serializer rejects
+/// deferred values. The same `validate_config` runs again at plan/apply
+/// time once the refs have been substituted by
+/// [`resolve_provider_attributes_with_remote`], so no plugin-side check
+/// is permanently lost. carina#3182.
 pub fn validate_provider_config<E>(
     parsed: &crate::parser::File<E>,
     factories: &[Box<dyn ProviderFactory>],
@@ -710,9 +745,17 @@ pub fn validate_provider_config<E>(
                     .map_err(|e| format!("provider {}: {}: {}", provider.name, attr_name, e))?;
             }
         }
-        // Provider-specific validation.
+        // Plugin-side validation. Drop attributes containing unresolved
+        // refs before crossing the WASM boundary; they will be checked
+        // again at plan/apply time post-resolution.
+        let serializable: IndexMap<String, Value> = provider
+            .attributes
+            .iter()
+            .filter(|(_, value)| !value_contains_unresolved_ref(value))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
         factory
-            .validate_config(&provider.attributes)
+            .validate_config(&serializable)
             .map_err(|e| format!("provider {}: {}", provider.name, e))?;
     }
     Ok(())

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -2837,3 +2837,207 @@ fn ref_with_chained_field_on_struct_flags_unknown_field() {
         "known fields list must enumerate all siblings, got: {err}",
     );
 }
+
+type ValidateConfigCallLog = std::sync::Arc<std::sync::Mutex<Vec<IndexMap<String, Value>>>>;
+
+/// Test-only factory that records every call to `validate_config` so a
+/// test can assert what attributes did or didn't cross the WASM-equivalent
+/// boundary. carina#3182.
+struct RecordingFactory {
+    name: String,
+    seen: ValidateConfigCallLog,
+}
+
+impl RecordingFactory {
+    fn new(name: &str) -> (Self, ValidateConfigCallLog) {
+        let seen: ValidateConfigCallLog = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let f = Self {
+            name: name.to_string(),
+            seen: std::sync::Arc::clone(&seen),
+        };
+        (f, seen)
+    }
+}
+
+impl crate::provider::ProviderFactory for RecordingFactory {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn display_name(&self) -> &str {
+        &self.name
+    }
+
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+
+    fn validate_config(&self, attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        self.seen.lock().unwrap().push(attributes.clone());
+        Ok(())
+    }
+
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        String::new()
+    }
+
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> futures::future::BoxFuture<
+        '_,
+        crate::provider::ProviderResult<Box<dyn crate::provider::Provider>>,
+    > {
+        unimplemented!("RecordingFactory::create_provider is not used in these tests")
+    }
+
+    fn schemas(&self) -> Vec<crate::schema::ResourceSchema> {
+        Vec::new()
+    }
+}
+
+#[test]
+fn validate_provider_config_skips_attributes_with_deferred_refs() {
+    // carina#3182: an attribute carrying an unresolved ref (e.g.
+    // `assume_role = { role_arn = upstream.arn }` before
+    // `load_upstream_states` has resolved it) must be dropped before
+    // the plugin-side `validate_config` runs, so the WASM serializer
+    // never sees the deferred value. Concrete sibling attributes
+    // (`region`) must still reach the plugin.
+    use crate::parser::ProviderConfig;
+    use crate::resource::{AccessPath, DeferredValue};
+
+    let role_arn = Value::Deferred(DeferredValue::ResourceRef {
+        path: AccessPath::new("mgmt", "role_arn"),
+    });
+    let mut assume_inner: IndexMap<String, Value> = IndexMap::new();
+    assume_inner.insert("role_arn".to_string(), role_arn);
+    assume_inner.insert(
+        "session_name".to_string(),
+        Value::Concrete(ConcreteValue::String("sess".to_string())),
+    );
+
+    let mut attrs: IndexMap<String, Value> = IndexMap::new();
+    attrs.insert(
+        "region".to_string(),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    );
+    attrs.insert(
+        "assume_role".to_string(),
+        Value::Concrete(ConcreteValue::Map(assume_inner)),
+    );
+
+    let pc = ProviderConfig {
+        name: "aws".to_string(),
+        attributes: attrs,
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+        unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
+    };
+    let mut parsed = empty_parsed();
+    parsed.providers.push(pc);
+
+    let (factory, seen_handle) = RecordingFactory::new("aws");
+    let factories: Vec<Box<dyn crate::provider::ProviderFactory>> = vec![Box::new(factory)];
+
+    validate_provider_config(&parsed, &factories).expect("validate must not error");
+
+    let seen = seen_handle
+        .lock()
+        .unwrap()
+        .last()
+        .cloned()
+        .expect("validate_config must have been called once");
+    assert!(
+        seen.contains_key("region"),
+        "literal attribute must reach validate_config; got: {seen:?}",
+    );
+    assert!(
+        !seen.contains_key("assume_role"),
+        "attribute containing a deferred ref must be filtered out; got: {seen:?}",
+    );
+}
+
+#[test]
+fn value_contains_unresolved_ref_detects_nested_resource_ref() {
+    // carina#3182: a `ResourceRef` nested inside a Map (the
+    // `assume_role = { role_arn = upstream.arn }` shape) must be
+    // detected so the validate path drops that attribute from the
+    // WASM `validate_config` payload.
+    use crate::resource::{AccessPath, DeferredValue};
+
+    let role_arn = Value::Deferred(DeferredValue::ResourceRef {
+        path: AccessPath::new("mgmt", "role_arn"),
+    });
+    let mut inner: IndexMap<String, Value> = IndexMap::new();
+    inner.insert("role_arn".to_string(), role_arn);
+    inner.insert(
+        "session_name".to_string(),
+        Value::Concrete(ConcreteValue::String("sess".to_string())),
+    );
+    let assume_role = Value::Concrete(ConcreteValue::Map(inner));
+
+    assert!(
+        value_contains_unresolved_ref(&assume_role),
+        "nested ResourceRef inside a Map must be detected",
+    );
+}
+
+#[test]
+fn value_contains_unresolved_ref_false_for_pure_literal() {
+    let mut m: IndexMap<String, Value> = IndexMap::new();
+    m.insert(
+        "region".to_string(),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    );
+    let v = Value::Concrete(ConcreteValue::Map(m));
+
+    assert!(
+        !value_contains_unresolved_ref(&v),
+        "fully-literal value must not be flagged",
+    );
+}
+
+#[test]
+fn value_contains_unresolved_ref_detects_list_element() {
+    use crate::resource::{AccessPath, DeferredValue};
+
+    let v = Value::Concrete(ConcreteValue::List(vec![
+        Value::Concrete(ConcreteValue::String("ok".to_string())),
+        Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new("x", "y"),
+        }),
+    ]));
+    assert!(
+        value_contains_unresolved_ref(&v),
+        "ResourceRef inside a List element must be detected",
+    );
+}
+
+#[test]
+fn value_contains_unresolved_ref_unwraps_secret() {
+    use crate::resource::{AccessPath, DeferredValue};
+
+    let secret_with_ref = Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
+        DeferredValue::ResourceRef {
+            path: AccessPath::new("vault", "token"),
+        },
+    ))));
+    assert!(
+        value_contains_unresolved_ref(&secret_with_ref),
+        "Secret(ResourceRef) must propagate the unresolved signal",
+    );
+
+    let secret_literal = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("plaintext".to_string()),
+    ))));
+    assert!(
+        !value_contains_unresolved_ref(&secret_literal),
+        "Secret(literal) must not be flagged",
+    );
+}


### PR DESCRIPTION
## Summary

`provider aws { assume_role = { role_arn = upstream.delegation_writer_role_arn } }` previously failed at validate/plan/apply with `cannot serialize at WASM provider boundary: unresolved reference <binding>.<attr>` because `provider.attributes` had no resolver pass — refs survived from parse all the way to the WASM `create_provider` / `validate_config` boundary. The same reference works fine when used inside a resource attribute, because resource attributes go through `resolve_refs_*` after `load_upstream_states`.

This PR adds a symmetric pass for `provider.attributes` and adjusts the validate-time path so it tolerates not-yet-resolved refs.

Closes #3182

## Changes

- **carina-core**
  - New `resolve_provider_attributes_with_remote` in `parser/resolve.rs`. The plan/apply-time counterpart to the existing `resolve_provider_unresolved_attributes` (which only handles the `default_tags`-class `unresolved_attributes` bucket). Walks every value in each `provider.attributes` and substitutes refs via `resolve_value_with_config` using a binding map built from `parsed`'s top-level resources plus `remote_bindings`.
  - `validate_provider_config` now drops attributes whose value contains an unresolved ref before invoking the plugin's `validate_config`. Host-side type validation (`AttributeType::validate`) is deferred-aware and runs on every attribute; only the plugin's WASM-bound `validate_config` skips the ref-containing ones. The plugin's `validate_config` re-runs at plan/apply once the refs have been substituted, so no plugin-side check is permanently lost.
  - New helper `value_contains_unresolved_ref` recognises `ResourceRef` / `BindingRef` / `Interpolation` / `FunctionCall` / `Unknown` (and `Secret`-wrapped variants) at any nesting depth inside `List` / `Map`.

- **carina-cli**
  - `plan.rs`: call the new resolver immediately after `load_upstream_states`, before `create_plan_from_parsed_with_upstream` (which internally builds the provider via `get_provider_with_ctx`).
  - `apply/mod.rs`: reorder so `load_upstream_states` runs **before** `get_provider_with_ctx`, with the new resolver between them. The pre-existing `get_provider_with_ctx`-before-upstream order would not have worked even if the resolver existed.

## Tests

- carina-core unit tests:
  - `resolve_provider_attributes_with_remote_substitutes_upstream_refs`: nested-in-Map `ResourceRef` is substituted from `remote_bindings`; literal siblings preserved.
  - `resolve_provider_attributes_with_remote_leaves_unknown_refs_alone`: unknown bindings are not invented.
  - `validate_provider_config_skips_attributes_with_deferred_refs`: a recording fake `ProviderFactory` confirms ref-containing attributes are dropped before the plugin call while literal ones reach the plugin.
  - `value_contains_unresolved_ref_*` (4 cases): nested Map, plain literal, List element, `Secret(ResourceRef)` unwrap.
- carina-cli integration test `provider_upstream_state_e2e.rs`: directory-scoped `tempdir` fixture (4 `.crn` files: `backend.crn` / `upstream.crn` / `providers.crn` / `main.crn`) reproducing the issue body's repro, asserting parse → resolve substitutes the ref into a concrete `String`.

## Verification

- `cargo nextest run --workspace`: 3537 tests pass, 0 failures
- `cargo test --workspace --doc`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `bash scripts/check-*.sh`: all five repo-invariant scripts pass

## Test plan

- [ ] CI green (Test, Clippy, Doctests, check-* scripts)
- [ ] Smoke against `carina-rs/infra` branch `route53-delegation-phase3` (Phase 3 was held off pending this fix per the issue body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
