### PR TITLE
carina-core+cli: route export-only apply on has_mutations (#3270)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -352,11 +352,14 @@ pub async fn save_state_unlocked(
     backend.write_state(state).await.map_err(AppError::Backend)
 }
 
-/// Persist export changes when the resource plan is empty.
+/// Persist export changes when the plan has no mutating effects.
 ///
-/// Used when `plan.is_empty()` short-circuits apply: resources don't need
-/// any work, but exports may have changed. Rebuild the exports from the
-/// current state + desired `export_params` and write the state.
+/// Used when `!plan.has_mutations()` short-circuits apply: no
+/// managed-resource Create/Update/Delete is needed (the plan is
+/// either empty or carries only `Read`/`Wait` effects), but
+/// exports may have changed. Rebuild the exports from the current
+/// state + desired `export_params` and write the state
+/// (carina#3270).
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn persist_exports_only(
     backend: &dyn StateBackend,
@@ -1211,9 +1214,16 @@ async fn run_apply_locked(
         )));
     }
 
-    if plan.is_empty() {
-        // Even when no resources need changes, exports may have changed.
-        // Persist them before returning so state stays in sync with config.
+    if !plan.has_mutations() {
+        // No mutating effects — the plan only holds `Read` (data-source
+        // reads) or `Wait` effects, or is entirely empty. Either way no
+        // resource apply pipeline needs to run; route through the
+        // export-only fast path. Without this, a plan whose only
+        // difference from state is an export expression that reads a
+        // data source (a `Read` effect lands in the plan, but no
+        // mutation does) silently falls through into the
+        // resource-apply pipeline and the `Persisting N export
+        // change(s) to state.` banner never prints (carina#3270).
         let resolved_exports = crate::commands::plan::resolve_export_values_for_display(
             &parsed.export_params,
             &sorted_resources,

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -179,6 +179,21 @@ impl Plan {
         self.effects.iter().filter(|e| e.is_mutating()).count()
     }
 
+    /// True iff the plan contains at least one mutating effect.
+    ///
+    /// `is_empty()` returns false for a plan that holds only `Read` /
+    /// `Wait` effects, even though those do not change infrastructure.
+    /// Callers that route apply between the export-only fast path
+    /// (`persist_exports_only`) and the full resource-apply pipeline
+    /// MUST gate on this, not on `is_empty()`: a config whose only
+    /// difference from state is an export expression that reads a
+    /// data source produces a plan with `Read` effects but no
+    /// mutations, and `is_empty()` would mis-route it through the
+    /// resource-apply path (carina#3270).
+    pub fn has_mutations(&self) -> bool {
+        self.effects.iter().any(|e| e.is_mutating())
+    }
+
     /// Generate a summary of the Plan for display
     pub fn summary(&self) -> PlanSummary {
         let mut summary = PlanSummary::default();
@@ -416,6 +431,40 @@ mod tests {
         let plan = Plan::new();
         assert!(plan.is_empty());
         assert_eq!(plan.mutation_count(), 0);
+        assert!(!plan.has_mutations());
+    }
+
+    /// carina#3270: a plan that holds only `Read` effects (data-source
+    /// reads, with no managed-resource mutation) must report
+    /// `has_mutations() == false`. The export-only apply path
+    /// (`persist_exports_only`) gates on this; the old `is_empty()`
+    /// check returned false for the same plan and mis-routed the
+    /// run through the full resource-apply pipeline.
+    #[test]
+    fn read_only_plan_has_no_mutations() {
+        use crate::resource::DataSource;
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Read {
+            resource: DataSource::with_provider("aws", "iam.Roles", "admin_access_roles", None),
+        });
+        // `is_empty()` is false — Read counts as a present effect.
+        assert!(!plan.is_empty());
+        // But there is no mutation, so the export-only fast path
+        // must take this plan.
+        assert!(!plan.has_mutations());
+        assert_eq!(plan.mutation_count(), 0);
+    }
+
+    #[test]
+    fn plan_with_create_has_mutations() {
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(ManagedResource::new(
+            "acm.Certificate",
+            "cert",
+        )));
+        assert!(plan.has_mutations());
+        assert_eq!(plan.mutation_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`carina apply` for a config whose only difference from state was an
export expression reading a data source silently fell through into
the resource-apply pipeline instead of taking the export-only fast
path (`persist_exports_only`). The `Persisting N export change(s) to
state.` banner never printed and `Apply complete! 0 changes
applied.` was reported instead — even though the export-only path
was the intended route. Operators were left without confirmation
that the export-only branch ran.

(The export value itself was correct after #3266 landed; this is
the routing/UX gap that #3266's body called out as a separate
follow-up.)

## Root cause

`run_apply_locked` gated the fast-path routing on `plan.is_empty()`.
`Plan::is_empty()` returns false as soon as the plan holds any
`Effect`, including `Effect::Read` from data sources. A config with
`let ds = read aws.X { ... }` always produces a Read effect at plan
time, so the gate failed and routing dropped to the resource-apply
pipeline. The condition needed to be "no *mutating* effects", not
"no effects".

## Fix

- Add `Plan::has_mutations()` (true iff at least one effect
  satisfies `Effect::is_mutating()` — i.e. anything other than
  `Read` or `Wait`).
- Gate the fast path on `!plan.has_mutations()` in
  `run_apply_locked`. The export-only path now correctly handles
  "plan with only Read effects + export change".
- Refresh the `persist_exports_only` docstring to describe the new
  gate.

## Test plan

- [x] `read_only_plan_has_no_mutations` pins the desired semantics:
  a plan with a single `Read` effect has `is_empty() == false` but
  `has_mutations() == false`.
- [x] `plan_with_create_has_mutations` covers the positive case.
- [x] `empty_plan` updated to also assert `has_mutations() == false`
  for a fresh plan.
- [x] `cargo nextest run -p carina-core plan::tests` — 11 passed
- [x] `cargo nextest run -p carina-cli` — 497 passed
- [x] `cargo nextest run --workspace --all-features` — 3600 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed
- [x] All `scripts/check-*.sh` — passed

## Out of scope

`run_apply_from_plan_locked` (saved-plan apply at line 1618) still
uses `plan.is_empty()`. The saved-plan path has no
`persist_exports_only` branch, so applying the same gate change
there would be inert. Left as-is to keep scope to the source-driven
apply path actually reported in the issue.

Closes #3270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
