### PR TITLE
typecheck: accept ResourceRef in list/map/struct module-arg arms

### DIFF
--- a/carina-core/src/module_resolver/error.rs
+++ b/carina-core/src/module_resolver/error.rs
@@ -14,11 +14,20 @@ pub enum ModuleError {
     #[error("Missing required argument '{argument}' for module '{module}'")]
     MissingArgument { module: String, argument: String },
 
-    #[error("Invalid argument type for '{argument}' in module '{module}': expected {expected}")]
+    #[error(
+        "Invalid argument type for '{argument}' in module '{module}': expected {expected}, got {actual}"
+    )]
     InvalidArgumentType {
         module: String,
         argument: String,
         expected: String,
+        /// Short, human-readable description of the value shape that was
+        /// passed (e.g. `string`, `int`, `list`, `map`, `resource reference`).
+        /// Surfacing the actual shape avoids the misleading
+        /// `expected list(...)` reading that sent issue #3238's reporter
+        /// hunting for an element-type mismatch when the real cause was
+        /// a value-shape mismatch.
+        actual: String,
     },
 
     #[error("IO error: {0}")]

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -4343,3 +4343,260 @@ let r = registry {
     assert_eq!(parsed.wait_bindings[0].binding, "r.cert_issued");
     assert_eq!(parsed.wait_bindings[0].target, "r.cert");
 }
+
+/// carina#3238: a `list(T)`-typed module argument must accept a bare
+/// `ResourceRef` whose runtime value is a list (e.g. the `arns` output
+/// of `read aws.iam.Roles`). Before the fix the `TypeExpr::List` arm of
+/// the module-arg typecheck only accepted `ConcreteValue::List`, so
+/// passing `roles.arns` was rejected with a misleading
+/// `expected list(...)` error — forcing the user to wrap it in a
+/// literal `[roles.arns[0]]` that silently drops every element past
+/// index 0. The scalar arms (`String`, `Simple`, `Ref`, `SchemaType`)
+/// already accepted `ResourceRef`; only the collection arms didn't.
+#[test]
+fn argument_type_list_accepts_resource_ref() {
+    let mut module = create_test_module();
+    module.arguments = vec![ArgumentParameter {
+        name: "role_arns".to_string(),
+        type_expr: TypeExpr::List(Box::new(TypeExpr::Simple("arn".to_string()))),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    }];
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert("test_module".to_string(), module);
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "test_module".to_string(),
+        binding_name: Some("a".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            args.insert(
+                "role_arns".to_string(),
+                Value::resource_ref("admin_access_roles", "arns", Vec::new()),
+            );
+            args
+        },
+    };
+
+    let result = resolver.expand_module_call(&call, "a", None);
+    assert!(
+        result.is_ok(),
+        "list(T) argument should accept ResourceRef (carina#3238); got {:?}",
+        result
+    );
+}
+
+/// carina#3238 sibling case: `map(T)` arguments must also accept a
+/// `ResourceRef` whose runtime value is a map. Same root cause and same
+/// fix as the list case — the collection arms were symmetric in
+/// rejecting deferred refs.
+#[test]
+fn argument_type_map_accepts_resource_ref() {
+    let mut module = create_test_module();
+    module.arguments = vec![ArgumentParameter {
+        name: "tags".to_string(),
+        type_expr: TypeExpr::Map(Box::new(TypeExpr::String)),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    }];
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert("test_module".to_string(), module);
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "test_module".to_string(),
+        binding_name: Some("a".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            args.insert(
+                "tags".to_string(),
+                Value::resource_ref("some_resource", "tags", Vec::new()),
+            );
+            args
+        },
+    };
+
+    let result = resolver.expand_module_call(&call, "a", None);
+    assert!(
+        result.is_ok(),
+        "map(T) argument should accept ResourceRef (carina#3238); got {:?}",
+        result
+    );
+}
+
+/// carina#3238 sibling case: `struct { ... }` arguments must also
+/// accept a `ResourceRef`. Same root cause and same fix as List/Map —
+/// the collection arms were symmetric in rejecting deferred refs.
+#[test]
+fn argument_type_struct_accepts_resource_ref() {
+    let mut module = create_test_module();
+    module.arguments = vec![ArgumentParameter {
+        name: "options".to_string(),
+        type_expr: TypeExpr::Struct {
+            fields: vec![("name".to_string(), TypeExpr::String)],
+        },
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    }];
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert("test_module".to_string(), module);
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "test_module".to_string(),
+        binding_name: Some("a".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            args.insert(
+                "options".to_string(),
+                Value::resource_ref("some_resource", "options", Vec::new()),
+            );
+            args
+        },
+    };
+
+    let result = resolver.expand_module_call(&call, "a", None);
+    assert!(
+        result.is_ok(),
+        "struct argument should accept ResourceRef (carina#3238); got {:?}",
+        result
+    );
+}
+
+/// carina#3238 end-to-end: a multi-file directory fixture that mirrors
+/// the real `infra-deploy` reproducer — a usecase module declares
+/// `list(T)` and `map(T)` arguments, and the root caller feeds them
+/// from a `read` data source's attributes (a list-typed and a
+/// map-typed `ResourceRef`). Before the fix, `resolve_modules` failed
+/// with `Invalid argument type ... expected list(...)`; the workaround
+/// was `[xs[0]]` which silently dropped every element past index 0.
+#[test]
+fn list_and_map_args_accept_read_attribute_passthrough_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Usecase module: declares list(String) + map(String) arguments,
+    // split across the multi-file shape used in carina-rs/infra (the
+    // issue's real reproducer lived in `usecases/registry/infra-deploy`).
+    let usecase_dir = tmp.path().join("usecases/infra_deploy");
+    fs::create_dir_all(&usecase_dir).unwrap();
+    fs::write(
+        usecase_dir.join("arguments.crn"),
+        r#"
+arguments {
+  sso_admin_role_arns: list(String)
+  account_tags:        map(String)
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        usecase_dir.join("main.crn"),
+        r#"
+let r = awscc.iam.Role {
+  role_name = 'r'
+  assume_role_policy_document = {}
+}
+"#,
+    )
+    .unwrap();
+
+    // Root caller: feeds a `read` data source's list-typed and map-typed
+    // attributes directly into the usecase's list/map args. Pre-fix, the
+    // module-arg typecheck rejected the bare ResourceRef.
+    let root_dir = tmp.path().join("root");
+    fs::create_dir_all(&root_dir).unwrap();
+    fs::write(
+        root_dir.join("main.crn"),
+        r#"
+let admin_access_roles = read aws.iam.Roles {
+  path_prefix = '/aws-reserved/sso.amazonaws.com/'
+  name_regex  = '^AWSReservedSSO_AdministratorAccess_[0-9a-f]{16}$'
+}
+
+let infra_deploy = use {
+  source = '../usecases/infra_deploy'
+}
+
+let rd = infra_deploy {
+  sso_admin_role_arns = admin_access_roles.arns
+  account_tags        = admin_access_roles.tags
+}
+"#,
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(root_dir.join("main.crn")).unwrap();
+    let mut parsed = crate::parser::parse(&content, &ProviderContext::default()).unwrap();
+    let result = resolve_modules(&mut parsed, &root_dir);
+    assert!(
+        result.is_ok(),
+        "list(T)/map(T) usecase arguments must accept a `read`'s \
+         list/map-typed attribute via bare ResourceRef (carina#3238); \
+         got {:?}",
+        result
+    );
+}
+
+/// carina#3238: the error message for a true list-vs-scalar mismatch
+/// must show the actual value shape, not just the expected type. The
+/// previous wording (`expected list(aws.iam.Role.Arn)`) sent the
+/// reporter hunting for an element-type mismatch when the actual cause
+/// was a value-shape mismatch. The fix surfaces both sides.
+#[test]
+fn argument_type_mismatch_error_shows_actual_value_shape() {
+    let mut module = create_test_module();
+    module.arguments = vec![ArgumentParameter {
+        name: "role_arns".to_string(),
+        type_expr: TypeExpr::List(Box::new(TypeExpr::Simple("arn".to_string()))),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    }];
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert("test_module".to_string(), module);
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "test_module".to_string(),
+        binding_name: Some("a".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            // Pass a plain string where list is expected.
+            args.insert(
+                "role_arns".to_string(),
+                Value::Concrete(ConcreteValue::String("arn:aws:iam::123:role/A".to_string())),
+            );
+            args
+        },
+    };
+
+    let result = resolver.expand_module_call(&call, "a", None);
+    let Err(err) = result else {
+        panic!("expected InvalidArgumentType error, got Ok");
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("got"),
+        "error should include the actual value shape (carina#3238); got: {msg}"
+    );
+    assert!(
+        msg.contains("string"),
+        "error should name the actual value shape (string) for a string-into-list mismatch (carina#3238); got: {msg}"
+    );
+}

--- a/carina-core/src/module_resolver/typecheck.rs
+++ b/carina-core/src/module_resolver/typecheck.rs
@@ -26,12 +26,42 @@ pub(super) fn check_module_arg_type(
             module: module_name.to_string(),
             argument: arg_name.to_string(),
             expected: type_expr.to_string(),
+            actual: describe_value_shape(value).to_string(),
         }),
         TypeCheckResult::ValidationError(e) => Err(ModuleError::InvalidArgumentType {
             module: module_name.to_string(),
             argument: arg_name.to_string(),
             expected: format!("{} ({})", type_expr, e),
+            actual: describe_value_shape(value).to_string(),
         }),
+    }
+}
+
+/// One-word description of a value's shape for error messages.
+///
+/// The previous `expected list(T)`-only message was misleading because
+/// it didn't say what the user actually passed — a string, a map, a
+/// reference to another resource's attribute, etc. Naming the actual
+/// shape lets the reader see at a glance whether the mismatch is
+/// element-type or value-shape (carina#3238).
+fn describe_value_shape(value: &Value) -> &'static str {
+    match value {
+        Value::Concrete(ConcreteValue::String(_)) => "string",
+        Value::Concrete(ConcreteValue::Int(_)) => "int",
+        Value::Concrete(ConcreteValue::Float(_)) => "float",
+        Value::Concrete(ConcreteValue::Bool(_)) => "bool",
+        Value::Concrete(ConcreteValue::Duration(_)) => "duration",
+        Value::Concrete(ConcreteValue::List(_)) | Value::Concrete(ConcreteValue::StringList(_)) => {
+            "list"
+        }
+        Value::Concrete(ConcreteValue::Map(_)) => "map",
+        Value::Concrete(ConcreteValue::EnumIdentifier(_)) => "enum identifier",
+        Value::Deferred(DeferredValue::ResourceRef { .. }) => "resource reference",
+        Value::Deferred(DeferredValue::BindingRef { .. }) => "binding reference",
+        Value::Deferred(DeferredValue::Interpolation(_)) => "interpolation",
+        Value::Deferred(DeferredValue::FunctionCall { .. }) => "function call",
+        Value::Deferred(DeferredValue::Secret(_)) => "secret",
+        Value::Deferred(DeferredValue::Unknown(_)) => "unknown",
     }
 }
 
@@ -131,8 +161,8 @@ pub(super) fn check_type_match(
                 TypeCheckResult::Mismatch
             }
         }
-        TypeExpr::List(inner) => {
-            if let Value::Concrete(ConcreteValue::List(items)) = value {
+        TypeExpr::List(inner) => match value {
+            Value::Concrete(ConcreteValue::List(items)) => {
                 for item in items {
                     match check_type_match(inner, item, config, enclosing_args) {
                         TypeCheckResult::Ok => {}
@@ -140,12 +170,35 @@ pub(super) fn check_type_match(
                     }
                 }
                 TypeCheckResult::Ok
-            } else {
-                TypeCheckResult::Mismatch
             }
-        }
-        TypeExpr::Map(inner) => {
-            if let Value::Concrete(ConcreteValue::Map(entries)) = value {
+            // `StringList` is the canonical form for the
+            // `string_or_list_of_strings` union shape (#2481, #2510);
+            // structurally it is a list of strings, so accept it where
+            // `list(T)` is declared and recurse so the inner type
+            // arm applies the same check it would for a regular list
+            // of string-shaped values.
+            Value::Concrete(ConcreteValue::StringList(items)) => {
+                for s in items {
+                    let item = Value::Concrete(ConcreteValue::String(s.clone()));
+                    match check_type_match(inner, &item, config, enclosing_args) {
+                        TypeCheckResult::Ok => {}
+                        other => return other,
+                    }
+                }
+                TypeCheckResult::Ok
+            }
+            // A reference to another resource's attribute (e.g.
+            // `roles.arns` from `read aws.iam.Roles`) is a deferred
+            // value whose element type cannot be checked here. The
+            // scalar arms (`String`, `Simple`, `Ref`, `SchemaType`)
+            // already accept `ResourceRef` for the same reason;
+            // collection arms must do the same so a `list(T)` argument
+            // can receive a list-typed attribute (carina#3238).
+            Value::Deferred(DeferredValue::ResourceRef { .. }) => TypeCheckResult::Ok,
+            _ => TypeCheckResult::Mismatch,
+        },
+        TypeExpr::Map(inner) => match value {
+            Value::Concrete(ConcreteValue::Map(entries)) => {
                 for v in entries.values() {
                     match check_type_match(inner, v, config, enclosing_args) {
                         TypeCheckResult::Ok => {}
@@ -153,10 +206,11 @@ pub(super) fn check_type_match(
                     }
                 }
                 TypeCheckResult::Ok
-            } else {
-                TypeCheckResult::Mismatch
             }
-        }
+            // Sibling case to the `List` arm above (carina#3238).
+            Value::Deferred(DeferredValue::ResourceRef { .. }) => TypeCheckResult::Ok,
+            _ => TypeCheckResult::Mismatch,
+        },
         // Simple types (cidr, arn, iam_policy_arn, etc.) are string subtypes
         TypeExpr::Simple(name) => {
             if !matches!(
@@ -190,6 +244,13 @@ pub(super) fn check_type_match(
             }
         }
         TypeExpr::Struct { fields } => {
+            // Sibling case to the `List` / `Map` arms above (carina#3238):
+            // a struct-typed argument fed from another resource's
+            // attribute can't have its fields checked here. Defer to
+            // expansion time, same as List/Map.
+            if matches!(value, Value::Deferred(DeferredValue::ResourceRef { .. })) {
+                return TypeCheckResult::Ok;
+            }
             let Value::Concrete(ConcreteValue::Map(entries)) = value else {
                 return TypeCheckResult::Mismatch;
             };


### PR DESCRIPTION
## Summary

The module-arg typecheck rejected `Value::Deferred(DeferredValue::ResourceRef { .. })` in the `TypeExpr::List` / `Map` / `Struct` arms, even though the scalar arms (`String`, `Simple`, `Ref`, `SchemaType`) already accept it. Passing `read aws.iam.Roles { ... }.arns` into a `list(aws.iam.Role.Arn)` argument therefore failed with `Invalid argument type ... expected list(aws.iam.Role.Arn)`, forcing the caller into a `[xs[0]]` workaround that silently drops every element past index 0.

The issue reporter suspected an `ordered: true/false` mismatch, but `TypeExpr::List` has no `ordered` axis (that lives only in the schema layer's `AttributeType::List`). The actual cause was the scalar / collection arm asymmetry; the misleading error message reinforced the wrong diagnosis.

## Changes

- `typecheck.rs`: `TypeExpr::List` / `Map` / `Struct` accept `DeferredValue::ResourceRef` (deferred until expansion, same as the scalar arms). `TypeExpr::List` also accepts `ConcreteValue::StringList` (the `string_or_list_of_strings` union shape from #2481/#2510) so a structurally-equivalent list does not become a footgun.
- `error.rs`: `InvalidArgumentType` gains an `actual: String` field; the message becomes `expected X, got Y` so a value-shape mismatch surfaces immediately instead of looking like an element-type mismatch. `describe_value_shape` names the actual shape in one word.
- 5 new tests in `module_resolver/tests.rs`: list / map / struct unit tests for the new arm, an error-message test, and a directory-fixture E2E test (`tempfile::tempdir()` mirroring `usecases/infra_deploy` per the project's "directory-scoped, never single-file" rule) that runs the full `resolve_modules` path with `read.arns` and `read.tags` going into `list(String)` and `map(String)` arguments.

## Deliberately out of scope

- `DeferredValue::Secret` / `Interpolation` in collection arms — the scalar arms also reject these; preexisting behavior left as-is.
- Re-typecheck after expansion (element type vs declared `list(T)`) — no scalar arm does this either; separate concern. A future improvement could re-check element types once `ResourceRef` resolves.
- `set(T)` / `unordered_list(T)` DSL syntax — orthogonal feature; the rejection this PR fixes was not actually about the ordered axis.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3541 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed
- [x] `bash scripts/check-*.sh` — 5/5 passed
- [x] All 5 new tests fail without the typecheck fix (verified via `git stash`)
- [x] Directory-fixture test exercises the real `resolve_modules` path with the issue's reproducer shape

Closes #3238