### PR TITLE
plan display: per-element +/- for nested-in-Map string lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ plan-list-diff-paired-all-unchanged-dropped:
 	$(PLAN_FIXTURE) list_diff_paired_all_unchanged_dropped
 plan-list-diff-string-list-grew:
 	$(PLAN_FIXTURE) list_diff_string_list_grew
+plan-map-field-string-list-grew:
+	$(PLAN_FIXTURE) map_field_string_list_grew
 plan-nested-list-of-maps-all-dropped:
 	$(PLAN_FIXTURE) nested_list_of_maps_all_dropped
 plan-enum-display:
@@ -116,6 +118,8 @@ plan-fixtures:
 	@$(MAKE) plan-list-diff-paired-all-unchanged-dropped
 	@echo "---"
 	@$(MAKE) plan-list-diff-string-list-grew
+	@echo "---"
+	@$(MAKE) plan-map-field-string-list-grew
 	@echo "---"
 	@$(MAKE) plan-nested-list-of-maps-all-dropped
 	@echo ""

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1411,6 +1411,17 @@ fn render_map_diff_entries(out: &mut String, entries: &[MapDiffEntryIR], attr_pr
                     &nested_prefix,
                 );
             }
+            MapDiffEntryIR::StringListChanged {
+                key,
+                unchanged,
+                added,
+                removed,
+            } => {
+                // #3234: nested List<scalar> in a Map.
+                writeln!(out, "{}    {}:", attr_prefix, key).unwrap();
+                let nested_prefix = format!("{}    ", attr_prefix);
+                render_string_list_diff_entries(out, unchanged, added, removed, &nested_prefix);
+            }
         }
     }
 }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -1242,6 +1242,33 @@ fn snapshot_list_diff_string_list_grew() {
     insta::assert_snapshot!(output);
 }
 
+/// #3234: a `List<String>` field nested inside a Map (`principal`) which
+/// is itself inside a list-of-maps element (`statement`) must render the
+/// list growth multi-line with `+` markers, not as a single inline
+/// `aws: [...] → [...]` overflow line. The pre-fix `MapDiffEntryIR`
+/// only had `Changed` for the non-map / non-list-of-maps fallthrough,
+/// which collapsed long IAM principal lists onto one unscannable line.
+#[test]
+fn snapshot_map_field_string_list_grew() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("map_field_string_list_grew");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+    ));
+    assert!(
+        !output.lines().any(|l| l.len() > 200),
+        "string-list diff inside a nested map field should not render inline; got: {}",
+        output
+    );
+    insta::assert_snapshot!(output);
+}
+
 // #2881 follow-on: exercises the modified-with-nested branch where the
 // only changed field is a nested Map (`config`). Locks in the
 // `~ { ... }` block-style layout: nested map diff first, then

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_map_field_string_list_grew.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_map_field_string_list_grew.snap
@@ -1,0 +1,18 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.iam.RolePolicy policy
+      statement:
+        ~ {
+            principal:
+                aws:
+                  + "arn:aws:iam::412038850359:role/aws-reserved/sso.amazonaws.com/ap-northeast-1/AWSReservedSSO_AdministratorAccess_1ade6440f2d3bcdd"
+                  # (1 unchanged element hidden)
+            # (4 unchanged fields hidden)
+          }
+      # (2 unchanged attributes hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/map_field_string_list_grew/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_field_string_list_grew/carina.state.json
@@ -1,0 +1,51 @@
+{
+  "version": 6,
+  "serial": 1,
+  "lineage": "test-lineage-map-field-string-list-grew",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "delegation-writer|trust-policy",
+      "attributes": {
+        "policy_name": "trust-policy",
+        "role_name": "delegation-writer",
+        "statement": [
+          {
+            "sid": "AllowAssumeRole",
+            "effect": "Allow",
+            "principal": {
+              "aws": [
+                "arn:aws:iam::151116838382:role/carina-registry-infra-deploy"
+              ]
+            },
+            "action": "sts:AssumeRole",
+            "resource": "*"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "policy",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/map_field_string_list_grew/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/map_field_string_list_grew/main.crn
@@ -1,0 +1,39 @@
+# Update plan: a List<String> field nested inside a Map (struct) field,
+# which is itself nested inside a list-of-maps element, grew by one
+# trailing entry (issue #3234). Pre-fix this rendered as a single
+# inline `aws: ["arn..."] → ["arn...", "arn..."]` line that overflowed
+# the terminal for realistic IAM principal lists. Post-fix it is laid
+# out multi-line with `+` lines for added entries.
+#
+# The shape is statement[0].principal.aws: statement is list-of-maps,
+# principal is a struct/map, aws is a list. Pre-fix the principal-map
+# diff path emitted `MapDiffEntryIR::Changed` for `aws` (the inline
+# form); post-fix it emits the new `MapDiffEntryIR::StringListChanged`
+# variant for per-element +/- rendering.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'trust-policy'
+  role_name   = 'delegation-writer'
+  statement = [
+    {
+      sid    = 'AllowAssumeRole'
+      effect = 'Allow'
+      principal = {
+        aws = [
+          'arn:aws:iam::151116838382:role/carina-registry-infra-deploy',
+          'arn:aws:iam::412038850359:role/aws-reserved/sso.amazonaws.com/ap-northeast-1/AWSReservedSSO_AdministratorAccess_1ade6440f2d3bcdd',
+        ]
+      }
+      action   = 'sts:AssumeRole'
+      resource = '*'
+    },
+  ]
+}
+
+exports {
+  policy_name = policy.policy_name
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -180,6 +180,17 @@ pub enum MapDiffEntryIR {
         key: String,
         block: NonEmptyListOfMapsBlock,
     },
+    /// Per-element `List<String>` field diff inside a nested map (#3234).
+    /// Mirrors `ListOfMapsDiffField::StringListChanged` but lives at the
+    /// map-entry layer so a list-valued struct field (e.g.
+    /// `principal.aws`) renders as multi-line `+` / `-` markers instead
+    /// of the inline `[A] → [A, B]` form that overflows the terminal.
+    StringListChanged {
+        key: String,
+        unchanged: Vec<String>,
+        added: Vec<String>,
+        removed: Vec<String>,
+    },
 }
 
 /// A list-of-maps diff bundle whose constructor refuses the
@@ -1042,6 +1053,16 @@ fn compute_map_diff_entries(
                             block,
                         });
                     }
+                } else if let Some(diff) =
+                    compute_string_list_change(Some(&e.old_value), &e.new_value, entry_type)
+                {
+                    // #3234: see MapDiffEntryIR::StringListChanged docs.
+                    entries.push(MapDiffEntryIR::StringListChanged {
+                        key: e.key.clone(),
+                        unchanged: diff.unchanged,
+                        added: diff.added,
+                        removed: diff.removed,
+                    });
                 } else {
                     entries.push(MapDiffEntryIR::Changed {
                         key: e.key.clone(),

--- a/carina-tui/src/ui/diff.rs
+++ b/carina-tui/src/ui/diff.rs
@@ -131,6 +131,25 @@ pub(super) fn render_map_diff_entries(lines: &mut Vec<Line>, entries: &[MapDiffE
                     lines.push(Line::from(indented_spans));
                 }
             }
+            MapDiffEntryIR::StringListChanged {
+                key,
+                unchanged,
+                added,
+                removed,
+            } => {
+                // #3234.
+                lines.push(Line::from(vec![
+                    Span::raw("      "),
+                    Span::raw(format!("{}:", key)),
+                ]));
+                let mut nested_lines = Vec::new();
+                render_string_list_diff_entries(&mut nested_lines, unchanged, added, removed);
+                for line in nested_lines {
+                    let mut indented_spans = vec![Span::raw("    ")];
+                    indented_spans.extend(line.spans);
+                    lines.push(Line::from(indented_spans));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #3234

## Summary

When a `List<scalar>` field is nested inside a Map (struct) field that is itself nested inside a list-of-maps element — the typical shape for IAM trust-policy `principal.aws` — `carina plan` rendered the diff as a single inline `aws: [A] → [A, B]` line that overflowed the terminal.

This PR adds a new `MapDiffEntryIR::StringListChanged` variant so the same per-element `+` / `-` rendering used by `ListOfMapsDiffField::StringListChanged` (#2943) also applies one layer up at the map-entry layer.

### Before

```
~ awscc.iam.RolePolicy policy
    statement:
      ~ {
          principal:
            ~ aws: ["arn:aws:iam::1111:role/..."] → ["arn:aws:iam::1111:role/...", "arn:aws:iam::2222:role/aws-reserved/sso.amazonaws.com/.../AWSReservedSSO_AdministratorAccess_..."]
          # (4 unchanged fields hidden)
        }
```

### After

```
~ awscc.iam.RolePolicy policy
    statement:
      ~ {
          principal:
              aws:
                + "arn:aws:iam::2222:role/aws-reserved/sso.amazonaws.com/.../AWSReservedSSO_AdministratorAccess_..."
                # (1 unchanged element hidden)
          # (4 unchanged fields hidden)
        }
```

## Changes

- `carina-core/src/detail_rows.rs` — new `MapDiffEntryIR::StringListChanged` variant; `compute_map_diff_entries` calls `compute_string_list_change` before the inline `Changed` fallthrough, so any list-vs-list diff in a map field uses the per-element shape. `entry_type` is threaded through, so #3075 `StringEnum` set-diff canonicalization still works for nested-in-Map enum lists.
- `carina-cli/src/display/mod.rs` — render arm for the new variant; delegates to the shared `render_string_list_diff_entries` helper.
- `carina-tui/src/ui/diff.rs` — TUI render arm; layout mirrors the sibling `NestedMapDiff` arm.
- `carina-cli/tests/fixtures/plan_display/map_field_string_list_grew/` — new fixture reproducing #3234's exact shape (`statement[].principal.aws` growing from 1 → 2 entries with a long SSO ARN).
- `carina-cli/src/plan_snapshot_tests.rs` — snapshot test that also asserts no line exceeds 200 chars (the regression guard).
- `Makefile` — `plan-map-field-string-list-grew` target + inclusion in `plan-fixtures`, per the project convention.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3538 tests pass
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all pass (incl. `check-plan-fixtures.sh`)
- [x] `make plan-map-field-string-list-grew` — visual confirmation
- [x] 5 rounds of self-review — no correctness or integration issues found
