### PR TITLE
fix: emit state-migration warning once per run with actionable wording (#3283)

### DIFF
--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -70,7 +70,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         // load. Direct `serde_json::from_str` would silently drop the
         // legacy field and leave `explicit` empty, breaking the
         // moved_prev_keys snapshot test.
-        Some(check_and_migrate(&json).unwrap())
+        Some(check_and_migrate(&json).unwrap().into_state())
     } else {
         None
     };
@@ -141,7 +141,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         let bindings = std::fs::read_to_string(&state_path)
             .ok()
             .and_then(|content| check_and_migrate(&content).ok())
-            .map(|sf| sf.build_remote_bindings())
+            .map(|migrated| migrated.state.build_remote_bindings())
             .unwrap_or_default();
         remote_bindings.insert(us.binding.clone(), bindings);
     }

--- a/carina-cli/tests/plan_state_migration_warning_once.rs
+++ b/carina-cli/tests/plan_state_migration_warning_once.rs
@@ -1,0 +1,121 @@
+//! Regression test for carina#3283.
+//!
+//! `carina plan` reads the state file twice per run (T0 snapshot
+//! followed by a post-plan drift re-read). Before the fix, the
+//! state-schema migration warning was emitted directly from inside
+//! `check_and_migrate` via `eprintln!`, so a single physical v6 state
+//! file produced two (or three, once the refresh phase is also
+//! involved) identical `Warning: Migrating state file...` lines per
+//! run — noise that trained operators to ignore warnings.
+//!
+//! The fix moves the warning emission out of `check_and_migrate`,
+//! which now returns the migration event as a typed `MigrationInfo`
+//! value, and into the backend impls, where a per-instance
+//! `OnceLock<MigrationInfo>` guarantees at most one log per
+//! backend per process. This test pins the contract on the real
+//! `carina plan` binary so a future refactor that re-introduces the
+//! library-level `eprintln!` (or otherwise loses the dedupe) fails
+//! loudly.
+
+use std::fs;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn plain_text_command(bin: &str) -> Command {
+    let mut cmd = Command::new(bin);
+    cmd.env("NO_COLOR", "1").env_remove("CLICOLOR_FORCE");
+    cmd
+}
+
+/// Write a minimal local-backend project plus a hand-authored v6
+/// state file so the very next `carina plan` triggers a v6 → v7
+/// in-memory migration.
+fn init_project_with_v6_state(dir: &std::path::Path) {
+    fs::write(
+        dir.join("main.crn"),
+        r#"backend local { path = "carina.state.json" }
+exports { region: String = "ap-northeast-1" }"#,
+    )
+    .unwrap();
+
+    let state = serde_json::json!({
+        "version": 6,
+        "serial": 1,
+        "lineage": "11111111-1111-1111-1111-111111111111",
+        "carina_version": "0.0.0-test",
+        "resources": [],
+        "exports": { "region": "ap-northeast-1" }
+    });
+    fs::write(
+        dir.join("carina.state.json"),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let status = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .args(["init", dir.to_str().unwrap()])
+        .status()
+        .expect("failed to execute carina init");
+    assert!(status.success(), "carina init failed");
+}
+
+#[test]
+fn plan_emits_migration_warning_exactly_once_for_v6_state_file() {
+    let dir = TempDir::new().unwrap();
+    init_project_with_v6_state(dir.path());
+
+    let output = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .current_dir(dir.path())
+        .args(["plan", "."])
+        .output()
+        .expect("failed to run carina plan");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // The warning is the new wording (carina#3283): mentions the
+    // on-disk version, the in-memory upgrade target, and the
+    // operator's actionable next step. Match on the stable prefix
+    // so a copy-edit doesn't break the test.
+    let occurrences = stderr.matches("is v6 on disk").count();
+    assert_eq!(
+        occurrences, 1,
+        "expected exactly one migration warning per `carina plan` run, \
+         got {occurrences}. Full stderr:\n{stderr}\nstdout:\n{stdout}"
+    );
+
+    // Sanity-check that the old wording — which would re-appear if
+    // a future change put the eprintln! back inside `check_and_migrate`
+    // — is gone.
+    assert!(
+        !stderr.contains("Migrating state file from v"),
+        "old past-tense wording leaked back into the warning. \
+         stderr:\n{stderr}"
+    );
+
+    // Pin the *actionable* parts of the warning so a future copy-edit
+    // that strips the operator's next-step guidance fails loudly: the
+    // user needs to know (a) the in-memory target version, and (b) at
+    // least one command that will rewrite disk state. Target version
+    // is pulled from `StateFile::CURRENT_VERSION` so the test does
+    // not break when a future schema bump lands.
+    let current_version_token = format!("v{}", carina_state::StateFile::CURRENT_VERSION);
+    assert!(
+        stderr.contains(&current_version_token),
+        "warning must name the target version ({current_version_token}). stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("state refresh") || stderr.contains("apply"),
+        "warning must point operators at an actionable command \
+         (carina apply / carina state refresh). stderr:\n{stderr}"
+    );
+
+    // Identify *which* file is stale (matters when upstream_state
+    // chains read multiple state files in one process). The state
+    // file path is fixed by `init_project_with_v6_state`.
+    assert!(
+        stderr.contains("carina.state.json"),
+        "warning must name the affected state file. stderr:\n{stderr}"
+    );
+}

--- a/carina-cli/tests/state_value_round_trip.rs
+++ b/carina-cli/tests/state_value_round_trip.rs
@@ -65,7 +65,7 @@ fn fixture_attributes_round_trip_through_value_codec() {
         let raw = std::fs::read_to_string(path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
         let state = match check_and_migrate(&raw) {
-            Ok(s) => s,
+            Ok(s) => s.into_state(),
             Err(e) => {
                 failures.push(format!("{}: deserialize StateFile: {e}", path.display()));
                 continue;

--- a/carina-state/src/backends/local.rs
+++ b/carina-state/src/backends/local.rs
@@ -7,12 +7,13 @@ use async_trait::async_trait;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::time::Duration;
 use tokio::time::sleep as async_sleep;
 
 use crate::backend::{BackendConfig, BackendError, BackendResult, StateBackend};
 use crate::lock::LockInfo;
-use crate::state::{self, StateFile};
+use crate::state::{self, MigrationInfo, StateFile, log_state_migration_once};
 
 /// Local file backend for development and simple use cases
 pub struct LocalBackend {
@@ -20,6 +21,13 @@ pub struct LocalBackend {
     state_path: PathBuf,
     /// Path to the lock file
     lock_path: PathBuf,
+    /// Tracks the first in-memory state-schema migration observed by
+    /// `read_state` on this backend instance, so the warning is emitted
+    /// exactly once per backend (carina#3283). `carina plan` reads state
+    /// twice per run (T0 snapshot + post-plan drift re-read) and an
+    /// unguarded `eprintln!` inside `check_and_migrate` would surface
+    /// the warning twice for a single physical file.
+    migration_logged: OnceLock<MigrationInfo>,
 }
 
 const RECOVERY_CLAIM_TIMEOUT_SECS: i64 = 30;
@@ -50,6 +58,7 @@ impl LocalBackend {
         Self {
             state_path,
             lock_path,
+            migration_logged: OnceLock::new(),
         }
     }
 
@@ -236,9 +245,15 @@ impl StateBackend for LocalBackend {
             }
         };
 
-        let state = state::check_and_migrate(&content)?;
-
-        Ok(Some(state))
+        let outcome = state::check_and_migrate(&content)?;
+        if let Some(info) = outcome.migration {
+            log_state_migration_once(
+                &self.migration_logged,
+                info,
+                &self.state_path.display().to_string(),
+            );
+        }
+        Ok(Some(outcome.state))
     }
 
     async fn write_state(&self, state: &StateFile) -> BackendResult<()> {

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -7,11 +7,13 @@ use aws_sdk_s3::operation::head_bucket::HeadBucketError;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{PublicAccessBlockConfiguration, ServerSideEncryption};
 
+use std::sync::OnceLock;
+
 use carina_core::utils::convert_region_value;
 
 use crate::backend::{AwsError, BackendConfig, BackendError, BackendResult, StateBackend};
 use crate::lock::LockInfo;
-use crate::state::{self, StateFile};
+use crate::state::{self, MigrationInfo, StateFile, log_state_migration_once};
 
 const REGION_UNRESOLVED_MESSAGE: &str = "S3 backend has no region: set `region` in the backend block, or configure AWS_REGION / a profile region";
 
@@ -35,6 +37,10 @@ pub struct S3Backend {
     encrypt: bool,
     /// Whether to auto-create the bucket if it doesn't exist (default: true)
     auto_create: bool,
+    /// Tracks the first in-memory state-schema migration observed by
+    /// `read_state` on this backend instance (carina#3283). See the
+    /// equivalent field on `LocalBackend` for the rationale.
+    migration_logged: OnceLock<MigrationInfo>,
 }
 
 impl S3Backend {
@@ -100,6 +106,7 @@ impl S3Backend {
             region,
             encrypt,
             auto_create,
+            migration_logged: OnceLock::new(),
         }
     }
 
@@ -264,8 +271,15 @@ impl StateBackend for S3Backend {
                     .await
                     .map_err(|e| BackendError::Io(e.to_string()))?;
                 let bytes = body.into_bytes();
-                let state = state::check_and_migrate_bytes(&bytes)?;
-                Ok(Some(state))
+                let outcome = state::check_and_migrate_bytes(&bytes)?;
+                if let Some(info) = outcome.migration {
+                    log_state_migration_once(
+                        &self.migration_logged,
+                        info,
+                        &format!("s3://{}/{}", self.bucket, self.key.trim_start_matches('/')),
+                    );
+                }
+                Ok(Some(outcome.state))
             }
             Err(err) => {
                 if is_not_found_error(&err) {

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -57,4 +57,7 @@ pub use backends::{
     resolve_backend_anchored,
 };
 pub use lock::LockInfo;
-pub use state::{ResourceState, StateFile, check_and_migrate, check_and_migrate_bytes};
+pub use state::{
+    MigratedStateFile, MigrationInfo, ResourceState, StateFile, check_and_migrate,
+    check_and_migrate_bytes, log_state_migration_once,
+};

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -403,20 +403,94 @@ struct VersionCheck {
     version: u32,
 }
 
+/// Reports an in-memory schema upgrade applied to a state file by
+/// [`check_and_migrate`]. The function itself never writes to stderr —
+/// the caller (a backend impl) decides whether and how often to log,
+/// which lets `carina plan` emit the migration warning exactly once
+/// per run even when state is read multiple times (T0 snapshot +
+/// post-plan drift re-read, see carina#3283).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationInfo {
+    /// On-disk version that was read.
+    pub from: u32,
+    /// Version the state was migrated to (always `StateFile::CURRENT_VERSION`).
+    pub to: u32,
+}
+
+/// Successful outcome of [`check_and_migrate`].
+///
+/// Always carries the parsed (and possibly schema-upgraded) state.
+/// `migration` is `Some` iff the on-disk version was older than
+/// [`StateFile::CURRENT_VERSION`] and an in-memory upgrade was applied;
+/// `None` for state files that were already current.
+///
+/// Intentionally not `Clone`: a [`StateFile`] can hold every resource
+/// in the deployment, so accidentally cloning the wrapper would clone
+/// the full state. The wrapper is consumed at the backend boundary
+/// (`read_state` → caller takes `.state` or `.into_state()`).
+#[derive(Debug)]
+pub struct MigratedStateFile {
+    pub state: StateFile,
+    pub migration: Option<MigrationInfo>,
+}
+
+impl MigratedStateFile {
+    /// Discard the migration info and return just the state. Convenience
+    /// for call sites (e.g. unit tests, fixture loaders) that only need
+    /// the parsed `StateFile` and never log the migration.
+    pub fn into_state(self) -> StateFile {
+        self.state
+    }
+}
+
+/// Emit the state-schema migration warning to stderr at most once for
+/// the given `OnceLock`-protected slot. Backends call this from
+/// `read_state` so a single `carina plan` run — which reads state
+/// twice (T0 snapshot plus post-plan drift re-read, carina#3283) —
+/// surfaces the warning exactly once per backend instance.
+///
+/// `display_target` should identify the underlying state file (e.g. a
+/// local path or `s3://bucket/key`) so an operator running with
+/// `upstream_state` chains or multiple backends in one process can
+/// tell which file the warning refers to.
+///
+/// Dedupe is per-backend-instance, not per `(from, to)` pair: once
+/// any migration has been logged through this slot, no subsequent
+/// `read_state` on the same backend logs again, even if a later read
+/// observed a different `from` version. This matches the only
+/// realistic case (each backend points at one physical state file)
+/// and keeps the API trivially correct.
+pub fn log_state_migration_once(
+    slot: &std::sync::OnceLock<MigrationInfo>,
+    info: MigrationInfo,
+    display_target: &str,
+) {
+    if slot.set(info).is_ok() {
+        eprintln!(
+            "Warning: state file {} is v{} on disk; in-memory migration \
+             to v{} applied for this run. Disk state will be rewritten \
+             on the next `carina apply` or `carina state refresh` in \
+             that directory.",
+            display_target, info.from, info.to
+        );
+    }
+}
+
 /// Deserialize a state file from a JSON string, checking the version and
 /// migrating from older formats if necessary.
 ///
-/// - Current version: deserialized directly.
+/// - Current version: deserialized directly; returned with `migration = None`.
 /// - Future version (newer than supported): returns a clear error asking the
 ///   user to upgrade Carina.
 /// - Older version: attempts deserialization with serde defaults and bumps
-///   the version to current. When a future version introduces breaking changes,
-///   explicit migration functions should be added here.
+///   the version to current. The from/to versions are returned as
+///   [`MigrationInfo`] so the caller can log the event (carina#3283).
 /// - Invalid JSON: returns a parse error.
-pub fn check_and_migrate(content: &str) -> Result<StateFile, BackendError> {
+pub fn check_and_migrate(content: &str) -> Result<MigratedStateFile, BackendError> {
     let check: VersionCheck = serde_json::from_str(content)
         .map_err(|e| BackendError::InvalidState(format!("Failed to parse state version: {}", e)))?;
 
+    let mut migration: Option<MigrationInfo> = None;
     let mut state: StateFile = match check.version {
         v if v == StateFile::CURRENT_VERSION => serde_json::from_str(content).map_err(|e| {
             BackendError::InvalidState(format!("Failed to parse state file: {}", e))
@@ -429,13 +503,10 @@ pub fn check_and_migrate(content: &str) -> Result<StateFile, BackendError> {
             )));
         }
         v => {
-            // Older version — for now, try to deserialize with serde defaults.
-            // In the future, add explicit migration functions here.
-            eprintln!(
-                "Warning: Migrating state file from v{} to v{}",
-                v,
-                StateFile::CURRENT_VERSION
-            );
+            migration = Some(MigrationInfo {
+                from: v,
+                to: StateFile::CURRENT_VERSION,
+            });
             let mut state: StateFile = serde_json::from_str(content).map_err(|e| {
                 BackendError::InvalidState(format!(
                     "Failed to migrate state file from v{}: {}",
@@ -475,7 +546,7 @@ pub fn check_and_migrate(content: &str) -> Result<StateFile, BackendError> {
     // rewritten to the canonical form on read so existing state files
     // resolve cleanly against new emissions. See #1903.
     state.canonicalize_addresses();
-    Ok(state)
+    Ok(MigratedStateFile { state, migration })
 }
 
 /// Deserialize a state file from a byte slice, checking the version and
@@ -483,7 +554,7 @@ pub fn check_and_migrate(content: &str) -> Result<StateFile, BackendError> {
 ///
 /// This is the byte-slice equivalent of [`check_and_migrate`] for backends
 /// that read raw bytes (e.g., S3).
-pub fn check_and_migrate_bytes(bytes: &[u8]) -> Result<StateFile, BackendError> {
+pub fn check_and_migrate_bytes(bytes: &[u8]) -> Result<MigratedStateFile, BackendError> {
     let content = std::str::from_utf8(bytes)
         .map_err(|e| BackendError::InvalidState(format!("State file is not valid UTF-8: {}", e)))?;
     check_and_migrate(content)

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -505,7 +505,9 @@ fn test_migrate_v6_empty_struct_to_unrecorded() {
             }
         ]
     }"#;
-    let state = check_and_migrate(v6).expect("migration should succeed");
+    let state = check_and_migrate(v6)
+        .expect("migration should succeed")
+        .into_state();
     assert_eq!(state.version, StateFile::CURRENT_VERSION);
     let rs = state
         .resources
@@ -550,7 +552,9 @@ fn test_migrate_v6_preserves_populated_explicit() {
             }
         ]
     }"#;
-    let state = check_and_migrate(v6).expect("migration should succeed");
+    let state = check_and_migrate(v6)
+        .expect("migration should succeed")
+        .into_state();
     let rs = state.resources.iter().find(|r| r.name == "vpc").unwrap();
     let ExplicitFields::Struct { children } = &rs.explicit else {
         panic!(
@@ -597,7 +601,9 @@ fn test_migrate_v6_does_not_rewrite_nested_empty_struct() {
             }
         ]
     }"#;
-    let state = check_and_migrate(v6).expect("migration should succeed");
+    let state = check_and_migrate(v6)
+        .expect("migration should succeed")
+        .into_state();
     let rs = state.resources.iter().find(|r| r.name == "vpc").unwrap();
     let ExplicitFields::Struct { children } = &rs.explicit else {
         panic!("expected top-level Struct, got {:?}", rs.explicit);
@@ -899,7 +905,7 @@ fn test_check_and_migrate_current_version() {
 
     let state = StateFile::new();
     let json = serde_json::to_string_pretty(&state).unwrap();
-    let result = check_and_migrate(&json).unwrap();
+    let result = check_and_migrate(&json).unwrap().into_state();
     assert_eq!(result.version, StateFile::CURRENT_VERSION);
     assert_eq!(result.lineage, state.lineage);
 }
@@ -942,7 +948,7 @@ fn test_check_and_migrate_older_version_migrates() {
         "resources": []
     }"#;
 
-    let result = check_and_migrate(json).unwrap();
+    let result = check_and_migrate(json).unwrap().into_state();
     assert_eq!(
         result.version,
         StateFile::CURRENT_VERSION,
@@ -971,7 +977,9 @@ fn test_check_and_migrate_bytes_works() {
 
     let state = StateFile::new();
     let json = serde_json::to_string_pretty(&state).unwrap();
-    let result = check_and_migrate_bytes(json.as_bytes()).unwrap();
+    let result = check_and_migrate_bytes(json.as_bytes())
+        .unwrap()
+        .into_state();
     assert_eq!(result.version, StateFile::CURRENT_VERSION);
 }
 
@@ -984,6 +992,48 @@ fn test_check_and_migrate_bytes_invalid_utf8() {
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(err.contains("UTF-8"), "error should mention UTF-8 issue");
+}
+
+// carina#3283: check_and_migrate is library-level and must not write to
+// stderr. The migration event is returned as a typed value so the caller
+// (a backend impl) can decide *when* and *how often* to log it. Without
+// this, every read_state call on the same physical state file emits a
+// fresh "Migrating state file..." line — for `carina plan` that means
+// the warning fires twice (T0 + T1 drift re-read) and even three times
+// when the run also crosses the refresh phase (#3283 repro).
+#[test]
+fn test_check_and_migrate_returns_migration_info_for_older_version() {
+    use super::check_and_migrate;
+
+    let json = r#"{
+        "version": 6,
+        "serial": 14,
+        "lineage": "test-lineage",
+        "carina_version": "0.0.1",
+        "resources": []
+    }"#;
+
+    let outcome = check_and_migrate(json).unwrap();
+    let migration = outcome
+        .migration
+        .expect("migration info should be present for v6 → v7");
+    assert_eq!(migration.from, 6);
+    assert_eq!(migration.to, StateFile::CURRENT_VERSION);
+    assert_eq!(outcome.state.version, StateFile::CURRENT_VERSION);
+}
+
+#[test]
+fn test_check_and_migrate_no_migration_info_for_current_version() {
+    use super::check_and_migrate;
+
+    let state = StateFile::new();
+    let json = serde_json::to_string_pretty(&state).unwrap();
+    let outcome = check_and_migrate(&json).unwrap();
+    assert!(
+        outcome.migration.is_none(),
+        "current-version reads must not report a migration"
+    );
+    assert_eq!(outcome.state.version, StateFile::CURRENT_VERSION);
 }
 
 #[test]
@@ -1465,7 +1515,7 @@ fn check_and_migrate_canonicalizes_legacy_map_key_addresses() {
         }}"#,
         ver = StateFile::CURRENT_VERSION,
     );
-    let state = check_and_migrate(&json).expect("load state");
+    let state = check_and_migrate(&json).expect("load state").into_state();
     let r = &state.resources[0];
     assert_eq!(r.name, "_accounts.registry_prod");
     assert_eq!(r.binding.as_deref(), Some("_accounts.registry_prod"));
@@ -1535,7 +1585,9 @@ fn v5_state_read_converts_desired_keys_to_explicit_leaves() {
         }]
     }"#;
 
-    let state = check_and_migrate(v5).expect("migration must succeed");
+    let state = check_and_migrate(v5)
+        .expect("migration must succeed")
+        .into_state();
     assert_eq!(state.version, StateFile::CURRENT_VERSION);
     assert_eq!(state.resources.len(), 1);
 
@@ -1574,7 +1626,7 @@ fn current_state_writes_and_reads_full_explicit_tree() {
     state.upsert_resource(rs);
 
     let json = serde_json::to_string(&state).expect("serialize");
-    let back = check_and_migrate(&json).expect("read");
+    let back = check_and_migrate(&json).expect("read").into_state();
     assert_eq!(back.version, StateFile::CURRENT_VERSION);
     assert_eq!(back.resources[0].explicit, state.resources[0].explicit);
 }


### PR DESCRIPTION
## Summary

`carina plan` reads state at least twice per run (T0 snapshot plus a post-plan drift re-read at T1; up to three times when the refresh phase is also involved). The state-schema migration warning was emitted via `eprintln!` inside `check_and_migrate`, so a single physical v6 state file produced **2–3 identical** `Warning: Migrating state file from v6 to v7` lines per run. The past-tense "Migrating" wording also implied a write that the read-only `plan` never performs, so every subsequent run replayed the same warnings against the same v6 file.

Closes #3283.

## What changed

- `carina-state::state::check_and_migrate` now returns `MigratedStateFile { state, migration: Option<MigrationInfo> }` instead of writing to stderr. The library never side-effects; callers decide whether and how often to log. `MigratedStateFile` is intentionally **not** `Clone` (a full `StateFile` can be large; the wrapper is consumed once at the backend boundary).
- New pub helper `log_state_migration_once(slot, info, display_target)` emits the warning at most once per `OnceLock<MigrationInfo>` slot.
- `LocalBackend` and `S3Backend` each hold a `migration_logged: OnceLock<MigrationInfo>` field and call the helper from `read_state` with a display target (local path, or `s3://bucket/key`). T0 + drift-T1 reads on the same backend instance now produce exactly one warning.
- Reworded the warning to be honest about what happened and what the operator should do next:

  > `Warning: state file <path|s3-uri> is v6 on disk; in-memory migration to v7 applied for this run. Disk state will be rewritten on the next ` + `carina apply` + ` or ` + `carina state refresh` + ` in that directory.`

  `carina state refresh` already takes a write lock and rewrites state, so the suggested next step actually persists the upgrade.

## Why type-safe (not just a `OnceLock<()>` flag)

The bug class is "library function silently writes to stderr from inside a deserialization helper, and any caller that reads state more than once duplicates the message". The fix promotes the migration event to a typed value (`MigrationInfo`), removes the side effect from the library, and pushes the dedupe to the backend (which is already the natural per-state-file boundary). Future backends (`StateBackend` impls outside the workspace) get a clear contract: receive `MigratedStateFile`, decide whether/where to log.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3619/3619 pass.
- [x] `cargo test --workspace --doc` — pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `scripts/check-*.sh` — all pass.
- [x] New `carina-cli/tests/plan_state_migration_warning_once.rs` drives the real `carina plan` binary against a hand-authored v6 state file and asserts: exactly one warning per run, the wording names the target version (sourced from `StateFile::CURRENT_VERSION`) and an actionable command (`apply` or `state refresh`), identifies the state file, and the old `Migrating state file from v` phrasing is gone.
- [x] New unit tests in `carina-state/src/state/tests.rs` pin the `MigrationInfo` return contract for older / current versions.
- [ ] Manual repro against `carina-rs/infra@main, aws/management/identity-center/` (user-driven; requires aws-vault credentials).