### PR TITLE
carina-cli: refresh data sources, pin post-apply state merge in a newtype (#3271)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -34,8 +34,8 @@ use crate::commands::shared::progress::{
     RefreshProgress, emit_newline_on_interrupt, refresh_multi_progress,
 };
 use crate::commands::shared::state_writeback::{
-    ApplyStateSave, FinalizeApplyInput, apply_name_overrides, build_state_after_apply,
-    resolve_exports,
+    ApplyStateSave, FinalizeApplyInput, PostApplyStates, apply_name_overrides,
+    build_state_after_apply, resolve_exports,
 };
 use crate::commands::state::map_lock_error;
 use crate::cursor::CursorReveal;
@@ -301,14 +301,15 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
     // no source-side view of which exports the user intends — see the
     // `FinalizeApplyInput::export_params` doc-comment.
     if let Some(params) = input.export_params {
+        let post_apply_states =
+            PostApplyStates::from_current_and_state(input.current_states, &state);
         state.exports = resolve_exports(
             params,
             input.sorted_resources,
             input.data_sources,
             input.pre_resolve_virtuals,
-            &state,
+            &post_apply_states,
             input.wait_aliases,
-            input.current_states,
         )?;
     }
 
@@ -373,14 +374,14 @@ pub(crate) async fn persist_exports_only(
     current_states: &HashMap<ResourceId, carina_core::resource::State>,
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
+    let post_apply_states = PostApplyStates::from_current_and_state(current_states, &state);
     let exports = resolve_exports(
         export_params,
         sorted_resources,
         data_sources,
         pre_resolve_virtuals,
-        &state,
+        &post_apply_states,
         wait_aliases,
-        current_states,
     )?;
     state.exports = exports;
     if let Some(lk) = lock {

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1137,14 +1137,18 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     registry_prod.binding = Some("registry_prod".to_string());
     let sorted_resources = vec![registry_prod];
 
+    let post_apply_states =
+        crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
+            &std::collections::HashMap::new(),
+            &state,
+        );
     let exports = resolve_exports(
         &export_params,
         &sorted_resources,
         &[],
         &[],
-        &state,
+        &post_apply_states,
         &[],
-        &std::collections::HashMap::new(),
     )
     .unwrap();
 
@@ -1224,14 +1228,18 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
         })),
     }];
 
+    let post_apply_states =
+        crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
+            &std::collections::HashMap::new(),
+            &state,
+        );
     let exports = resolve_exports(
         &export_params,
         &sorted_resources,
         &[],
         &pre_resolve_virtuals,
-        &state,
+        &post_apply_states,
         &[],
-        &std::collections::HashMap::new(),
     )
     .unwrap();
 
@@ -1330,14 +1338,18 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
     }];
 
     let pre_resolve_virtuals = vec![inner_virtual, outer_virtual];
+    let post_apply_states =
+        crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
+            &std::collections::HashMap::new(),
+            &state,
+        );
     let exports = resolve_exports(
         &export_params,
         &sorted_resources,
         &[],
         &pre_resolve_virtuals,
-        &state,
+        &post_apply_states,
         &[],
-        &std::collections::HashMap::new(),
     )
     .unwrap();
 
@@ -1500,14 +1512,18 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
         })),
     }];
 
+    let post_apply_states =
+        crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
+            &std::collections::HashMap::new(),
+            &post_apply_state_file,
+        );
     let exports = resolve_exports(
         &export_params,
         &sorted_resources,
         &[],
         &pre_resolve_virtuals,
-        &post_apply_state_file,
+        &post_apply_states,
         &[],
-        &std::collections::HashMap::new(),
     )
     .unwrap();
 
@@ -1604,14 +1620,18 @@ fn resolve_exports_resolves_data_source_attribute_after_apply_3266() {
         })),
     }];
 
+    let post_apply_states =
+        crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
+            &current_states,
+            &post_apply_state_file,
+        );
     let exports = resolve_exports(
         &export_params,
         &[],
         &data_sources,
         &[],
-        &post_apply_state_file,
+        &post_apply_states,
         &[],
-        &current_states,
     )
     .unwrap();
 

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -61,6 +61,79 @@ pub(crate) fn queue_state_refresh(
     }
 }
 
+/// Resource attribute map ready for export-resolution after an apply
+/// or state-refresh.
+///
+/// Pinning the merge rule in a type closes a class of bug that
+/// recurred between #3266 and #3271. Two facts about the inputs:
+///
+/// 1. `state.resources` carries only **managed** resources — data
+///    sources are read each run and discarded at writeback, so
+///    consulting `state.resources` alone leaves any
+///    `<data_source>.<attr>` reference in `exports {}` unresolved
+///    (carina#3266, carina#3271).
+/// 2. `current_states` holds the live execution view — every
+///    resource read this run, including data sources. For managed
+///    resources it may still carry the **pre-apply** snapshot
+///    (whatever the executor read at refresh time, before the apply
+///    mutation ran), so the post-apply attribute values in
+///    `state.resources` must win on key collision.
+///
+/// The single correct merge is therefore: seed from
+/// `current_states.clone()` (so data sources survive), then overlay
+/// entries derived from `state.resources` (so managed
+/// post-apply values win). Earlier ad-hoc call sites that built
+/// `current_states` HashMaps by hand re-introduced the bug each
+/// time they forgot one half of the merge; this newtype forces the
+/// merge to happen exactly once, in
+/// [`PostApplyStates::from_current_and_state`].
+#[derive(Debug, Clone)]
+pub(crate) struct PostApplyStates {
+    map: HashMap<ResourceId, carina_core::resource::State>,
+}
+
+impl PostApplyStates {
+    /// Build the post-apply view from the live execution `current_states`
+    /// (with data-source read results) and the `StateFile` whose
+    /// `state.resources` was just rewritten by the apply writeback.
+    ///
+    /// State-derived managed entries win on key collision (see the
+    /// type-level doc-comment for why).
+    pub(crate) fn from_current_and_state(
+        current_states: &HashMap<ResourceId, carina_core::resource::State>,
+        state: &StateFile,
+    ) -> Self {
+        let mut map = current_states.clone();
+        for rs in &state.resources {
+            let id = ResourceId::with_provider(
+                &rs.provider,
+                &rs.resource_type,
+                &rs.name,
+                rs.directives.provider_instance.clone(),
+            );
+            let attrs: HashMap<String, carina_core::resource::Value> = rs
+                .attributes
+                .iter()
+                .filter_map(|(k, v)| {
+                    carina_core::value::json_to_dsl_value(v).map(|val| (k.clone(), val))
+                })
+                .collect();
+            map.insert(
+                id.clone(),
+                carina_core::resource::State::existing(id, attrs),
+            );
+        }
+        Self { map }
+    }
+
+    /// Borrow the underlying map for callers that need to feed it
+    /// into a `PreApplyInputs.current_states` slot. Read-only — the
+    /// merge is finalized at construction time.
+    pub(crate) fn as_map(&self) -> &HashMap<ResourceId, carina_core::resource::State> {
+        &self.map
+    }
+}
+
 /// Input parameters for `finalize_apply`.
 ///
 /// Groups the execution result, resource data, and backend configuration
@@ -171,50 +244,17 @@ pub(crate) fn resolve_exports(
     sorted_resources: &[ManagedResource],
     data_sources: &[carina_core::resource::DataSource],
     pre_resolve_virtuals: &[carina_core::resource::VirtualResource],
-    state: &StateFile,
+    post_apply_states: &PostApplyStates,
     wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
-    current_states: &HashMap<ResourceId, carina_core::resource::State>,
 ) -> Result<HashMap<String, serde_json::Value>, AppError> {
     use carina_core::binding_index::ResolvedBindings;
     use carina_core::resolver::resolve_virtual_refs_post_apply;
-    use carina_core::resource::Value;
 
-    // Step 1: rebuild post-apply `current_states` from
-    // `state.resources` for managed resources, and layer in
-    // `current_states` for entries (notably data sources) that the
-    // writeback never persists.
-    //
-    // carina#3266: data sources are not written to `state.resources`,
-    // so an exports expression referencing `<data_source>.<attr>`
-    // would resolve against an empty data-source binding without the
-    // `current_states` layer. With it, `layer_data_source_bindings`
-    // (carina#3265) sees the provider-read attrs and the export
-    // resolves to the read result. State-derived managed entries
-    // win on key collision because they reflect the post-apply
-    // writeback, while `current_states` may still hold the
-    // pre-apply snapshot for any managed resource that was just
-    // applied.
-    let mut post_apply_states: HashMap<ResourceId, carina_core::resource::State> =
-        current_states.clone();
-    for rs in &state.resources {
-        let id = ResourceId::with_provider(
-            &rs.provider,
-            &rs.resource_type,
-            &rs.name,
-            rs.directives.provider_instance.clone(),
-        );
-        let attrs: HashMap<String, Value> = rs
-            .attributes
-            .iter()
-            .filter_map(|(k, v)| {
-                carina_core::value::json_to_dsl_value(v).map(|val| (k.clone(), val))
-            })
-            .collect();
-        post_apply_states.insert(
-            id.clone(),
-            carina_core::resource::State::existing(id, attrs),
-        );
-    }
+    // Step 1: the post-apply state view was assembled by
+    // [`PostApplyStates::from_current_and_state`] before this call.
+    // See that type's doc-comment for the merge rule that pins
+    // carina#3266 (data-source survives) and carina#3271 (state
+    // refresh path uses the same shape).
 
     // Virtuals: fresh clone of the **pre-resolve** snapshot. Their
     // attributes still carry `ResourceRef`s, so the post-apply
@@ -236,7 +276,7 @@ pub(crate) fn resolve_exports(
         managed: sorted_resources,
         virtuals: &[],
         data_sources,
-        current_states: &post_apply_states,
+        current_states: post_apply_states.as_map(),
         remote_bindings: &HashMap::new(),
         wait_aliases,
     });
@@ -634,6 +674,90 @@ pub(crate) fn build_orphan_resource(
         dependency_bindings: rs.dependency_bindings.clone(),
         module_source: None,
         quoted_string_attrs: std::collections::HashSet::new(),
+    }
+}
+
+#[cfg(test)]
+mod post_apply_states_tests {
+    use super::*;
+    use carina_core::resource::{ConcreteValue, ResourceId, State, Value};
+    use carina_state::StateFile;
+
+    /// Type-level contract pin for the carina#3266 + carina#3271 merge rule.
+    ///
+    /// `from_current_and_state` must:
+    /// 1. Keep entries that exist in `current_states` but **not** in
+    ///    `state.resources` — data sources land here (they are never
+    ///    persisted to `state.resources`).
+    /// 2. For entries present in **both** maps, pick the one
+    ///    derived from `state.resources` — that is the post-apply
+    ///    writeback value, while `current_states` may still hold
+    ///    the pre-apply snapshot.
+    #[test]
+    fn data_source_only_in_current_states_survives() {
+        let ds_id = ResourceId::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+        let mut ds_attrs = HashMap::new();
+        ds_attrs.insert(
+            "arns".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("arn:aws:iam::1:role/x".to_string()),
+            )])),
+        );
+        let mut current_states = HashMap::new();
+        current_states.insert(
+            ds_id.clone(),
+            State::existing(ds_id.clone(), ds_attrs.clone()),
+        );
+
+        // state.resources has no entry for the data source — that is
+        // the production reality the bug springs from.
+        let state = StateFile::new();
+
+        let post = PostApplyStates::from_current_and_state(&current_states, &state);
+        let entry = post
+            .as_map()
+            .get(&ds_id)
+            .expect("data-source entry must survive merge");
+        assert_eq!(entry.attributes.get("arns"), ds_attrs.get("arns"));
+    }
+
+    #[test]
+    fn state_resources_entry_wins_over_current_states_on_collision() {
+        let id = ResourceId::with_provider("awscc", "s3.Bucket", "log", None);
+
+        // current_states carries the PRE-apply attribute value.
+        let mut pre_attrs = HashMap::new();
+        pre_attrs.insert(
+            "versioning".to_string(),
+            Value::Concrete(ConcreteValue::String("Suspended".to_string())),
+        );
+        let mut current_states = HashMap::new();
+        current_states.insert(id.clone(), State::existing(id.clone(), pre_attrs));
+
+        // state.resources carries the POST-apply value — this must win.
+        let json = serde_json::json!({
+            "version": 5,
+            "serial": 1,
+            "lineage": "test",
+            "carina_version": "0.4.0",
+            "resources": [
+                {
+                    "resource_type": "s3.Bucket",
+                    "name": "log",
+                    "identifier": "log-bucket",
+                    "provider": "awscc",
+                    "attributes": { "versioning": "Enabled" }
+                }
+            ]
+        });
+        let state: StateFile = serde_json::from_value(json).unwrap();
+
+        let post = PostApplyStates::from_current_and_state(&current_states, &state);
+        let entry = post.as_map().get(&id).expect("merged entry");
+        match entry.attributes.get("versioning") {
+            Some(Value::Concrete(ConcreteValue::String(s))) => assert_eq!(s, "Enabled"),
+            other => panic!("expected post-apply 'Enabled', got: {other:?}"),
+        }
     }
 }
 

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -23,7 +23,8 @@ use crate::commands::shared::state_writeback::apply_name_overrides;
 use crate::error::AppError;
 use crate::wiring::{
     WiringContext, build_factories_from_providers, get_provider_with_ctx,
-    reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
+    read_data_source_with_retry, reconcile_anonymous_identifiers_with_ctx,
+    reconcile_prefixed_names, resolve_data_source_refs_for_refresh,
 };
 
 /// Convert a lock acquisition error into an `AppError`.
@@ -729,6 +730,41 @@ pub(crate) async fn run_state_refresh_locked(
         current_states.insert(id.clone(), fresh_state);
     }
 
+    // carina#3271: re-read every `read aws.*` data source. Without
+    // this, `current_states` has no entry for any data source and
+    // the downstream `resolve_exports` (after #3266) cannot resolve
+    // `<data_source>.<attr>` references in `exports {}`, so
+    // `state.exports` keeps the pre-refresh literal for any export
+    // whose value depends on a data source.
+    //
+    // Mirrors the data-source phase of `run_apply_locked`
+    // (`resolve_data_source_refs_for_refresh` + `read_data_source_with_retry`):
+    // resolve input attribute `ResourceRef`s against the
+    // already-refreshed managed `current_states`, then read each
+    // data source through the provider.
+    if !parsed.data_sources.is_empty() {
+        let wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+            .wait_bindings
+            .iter()
+            .map(carina_core::binding_index::WaitAliasSpec::from)
+            .collect();
+        let resolved_data_sources = resolve_data_source_refs_for_refresh(
+            &sorted_resources,
+            &parsed.virtual_resources,
+            &parsed.data_sources,
+            &current_states,
+            &HashMap::new(),
+            ctx.schemas(),
+            &wait_aliases,
+        )?;
+        for resource in &resolved_data_sources {
+            let fresh_state = read_data_source_with_retry(&provider, resource)
+                .await
+                .map_err(AppError::Provider)?;
+            current_states.insert(resource.id.clone(), fresh_state);
+        }
+    }
+
     // Restore unreturned attributes from state file (CloudControl doesn't always return them)
     let mut saved_attrs = state_file
         .as_ref()
@@ -805,14 +841,18 @@ pub(crate) async fn run_state_refresh_locked(
         // so `parsed.virtual_resources` still carry the authored
         // `ResourceRef` snapshots that `resolve_exports`'s post-apply
         // re-resolution needs (#3169 / #3177).
+        let post_apply_states =
+            crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
+                &current_states,
+                &state,
+            );
         state.exports = crate::commands::shared::state_writeback::resolve_exports(
             &parsed.export_params,
             &sorted_resources,
             &parsed.data_sources,
             &parsed.virtual_resources,
-            &state,
+            &post_apply_states,
             &wait_aliases,
-            &current_states,
         )?;
     }
 


### PR DESCRIPTION
## Summary

`carina state refresh` re-read every managed resource but **never
re-read data sources**, and never recomputed `state.exports` for any
export whose value depended on a data source. The refresh loop
iterated only `sorted_resources` (managed). Once #3266 threaded
`current_states` into `resolve_exports`, the data-source ref still
resolved to nothing on the refresh path and `state.exports` kept the
pre-refresh literal — every refresh against a rotating data source
left exports stale until the next `apply`.

## Fix has two strands

### 1. Refresh now reads data sources

Mirror the data-source phase from `run_apply_locked`:
`resolve_data_source_refs_for_refresh` resolves input attribute
`ResourceRef`s against the already-refreshed managed
`current_states`, then `read_data_source_with_retry` reads each
data source through the provider, and the result is inserted into
the same map. The downstream `resolve_exports` then sees the live
data-source attrs via `layer_data_source_bindings` (#3265).

### 2. `PostApplyStates` newtype pins the merge rule

This issue is the direct consequence of how #3266 was shaped. The
"`current_states.clone()` then overlay entries derived from
`state.resources`" merge was inline inside `resolve_exports` and
implicit: callers passed a `&HashMap<ResourceId, State>` and trusted
`resolve_exports` to do the right thing. The state-refresh path
slipped past #3266 because it built its `current_states` without
data sources and there was no type-level signal that something was
wrong.

This PR pulls the merge into a newtype:

- `PostApplyStates::from_current_and_state(&current_states,
  &state_file)` is the only way to construct a `PostApplyStates`.
- `resolve_exports` now takes `&PostApplyStates` instead of
  `&HashMap<ResourceId, State>`.
- Every call site (apply `finalize_apply`, `persist_exports_only`,
  state-refresh `run_state_refresh_locked`, all existing tests) now
  goes through that constructor.

The bug class — "forgot one half of the merge" — is now a compile
error. A future call site cannot reconstruct the hand-rolled
half-merge without going through `from_current_and_state`.

## Test plan

- [x] Unit tests for the merge rule:
  - `data_source_only_in_current_states_survives` — data-source
    entries from `current_states` persist through the merge.
  - `state_resources_entry_wins_over_current_states_on_collision` —
    when both maps carry an entry, the `state.resources`-derived
    value wins (post-apply > pre-apply snapshot).
- [x] `cargo nextest run -p carina-cli` — 497 passed
- [x] `cargo nextest run --workspace --all-features` — 3602 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed
- [x] All `scripts/check-*.sh` — passed

Closes #3271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
