### PR TITLE
winterbaume 0.2.1: enable lock-contention and KeyId tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5690,9 +5690,9 @@ dependencies = [
 
 [[package]]
 name = "winterbaume-kms"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad02ac483c8a27015ef8857d6d859adbeee4c57a7c45a6e2043a1411978d71bf"
+checksum = "054d190c98fa7df63b2fee481f2db74a00feaf54e724d1aa28a438088b55f92b"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -5714,9 +5714,9 @@ dependencies = [
 
 [[package]]
 name = "winterbaume-s3"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48730964f4f607ae4739f90d75ab295dac32d06f2ed95892e5ad902748c0be59"
+checksum = "8a970d46d8ed2309cda242f31fa147c51bc230a235969a8bbf9e6cab145d7f10"
 dependencies = [
  "bytes",
  "chrono",

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -65,4 +65,4 @@ tower-lsp = "0.20"
 # base64 → KMS:Decrypt → UTF-8 path with no real AWS and no external
 # process (#3227, follow-up to #3206).
 winterbaume-core = "0.2"
-winterbaume-kms = "0.2"
+winterbaume-kms = "0.2.1"

--- a/carina-cli/tests/kms_decryptor_winterbaume.rs
+++ b/carina-cli/tests/kms_decryptor_winterbaume.rs
@@ -12,15 +12,12 @@
 //! real base64 → `KMS:Decrypt` → UTF-8 path with no real AWS and no
 //! external process (#3227).
 //!
-//! Scope note: `decrypt_one`'s `Some(key)` branch (the optional
-//! `KeyId` argument) is not covered here. Real AWS validates `KeyId`
-//! against the ciphertext header and returns `IncorrectKeyException`
-//! on mismatch (per the `KMS:Decrypt` API docs), but `winterbaume-kms`
-//! 0.2 ignores the request-side `KeyId` and resolves the key from the
-//! ciphertext header alone — so a key-mismatch test would silently
-//! succeed and a key-match test would also succeed if the branch were
-//! reduced to a no-op. Neither shape is evidence. Tracked in
-//! winterbaume issue moriyoshi/winterbaume#5.
+//! KeyId coverage: `decrypt_one`'s `Some(key)` branch (the optional
+//! `KeyId` argument) is exercised in
+//! `decryptor_rejects_wrong_key_id_with_incorrect_key_exception` —
+//! `winterbaume-kms` 0.2.1 validates the request-side `KeyId` against
+//! the ciphertext header and surfaces `IncorrectKeyException`, matching
+//! the documented AWS behaviour.
 
 use aws_sdk_kms::Client;
 use aws_sdk_kms::primitives::Blob;
@@ -78,6 +75,66 @@ async fn decryptor_round_trips_base64_ciphertext_through_kms() {
         plaintext.as_bytes(),
         TEST_PLAINTEXT,
         "decryptor must return the original plaintext bytes",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decryptor_round_trips_with_matching_key_id() {
+    // `Some(key)` branch, matching ciphertext key: real KMS accepts the
+    // request and `decrypt_one` returns the plaintext. Without this case
+    // a no-op `Some` branch (e.g. one that silently ignored the argument)
+    // would not be caught by the `None` happy-path test.
+    let client = mock_kms_client().await;
+    let key = client.create_key().send().await.expect("create_key");
+    let key_id = key.key_metadata().unwrap().key_id().to_string();
+
+    let enc = client
+        .encrypt()
+        .key_id(&key_id)
+        .plaintext(Blob::new(TEST_PLAINTEXT.to_vec()))
+        .send()
+        .await
+        .expect("encrypt");
+    let ciphertext_b64 =
+        base64::engine::general_purpose::STANDARD.encode(enc.ciphertext_blob().unwrap().as_ref());
+
+    let decryptor = build_kms_decryptor(client);
+
+    let plaintext = decryptor(&ciphertext_b64, Some(&key_id))
+        .expect("decryptor must succeed when KeyId matches the ciphertext");
+    assert_eq!(plaintext.as_bytes(), TEST_PLAINTEXT);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decryptor_rejects_wrong_key_id_with_incorrect_key_exception() {
+    // `Some(key)` branch, mismatched ciphertext key: real KMS returns
+    // `IncorrectKeyException` per the `KMS:Decrypt` API docs. winterbaume
+    // 0.2.1 enforces the same. The decryptor must propagate this as a
+    // `decrypt(): KMS decrypt failed:` error rather than silently
+    // returning the wrong-key plaintext.
+    let client = mock_kms_client().await;
+    let key_a = client.create_key().send().await.expect("create_key a");
+    let key_a_id = key_a.key_metadata().unwrap().key_id().to_string();
+    let key_b = client.create_key().send().await.expect("create_key b");
+    let key_b_id = key_b.key_metadata().unwrap().key_id().to_string();
+
+    let enc = client
+        .encrypt()
+        .key_id(&key_a_id)
+        .plaintext(Blob::new(TEST_PLAINTEXT.to_vec()))
+        .send()
+        .await
+        .expect("encrypt under key_a");
+    let ciphertext_b64 =
+        base64::engine::general_purpose::STANDARD.encode(enc.ciphertext_blob().unwrap().as_ref());
+
+    let decryptor = build_kms_decryptor(client);
+
+    let err = decryptor(&ciphertext_b64, Some(&key_b_id))
+        .expect_err("decrypt with a KeyId that does not match the ciphertext must fail");
+    assert!(
+        err.starts_with("decrypt(): KMS decrypt failed:"),
+        "wrong-KeyId failure must be surfaced via the KMS error label, got: {err}",
     );
 }
 

--- a/carina-state/Cargo.toml
+++ b/carina-state/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = "3"
 # inject a winterbaume-backed S3 client and exercise the StateBackend
 # I/O path with no real AWS and no external process (#3203).
 winterbaume-core = "0.2"
-winterbaume-s3 = "0.2"
+winterbaume-s3 = "0.2.1"
 # Lets the s3.rs unit tests build a real HTTP response (with a status
 # code) so the HTTP-status-based not-found classifier can be exercised
 # directly.

--- a/carina-state/tests/s3_backend_winterbaume.rs
+++ b/carina-state/tests/s3_backend_winterbaume.rs
@@ -7,17 +7,16 @@
 //! parsing, error classification) with no network I/O and no external
 //! process.
 //!
-//! Scope note (#3203): `winterbaume-s3` 0.2 parses the S3 conditional
-//! write headers (`If-None-Match` / `If-Match`) but does not enforce
-//! them — there is no `PreconditionFailed` path — so the lock-contention
-//! and conditional-write-conflict paths cannot be covered here. See the
-//! issue and #3205 for the follow-up. These tests cover what the mock
-//! honors faithfully: state write/read, bucket auto-create, and
-//! single-holder lock acquire/release.
+//! Conditional-write coverage (#3205): `winterbaume-s3` 0.2.1 enforces
+//! `If-None-Match` / `If-Match` and returns `412 PreconditionFailed`
+//! on a conflict, so the lock-contention and expired-lock takeover
+//! paths are exercised here (in addition to state write/read,
+//! bucket auto-create, and single-holder lock acquire/release).
 
 use aws_sdk_s3::Client;
+use aws_sdk_s3::primitives::ByteStream;
 use carina_state::backends::S3Backend;
-use carina_state::{StateBackend, StateFile};
+use carina_state::{BackendError, LockInfo, StateBackend, StateFile};
 use winterbaume_core::MockAws;
 use winterbaume_s3::S3Service;
 
@@ -37,14 +36,33 @@ async fn mock_s3_client() -> Client {
 /// disabled because the mock does not need server-side encryption and
 /// leaving it on only adds a header the mock ignores.
 async fn mock_backend() -> S3Backend {
-    S3Backend::from_client(
-        mock_s3_client().await,
+    mock_backend_with_client().await.0
+}
+
+/// Build an `S3Backend` and return both the backend and a second
+/// `aws_sdk_s3::Client` wired to the same in-process mock. The shared
+/// client lets a test seed S3 objects directly (e.g. an expired lock
+/// file) that the backend will then observe.
+async fn mock_backend_with_client() -> (S3Backend, Client) {
+    let mock = MockAws::builder().with_service(S3Service::new()).build();
+    let sdk_config = mock.sdk_config(TEST_REGION).await;
+    let backend = S3Backend::from_client(
+        Client::new(&sdk_config),
         TEST_BUCKET.to_string(),
         TEST_KEY.to_string(),
         TEST_REGION.to_string(),
         false, // encrypt
         true,  // auto_create
-    )
+    );
+    let raw_client = Client::new(&sdk_config);
+    (backend, raw_client)
+}
+
+/// S3 key the backend uses for its lock file. Mirrors `S3Backend::lock_key`
+/// (which is `pub(crate)`): tests need the same key to plant or replace
+/// the lock object out-of-band.
+fn lock_key() -> String {
+    format!("{TEST_KEY}.lock")
 }
 
 #[tokio::test]
@@ -172,11 +190,9 @@ async fn read_state_returns_none_when_object_absent() {
 #[tokio::test]
 async fn acquire_then_release_lock_round_trips() {
     // Covers the single-holder lock mechanics: write the lock object,
-    // read it back to verify ownership on release, then delete it. It
-    // does *not* cover contention — `winterbaume-s3` 0.2 does not enforce
-    // the `If-None-Match` conditional header, so a second `acquire_lock`
-    // would succeed instead of conflicting. The contention path is
-    // tracked separately (#3203 Notes / follow-up #3205).
+    // read it back to verify ownership on release, then delete it. The
+    // conditional-write contention path is exercised separately in
+    // `acquire_lock_conflicts_with_held_lock` (#3205).
     let backend = mock_backend().await;
     backend.init().await.unwrap();
 
@@ -242,6 +258,153 @@ async fn write_state_locked_rejects_write_when_lock_not_held() {
     assert!(
         matches!(err, carina_state::BackendError::LockNotHeld(_)),
         "expected LockNotHeld when the lock object is absent, got: {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn acquire_lock_conflicts_with_held_lock() {
+    // #3205: a second `acquire_lock` while a non-expired lock is held
+    // must return `BackendError::Locked`. The path under test is
+    // `write_lock_if_absent` -> `If-None-Match: *` -> 412 ->
+    // `is_conditional_write_conflict` -> `read_lock_with_etag` ->
+    // `!is_expired` -> `Locked`. Without winterbaume enforcing the
+    // conditional header the second PUT would silently overwrite and
+    // this test would fail.
+    let backend = mock_backend().await;
+    backend.init().await.unwrap();
+
+    let first = backend.acquire_lock("apply").await.unwrap();
+
+    let err = backend
+        .acquire_lock("plan")
+        .await
+        .expect_err("a second acquire while a fresh lock is held must conflict");
+    match err {
+        BackendError::Locked {
+            lock_id, operation, ..
+        } => {
+            assert_eq!(
+                lock_id, first.id,
+                "Locked error must report the holder's id"
+            );
+            assert_eq!(
+                operation, "apply",
+                "Locked error must report the holder's operation",
+            );
+        }
+        other => panic!("expected BackendError::Locked, got: {other:?}"),
+    }
+
+    backend.release_lock(&first).await.unwrap();
+}
+
+#[tokio::test]
+async fn acquire_lock_takes_over_expired_lock() {
+    // #3205: when the holder of the existing lock has expired,
+    // `acquire_lock` must replace it via `replace_lock_if_match`
+    // (`If-Match: <etag>` -> 200) and return the new lock. This
+    // exercises the second branch of the acquire loop, which only
+    // works when the mock enforces `If-Match`.
+    let (backend, client) = mock_backend_with_client().await;
+    backend.init().await.unwrap();
+
+    // Plant an expired lock under the same key the backend uses.
+    let expired = LockInfo::with_timeout("apply", -60);
+    assert!(
+        expired.is_expired(),
+        "precondition: planted lock is expired"
+    );
+    let body = serde_json::to_vec(&expired).unwrap();
+    client
+        .put_object()
+        .bucket(TEST_BUCKET)
+        .key(lock_key())
+        .body(ByteStream::from(body))
+        .content_type("application/json")
+        .send()
+        .await
+        .expect("planting the expired lock must succeed");
+
+    // acquire_lock sees the expired lock and replaces it with a fresh one.
+    let taken_over = backend.acquire_lock("plan").await.unwrap();
+    assert_ne!(
+        taken_over.id, expired.id,
+        "takeover must mint a new lock id, not reuse the expired holder's",
+    );
+    assert_eq!(taken_over.operation, "plan");
+    assert!(
+        !taken_over.is_expired(),
+        "the taken-over lock must have a fresh, non-expired TTL",
+    );
+
+    backend.release_lock(&taken_over).await.unwrap();
+}
+
+#[tokio::test]
+async fn renew_lock_rejects_when_lock_was_replaced() {
+    // #3205: `renew_lock` must refuse to refresh when the lock object
+    // was replaced out from under the holder. The rejection path under
+    // test is the id-mismatch check in `renew_lock`; the
+    // `If-Match`-conditional `replace_lock_if_match` further guards
+    // against TOCTOU between the read and the write.
+    let (backend, client) = mock_backend_with_client().await;
+    backend.init().await.unwrap();
+
+    let original = backend.acquire_lock("apply").await.unwrap();
+
+    // Replace the lock object out-of-band with a different lock id.
+    let usurper = LockInfo::new("plan");
+    assert_ne!(usurper.id, original.id);
+    let body = serde_json::to_vec(&usurper).unwrap();
+    client
+        .put_object()
+        .bucket(TEST_BUCKET)
+        .key(lock_key())
+        .body(ByteStream::from(body))
+        .content_type("application/json")
+        .send()
+        .await
+        .expect("planting the usurping lock must succeed");
+
+    let err = backend
+        .renew_lock(&original)
+        .await
+        .expect_err("renew_lock must fail when the lock was replaced concurrently");
+    assert!(
+        matches!(err, BackendError::LockNotHeld(_)),
+        "expected LockNotHeld after a concurrent replacement, got: {err:?}",
+    );
+}
+
+#[tokio::test]
+async fn head_bucket_resolves_to_typed_not_found_on_missing_bucket() {
+    // winterbaume#3 fix: `HeadBucket` on a missing bucket must return a
+    // body-less 404 so `aws-sdk-rust` resolves the response into the
+    // typed `HeadBucketError::NotFound` variant. If the mock ever
+    // regresses to returning an `<Error>` XML body, the SDK falls back
+    // to `Unhandled` and this test fails — flagging that the body-less
+    // contract has broken before `bucket_exists`'s 404-status fallback
+    // hides it.
+    use aws_sdk_s3::error::SdkError;
+    use aws_sdk_s3::operation::head_bucket::HeadBucketError;
+
+    let (_backend, client) = mock_backend_with_client().await;
+
+    let err = client
+        .head_bucket()
+        .bucket(TEST_BUCKET)
+        .send()
+        .await
+        .expect_err("HeadBucket on an absent bucket must fail");
+    let service_err = match &err {
+        SdkError::ServiceError(svc) => svc.err(),
+        other => panic!("expected SdkError::ServiceError, got: {other:?}"),
+    };
+    assert!(
+        matches!(service_err, HeadBucketError::NotFound(_)),
+        "HeadBucket must resolve to the typed NotFound variant; got {service_err:?}. \
+         An Unhandled variant here means winterbaume regressed and is returning a \
+         response body on a 4xx HEAD response (see moriyoshi/winterbaume#3).",
     );
 }
 


### PR DESCRIPTION
## Summary

- Bump `winterbaume-s3` and `winterbaume-kms` dev-deps from 0.2 to 0.2.1.
- Upstream 0.2.1 fixes the three carina-side gaps that 0.2 had:
  - `winterbaume-s3` now enforces `If-None-Match` / `If-Match` and returns 412 on conflict (moriyoshi/winterbaume#4).
  - `winterbaume-s3`'s `HeadBucket` now returns a body-less 404, letting the SDK resolve the typed `HeadBucketError::NotFound` (moriyoshi/winterbaume#3).
  - `winterbaume-kms` now validates the request-side `KeyId` on `Decrypt` and returns `IncorrectKeyException` (moriyoshi/winterbaume#5).
- Drop the scope notes that documented the 0.2 gaps and add the tests they had to skip.

## New tests

`carina-state/tests/s3_backend_winterbaume.rs`:
- `acquire_lock_conflicts_with_held_lock` — second `acquire_lock` under a held lock returns `BackendError::Locked` via the 412 conditional path.
- `acquire_lock_takes_over_expired_lock` — expired lock planted out-of-band is replaced via `replace_lock_if_match` (the `If-Match` branch).
- `renew_lock_rejects_when_lock_was_replaced` — id-mismatch path after a concurrent replacement.
- `head_bucket_resolves_to_typed_not_found_on_missing_bucket` — pins the body-less 404 contract so a regression is caught directly instead of being absorbed by `bucket_exists`'s 404-status fallback.

`carina-cli/tests/kms_decryptor_winterbaume.rs`:
- `decryptor_round_trips_with_matching_key_id` — `Some(key)` happy path.
- `decryptor_rejects_wrong_key_id_with_incorrect_key_exception` — mismatched `KeyId` is propagated as a KMS error rather than silently decrypting under the ciphertext's actual key.

## Test plan

- [x] `cargo nextest run -p carina-state --test s3_backend_winterbaume` — 11/11
- [x] `cargo nextest run -p carina-cli --test kms_decryptor_winterbaume` — 5/5
- [x] `cargo nextest run -p carina-state -p carina-cli`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy -p carina-state -p carina-cli --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

Closes #3205.