### PR TITLE
carina-core+cli: delete Plan::is_empty(), fix saved-plan routing (#3275)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1619,7 +1619,14 @@ async fn run_apply_from_plan_locked(
         )));
     }
 
-    if plan.is_empty() {
+    if !plan.has_mutations() {
+        // Saved plans serialize every `Effect::Read` produced by the
+        // differ; gating on `is_empty()` would skip this branch for
+        // any data-source-bearing config, even when no managed
+        // resource needs work, and fall through into the
+        // resource-apply pipeline. Mirrors the source-driven apply
+        // path's gate (carina#3270 → run_apply_locked).
+        // carina#3275.
         println!("{}", "No changes needed.".green());
         return Ok(());
     }

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -1332,7 +1332,7 @@ mod tests {
     fn build_plan_from_state_empty() {
         let state = StateFile::new();
         let plan = build_plan_from_state(&state);
-        assert!(plan.is_empty());
+        assert!(plan.effects().is_empty());
     }
 
     #[test]

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -263,7 +263,8 @@ pub fn format_plan(
 ) -> String {
     let mut out = String::new();
 
-    if plan.is_empty() && deferred_for_expressions.is_empty() && export_changes.is_empty() {
+    if plan.effects().is_empty() && deferred_for_expressions.is_empty() && export_changes.is_empty()
+    {
         writeln!(
             out,
             "{}",
@@ -389,7 +390,7 @@ pub fn format_destroy_plan(
 ) -> String {
     let mut out = String::new();
 
-    if plan.is_empty() {
+    if plan.effects().is_empty() {
         return out;
     }
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -205,7 +205,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
         &[],
     );
     assert!(
-        !plan_without.is_empty(),
+        !plan_without.effects().is_empty(),
         "Without normalize_state, differ should see a false diff"
     );
 
@@ -224,7 +224,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
         &[],
     );
     assert!(
-        plan_with.is_empty(),
+        plan_with.effects().is_empty(),
         "After normalize_state, no false diff should occur"
     );
 }
@@ -316,7 +316,7 @@ fn test_merge_default_tags_prevents_false_diff() {
         &[],
     );
     assert!(
-        !plan_without.is_empty(),
+        !plan_without.effects().is_empty(),
         "Without merge_default_tags, differ should see a false diff"
     );
 
@@ -346,7 +346,7 @@ fn test_merge_default_tags_prevents_false_diff() {
         &[],
     );
     assert!(
-        plan_with.is_empty(),
+        plan_with.effects().is_empty(),
         "After merge_default_tags, no false diff should occur"
     );
 }

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -49,9 +49,14 @@ impl Plan {
         &self.effects
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.effects.is_empty()
-    }
+    // No `Plan::is_empty()`: it ambiguously straddled "no effects at
+    // all" (display semantics) and "nothing to apply" (routing
+    // semantics). Read/Wait effects are non-mutating but non-empty,
+    // and routing on `is_empty()` mis-routed export-only configs
+    // through the resource-apply pipeline (carina#3270, carina#3275).
+    // Call sites must say what they mean:
+    //   - display "no effects at all" → `plan.effects().is_empty()`
+    //   - routing "nothing to apply"   → `!plan.has_mutations()`
 
     /// Add a directive constraint violation error
     pub fn add_error(&mut self, error: PlanError) {
@@ -181,15 +186,15 @@ impl Plan {
 
     /// True iff the plan contains at least one mutating effect.
     ///
-    /// `is_empty()` returns false for a plan that holds only `Read` /
-    /// `Wait` effects, even though those do not change infrastructure.
-    /// Callers that route apply between the export-only fast path
-    /// (`persist_exports_only`) and the full resource-apply pipeline
-    /// MUST gate on this, not on `is_empty()`: a config whose only
-    /// difference from state is an export expression that reads a
-    /// data source produces a plan with `Read` effects but no
-    /// mutations, and `is_empty()` would mis-route it through the
-    /// resource-apply path (carina#3270).
+    /// This is the **only** correct routing predicate for "does this
+    /// plan need the resource-apply pipeline?". `Read`/`Wait` effects
+    /// do not mutate infrastructure, so a plan that holds only those
+    /// must take the export-only fast path (`persist_exports_only`)
+    /// or short-circuit with "no changes". A predicate built on
+    /// `effects().is_empty()` mis-routes any plan that carries a
+    /// data-source read — every config with `let x = read aws.*`
+    /// produces one (carina#3270 source-driven apply, carina#3275
+    /// saved-plan apply).
     pub fn has_mutations(&self) -> bool {
         self.effects.iter().any(|e| e.is_mutating())
     }
@@ -429,7 +434,7 @@ mod tests {
     #[test]
     fn empty_plan() {
         let plan = Plan::new();
-        assert!(plan.is_empty());
+        assert!(plan.effects().is_empty());
         assert_eq!(plan.mutation_count(), 0);
         assert!(!plan.has_mutations());
     }
@@ -448,8 +453,8 @@ mod tests {
         plan.add(Effect::Read {
             resource: DataSource::with_provider("aws", "iam.Roles", "admin_access_roles", None),
         });
-        // `is_empty()` is false — Read counts as a present effect.
-        assert!(!plan.is_empty());
+        // `effects().is_empty()` is false — Read counts as a present effect.
+        assert!(!plan.effects().is_empty());
         // But there is no mutation, so the export-only fast path
         // must take this plan.
         assert!(!plan.has_mutations());


### PR DESCRIPTION
## Summary

`run_apply_from_plan_locked` still gated its "no work to do"
short-circuit on `plan.is_empty()`. A saved plan that serializes
`Effect::Read` (data-source reads) for a config whose only effective
diff is an export change has a non-empty effects vector but no
mutating effects. `is_empty()` returned false, the short-circuit was
skipped, and the run fell through into the resource-apply pipeline
that #3270 already taught not to take.

This was explicitly called out as a follow-up in PR #3273's "Out of
scope" section; #3275 retracts that scope decision and fixes the
class properly at the type level.

## Two-part fix

### 1. Gate fix (the bug)

```rust
-    if plan.is_empty() {
+    if !plan.has_mutations() {
         println!("{}", "No changes needed.".green());
         return Ok(());
     }
```

Mirrors the change #3270 made for `run_apply_locked` (source-driven
apply). Saved plans with only `Read`/`Wait` effects now report "No
changes needed." and return.

### 2. Delete `Plan::is_empty()` (the type-level closure)

#3270 shipped `has_mutations()` as the correct routing predicate
but left `is_empty()` in place with a docstring warning. That left
the next call site free to pick the wrong one — exactly what
`run_apply_from_plan_locked` did. **Deleting `Plan::is_empty()`
turns "forgot to gate on `has_mutations()`" into a compile error.**

Display call sites that genuinely mean "the effects vector is
empty" (not "no work to do") are migrated to
`plan.effects().is_empty()`, which says what it means and cannot be
mistaken for routing.

The deletion also serves as an in-code anti-pattern marker — the
removed-method comment in `plan.rs` documents *why* the method is
gone, so a future reintroduction would have to consciously override
that note rather than slip in unnoticed.

```rust
// No `Plan::is_empty()`: it ambiguously straddled "no effects at
// all" (display semantics) and "nothing to apply" (routing
// semantics). Read/Wait effects are non-mutating but non-empty,
// and routing on `is_empty()` mis-routed export-only configs
// through the resource-apply pipeline (carina#3270, carina#3275).
// Call sites must say what they mean:
//   - display "no effects at all" → `plan.effects().is_empty()`
//   - routing "nothing to apply"   → `!plan.has_mutations()`
```

## Test plan

- [x] The carina#3270 `read_only_plan_has_no_mutations` test
  already pinned the routing predicate's behavior for a Read-only
  plan. With `is_empty()` deleted, *both* `run_apply_locked` and
  `run_apply_from_plan_locked` now route through that same
  predicate; the test indirectly guards both call sites.
- [x] All test assertions that used `plan.is_empty()` to mean
  "effects vector empty" migrated to `plan.effects().is_empty()`.
- [x] `cargo nextest run -p carina-core plan::tests` — 11 passed
- [x] `cargo nextest run -p carina-cli` — 499 passed
- [x] `cargo nextest run --workspace --all-features` — 3602 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed
- [x] All `scripts/check-*.sh` — passed

## Why the type-level closure matters

This is the **third** PR in the #3266 / #3270 / #3271 / #3275 chain
that needed to fix the same shape of bug: an implicit predicate
choice that the docstring warned about but did not enforce.
#3271's `PostApplyStates` newtype was the model — pull the rule
into a type so the bug becomes a compile error. #3275 does the
inverse: remove the *wrong* predicate so only the right one is
available.

Closes #3275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
