### PR TITLE
carina-cli: pin expand+child-refresh+hydrate+lift in ExpandedRefreshState (#3278)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1048,25 +1048,38 @@ async fn run_apply_locked(
     // Create. The #1844 sort constraint (expanded resources must be in
     // the sorted/refreshed/diffed set) is honored by the re-sort
     // inside `expand_same_config_deferred_for`.
+    //
+    // carina#3278: the expand → child-refresh → hydrate(2nd) → lift
+    // quartet runs through `expand_refresh_and_lift_states` so the
+    // apply and refresh paths cannot diverge on these phases. The
+    // constructor is the only way to obtain an `ExpandedRefreshState`
+    // — leaving a phase out becomes a compile error.
     let moved_targets: HashSet<ResourceId> = moved_pairs.iter().map(|(_, to)| to.clone()).collect();
-    let crate::wiring::DeferredForExpansion {
+    let crate::wiring::ExpandedRefreshState {
         sorted_resources: resorted,
         residual_deferred_for,
-        new_child_ids,
-        refreshable_child_ids,
+        new_child_ids: _,
+        refreshable_child_ids: _,
         // `printed_warnings` drives the plan path's spinner-bar-region
         // close (#3150); the apply path's post-refresh bar handling is
         // tracked separately in #3151 and does not consume it here.
         printed_warnings: _,
-    } = crate::wiring::expand_same_config_deferred_for(
+    } = crate::wiring::expand_refresh_and_lift_states(crate::wiring::ExpandRefreshAndLiftInputs {
         parsed,
-        &sorted_resources,
-        &current_states,
-        &remote_bindings,
-        &wait_aliases,
-        &moved_targets,
-        &orphan_refreshed_ids,
-    )?;
+        provider: &provider,
+        sorted_resources: &sorted_resources,
+        current_states: &mut current_states,
+        remote_bindings: &remote_bindings,
+        wait_aliases: &wait_aliases,
+        moved_targets: &moved_targets,
+        already_refreshed: &orphan_refreshed_ids,
+        state_file: &state_file,
+        saved_dep_bindings: &HashMap::new(),
+        saved_attrs: &saved_attrs,
+        multi: &multi,
+        schemas: ctx.schemas(),
+    })
+    .await?;
     sorted_resources = resorted;
     // Expansion borrows `parsed` immutably (expands a clone), so
     // `parsed.deferred_for_expressions` is NOT drained of resolved
@@ -1077,39 +1090,10 @@ async fn run_apply_locked(
     // "deferred" entry. Mirrors the plan path's `ctx.residual_deferred_for`
     // (`commands/plan.rs`).
 
-    if !new_child_ids.is_empty() {
-        // Refresh only `refreshable_child_ids` (carina#3141): a child
-        // that is also a `moved` target keeps the migrated state from
-        // `materialize_moved_states`; re-reading it would clobber that
-        // state with `not_found`. `select` is the same (and only)
-        // constructor the plan path uses — there is no way to filter by
-        // the wider `new_child_ids` here, so a divergence is a compile
-        // error, not a silent parity bug.
-        let children = refreshable_child_ids.select(&sorted_resources);
-        crate::wiring::refresh_resource_set(
-            provider_ref,
-            &multi,
-            children,
-            &state_file,
-            &HashMap::new(),
-            &mut current_states,
-        )
-        .await?;
-        provider
-            .hydrate_read_state(&mut current_states, &saved_attrs)
-            .await;
-    }
-
-    // awscc#251: lift the provider-read `current_states` (not just
-    // `saved_attrs` above) — a refresh whose `provider.read()` returns
-    // plain-`String` IAM enum values must be lifted before the differ
-    // consumes it, same as the plan path. Both refresh phases have
-    // populated `current_states` by here.
-    carina_core::utils::lift_current_state_string_enums(
-        &mut current_states,
-        &sorted_resources,
-        ctx.schemas(),
-    );
+    // Data-source lifting stays inline: it operates on
+    // `parsed.data_sources` (not `sorted_resources`), so it is
+    // independent of the deferred-for expansion sequence the helper
+    // above pins.
     carina_core::utils::lift_current_state_string_enums_for_data_sources(
         &mut current_states,
         &data_sources,

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -22,9 +22,9 @@ use super::validate_and_resolve_with_config;
 use crate::commands::shared::state_writeback::apply_name_overrides;
 use crate::error::AppError;
 use crate::wiring::{
-    WiringContext, build_factories_from_providers, expand_same_config_deferred_for,
-    get_provider_with_ctx, read_data_source_with_retry, reconcile_anonymous_identifiers_with_ctx,
-    reconcile_prefixed_names, refresh_resource_set, resolve_data_source_refs_for_refresh,
+    WiringContext, build_factories_from_providers, get_provider_with_ctx,
+    read_data_source_with_retry, reconcile_anonymous_identifiers_with_ctx,
+    reconcile_prefixed_names, resolve_data_source_refs_for_refresh,
 };
 
 /// Convert a lock acquisition error into an `AppError`.
@@ -715,60 +715,54 @@ pub(crate) async fn run_state_refresh_locked(
         .iter()
         .map(carina_core::binding_index::WaitAliasSpec::from)
         .collect();
-    let crate::wiring::DeferredForExpansion {
+    // carina#3278: route the expand → child-refresh → hydrate(2nd) →
+    // lift quartet through the shared constructor so this path and
+    // `run_apply_locked` cannot drift on the sequence again.
+    let saved_attrs_for_expansion = state_file
+        .as_ref()
+        .map(|sf| sf.build_saved_attrs())
+        .unwrap_or_default();
+    let saved_dep_bindings: HashMap<ResourceId, BTreeSet<String>> = state_file
+        .as_ref()
+        .map(|sf| {
+            sorted_resources
+                .iter()
+                .filter_map(|r| {
+                    let rs =
+                        sf.find_resource(&r.id.provider, &r.id.resource_type, r.id.name_str())?;
+                    if rs.dependency_bindings.is_empty() {
+                        None
+                    } else {
+                        Some((r.id.clone(), rs.dependency_bindings.clone()))
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let multi = indicatif::MultiProgress::new();
+    let crate::wiring::ExpandedRefreshState {
         sorted_resources: resorted,
-        new_child_ids,
-        refreshable_child_ids,
-        // residual / warnings: not consumed by the refresh path.
+        new_child_ids: _,
+        refreshable_child_ids: _,
         residual_deferred_for: _,
         printed_warnings: _,
-    } = expand_same_config_deferred_for(
+    } = crate::wiring::expand_refresh_and_lift_states(crate::wiring::ExpandRefreshAndLiftInputs {
         parsed,
-        &sorted_resources,
-        &current_states,
-        &HashMap::new(),
-        &wait_aliases_for_expansion,
-        &HashSet::new(),
-        &already_refreshed,
-    )?;
+        provider: &provider,
+        sorted_resources: &sorted_resources,
+        current_states: &mut current_states,
+        remote_bindings: &HashMap::new(),
+        wait_aliases: &wait_aliases_for_expansion,
+        moved_targets: &HashSet::new(),
+        already_refreshed: &already_refreshed,
+        state_file: &state_file,
+        saved_dep_bindings: &saved_dep_bindings,
+        saved_attrs: &saved_attrs_for_expansion,
+        multi: &multi,
+        schemas: ctx.schemas(),
+    })
+    .await?;
     sorted_resources = resorted;
-
-    // Read state for any for-loop-materialised children that the
-    // initial managed loop didn't visit.
-    if !new_child_ids.is_empty() {
-        // Mirror the apply path's hand-rolled `saved_dep_bindings`
-        // build (apply/mod.rs ~874): `Provider::read` does not return
-        // `dependency_bindings`, so we have to pull them from the
-        // state file ourselves to restore them on the fresh state.
-        let saved_dep_bindings: HashMap<ResourceId, BTreeSet<String>> = state_file
-            .as_ref()
-            .map(|sf| {
-                sorted_resources
-                    .iter()
-                    .filter_map(|r| {
-                        let rs =
-                            sf.find_resource(&r.id.provider, &r.id.resource_type, r.id.name_str())?;
-                        if rs.dependency_bindings.is_empty() {
-                            None
-                        } else {
-                            Some((r.id.clone(), rs.dependency_bindings.clone()))
-                        }
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        let children = refreshable_child_ids.select(&sorted_resources);
-        let multi = indicatif::MultiProgress::new();
-        let _ = refresh_resource_set(
-            &provider,
-            &multi,
-            children,
-            &state_file,
-            &saved_dep_bindings,
-            &mut current_states,
-        )
-        .await?;
-    }
 
     // Also read states for orphaned resources (in state but removed from config)
     let desired_ids: HashSet<ResourceId> = sorted_resources.iter().map(|r| r.id.clone()).collect();

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1341,6 +1341,138 @@ pub fn expand_same_config_deferred_for<E: Clone>(
     })
 }
 
+/// Result of the deferred-for-expansion + materialised-child-read +
+/// StringEnum-lift trio that every refresh path runs on its
+/// `current_states`.
+///
+/// Closes the bug class behind carina#3266 / #3271 / #3272 at the type
+/// level — same closure pattern as
+/// [`PostApplyStates`](crate::commands::shared::state_writeback::PostApplyStates).
+/// Every call site that needs a post-expansion view of `sorted_resources`
+/// (apply `run_apply_locked`, refresh `run_state_refresh_locked`) MUST
+/// obtain it via [`expand_refresh_and_lift_states`], and the constructor
+/// performs all three phases or none:
+///
+/// 1. `expand_same_config_deferred_for` — synthesise for-loop children
+///    and re-sort the augmented set.
+/// 2. `refresh_resource_set` — read each materialised child through
+///    the provider (filtered through `refreshable_child_ids` so a
+///    `moved`-target or orphan-pre-read child is not re-read).
+/// 3. `lift_current_state_string_enums` on the **post-expansion**
+///    `sorted_resources`, so enum-typed attrs on the new children are
+///    not surfaced as phantom case diffs (carina#3272).
+///
+/// The constructor mutates `current_states` in place (read results are
+/// inserted, then lifted). Caller-side `provider.hydrate_read_state`
+/// stays at the call site — the apply path needs a second hydrate
+/// after this trio (saved_attrs for the new children), the refresh
+/// path runs hydrate once after the trio; encoding that difference
+/// in the constructor would re-introduce the divergence this newtype
+/// is meant to close.
+#[non_exhaustive]
+pub struct ExpandedRefreshState {
+    pub sorted_resources: Vec<ManagedResource>,
+    pub residual_deferred_for: Vec<carina_core::parser::DeferredForExpression>,
+    pub new_child_ids: HashSet<ResourceId>,
+    pub refreshable_child_ids: RefreshableChildIds,
+    pub printed_warnings: bool,
+}
+
+/// Inputs for [`expand_refresh_and_lift_states`].
+///
+/// Grouped into a struct because the underlying phases need many of
+/// the same inputs (provider, schemas, wait_aliases, …) and a flat
+/// arg list would already trip the 7-argument lint here.
+pub struct ExpandRefreshAndLiftInputs<'a, E: Clone, P: Provider + ProviderNormalizer> {
+    pub parsed: &'a carina_core::parser::File<E>,
+    pub provider: &'a P,
+    pub sorted_resources: &'a [ManagedResource],
+    pub current_states: &'a mut HashMap<ResourceId, State>,
+    pub remote_bindings: &'a HashMap<String, HashMap<String, Value>>,
+    pub wait_aliases: &'a [WaitAliasSpec],
+    pub moved_targets: &'a HashSet<ResourceId>,
+    pub already_refreshed: &'a HashSet<ResourceId>,
+    pub state_file: &'a Option<StateFile>,
+    pub saved_dep_bindings: &'a HashMap<ResourceId, BTreeSet<String>>,
+    /// Saved attribute values to carry forward to materialised children
+    /// via `provider.hydrate_read_state` after their initial read. Pass
+    /// the same `SavedAttrs` the caller built once at the head of its
+    /// pipeline — `hydrate_read_state` is idempotent, so passing it
+    /// here and re-hydrating downstream of this function is safe.
+    pub saved_attrs: &'a carina_core::provider::SavedAttrs,
+    pub multi: &'a indicatif::MultiProgress,
+    pub schemas: &'a carina_core::schema::SchemaRegistry,
+}
+
+/// Run the expand → child-refresh → hydrate → lift quartet in
+/// lock-step.
+///
+/// See [`ExpandedRefreshState`] for why this is a single function.
+pub async fn expand_refresh_and_lift_states<E: Clone, P: Provider + ProviderNormalizer>(
+    inputs: ExpandRefreshAndLiftInputs<'_, E, P>,
+) -> Result<ExpandedRefreshState, AppError> {
+    // Phase 1: expand for-loops.
+    let DeferredForExpansion {
+        sorted_resources,
+        residual_deferred_for,
+        new_child_ids,
+        refreshable_child_ids,
+        printed_warnings,
+    } = expand_same_config_deferred_for(
+        inputs.parsed,
+        inputs.sorted_resources,
+        inputs.current_states,
+        inputs.remote_bindings,
+        inputs.wait_aliases,
+        inputs.moved_targets,
+        inputs.already_refreshed,
+    )?;
+
+    // Phase 2: read materialised children that weren't already
+    // refreshed (moved-target / orphan-pre-read are excluded by
+    // `refreshable_child_ids`).
+    //
+    // Phase 2.5: carry forward saved_attrs to the newly-read children
+    // so create-only / API-unreturned fields survive. Mirrors the
+    // 2nd `hydrate_read_state` call apply ran by hand
+    // (apply/mod.rs ~1098); collapsing it into this constructor stops
+    // the next caller from forgetting it.
+    if !new_child_ids.is_empty() {
+        let children = refreshable_child_ids.select(&sorted_resources);
+        refresh_resource_set(
+            inputs.provider,
+            inputs.multi,
+            children,
+            inputs.state_file,
+            inputs.saved_dep_bindings,
+            inputs.current_states,
+        )
+        .await?;
+        inputs
+            .provider
+            .hydrate_read_state(inputs.current_states, inputs.saved_attrs)
+            .await;
+    }
+
+    // Phase 3: lift StringEnums on the post-expansion slice. Both
+    // pre-existing managed resources and the new for-loop children
+    // need this so enum-typed attrs aren't surfaced as phantom case
+    // diffs (carina#3272).
+    carina_core::utils::lift_current_state_string_enums(
+        inputs.current_states,
+        &sorted_resources,
+        inputs.schemas,
+    );
+
+    Ok(ExpandedRefreshState {
+        sorted_resources,
+        residual_deferred_for,
+        new_child_ids,
+        refreshable_child_ids,
+        printed_warnings,
+    })
+}
+
 /// Create a plan from parsed configuration (without upstream state bindings).
 ///
 /// This is a convenience wrapper around `create_plan_from_parsed_with_upstream`


### PR DESCRIPTION
## Summary

Close the post-fetch phase-divergence bug class at the type level.

The expand → child-refresh → hydrate → lift sequence was duplicated inline in both `run_apply_locked` (apply/mod.rs ~1042–1117) and `run_state_refresh_locked` (commands/state.rs ~700–771). Three bugs in the carina#3266 chain were exactly the "one path added a phase, the other forgot it" failure mode:

- #3266 — apply built `current_states` for export resolution and missed data sources.
- #3271 — refresh built `current_states` and missed the data-source read phase apply already had.
- #3272 — refresh built `sorted_resources` and missed the `expand_same_config_deferred_for` phase apply already had.

Each one landed as a surgical fix. The structural exposure — "two hand-rolled call sites that have to track each other manually" — stayed in place.

This PR closes it. The only way to obtain an `ExpandedRefreshState` is to call `expand_refresh_and_lift_states`, and the constructor runs all four phases or none.

## Constructor

```rust
pub async fn expand_refresh_and_lift_states<E, P>(
    inputs: ExpandRefreshAndLiftInputs<'_, E, P>,
) -> Result<ExpandedRefreshState, AppError>
where
    E: Clone,
    P: Provider + ProviderNormalizer,
```

Phases:

1. `expand_same_config_deferred_for` — materialise for-loop children.
2. `refresh_resource_set` — read materialised children through the provider (filtered through `refreshable_child_ids` so a `moved`-target or orphan-pre-read child is not re-read).
3. `provider.hydrate_read_state` — carry forward saved_attrs onto the newly-read children. Mirrors the 2nd hydrate apply ran by hand at apply/mod.rs:1098; collapsing it here stops the next caller from forgetting it.
4. `lift_current_state_string_enums` on the **post-expansion** `sorted_resources`, so enum-typed attrs on the new children aren't surfaced as phantom case diffs (carina#3272).

`ExpandedRefreshState` is `#[non_exhaustive]` and only the constructor returns it, so a future caller can't reproduce the hand-rolled half-sequence by accident.

## Per-path divergences stay outside the constructor

The constructor scope is "the phases that *must* run together"; per-path differences stay inline at the call site so the type stays honest:

- Apply keeps `lift_current_state_string_enums_for_data_sources` inline (it operates on `parsed.data_sources`, independent of the managed-resource expansion sequence) and `canonicalize_states_with_schemas` (apply-only normalisation step, not run on the refresh path).
- Refresh keeps its post-helper `hydrate_read_state` + lift inline: the refresh path's orphan + data-source reads land in `current_states` *after* the constructor returns, so they need their own hydrate / lift pass. Both are idempotent, so the overlap with the in-constructor hydrate is safe.

Trying to push every difference into the constructor would either (a) encode "is this apply or refresh" as a runtime flag (defeats the type-level closure) or (b) push apply-only steps into the refresh path (changes behaviour). Keeping the divergent steps where they belong leaves the constructor with one job — the four phases that always run together.

## Test plan

- [x] `cargo nextest run -p carina-cli` — 499 passed
- [x] `cargo nextest run --workspace --all-features` — 3602 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed
- [x] All `scripts/check-*.sh` — passed
- ⚠️ **No new unit test for the constructor's phase ordering.** Building a `Provider + ProviderNormalizer` recording mock to pin "phase 1 finishes before phase 2 starts" etc. is real work and belongs in its own change. The existing 3602 workspace tests exercise the constructor indirectly through the migrated apply path — anything that broke the apply pipeline's behaviour would fail there. A direct contract test is filed as a follow-up.

## Out of scope (follow-up)

- A direct unit test of the constructor's phase ordering, using a `Provider + ProviderNormalizer` recording mock in `wiring/tests.rs`.

## Reference: the carina#3266 chain this closes

| Issue | PR | Symptom |
| --- | --- | --- |
| #3266 | #3269 | apply: `state.exports` not updated for data-source-derived value |
| #3270 | #3273 | apply: routing on `is_empty()` instead of `has_mutations()` |
| #3271 | #3274 | state refresh: data sources not re-read; `PostApplyStates` newtype |
| #3275 | #3276 | saved-plan apply: same `is_empty()` routing bug, `Plan::is_empty()` deleted |
| #3272 | #3277 | state refresh: for-loop children misclassified as orphan + phantom enum-case diffs |
| **#3278 (this PR)** | — | type-level closure: `ExpandedRefreshState` newtype |

Closes #3278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
