### PR TITLE
parser: reject unknown bare custom types in type positions (closes #3239)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -142,6 +142,9 @@ fn enrich_provider_context(
             },
         )),
         schema_types: Default::default(),
+        // carina#3239: schemas are loaded at this point, so the strict
+        // "unknown custom type in type position" parser check applies.
+        customs_loaded: true,
     }
 }
 
@@ -253,6 +256,23 @@ pub fn validate_and_resolve_errors_with_factories(
 
     // Enrich provider context with custom type validators from loaded schemas
     let enriched_context = enrich_provider_context(ctx.schemas(), ctx.factories_arc());
+
+    // carina#3239: reject `arguments { foo: TotallyMadeUpType }`-shaped
+    // unknown bare custom-type names in the root parse. The root
+    // config was parsed up in `load_configuration_with_config` with
+    // the bootstrap context (`customs_loaded = false`) — schemas had
+    // not been collected yet, so the parser-side `customs_loaded` gate
+    // could not fire there. This post-parse walk re-applies the same
+    // predicate against the now-enriched context, closing the
+    // standalone-module-validate path so a typo or renamed-then-
+    // removed type cannot ride into apply. Imported modules
+    // re-parsed below by `resolve_modules_with_config` see the
+    // enriched context directly and the parser gate covers them.
+    for finding in
+        carina_core::validation::validate_argument_custom_types(parsed, &enriched_context)
+    {
+        errors.push(AppError::Validation(finding));
+    }
 
     // Validate module call arguments before expansion (needs enriched
     // context for custom type validators)

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -282,6 +282,10 @@ fn create_provider_context() -> carina_core::parser::ProviderContext {
         validators: std::collections::HashMap::new(),
         custom_type_validator: None,
         schema_types: Default::default(),
+        // Schemas not yet loaded — early-parse runs before
+        // `enrich_provider_context` populates the validator set, so the
+        // carina#3239 strict check is deferred to that later context.
+        customs_loaded: false,
     }
 }
 

--- a/carina-cli/tests/validate_unknown_custom_type_e2e.rs
+++ b/carina-cli/tests/validate_unknown_custom_type_e2e.rs
@@ -1,0 +1,346 @@
+//! End-to-end validation regression for carina#3239.
+//!
+//! Declaring a module argument with an unknown bare custom-type name —
+//! whether a typo (`TotallyMadeUpType`) or a renamed-then-removed
+//! legacy spelling (`IamOidcProviderArn` — the issue's headline case,
+//! where the registered identity is now `aws.iam.OidcProvider.Arn`) —
+//! must fail `carina validate` with a clear "unknown custom type" error
+//! instead of silently degrading into an untyped string.
+//!
+//! The check fires at parse time, gated by
+//! `ProviderContext::customs_loaded`. Production runs through
+//! `enrich_provider_context`, which sets that flag once schemas have
+//! been collected; this test exercises the same CLI surface
+//! (`validate_with_factories`) that `carina-cli/tests/nested_module_call_ref_e2e.rs`
+//! does, so the fixture covers the real validate path end-to-end —
+//! including the [[feedback_directory_scoped_features]] requirement
+//! that any DSL-source feature be tested against a real multi-file
+//! module directory, not a bare string.
+
+use carina_core::provider::{
+    BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
+};
+use carina_core::resource::{DataSource, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Minimal awscc provider factory; the fixture only references
+// `awscc.ec2.Vpc` so the error surface is the carina#3239 unknown-type
+// check itself, not an unrelated "unknown provider" diagnostic.
+// ---------------------------------------------------------------------------
+
+struct AwsccTestFactory;
+
+impl ProviderFactory for AwsccTestFactory {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+    fn display_name(&self) -> &str {
+        "AWSCC (carina#3239 test stub)"
+    }
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+    fn validate_custom_type(
+        &self,
+        _type_name: &carina_core::schema::TypeIdentity,
+        _value: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "us-east-1".to_string()
+    }
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
+    }
+    fn create_normalizer(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+        Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+    }
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![
+            ResourceSchema::new("ec2.Vpc")
+                .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+                .attribute(AttributeSchema::new("vpc_id", AttributeType::String)),
+        ]
+    }
+}
+
+struct NoopProvider;
+
+impl Provider for NoopProvider {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+    fn read(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: Option<&str>,
+        _request: carina_core::provider::ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::not_found(id)) })
+    }
+    fn read_data_source(
+        &self,
+        resource: &DataSource,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn create(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn update(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn delete(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn factories() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(AwsccTestFactory) as Box<dyn ProviderFactory>]
+}
+
+/// Two-directory fixture: a module that *declares* an unknown
+/// custom-type argument, and a root caller. Module is the surface
+/// `arguments { ... }` legitimately appears on — the parser check fires
+/// on the module's `.crn` files when the caller's validate pass loads
+/// the imported module through `module_resolver::load_module`.
+fn write_fixture(arg_type: &str) -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    std::fs::create_dir(dir.path().join("inner")).unwrap();
+    std::fs::create_dir(dir.path().join("caller")).unwrap();
+
+    // The module's `arguments` block carries the offending unknown
+    // type. The body is otherwise minimal — the test asserts on the
+    // type-name diagnostic, not on any downstream module behavior.
+    std::fs::write(
+        dir.path().join("inner/main.crn"),
+        format!(
+            r#"arguments {{
+  bad_arg: {arg_type}
+}}
+
+let vpc = awscc.ec2.Vpc {{
+  cidr_block = '10.0.0.0/16'
+}}
+"#
+        ),
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.path().join("caller/providers.crn"),
+        r#"provider awscc {
+  region = "us-east-1"
+}
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.path().join("caller/main.crn"),
+        r#"let inner = use { source = '../inner' }
+
+let m = inner {
+  bad_arg = 'anything'
+}
+"#,
+    )
+    .unwrap();
+
+    dir
+}
+
+/// Headline case from the issue: a clearly-fake PascalCase name in a
+/// module argument's type position must be rejected.
+#[test]
+fn validate_rejects_fake_custom_type_name() {
+    let fixture = write_fixture("TotallyMadeUpType");
+    let caller = fixture.path().join("caller");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(&caller, factories());
+
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("unknown custom type") && d.contains("TotallyMadeUpType")),
+        "validate must reject an unknown custom-type name with a clear \
+         message; got diagnostics: {:#?}",
+        diags
+    );
+}
+
+/// The actual carina#3239 motivating case: `IamOidcProviderArn` is a
+/// legacy spelling whose registered identity has been renamed to
+/// `aws.iam.OidcProvider.Arn`. The bare name is *not* registered, so
+/// it must be rejected the same as any other unknown name.
+#[test]
+fn validate_rejects_renamed_legacy_custom_type_name() {
+    let fixture = write_fixture("IamOidcProviderArn");
+    let caller = fixture.path().join("caller");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(&caller, factories());
+
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("unknown custom type") && d.contains("IamOidcProviderArn")),
+        "validate must reject a renamed-then-removed custom-type name \
+         (carina#3239 headline case); got diagnostics: {:#?}",
+        diags
+    );
+}
+
+/// Negative control: a built-in DSL custom type (`Ipv4Cidr`) must
+/// still be accepted. Guards against the strict check over-firing on
+/// the four `carina-core` built-ins, which carry no provider
+/// registration and would be the first false-positive class to break.
+#[test]
+fn validate_accepts_builtin_custom_type_name() {
+    let fixture = write_fixture("Ipv4Cidr");
+    let caller = fixture.path().join("caller");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(&caller, factories());
+
+    assert!(
+        !diags.iter().any(|d| d.contains("unknown custom type")),
+        "validate must accept the built-in `Ipv4Cidr` custom type; got \
+         diagnostics: {:#?}",
+        diags
+    );
+}
+
+/// `attributes` parameters are the module-callable equivalent of
+/// `arguments` for attribute-level lookups, and they share the same
+/// silent-accept bug if the post-parse walk is restricted to
+/// `arguments` alone. This test pins coverage so a future regression
+/// in the walker's parameter set is caught.
+#[test]
+fn validate_rejects_fake_custom_type_in_attributes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(dir.path().join("inner")).unwrap();
+
+    std::fs::write(
+        dir.path().join("inner/main.crn"),
+        r#"attributes {
+  bad_attr: TotallyMadeUpType = 'placeholder'
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+"#,
+    )
+    .unwrap();
+
+    let diags = carina_cli::commands::validate::validate_with_factories(
+        &dir.path().join("inner"),
+        factories(),
+    );
+
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("unknown custom type") && d.contains("TotallyMadeUpType")),
+        "validate must reject an unknown bare custom-type name in an \
+         `attributes` declaration; got diagnostics: {:#?}",
+        diags
+    );
+}
+
+/// `exports` declarations carry an optional type annotation; an
+/// unknown bare custom type there is the same class of silent-accept
+/// bug as `arguments` / `attributes`.
+#[test]
+fn validate_rejects_fake_custom_type_in_exports() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(dir.path().join("inner")).unwrap();
+
+    std::fs::write(
+        dir.path().join("inner/main.crn"),
+        r#"let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+exports {
+  bad_export: TotallyMadeUpType = vpc.vpc_id
+}
+"#,
+    )
+    .unwrap();
+
+    let diags = carina_cli::commands::validate::validate_with_factories(
+        &dir.path().join("inner"),
+        factories(),
+    );
+
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("unknown custom type") && d.contains("TotallyMadeUpType")),
+        "validate must reject an unknown bare custom-type name in an \
+         `exports` declaration; got diagnostics: {:#?}",
+        diags
+    );
+}
+
+/// Standalone-module validate: `carina validate ./my_module/` runs
+/// against the module directory directly, with no caller in sight.
+/// The root parse used the bootstrap `ProviderContext`
+/// (`customs_loaded = false`), so the strict parser gate did not fire;
+/// the post-parse `validate_argument_custom_types` walk in
+/// `validate_and_resolve_errors_with_factories` is what catches the
+/// unknown name here. Without that walk, the bug-headline shape
+/// (`arguments { bad_arg: TotallyMadeUpType }` validated standalone)
+/// would slip through and the issue would only partially be fixed.
+#[test]
+fn validate_rejects_fake_custom_type_in_standalone_module() {
+    let fixture = write_fixture("TotallyMadeUpType");
+    let inner = fixture.path().join("inner");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(&inner, factories());
+
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("unknown custom type") && d.contains("TotallyMadeUpType")),
+        "validate must reject an unknown custom-type name even when the \
+         module is validated standalone (no caller); got diagnostics: \
+         {:#?}",
+        diags
+    );
+}

--- a/carina-core/src/builtins/decrypt.rs
+++ b/carina-core/src/builtins/decrypt.rs
@@ -94,6 +94,7 @@ mod tests {
             validators: HashMap::new(),
             custom_type_validator: None,
             schema_types: Default::default(),
+            customs_loaded: false,
         }
     }
 

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -2724,6 +2724,7 @@ fn test_argument_type_custom_validator() {
         validators,
         custom_type_validator: None,
         schema_types: Default::default(),
+        customs_loaded: false,
     };
 
     let mut module = create_test_module();
@@ -2799,6 +2800,7 @@ fn test_argument_type_list_of_custom_type() {
         validators,
         custom_type_validator: None,
         schema_types: Default::default(),
+        customs_loaded: false,
     };
 
     let mut module = create_test_module();

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -442,6 +442,15 @@ pub type ExportParameter = ParsedExportParam;
 pub trait ExportParamLike {
     fn name(&self) -> &str;
     fn value(&self) -> Option<&Value>;
+    /// The export's declared type, when one is available.
+    ///
+    /// The parser phase carries `Option<TypeExpr>` (the user may have
+    /// omitted the annotation, inference fills it later); the post-
+    /// inference phase carries a bare `TypeExpr` and the impl returns
+    /// `Some(&type_expr)` unconditionally. Carina#3239's argument-side
+    /// custom-type walk uses this so it can validate both phases through
+    /// the same trait.
+    fn type_expr_opt(&self) -> Option<&TypeExpr>;
 }
 
 impl ExportParamLike for ParsedExportParam {
@@ -450,6 +459,9 @@ impl ExportParamLike for ParsedExportParam {
     }
     fn value(&self) -> Option<&Value> {
         self.value.as_ref()
+    }
+    fn type_expr_opt(&self) -> Option<&TypeExpr> {
+        self.type_expr.as_ref()
     }
 }
 
@@ -764,6 +776,9 @@ impl ExportParamLike for InferredExportParam {
     }
     fn value(&self) -> Option<&Value> {
         self.value.as_ref()
+    }
+    fn type_expr_opt(&self) -> Option<&TypeExpr> {
+        Some(&self.type_expr)
     }
 }
 

--- a/carina-core/src/parser/config.rs
+++ b/carina-core/src/parser/config.rs
@@ -51,6 +51,22 @@ pub struct ProviderContext {
     /// path as `TypeExpr::SchemaType`; otherwise it falls back to
     /// `TypeExpr::Ref`.
     pub schema_types: HashSet<(String, String, String)>,
+    /// Whether the provider-registration phase has populated this
+    /// context with the full custom-type set. When `true`, the parser
+    /// rejects any bare PascalCase type name that is not a built-in DSL
+    /// custom type and is not present in [`validators`] as a bare
+    /// identity — the carina#3239 root-cause fix that turns "silent
+    /// accept of unknown custom types" into a parse error.
+    ///
+    /// The default is `false` so that early-parse paths that legitimately
+    /// run before any provider has registered (LSP mid-edit reparse,
+    /// `parse_type_expr_str` for completion ranking, unit tests built
+    /// from string fixtures) keep their pre-#3239 behavior and do not
+    /// lose every `Simple`-shaped type name to a hard error. CLI / LSP
+    /// validation that *has* loaded schemas sets this to `true` so the
+    /// strict check takes effect; see `enrich_provider_context` in the
+    /// CLI command surface.
+    pub customs_loaded: bool,
 }
 
 impl ProviderContext {
@@ -88,6 +104,7 @@ impl std::fmt::Debug for ProviderContext {
                 &self.custom_type_validator.as_ref().map(|_| "..."),
             )
             .field("schema_types", &self.schema_types)
+            .field("customs_loaded", &self.customs_loaded)
             .finish()
     }
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -36,6 +36,7 @@ pub use resolve::{
     resolve_provider_unresolved_attributes, resolve_resource_refs,
     resolve_resource_refs_with_config,
 };
+pub(crate) use types::is_known_bare_custom_type;
 pub use types::parse_type_expr_str;
 pub(crate) use util::{eval_type_name, value_type_name};
 pub use util::{pascal_to_snake, snake_to_pascal};

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -6362,6 +6362,7 @@ fn parse_decrypt_uses_config_decryptor() {
         validators: HashMap::new(),
         custom_type_validator: None,
         schema_types: Default::default(),
+        customs_loaded: false,
     };
 
     // decrypt() in resource attributes is resolved during resolve_resource_refs,
@@ -6424,6 +6425,7 @@ fn parse_custom_validator_accepts_valid() {
         validators,
         custom_type_validator: None,
         schema_types: Default::default(),
+        customs_loaded: false,
     };
 
     let result = validate_custom_type(
@@ -6465,6 +6467,7 @@ fn parse_custom_validator_rejects_invalid() {
         validators,
         custom_type_validator: None,
         schema_types: Default::default(),
+        customs_loaded: false,
     };
 
     // Test validate_custom_type directly since the grammar may not accept

--- a/carina-core/src/parser/types.rs
+++ b/carina-core/src/parser/types.rs
@@ -64,6 +64,41 @@ pub(super) fn parse_type_expr(
     }
 }
 
+/// The set of bare PascalCase custom types built into the DSL itself.
+/// These are accepted in a type position regardless of which providers
+/// (if any) have registered, because their validators live in
+/// `carina-core` rather than in any provider — see the matching arms in
+/// [`crate::parser::functions::validate_custom_type`].
+const BUILTIN_BARE_CUSTOM_TYPES: &[&str] =
+    &["ipv4_cidr", "ipv4_address", "ipv6_cidr", "ipv6_address"];
+
+/// True iff a snake-cased bare type name resolves to a known custom
+/// type — either a `carina-core` built-in or an identity registered in
+/// `config.validators` with no provider/segment axis. The carina#3239
+/// strict-parse gate consults this when
+/// [`ProviderContext::customs_loaded`] is `true`.
+///
+/// `TypeExpr::Simple` only carries the bare axis, so this check is
+/// deliberately scoped to bare identities — provider-scoped types like
+/// `aws.iam.Role.Arn` arrive through the `TypeExpr::SchemaType` path
+/// instead and are validated by `schema_types`.
+///
+/// Exposed at the crate root so the validation layer
+/// (`crate::validation`) can apply the same predicate to argument
+/// declarations parsed earlier with a bootstrap context — the
+/// standalone-module-validate path where the strict parse-time gate
+/// did not fire.
+pub(crate) fn is_known_bare_custom_type(snake: &str, config: &ProviderContext) -> bool {
+    if BUILTIN_BARE_CUSTOM_TYPES.contains(&snake) {
+        return true;
+    }
+    let pascal = snake_to_pascal(snake);
+    config
+        .validators
+        .keys()
+        .any(|id| id.provider.is_none() && id.segments.is_empty() && id.kind == pascal)
+}
+
 fn parse_type_expr_atom(
     pair: pest::iterators::Pair<Rule>,
     config: &ProviderContext,
@@ -109,7 +144,21 @@ fn parse_type_expr_atom(
                     ),
                 }),
                 other if other.chars().next().is_some_and(|c| c.is_ascii_uppercase()) => {
-                    Ok(TypeExpr::Simple(pascal_to_snake(other)))
+                    let snake = pascal_to_snake(other);
+                    // carina#3239: when the provider-registration phase
+                    // has populated `config`, an unknown bare custom-type
+                    // name in a type position is a parse error. Before
+                    // this gate, any PascalCase identifier became
+                    // `TypeExpr::Simple(snake)` and downstream `validate`
+                    // silently treated unknowns as untyped strings — so
+                    // typos and renamed-then-removed types went unnoticed.
+                    if config.customs_loaded && !is_known_bare_custom_type(&snake, config) {
+                        return Err(ParseError::InvalidExpression {
+                            line,
+                            message: format!("unknown custom type '{other}'"),
+                        });
+                    }
+                    Ok(TypeExpr::Simple(snake))
                 }
                 other => Err(ParseError::InvalidExpression {
                     line,
@@ -261,5 +310,79 @@ mod tests {
         assert_eq!(parse_type_expr_str("!!!", &ctx), None);
         assert_eq!(parse_type_expr_str("List(", &ctx), None);
         assert_eq!(parse_type_expr_str("", &ctx), None);
+    }
+
+    /// Default `ProviderContext` (no provider phase has run yet, so
+    /// `customs_loaded` is false) keeps the legacy lax behavior: any
+    /// PascalCase identifier becomes `TypeExpr::Simple(snake_case)`. This
+    /// preserves the LSP early-parse path that runs before schemas are
+    /// loaded — without it, every mid-edit buffer would lose all
+    /// `Simple`-shaped type completions.
+    #[test]
+    fn parse_type_expr_str_accepts_unknown_when_customs_not_loaded() {
+        let ctx = ProviderContext::default();
+        assert!(matches!(
+            parse_type_expr_str("TotallyMadeUpType", &ctx),
+            Some(TypeExpr::Simple(ref s)) if s == "totally_made_up_type"
+        ));
+    }
+
+    /// After the provider phase has run (`customs_loaded = true`), an
+    /// unknown bare PascalCase custom-type name in a type position is
+    /// rejected at parse time rather than silently accepted as
+    /// `TypeExpr::Simple`. This is the carina#3239 fix: typos and
+    /// renamed-then-removed types stop being silent.
+    #[test]
+    fn parse_type_expr_str_rejects_unknown_when_customs_loaded() {
+        let ctx = ProviderContext {
+            customs_loaded: true,
+            ..Default::default()
+        };
+        // No validators registered → only the four built-ins are valid.
+        // A clearly-fake name is rejected.
+        assert_eq!(parse_type_expr_str("TotallyMadeUpType", &ctx), None);
+        // A historical-but-removed name is rejected the same way — the
+        // bug-headline example from carina#3239.
+        assert_eq!(parse_type_expr_str("IamOidcProviderArn", &ctx), None);
+    }
+
+    /// Built-in DSL custom types (`Ipv4Cidr`, `Ipv4Address`, `Ipv6Cidr`,
+    /// `Ipv6Address`) are always accepted, even when no provider has
+    /// registered any validators — they are part of `carina-core` itself.
+    #[test]
+    fn parse_type_expr_str_accepts_builtins_when_customs_loaded() {
+        let ctx = ProviderContext {
+            customs_loaded: true,
+            ..Default::default()
+        };
+        for name in ["Ipv4Cidr", "Ipv4Address", "Ipv6Cidr", "Ipv6Address"] {
+            assert!(
+                matches!(parse_type_expr_str(name, &ctx), Some(TypeExpr::Simple(_))),
+                "built-in custom type '{name}' must parse with customs_loaded=true"
+            );
+        }
+    }
+
+    /// A bare custom-type identity registered in `ProviderContext.validators`
+    /// makes the corresponding PascalCase name acceptable in a type
+    /// position. Provider-scoped identities (`aws.iam.Role.Arn`) live on
+    /// the `TypeExpr::SchemaType` path, not here — `TypeExpr::Simple`
+    /// only carries the *bare* axis.
+    #[test]
+    fn parse_type_expr_str_accepts_registered_bare_custom_when_customs_loaded() {
+        use crate::schema::TypeIdentity;
+
+        let mut ctx = ProviderContext {
+            customs_loaded: true,
+            ..Default::default()
+        };
+        ctx.validators
+            .insert(TypeIdentity::bare("EmailAddress"), Box::new(|_| Ok(())));
+        assert!(matches!(
+            parse_type_expr_str("EmailAddress", &ctx),
+            Some(TypeExpr::Simple(ref s)) if s == "email_address"
+        ));
+        // A bare key does NOT make an unrelated name valid.
+        assert_eq!(parse_type_expr_str("TotallyMadeUpType", &ctx), None);
     }
 }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -671,6 +671,115 @@ pub fn validate_no_arguments_in_root<E>(parsed: &crate::parser::File<E>) -> Resu
     Ok(())
 }
 
+/// Reject module-level type declarations whose type position names an
+/// unknown bare custom type (carina#3239).
+///
+/// Walks every typed parameter `parsed` carries — `arguments`,
+/// `attributes`, `exports` (when typed) — and applies the same
+/// predicate the parser's `customs_loaded` gate uses.
+///
+/// The parser already rejects unknown `TypeExpr::Simple` names when
+/// it is handed a `ProviderContext` with `customs_loaded = true`. That
+/// gate fires for every parse path *after* the provider-registration
+/// phase has populated the context — imported modules re-parsed by
+/// `module_resolver::resolve_modules_with_config` and every LSP
+/// diagnostic pass.
+///
+/// The root-config parse is the one exception: `load_configuration_with_config`
+/// runs with the bootstrap context (`customs_loaded = false`) because
+/// schemas have not been collected yet, so a standalone-module
+/// validate (`carina validate ./my_module/`) would let an unknown
+/// custom-type name in `arguments { foo: TotallyMadeUpType }` slip
+/// through. This post-parse walk re-applies the same predicate against
+/// the now-enriched context, closing the gap without re-parsing.
+///
+/// `attributes` and `exports` are covered for the same reason as
+/// `arguments`: all three are module-boundary type declarations, all
+/// three are reached through the same root-config parse, and an
+/// unknown bare custom type in any of them surfaces the identical
+/// silent-accept bug.
+///
+/// The check is restricted to bare PascalCase names that parsed as
+/// `TypeExpr::Simple`. Provider-scoped customs (`aws.iam.Role.Arn`)
+/// travel through `TypeExpr::SchemaType` and have their own
+/// `schema_types`-based validation; they are out of scope here.
+pub fn validate_argument_custom_types<E: crate::parser::ExportParamLike>(
+    parsed: &crate::parser::File<E>,
+    config: &ProviderContext,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    for arg in &parsed.arguments {
+        collect_unknown_simple_types_in(&arg.type_expr, config, "argument", &arg.name, &mut errors);
+    }
+    for ap in &parsed.attribute_params {
+        if let Some(ty) = &ap.type_expr {
+            collect_unknown_simple_types_in(ty, config, "attribute", &ap.name, &mut errors);
+        }
+    }
+    for ep in &parsed.export_params {
+        if let Some(ty) = ep.type_expr_opt() {
+            collect_unknown_simple_types_in(ty, config, "export", ep.name(), &mut errors);
+        }
+    }
+    errors
+}
+
+/// Recursively walk a [`TypeExpr`] and push one diagnostic per
+/// [`TypeExpr::Simple`] whose name is not a known bare custom type
+/// under `config`. Helper for [`validate_argument_custom_types`].
+///
+/// Each emitted message is a single line (no embedded newlines) so the
+/// caller can `split('\n')` to lift findings into individual errors.
+///
+/// Variants that carry no nested `TypeExpr` are listed explicitly
+/// rather than caught by a wildcard: a future variant that *does* nest
+/// a `TypeExpr` should be a compile error here, not a silent
+/// type-checking gap.
+fn collect_unknown_simple_types_in(
+    ty: &crate::parser::TypeExpr,
+    config: &ProviderContext,
+    decl_kind: &str,
+    decl_name: &str,
+    errors: &mut Vec<String>,
+) {
+    use crate::parser::TypeExpr;
+    match ty {
+        TypeExpr::Simple(snake) => {
+            if !crate::parser::is_known_bare_custom_type(snake, config) {
+                let pascal = crate::parser::snake_to_pascal(snake);
+                errors.push(format!(
+                    "{decl_kind} '{decl_name}': unknown custom type '{pascal}'"
+                ));
+            }
+        }
+        TypeExpr::List(inner) | TypeExpr::Map(inner) => {
+            collect_unknown_simple_types_in(inner, config, decl_kind, decl_name, errors);
+        }
+        TypeExpr::Union(members) => {
+            for m in members {
+                collect_unknown_simple_types_in(m, config, decl_kind, decl_name, errors);
+            }
+        }
+        TypeExpr::Struct { fields } => {
+            for (_, field_ty) in fields {
+                collect_unknown_simple_types_in(field_ty, config, decl_kind, decl_name, errors);
+            }
+        }
+        // Leaves with no nested `TypeExpr` to recurse into. Listed
+        // explicitly so a future variant that *does* nest one fails to
+        // compile here instead of silently bypassing the walk.
+        TypeExpr::String
+        | TypeExpr::Bool
+        | TypeExpr::Int
+        | TypeExpr::Float
+        | TypeExpr::Duration
+        | TypeExpr::Ref(_)
+        | TypeExpr::SchemaType { .. }
+        | TypeExpr::StringLiteral(_)
+        | TypeExpr::Unknown => {}
+    }
+}
+
 /// Check that a module file does not contain provider blocks.
 ///
 /// Provider configuration should only be defined at the root configuration level,

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -46,6 +46,7 @@ fn context_with_iam_policy_arn_validator() -> ProviderContext {
         validators,
         custom_type_validator: None,
         schema_types: Default::default(),
+        customs_loaded: false,
     }
 }
 
@@ -3039,5 +3040,164 @@ fn value_contains_unresolved_ref_unwraps_secret() {
     assert!(
         !value_contains_unresolved_ref(&secret_literal),
         "Secret(literal) must not be flagged",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// carina#3239: post-parse argument-side unknown-custom-type walker.
+// These cover the validator unit; the end-to-end CLI / LSP wiring is
+// exercised by `carina-cli/tests/validate_unknown_custom_type_e2e.rs`.
+// ---------------------------------------------------------------------------
+
+fn enriched_context_with_iam_policy_arn() -> ProviderContext {
+    let mut ctx = context_with_iam_policy_arn_validator();
+    ctx.customs_loaded = true;
+    ctx
+}
+
+#[test]
+fn validate_argument_custom_types_rejects_unknown_in_arguments() {
+    use crate::parser::{ArgumentParameter, TypeExpr};
+
+    let mut parsed = empty_parsed();
+    parsed.arguments.push(ArgumentParameter {
+        name: "bad_arg".to_string(),
+        type_expr: TypeExpr::Simple("totally_made_up_type".to_string()),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    });
+
+    let findings = validate_argument_custom_types(&parsed, &enriched_context_with_iam_policy_arn());
+
+    assert_eq!(findings.len(), 1, "expected one finding, got {findings:?}");
+    let only = &findings[0];
+    assert!(
+        only.contains("argument 'bad_arg'")
+            && only.contains("unknown custom type")
+            && only.contains("TotallyMadeUpType"),
+        "diagnostic must name the offending arg and the offending PascalCase type; got: {only}"
+    );
+}
+
+#[test]
+fn validate_argument_custom_types_accepts_registered_bare_identity() {
+    use crate::parser::{ArgumentParameter, TypeExpr};
+
+    let mut parsed = empty_parsed();
+    parsed.arguments.push(ArgumentParameter {
+        name: "policy".to_string(),
+        // The fixture registers `IamPolicyArn` as a bare-identity
+        // validator; this is the round-trip "name a registered custom
+        // type and have it pass" path that proves the walker isn't
+        // over-firing.
+        type_expr: TypeExpr::Simple("iam_policy_arn".to_string()),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    });
+
+    let findings = validate_argument_custom_types(&parsed, &enriched_context_with_iam_policy_arn());
+    assert!(
+        findings.is_empty(),
+        "registered bare custom type must pass the walker; got: {findings:?}"
+    );
+}
+
+#[test]
+fn validate_argument_custom_types_walks_into_list_map_union_struct() {
+    use crate::parser::{ArgumentParameter, TypeExpr};
+
+    let mut parsed = empty_parsed();
+
+    // List<UnknownA>
+    parsed.arguments.push(ArgumentParameter {
+        name: "in_list".to_string(),
+        type_expr: TypeExpr::List(Box::new(TypeExpr::Simple("unknown_a".to_string()))),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    });
+
+    // Map<UnknownB>
+    parsed.arguments.push(ArgumentParameter {
+        name: "in_map".to_string(),
+        type_expr: TypeExpr::Map(Box::new(TypeExpr::Simple("unknown_b".to_string()))),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    });
+
+    // Union of two unknowns. Each member is reported independently —
+    // this is intentional: the union shape is ambiguous about which
+    // member the user "meant", so calling out every unknown helps
+    // the user pinpoint the typo.
+    parsed.arguments.push(ArgumentParameter {
+        name: "in_union".to_string(),
+        type_expr: TypeExpr::Union(vec![
+            TypeExpr::Simple("unknown_c".to_string()),
+            TypeExpr::Simple("unknown_d".to_string()),
+        ]),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    });
+
+    // Struct { nested: UnknownE }
+    parsed.arguments.push(ArgumentParameter {
+        name: "in_struct".to_string(),
+        type_expr: TypeExpr::Struct {
+            fields: vec![(
+                "nested".to_string(),
+                TypeExpr::Simple("unknown_e".to_string()),
+            )],
+        },
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    });
+
+    let findings = validate_argument_custom_types(&parsed, &enriched_context_with_iam_policy_arn());
+
+    let joined = findings.join("\n");
+    for expected in ["UnknownA", "UnknownB", "UnknownC", "UnknownD", "UnknownE"] {
+        assert!(
+            joined.contains(expected),
+            "walker must descend into List/Map/Union/Struct and surface {expected}; got: {joined}"
+        );
+    }
+}
+
+#[test]
+fn validate_argument_custom_types_is_independent_of_customs_loaded_flag() {
+    use crate::parser::{ArgumentParameter, TypeExpr};
+
+    let mut parsed = empty_parsed();
+    parsed.arguments.push(ArgumentParameter {
+        name: "bad_arg".to_string(),
+        type_expr: TypeExpr::Simple("totally_made_up_type".to_string()),
+        default: None,
+        description: None,
+        validations: Vec::new(),
+    });
+
+    // Bootstrap context — `customs_loaded` defaults to `false`. The
+    // walker delegates to `is_known_bare_custom_type`, whose contract
+    // is "true iff snake matches a built-in or a bare-registered
+    // validator"; on an empty validator set the only accepted names
+    // are the four built-ins, so an unknown name still produces a
+    // finding even with the parser gate inactive. This pins that the
+    // walker is *independent* of `customs_loaded` — only the parser
+    // is gated; the post-parse walker always reports. Callers that
+    // need the bootstrap-context exemption (e.g. LSP orphaned-file
+    // diagnostics) must withhold the call themselves.
+    let mut ctx = ProviderContext::default();
+    assert!(!ctx.customs_loaded);
+    ctx.validators = HashMap::new();
+    let findings = validate_argument_custom_types(&parsed, &ctx);
+    assert_eq!(
+        findings.len(),
+        1,
+        "walker always reports unknowns; gating is the caller's choice"
     );
 }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -75,6 +75,25 @@ impl DiagnosticEngine {
         factories: Arc<Vec<Box<dyn ProviderFactory>>>,
     ) -> Self {
         let factories_clone = Arc::clone(&factories);
+        // carina#3239 gate: the strict "unknown custom type in type
+        // position" parser check requires the project to actually
+        // *have* a provider surface to compare against. The LSP
+        // backend keeps an *empty* fallback `ProviderState` for files
+        // that don't belong to any known config directory and aren't
+        // reachable through the import map (`carina-lsp/src/backend.rs`'s
+        // `ProviderStates::empty`); for that fallback, no provider
+        // was ever declared and the orphaned file has no way to
+        // resolve a custom type name, so disabling the strict check
+        // avoids a flood of false positives.
+        //
+        // The flag keys off `provider_names` rather than
+        // `factories.is_empty()` so a project whose declared
+        // providers failed to load (network error, missing install,
+        // …) still gets the strict check — the user sees the provider
+        // load error and the unknown-custom-type error together
+        // instead of having the carina#3239 fix silently masked by an
+        // unrelated install failure.
+        let customs_loaded = !provider_names.is_empty();
         let provider_context = carina_core::parser::ProviderContext {
             decryptor: None,
             validators: carina_core::provider::collect_custom_type_validators(&schemas),
@@ -87,6 +106,7 @@ impl DiagnosticEngine {
                 },
             )),
             schema_types: Default::default(),
+            customs_loaded,
         };
         Self {
             schemas,
@@ -158,6 +178,73 @@ impl DiagnosticEngine {
         if let Some(merged) = merged.as_ref() {
             for err in carina_core::parser::check_provider_instance_routing(merged) {
                 diagnostics.push(parse_error_to_diagnostic(&err));
+            }
+        }
+
+        // carina#3239: surface unknown bare custom-type names in
+        // `arguments` / `attributes` / `exports` declarations as
+        // editor diagnostics. Two paths feed the walker:
+        //
+        // 1. The directory-merged parse (`merged`) — when present,
+        //    it carries every sibling `.crn`'s declarations so an
+        //    `arguments { foo: TotallyMadeUpType }` in
+        //    `args.crn` is caught while editing `main.crn`.
+        //
+        // 2. The buffer-only parse (`doc.parsed()`) — load-bearing
+        //    fallback when the merged parse failed. The merged parse
+        //    uses the enriched `customs_loaded=true` context, so the
+        //    parser's strict gate raises `ParseError::InvalidExpression`
+        //    on the very unknown-type-name shape we want to report.
+        //    `parse_merged_with_buffer` swallows that error through
+        //    `.ok()?`, so without this fallback the diagnostic would
+        //    silently disappear exactly when the user introduces the
+        //    bug. The buffer-only parse uses the bootstrap context
+        //    (`customs_loaded=false`), so it always succeeds and
+        //    `doc.parsed()` is `Some`, letting the walker still run
+        //    against the user's in-flight edits.
+        //
+        // Both paths walk the same `arguments` set when the edited
+        // file is the one declaring them, so the merged path is the
+        // strict preference and the fallback only fires on its
+        // failure — no double-report.
+        //
+        // Position note: the diagnostic uses `Range::default()`
+        // (line 0). The AST parameter structs do not carry a source
+        // span, so threading a precise location requires a wider
+        // change (extend `ArgumentParameter` / `AttributeParameter`
+        // / `ParsedExportParam` with a `line: usize` field and update
+        // every constructor). The CLI emits the same message without
+        // a span — we accept the same trade-off here so the LSP
+        // reaches CLI parity in this PR; precise spans can land as a
+        // follow-up.
+        // Gate on `customs_loaded`. The walker itself is unconditional
+        // by design (the carina-core helper "always reports unknowns;
+        // gating is the caller's choice"); the orphaned-file
+        // fallback context turns this flag off so its diagnostics
+        // don't over-fire for `arguments {}` blocks in files outside
+        // any known project root.
+        if self.provider_context.customs_loaded {
+            let custom_type_findings = match merged.as_ref() {
+                Some(m) => carina_core::validation::validate_argument_custom_types(
+                    m,
+                    &self.provider_context,
+                ),
+                None => doc
+                    .parsed()
+                    .map(|p| {
+                        carina_core::validation::validate_argument_custom_types(
+                            p,
+                            &self.provider_context,
+                        )
+                    })
+                    .unwrap_or_default(),
+            };
+            for msg in custom_type_findings {
+                diagnostics.push(carina_diagnostic_range(
+                    tower_lsp::lsp_types::Range::default(),
+                    tower_lsp::lsp_types::DiagnosticSeverity::ERROR,
+                    msg,
+                ));
             }
         }
 

--- a/carina-lsp/src/diagnostics/tests/basic.rs
+++ b/carina-lsp/src/diagnostics/tests/basic.rs
@@ -857,6 +857,54 @@ fn arguments_literal_union_type_does_not_surface_parser_error() {
     );
 }
 
+/// carina#3239 LSP parity: when a project has at least one provider
+/// registered (`provider_names` non-empty), an unknown bare custom-type
+/// name in an `arguments { ... }` declaration must surface as an
+/// editor diagnostic — the same finding the CLI's `carina validate`
+/// produces. Without this coverage the bug-headline case
+/// (`IamOidcProviderArn` left over from a provider rename) shows zero
+/// diagnostics in the editor and only fails at validate time, breaking
+/// the [[feedback_validate_lsp_parity]] contract.
+///
+/// The test path runs `analyze(&doc, None)` which short-circuits the
+/// directory-merged parse and forces the buffer-only fallback in the
+/// LSP walker wiring — the load-bearing path Round 5 review caught.
+#[test]
+fn arguments_unknown_custom_type_surfaces_lsp_diagnostic() {
+    let engine = test_engine_with_wait_target();
+    let doc = create_document("arguments {\n  oidc_provider_arn: IamOidcProviderArn\n}\n");
+    let diagnostics = engine.analyze(&doc, None);
+    assert!(
+        diagnostics.iter().any(|d| {
+            d.message.contains("unknown custom type") && d.message.contains("IamOidcProviderArn")
+        }),
+        "LSP must surface the unknown bare custom-type name when at \
+         least one provider is registered; got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Companion to the test above: when no provider is registered
+/// (`provider_names` empty — the LSP's orphaned-file fallback), the
+/// strict check must *not* fire, otherwise every user-defined custom
+/// type in an orphaned file would redline. This pins the
+/// `customs_loaded = !provider_names.is_empty()` guard in
+/// `DiagnosticEngine::new`.
+#[test]
+fn arguments_unknown_custom_type_silent_without_providers() {
+    let engine = test_engine();
+    let doc = create_document("arguments {\n  oidc_provider_arn: IamOidcProviderArn\n}\n");
+    let diagnostics = engine.analyze(&doc, None);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.contains("unknown custom type")),
+        "LSP must not surface unknown-custom-type errors when no \
+         provider is registered (orphaned-file fallback); got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 /// Issue #2623 regression: a single-literal annotation
 /// (`'dev'` alone) is the degenerate case of the same grammar
 /// production. Pinning it separately so a future tightening of the

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -142,6 +142,10 @@ async fn main() {
             validators: HashMap::new(),
             custom_type_validator: None,
             schema_types: Default::default(),
+            // Schemas load asynchronously after LSP initialize; the
+            // strict carina#3239 parser check is enabled inside
+            // `DiagnosticEngine::new` once schemas are present.
+            customs_loaded: false,
         };
 
         // Pass factory builder callback — actual WASM loading happens asynchronously

--- a/carina-lsp/tests/support/test_client.rs
+++ b/carina-lsp/tests/support/test_client.rs
@@ -32,6 +32,7 @@ impl TestClient {
                 validators: HashMap::new(),
                 custom_type_validator: None,
                 schema_types: Default::default(),
+                customs_loaded: false,
             };
             Backend::new(client, provider_context, None)
         });


### PR DESCRIPTION
Closes #3239.

## Summary

Argument declarations with an unknown custom-type name (e.g. `oidc_provider_arn: IamOidcProviderArn` after the provider renamed the registered identity to `aws.iam.OidcProvider.Arn`) used to pass `carina validate` and `plan` silently. The parser accepted any PascalCase identifier as `TypeExpr::Simple(snake)` and downstream validators fell back to "treat as untyped string" for unregistered identities, so typos and stale post-rename spellings rode all the way to apply.

## Approach: parser layer + flag

Per the user's choice of long-term, type-safe, root-cause fix:

- Add `ProviderContext.customs_loaded: bool` (default `false`).
- Parser `Rule::type_simple` PascalCase arm: when `customs_loaded=true`, reject bare names not in (built-ins: `Ipv4Cidr`/`Ipv4Address`/`Ipv6Cidr`/`Ipv6Address`) ∪ (bare-identity validators in `config.validators`). Raises `ParseError::InvalidExpression { message: "unknown custom type 'X'" }`.
- CLI `enrich_provider_context` and LSP `DiagnosticEngine::new` set `customs_loaded=true` once schemas are loaded. Bootstrap contexts (`main.rs` in cli and lsp) keep `false` so LSP early-parse / completion paths that legitimately run before schemas load don't lose every `Simple`-shaped name.
- LSP guards on `!provider_names.is_empty()` so the orphaned-file fallback `ProviderState` doesn't over-fire; a project whose providers failed to load still gets the strict check (the load error shows separately).

The root-config parse uses the bootstrap context, so add a post-parse `validate_argument_custom_types` walker in `carina_core::validation` that re-applies the same predicate against the enriched context — closing the standalone-module-validate path (`carina validate ./inner/`) and the LSP merged-parse path where `parse_merged_with_buffer` swallows `ParseError` through `.ok()?`.

The walker covers `arguments`, `attribute_params`, and `export_params` (via a new `ExportParamLike::type_expr_opt` trait method), and enumerates every `TypeExpr` variant explicitly so a future variant that nests a `TypeExpr` is a compile error rather than a silent gap.

## Tests

- **Parser unit** (4): `carina-core/src/parser/types.rs` — strict gate fires only when `customs_loaded=true`; built-ins and bare-registered identities still pass; unknown names are rejected.
- **Walker unit** (4): `carina-core/src/validation/tests.rs` — covers `arguments`, registered-bare-identity acceptance, `List`/`Map`/`Union`/`Struct` recursion, and flag independence.
- **CLI e2e** (6): `carina-cli/tests/validate_unknown_custom_type_e2e.rs` — `arguments`/`attributes`/`exports` shapes, the bug-headline `IamOidcProviderArn` case, built-in acceptance, and standalone-module validate.
- **LSP integration** (2): `carina-lsp/src/diagnostics/tests/basic.rs` — strict check fires with providers registered, silent without (orphaned-file fallback).

## Real-infra verification

Against `carina-rs/infra/usecases/registry/infra-deploy/main.crn`:

```
$ cargo run -p carina-cli -- validate .../usecases/registry/infra-deploy
Validating...
Error: argument 'oidc_provider_arn': unknown custom type 'IamOidcProviderArn'
Error: argument 'delegation_writer_role_arn': unknown custom type 'IamRoleArn'
```

Both legacy names from the issue's repro are caught.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3580 passed, 72 skipped
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all green
- [x] Real `carina-rs/infra` smoke test — `IamOidcProviderArn` + `IamRoleArn` both surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)