### PR TITLE
fix: ignore stale data-source rows in state.resources for export resolution (#3266)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -301,8 +301,11 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
     // no source-side view of which exports the user intends — see the
     // `FinalizeApplyInput::export_params` doc-comment.
     if let Some(params) = input.export_params {
-        let post_apply_states =
-            PostApplyStates::from_current_and_state(input.current_states, &state);
+        let post_apply_states = PostApplyStates::from_current_and_state(
+            input.current_states,
+            &state,
+            input.data_sources,
+        );
         state.exports = resolve_exports(
             params,
             input.sorted_resources,
@@ -374,7 +377,8 @@ pub(crate) async fn persist_exports_only(
     current_states: &HashMap<ResourceId, carina_core::resource::State>,
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
-    let post_apply_states = PostApplyStates::from_current_and_state(current_states, &state);
+    let post_apply_states =
+        PostApplyStates::from_current_and_state(current_states, &state, data_sources);
     let exports = resolve_exports(
         export_params,
         sorted_resources,

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1141,6 +1141,7 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
         crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
             &std::collections::HashMap::new(),
             &state,
+            &[],
         );
     let exports = resolve_exports(
         &export_params,
@@ -1232,6 +1233,7 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
         crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
             &std::collections::HashMap::new(),
             &state,
+            &[],
         );
     let exports = resolve_exports(
         &export_params,
@@ -1342,6 +1344,7 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
         crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
             &std::collections::HashMap::new(),
             &state,
+            &[],
         );
     let exports = resolve_exports(
         &export_params,
@@ -1516,6 +1519,7 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
         crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
             &std::collections::HashMap::new(),
             &post_apply_state_file,
+            &[],
         );
     let exports = resolve_exports(
         &export_params,
@@ -1624,6 +1628,7 @@ fn resolve_exports_resolves_data_source_attribute_after_apply_3266() {
         crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
             &current_states,
             &post_apply_state_file,
+            &[],
         );
     let exports = resolve_exports(
         &export_params,

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -98,11 +98,25 @@ impl PostApplyStates {
     /// `state.resources` was just rewritten by the apply writeback.
     ///
     /// State-derived managed entries win on key collision (see the
-    /// type-level doc-comment for why).
+    /// type-level doc-comment for why) — except for entries whose id
+    /// matches a known data source: those are NOT overlaid, so a
+    /// stale `state.resources` row (historical artifact from a
+    /// pre-#3181 carina version that persisted data sources) does
+    /// not clobber the fresh `current_states` read from phase 2
+    /// (carina#3266 re-open).
+    ///
+    /// Threading `data_sources` is mandatory: a caller with no data
+    /// sources passes `&[]` and gets the original "state.resources
+    /// wins" behavior. A caller that has data sources but forgets
+    /// to pass them re-introduces carina#3266 — making the parameter
+    /// required keeps that mistake impossible at the call site.
     pub(crate) fn from_current_and_state(
         current_states: &HashMap<ResourceId, carina_core::resource::State>,
         state: &StateFile,
+        data_sources: &[carina_core::resource::DataSource],
     ) -> Self {
+        let data_source_ids: std::collections::HashSet<ResourceId> =
+            data_sources.iter().map(|d| d.id.clone()).collect();
         let mut map = current_states.clone();
         for rs in &state.resources {
             let id = ResourceId::with_provider(
@@ -111,6 +125,12 @@ impl PostApplyStates {
                 &rs.name,
                 rs.directives.provider_instance.clone(),
             );
+            // carina#3266 (re-opened): a stale data-source row in
+            // `state.resources` must not overwrite the fresh
+            // `current_states[ds.id]` entry phase-2 just produced.
+            if data_source_ids.contains(&id) {
+                continue;
+            }
             let attrs: HashMap<String, carina_core::resource::Value> = rs
                 .attributes
                 .iter()
@@ -713,12 +733,86 @@ mod post_apply_states_tests {
         // the production reality the bug springs from.
         let state = StateFile::new();
 
-        let post = PostApplyStates::from_current_and_state(&current_states, &state);
+        let post = PostApplyStates::from_current_and_state(&current_states, &state, &[]);
         let entry = post
             .as_map()
             .get(&ds_id)
             .expect("data-source entry must survive merge");
         assert_eq!(entry.attributes.get("arns"), ds_attrs.get("arns"));
+    }
+
+    /// carina#3266 (re-opened): when `state.resources` carries a STALE
+    /// data-source row (a historical artifact — an older carina release
+    /// persisted them, or a pre-#3181 `state refresh` did), the
+    /// post-apply merge must NOT overlay it on top of the
+    /// `current_states[ds.id]` fresh read. Without this guard, every
+    /// apply rewrites `state.exports` from the stale on-disk attrs and
+    /// the data-source-derived export never converges to the live
+    /// provider value.
+    #[test]
+    fn data_source_current_states_wins_over_stale_state_resources_3266() {
+        use carina_core::resource::DataSource;
+
+        let ds_id = ResourceId::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+
+        // current_states: phase-2 fresh read returned the NEW value.
+        let new_arn = "arn:aws:iam::1:role/sso/NEW";
+        let mut fresh_attrs = HashMap::new();
+        fresh_attrs.insert(
+            "arns".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String(new_arn.to_string()),
+            )])),
+        );
+        let mut current_states = HashMap::new();
+        current_states.insert(ds_id.clone(), State::existing(ds_id.clone(), fresh_attrs));
+
+        // state.resources carries the STALE value (historical artifact:
+        // a pre-#3181 carina version persisted the data source here).
+        let stale_arn = "arn:aws:iam::1:role/sso/OLD";
+        let state_json = serde_json::json!({
+            "version": 7,
+            "serial": 1,
+            "lineage": "test",
+            "carina_version": "0.4.0",
+            "resources": [
+                {
+                    "resource_type": "iam.Roles",
+                    "name": "admin_access_roles",
+                    "identifier": null,
+                    "provider": "aws",
+                    "attributes": { "arns": [stale_arn] }
+                }
+            ]
+        });
+        let state: StateFile = serde_json::from_value(state_json).unwrap();
+
+        // Declare the data source so the merge knows to exclude its id
+        // from the state.resources overlay.
+        let mut ds = DataSource::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+        ds.binding = Some("admin_access_roles".to_string());
+        let data_sources = vec![ds];
+
+        let post = PostApplyStates::from_current_and_state(&current_states, &state, &data_sources);
+        let entry = post
+            .as_map()
+            .get(&ds_id)
+            .expect("data-source entry must be present after merge");
+        match entry.attributes.get("arns") {
+            Some(Value::Concrete(ConcreteValue::List(items))) => {
+                let s = match items.first() {
+                    Some(Value::Concrete(ConcreteValue::String(s))) => s.as_str(),
+                    other => panic!("unexpected list element: {other:?}"),
+                };
+                assert_eq!(
+                    s, new_arn,
+                    "data-source attrs must be the FRESH `current_states` value, \
+                     not the stale state.resources row carried over from a prior \
+                     carina version. Got: {s}"
+                );
+            }
+            other => panic!("expected list of arns, got: {other:?}"),
+        }
     }
 
     #[test]
@@ -752,7 +846,7 @@ mod post_apply_states_tests {
         });
         let state: StateFile = serde_json::from_value(json).unwrap();
 
-        let post = PostApplyStates::from_current_and_state(&current_states, &state);
+        let post = PostApplyStates::from_current_and_state(&current_states, &state, &[]);
         let entry = post.as_map().get(&id).expect("merged entry");
         match entry.attributes.get("versioning") {
             Some(Value::Concrete(ConcreteValue::String(s))) => assert_eq!(s, "Enabled"),

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -919,6 +919,7 @@ pub(crate) async fn run_state_refresh_locked(
             crate::commands::shared::state_writeback::PostApplyStates::from_current_and_state(
                 &current_states,
                 &state,
+                &parsed.data_sources,
             );
         state.exports = crate::commands::shared::state_writeback::resolve_exports(
             &parsed.export_params,

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -2926,6 +2926,111 @@ async fn persist_exports_only_writes_state_with_new_exports() {
     );
 }
 
+/// carina#3266 (re-opened) — integration-level pin.
+///
+/// The production repro: the on-disk state file carries a stale
+/// `state.resources` row for a data source (historical artifact from
+/// a pre-#3181 carina version that persisted data sources). The
+/// post-apply binding view must take the FRESH `current_states`
+/// read, not the stale `state.resources` row, so a
+/// `<data_source>.<attr>` export updates on disk.
+///
+/// Without the `PostApplyStates::from_current_and_state(..., data_sources)`
+/// filter, `persist_exports_only` reads the stale row, layers it into
+/// bindings via `layer_data_source_bindings`, resolves the export
+/// against the stale value, and rewrites `state.exports` with the
+/// pre-apply literal — every apply prints "Exports updated" but the
+/// on-disk value never converges. Plan keeps showing the same diff.
+#[tokio::test]
+async fn persist_exports_only_ignores_stale_data_source_row_in_state_resources_3266() {
+    use carina_core::parser::{InferredExportParam, TypeExpr};
+    use carina_core::resource::{
+        AccessPath, ConcreteValue, DataSource, DeferredValue, ResourceId, State as ResourceState,
+        Value,
+    };
+
+    let captured = Arc::new(Mutex::new(None));
+    let backend = CapturingBackend {
+        captured: captured.clone(),
+    };
+    let lock = LockInfo::new("apply");
+
+    let old_arn = "arn:aws:iam::1:role/sso/OLD";
+    let new_arn = "arn:aws:iam::1:role/sso/NEW";
+
+    // Pre-apply state: BOTH the stale exports literal AND a stale
+    // `state.resources` row for the data source (the historical
+    // artifact from a pre-#3181 carina version).
+    let state_json = serde_json::json!({
+        "version": 7,
+        "serial": 14,
+        "lineage": "33333333-3333-3333-3333-333333333333",
+        "carina_version": "0.0.0-test",
+        "resources": [
+            {
+                "resource_type": "iam.Roles",
+                "name": "admin_access_roles",
+                "identifier": null,
+                "provider": "aws",
+                "attributes": { "arns": [old_arn] }
+            }
+        ],
+        "exports": { "admin_access_role_arns": [old_arn] }
+    });
+    let state_in: StateFile = serde_json::from_value(state_json).unwrap();
+
+    // Data source declared in source.
+    let ds_id = ResourceId::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+    let mut ds = DataSource::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+    ds.binding = Some("admin_access_roles".to_string());
+    let data_sources = vec![ds];
+
+    // Phase-2 fresh read: NEW value lives in `current_states[ds.id]`.
+    let mut current_states: HashMap<ResourceId, ResourceState> = HashMap::new();
+    let mut attrs: HashMap<String, Value> = HashMap::new();
+    attrs.insert(
+        "arns".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String(new_arn.to_string()),
+        )])),
+    );
+    current_states.insert(ds_id.clone(), ResourceState::existing(ds_id, attrs));
+
+    let export_params = vec![InferredExportParam {
+        name: "admin_access_role_arns".to_string(),
+        type_expr: TypeExpr::Unknown,
+        value: Some(Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new("admin_access_roles", "arns"),
+        })),
+    }];
+
+    let result = crate::commands::apply::persist_exports_only(
+        &backend,
+        Some(&lock),
+        Some(state_in),
+        &[],
+        &data_sources,
+        &[],
+        &export_params,
+        &[],
+        &current_states,
+    )
+    .await;
+
+    assert!(result.is_ok(), "persist_exports_only failed: {:?}", result);
+
+    let written = captured.lock().unwrap();
+    let state = written.as_ref().expect("state should be written");
+    assert_eq!(
+        state.exports.get("admin_access_role_arns"),
+        Some(&serde_json::json!([new_arn])),
+        "state.exports must hold the NEW data-source value, not the \
+         stale row carried over from state.resources. \
+         Got state.exports: {:?}",
+        state.exports,
+    );
+}
+
 /// Regression test for #2932: when the user removes the entire
 /// `exports {}` block (so `parsed.export_params` is empty) but the
 /// plan has resource changes, `finalize_apply` must still drop


### PR DESCRIPTION
## Summary

`carina apply` against `aws/management/identity-center/` was leaving `state.exports.admin_access_role_arns` stuck at the previous IAM role ARN, even though `plan` correctly identified the diff and apply printed `✓ Exports updated`. Every re-apply advanced `state.serial` but `state.exports` never converged to the live data-source read.

Closes #3266.

## Root cause (production-traced)

Live-binary `eprintln!` instrumentation against the real `carina-rs/infra/aws/management/identity-center/` showed:

1. **Phase 2 reads NEW**: `current_states[aws.iam.Roles.admin_access_roles].attributes["arns"]` correctly held `[..._ed2ecac126d82b94]` (the new ARN) after the live provider read.
2. **`state.resources` holds stale data-source row**: the on-disk state file carried a row `{ resource_type: "iam.Roles", name: "admin_access_roles", attributes: { arns: [..._1ade6440f2d3bcdd] } }`. This row is a historical artifact from a pre-#3181 carina version that persisted data sources into `state.resources`. Newer code never writes such rows, so the artifact survives indefinitely.
3. **Overlay clobbers**: `PostApplyStates::from_current_and_state` overlays every `state.resources` row on top of `current_states`, so the stale row overwrote the fresh phase-2 read in the post-apply view.
4. **Bindings see OLD**: `layer_data_source_bindings` then sourced `bindings.get(\"admin_access_roles\").arns` from the clobbered overlay; export resolution picked up the OLD ARN and wrote it straight back to `state.exports`.

The unit-level tests already in the repo did not catch this because they never simulated the stale `state.resources` row.

## Fix

Thread the `data_sources` slice through `PostApplyStates::from_current_and_state` and skip any `state.resources` row whose id matches a declared data source. The third parameter is **mandatory** (no `&[]` default) so a future caller cannot silently re-introduce the bug — passing `&[]` is an explicit "this code path observes no data sources" assertion.

This is the minimal correctness fix. The stale rows themselves remain in `state.resources` until a separate cleanup pass; a follow-up will prune them (`apply_destroy_to_state` carries the same class of issue and is out of scope here).

## Production verification

```
$ aws s3 cp s3://carina-rs-state/management/identity-center/carina.state.json - | jq '.exports'
{ "admin_access_role_arns": ["arn:...AWSReservedSSO_AdministratorAccess_1ade6440f2d3bcdd"] }   # OLD

$ aws-vault exec carina-rs -- carina apply --auto-approve .
... Persisting 1 export change(s) to state.
  ✓ State saved (serial: 18)
  ✓ Exports updated

$ aws s3 cp ... | jq '.exports'
{ "admin_access_role_arns": ["arn:...AWSReservedSSO_AdministratorAccess_ed2ecac126d82b94"] }   # NEW

$ aws-vault exec carina-rs -- carina plan .
Plan: 3 to read, 0 to add, 0 to change, 0 to destroy.   # converged
```

## Test plan

- [x] `cargo nextest run -p carina-cli` — 502/502 pass (includes 2 new regression tests).
- [x] `cargo test --workspace --doc` — pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `scripts/check-*.sh` — all pass.
- [x] `cargo nextest run --workspace --all-features` — pass apart from pre-existing flaky `carina-plugin-host wasm_precompile` (fails on main too, unrelated).
- [x] Real-binary apply against `carina-rs/infra/aws/management/identity-center/` confirmed `state.exports` updated to the new ARN; subsequent plan shows no export changes.

## Regression coverage

- `state_writeback::post_apply_states_tests::data_source_current_states_wins_over_stale_state_resources_3266` — unit test directly on `PostApplyStates` asserting that a stale `state.resources` row does NOT clobber the fresh `current_states[ds.id]` value when the id matches a declared data source.
- `tests::persist_exports_only_ignores_stale_data_source_row_in_state_resources_3266` — integration test that drives `persist_exports_only` end-to-end via `CapturingBackend`, with both the stale row in `state.resources` and the fresh read in `current_states`, and asserts the persisted `state.exports` holds the NEW value.

## Follow-up

`apply_destroy_to_state` does not prune legacy data-source rows from `state.resources` either. Same class of issue but unrelated to the apply/persist-exports path this PR fixes — will file as a separate issue.