### PR TITLE
binding_index: unified pre-apply ResolvedBindings constructor (#3246, #3248)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1001,6 +1001,7 @@ async fn run_apply_locked(
     // and refresh them via `read_data_source` (#1683, #1685).
     let resolved_data_sources = resolve_data_source_refs_for_refresh(
         &sorted_resources,
+        &parsed.virtual_resources,
         &data_sources,
         &current_states,
         &remote_bindings,
@@ -1092,15 +1093,6 @@ async fn run_apply_locked(
             .await;
     }
 
-    // Build initial bindings for reference resolution (wait_aliases
-    // defined above before Phase 2).
-    let mut bindings = ResolvedBindings::from_resources_with_state(
-        &sorted_resources,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-    );
-
     // awscc#251: lift the provider-read `current_states` (not just
     // `saved_attrs` above) — a refresh whose `provider.read()` returns
     // plain-`String` IAM enum values must be lifted before the differ
@@ -1119,38 +1111,41 @@ async fn run_apply_locked(
 
     // Snapshot each virtual resource's *pre-resolve* attributes
     // (still carrying `ResourceRef`s) before the head-of-pipeline
-    // `resolve_refs_with_state_and_remote` call below replaces them
-    // with pre-apply concrete values. `finalize_apply`'s export
-    // resolution needs this snapshot to re-resolve virtuals against
-    // the post-apply state — see #3169 / #3177. Without it, every
-    // virtual ref is frozen at the pre-apply value and `state.exports`
-    // captures stale data after any Replace on a referenced managed
-    // resource.
+    // resolver call below replaces them with pre-apply concrete
+    // values. `finalize_apply`'s export resolution needs this
+    // snapshot to re-resolve virtuals against the post-apply state —
+    // see #3169 / #3177. Without it, every virtual ref is frozen at
+    // the pre-apply value and `state.exports` captures stale data
+    // after any Replace on a referenced managed resource.
     // carina#3181: virtual resources live in `parsed.virtual_resources`
     // as their own typed slice.
     let pre_resolve_virtuals: Vec<carina_core::resource::VirtualResource> =
         parsed.virtual_resources.clone();
 
+    // Build the unified pre-apply bindings view (carina#3248): every
+    // kind of binding the configuration declares (managed, virtual,
+    // data source) is in the same view, so a managed attribute
+    // referencing `<module_instance>.<attr>` chains through the
+    // virtual's attribute map to the managed sibling literal
+    // (carina#3246).
+    let mut bindings = ResolvedBindings::pre_apply(carina_core::binding_index::PreApplyInputs {
+        managed: &sorted_resources,
+        virtuals: &pre_resolve_virtuals,
+        data_sources: &data_sources,
+        current_states: &current_states,
+        remote_bindings: &remote_bindings,
+        wait_aliases: &wait_aliases,
+    });
+
     // Resolve references and enum identifiers, then create initial plan for display
     let mut resources_for_plan = sorted_resources.clone();
-    resolve_refs_with_state_and_remote(
-        &mut resources_for_plan,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-    )?;
+    resolve_refs_with_state_and_remote(&mut resources_for_plan, &bindings)?;
 
     // Resolve data-source input refs and canonicalize, so each `read`
     // resource flows into `create_plan` with concrete attribute values
     // (carina#3181).
     let mut data_sources_for_plan = data_sources.clone();
-    carina_core::resolver::resolve_data_source_refs(
-        &mut data_sources_for_plan,
-        &resources_for_plan,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-    )?;
+    carina_core::resolver::resolve_data_source_refs(&mut data_sources_for_plan, &bindings)?;
 
     // Type-level canonicalization for `Union[String, list(String)]`
     // fields (IAM-style `string_or_list_of_strings`). See #2481, #2511.
@@ -1219,6 +1214,8 @@ async fn run_apply_locked(
         let resolved_exports = crate::commands::plan::resolve_export_values_for_display(
             &parsed.export_params,
             &sorted_resources,
+            &parsed.virtual_resources,
+            &parsed.data_sources,
             &current_states,
             &wait_aliases,
         );
@@ -1306,6 +1303,8 @@ async fn run_apply_locked(
     let resolved_exports = crate::commands::plan::resolve_export_values_for_display(
         &parsed.export_params,
         &sorted_resources,
+        &parsed.virtual_resources,
+        &parsed.data_sources,
         &current_states,
         &wait_aliases,
     );
@@ -1422,16 +1421,16 @@ pub async fn run_apply_from_plan(
     let plan_file: PlanFile =
         serde_json::from_str(&content).map_err(|e| format!("Failed to parse plan file: {}", e))?;
 
-    // Validate version compatibility. Plan-file version 3 (carina#3181)
-    // changed the saved `Effect` payload shapes — managed effects carry
-    // `ManagedResource`, `Read` carries `DataSource`, neither serializes
-    // the legacy `kind` / `virtual_module` fields. Older plans
-    // (version 2 and below) deserialize into a different `Effect` shape
-    // and cannot be applied, so they are rejected outright per the
-    // repo's no-backward-compat policy.
-    if plan_file.version != 3 {
+    // Validate version compatibility. Plan-file version 4
+    // (carina#3248) persists `virtual_resources` so the saved-plan
+    // apply path can rebuild the same `ResolvedBindings` view as the
+    // live-apply path (carina#3246). Older plans (version 3 and
+    // below) lack the `virtual_resources` field and cannot be applied
+    // by the post-#3248 binding-construction path, so they are
+    // rejected outright per the repo's no-backward-compat policy.
+    if plan_file.version != 4 {
         return Err(AppError::Config(format!(
-            "Unsupported plan file version: {} (expected 3). \
+            "Unsupported plan file version: {} (expected 4). \
              Re-run 'carina plan' to produce a plan in the current format.",
             plan_file.version
         )));
@@ -1667,12 +1666,24 @@ async fn run_apply_from_plan_locked(
             target: carina_core::parser::BindingName::new(wb.target.clone()),
         })
         .collect();
-    let mut bindings = ResolvedBindings::from_resources_with_state(
-        sorted_resources,
-        &current_states,
-        &upstream_snapshot,
-        &wait_aliases,
-    );
+    // carina#3248: saved plans (version 4) persist both
+    // `virtual_resources` and `data_sources`, so the saved-plan apply
+    // path builds the same unified pre-apply bindings view as the
+    // live-apply path. The view includes virtuals so a managed
+    // attribute referencing `<module_instance>.<attr>` chains through
+    // to the managed sibling literal (carina#3246), and includes data
+    // sources so a managed attribute referencing `<read_binding>.<attr>`
+    // resolves through the data source's attribute map.
+    let plan_virtuals: &[carina_core::resource::VirtualResource] = &plan_file.virtual_resources;
+    let plan_data_sources: &[carina_core::resource::DataSource] = &plan_file.data_sources;
+    let mut bindings = ResolvedBindings::pre_apply(carina_core::binding_index::PreApplyInputs {
+        managed: sorted_resources,
+        virtuals: plan_virtuals,
+        data_sources: plan_data_sources,
+        current_states: &current_states,
+        remote_bindings: &upstream_snapshot,
+        wait_aliases: &wait_aliases,
+    });
 
     println!("{}", "Applying changes...".cyan().bold());
     println!();
@@ -1695,9 +1706,7 @@ async fn run_apply_from_plan_locked(
         &mut bindings,
         &mut current_states,
         &unresolved_resources,
-        // Saved plan files do not persist virtual resources; the
-        // `apply --plan` path has no post-expansion virtual slice.
-        &[],
+        plan_virtuals,
     )
     .await;
 
@@ -1715,9 +1724,7 @@ async fn run_apply_from_plan_locked(
         result: &result,
         state_file,
         sorted_resources,
-        // No export resolution runs from the `apply --plan` path, so an
-        // empty data-source slice is correct here.
-        data_sources: &[],
+        data_sources: plan_data_sources,
         current_states: &current_states,
         plan,
         backend,

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1368,7 +1368,7 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
     // `sorted_resources`) to build a fresh post-apply
     // `ResolvedBindings` view via the typestate-split API
     // (`from_managed_with_state` + `resolve_virtual_refs_post_apply`
-    // + `add_virtual_resources`). Exports then resolve against the
+    // + `layer_virtuals_post_apply`). Exports then resolve against the
     // post-apply view.
     //
     // **The test** mirrors that production pipeline: it (1)
@@ -1470,13 +1470,17 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
     // Step (d): head-of-pipeline resolver — runs over the managed
     // slice only. Virtuals are not part of it, so the pre-resolve
     // snapshot above is preserved verbatim.
-    resolve_managed_refs_with_state_and_remote(
-        &mut sorted_resources,
-        &pre_apply_current_states,
-        &HashMap::new(),
-        &[],
-    )
-    .unwrap();
+    let bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+        carina_core::binding_index::PreApplyInputs {
+            managed: &sorted_resources.clone(),
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &pre_apply_current_states,
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        },
+    );
+    resolve_managed_refs_with_state_and_remote(&mut sorted_resources, &bindings).unwrap();
 
     let export_params = vec![ExportParameter {
         name: "role_arn".to_string(),
@@ -1812,6 +1816,67 @@ mod apply_deferred_for_parity {
             !out.refreshable_child_ids.contains(&child_id),
             "apply: a `moved` target child must be excluded from \
              refreshable_child_ids (carina#3141 parity with plan path)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod saved_plan_version_tests {
+    //! carina#3248: saved plans now persist `virtual_resources` and
+    //! `data_sources` (version `4`). Older plans (version `3` and
+    //! below) are rejected outright per the repo's
+    //! no-backward-compat policy — re-running `carina plan` is the
+    //! supported migration path.
+
+    use tempfile::TempDir;
+
+    /// A `version: 3` saved plan must be rejected by
+    /// `run_apply_from_plan` with a message that names the expected
+    /// version and points the user at re-running `plan`.
+    ///
+    /// The test writes a minimal v3-shaped JSON to disk and asserts
+    /// the rejection. The plan body is deliberately tiny — the
+    /// version gate runs first, before any field is consumed, so a
+    /// stub `effects: []` / `sorted_resources: []` is enough.
+    #[tokio::test]
+    async fn version_3_saved_plan_is_rejected() {
+        let dir = TempDir::new().expect("tempdir");
+        let plan_path = dir.path().join("plan.json");
+        // A v3 plan: everything required by the pre-#3248 PlanFile
+        // shape, no `virtual_resources` field.
+        let v3 = serde_json::json!({
+            "version": 3,
+            "carina_version": "0.4.0",
+            "timestamp": "2026-05-24T00:00:00Z",
+            "source_path": "test.crn",
+            "state_lineage": null,
+            "state_serial": null,
+            "provider_configs": [],
+            "backend_config": null,
+            "plan": { "effects": [] },
+            "sorted_resources": [],
+            "current_states": [],
+            "upstream_snapshot": {},
+            "upstream_sources": [],
+            "wait_bindings": [],
+        });
+        std::fs::write(&plan_path, serde_json::to_string(&v3).unwrap()).expect("write plan");
+
+        let result = crate::commands::apply::run_apply_from_plan(&plan_path, true, false).await;
+
+        let err = result.expect_err("v3 saved plan must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Unsupported plan file version: 3"),
+            "error must name the rejected version, got: {msg}",
+        );
+        assert!(
+            msg.contains("expected 4"),
+            "error must name the expected version, got: {msg}",
+        );
+        assert!(
+            msg.contains("Re-run 'carina plan'"),
+            "error must point the user at the supported migration path, got: {msg}",
         );
     }
 }

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -53,6 +53,43 @@ pub struct PlanFile {
     pub plan: Plan,
     /// Resources sorted by dependencies (for post-apply state saving)
     pub sorted_resources: Vec<ManagedResource>,
+    /// Virtual resources (module-call attribute containers) emitted
+    /// by module expansion at plan time (carina#3248). Persisted so
+    /// the saved-plan apply path builds the same `ResolvedBindings`
+    /// view as the live-apply path: an attribute referencing
+    /// `<module_instance>.<attr>` chains through the virtual's
+    /// attribute map to the managed sibling literal that backs it.
+    ///
+    /// Pre-carina#3248 saved plans (version `3`) did not persist
+    /// virtuals and apply-from-plan passed `&[]` into the executor —
+    /// any virtual-rooted ref would survive resolution as a
+    /// `ResourceRef` and fail-fast at the executor's
+    /// `assert_fully_resolved` check, or produce a spurious diff if
+    /// it reached the differ (carina#3246).
+    ///
+    /// Empty when the configuration declares no module calls /
+    /// `attributes { ... }` blocks.
+    #[serde(default)]
+    pub virtual_resources: Vec<carina_core::resource::VirtualResource>,
+    /// Data sources (`let x = read aws.iam.user { ... }`) emitted by
+    /// module expansion at plan time (carina#3248). Persisted so the
+    /// saved-plan apply path can re-create the same unified
+    /// `ResolvedBindings` view as the live-apply path: a managed
+    /// attribute referencing `<read_binding>.<attr>` resolves through
+    /// the data source's attribute map.
+    ///
+    /// Pre-carina#3248 saved plans did not persist data sources
+    /// separately (the field was missing); a managed→data-source ref
+    /// would have left a `ResourceRef` unresolved at apply time. The
+    /// typed-split (#3181) moved data sources out of
+    /// `sorted_resources`, so persisting them explicitly is the only
+    /// way to keep the saved-plan apply path consistent with the
+    /// live-apply path.
+    ///
+    /// Empty when the configuration declares no `read`-bound
+    /// bindings.
+    #[serde(default)]
+    pub data_sources: Vec<carina_core::resource::DataSource>,
     /// Current states (for binding_map + state saving)
     pub current_states: Vec<CurrentStateEntry>,
     /// `upstream_state` bindings as resolved at plan time (#2303).
@@ -124,10 +161,12 @@ fn build_plan_file<E>(
     ctx: &crate::wiring::PlanContext,
 ) -> Result<PlanFile, carina_core::value::SerializationError> {
     Ok(PlanFile {
-        // carina#3181 PR D: bumped 2→3 — Effect payloads are now typestate
-        // structs, so the saved-plan JSON shape changed (managed/data-source
-        // payloads no longer carry `kind` / `virtual_module`).
-        version: 3,
+        // carina#3248: bumped 3→4 — saved plans now persist
+        // `virtual_resources` so the saved-plan apply path can rebuild
+        // the same `ResolvedBindings` view as the live-apply path.
+        // Older plans (version `3` and below) are rejected with a
+        // clear message pointing the user at re-running `plan`.
+        version: 4,
         carina_version: env!("CARGO_PKG_VERSION").to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
         source_path: path.display().to_string(),
@@ -140,6 +179,16 @@ fn build_plan_file<E>(
             .sorted_resources
             .iter()
             .map(redact_secrets_in_resource)
+            .collect::<Result<Vec<_>, _>>()?,
+        virtual_resources: parsed
+            .virtual_resources
+            .iter()
+            .map(carina_core::value::redact_secrets_in_virtual)
+            .collect::<Result<Vec<_>, _>>()?,
+        data_sources: parsed
+            .data_sources
+            .iter()
+            .map(carina_core::value::redact_secrets_in_data_source)
             .collect::<Result<Vec<_>, _>>()?,
         current_states: ctx
             .current_states
@@ -576,6 +625,8 @@ pub async fn run_plan(
         let resolved_exports = resolve_export_values_for_display(
             &parsed.export_params,
             &ctx.sorted_resources,
+            &parsed.virtual_resources,
+            &parsed.data_sources,
             &ctx.current_states,
             &export_wait_aliases,
         );
@@ -638,14 +689,23 @@ pub async fn run_plan(
 pub(crate) fn resolve_export_values_for_display(
     export_params: &[carina_core::parser::InferredExportParam],
     resources: &[ManagedResource],
+    virtuals: &[carina_core::resource::VirtualResource],
+    data_sources: &[carina_core::resource::DataSource],
     current_states: &HashMap<ResourceId, State>,
     wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
 ) -> Vec<carina_core::parser::InferredExportParam> {
-    let bindings = carina_core::binding_index::ResolvedBindings::from_resources_with_state(
-        resources,
-        current_states,
-        &HashMap::new(),
-        wait_aliases,
+    // carina#3248: build the unified pre-apply bindings view so an
+    // export referencing `<module_instance>.<attr>` chains through the
+    // virtual to the managed sibling literal (carina#3246).
+    let bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+        carina_core::binding_index::PreApplyInputs {
+            managed: resources,
+            virtuals,
+            data_sources,
+            current_states,
+            remote_bindings: &HashMap::new(),
+            wait_aliases,
+        },
     );
 
     export_params

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -154,7 +154,7 @@ pub(crate) struct FinalizeApplyInput<'a> {
 ///    [`resolve_virtual_refs_post_apply`] (#3175), so a virtual that
 ///    references a Replaced managed gets the *post*-replace value.
 /// 5. Layer the re-resolved virtuals onto the bindings view via
-///    `add_virtual_resources` (#3176).
+///    `layer_virtuals_post_apply` (#3176).
 /// 6. Resolve export expressions against the combined view.
 pub(crate) fn resolve_exports(
     export_params: &[carina_core::parser::InferredExportParam],
@@ -203,20 +203,22 @@ pub(crate) fn resolve_exports(
     let mut virtuals: Vec<carina_core::resource::VirtualResource> = pre_resolve_virtuals.to_vec();
 
     // Step 3: build the bindings view from the managed slice plus
-    // post-apply states. carina#3181: `sorted_resources` is the
-    // managed-only resolved working copy. Wait aliases land at the end
-    // of construction and snapshot whatever binding the alias targets
-    // (carina#3085).
-    let mut bindings = ResolvedBindings::from_managed_with_state(
-        sorted_resources,
-        &post_apply_states,
-        &HashMap::new(),
+    // post-apply states, **with data sources but no virtuals yet**.
+    // The virtuals' attribute maps still hold pre-apply
+    // `ResourceRef`s and need to be re-resolved against the
+    // post-apply state in Step 4; only after that re-resolution can
+    // they be layered into the bindings view. We use `pre_apply`
+    // with `virtuals: &[]` here, then call
+    // `layer_virtuals_post_apply` once the re-resolution is done.
+    // (carina#3181, carina#3248)
+    let mut bindings = ResolvedBindings::pre_apply(carina_core::binding_index::PreApplyInputs {
+        managed: sorted_resources,
+        virtuals: &[],
+        data_sources,
+        current_states: &post_apply_states,
+        remote_bindings: &HashMap::new(),
         wait_aliases,
-    );
-    // Layer the data-source bindings so `exports { x = some_read.attr }`
-    // resolves against the `read` resource's resolved attributes
-    // (carina#3181).
-    bindings.add_data_sources(data_sources);
+    });
 
     // Step 4: re-resolve each virtual's attributes against the
     // post-apply bindings view. After this, a virtual's
@@ -227,7 +229,7 @@ pub(crate) fn resolve_exports(
     // Step 5: layer the re-resolved virtuals onto the bindings view.
     // Now `exports { foo = some_module.role_arn }` resolves against
     // a binding whose `role_arn` is the post-apply value.
-    bindings.add_virtual_resources(&virtuals)?;
+    bindings.layer_virtuals_post_apply(&virtuals)?;
 
     // Step 6: resolve the export expressions against the combined
     // view.

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -156,22 +156,30 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         .iter()
         .map(carina_core::binding_index::WaitAliasSpec::from)
         .collect();
-    resolve_refs_for_plan(
-        &mut resources,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-    )
-    .expect("Failed to resolve refs with state");
+    // carina#3248: build unified pre-apply bindings (managed +
+    // virtual + data sources) so virtual-rooted refs in the fixture
+    // resolve through the virtual layer to the managed sibling.
+    let upstream_binding_names: std::collections::HashSet<&str> =
+        remote_bindings.keys().map(String::as_str).collect();
+    let plan_bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+        carina_core::binding_index::PreApplyInputs {
+            managed: &resources,
+            virtuals: &parsed.virtual_resources,
+            data_sources: &data_sources,
+            current_states: &current_states,
+            remote_bindings: &remote_bindings,
+            wait_aliases: &wait_aliases,
+        },
+    );
+    resolve_refs_for_plan(&mut resources, &plan_bindings, &upstream_binding_names)
+        .expect("Failed to resolve refs with state");
 
     // Resolve data-source input refs for the plan (carina#3181).
     let mut data_sources_for_plan = data_sources.clone();
     carina_core::resolver::resolve_data_source_refs_for_plan(
         &mut data_sources_for_plan,
-        &resources,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
+        &plan_bindings,
+        &upstream_binding_names,
     )
     .expect("Failed to resolve data source refs with state");
 

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -302,7 +302,7 @@ fn plan_file_serde_round_trip() {
     }];
 
     let plan_file = PlanFile {
-        version: 3,
+        version: 4,
         carina_version: "0.1.0".to_string(),
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         source_path: "example.crn".to_string(),
@@ -340,6 +340,8 @@ fn plan_file_serde_round_trip() {
         plan,
         sorted_resources,
         current_states,
+        virtual_resources: vec![],
+        data_sources: vec![],
         upstream_snapshot: HashMap::new(),
         upstream_sources: Vec::new(),
         wait_bindings: vec![],
@@ -348,7 +350,7 @@ fn plan_file_serde_round_trip() {
     let json = serde_json::to_string_pretty(&plan_file).unwrap();
     let deserialized: PlanFile = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(deserialized.version, 3);
+    assert_eq!(deserialized.version, 4);
     assert_eq!(deserialized.carina_version, "0.1.0");
     assert_eq!(deserialized.source_path, "example.crn");
     assert_eq!(deserialized.state_lineage, Some("test-lineage".to_string()));
@@ -2749,7 +2751,7 @@ fn plan_file_serialization_redacts_secrets() {
 
     // Redact before building PlanFile (same as production code does)
     let plan_file = PlanFile {
-        version: 3,
+        version: 4,
         carina_version: "0.1.0".to_string(),
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         source_path: "example.crn".to_string(),
@@ -2759,6 +2761,8 @@ fn plan_file_serialization_redacts_secrets() {
         backend_config: None,
         plan: redact_secrets_in_plan(&plan).unwrap(),
         sorted_resources: vec![redact_secrets_in_resource(&resource_with_secret).unwrap()],
+        virtual_resources: vec![],
+        data_sources: vec![],
         current_states: vec![CurrentStateEntry {
             id: ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None),
             state: redact_secrets_in_state(&state_with_secret).unwrap(),

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use colored::Colorize;
 use futures::stream::{self, StreamExt};
 
-use carina_core::binding_index::{ResolvedBindings, WaitAliasSpec};
+use carina_core::binding_index::{PreApplyInputs, ResolvedBindings, WaitAliasSpec};
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
@@ -1270,12 +1270,14 @@ pub fn expand_same_config_deferred_for<E: Clone>(
         });
     }
 
-    let iterable_bindings = ResolvedBindings::from_resources_with_state(
-        sorted_resources,
+    let iterable_bindings = ResolvedBindings::pre_apply(PreApplyInputs {
+        managed: sorted_resources,
+        virtuals: &parsed.virtual_resources,
+        data_sources: &parsed.data_sources,
         current_states,
         remote_bindings,
         wait_aliases,
-    )
+    })
     .project_iterable_bindings();
 
     // `expand_deferred_for_expressions` is a `&mut self` method that
@@ -1562,6 +1564,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
             .collect();
         let resolved_data_sources = resolve_data_source_refs_for_refresh(
             &sorted_resources,
+            &parsed.virtual_resources,
             &data_sources,
             &current_states,
             remote_bindings,
@@ -1759,22 +1762,33 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         &data_sources,
         ctx.schemas(),
     );
-    resolve_refs_for_plan(
-        &mut resources,
-        &current_states,
-        remote_bindings,
-        &wait_aliases,
-    )?;
+    // Build the unified pre-apply bindings view once (carina#3248):
+    // every kind of binding the configuration declares (managed,
+    // virtual, data source) is in the same view, so a managed
+    // attribute referencing `<module_instance>.<attr>` (a virtual)
+    // chains through to the managed sibling literal instead of
+    // surviving as an unresolved `ResourceRef` (carina#3246).
+    let upstream_binding_names: std::collections::HashSet<&str> =
+        remote_bindings.keys().map(String::as_str).collect();
+    let plan_bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+        carina_core::binding_index::PreApplyInputs {
+            managed: &resources,
+            virtuals: &parsed.virtual_resources,
+            data_sources: &data_sources,
+            current_states: &current_states,
+            remote_bindings,
+            wait_aliases: &wait_aliases,
+        },
+    );
+    resolve_refs_for_plan(&mut resources, &plan_bindings, &upstream_binding_names)?;
     // Resolve data-source input refs for the plan and canonicalize, so
     // each `read` resource flows into `create_plan` with concrete
     // attribute values (carina#3181).
     let mut data_sources_for_plan = data_sources.clone();
     carina_core::resolver::resolve_data_source_refs_for_plan(
         &mut data_sources_for_plan,
-        &resources,
-        &current_states,
-        remote_bindings,
-        &wait_aliases,
+        &plan_bindings,
+        &upstream_binding_names,
     )?;
     carina_core::value::canonicalize_data_sources_with_schemas(
         &mut data_sources_for_plan,
@@ -2247,6 +2261,7 @@ pub async fn read_data_source_with_retry(
 /// `binding` — data sources reference those.
 pub(crate) fn resolve_data_source_refs_for_refresh(
     managed: &[ManagedResource],
+    virtuals: &[carina_core::resource::VirtualResource],
     data_sources: &[carina_core::resource::DataSource],
     current_states: &HashMap<ResourceId, State>,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
@@ -2254,14 +2269,19 @@ pub(crate) fn resolve_data_source_refs_for_refresh(
     wait_aliases: &[WaitAliasSpec],
 ) -> Result<Vec<carina_core::resource::DataSource>, AppError> {
     let mut resolved = data_sources.to_vec();
-    carina_core::resolver::resolve_data_source_refs(
-        &mut resolved,
+    // carina#3248: unified pre-apply bindings include virtuals so a
+    // data-source input referencing `<module_instance>.<attr>` chains
+    // through the virtual layer to the managed sibling literal.
+    let bindings = ResolvedBindings::pre_apply(PreApplyInputs {
         managed,
+        virtuals,
+        data_sources,
         current_states,
         remote_bindings,
         wait_aliases,
-    )
-    .map_err(AppError::Validation)?;
+    });
+    carina_core::resolver::resolve_data_source_refs(&mut resolved, &bindings)
+        .map_err(AppError::Validation)?;
     carina_core::value::canonicalize_data_sources_with_schemas(&mut resolved, schemas);
     Ok(resolved)
 }

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -512,6 +512,7 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
     let empty_registry = carina_core::schema::SchemaRegistry::new();
     let resolved = resolve_data_source_refs_for_refresh(
         &[sso],
+        &[],
         &[mizzy],
         &current_states,
         &HashMap::new(),

--- a/carina-cli/tests/virtual_binding_resolve_e2e.rs
+++ b/carina-cli/tests/virtual_binding_resolve_e2e.rs
@@ -1,0 +1,331 @@
+//! End-to-end regression for carina#3246.
+//!
+//! A managed-resource attribute that references `<module_instance>.<attr>`
+//! (where `<module_instance>` is a `VirtualResource` produced by module
+//! expansion) must resolve to the concrete managed-sibling literal that
+//! backs it. Pre-carina#3248, the plan-path resolver built bindings from
+//! the managed slice only, so the virtual-rooted ref survived as
+//! `ResourceRef` and the differ compared it against the literal already
+//! in state — producing a spurious "must be replaced" diff for what is
+//! the same value.
+//!
+//! Post-carina#3248, the resolver consumes a unified `ResolvedBindings`
+//! built via `pre_apply`, which lays virtuals into the binding map.
+//! The virtual-rooted ref chains through the virtual's attribute map
+//! to the managed sibling literal.
+//!
+//! Per CLAUDE.md "Directory-scoped, never single-file", the fixture
+//! mirrors the real infra shape: a caller that imports an outer module
+//! which itself imports an inner module. The inner module declares a
+//! managed resource and exposes one of its attributes through
+//! `attributes { ... }`; the outer module instantiates the inner via
+//! `let X = inner { ... }` and references `X.<attr>` from a sibling
+//! anonymous resource — exactly the shape of the issue's repro
+//! (`envs/registry/dev/bootstrap/`).
+
+use carina_core::provider::{
+    BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
+};
+use carina_core::resource::{DataSource, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+struct AwsccTestFactory;
+
+impl ProviderFactory for AwsccTestFactory {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+    fn display_name(&self) -> &str {
+        "AWSCC (carina#3246 test stub)"
+    }
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+    fn validate_custom_type(
+        &self,
+        _type_name: &carina_core::schema::TypeIdentity,
+        _value: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "us-east-1".to_string()
+    }
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
+    }
+    fn create_normalizer(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+        Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+    }
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![role_schema(), role_policy_schema()]
+    }
+}
+
+fn role_schema() -> ResourceSchema {
+    ResourceSchema::new("iam.Role")
+        .attribute(AttributeSchema::new("role_name", AttributeType::String))
+        .attribute(AttributeSchema::new("arn", AttributeType::String))
+}
+
+fn role_policy_schema() -> ResourceSchema {
+    ResourceSchema::new("iam.RolePolicy")
+        .attribute(AttributeSchema::new("role_name", AttributeType::String))
+        .attribute(AttributeSchema::new("policy_name", AttributeType::String))
+}
+
+struct NoopProvider;
+
+impl Provider for NoopProvider {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+    fn read(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: Option<&str>,
+        _request: carina_core::provider::ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::not_found(id)) })
+    }
+    fn read_data_source(
+        &self,
+        resource: &DataSource,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn create(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn update(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn delete(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn factories() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(AwsccTestFactory) as Box<dyn ProviderFactory>]
+}
+
+fn write_fixture() -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    std::fs::create_dir(dir.path().join("inner")).unwrap();
+    std::fs::create_dir(dir.path().join("outer")).unwrap();
+    std::fs::create_dir(dir.path().join("caller")).unwrap();
+
+    std::fs::write(
+        dir.path().join("inner/main.crn"),
+        r#"arguments {
+  role_name: String = 'carina-bootstrap'
+}
+
+attributes {
+  role_name = role.role_name
+}
+
+let role = awscc.iam.Role {
+  role_name = role_name
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.path().join("outer/main.crn"),
+        r#"arguments {
+  role_name: String = 'carina-bootstrap'
+}
+
+let inner = use { source = '../inner' }
+
+let bootstrap = inner {
+  role_name = role_name
+}
+
+awscc.iam.RolePolicy {
+  role_name   = bootstrap.role_name
+  policy_name = "policy-inline"
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.path().join("caller/providers.crn"),
+        r#"provider awscc {
+  region = "us-east-1"
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.path().join("caller/main.crn"),
+        r#"let outer = use { source = '../outer' }
+
+let bs = outer { }
+"#,
+    )
+    .unwrap();
+
+    dir
+}
+
+/// Validate-path smoke: the fixture must validate cleanly. The
+/// virtual-rooted ref `bootstrap.role_name` is reachable from the
+/// anonymous RolePolicy and must not surface as a binding or type
+/// error after expansion.
+#[test]
+fn validate_passes_for_virtual_rooted_ref() {
+    let fixture = write_fixture();
+    let caller = fixture.path().join("caller");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(&caller, factories());
+
+    assert!(
+        diags.is_empty(),
+        "validate must produce no errors for the fixture; got: {:#?}",
+        diags
+    );
+}
+
+/// Plan-path regression: a RolePolicy attribute referencing
+/// `<module_instance>.role_name` (a virtual-rooted ref) must resolve
+/// to the concrete literal through the unified `ResolvedBindings`
+/// view that `pre_apply` constructs (carina#3246 / carina#3248).
+///
+/// Pre-fix, the plan-path resolver built bindings from the managed
+/// slice only and the virtual-rooted ref survived as `ResourceRef`,
+/// producing a spurious diff against state's matching literal.
+#[test]
+fn resolve_refs_for_plan_chains_through_virtual_in_multi_file_fixture() {
+    use carina_core::config_loader::load_configuration_with_config;
+    use carina_core::parser::ProviderContext;
+    use carina_core::resource::{ConcreteValue, DeferredValue, Value};
+    use carina_core::schema::SchemaRegistry;
+
+    let fixture = write_fixture();
+    let caller = fixture.path().join("caller");
+
+    let provider_context = ProviderContext::default();
+    let loaded = load_configuration_with_config(&caller, &provider_context, &SchemaRegistry::new())
+        .expect("load should succeed");
+    let mut parsed = loaded.parsed;
+
+    // `load_configuration_with_config` does not run nested module
+    // expansion; the CLI command pipeline calls it after validate.
+    // Drive it explicitly here so the post-expansion shape (RolePolicy
+    // in `resources`, `_virtual.bs.bootstrap` in `virtual_resources`)
+    // is in place for the assertion below.
+    carina_core::module_resolver::resolve_modules_with_config(
+        &mut parsed,
+        &caller,
+        &provider_context,
+    )
+    .expect("module expansion should succeed");
+
+    // Sanity: module expansion produced both the RolePolicy resource
+    // and the `_virtual.bs.bootstrap` row.
+    assert!(
+        parsed
+            .resources
+            .iter()
+            .any(|r| r.id.resource_type == "iam.RolePolicy"),
+        "RolePolicy must be present after expansion",
+    );
+    assert!(
+        parsed
+            .virtual_resources
+            .iter()
+            .any(|v| v.binding.as_deref() == Some("bs.bootstrap")),
+        "virtual `bs.bootstrap` must be present after expansion",
+    );
+
+    // Pre-resolve: the RolePolicy carries the virtual-rooted ref.
+    let policy = parsed
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "iam.RolePolicy")
+        .expect("RolePolicy");
+    match policy.get_attr("role_name") {
+        Some(Value::Deferred(DeferredValue::ResourceRef { path })) => {
+            assert_eq!(
+                path.binding(),
+                "bs.bootstrap",
+                "expected the virtual-rooted ref shape; got: {}",
+                path.binding()
+            );
+        }
+        other => panic!("expected ResourceRef pre-resolve, got: {:?}", other),
+    }
+
+    // Build the unified pre-apply bindings view per the carina#3248
+    // contract and run the plan-path resolver. The fix: `pre_apply`
+    // lays virtuals into the binding map so the virtual-rooted ref
+    // chains through to the managed sibling literal.
+    let mut resources = parsed.resources.clone();
+    let bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+        carina_core::binding_index::PreApplyInputs {
+            managed: &resources,
+            virtuals: &parsed.virtual_resources,
+            data_sources: &parsed.data_sources,
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        },
+    );
+    carina_core::resolver::resolve_refs_for_plan(
+        &mut resources,
+        &bindings,
+        &std::collections::HashSet::new(),
+    )
+    .expect("resolve_refs_for_plan should succeed");
+
+    let policy = resources
+        .iter()
+        .find(|r| r.id.resource_type == "iam.RolePolicy")
+        .expect("RolePolicy");
+    assert_eq!(
+        policy.get_attr("role_name"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "carina-bootstrap".to_string()
+        ))),
+        "expected RolePolicy.role_name to resolve to the concrete literal; got: {:?}",
+        policy.get_attr("role_name")
+    );
+}

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -381,13 +381,18 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
         .iter()
         .map(carina_core::binding_index::WaitAliasSpec::from)
         .collect();
-    carina_core::resolver::resolve_refs_with_state_and_remote(
-        &mut resources_for_plan,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-    )
-    .expect("resolve_refs");
+    let bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+        carina_core::binding_index::PreApplyInputs {
+            managed: &resources_for_plan.clone(),
+            virtuals: &parsed.virtual_resources,
+            data_sources: &[],
+            current_states: &current_states,
+            remote_bindings: &remote_bindings,
+            wait_aliases: &wait_aliases,
+        },
+    );
+    carina_core::resolver::resolve_refs_with_state_and_remote(&mut resources_for_plan, &bindings)
+        .expect("resolve_refs");
 
     carina_core::value::canonicalize_resources_with_schemas(&mut resources_for_plan, ctx.schemas());
     carina_core::value::canonicalize_states_with_schemas(&mut current_states, ctx.schemas());

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -430,33 +430,78 @@ pub struct ResolvedBindings {
     by_name: HashMap<String, ResolvedBinding>,
 }
 
+/// Required inputs for [`ResolvedBindings::pre_apply`] (carina#3248).
+///
+/// All fields are mandatory; no `Default`, no `Option`. This shape
+/// turns "forgot virtuals at a new call site" into a compile error —
+/// a struct-literal with a missing field fails to compile, so the
+/// pre-apply path cannot be silently constructed without the kind
+/// of binding sources it needs (carina#3246).
+///
+/// Slices and maps are borrowed: the constructor reads them once and
+/// stores owned copies internally, so the caller retains ownership
+/// without forcing a clone at the API boundary.
+pub struct PreApplyInputs<'a> {
+    pub managed: &'a [ManagedResource],
+    pub virtuals: &'a [VirtualResource],
+    pub data_sources: &'a [crate::resource::DataSource],
+    pub current_states: &'a HashMap<ResourceId, State>,
+    pub remote_bindings: &'a HashMap<String, HashMap<String, Value>>,
+    pub wait_aliases: &'a [WaitAliasSpec],
+}
+
 impl ResolvedBindings {
-    /// Build the resolved view from the same three inputs the resolver
-    /// already takes: top-level resources (DSL), the last-known state map,
-    /// and upstream-state bindings.
+    /// Single typed pre-apply constructor (carina#3248).
     ///
-    /// DSL keys win over state keys on conflict. Upstream bindings are
-    /// inserted last and overwrite any local binding of the same name.
+    /// Builds the bindings view from every kind of binding that
+    /// reference resolution can name — managed resources, virtual
+    /// resources (module-call attribute containers), and data
+    /// sources — plus the same `current_states`, `remote_bindings`,
+    /// and `wait_aliases` inputs the legacy entries took.
     ///
-    /// `wait_aliases` materialises each `wait` binding as a passthrough
-    /// alias to its target: an entry whose attributes are a snapshot of
-    /// the target's resolved attributes and whose source is
-    /// [`BindingValueSource::WaitAlias`] (carina#3085). Materialising
-    /// the alias here — rather than via a second lookup in
-    /// `resolve_ref_value` — means a wait binding is resolved by exactly
-    /// the same code path as a resource binding (it simply *has* an
-    /// entry). The wait's *dependency edge* is independent and handled
-    /// separately by `Effect::Wait` lowering; this only restores the
-    /// value-identity half (design value semantics).
-    pub fn from_resources_with_state(
-        resources: &[ManagedResource],
+    /// The required-fields `PreApplyInputs` struct turns "forgot to
+    /// include virtuals at a new call site" into a compile error
+    /// rather than a runtime symptom: any missing field on the
+    /// struct-literal fails to compile, so a new pre-apply call site
+    /// cannot accidentally lose the virtual / data-source layer the
+    /// way the previous managed-only constructor + opt-in
+    /// `add_virtual_resources` shape allowed (carina#3246).
+    ///
+    /// Layering order: managed first (merged with `current_states`,
+    /// DSL-wins-on-collision), then data sources, then virtuals,
+    /// then wait aliases. The post-apply layering in
+    /// `state_writeback.rs` uses the same order, so a same-stack
+    /// collision resolves identically on the pre-apply and post-apply
+    /// sides. (Same-name collisions are independently rejected by the
+    /// parser's `DuplicateBinding` check, so the order is observable
+    /// only in test code that constructs colliding inputs by hand.)
+    pub fn pre_apply(inputs: PreApplyInputs<'_>) -> Self {
+        let mut bindings = Self::build_managed_core(
+            inputs.managed,
+            inputs.current_states,
+            inputs.remote_bindings,
+        );
+        bindings.layer_data_sources_post_apply(inputs.data_sources);
+        bindings
+            .layer_virtuals_post_apply(inputs.virtuals)
+            .expect("layer_virtuals_post_apply is currently infallible");
+        bindings.layer_wait_aliases(inputs.wait_aliases);
+        bindings
+    }
+
+    /// Shared managed + remote-bindings layering used by both the
+    /// pre-apply constructor and the legacy entries during the
+    /// migration window. Wait-aliases are layered separately by the
+    /// caller after data sources / virtuals so a wait whose target is
+    /// a data source or virtual still snapshots the resolved attrs.
+    fn build_managed_core(
+        managed: &[ManagedResource],
         current_states: &HashMap<ResourceId, State>,
         remote_bindings: &HashMap<String, HashMap<String, Value>>,
-        wait_aliases: &[WaitAliasSpec],
     ) -> Self {
         let mut by_name: HashMap<String, ResolvedBinding> = HashMap::new();
 
-        for resource in resources.iter() {
+        for resource in managed.iter() {
             let Some(binding_name) = resource.binding.as_ref() else {
                 continue;
             };
@@ -487,23 +532,20 @@ impl ResolvedBindings {
             );
         }
 
-        // Wait aliases materialise last, after both local and upstream
-        // entries exist, so a wait whose target is *either* a resource
-        // or an upstream binding sees the target's resolved attributes.
-        // The alias attributes are an independent snapshot (clone), not
-        // a shared reference: a later `set("target", …)` write-back
-        // must not mutate the alias and vice versa (design: the alias
-        // is a read-time snapshot). If the target has no entry (typo /
-        // scoped-out — the same condition `create_plan` reports as a
-        // `PlanError`), no alias is created: the ref stays unresolved
-        // and that existing error surfaces it, rather than a panic or a
-        // phantom.
+        Self { by_name }
+    }
+
+    /// Layer wait aliases on the view. Extracted from
+    /// `pre_apply` so `pre_apply` can sequence the
+    /// layering (managed → data sources → virtuals → wait aliases)
+    /// without duplicating the alias logic.
+    fn layer_wait_aliases(&mut self, wait_aliases: &[WaitAliasSpec]) {
         for spec in wait_aliases {
-            let Some(target_entry) = by_name.get(spec.target.as_str()) else {
+            let Some(target_entry) = self.by_name.get(spec.target.as_str()) else {
                 continue;
             };
             let snapshot = target_entry.attributes.clone();
-            by_name.insert(
+            self.by_name.insert(
                 spec.binding.as_str().to_string(),
                 ResolvedBinding {
                     attributes: snapshot,
@@ -513,31 +555,19 @@ impl ResolvedBindings {
                 },
             );
         }
-
-        Self { by_name }
-    }
-
-    /// Typed pre-apply constructor (#3176): build the bindings view
-    /// from a `ManagedResource` slice plus the same `current_states`,
-    /// `remote_bindings`, and `wait_aliases` inputs that
-    /// [`Self::from_resources_with_state`] consumes.
-    ///
-    /// Encodes the typestate-split invariant at the input side:
-    /// virtuals cannot be passed here. The pre-apply binding view a
-    /// caller builds via this constructor is the *only* view a
-    /// pre-apply resolver should consult; virtuals layer in
-    /// post-apply via [`Self::add_virtual_resources`].
-    pub fn from_managed_with_state(
-        managed: &[ManagedResource],
-        current_states: &HashMap<ResourceId, State>,
-        remote_bindings: &HashMap<String, HashMap<String, Value>>,
-        wait_aliases: &[WaitAliasSpec],
-    ) -> Self {
-        Self::from_resources_with_state(managed, current_states, remote_bindings, wait_aliases)
     }
 
     /// Typed post-apply layering (#3176): add virtual-resource
     /// bindings onto an existing view.
+    ///
+    /// **Scope:** post-apply increment layering (carina#3248). The
+    /// canonical caller is `state_writeback.rs`, which re-resolves
+    /// virtuals against post-apply state via
+    /// `resolve_virtual_refs_post_apply` and then layers them on top
+    /// of the pre-apply binding view for export resolution. Pre-apply
+    /// call sites must use [`ResolvedBindings::pre_apply`] instead —
+    /// that constructor lays virtuals in once at the start and makes
+    /// "forgot virtuals" a compile error.
     ///
     /// **Ordering contract**: must be called *after* the managed-side
     /// bindings have been constructed, so any virtual whose
@@ -546,7 +576,7 @@ impl ResolvedBindings {
     /// responsible for that ordering; the function itself just
     /// appends.
     ///
-    /// Unlike `from_managed_with_state`, this entry does **not** merge
+    /// Unlike `pre_apply`, this entry does **not** merge
     /// `current_states`: virtuals have no provider-side state to
     /// merge. The virtual's own attribute map (as authored, after
     /// `resolve_virtual_refs_post_apply` materialised any refs) is
@@ -563,7 +593,10 @@ impl ResolvedBindings {
     /// hard error on a same-name collision when the post-apply layer
     /// expects to merge rather than overwrite) be added without
     /// breaking the signature.
-    pub fn add_virtual_resources(&mut self, virtuals: &[VirtualResource]) -> Result<(), String> {
+    pub fn layer_virtuals_post_apply(
+        &mut self,
+        virtuals: &[VirtualResource],
+    ) -> Result<(), String> {
         for v in virtuals.iter() {
             let Some(binding_name) = v.binding.as_ref() else {
                 continue;
@@ -587,7 +620,12 @@ impl ResolvedBindings {
     /// layered in explicitly rather than collapsed into the managed
     /// slice. The resolved attribute map is recorded verbatim — data
     /// sources have no provider-side state to merge here.
-    pub fn add_data_sources(&mut self, data_sources: &[crate::resource::DataSource]) {
+    ///
+    /// **Scope:** post-apply increment layering (carina#3248). Same
+    /// as [`Self::layer_virtuals_post_apply`] — pre-apply call sites
+    /// must use [`ResolvedBindings::pre_apply`] instead so the
+    /// data-source layer is established at construction time.
+    pub fn layer_data_sources_post_apply(&mut self, data_sources: &[crate::resource::DataSource]) {
         for d in data_sources.iter() {
             let Some(binding_name) = d.binding.as_ref() else {
                 continue;
@@ -617,7 +655,7 @@ impl ResolvedBindings {
     /// what the provider just reported. **State wins on key collision** —
     /// the provider's freshly-returned values (e.g. an auto-assigned
     /// `id`) are by definition the source of truth for the binding's
-    /// downstream consumers. This is the inverse of `from_resources_with_state`'s
+    /// downstream consumers. This is the inverse of `pre_apply`'s
     /// "DSL wins" pre-apply rule: pre-apply we trust the DSL, post-apply
     /// we trust the provider.
     ///
@@ -670,7 +708,7 @@ impl ResolvedBindings {
     ///
     /// Every entry's merged attribute map (local DSL ⊕ refreshed state,
     /// with upstream and wait-alias entries already folded in by
-    /// [`Self::from_resources_with_state`]) is exposed under its binding
+    /// [`Self::pre_apply`]) is exposed under its binding
     /// name. This is the *only* same-config-aware constructor of
     /// `IterableBindings`: a deferred-for iterable resolves against the
     /// exact post-refresh view every non-loop `ResourceRef` resolves
@@ -927,8 +965,14 @@ mod resolved_bindings_tests {
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved =
-            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &states,
+            remote_bindings: &remote,
+            wait_aliases: &[],
+        });
 
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
@@ -976,8 +1020,14 @@ mod resolved_bindings_tests {
         );
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved =
-            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &states,
+            remote_bindings: &remote,
+            wait_aliases: &[],
+        });
 
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert_eq!(
@@ -1010,8 +1060,14 @@ mod resolved_bindings_tests {
         );
         remote.insert("network".to_string(), network_attrs);
 
-        let resolved =
-            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &states,
+            remote_bindings: &remote,
+            wait_aliases: &[],
+        });
 
         let attrs = resolved.get("network").expect("upstream binding present");
         assert_eq!(
@@ -1039,8 +1095,14 @@ mod resolved_bindings_tests {
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved =
-            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &states,
+            remote_bindings: &remote,
+            wait_aliases: &[],
+        });
         assert!(resolved.get("anonymous").is_none());
     }
 
@@ -1070,8 +1132,14 @@ mod resolved_bindings_tests {
             .collect(),
         );
 
-        let resolved =
-            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &states,
+            remote_bindings: &remote,
+            wait_aliases: &[],
+        });
         let attrs = resolved.get("shared").expect("shared binding present");
         assert_eq!(
             attrs.get("kind"),
@@ -1118,8 +1186,14 @@ mod resolved_bindings_tests {
         );
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        let resolved =
-            ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &states,
+            remote_bindings: &remote,
+            wait_aliases: &[],
+        });
         let attrs = resolved.get("vpc").expect("vpc binding present");
         assert!(
             attrs.get("id").is_none(),
@@ -1227,7 +1301,14 @@ mod resolved_bindings_tests {
         )];
         let states: HashMap<ResourceId, State> = HashMap::new();
         let remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
-        let parent = ResolvedBindings::from_resources_with_state(&resources, &states, &remote, &[]);
+        let parent = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &states,
+            remote_bindings: &remote,
+            wait_aliases: &[],
+        });
 
         let mut child = parent.clone();
         let extra_state = State {
@@ -1317,12 +1398,14 @@ mod resolved_bindings_tests {
                 )),
             )],
         );
-        let resolved = ResolvedBindings::from_resources_with_state(
-            &[cert],
-            &HashMap::new(),
-            &HashMap::new(),
-            &[wait_spec("cert_issued", "cert")],
-        );
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &[cert],
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[wait_spec("cert_issued", "cert")],
+        });
         assert_eq!(
             resolved
                 .get("cert_issued")
@@ -1346,12 +1429,14 @@ mod resolved_bindings_tests {
     /// and the existing PlanError path (not a panic) surfaces it.
     #[test]
     fn wait_alias_absent_target_creates_no_entry() {
-        let resolved = ResolvedBindings::from_resources_with_state(
-            &[],
-            &HashMap::new(),
-            &HashMap::new(),
-            &[wait_spec("cert_issued", "nonexistent")],
-        );
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &[],
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[wait_spec("cert_issued", "nonexistent")],
+        });
         assert!(
             resolved.get("cert_issued").is_none(),
             "no alias when target is absent (ref stays unresolved → existing PlanError)"
@@ -1370,12 +1455,14 @@ mod resolved_bindings_tests {
             Value::Concrete(ConcreteValue::String("up-1".to_string())),
         );
         remote.insert("up".to_string(), attrs);
-        let resolved = ResolvedBindings::from_resources_with_state(
-            &[],
-            &HashMap::new(),
-            &remote,
-            &[wait_spec("waited", "up")],
-        );
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &[],
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &remote,
+            wait_aliases: &[wait_spec("waited", "up")],
+        });
         assert_eq!(
             resolved.get("waited").and_then(|a| a.get("id")),
             Some(&Value::Concrete(ConcreteValue::String("up-1".to_string())))
@@ -1395,12 +1482,14 @@ mod resolved_bindings_tests {
                 Value::Concrete(ConcreteValue::String("arn:old".to_string())),
             )],
         );
-        let mut resolved = ResolvedBindings::from_resources_with_state(
-            &[cert],
-            &HashMap::new(),
-            &HashMap::new(),
-            &[wait_spec("cert_issued", "cert")],
-        );
+        let mut resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &[cert],
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[wait_spec("cert_issued", "cert")],
+        });
         let mut new_attrs = HashMap::new();
         new_attrs.insert(
             "certificate_arn".to_string(),
@@ -1435,12 +1524,14 @@ mod resolved_bindings_tests {
                 Value::Concrete(ConcreteValue::String("arn:shared".to_string())),
             )],
         );
-        let resolved = ResolvedBindings::from_resources_with_state(
-            &[cert],
-            &HashMap::new(),
-            &HashMap::new(),
-            &[wait_spec("cert_issued", "cert")],
-        );
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &[cert],
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[wait_spec("cert_issued", "cert")],
+        });
         // Two independent consumers both resolve the same value.
         let a = resolved
             .get("cert_issued")
@@ -1619,12 +1710,14 @@ let chosen = if true { "primary" } else { "fallback" }
 
         // Value-side: `ResolvedBindings` does NOT carry an entry for
         // `chosen`, so a `ResourceRef` to `chosen.foo` cannot resolve.
-        let resolved = ResolvedBindings::from_resources_with_state(
-            &parsed.resources,
-            &HashMap::new(),
-            &HashMap::new(),
-            &[],
-        );
+        let resolved = ResolvedBindings::pre_apply(PreApplyInputs {
+            managed: &parsed.resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        });
         assert!(
             resolved.get("chosen").is_none(),
             "structural bindings must stay invisible to ResourceRef resolution",

--- a/carina-core/src/binding_index_split_tests.rs
+++ b/carina-core/src/binding_index_split_tests.rs
@@ -1,11 +1,11 @@
 //! Tests for #3176: typed `ResolvedBindings` constructors.
 //!
-//! - `ResolvedBindings::from_managed_with_state(&[ManagedResource], …)` —
+//! - `ResolvedBindings::pre_apply(PreApplyInputs)` is the unified pre-apply constructor;
 //!   pre-apply bindings from a managed slice plus current state.
-//! - `ResolvedBindings::add_virtual_resources(&mut self, &[VirtualResource])` —
+//! - `ResolvedBindings::layer_virtuals_post_apply(&mut self, &[VirtualResource])` —
 //!   layer virtual bindings on top, called only after managed bindings exist.
 //!
-//! The legacy `from_resources_with_state(&[ManagedResource], …)` constructor is
+//! the legacy `from_*_with_state` entries have been removed (carina#3248).
 //! a thin shim over the two new entry points.
 
 use std::collections::{BTreeSet, HashMap};
@@ -53,16 +53,22 @@ fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> VirtualResource {
 }
 
 #[test]
-fn from_managed_with_state_records_dsl_attributes() {
+fn pre_apply_records_dsl_attributes() {
     let m = make_managed("a", &[("value", s("hello"))]);
-    let bindings =
-        ResolvedBindings::from_managed_with_state(&[m], &HashMap::new(), &HashMap::new(), &[]);
+    let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: &[m],
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     let view = bindings.get("a").expect("binding present");
     assert_eq!(view.get("value"), Some(&s("hello")));
 }
 
 #[test]
-fn from_managed_with_state_merges_state_for_missing_dsl_keys() {
+fn pre_apply_merges_state_for_missing_dsl_keys() {
     // DSL has `dsl_only`; state has `state_only` and the same `dsl_only`.
     // DSL wins on collision (pre-apply: trust the DSL).
     let m = make_managed("a", &[("dsl_only", s("from_dsl"))]);
@@ -73,37 +79,51 @@ fn from_managed_with_state_merges_state_for_missing_dsl_keys() {
     let mut current_states = HashMap::new();
     current_states.insert(m.id.clone(), State::existing(m.id.clone(), state_attrs));
 
-    let bindings =
-        ResolvedBindings::from_managed_with_state(&[m], &current_states, &HashMap::new(), &[]);
+    let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: &[m],
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &current_states,
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     let view = bindings.get("a").expect("binding present");
     assert_eq!(view.get("dsl_only"), Some(&s("from_dsl")));
     assert_eq!(view.get("state_only"), Some(&s("from_state")));
 }
 
 #[test]
-fn from_managed_with_state_skips_resources_without_binding() {
+fn pre_apply_skips_resources_without_binding() {
     let mut m = make_managed("a", &[("k", s("v"))]);
     m.binding = None;
-    let bindings =
-        ResolvedBindings::from_managed_with_state(&[m], &HashMap::new(), &HashMap::new(), &[]);
+    let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: &[m],
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     assert!(bindings.get("a").is_none());
 }
 
 #[test]
 fn add_virtual_resources_layers_on_top_of_managed() {
     let managed = make_managed("a", &[("value", s("from_managed"))]);
-    let mut bindings = ResolvedBindings::from_managed_with_state(
-        &[managed],
-        &HashMap::new(),
-        &HashMap::new(),
-        &[],
-    );
+    let mut bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: &[managed],
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     assert!(bindings.get("a").is_some());
 
     let virt = make_virtual("v", &[("role_arn", s("post_apply_arn"))]);
     bindings
-        .add_virtual_resources(&[virt])
-        .expect("add_virtual_resources");
+        .layer_virtuals_post_apply(&[virt])
+        .expect("layer_virtuals_post_apply");
 
     // Both bindings present after layering.
     assert!(bindings.get("a").is_some());
@@ -114,19 +134,21 @@ fn add_virtual_resources_layers_on_top_of_managed() {
 #[test]
 fn add_virtual_resources_overwrites_same_name_managed_binding() {
     // If a virtual happens to share a binding name with a managed one,
-    // add_virtual_resources lands later → the virtual wins. This is the
+    // layer_virtuals_post_apply lands later → the virtual wins. This is the
     // "post-apply view layers on the pre-apply view" semantic.
     let managed = make_managed("rd", &[("v", s("pre_apply"))]);
-    let mut bindings = ResolvedBindings::from_managed_with_state(
-        &[managed],
-        &HashMap::new(),
-        &HashMap::new(),
-        &[],
-    );
+    let mut bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: &[managed],
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     let virt = make_virtual("rd", &[("v", s("post_apply"))]);
     bindings
-        .add_virtual_resources(&[virt])
-        .expect("add_virtual_resources");
+        .layer_virtuals_post_apply(&[virt])
+        .expect("layer_virtuals_post_apply");
 
     let view = bindings.get("rd").expect("rd binding present");
     assert_eq!(view.get("v"), Some(&s("post_apply")));
@@ -136,32 +158,42 @@ fn add_virtual_resources_overwrites_same_name_managed_binding() {
 fn add_virtual_resources_skips_unbound() {
     let mut virt = make_virtual("v", &[("k", s("x"))]);
     virt.binding = None;
-    let mut bindings =
-        ResolvedBindings::from_managed_with_state(&[], &HashMap::new(), &HashMap::new(), &[]);
+    let mut bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: &[],
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     bindings
-        .add_virtual_resources(&[virt])
-        .expect("add_virtual_resources");
+        .layer_virtuals_post_apply(&[virt])
+        .expect("layer_virtuals_post_apply");
     assert!(bindings.get("v").is_none());
 }
 
 #[test]
 fn managed_plus_virtual_layering() {
     // carina#3181: managed resources and virtual resources are
-    // separate typestates. `from_managed_with_state` builds the
-    // pre-apply view from the managed slice; `add_virtual_resources`
-    // layers the virtual bindings on top.
+    // separate typestates. `pre_apply` builds the pre-apply view
+    // from all kinds (managed + virtual + data_sources). This test
+    // exercises the *increment* path used by `state_writeback`:
+    // build via `pre_apply` with `virtuals: &[]`, then layer them
+    // on top via `layer_virtuals_post_apply` after re-resolution.
     let managed = make_managed("a", &[("value", s("hello"))]);
     let virt = make_virtual("v", &[("forwarded", s("via_virtual"))]);
 
-    let mut typed = ResolvedBindings::from_managed_with_state(
-        std::slice::from_ref(&managed),
-        &HashMap::new(),
-        &HashMap::new(),
-        &[],
-    );
+    let mut typed = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: std::slice::from_ref(&managed),
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     typed
-        .add_virtual_resources(std::slice::from_ref(&virt))
-        .expect("add_virtual_resources");
+        .layer_virtuals_post_apply(std::slice::from_ref(&virt))
+        .expect("layer_virtuals_post_apply");
 
     assert_eq!(
         typed.get("a").and_then(|m| m.get("value")),

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -29,56 +29,56 @@ pub fn resolve_refs_with_state(
     resources: &mut [ManagedResource],
     current_states: &HashMap<ResourceId, State>,
 ) -> Result<(), String> {
-    resolve_refs_with_state_and_remote(resources, current_states, &HashMap::new(), &[])
+    let bindings =
+        crate::binding_index::ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states,
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        });
+    resolve_refs_with_state_and_remote(resources, &bindings)
 }
 
-/// Resolve all ResourceRef values in resources using current state and
-/// upstream state bindings. `wait_aliases` makes `<wait-binding>.<attr>`
-/// resolve to `<target>.<attr>` (carina#3085 passthrough).
+/// Resolve all `ResourceRef` values in `resources` against a
+/// pre-built `ResolvedBindings` view. carina#3248: the caller is
+/// responsible for assembling the bindings view via
+/// [`ResolvedBindings::pre_apply`], so this entry point is a pure
+/// transform that takes the view as input.
+///
+/// Use this on the apply path. Use [`resolve_refs_for_plan`] on the
+/// plan path — it additionally stamps any surviving
+/// `ResourceRef` whose root binding is named in
+/// `bindings_upstream_keys` as
+/// `Value::Unknown(UnknownReason::UpstreamRef { path })` so plan
+/// display can render it as `(known after upstream apply: <ref>)`
+/// instead of the raw dot-form.
 pub fn resolve_refs_with_state_and_remote(
     resources: &mut [ManagedResource],
-    current_states: &HashMap<ResourceId, State>,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    wait_aliases: &[crate::binding_index::WaitAliasSpec],
+    bindings: &ResolvedBindings,
 ) -> Result<(), String> {
-    resolve_refs_inner(
-        resources,
-        current_states,
-        remote_bindings,
-        wait_aliases,
-        false,
-    )
+    resolve_refs_inner(resources, bindings, &std::collections::HashSet::new())
 }
 
-/// Plan-only counterpart used when an upstream's state file is missing or
-/// its export is absent. Behaves like
-/// [`resolve_refs_with_state_and_remote`], but any surviving
-/// `Value::ResourceRef` whose root binding is named in `remote_bindings`
-/// is replaced with `Value::Unknown(UnknownReason::UpstreamRef { path })`
-/// so plan display can render it as `(known after upstream apply: <ref>)`
-/// instead of the raw dot-form. `apply` continues to call the strict
-/// variant. See #2366 / RFC #2371.
+/// Plan-only counterpart of [`resolve_refs_with_state_and_remote`].
+/// Same input/output shape (pre-built `ResolvedBindings`), with the
+/// addition of `unresolved_upstream_bindings`: the set of upstream-
+/// state binding names whose surviving refs should be stamped as
+/// `Value::Unknown(UnknownReason::UpstreamRef { path })` for display.
+/// `apply` continues to call the strict variant. See #2366 / RFC #2371.
 pub fn resolve_refs_for_plan(
     resources: &mut [ManagedResource],
-    current_states: &HashMap<ResourceId, State>,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    wait_aliases: &[crate::binding_index::WaitAliasSpec],
+    bindings: &ResolvedBindings,
+    unresolved_upstream_bindings: &std::collections::HashSet<&str>,
 ) -> Result<(), String> {
-    resolve_refs_inner(
-        resources,
-        current_states,
-        remote_bindings,
-        wait_aliases,
-        true,
-    )
+    resolve_refs_inner(resources, bindings, unresolved_upstream_bindings)
 }
 
 fn resolve_refs_inner(
     resources: &mut [ManagedResource],
-    current_states: &HashMap<ResourceId, State>,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    wait_aliases: &[crate::binding_index::WaitAliasSpec],
-    mark_unresolved_upstream: bool,
+    bindings: &ResolvedBindings,
+    unresolved_upstream_bindings: &std::collections::HashSet<&str>,
 ) -> Result<(), String> {
     // Save dependency bindings before resolution destroys ResourceRef values.
     // This metadata is used by plan tree building to recover parent-child
@@ -90,18 +90,7 @@ fn resolve_refs_inner(
         }
     }
 
-    let bindings = ResolvedBindings::from_resources_with_state(
-        resources,
-        current_states,
-        remote_bindings,
-        wait_aliases,
-    );
-
-    let upstream_binding_names: std::collections::HashSet<&str> = if mark_unresolved_upstream {
-        remote_bindings.keys().map(String::as_str).collect()
-    } else {
-        std::collections::HashSet::new()
-    };
+    let mark_unresolved_upstream = !unresolved_upstream_bindings.is_empty();
 
     // Resolve ResourceRef values in all resources. Stay in `IndexMap`
     // so the user's authored attribute order survives resolution
@@ -109,9 +98,9 @@ fn resolve_refs_inner(
     for resource in resources.iter_mut() {
         let mut resolved_attrs: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
         for (key, value) in &resource.attributes {
-            let resolved = resolve_ref_value(value, &bindings)?;
+            let resolved = resolve_ref_value(value, bindings)?;
             let final_value = if mark_unresolved_upstream {
-                stamp_unresolved_upstream(resolved, &upstream_binding_names)
+                stamp_unresolved_upstream(resolved, unresolved_upstream_bindings)
             } else {
                 resolved
             };
@@ -129,94 +118,55 @@ fn resolve_refs_inner(
 /// Pre-apply path: resolve `ResourceRef` values across a slice of
 /// `ManagedResource`s.
 ///
-/// Encodes the design-doc invariant ("`VirtualResource`s are never
-/// resolved against pre-apply state") at the type level: the slice
-/// type rejects virtuals at compile time. For virtuals, use
-/// [`resolve_virtual_refs_post_apply`] from `finalize_apply` (#3177).
-///
-/// # Scope limitation
-///
-/// Bindings are built from the managed slice alone — virtual bindings
-/// are **not** in the binding map. A managed attribute that references
-/// a virtual binding pre-apply (`managed_x.attr = ref some_module.role_arn`)
-/// will leave its ResourceRef un-resolved. The typestate split treats
-/// this as a non-case: in the migration target, managed inputs that
-/// depend on virtual outputs are routed via `wait` bindings or
-/// upstream-state passthroughs. If a real call site needs the
-/// mixed-bindings shape, prefer the legacy shim
-/// [`resolve_refs_with_state_and_remote`] until #3176 ships a typed
-/// constructor that accepts both slices.
-///
+/// carina#3248: virtuals and data sources are first-class binding
+/// sources on the pre-apply path. `bindings` must therefore include
+/// all kinds the configuration declares, via
+/// [`ResolvedBindings::pre_apply`]. A managed attribute referencing
+/// `<module_instance>.<attr>` (a virtual binding) chains through the
+/// virtual's attribute map to the managed sibling literal that backs
+/// it. The earlier "wait / upstream-state passthrough" guidance for
+/// this shape (referring to cross-stack consumption) does not apply
+/// to same-stack module attribute references — those resolve through
+/// the in-process virtual binding directly.
 pub fn resolve_managed_refs_with_state_and_remote(
     managed: &mut [ManagedResource],
-    current_states: &HashMap<ResourceId, State>,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    wait_aliases: &[crate::binding_index::WaitAliasSpec],
+    bindings: &ResolvedBindings,
 ) -> Result<(), String> {
-    resolve_refs_inner(
-        managed,
-        current_states,
-        remote_bindings,
-        wait_aliases,
-        false,
-    )
+    resolve_refs_inner(managed, bindings, &std::collections::HashSet::new())
 }
 
 /// Resolve `ResourceRef` values in a slice of [`DataSource`]s against
-/// the binding view built from the managed resources plus
-/// `current_states` / `remote_bindings` (carina#3181).
+/// a pre-built `ResolvedBindings` view (carina#3248).
 ///
 /// Data sources are read-only; their input attributes (`read aws.iam.user
-/// { user_name = some_let.name }`) reference managed resources, so the
-/// binding map is built from the managed slice. Each data source's
-/// `dependency_bindings` is recorded before resolution destroys the
-/// `ResourceRef` values, mirroring [`resolve_refs_inner`].
+/// { user_name = some_let.name }`) reference managed resources, virtuals,
+/// or other data sources, so the binding map the caller passes must
+/// include all kinds via [`ResolvedBindings::pre_apply`]. Each data
+/// source's `dependency_bindings` is recorded before resolution
+/// destroys the `ResourceRef` values, mirroring [`resolve_refs_inner`].
 pub fn resolve_data_source_refs(
     data_sources: &mut [DataSource],
-    managed: &[ManagedResource],
-    current_states: &HashMap<ResourceId, State>,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    wait_aliases: &[crate::binding_index::WaitAliasSpec],
+    bindings: &ResolvedBindings,
 ) -> Result<(), String> {
-    resolve_data_source_refs_inner(
-        data_sources,
-        managed,
-        current_states,
-        remote_bindings,
-        wait_aliases,
-        false,
-    )
+    resolve_data_source_refs_inner(data_sources, bindings, &std::collections::HashSet::new())
 }
 
-/// Plan-only counterpart of [`resolve_data_source_refs`]: any surviving
-/// `Value::ResourceRef` whose root binding is named in `remote_bindings`
-/// is replaced with the unresolved-upstream marker so plan display can
-/// render it as `(known after upstream apply: <ref>)`. Mirrors
-/// [`resolve_refs_for_plan`] for data sources.
+/// Plan-only counterpart of [`resolve_data_source_refs`]. Mirrors
+/// [`resolve_refs_for_plan`]: takes the set of upstream-binding
+/// names whose surviving refs should be stamped as
+/// `Value::Unknown(UnknownReason::UpstreamRef { path })`.
 pub fn resolve_data_source_refs_for_plan(
     data_sources: &mut [DataSource],
-    managed: &[ManagedResource],
-    current_states: &HashMap<ResourceId, State>,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    wait_aliases: &[crate::binding_index::WaitAliasSpec],
+    bindings: &ResolvedBindings,
+    unresolved_upstream_bindings: &std::collections::HashSet<&str>,
 ) -> Result<(), String> {
-    resolve_data_source_refs_inner(
-        data_sources,
-        managed,
-        current_states,
-        remote_bindings,
-        wait_aliases,
-        true,
-    )
+    resolve_data_source_refs_inner(data_sources, bindings, unresolved_upstream_bindings)
 }
 
 fn resolve_data_source_refs_inner(
     data_sources: &mut [DataSource],
-    managed: &[ManagedResource],
-    current_states: &HashMap<ResourceId, State>,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    wait_aliases: &[crate::binding_index::WaitAliasSpec],
-    mark_unresolved_upstream: bool,
+    bindings: &ResolvedBindings,
+    unresolved_upstream_bindings: &std::collections::HashSet<&str>,
 ) -> Result<(), String> {
     for data_source in data_sources.iter_mut() {
         let deps = crate::deps::get_resource_value_ref_dependencies(data_source);
@@ -224,23 +174,13 @@ fn resolve_data_source_refs_inner(
             data_source.dependency_bindings = deps.into_iter().collect();
         }
     }
-    let bindings = ResolvedBindings::from_resources_with_state(
-        managed,
-        current_states,
-        remote_bindings,
-        wait_aliases,
-    );
-    let upstream_binding_names: std::collections::HashSet<&str> = if mark_unresolved_upstream {
-        remote_bindings.keys().map(String::as_str).collect()
-    } else {
-        std::collections::HashSet::new()
-    };
+    let mark_unresolved_upstream = !unresolved_upstream_bindings.is_empty();
     for data_source in data_sources.iter_mut() {
         let mut resolved_attrs: IndexMap<String, Value> = IndexMap::new();
         for (key, value) in &data_source.attributes {
-            let resolved = resolve_ref_value(value, &bindings)?;
+            let resolved = resolve_ref_value(value, bindings)?;
             let final_value = if mark_unresolved_upstream {
-                stamp_unresolved_upstream(resolved, &upstream_binding_names)
+                stamp_unresolved_upstream(resolved, unresolved_upstream_bindings)
             } else {
                 resolved
             };
@@ -563,9 +503,9 @@ mod tests {
     }
 
     /// Build a `ResolvedBindings` from a flat `binding_name → attributes`
-    /// map. Each entry is dropped in via `from_resources_with_state` so
-    /// the resulting view is identical to what production code constructs
-    /// — there is no test-only back door into the type.
+    /// map. Each entry is dropped in via `pre_apply` so the resulting
+    /// view is identical to what production code constructs — there is
+    /// no test-only back door into the type.
     fn bindings_from(entries: Vec<(&str, Vec<(&str, Value)>)>) -> ResolvedBindings {
         let resources: Vec<ManagedResource> = entries
             .into_iter()
@@ -573,12 +513,56 @@ mod tests {
                 make_resource(&format!("{}-resource", binding), Some(binding), attrs)
             })
             .collect();
-        ResolvedBindings::from_resources_with_state(
-            &resources,
-            &HashMap::new(),
-            &HashMap::new(),
-            &[],
-        )
+        ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        })
+    }
+
+    /// Test-only adapter that preserves the pre-#3248 four-arg
+    /// signature so the bulky test corpus migrates mechanically.
+    /// Builds the bindings view here, then delegates to the new
+    /// signature.
+    fn resolve_refs_with_state_and_remote_legacy(
+        resources: &mut [ManagedResource],
+        current_states: &HashMap<ResourceId, State>,
+        remote_bindings: &HashMap<String, HashMap<String, Value>>,
+        wait_aliases: &[crate::binding_index::WaitAliasSpec],
+    ) -> Result<(), String> {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states,
+            remote_bindings,
+            wait_aliases,
+        });
+        resolve_refs_with_state_and_remote(resources, &bindings)
+    }
+
+    /// Test-only adapter for the plan-path resolver (mirrors
+    /// `resolve_refs_with_state_and_remote_legacy`).
+    fn resolve_refs_for_plan_legacy(
+        resources: &mut [ManagedResource],
+        current_states: &HashMap<ResourceId, State>,
+        remote_bindings: &HashMap<String, HashMap<String, Value>>,
+        wait_aliases: &[crate::binding_index::WaitAliasSpec],
+    ) -> Result<(), String> {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: resources,
+            virtuals: &[],
+            data_sources: &[],
+            current_states,
+            remote_bindings,
+            wait_aliases,
+        });
+        let upstream_keys: std::collections::HashSet<&str> =
+            remote_bindings.keys().map(String::as_str).collect();
+        resolve_refs_for_plan(resources, &bindings, &upstream_keys)
     }
 
     #[test]
@@ -1602,8 +1586,13 @@ mod tests {
         );
         remote_bindings.insert("network".to_string(), network_map);
 
-        resolve_refs_with_state_and_remote(&mut resources, &current_states, &remote_bindings, &[])
-            .unwrap();
+        resolve_refs_with_state_and_remote_legacy(
+            &mut resources,
+            &current_states,
+            &remote_bindings,
+            &[],
+        )
+        .unwrap();
 
         assert_eq!(
             resources[0].get_attr("vpc_id"),
@@ -1655,8 +1644,13 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
-            .unwrap();
+        resolve_refs_with_state_and_remote_legacy(
+            &mut resources,
+            &HashMap::new(),
+            &remote_bindings,
+            &[],
+        )
+        .unwrap();
 
         assert_eq!(
             resources[0].get_attr("principal_arn"),
@@ -1708,7 +1702,7 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
-        let err = resolve_refs_with_state_and_remote(
+        let err = resolve_refs_with_state_and_remote_legacy(
             &mut resources,
             &HashMap::new(),
             &remote_bindings,
@@ -1756,7 +1750,7 @@ mod tests {
                 }),
             )],
         )];
-        let err = resolve_refs_with_state_and_remote(
+        let err = resolve_refs_with_state_and_remote_legacy(
             &mut resources,
             &HashMap::new(),
             &remote_bindings,
@@ -1796,8 +1790,13 @@ mod tests {
         )];
 
         let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
-        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
-            .expect("unloaded upstream subscript must not error");
+        resolve_refs_with_state_and_remote_legacy(
+            &mut resources,
+            &HashMap::new(),
+            &remote_bindings,
+            &[],
+        )
+        .expect("unloaded upstream subscript must not error");
         assert!(
             matches!(
                 resources[0].get_attr("principal_arn"),
@@ -1845,8 +1844,13 @@ mod tests {
                 }),
             )],
         )];
-        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
-            .unwrap();
+        resolve_refs_with_state_and_remote_legacy(
+            &mut resources,
+            &HashMap::new(),
+            &remote_bindings,
+            &[],
+        )
+        .unwrap();
         assert_eq!(
             resources[0].get_attr("az"),
             Some(&Value::Concrete(ConcreteValue::String("aza".to_string())))
@@ -1893,7 +1897,7 @@ mod tests {
                 }),
             )],
         )];
-        let err = resolve_refs_with_state_and_remote(
+        let err = resolve_refs_with_state_and_remote_legacy(
             &mut resources,
             &HashMap::new(),
             &remote_bindings,
@@ -1926,8 +1930,13 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_with_state_and_remote(&mut resources, &current_states, &remote_bindings, &[])
-            .unwrap();
+        resolve_refs_with_state_and_remote_legacy(
+            &mut resources,
+            &current_states,
+            &remote_bindings,
+            &[],
+        )
+        .unwrap();
 
         // Should remain as ResourceRef since "nonexistent" binding is not found
         assert!(matches!(
@@ -1957,7 +1966,8 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
+        resolve_refs_for_plan_legacy(&mut resources, &HashMap::new(), &remote_bindings, &[])
+            .unwrap();
 
         match resources[0].get_attr("vpc_id") {
             Some(Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { path }))) => {
@@ -1988,8 +1998,13 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings, &[])
-            .unwrap();
+        resolve_refs_with_state_and_remote_legacy(
+            &mut resources,
+            &HashMap::new(),
+            &remote_bindings,
+            &[],
+        )
+        .unwrap();
 
         assert!(matches!(
             resources[0].get_attr("vpc_id"),
@@ -2020,7 +2035,8 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("bootstrap".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
+        resolve_refs_for_plan_legacy(&mut resources, &HashMap::new(), &remote_bindings, &[])
+            .unwrap();
 
         match resources[0].get_attr("raw") {
             Some(Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamBareRef {
@@ -2058,7 +2074,8 @@ mod tests {
         remote_bindings.insert("bootstrap".to_string(), HashMap::new());
         remote_bindings.insert("secondary".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
+        resolve_refs_for_plan_legacy(&mut resources, &HashMap::new(), &remote_bindings, &[])
+            .unwrap();
 
         match resources[0].get_attr("raws") {
             Some(Value::Concrete(ConcreteValue::List(items))) => {
@@ -2092,7 +2109,8 @@ mod tests {
         )];
         let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
+        resolve_refs_for_plan_legacy(&mut resources, &HashMap::new(), &remote_bindings, &[])
+            .unwrap();
 
         assert!(matches!(
             resources[0].get_attr("vpc_id"),
@@ -2122,7 +2140,8 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
+        resolve_refs_for_plan_legacy(&mut resources, &HashMap::new(), &remote_bindings, &[])
+            .unwrap();
 
         match resources[0].get_attr("security_group_ids") {
             Some(Value::Concrete(ConcreteValue::List(items))) => {
@@ -2161,7 +2180,8 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
+        resolve_refs_for_plan_legacy(&mut resources, &HashMap::new(), &remote_bindings, &[])
+            .unwrap();
 
         assert!(
             resources[0].dependency_bindings.contains("network"),
@@ -2189,7 +2209,8 @@ mod tests {
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
         remote_bindings.insert("network".to_string(), HashMap::new());
 
-        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings, &[]).unwrap();
+        resolve_refs_for_plan_legacy(&mut resources, &HashMap::new(), &remote_bindings, &[])
+            .unwrap();
 
         match resources[0].get_attr("tags") {
             Some(Value::Concrete(ConcreteValue::Map(m))) => match m.get("VpcId") {
@@ -2217,15 +2238,17 @@ mod tests {
                 )),
             )],
         );
-        let bindings = ResolvedBindings::from_resources_with_state(
-            &[cert],
-            &HashMap::new(),
-            &HashMap::new(),
-            &[crate::binding_index::WaitAliasSpec {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &[cert],
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[crate::binding_index::WaitAliasSpec {
                 binding: crate::parser::BindingName::new("cert_issued"),
                 target: crate::parser::BindingName::new("cert"),
             }],
-        );
+        });
         let path = crate::resource::AccessPath::new("cert_issued", "certificate_arn");
         let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
@@ -2244,15 +2267,17 @@ mod tests {
     /// PlanError path — not a panic — surfaces it.
     #[test]
     fn resolve_ref_value_wait_binding_absent_target_left_intact() {
-        let bindings = ResolvedBindings::from_resources_with_state(
-            &[],
-            &HashMap::new(),
-            &HashMap::new(),
-            &[crate::binding_index::WaitAliasSpec {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &[],
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[crate::binding_index::WaitAliasSpec {
                 binding: crate::parser::BindingName::new("cert_issued"),
                 target: crate::parser::BindingName::new("nonexistent"),
             }],
-        );
+        });
         let path = crate::resource::AccessPath::new("cert_issued", "certificate_arn");
         let ref_value = Value::Deferred(DeferredValue::ResourceRef { path });
         let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();

--- a/carina-core/src/resolver_split_tests.rs
+++ b/carina-core/src/resolver_split_tests.rs
@@ -73,8 +73,18 @@ fn resolve_managed_refs_resolves_resource_ref_against_managed_sibling() {
     let b = make_managed("b", &[("dep", ref_to("a", "value"))]);
     let mut managed = vec![a, b];
 
-    resolve_managed_refs_with_state_and_remote(&mut managed, &HashMap::new(), &HashMap::new(), &[])
-        .expect("resolve managed");
+    {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &managed,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        });
+        resolve_managed_refs_with_state_and_remote(&mut managed, &bindings)
+    }
+    .expect("resolve managed");
 
     // After resolution `b.dep` should be the literal string from `a`.
     let dep = managed[1].attributes.get("dep").expect("dep present");
@@ -87,8 +97,18 @@ fn resolve_managed_refs_records_dependency_bindings() {
     let b = make_managed("b", &[("dep", ref_to("a", "value"))]);
     let mut managed = vec![a, b];
 
-    resolve_managed_refs_with_state_and_remote(&mut managed, &HashMap::new(), &HashMap::new(), &[])
-        .expect("resolve managed");
+    {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &managed,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        });
+        resolve_managed_refs_with_state_and_remote(&mut managed, &bindings)
+    }
+    .expect("resolve managed");
 
     assert!(
         managed[1].dependency_bindings.contains("a"),
@@ -113,8 +133,18 @@ fn resolve_managed_refs_falls_through_state_attributes() {
         State::existing(managed[0].id.clone(), state_attrs),
     );
 
-    resolve_managed_refs_with_state_and_remote(&mut managed, &current_states, &HashMap::new(), &[])
-        .expect("resolve managed");
+    {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &managed,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &current_states,
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        });
+        resolve_managed_refs_with_state_and_remote(&mut managed, &bindings)
+    }
+    .expect("resolve managed");
 
     let dep = managed[1].attributes.get("dep").expect("dep present");
     assert_eq!(*dep, s("from_state"), "expected state value, got {dep:?}");
@@ -126,12 +156,14 @@ fn resolve_virtual_refs_post_apply_uses_provided_bindings() {
     // that the post-apply entry resolves `VirtualResource` refs
     // against the supplied view.
     let referenced = make_managed("a", &[("value", s("post_apply_value"))]);
-    let bindings = ResolvedBindings::from_resources_with_state(
-        std::slice::from_ref(&referenced),
-        &HashMap::new(),
-        &HashMap::new(),
-        &[],
-    );
+    let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: std::slice::from_ref(&referenced),
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
 
     let mut virtuals = vec![make_virtual("v", &[("forwarded", ref_to("a", "value"))])];
     resolve_virtual_refs_post_apply(&mut virtuals, &bindings).expect("resolve virtuals");
@@ -151,12 +183,14 @@ fn resolve_virtual_refs_post_apply_picks_post_apply_value_not_pre_apply() {
     // the post-apply state. Verify the post-apply entry selects the
     // post-apply value when handed the post-apply bindings view.
     let role = make_managed("role", &[("arn", s("post_apply_arn"))]);
-    let post_apply_bindings = ResolvedBindings::from_resources_with_state(
-        std::slice::from_ref(&role),
-        &HashMap::new(),
-        &HashMap::new(),
-        &[],
-    );
+    let post_apply_bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: std::slice::from_ref(&role),
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
 
     let mut virtuals = vec![make_virtual("rd", &[("role_arn", ref_to("role", "arn"))])];
     resolve_virtual_refs_post_apply(&mut virtuals, &post_apply_bindings).expect("resolve virtuals");
@@ -176,8 +210,14 @@ fn resolve_virtual_refs_post_apply_picks_post_apply_value_not_pre_apply() {
 fn resolve_virtual_refs_post_apply_leaves_non_ref_values_intact() {
     // A literal attribute on a `VirtualResource` should be preserved
     // verbatim by the post-apply pass.
-    let bindings =
-        ResolvedBindings::from_resources_with_state(&[], &HashMap::new(), &HashMap::new(), &[]);
+    let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: &[],
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     let mut virtuals = vec![make_virtual("v", &[("literal", s("kept"))])];
 
     resolve_virtual_refs_post_apply(&mut virtuals, &bindings).expect("resolve virtuals");
@@ -192,15 +232,31 @@ fn resolve_virtual_refs_post_apply_leaves_non_ref_values_intact() {
 #[test]
 fn resolve_managed_refs_with_empty_slice_is_ok() {
     let mut managed: Vec<ManagedResource> = Vec::new();
-    resolve_managed_refs_with_state_and_remote(&mut managed, &HashMap::new(), &HashMap::new(), &[])
-        .expect("empty managed slice resolves cleanly");
+    {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &managed,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        });
+        resolve_managed_refs_with_state_and_remote(&mut managed, &bindings)
+    }
+    .expect("empty managed slice resolves cleanly");
     assert!(managed.is_empty());
 }
 
 #[test]
 fn resolve_virtual_refs_post_apply_with_empty_slice_is_ok() {
-    let bindings =
-        ResolvedBindings::from_resources_with_state(&[], &HashMap::new(), &HashMap::new(), &[]);
+    let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+        managed: &[],
+        virtuals: &[],
+        data_sources: &[],
+        current_states: &HashMap::new(),
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &[],
+    });
     let mut virtuals: Vec<VirtualResource> = Vec::new();
     resolve_virtual_refs_post_apply(&mut virtuals, &bindings)
         .expect("empty virtual slice resolves cleanly");
@@ -216,17 +272,32 @@ fn resolve_managed_refs_legacy_shim_produces_identical_result() {
     let b_new = make_managed("b", &[("dep", ref_to("a", "value"))]);
     let mut managed = vec![a_new.clone(), b_new.clone()];
 
-    resolve_managed_refs_with_state_and_remote(&mut managed, &HashMap::new(), &HashMap::new(), &[])
-        .expect("resolve managed");
+    {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &managed,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        });
+        resolve_managed_refs_with_state_and_remote(&mut managed, &bindings)
+    }
+    .expect("resolve managed");
 
     let mut legacy: Vec<ManagedResource> = vec![a_new.clone(), b_new.clone()];
-    crate::resolver::resolve_refs_with_state_and_remote(
-        &mut legacy,
-        &HashMap::new(),
-        &HashMap::new(),
-        &[],
-    )
-    .expect("resolve legacy");
+    {
+        let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
+            managed: &legacy,
+            virtuals: &[],
+            data_sources: &[],
+            current_states: &HashMap::new(),
+            remote_bindings: &HashMap::new(),
+            wait_aliases: &[],
+        });
+        crate::resolver::resolve_refs_with_state_and_remote(&mut legacy, &bindings)
+            .expect("resolve legacy");
+    }
 
     for (m, l) in managed.iter().zip(legacy.iter()) {
         assert_eq!(

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -754,6 +754,33 @@ pub fn redact_secrets_in_data_source(
     })
 }
 
+/// Redact all secrets in a
+/// [`VirtualResource`](crate::resource::VirtualResource) (carina#3248).
+///
+/// Virtuals are now persisted in saved plan files (`PlanFile`
+/// version `4`) so the saved-plan apply path can rebuild the same
+/// `ResolvedBindings` view as the live-apply path (carina#3246). A
+/// virtual's attribute map can hold values copied through from an
+/// inner module's `attributes { ... }` block — including literal
+/// secrets — so it must pass through the same per-kind redaction as
+/// managed resources / data sources / state before serialization.
+/// The `IndexMap<String, Value>` shape (vs `HashMap` for managed
+/// resources) is preserved so the user-authored attribute order
+/// survives redaction.
+pub fn redact_secrets_in_virtual(
+    resource: &crate::resource::VirtualResource,
+) -> Result<crate::resource::VirtualResource, SerializationError> {
+    let attributes: Result<indexmap::IndexMap<String, Value>, _> = resource
+        .attributes
+        .iter()
+        .map(|(k, e)| redact_secrets_in_value(e).map(|rv| (k.clone(), rv)))
+        .collect();
+    Ok(crate::resource::VirtualResource {
+        attributes: attributes?,
+        ..resource.clone()
+    })
+}
+
 /// Redact all secrets in a `State`, returning a new State with secrets replaced by hashes.
 pub fn redact_secrets_in_state(
     state: &crate::resource::State,
@@ -2328,6 +2355,68 @@ mod tests {
             "Serialized output must not contain plaintext secret, got: {}",
             json
         );
+    }
+
+    #[test]
+    fn test_redact_secrets_in_virtual_redacts_attribute_secrets() {
+        // carina#3248: virtuals are now persisted in saved plans, so
+        // a literal secret authored inside a module's `attributes { ... }`
+        // block (which lands as a `Value::Secret` in the virtual's
+        // attribute map) must be redacted before serialization, the
+        // same way managed-resource attributes are redacted.
+        use crate::resource::{ResourceId, VirtualResource};
+        use std::collections::{BTreeSet, HashSet};
+        let mut attrs = indexmap::IndexMap::new();
+        attrs.insert(
+            "non_secret".to_string(),
+            Value::Concrete(ConcreteValue::String("kept".to_string())),
+        );
+        attrs.insert(
+            "secret_field".to_string(),
+            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+                ConcreteValue::String("plaintext-must-not-leak".to_string()),
+            )))),
+        );
+        let virt = VirtualResource {
+            id: ResourceId::new("_virtual", "module_instance"),
+            attributes: attrs,
+            binding: Some("module_instance".to_string()),
+            dependency_bindings: BTreeSet::new(),
+            module_name: "m".to_string(),
+            instance: "module_instance".to_string(),
+            quoted_string_attrs: HashSet::new(),
+        };
+
+        let redacted = redact_secrets_in_virtual(&virt).expect("redact virtual");
+
+        // The non-secret attribute survives verbatim.
+        assert_eq!(
+            redacted.attributes.get("non_secret"),
+            Some(&Value::Concrete(ConcreteValue::String("kept".to_string()))),
+        );
+
+        // The secret attribute is replaced with the hash prefix, not the
+        // plaintext.
+        match redacted.attributes.get("secret_field") {
+            Some(Value::Concrete(ConcreteValue::String(s))) => {
+                assert!(
+                    s.starts_with(SECRET_PREFIX),
+                    "expected redacted hash prefix, got: {}",
+                    s
+                );
+                assert!(
+                    !s.contains("plaintext-must-not-leak"),
+                    "redacted form must not leak plaintext, got: {}",
+                    s
+                );
+            }
+            other => panic!("expected redacted secret, got: {:?}", other),
+        }
+
+        // The rest of the VirtualResource (id, binding, etc.) is
+        // preserved verbatim.
+        assert_eq!(redacted.binding.as_deref(), Some("module_instance"));
+        assert_eq!(redacted.id.resource_type, "_virtual");
     }
 
     #[test]

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -212,12 +212,19 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
         .iter()
         .map(carina_core::binding_index::WaitAliasSpec::from)
         .collect();
-    resolve_refs_with_state_and_remote(
-        &mut resources_for_plan,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-    )
+    {
+        let bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+            carina_core::binding_index::PreApplyInputs {
+                managed: &resources_for_plan.clone(),
+                virtuals: &[],
+                data_sources: &[],
+                current_states: &current_states,
+                remote_bindings: &remote_bindings,
+                wait_aliases: &wait_aliases,
+            },
+        );
+        resolve_refs_with_state_and_remote(&mut resources_for_plan, &bindings)
+    }
     .expect("resolve_refs should succeed");
 
     let registry = SchemaRegistry::new();
@@ -341,12 +348,19 @@ async fn nested_module_wait_binding_survives_two_expansions() {
         .iter()
         .map(carina_core::binding_index::WaitAliasSpec::from)
         .collect();
-    resolve_refs_with_state_and_remote(
-        &mut resources_for_plan,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-    )
+    {
+        let bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+            carina_core::binding_index::PreApplyInputs {
+                managed: &resources_for_plan.clone(),
+                virtuals: &[],
+                data_sources: &[],
+                current_states: &current_states,
+                remote_bindings: &remote_bindings,
+                wait_aliases: &wait_aliases,
+            },
+        );
+        resolve_refs_with_state_and_remote(&mut resources_for_plan, &bindings)
+    }
     .expect("resolve_refs should succeed");
 
     let registry = SchemaRegistry::new();
@@ -453,12 +467,19 @@ async fn carina3085_distribution_wait_ref_resolves_no_phantom_via_real_pipeline(
         .collect();
 
     let mut resources_for_plan = sorted_resources.clone();
-    resolve_refs_with_state_and_remote(
-        &mut resources_for_plan,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-    )
+    {
+        let bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+            carina_core::binding_index::PreApplyInputs {
+                managed: &resources_for_plan.clone(),
+                virtuals: &[],
+                data_sources: &[],
+                current_states: &current_states,
+                remote_bindings: &remote_bindings,
+                wait_aliases: &wait_aliases,
+            },
+        );
+        resolve_refs_with_state_and_remote(&mut resources_for_plan, &bindings)
+    }
     .expect("resolve_refs should succeed");
 
     // ---- The phantom is gone: the Distribution's nested


### PR DESCRIPTION
## Summary

Implements the design from #3249 (merged): the unified pre-apply `ResolvedBindings` constructor.

Replaces the asymmetric `from_managed_with_state` + opt-in layering API with a single typed constructor `ResolvedBindings::pre_apply(PreApplyInputs)`. `PreApplyInputs` is a required-field struct (`managed`, `virtuals`, `data_sources`, `current_states`, `remote_bindings`, `wait_aliases`) — forgetting any kind at a new call site is a compile error, not a runtime divergence.

Resolver entry points (`resolve_refs_for_plan`, `resolve_refs_with_state_and_remote`, `resolve_data_source_refs`, etc.) become pure transforms that consume a pre-built `&ResolvedBindings`. The post-apply increment helpers are renamed `layer_virtuals_post_apply` / `layer_data_sources_post_apply` so the phase distinction is visible at every call site.

**Saved-plan parity** (`apply --plan`):

- `PlanFile::version` bumps 3 → 4. Older plans error out with a clear message.
- `PlanFile` gains `virtual_resources` and `data_sources` so the saved-plan path rebuilds the same view as live apply. Review caught the data-source gap (pre-existing since #3181); closing it here removes a class of saved-plan-only divergence.
- New `redact_secrets_in_virtual` mirrors the per-kind redaction.

## Behavior changes (worth noting)

1. **`wait` aliases now snapshot data-source / virtual binding attributes.** Legacy ordering materialized `wait` aliases against managed+remote only; virtual / data-source `wait` targets snapshotted nothing. The new layering order (managed → data_sources → virtuals → wait_aliases) closes that gap. A `wait` targeting a managed binding behaves exactly as before.
2. **Same-config `for x in <module_instance>.<list_attr>` expansion** reaches virtual / data-source attribute targets that previously stayed deferred.

## Headline bug fix

#3246 closes structurally: the plan-path resolver consumes a view that includes virtuals from the start, the virtual-rooted ref chains through to the managed sibling literal, and the differ sees the same literal both sides.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3559 passed, 72 skipped
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all OK
- [x] Unit tests: `binding_index_split_tests.rs` (`pre_apply` semantics + layer order), `value.rs::test_redact_secrets_in_virtual_redacts_attribute_secrets`
- [x] E2E: `virtual_binding_resolve_e2e.rs` — multi-file directory fixture mirroring `envs/registry/dev/bootstrap/`, drives the plan path through `pre_apply` and asserts the managed→virtual→managed chain resolves to the concrete literal
- [x] Saved-plan version gate: `saved_plan_version_tests::version_3_saved_plan_is_rejected`

Real-infra smoke test against `carina-rs/infra/envs/registry/dev/bootstrap/` was not run locally because the existing main-branch binary fails to load WASM providers in the current local environment (pre-existing wit-submodule version mismatch unrelated to this PR). The unit tests + e2e directory fixture cover the same shape.

Closes #3246. Refs #3248 (design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
