### PR TITLE
expander: prefix intra-module refs to module-call bindings (#3243)

### DIFF
--- a/carina-cli/tests/nested_module_call_ref_e2e.rs
+++ b/carina-cli/tests/nested_module_call_ref_e2e.rs
@@ -1,0 +1,231 @@
+//! End-to-end validation regression for carina#3243.
+//!
+//! When a module declares `let X = inner_module { ... }` and a sibling
+//! resource in the same module references `X.<attr>`, expanding the
+//! outer module as a nested call must instance-prefix the reference
+//! along with the storage row. Pre-fix, the reference was left bare
+//! and `carina validate` failed with `unknown binding 'X' in reference
+//! X.<attr>`.
+//!
+//! This test drives the full `carina-cli` validate surface against a
+//! three-directory multi-file fixture (caller / outer / inner) — the
+//! same shape as the real `carina-rs/infra` bootstrap stack the issue
+//! was filed against.
+
+use carina_core::provider::{
+    BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
+};
+use carina_core::resource::{DataSource, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Minimal awscc provider factory exposing the two resource types the
+// fixture needs: `ec2.Vpc` and `ec2.SecurityGroup`.
+// ---------------------------------------------------------------------------
+
+struct AwsccTestFactory;
+
+impl ProviderFactory for AwsccTestFactory {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+    fn display_name(&self) -> &str {
+        "AWSCC (carina#3243 test stub)"
+    }
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+    fn validate_custom_type(
+        &self,
+        _type_name: &carina_core::schema::TypeIdentity,
+        _value: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "us-east-1".to_string()
+    }
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
+    }
+    fn create_normalizer(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+        Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+    }
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![vpc_schema(), security_group_schema()]
+    }
+}
+
+fn vpc_schema() -> ResourceSchema {
+    ResourceSchema::new("ec2.Vpc")
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+        .attribute(AttributeSchema::new("vpc_id", AttributeType::String))
+}
+
+fn security_group_schema() -> ResourceSchema {
+    ResourceSchema::new("ec2.SecurityGroup")
+        .attribute(AttributeSchema::new(
+            "group_description",
+            AttributeType::String,
+        ))
+        .attribute(AttributeSchema::new("vpc_id", AttributeType::String))
+}
+
+struct NoopProvider;
+
+impl Provider for NoopProvider {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+    fn read(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: Option<&str>,
+        _request: carina_core::provider::ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::not_found(id)) })
+    }
+    fn read_data_source(
+        &self,
+        resource: &DataSource,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn create(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn update(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn delete(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn factories() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(AwsccTestFactory) as Box<dyn ProviderFactory>]
+}
+
+/// Build a three-directory fixture:
+///   <tempdir>/inner/main.crn       — leaf module
+///   <tempdir>/outer/main.crn       — middle module that calls `inner`
+///   <tempdir>/caller/main.crn      — root that calls `outer`
+/// and return the tempdir + caller path.
+fn write_fixture() -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    std::fs::create_dir(dir.path().join("inner")).unwrap();
+    std::fs::create_dir(dir.path().join("outer")).unwrap();
+    std::fs::create_dir(dir.path().join("caller")).unwrap();
+
+    std::fs::write(
+        dir.path().join("inner/main.crn"),
+        r#"arguments {
+  cidr_block: String
+}
+
+attributes {
+  vpc_id = vpc.vpc_id
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block = cidr_block
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.path().join("outer/main.crn"),
+        r#"arguments {
+  cidr_block: String = '10.0.0.0/16'
+}
+
+let inner = use { source = '../inner' }
+
+let net = inner {
+  cidr_block = cidr_block
+}
+
+let sg = awscc.ec2.SecurityGroup {
+  group_description = 'test'
+  vpc_id            = net.vpc_id
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.path().join("caller/providers.crn"),
+        r#"provider awscc {
+  region = "us-east-1"
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.path().join("caller/main.crn"),
+        r#"let outer = use { source = '../outer' }
+
+let o = outer {
+  cidr_block = '10.1.0.0/16'
+}
+"#,
+    )
+    .unwrap();
+
+    dir
+}
+
+#[test]
+fn validate_resolves_intra_module_ref_to_module_call_binding() {
+    let fixture = write_fixture();
+    let caller = fixture.path().join("caller");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(&caller, factories());
+
+    assert!(
+        !diags.iter().any(|d| d.contains("unknown binding")),
+        "validate must not flag an intra-module reference to a module-call binding \
+         as `unknown binding`; got: {:#?}",
+        diags
+    );
+    assert!(
+        diags.is_empty(),
+        "validate must produce no errors for the well-formed fixture; got: {:#?}",
+        diags
+    );
+}

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -203,7 +203,11 @@ impl ModuleResolver<'_> {
         // resource bindings so a downstream resource referencing
         // `<wait_binding>.<attr>` is instance-prefixed the same way —
         // otherwise its dependency edge to the wait is lost
-        // (carina#3061; see `prefix_wait_binding`).
+        // (carina#3061; see `prefix_wait_binding`). Module-call bindings
+        // (`let x = inner { ... }`) need the same treatment so a sibling
+        // resource referencing `x.<attr>` lines up with the
+        // `_virtual.<prefix>.x` row produced by the inner expansion
+        // (carina#3243).
         let intra_module_bindings: HashSet<String> = module
             .resources
             .iter()
@@ -214,6 +218,12 @@ impl ModuleResolver<'_> {
                     .wait_bindings
                     .iter()
                     .map(|w| w.binding.as_str().to_string()),
+            )
+            .chain(
+                module
+                    .module_calls
+                    .iter()
+                    .filter_map(|c| c.binding_name.clone()),
             )
             .collect();
 

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -1702,6 +1702,51 @@ fn test_nested_module_two_level() {
 }
 
 #[test]
+fn test_nested_module_intra_ref_to_module_call_is_prefixed() {
+    // carina#3243 regression: `outer_module` declares
+    //   let net = inner { ... }          (module call → virtual resource)
+    //   let sg  = ... { vpc_id = net.vpc_id }
+    // When the *outer* module is itself expanded (root.crn calls
+    // `outer` with binding `web`), the `net.vpc_id` reference inside
+    // `sg` must be rewritten to `web.net.vpc_id`. Pre-fix, only
+    // `module.resources` / `module.data_sources` / `module.wait_bindings`
+    // were treated as intra-module bindings, so a module-call binding
+    // like `net` was left bare and the downstream validation step
+    // reported `unknown binding 'net' in reference net.vpc_id`.
+    let fixtures_dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/nested_modules");
+    let content = fs::read_to_string(fixtures_dir.join("root.crn")).unwrap();
+    let mut parsed = crate::parser::parse(&content, &ProviderContext::default()).unwrap();
+
+    resolve_modules(&mut parsed, &fixtures_dir).unwrap();
+
+    // Find the SecurityGroup resource and read its `vpc_id` attribute.
+    let sg = parsed
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "ec2.SecurityGroup")
+        .expect("SecurityGroup from outer module must be present");
+    let vpc_id = sg
+        .get_attr("vpc_id")
+        .expect("SecurityGroup must carry the vpc_id attribute");
+
+    // After expansion the binding must be instance-prefixed (`web.net`),
+    // not the bare intra-module name (`net`).
+    match vpc_id {
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            assert_eq!(
+                path.binding(),
+                "web.net",
+                "expected instance-prefixed binding, got: {}",
+                path.binding()
+            );
+            assert_eq!(path.attribute(), "vpc_id");
+        }
+        other => panic!("expected ResourceRef for sg.vpc_id, got: {:?}", other),
+    }
+}
+
+#[test]
 fn test_nested_module_three_level() {
     // root -> middle_module -> inner_module
     let fixtures_dir =


### PR DESCRIPTION
## Summary

Under a nested module call, a sibling resource referencing
`<module_call_binding>.<attr>` was left with the bare binding name
because `module.module_calls[].binding_name` was missing from
`intra_module_bindings` (carina-core/src/module_resolver/expander.rs).
The storage row was still instance-prefixed, so validation looked up
the bare name, did not find it, and reported
`unknown binding '<name>' in reference <name>.<attr>` — blocking
real-world usecases like the `carina-rs/infra` bootstrap stack.

The fix adds module-call binding names to the intra-module set so that
`rewrite_intra_module_refs` rewrites a sibling reference to
`<prefix>.<binding>.<attr>`, lining up with the `_virtual.<prefix>.<binding>`
row produced by the inner expansion.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3545 passed, 72 skipped
- [x] `cargo test --workspace --doc` — 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all OK
- [x] Real-infra smoke: `carina-rs/infra/envs/registry/dev/bootstrap` — `carina validate .` succeeds (`✓ 7 resources validated successfully.`)
- [x] Unit test `test_nested_module_intra_ref_to_module_call_is_prefixed` (carina-core) — asserts post-expansion `ResourceRef.binding() == "web.net"`
- [x] E2E test `validate_resolves_intra_module_ref_to_module_call_binding` (carina-cli) — directory fixture, runs full validate, asserts diagnostic absent (red-then-green verified)

Closes #3243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
