### PR TITLE
carina-cli: state.exports rebuild must keep data-source read results (#3266)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -308,6 +308,7 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
             input.pre_resolve_virtuals,
             &state,
             input.wait_aliases,
+            input.current_states,
         )?;
     }
 
@@ -366,6 +367,7 @@ pub(crate) async fn persist_exports_only(
     pre_resolve_virtuals: &[carina_core::resource::VirtualResource],
     export_params: &[carina_core::parser::InferredExportParam],
     wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
+    current_states: &HashMap<ResourceId, carina_core::resource::State>,
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
     let exports = resolve_exports(
@@ -375,6 +377,7 @@ pub(crate) async fn persist_exports_only(
         pre_resolve_virtuals,
         &state,
         wait_aliases,
+        current_states,
     )?;
     state.exports = exports;
     if let Some(lk) = lock {
@@ -1275,6 +1278,7 @@ async fn run_apply_locked(
             &pre_resolve_virtuals_noop,
             &parsed.export_params,
             &wait_aliases,
+            &current_states,
         )
         .await?;
         return Ok(());

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1137,8 +1137,16 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     registry_prod.binding = Some("registry_prod".to_string());
     let sorted_resources = vec![registry_prod];
 
-    let exports =
-        resolve_exports(&export_params, &sorted_resources, &[], &[], &state, &[]).unwrap();
+    let exports = resolve_exports(
+        &export_params,
+        &sorted_resources,
+        &[],
+        &[],
+        &state,
+        &[],
+        &std::collections::HashMap::new(),
+    )
+    .unwrap();
 
     assert_eq!(
         exports.get("account_id"),
@@ -1223,6 +1231,7 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
         &pre_resolve_virtuals,
         &state,
         &[],
+        &std::collections::HashMap::new(),
     )
     .unwrap();
 
@@ -1328,6 +1337,7 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
         &pre_resolve_virtuals,
         &state,
         &[],
+        &std::collections::HashMap::new(),
     )
     .unwrap();
 
@@ -1497,6 +1507,7 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
         &pre_resolve_virtuals,
         &post_apply_state_file,
         &[],
+        &std::collections::HashMap::new(),
     )
     .unwrap();
 
@@ -1506,6 +1517,109 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
         "exports.role_arn must be the POST-apply ARN ({post_apply_arn}) — \
          the value carried by state.resources, NOT a pre-apply snapshot. \
          Got: {exports:?}",
+    );
+}
+
+#[test]
+fn resolve_exports_resolves_data_source_attribute_after_apply_3266() {
+    // carina#3266 root-cause regression test.
+    //
+    // The bug: `resolve_exports` builds `post_apply_states` from
+    // `state.resources` only. Managed resources are persisted there,
+    // but data sources are not — they are queried each run and the
+    // result lives in `current_states` during execution and is
+    // discarded at writeback. So when an export references a
+    // data-source attribute (e.g. `exports { x = ds.arns }`), the
+    // post-apply binding view layered onto `pre_apply` finds no
+    // attributes for the data source (#3265's `layer_data_source_bindings`
+    // merge fires only when `current_states[ds.id]` carries the read
+    // result), the ResourceRef resolves to nothing, and the resolver
+    // silently keeps the prior literal in `state.exports`.
+    //
+    // The fix: thread `current_states` from `finalize_apply` into
+    // `resolve_exports` so the read results stay visible across the
+    // exports-resolution boundary. `layer_data_source_bindings` then
+    // merges the read attrs and `ds.arns` resolves to the read value.
+    //
+    // Without the fix, `resolve_exports` returns an empty map (no
+    // entry for the export) instead of the NEW arn — exports stays
+    // at the pre-apply literal in production.
+    use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
+    use carina_core::resource::{
+        AccessPath, ConcreteValue, DataSource, DeferredValue, ResourceId, State as ResourceState,
+        Value,
+    };
+    use carina_state::StateFile;
+    use std::collections::HashMap;
+
+    let new_arn = "arn:aws:iam::412038850359:role/aws-reserved/sso.amazonaws.com/ap-northeast-1/AWSReservedSSO_AdministratorAccess_ed2ecac126d82b94";
+
+    // Post-apply state file: no managed resource entries needed; the
+    // export's only input is a data source, which is never persisted
+    // to `state.resources`.
+    let post_apply_state_file = {
+        let json = serde_json::json!({
+            "version": 5,
+            "serial": 2,
+            "lineage": "test",
+            "carina_version": "0.4.0",
+            "resources": []
+        });
+        serde_json::from_value::<StateFile>(json).unwrap()
+    };
+
+    // The authored data source: `let admin_access_roles = read aws.iam.Roles { ... }`.
+    let ds_id = ResourceId::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+    let mut ds = DataSource::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+    ds.binding = Some("admin_access_roles".to_string());
+    ds.attributes.insert(
+        "path_prefix".to_string(),
+        Value::Concrete(ConcreteValue::String(
+            "/aws-reserved/sso.amazonaws.com/".to_string(),
+        )),
+    );
+    let data_sources = vec![ds];
+
+    // The provider-read result that `read_data_source_with_retry`
+    // writes into `current_states[ds.id]` during apply execution.
+    let current_states: HashMap<ResourceId, ResourceState> = {
+        let mut attrs: HashMap<String, Value> = HashMap::new();
+        attrs.insert(
+            "arns".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String(new_arn.to_string()),
+            )])),
+        );
+        let mut m = HashMap::new();
+        m.insert(ds_id.clone(), ResourceState::existing(ds_id, attrs));
+        m
+    };
+
+    // The export: `exports { admin_access_role_arns = admin_access_roles.arns }`.
+    let export_params = vec![ExportParameter {
+        name: "admin_access_role_arns".to_string(),
+        type_expr: TypeExpr::Unknown,
+        value: Some(Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new("admin_access_roles", "arns"),
+        })),
+    }];
+
+    let exports = resolve_exports(
+        &export_params,
+        &[],
+        &data_sources,
+        &[],
+        &post_apply_state_file,
+        &[],
+        &current_states,
+    )
+    .unwrap();
+
+    let expected_json = serde_json::json!([new_arn]);
+    assert_eq!(
+        exports.get("admin_access_role_arns"),
+        Some(&expected_json),
+        "data-source-derived export must resolve via current_states read result, got: {exports:?}",
     );
 }
 

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -73,6 +73,13 @@ pub(crate) struct FinalizeApplyInput<'a> {
     /// export-resolution binding view so `exports { x = some_read.attr }`
     /// resolves (carina#3181).
     pub data_sources: &'a [carina_core::resource::DataSource],
+    /// Live execution view of every resource read this run, including
+    /// data-source results. Forwarded to `resolve_exports` so a
+    /// `<data_source>.<attr>` export reference can resolve against
+    /// the provider-read attributes — `state.resources` never persists
+    /// data sources, so consulting it alone leaves those references
+    /// unresolved and `state.exports` stuck at the prior literal
+    /// (carina#3266).
     pub current_states: &'a HashMap<ResourceId, State>,
     pub plan: &'a Plan,
     pub backend: &'a dyn StateBackend,
@@ -143,8 +150,11 @@ pub(crate) struct FinalizeApplyInput<'a> {
 /// The fix splits `sorted_resources` by kind and re-resolves virtual
 /// attributes against the post-apply view before exports use them:
 ///
-/// 1. Build `post_apply_states` from `state.resources` (managed
-///    resources' applied attributes).
+/// 1. Build `post_apply_states` by starting from the live
+///    `current_states` (so data-source read results survive — see
+///    carina#3266) and overlaying entries derived from
+///    `state.resources` (managed resources' applied attributes win
+///    over any pre-apply snapshot left in `current_states`).
 /// 2. Split `sorted_resources` into a managed view (Managed +
 ///    DataSource collapsed onto `ManagedResource` by field projection)
 ///    and a virtual view ([`VirtualResource::try_from`]).
@@ -163,37 +173,48 @@ pub(crate) fn resolve_exports(
     pre_resolve_virtuals: &[carina_core::resource::VirtualResource],
     state: &StateFile,
     wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
+    current_states: &HashMap<ResourceId, carina_core::resource::State>,
 ) -> Result<HashMap<String, serde_json::Value>, AppError> {
     use carina_core::binding_index::ResolvedBindings;
     use carina_core::resolver::resolve_virtual_refs_post_apply;
     use carina_core::resource::Value;
 
     // Step 1: rebuild post-apply `current_states` from
-    // `state.resources` (the writeback already wrote the post-apply
-    // attribute values into the StateFile).
-    let post_apply_states = state
-        .resources
-        .iter()
-        .map(|rs| {
-            let id = ResourceId::with_provider(
-                &rs.provider,
-                &rs.resource_type,
-                &rs.name,
-                rs.directives.provider_instance.clone(),
-            );
-            let attrs: HashMap<String, Value> = rs
-                .attributes
-                .iter()
-                .filter_map(|(k, v)| {
-                    carina_core::value::json_to_dsl_value(v).map(|val| (k.clone(), val))
-                })
-                .collect();
-            (
-                id.clone(),
-                carina_core::resource::State::existing(id, attrs),
-            )
-        })
-        .collect::<HashMap<_, _>>();
+    // `state.resources` for managed resources, and layer in
+    // `current_states` for entries (notably data sources) that the
+    // writeback never persists.
+    //
+    // carina#3266: data sources are not written to `state.resources`,
+    // so an exports expression referencing `<data_source>.<attr>`
+    // would resolve against an empty data-source binding without the
+    // `current_states` layer. With it, `layer_data_source_bindings`
+    // (carina#3265) sees the provider-read attrs and the export
+    // resolves to the read result. State-derived managed entries
+    // win on key collision because they reflect the post-apply
+    // writeback, while `current_states` may still hold the
+    // pre-apply snapshot for any managed resource that was just
+    // applied.
+    let mut post_apply_states: HashMap<ResourceId, carina_core::resource::State> =
+        current_states.clone();
+    for rs in &state.resources {
+        let id = ResourceId::with_provider(
+            &rs.provider,
+            &rs.resource_type,
+            &rs.name,
+            rs.directives.provider_instance.clone(),
+        );
+        let attrs: HashMap<String, Value> = rs
+            .attributes
+            .iter()
+            .filter_map(|(k, v)| {
+                carina_core::value::json_to_dsl_value(v).map(|val| (k.clone(), val))
+            })
+            .collect();
+        post_apply_states.insert(
+            id.clone(),
+            carina_core::resource::State::existing(id, attrs),
+        );
+    }
 
     // Virtuals: fresh clone of the **pre-resolve** snapshot. Their
     // attributes still carry `ResourceRef`s, so the post-apply

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -812,6 +812,7 @@ pub(crate) async fn run_state_refresh_locked(
             &parsed.virtual_resources,
             &state,
             &wait_aliases,
+            &current_states,
         )?;
     }
 

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -2868,6 +2868,7 @@ async fn persist_exports_only_clears_state_exports_when_params_empty() {
         &[],
         &[],
         &[],
+        &std::collections::HashMap::new(),
     )
     .await;
 
@@ -2910,6 +2911,7 @@ async fn persist_exports_only_writes_state_with_new_exports() {
         &[],
         &export_params,
         &[],
+        &std::collections::HashMap::new(),
     )
     .await;
 


### PR DESCRIPTION
## Summary

`carina apply` failed to update `state.exports` whose value depends
on a `read aws.*` data source. Plan rendered the change correctly,
but the post-apply writeback left the previous literal in state,
breaking downstream `upstream_state` consumers that read the export.
Workarounds were limited to hand-editing state or destroying the
stack that owns the export.

## Root cause

`resolve_exports` rebuilds its post-apply binding view from
`state.resources` alone. Managed resources are persisted there, but
data sources are not — `read_data_source_with_retry` writes the read
result into `current_states[ds.id]` during execution, and the
writeback discards that map. So when an export reads
`<data_source>.<attr>`, the binding view has no attributes for the
data source (PR #3265's `layer_data_source_bindings` merge only
fires when `current_states[ds.id]` carries the read result), the
`ResourceRef` silently fails to resolve, `dsl_value_to_json` returns
no entry, and `state.exports` keeps the prior literal.

## Fix

Thread `current_states` from `finalize_apply` /
`persist_exports_only` / `run_state_refresh_locked` into
`resolve_exports`. Seed `post_apply_states` from
`current_states.clone()` so data-source entries survive, then
overlay `state.resources` so post-apply managed attributes still
win on key collision.

## Test plan

- [x] New regression test `resolve_exports_resolves_data_source_attribute_after_apply_3266`
  mirrors the issue's reproducer: a data source with a binding and a
  read result, an export referencing `<binding>.arns`, asserts the
  export resolves to the read value.
- [x] **Counterfactual:** reverted the `current_states` seed
  (`post_apply_states = HashMap::new()`) — the new test fails with
  the production error verbatim:

      cannot serialize at state writeback:
      unresolved reference admin_access_roles.arns

  Restoring the fix turns it green.
- [x] `cargo nextest run -p carina-cli --all-features` — 497 passed
- [x] `cargo nextest run --workspace --all-features` — 3598 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed
- [x] All `scripts/check-*.sh` — passed

## Out of scope (filed as separate issues)

The original issue listed three additional symptoms; each has a
different root cause from the export-binding bug and is tracked
separately:

- `persist_exports_only` not taken on the second apply (resource
  diff empty, exports diff non-empty → still routes through the
  resource-apply path)
- `carina state refresh` does not read data sources, so refreshing
  exports still skips data-source-derived values even after this fix
- `for _, _ in orgs.accounts` orphan classification on refresh

Closes #3266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
