### PR TITLE
wasi_http: dump request headers under trace switch (refs #3254)

### DIFF
--- a/carina-plugin-sdk/src/wasi_http.rs
+++ b/carina-plugin-sdk/src/wasi_http.rs
@@ -151,6 +151,27 @@ fn make_request(
         String::new()
     };
 
+    if trace {
+        // Dump request headers as we received them from the AWS SDK, before
+        // any wasi:http translation. Used to confirm whether DELETE requests
+        // carry `content-length: 0` / `transfer-encoding: chunked` /
+        // `expect: 100-continue` (the body-framing hypotheses being narrowed
+        // for the ~20 s S3 latency).
+        let body_in = request.body().bytes().map(|b| b.len()).unwrap_or(0);
+        let header_pairs: Vec<String> = request
+            .headers()
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        eprintln!(
+            "carina-wasi-http-trace-headers method={} uri={} body_in={} headers=[{}]",
+            trace_method,
+            trace_uri,
+            body_in,
+            header_pairs.join("; "),
+        );
+    }
+
     // Parse the URI
     let uri = request.uri().to_string();
     let parsed = uri


### PR DESCRIPTION
## Summary

Fourth tracing PR for #3254. Phase decomposition from #3264 pinned the 20 s S3 latency in `sender.send_request(request).await` for body-less DELETE. To distinguish between three concrete failure modes — (a) hyper waiting on a body that never declares end-of-stream, (b) missing `Content-Length` ambiguity, (c) `Expect: 100-continue` deadlock — we need to see the request headers the SDK hands us *before* wasi:http translation.

Add one extra stderr line at `make_request` entry under the same `CARINA_WASI_HTTP_TRACE=1` gate:

```
carina-wasi-http-trace-headers method=DELETE uri=https://s3...
body_in=0 headers=[host=...; x-amz-date=...; authorization=...; content-length=0]
```

Decision tree after the next acceptance run:

- DELETE with `content-length: 0` already present → bug is downstream in wasi:http → hyper body bridge (upstream wasmtime-wasi-http).
- DELETE with no `content-length` and no `transfer-encoding` → fix is on the WASM side: inject `content-length: 0` when body is empty.
- DELETE with `expect: 100-continue` → separate fix path.

## Test plan

- [x] `cargo nextest run -p carina-plugin-host` — 85/85 pass
- [x] `cargo check -p carina-plugin-sdk --target wasm32-wasip2` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2` — clean
- [x] All `scripts/check-*.sh` — clean

## Scope

Diagnostic only — no behavioural change when the env var is unset. The non-traced path is byte-identical to before.

refs #3254
