### PR TITLE
wasm_factory: host-side wasi:http tracing (refs #3254)

### DIFF
--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -369,10 +369,52 @@ impl wasmtime_wasi_http::p2::WasiHttpHooks for AllowListHttpHooks {
         config.connect_timeout = config.connect_timeout.min(cap);
         config.first_byte_timeout = config.first_byte_timeout.min(cap);
         config.between_bytes_timeout = config.between_bytes_timeout.min(cap);
+
+        if trace_http_enabled() {
+            let method = request.method().to_string();
+            let uri = request.uri().to_string();
+            let spawn_start = std::time::Instant::now();
+            let handle = wasmtime_wasi::runtime::spawn(async move {
+                let queue_ms = spawn_start.elapsed().as_millis();
+                let handler_start = std::time::Instant::now();
+                let result =
+                    wasmtime_wasi_http::p2::default_send_request_handler(request, config).await;
+                let handler_ms = handler_start.elapsed().as_millis();
+                eprintln!(
+                    "carina-host-http-trace method={} uri={} queue_ms={} handler_ms={} status={}",
+                    method,
+                    uri,
+                    queue_ms,
+                    handler_ms,
+                    match &result {
+                        Ok(resp) => format!("{}", resp.resp.status().as_u16()),
+                        Err(e) => format!("err:{:?}", e),
+                    },
+                );
+                Ok(result)
+            });
+            return Ok(wasmtime_wasi_http::p2::types::HostFutureIncomingResponse::pending(handle));
+        }
+
         Ok(wasmtime_wasi_http::p2::default_send_request(
             request, config,
         ))
     }
+}
+
+/// Companion to carina-plugin-sdk's `CARINA_WASI_HTTP_TRACE` switch.
+///
+/// When set to "1", the host-side `WasiHttpHooks::send_request` spawns the
+/// outgoing request via a wrapper around `default_send_request_handler`
+/// and emits the wall-clock breakdown to stderr. Off by default; the
+/// gate is a single atomic load per request when disabled.
+fn trace_http_enabled() -> bool {
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| {
+        std::env::var("CARINA_WASI_HTTP_TRACE")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    })
 }
 
 // -- Host state for WASI --


### PR DESCRIPTION
## Summary

Companion trace to #3257. The SDK-side breakdown showed `pollable_block` is the only non-zero phase on the WASM side, so the latency must live inside the spawned host task — i.e. inside `default_send_request_handler`. This PR adds a host-side wrapper around that handler, under the same `CARINA_WASI_HTTP_TRACE=1` gate, that records:

- `queue_ms` — elapsed between `wasmtime_wasi::runtime::spawn` and the handler actually starting (catches host-side reactor / scheduler stalls)
- `handler_ms` — wall-clock for the full `default_send_request_handler` (TCP connect + TLS handshake + HTTP handshake + `send_request` + body read)
- `status` — final HTTP status or transport error

Output:

```
carina-host-http-trace method=DELETE uri=https://s3... queue_ms=0 handler_ms=20094 status=400
```

Pairing it with the SDK trace from #3257 lets us split the ~20 s wait into "spent in the handler" vs "spent waiting for the handler to be polled". A follow-up will instrument *inside* the handler if and only if this split shows the cost is inside it.

## Why this PR, not a fix

`#3254` evidence so far: `pollable_block_ms ≈ 20000` on every DELETE, all other SDK-side phases at 0 ms. That narrows the bottleneck to the host task, but does not pinpoint *which* of TCP connect / TLS handshake / HTTP handshake / `send_request` / response collect eats it. Another evidence pass before the fix.

## Test plan

- [x] `cargo nextest run -p carina-plugin-host` — 85/85 pass
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] All `scripts/check-*.sh` — clean

## Scope

Diagnostic instrumentation only — no behavioural change when `CARINA_WASI_HTTP_TRACE` is unset (the default). Once the trace narrows which sub-phase eats the 20 s, the actual fix lands separately.

refs #3254
