### PR TITLE
refactor: rename ManagedResource → Resource (#3288)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -15,7 +15,7 @@ use carina_core::executor::{ExecutionInput, ExecutionResult};
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer, ReadRequest};
 use carina_core::resolver::resolve_refs_with_state_and_remote;
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::value::format_value;
 use carina_state::{LockInfo, StateBackend, StateFile, resolve_backend};
 
@@ -64,7 +64,7 @@ pub async fn execute_effects(
     schemas: &carina_core::schema::SchemaRegistry,
     bindings: &mut ResolvedBindings,
     current_states: &mut HashMap<ResourceId, State>,
-    unresolved_resources: &HashMap<ResourceId, ManagedResource>,
+    unresolved_resources: &HashMap<ResourceId, Resource>,
     virtual_resources: &[carina_core::resource::VirtualResource],
 ) -> ApplyResult {
     let input = ExecutionInput {
@@ -366,7 +366,7 @@ pub(crate) async fn persist_exports_only(
     backend: &dyn StateBackend,
     lock: Option<&LockInfo>,
     state_file: Option<StateFile>,
-    sorted_resources: &[ManagedResource],
+    sorted_resources: &[Resource],
     data_sources: &[carina_core::resource::DataSource],
     pre_resolve_virtuals: &[carina_core::resource::VirtualResource],
     export_params: &[carina_core::parser::InferredExportParam],
@@ -399,7 +399,7 @@ pub(crate) async fn persist_exports_only(
 /// Returns `Ok(None)` if no drift is detected, or `Ok(Some(messages))` with drift details.
 /// Returns `Err` if a resource is missing from planned_states or if a provider read fails.
 pub async fn detect_drift(
-    sorted_resources: &[ManagedResource],
+    sorted_resources: &[Resource],
     planned_states: &HashMap<ResourceId, State>,
     provider: &dyn Provider,
 ) -> Result<Option<Vec<String>>, AppError> {
@@ -484,7 +484,7 @@ pub async fn detect_drift(
             }
         } else {
             return Err(AppError::Config(format!(
-                "ManagedResource {} is present in plan but missing from planned states. \
+                "Resource {} is present in plan but missing from planned states. \
                  The plan file may be corrupted. Please re-run 'carina plan'.",
                 resource.id
             )));
@@ -1336,7 +1336,7 @@ async fn run_apply_locked(
     println!();
 
     // Build unresolved resource map for re-resolution at apply time
-    let unresolved_resources: HashMap<ResourceId, ManagedResource> = sorted_resources
+    let unresolved_resources: HashMap<ResourceId, Resource> = sorted_resources
         .iter()
         .map(|r| (r.id.clone(), r.clone()))
         .collect();
@@ -1695,7 +1695,7 @@ async fn run_apply_from_plan_locked(
     println!();
 
     // Build unresolved resource map for re-resolution at apply time
-    let unresolved_resources: HashMap<ResourceId, ManagedResource> = sorted_resources
+    let unresolved_resources: HashMap<ResourceId, Resource> = sorted_resources
         .iter()
         .map(|r| (r.id.clone(), r.clone()))
         .collect();

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -15,7 +15,7 @@ fn build_state_after_apply_finds_write_only_with_provider_prefix() {
     // Schema is registered with provider-prefixed key
     schemas.insert("awscc", schema);
 
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -93,8 +93,8 @@ fn build_state_after_apply_preserves_block_name_attribute() {
         );
     schemas.insert("awscc", schema);
 
-    // ManagedResource with resolved block name (policy -> policies)
-    let mut resource = ManagedResource::with_provider("awscc", "iam.role", "test-role", None);
+    // Resource with resolved block name (policy -> policies)
+    let mut resource = Resource::with_provider("awscc", "iam.role", "test-role", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("test-role".to_string())),
@@ -233,7 +233,7 @@ fn block_name_attribute_no_diff_when_hydrated() {
         );
 
     // Desired resource (after resolve_block_names: "policy" -> "policies")
-    let mut resource = ManagedResource::with_provider("awscc", "iam.role", "test-role", None);
+    let mut resource = Resource::with_provider("awscc", "iam.role", "test-role", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("test-role".to_string())),
@@ -342,8 +342,8 @@ fn block_name_attribute_state_roundtrip() {
         .attribute(AttributeSchema::new("description", AttributeType::String));
     schemas.insert("awscc", schema);
 
-    // ManagedResource with resolved block name
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.ipam", "test-ipam", None);
+    // Resource with resolved block name
+    let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam", None);
     resource.set_attr(
         "operating_regions".to_string(),
         Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
@@ -488,9 +488,9 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
         "rd.awscc_iam_role_policy_0cd2c914",
         None,
     );
-    let mut resource = ManagedResource {
+    let mut resource = Resource {
         id: new_id.clone(),
-        ..ManagedResource::with_provider(
+        ..Resource::with_provider(
             new_id.provider.clone(),
             new_id.resource_type.clone(),
             new_id.name.as_str(),
@@ -661,7 +661,7 @@ fn move_plus_update_keeps_post_update_attributes() {
     schemas.insert("awscc", schema);
 
     let new_id = ResourceId::with_provider("awscc", "ec2.Tag", "tag_new", None);
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Tag", "tag_new", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Tag", "tag_new", None);
     resource.set_attr(
         "key".to_string(),
         Value::Concrete(ConcreteValue::String("env".to_string())),
@@ -751,7 +751,7 @@ fn move_alone_carries_attributes_via_current_states() {
     );
 
     let new_id = ResourceId::with_provider("awscc", "s3.Bucket", "bucket_new", None);
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "bucket_new", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "bucket_new", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -866,7 +866,7 @@ fn failed_refresh_preserves_existing_row() {
     );
 
     let id = ResourceId::with_provider("awscc", "s3.Bucket", "stuck", None);
-    let resource = ManagedResource::with_provider("awscc", "s3.Bucket", "stuck", None);
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "stuck", None);
     let sorted_resources = vec![resource];
 
     let mut failed_refreshes = HashSet::new();
@@ -918,7 +918,7 @@ fn move_from_overlapping_desired_resource_errors() {
     );
 
     let id = ResourceId::with_provider("awscc", "s3.Bucket", "collision", None);
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "collision", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "collision", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("x".to_string())),
@@ -975,7 +975,7 @@ fn remove_overlapping_desired_resource_errors() {
     );
 
     let id = ResourceId::with_provider("awscc", "s3.Bucket", "collision", None);
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "collision", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "collision", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("x".to_string())),
@@ -1026,7 +1026,7 @@ fn self_move_overlapping_desired_resource_errors() {
     );
 
     let id = ResourceId::with_provider("awscc", "s3.Bucket", "self", None);
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "self", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "self", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("x".to_string())),
@@ -1133,7 +1133,7 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     // with a binding; provider-returned attributes flow in via
     // `current_states` derived from `state.resources`.
     let mut registry_prod =
-        ManagedResource::with_provider("awscc", "organizations.account", "registry-prod", None);
+        Resource::with_provider("awscc", "organizations.account", "registry-prod", None);
     registry_prod.binding = Some("registry_prod".to_string());
     let sorted_resources = vec![registry_prod];
 
@@ -1195,7 +1195,7 @@ fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
     };
 
     let mut role_resource =
-        ManagedResource::with_provider("awscc", "iam.Role", "github_actions_carina.role", None);
+        Resource::with_provider("awscc", "iam.Role", "github_actions_carina.role", None);
     role_resource.binding = Some("github_actions_carina.role".to_string());
 
     // Virtual resource as `expand_module_call` produces it: binding is
@@ -1289,8 +1289,7 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
         serde_json::from_value::<StateFile>(json).unwrap()
     };
 
-    let mut role_resource =
-        ManagedResource::with_provider("awscc", "iam.Role", "outer.inner.role", None);
+    let mut role_resource = Resource::with_provider("awscc", "iam.Role", "outer.inner.role", None);
     role_resource.binding = Some("outer.inner.role".to_string());
 
     // carina#3181: virtuals are a distinct typestate.
@@ -1463,7 +1462,7 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
     // head-of-pipeline resolver — they keep their authored
     // `ResourceRef`s, which is exactly the pre-resolve snapshot the
     // #3177 fix needs.
-    let mut role_managed = ManagedResource::with_provider("awscc", "iam.Role", "carina_role", None);
+    let mut role_managed = Resource::with_provider("awscc", "iam.Role", "carina_role", None);
     role_managed.binding = Some("role".to_string());
 
     let mut virt_attrs = indexmap::IndexMap::new();

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -16,7 +16,7 @@ use carina_core::deps::{
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
 use carina_core::provider::Provider;
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_state::{LockInfo, StateBackend, resolve_backend};
 
 use carina_core::parser::ProviderContext;
@@ -167,7 +167,7 @@ async fn run_destroy_locked(
 
     // Collect all resources (managed + orphans) before sorting.
     // We use the unsorted list for state reads, then sort once at the end.
-    let mut all_resources: Vec<ManagedResource> = parsed.resources.clone(); // allow: direct — plan-time reconciliation
+    let mut all_resources: Vec<Resource> = parsed.resources.clone(); // allow: direct — plan-time reconciliation
 
     if !refresh {
         eprintln!(
@@ -190,9 +190,9 @@ async fn run_destroy_locked(
         // from state. carina#3181: `all_resources` is sourced from
         // `parsed.resources`, which is managed-only — data sources and
         // virtual resources are not destroyed and never enter this list.
-        let managed_resources: Vec<&ManagedResource> = all_resources.iter().collect();
+        let resources: Vec<&Resource> = all_resources.iter().collect();
         let provider_ref = &provider;
-        let results: Vec<Result<(ResourceId, State), AppError>> = stream::iter(&managed_resources)
+        let results: Vec<Result<(ResourceId, State), AppError>> = stream::iter(&resources)
             .map(|resource| {
                 let progress = RefreshProgress::begin_multi(&multi, &resource.id);
                 let identifier = state_file
@@ -266,14 +266,14 @@ async fn run_destroy_locked(
     // Sort all resources (managed + orphans) for destroy ordering.
     // Uses depth-based pre-sorting to ensure stable ordering for independent
     // branches, then reverses for destroy order (dependents before dependencies).
-    let destroy_order: Vec<ManagedResource> =
+    let destroy_order: Vec<Resource> =
         sort_resources_for_destroy(&all_resources).map_err(AppError::Config)?;
 
     // Collect resources that exist and will be destroyed
     // Skip the state bucket if it matches the backend bucket
-    let mut protected_resources: Vec<&ManagedResource> = Vec::new();
-    let mut prevent_destroy_resources: Vec<&ManagedResource> = Vec::new();
-    let resources_to_destroy: Vec<&ManagedResource> = destroy_order
+    let mut protected_resources: Vec<&Resource> = Vec::new();
+    let mut prevent_destroy_resources: Vec<&Resource> = Vec::new();
+    let resources_to_destroy: Vec<&Resource> = destroy_order
         .iter()
         .filter(|r| {
             // carina#3181: `destroy_order` is managed-only — data
@@ -1153,7 +1153,7 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_deletion_succeeds_after_transient_exists() {
-        // ManagedResource exists on first poll, then disappears on second.
+        // Resource exists on first poll, then disappears on second.
         let id = ResourceId::new("s3.Bucket", "test");
         let existing_state = State::existing(id.clone(), HashMap::new());
         let provider =

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -9,9 +9,7 @@ use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::effect::Effect;
 use carina_core::parser::{BackendConfig, ProviderConfig, ProviderContext, UpstreamState};
 use carina_core::plan::Plan;
-use carina_core::resource::{
-    ConcreteValue, DeferredValue, ManagedResource, ResourceId, State, Value,
-};
+use carina_core::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};
 use carina_core::value::{
     redact_secrets_in_plan, redact_secrets_in_resource, redact_secrets_in_state,
 };
@@ -52,7 +50,7 @@ pub struct PlanFile {
     /// The plan (effects)
     pub plan: Plan,
     /// Resources sorted by dependencies (for post-apply state saving)
-    pub sorted_resources: Vec<ManagedResource>,
+    pub sorted_resources: Vec<Resource>,
     /// Virtual resources (module-call attribute containers) emitted
     /// by module expansion at plan time (carina#3248). Persisted so
     /// the saved-plan apply path builds the same `ResolvedBindings`
@@ -473,7 +471,7 @@ pub async fn run_plan(
             .green()
         );
         println!(
-            "  {} ManagedResource definition will be added to .crn file",
+            "  {} Resource definition will be added to .crn file",
             "→".cyan()
         );
         println!();
@@ -688,7 +686,7 @@ pub async fn run_plan(
 /// Resolve export value expressions for plan display.
 pub(crate) fn resolve_export_values_for_display(
     export_params: &[carina_core::parser::InferredExportParam],
-    resources: &[ManagedResource],
+    resources: &[Resource],
     virtuals: &[carina_core::resource::VirtualResource],
     data_sources: &[carina_core::resource::DataSource],
     current_states: &HashMap<ResourceId, State>,
@@ -1590,7 +1588,7 @@ mod plan_serialization_error_tests {
     //! attributes, nested List/Map, Replace cascade) propagates the
     //! error.
     use carina_core::resource::{
-        AccessPath, ConcreteValue, DeferredValue, ManagedResource, UnknownReason, Value,
+        AccessPath, ConcreteValue, DeferredValue, Resource, UnknownReason, Value,
     };
     use carina_core::value::{SerializationError, redact_secrets_in_resource, value_to_json};
 
@@ -1634,7 +1632,7 @@ mod plan_serialization_error_tests {
 
     #[test]
     fn redact_secrets_in_resource_errors_on_unknown_attribute() {
-        let mut r = ManagedResource::new("test.resource", "name");
+        let mut r = Resource::new("test.resource", "name");
         r.attributes.insert("vpc_id".into(), upstream_unknown());
         let err = redact_secrets_in_resource(&r).unwrap_err();
         assert!(matches!(err, SerializationError::UnknownNotAllowed { .. }));

--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -297,10 +297,10 @@ mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::executor::ProgressInfo;
-    use carina_core::resource::ManagedResource;
+    use carina_core::resource::Resource;
 
     fn dummy_create_effect() -> Effect {
-        Effect::Create(ManagedResource::new("aws.s3.Bucket", "demo"))
+        Effect::Create(Resource::new("aws.s3.Bucket", "demo"))
     }
 
     #[test]

--- a/carina-cli/src/commands/shared/retry.rs
+++ b/carina-cli/src/commands/shared/retry.rs
@@ -31,7 +31,7 @@ pub(crate) fn is_retryable_delete_error(e: &carina_core::provider::ProviderError
 /// Result of waiting for a resource deletion to complete.
 #[derive(Debug, PartialEq)]
 pub(crate) enum WaitResult {
-    /// ManagedResource confirmed deleted (`state.exists == false`).
+    /// Resource confirmed deleted (`state.exists == false`).
     Deleted,
     /// A `provider.read()` call returned an error.
     ReadError(String),

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use carina_core::effect::Effect;
 use carina_core::executor::ExecutionResult;
 use carina_core::plan::Plan;
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 use carina_state::{LockInfo, ResourceState, StateBackend, StateFile};
 
@@ -20,10 +20,7 @@ use crate::error::AppError;
 /// When a create_before_destroy replacement produces a non-renameable temporary name
 /// (can_rename=false), the state stores the permanent name. This function applies
 /// those overrides so the plan doesn't detect a false diff.
-pub(crate) fn apply_name_overrides(
-    resources: &mut [ManagedResource],
-    state_file: &Option<StateFile>,
-) {
+pub(crate) fn apply_name_overrides(resources: &mut [Resource], state_file: &Option<StateFile>) {
     let state_file = match state_file {
         Some(sf) => sf,
         None => return,
@@ -141,7 +138,7 @@ impl PostApplyStates {
 pub(crate) struct FinalizeApplyInput<'a> {
     pub result: &'a ExecutionResult,
     pub state_file: Option<StateFile>,
-    pub sorted_resources: &'a [ManagedResource],
+    pub sorted_resources: &'a [Resource],
     /// Data sources (`read`-keyword resources). Layered into the
     /// export-resolution binding view so `exports { x = some_read.attr }`
     /// resolves (carina#3181).
@@ -229,7 +226,7 @@ pub(crate) struct FinalizeApplyInput<'a> {
 ///    `state.resources` (managed resources' applied attributes win
 ///    over any pre-apply snapshot left in `current_states`).
 /// 2. Split `sorted_resources` into a managed view (Managed +
-///    DataSource collapsed onto `ManagedResource` by field projection)
+///    DataSource collapsed onto `Resource` by field projection)
 ///    and a virtual view ([`VirtualResource::try_from`]).
 /// 3. Build the bindings view from the managed slice via
 ///    [`ResolvedBindings::from_managed_with_state`] (#3176).
@@ -241,7 +238,7 @@ pub(crate) struct FinalizeApplyInput<'a> {
 /// 6. Resolve export expressions against the combined view.
 pub(crate) fn resolve_exports(
     export_params: &[carina_core::parser::InferredExportParam],
-    sorted_resources: &[ManagedResource],
+    sorted_resources: &[Resource],
     data_sources: &[carina_core::resource::DataSource],
     pre_resolve_virtuals: &[carina_core::resource::VirtualResource],
     post_apply_states: &PostApplyStates,
@@ -410,7 +407,7 @@ pub(crate) fn dsl_value_to_json(
 
 pub(crate) struct ApplyStateSave<'a> {
     pub state_file: Option<StateFile>,
-    pub sorted_resources: &'a [ManagedResource],
+    pub sorted_resources: &'a [Resource],
     pub current_states: &'a HashMap<ResourceId, State>,
     pub applied_states: &'a HashMap<ResourceId, State>,
     pub permanent_name_overrides: &'a HashMap<ResourceId, HashMap<String, String>>,
@@ -441,13 +438,13 @@ pub(crate) struct WritebackPlan<'a> {
     cleanups: HashSet<ResourceId>,
 }
 
-/// One planned upsert. Carrying the desired `&ManagedResource` here (rather
+/// One planned upsert. Carrying the desired `&Resource` here (rather
 /// than re-deriving it from `sorted_resources` in the apply loop)
 /// makes the "every upsert has a desired resource" invariant
 /// representable in the type — there is no separate lookup that can
 /// miss.
 struct PlannedUpsert<'a> {
-    resource: &'a ManagedResource,
+    resource: &'a Resource,
     source: UpsertSource<'a>,
 }
 
@@ -491,7 +488,7 @@ impl<'a> WritebackPlan<'a> {
     /// `UpsertCleanupOverlap`.
     fn add_upsert(
         &mut self,
-        resource: &'a ManagedResource,
+        resource: &'a Resource,
         source: UpsertSource<'a>,
     ) -> Result<(), WritebackConflict> {
         let id = &resource.id;
@@ -527,7 +524,7 @@ impl<'a> WritebackPlan<'a> {
 /// `Effect::Move` deliberately does **not** touch the `to` slot — that
 /// is Phase 1's job.
 fn decompose<'a>(
-    sorted_resources: &'a [ManagedResource],
+    sorted_resources: &'a [Resource],
     current_states: &'a HashMap<ResourceId, State>,
     applied_states: &'a HashMap<ResourceId, State>,
     plan: &Plan,
@@ -648,15 +645,12 @@ pub(crate) fn apply_destroy_to_state(
     state.exports.clear();
 }
 
-/// Build a minimal `ManagedResource` for an orphaned resource from the state file.
+/// Build a minimal `Resource` for an orphaned resource from the state file.
 ///
-/// This creates a ManagedResource with attributes reconstructed from state data,
+/// This creates a Resource with attributes reconstructed from state data,
 /// including `_binding` and `_dependency_bindings` so that dependency ordering
 /// and tree display work correctly.
-pub(crate) fn build_orphan_resource(
-    sf: &carina_state::StateFile,
-    id: &ResourceId,
-) -> ManagedResource {
+pub(crate) fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceId) -> Resource {
     let rs = sf
         .find_resource(&id.provider, &id.resource_type, id.name_str())
         .expect("orphan must exist in state file");
@@ -665,7 +659,7 @@ pub(crate) fn build_orphan_resource(
         .iter()
         .filter_map(|(k, v)| carina_core::value::json_to_dsl_value(v).map(|val| (k.clone(), val)))
         .collect();
-    ManagedResource {
+    Resource {
         id: id.clone(),
         attributes: attributes.into_iter().collect(),
         directives: rs.directives.clone(),

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -11,7 +11,7 @@ use carina_core::effect::Effect;
 use carina_core::parser::ProviderContext;
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, LockInfo, ResourceState, StateBackend,
@@ -301,10 +301,7 @@ fn format_state_lookup(
     };
 
     let rs = find_resource_by_query(state, resource_name).ok_or_else(|| {
-        AppError::Config(format!(
-            "ManagedResource '{}' not found in state.",
-            resource_name
-        ))
+        AppError::Config(format!("Resource '{}' not found in state.", resource_name))
     })?;
 
     match attribute {
@@ -955,14 +952,14 @@ pub(crate) async fn run_state_refresh_locked(
 ///
 /// When `resource` is `Some`, directives, prefixes, and desired keys
 /// are preserved from it. When `None` (orphan resources), a minimal
-/// `ManagedResource` is constructed from the id.
+/// `Resource` is constructed from the id.
 ///
 /// `label_suffix` is appended to the resource header (e.g., `" (orphan)"`).
 fn diff_display_update_resource(
     id: &ResourceId,
     fresh_state: &State,
     state: &mut carina_state::StateFile,
-    resource: Option<&ManagedResource>,
+    resource: Option<&Resource>,
     label_suffix: &str,
     updated_count: &mut u32,
     unchanged_count: &mut u32,
@@ -1056,7 +1053,7 @@ fn diff_display_update_resource(
         let res = match resource {
             Some(r) => r,
             None => {
-                owned_resource = ManagedResource::with_provider(
+                owned_resource = Resource::with_provider(
                     &id.provider,
                     &id.resource_type,
                     id.name_str(),
@@ -1222,7 +1219,7 @@ mod tests {
         let err = format_state_lookup(&state, "nonexistent", false).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("ManagedResource 'nonexistent' not found"),
+            msg.contains("Resource 'nonexistent' not found"),
             "unexpected error: {}",
             msg
         );

--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -506,10 +506,10 @@ mod tests {
     #[test]
     fn pending_named_direct_resource_does_not_render_trailing_dot() {
         use carina_core::parser::ParsedFile;
-        use carina_core::resource::ManagedResource;
+        use carina_core::resource::Resource;
 
         let mut parsed = ParsedFile::default();
-        let mut res = ManagedResource::new("s3.Bucket", "placeholder");
+        let mut res = Resource::new("s3.Bucket", "placeholder");
         res.id.provider = "aws".to_string();
         // Force the anonymous/not-yet-promoted state explicitly.
         res.id.name = ResourceName::Pending;

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -480,7 +480,7 @@ impl<'a> TreeRenderContext<'a> {
 
         let mut has_displayed_attrs = false;
 
-        // --- ManagedResource header line ---
+        // --- Resource header line ---
         match effect {
             Effect::Create(r) => {
                 if self.detail == DetailLevel::None {

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -2,10 +2,10 @@ use super::*;
 
 use carina_core::effect::{CascadingUpdate, Effect};
 use carina_core::plan::Plan;
-use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 
-fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) -> ManagedResource {
-    let mut r = ManagedResource::new(resource_type, name);
+fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) -> Resource {
+    let mut r = Resource::new(resource_type, name);
     r.binding = Some(binding.to_string());
     for dep in deps {
         r.set_attr(
@@ -22,7 +22,7 @@ fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) 
 /// `.unwrap()` could theoretically panic if `dep_idx` were invalid.
 #[test]
 fn test_print_plan_with_external_dependency_does_not_panic() {
-    // ManagedResource "b" depends on "a", but "a" is NOT in the plan.
+    // Resource "b" depends on "a", but "a" is NOT in the plan.
     // This simulates an external/unresolved dependency.
     let b = make_resource("test.resource", "b", "b", &["a"]);
     let mut plan = Plan::new();
@@ -380,7 +380,7 @@ fn test_dependency_free_resource_nested_under_shallowest_referencing_resource() 
 /// Test that extract_compact_hint returns only the first non-parent ResourceRef hint.
 #[test]
 fn test_extract_compact_hint_resource_ref() {
-    let mut r = ManagedResource::new("ec2.subnet_route_table_association", "hash123");
+    let mut r = Resource::new("ec2.subnet_route_table_association", "hash123");
     r.set_attr(
         "route_table_id".to_string(),
         Value::resource_ref("public_rt".to_string(), "id".to_string(), vec![]),
@@ -398,7 +398,7 @@ fn test_extract_compact_hint_resource_ref() {
 /// Test that extract_compact_hint skips ResourceRef that matches parent binding.
 #[test]
 fn test_extract_compact_hint_skips_parent_ref() {
-    let mut r = ManagedResource::new("ec2.subnet_route_table_association", "hash123");
+    let mut r = Resource::new("ec2.subnet_route_table_association", "hash123");
     r.set_attr(
         "route_table_id".to_string(),
         Value::resource_ref("database_rt".to_string(), "id".to_string(), vec![]),
@@ -416,7 +416,7 @@ fn test_extract_compact_hint_skips_parent_ref() {
 /// Test that extract_compact_hint falls back to string values when no ResourceRef.
 #[test]
 fn test_extract_compact_hint_string_fallback() {
-    let mut r = ManagedResource::new("ec2.route", "hash456");
+    let mut r = Resource::new("ec2.route", "hash456");
     r.set_attr(
         "destination_cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
@@ -429,7 +429,7 @@ fn test_extract_compact_hint_string_fallback() {
 /// Test that extract_compact_hint returns None when no useful attributes.
 #[test]
 fn test_extract_compact_hint_none() {
-    let r = ManagedResource::new("ec2.route", "hash789");
+    let r = Resource::new("ec2.route", "hash789");
     let hint = extract_compact_hint(&r, None);
     assert_eq!(hint, None);
 }
@@ -437,7 +437,7 @@ fn test_extract_compact_hint_none() {
 /// Test that extract_compact_hint prefers string over ResourceRef.
 #[test]
 fn test_extract_compact_hint_prefers_string_over_resource_ref() {
-    let mut r = ManagedResource::new("ec2.route", "hash_mixed");
+    let mut r = Resource::new("ec2.route", "hash_mixed");
     r.set_attr(
         "destination".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
@@ -455,7 +455,7 @@ fn test_extract_compact_hint_prefers_string_over_resource_ref() {
 /// Test that extract_compact_hint shortens service_name values.
 #[test]
 fn test_extract_compact_hint_service_name_shortening() {
-    let mut r = ManagedResource::new("ec2.vpc_endpoint", "hash_svc");
+    let mut r = Resource::new("ec2.vpc_endpoint", "hash_svc");
     r.set_attr(
         "service_name".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -467,7 +467,7 @@ fn test_extract_compact_hint_service_name_shortening() {
     assert_eq!(hint, Some("service: ecr.dkr".to_string()));
 
     // Single service component
-    let mut r2 = ManagedResource::new("ec2.vpc_endpoint", "hash_svc2");
+    let mut r2 = Resource::new("ec2.vpc_endpoint", "hash_svc2");
     r2.set_attr(
         "service_name".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -482,7 +482,7 @@ fn test_extract_compact_hint_service_name_shortening() {
 /// Test that extract_compact_hint falls back to string when all ResourceRefs match parent.
 #[test]
 fn test_extract_compact_hint_all_refs_match_parent() {
-    let mut r = ManagedResource::new("ec2.security_group_ingress", "hash_sg");
+    let mut r = Resource::new("ec2.security_group_ingress", "hash_sg");
     r.set_attr(
         "group_id".to_string(),
         Value::resource_ref("endpoint_sg".to_string(), "id".to_string(), vec![]),
@@ -500,7 +500,7 @@ fn test_extract_compact_hint_all_refs_match_parent() {
 /// Test that extract_compact_hint prefers string over ResourceRef for vpc_endpoint.
 #[test]
 fn test_extract_compact_hint_prefers_string_for_vpc_endpoint() {
-    let mut r = ManagedResource::new("ec2.vpc_endpoint", "hash_ep");
+    let mut r = Resource::new("ec2.vpc_endpoint", "hash_ep");
     r.set_attr(
         "service_name".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -528,11 +528,11 @@ fn test_extract_compact_hint_prefers_string_for_vpc_endpoint() {
 /// Test that has_binding correctly detects bound vs anonymous resources.
 #[test]
 fn test_has_binding() {
-    let mut bound = ManagedResource::new("ec2.Vpc", "vpc");
+    let mut bound = Resource::new("ec2.Vpc", "vpc");
     bound.binding = Some("vpc".to_string());
     assert!(has_binding(&bound));
 
-    let anonymous = ManagedResource::new("ec2.Vpc", "hash123");
+    let anonymous = Resource::new("ec2.Vpc", "hash123");
     assert!(!has_binding(&anonymous));
 }
 
@@ -540,7 +540,7 @@ fn test_has_binding() {
 /// parenthesized hints for anonymous resources.
 #[test]
 fn test_format_compact_name_bound_resource() {
-    let mut r = ManagedResource::new("ec2.Vpc", "vpc");
+    let mut r = Resource::new("ec2.Vpc", "vpc");
     r.binding = Some("vpc".to_string());
     // For bound resources, should show name as plain identifier (no quotes)
     let result = format_compact_name(&r, "vpc", None);
@@ -553,7 +553,7 @@ fn test_format_compact_name_bound_resource() {
 
 #[test]
 fn test_format_compact_name_anonymous_with_hint() {
-    let mut r = ManagedResource::new("ec2.subnet_route_table_association", "hash123");
+    let mut r = Resource::new("ec2.subnet_route_table_association", "hash123");
     r.set_attr(
         "subnet_id".to_string(),
         Value::resource_ref("database_subnet_1a".to_string(), "id".to_string(), vec![]),
@@ -598,7 +598,7 @@ fn test_print_plan_compact_does_not_panic() {
 /// keys are not printed (attributes are hidden in compact mode).
 #[test]
 fn test_print_plan_compact_with_anonymous_resources() {
-    let mut anon = ManagedResource::new("ec2.route", "hash_anon");
+    let mut anon = Resource::new("ec2.route", "hash_anon");
     anon.set_attr(
         "destination_cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
@@ -628,7 +628,7 @@ fn test_print_plan_compact_with_anonymous_resources() {
 /// e.g., security_group_ids = [endpoint_sg.group_id] should produce "security_group: endpoint_sg"
 #[test]
 fn test_extract_compact_hint_list_containing_resource_ref() {
-    let mut r = ManagedResource::new("ec2.vpc_endpoint", "hash_list_ref");
+    let mut r = Resource::new("ec2.vpc_endpoint", "hash_list_ref");
     r.set_attr(
         "security_group_ids".to_string(),
         Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
@@ -649,7 +649,7 @@ fn test_extract_compact_hint_list_containing_resource_ref() {
 /// Test that extract_compact_hint skips List<ResourceRef> when ref matches parent.
 #[test]
 fn test_extract_compact_hint_list_ref_skips_parent() {
-    let mut r = ManagedResource::new("ec2.vpc_endpoint", "hash_list_parent");
+    let mut r = Resource::new("ec2.vpc_endpoint", "hash_list_parent");
     r.set_attr(
         "security_group_ids".to_string(),
         Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
@@ -680,7 +680,7 @@ fn test_shorten_attr_name_ids_suffix() {
 /// Test that extract_compact_hint resolves DSL enum identifiers.
 #[test]
 fn test_extract_compact_hint_resolves_dsl_enum() {
-    let mut r = ManagedResource::new("ec2.Subnet", "hash_enum");
+    let mut r = Resource::new("ec2.Subnet", "hash_enum");
     r.set_attr(
         "availability_zone".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -701,7 +701,7 @@ fn test_extract_compact_hint_resolves_dsl_enum() {
 /// Test that extract_compact_hint skips _-prefixed attributes.
 #[test]
 fn test_extract_compact_hint_skips_internal_attributes() {
-    let mut r = ManagedResource::new("ec2.Vpc", "hash_internal");
+    let mut r = Resource::new("ec2.Vpc", "hash_internal");
     r.binding = Some("vpc".to_string());
     r.set_attr(
         "_hash".to_string(),
@@ -724,7 +724,7 @@ fn test_cascading_update_shows_attribute_diffs() {
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         )]),
     );
-    let vpc_to = ManagedResource::new("ec2.Vpc", "vpc")
+    let vpc_to = Resource::new("ec2.Vpc", "vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -744,7 +744,7 @@ fn test_cascading_update_shows_attribute_diffs() {
             ),
         ]),
     );
-    let subnet_to = ManagedResource::new("ec2.Subnet", "subnet")
+    let subnet_to = Resource::new("ec2.Subnet", "subnet")
         .with_attribute(
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -807,7 +807,7 @@ fn test_format_cascading_update_attr_diff() {
                 ),
             ]),
         )),
-        to: ManagedResource::new("ec2.Subnet", "subnet")
+        to: Resource::new("ec2.Subnet", "subnet")
             .with_attribute(
                 "vpc_id",
                 Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -987,7 +987,7 @@ fn test_format_cascading_update_diff_excludes_non_ref_attributes() {
                 ),
             ]),
         )),
-        to: ManagedResource::new("ec2.Subnet", "subnet")
+        to: Resource::new("ec2.Subnet", "subnet")
             .with_attribute(
                 "vpc_id",
                 Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -1045,7 +1045,7 @@ fn test_format_cascading_update_diff_includes_list_with_ref() {
                 )])),
             )]),
         )),
-        to: ManagedResource::new("ec2.Instance", "instance").with_attribute(
+        to: Resource::new("ec2.Instance", "instance").with_attribute(
             "security_group_ids",
             Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
                 "sg".to_string(),
@@ -1204,7 +1204,7 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
     // SG: Create effect with RESOLVED ref (string instead of ResourceRef).
     // This is what happens after resolve_refs_with_state() runs:
     // vpc_id = vpc.vpc_id becomes vpc_id = "vpc-0123456789abcdef0"
-    let mut sg = ManagedResource::new("ec2.SecurityGroup", "sg");
+    let mut sg = Resource::new("ec2.SecurityGroup", "sg");
     sg.binding = Some("sg".to_string());
     // This is the resolved value — a plain string, NOT a ResourceRef
     sg.set_attr(
@@ -1289,7 +1289,7 @@ fn format_effect_delete_falls_back_to_id_name() {
 /// so the type/address boundary is visible in plan/apply output.
 #[test]
 fn format_effect_create_separates_type_and_name_with_space() {
-    let mut r = ManagedResource::new("s3.Bucket", "state_bucket");
+    let mut r = Resource::new("s3.Bucket", "state_bucket");
     r.id = ResourceId::with_provider("aws", "s3.Bucket", "state_bucket", None);
     let effect = Effect::Create(r);
     assert_eq!(format_effect(&effect), "Create aws.s3.Bucket state_bucket");
@@ -1298,7 +1298,7 @@ fn format_effect_create_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_update_separates_type_and_name_with_space() {
     let id = ResourceId::with_provider("awscc", "iam.Role", "bs.bootstrap.role", None);
-    let mut to = ManagedResource::new("iam.Role", "bs.bootstrap.role");
+    let mut to = Resource::new("iam.Role", "bs.bootstrap.role");
     to.id = id.clone();
     let effect = Effect::Update {
         id,
@@ -1320,7 +1320,7 @@ fn format_effect_update_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_replace_separates_type_and_name_with_space() {
     let id = ResourceId::with_provider("awscc", "ec2.Vpc", "vpc", None);
-    let mut to = ManagedResource::new("ec2.Vpc", "vpc");
+    let mut to = Resource::new("ec2.Vpc", "vpc");
     to.id = id.clone();
     let effect = Effect::Replace {
         id,

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -11,7 +11,7 @@ use carina_core::parser::{ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{
-    ConcreteValue, DataSource, DeferredValue, Directives, ManagedResource, ResourceId, State, Value,
+    ConcreteValue, DataSource, DeferredValue, Directives, Resource, ResourceId, State, Value,
 };
 use carina_core::schema::{ResourceSchema, SchemaRegistry};
 use carina_state::{BackendError, LockInfo, ResourceState, StateBackend, StateFile};
@@ -106,7 +106,7 @@ impl Provider for TestProvider {
 
 #[tokio::test]
 async fn refresh_pending_states_updates_saved_state_from_provider_read() {
-    let resource = ManagedResource::with_provider("aws", "s3.Bucket", "bucket", None);
+    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket", None);
     let id = resource.id.clone();
     let identifier = "bucket-123";
 
@@ -168,7 +168,7 @@ async fn refresh_pending_states_updates_saved_state_from_provider_read() {
 
 #[tokio::test]
 async fn refresh_pending_states_removes_not_found_resource_from_saved_state() {
-    let resource = ManagedResource::with_provider("aws", "s3.Bucket", "bucket", None);
+    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket", None);
     let id = resource.id.clone();
     let identifier = "bucket-123";
 
@@ -215,7 +215,7 @@ async fn refresh_pending_states_removes_not_found_resource_from_saved_state() {
 
 #[tokio::test]
 async fn refresh_pending_states_does_not_overwrite_with_stale_snapshot_when_refresh_fails() {
-    let resource = ManagedResource::with_provider("aws", "s3.Bucket", "bucket", None);
+    let resource = Resource::with_provider("aws", "s3.Bucket", "bucket", None);
     let id = resource.id.clone();
     let identifier = "bucket-123";
 
@@ -270,7 +270,7 @@ fn plan_file_serde_round_trip() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
+        Resource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
         ),
@@ -285,7 +285,7 @@ fn plan_file_serde_round_trip() {
     });
 
     let sorted_resources = vec![
-        ManagedResource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
+        Resource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
         ),
@@ -366,7 +366,7 @@ fn plan_file_serde_round_trip() {
 #[test]
 #[ignore = "requires provider binary for schema-based prefix resolution"]
 fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -396,7 +396,7 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
 #[test]
 fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
     // If base attr doesn't exist in schema, leave _prefix as-is
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "nonexistent_attr_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("some-value".to_string())),
@@ -417,7 +417,7 @@ fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
 #[test]
 #[ignore = "requires provider binary for schema-based prefix resolution"]
 fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -441,7 +441,7 @@ fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
 #[test]
 #[ignore = "requires provider binary for schema-based prefix resolution"]
 fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("".to_string())),
@@ -457,7 +457,7 @@ fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
 #[ignore = "requires provider binary for schema-based name resolution"]
 fn test_resolve_names_handles_block_name_before_prefix() {
     // resolve_names should first resolve block names, then resolve attr prefixes
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.ipam", "test-ipam", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam", None);
     resource.set_attr(
         "operating_region".to_string(),
         Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
@@ -482,7 +482,7 @@ fn test_resolve_names_handles_block_name_before_prefix() {
 
 #[test]
 fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -515,7 +515,7 @@ fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
 
 #[test]
 fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "new-prefix-".to_string());
@@ -548,7 +548,7 @@ fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
 
 #[test]
 fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -581,7 +581,7 @@ fn test_detailed_exitcode_no_changes() {
 fn test_detailed_exitcode_with_changes() {
     // A plan with mutating effects means changes -- has_changes should be true
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "test")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "test")));
     let has_changes = plan.mutation_count() > 0;
     assert!(has_changes);
 }
@@ -620,13 +620,13 @@ fn make_awscc_provider(region_dsl: &str) -> ProviderConfig {
 #[ignore = "requires provider binary for identity_attributes"]
 fn test_anonymous_id_different_regions_produce_different_identifiers() {
     // Two anonymous ec2_vpc resources with same cidr_block but different provider regions
-    let mut r1 = ManagedResource::with_provider("awscc", "ec2.Vpc", "", None);
+    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r1.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
-    let mut r2 = ManagedResource::with_provider("awscc", "ec2.Vpc", "", None);
+    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r2.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -657,13 +657,13 @@ fn test_anonymous_id_different_regions_produce_different_identifiers() {
 #[ignore = "requires provider binary for identity_attributes"]
 fn test_anonymous_id_same_region_same_create_only_collides() {
     // Two anonymous ec2_vpc resources with same cidr_block and same provider region -> collision
-    let mut r1 = ManagedResource::with_provider("awscc", "ec2.Vpc", "", None);
+    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r1.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
-    let mut r2 = ManagedResource::with_provider("awscc", "ec2.Vpc", "", None);
+    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r2.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -680,13 +680,13 @@ fn test_anonymous_id_same_region_same_create_only_collides() {
 #[ignore = "requires provider binary for identity_attributes"]
 fn test_anonymous_id_different_create_only_same_region_no_collision() {
     // Two anonymous ec2_vpc resources with different cidr_block in same provider region -> no collision
-    let mut r1 = ManagedResource::with_provider("awscc", "ec2.Vpc", "", None);
+    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r1.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
 
-    let mut r2 = ManagedResource::with_provider("awscc", "ec2.Vpc", "", None);
+    let mut r2 = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     r2.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
@@ -704,7 +704,7 @@ fn test_anonymous_id_different_create_only_same_region_no_collision() {
 #[test]
 fn test_anonymous_id_named_resources_are_skipped() {
     // Named resources should not be processed by compute_anonymous_identifiers
-    let mut r1 = ManagedResource::with_provider("awscc", "ec2.Vpc", "my_vpc", None);
+    let mut r1 = Resource::with_provider("awscc", "ec2.Vpc", "my_vpc", None);
     r1.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -724,7 +724,7 @@ fn test_find_state_bucket_resource_matching_type() {
         providers: vec![],
         backend: None,
         resources: vec![
-            ManagedResource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
+            Resource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
                 "bucket",
                 Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
             ),
@@ -772,7 +772,7 @@ fn test_find_state_bucket_resource_matching_type() {
 #[test]
 #[ignore = "requires provider binary for resource type validation"]
 fn validate_data_source_without_read_keyword_errors() {
-    let resource = ManagedResource::with_provider("aws", "sts.caller_identity", "identity", None);
+    let resource = Resource::with_provider("aws", "sts.caller_identity", "identity", None);
     // read_only defaults to false, simulating missing `read` keyword
     let result = validate_resources(&[resource]);
     assert!(result.is_err());
@@ -790,14 +790,14 @@ fn validate_data_source_without_read_keyword_errors() {
 }
 
 // carina#3181: the former `validate_data_source_with_read_keyword_passes`
-// test is obsolete — `validate_resources` takes `&[ManagedResource]`, so a
+// test is obsolete — `validate_resources` takes `&[Resource]`, so a
 // data source cannot be passed into the managed-resource validation path
 // at all (the typestate split enforces this).
 
 #[test]
 #[ignore = "requires provider binary for resource type validation"]
 fn validate_regular_resource_without_read_keyword_passes() {
-    let resource = ManagedResource::with_provider("aws", "s3.Bucket", "my-bucket", None)
+    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket", None)
         .with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -815,7 +815,7 @@ fn validate_regular_resource_without_read_keyword_passes() {
 }
 
 // carina#3181: the former `destroy_plan_excludes_data_sources` test is
-// obsolete. The destroy path operates on `&[ManagedResource]`, and data
+// obsolete. The destroy path operates on `&[Resource]`, and data
 // sources are a distinct typestate (`DataSource`) — they can no longer
 // be mixed into the destroy candidate list, so "data sources are
 // excluded from destroy" is enforced by the type system rather than a
@@ -831,7 +831,7 @@ fn validate_regular_resource_without_read_keyword_passes() {
 fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
     // --- First run (apply) ---
     // 1. Parse: anonymous resource with bucket_name_prefix
-    let mut resource_run1 = ManagedResource::with_provider("awscc", "s3.Bucket", "", None);
+    let mut resource_run1 = Resource::with_provider("awscc", "s3.Bucket", "", None);
     resource_run1.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -885,7 +885,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
 
     // --- Second run (plan-verify) ---
     // 1. Parse again: same anonymous resource with bucket_name_prefix
-    let mut resource_run2 = ManagedResource::with_provider("awscc", "s3.Bucket", "", None);
+    let mut resource_run2 = Resource::with_provider("awscc", "s3.Bucket", "", None);
     resource_run2.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -935,7 +935,7 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     let providers = vec![make_awscc_provider("awscc.Region.ap_northeast_1")];
 
     // --- First run ---
-    let mut resource_run1 = ManagedResource::with_provider("awscc", "iam.role", "", None);
+    let mut resource_run1 = Resource::with_provider("awscc", "iam.role", "", None);
     resource_run1.set_attr(
         "role_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("carina-acc-test-".to_string())),
@@ -993,7 +993,7 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     state_file.upsert_resource(resource_state);
 
     // --- Second run ---
-    let mut resource_run2 = ManagedResource::with_provider("awscc", "iam.role", "", None);
+    let mut resource_run2 = Resource::with_provider("awscc", "iam.role", "", None);
     resource_run2.set_attr(
         "role_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("carina-acc-test-".to_string())),
@@ -1043,7 +1043,7 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     let providers = vec![make_awscc_provider("awscc.Region.ap_northeast_1")];
 
     // --- First run ---
-    let mut resource_run1 = ManagedResource::with_provider("awscc", "ec2.flow_log", "", None);
+    let mut resource_run1 = Resource::with_provider("awscc", "ec2.flow_log", "", None);
     resource_run1.set_attr(
         "resource_id".to_string(),
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -1100,7 +1100,7 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     state_file.upsert_resource(resource_state);
 
     // --- Second run ---
-    let mut resource_run2 = ManagedResource::with_provider("awscc", "ec2.flow_log", "", None);
+    let mut resource_run2 = Resource::with_provider("awscc", "ec2.flow_log", "", None);
     resource_run2.set_attr(
         "resource_id".to_string(),
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -1162,7 +1162,7 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
 
 #[tokio::test]
 async fn detect_drift_errors_when_resource_missing_from_planned_states() {
-    let resource = ManagedResource::with_provider("aws", "s3.Bucket", "my-bucket", None);
+    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket", None);
     let id = resource.id.clone();
 
     // Provider returns a non-existing state (identifier is None since no planned state)
@@ -1187,7 +1187,7 @@ async fn detect_drift_errors_when_resource_missing_from_planned_states() {
 
 #[tokio::test]
 async fn detect_drift_returns_none_when_no_drift() {
-    let resource = ManagedResource::with_provider("aws", "s3.Bucket", "my-bucket", None);
+    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket", None);
     let id = resource.id.clone();
     let identifier = "my-bucket";
 
@@ -1211,7 +1211,7 @@ async fn detect_drift_returns_none_when_no_drift() {
 
 #[tokio::test]
 async fn detect_drift_returns_messages_when_drift_detected() {
-    let resource = ManagedResource::with_provider("aws", "s3.Bucket", "my-bucket", None);
+    let resource = Resource::with_provider("aws", "s3.Bucket", "my-bucket", None);
     let id = resource.id.clone();
     let identifier = "my-bucket";
 
@@ -1268,7 +1268,7 @@ fn orphaned_state_resource_produces_delete_effect() {
 
     // Config only has "keep-bucket" -- "removed-bucket" was deleted from .crn
     let desired = vec![
-        ManagedResource::with_provider("aws", "s3.Bucket", "keep-bucket", None).with_attribute(
+        Resource::with_provider("aws", "s3.Bucket", "keep-bucket", None).with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("keep-bucket".to_string())),
         ),
@@ -1598,7 +1598,7 @@ async fn finalize_apply_uses_write_state_locked() {
 /// (post-replacement) dependency IDs, not stale pre-replacement IDs.
 struct RecordingProvider {
     /// Tracks the `to` resource passed to each update call, keyed by resource ID string.
-    update_calls: std::sync::Mutex<Vec<(String, ManagedResource)>>,
+    update_calls: std::sync::Mutex<Vec<(String, Resource)>>,
 }
 
 impl RecordingProvider {
@@ -1608,7 +1608,7 @@ impl RecordingProvider {
         }
     }
 
-    fn get_update_calls(&self) -> Vec<(String, ManagedResource)> {
+    fn get_update_calls(&self) -> Vec<(String, Resource)> {
         self.update_calls.lock().unwrap().clone()
     }
 }
@@ -1656,7 +1656,7 @@ impl Provider for RecordingProvider {
         _identifier: &str,
         request: carina_core::provider::UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        // Reconstruct a ManagedResource view of the desired post-update state for
+        // Reconstruct a Resource view of the desired post-update state for
         // existing tests that introspect the recorded `to`.
         let mut attrs = request.from.attributes.clone();
         for op in &request.patch.ops {
@@ -1672,7 +1672,7 @@ impl Provider for RecordingProvider {
                 }
             }
         }
-        let mut to = ManagedResource::with_provider(
+        let mut to = Resource::with_provider(
             &id.provider,
             &id.resource_type,
             id.name_str(),
@@ -1764,7 +1764,7 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
     )
     .with_identifier("my-bucket");
 
-    let new_resource = ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None)
+    let new_resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None)
         .with_attribute(
             "bucket_name",
             Value::Concrete(ConcreteValue::String("my-bucket-tmp123".to_string())),
@@ -1834,14 +1834,14 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
     // --- Unresolved resources (before ref resolution) ---
-    let vpc_unresolved = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc_unresolved = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet_unresolved = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet_unresolved = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -1854,7 +1854,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
 
     // --- Resolved resources (after ref resolution with old state) ---
     // The subnet's vpc_id has been eagerly resolved to "vpc-OLD"
-    let subnet_resolved = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet_resolved = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -1954,7 +1954,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     );
 
     // --- Unresolved resource map ---
-    let unresolved_resources: HashMap<ResourceId, ManagedResource> = HashMap::from([
+    let unresolved_resources: HashMap<ResourceId, Resource> = HashMap::from([
         (vpc_id.clone(), vpc_unresolved),
         (subnet_id.clone(), subnet_unresolved),
     ]);
@@ -2085,12 +2085,10 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
 
     // Config only has "keep-bucket" -- "orphan-bucket" was removed from .crn
     let mut parsed = carina_core::parser::InferredFile {
-        resources: vec![
-            ManagedResource::new("s3.Bucket", "keep-bucket").with_attribute(
-                "bucket",
-                Value::Concrete(ConcreteValue::String("keep-bucket".to_string())),
-            ),
-        ],
+        resources: vec![Resource::new("s3.Bucket", "keep-bucket").with_attribute(
+            "bucket",
+            Value::Concrete(ConcreteValue::String("keep-bucket".to_string())),
+        )],
         ..carina_core::parser::InferredFile::default()
     };
 
@@ -2243,7 +2241,7 @@ fn orphaned_resource_deleted_externally_should_not_produce_delete_effect() {
     );
 
     // No desired resources — "removed-bucket" was removed from .crn
-    let desired: Vec<ManagedResource> = vec![];
+    let desired: Vec<Resource> = vec![];
     let desired_ids: HashSet<ResourceId> = desired.iter().map(|r| r.id.clone()).collect();
 
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
@@ -2315,7 +2313,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
             .with_attribute("region", json!("ap-northeast-1")),
     );
 
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -2389,7 +2387,7 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
     );
 
     // No desired resources — the bucket was removed from .crn
-    let desired: Vec<ManagedResource> = vec![];
+    let desired: Vec<Resource> = vec![];
     let desired_ids: HashSet<ResourceId> = desired.iter().map(|r| r.id.clone()).collect();
 
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
@@ -2435,7 +2433,7 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
 fn refresh_false_without_state_file_treats_resources_as_new() {
     use carina_core::differ::create_plan;
 
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "new-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "new-bucket", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("new-bucket".to_string())),
@@ -2480,7 +2478,7 @@ fn import_effect_preserves_resource_metadata_in_state() {
     // overwrite the ResourceState with a bare ResourceState::new(), stripping
     // directives, prefixes, desired_keys, binding, and dependency_bindings.
 
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None)
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None)
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -2569,7 +2567,7 @@ fn build_state_after_apply_persists_write_only_attributes() {
     use carina_core::schema::{AttributeSchema, AttributeType};
 
     // Set up a resource with a write-only attribute (ipv4_netmask_length)
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -2647,7 +2645,7 @@ fn build_state_after_apply_write_only_detects_value_change() {
     use carina_core::schema::{AttributeSchema, AttributeType};
 
     // Simulate: user changed ipv4_netmask_length from 16 to 24
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/24".to_string())),
@@ -2727,13 +2725,12 @@ fn plan_file_serialization_redacts_secrets() {
         ConcreteValue::String("super-secret-pw".to_string()),
     ))));
 
-    let resource_with_secret =
-        ManagedResource::with_provider("awscc", "rds.db_instance", "my-db", None)
-            .with_attribute(
-                "name",
-                Value::Concrete(ConcreteValue::String("my-db".to_string())),
-            )
-            .with_attribute("master_password", secret_password.clone());
+    let resource_with_secret = Resource::with_provider("awscc", "rds.db_instance", "my-db", None)
+        .with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("my-db".to_string())),
+        )
+        .with_attribute("master_password", secret_password.clone());
 
     let mut plan = Plan::new();
     plan.add(Effect::Create(resource_with_secret.clone()));

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -24,7 +24,7 @@ use carina_core::provider::{
 };
 use carina_core::resolver::resolve_refs_for_plan;
 use carina_core::resource::{
-    ConcreteValue, DeferredValue, ManagedResource, ResourceId, State, Value, contains_resource_ref,
+    ConcreteValue, DeferredValue, Resource, ResourceId, State, Value, contains_resource_ref,
 };
 use carina_core::schema::{SchemaRegistry, resolve_block_names};
 use carina_core::validation;
@@ -37,7 +37,7 @@ use crate::error::AppError;
 /// Result of creating a plan, with context needed for saving
 pub struct PlanContext {
     pub plan: Plan,
-    pub sorted_resources: Vec<ManagedResource>,
+    pub sorted_resources: Vec<Resource>,
     pub current_states: HashMap<ResourceId, State>,
     /// Maps moved-to resource IDs to their original (moved-from) IDs.
     /// Used by display to show "(moved from: ...)" annotations on Update/Replace effects.
@@ -278,7 +278,7 @@ pub fn validate_resource_ref_types_with_ctx<E>(
 pub fn validate_attribute_param_ref_types_with_ctx(
     ctx: &WiringContext,
     attribute_params: &[carina_core::parser::AttributeParameter],
-    resources: &[ManagedResource],
+    resources: &[Resource],
 ) -> Vec<AppError> {
     lift_validation_result(validation::validate_attribute_param_ref_types(
         attribute_params,
@@ -365,10 +365,7 @@ fn value_contains_empty_interpolation(value: &Value) -> bool {
 }
 
 /// Resolve block name aliases and attribute prefixes in one step.
-pub fn resolve_names_with_ctx(
-    ctx: &WiringContext,
-    resources: &mut [ManagedResource],
-) -> Vec<AppError> {
+pub fn resolve_names_with_ctx(ctx: &WiringContext, resources: &mut [Resource]) -> Vec<AppError> {
     let mut errors = lift_validation_result(resolve_block_names(resources, ctx.schemas()));
     errors.extend(resolve_attr_prefixes_with_ctx(ctx, resources));
     errors
@@ -376,12 +373,12 @@ pub fn resolve_names_with_ctx(
 
 pub fn resolve_attr_prefixes_with_ctx(
     ctx: &WiringContext,
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
 ) -> Vec<AppError> {
     lift_validation_result(identifier::resolve_attr_prefixes(resources, ctx.schemas()))
 }
 
-pub fn reconcile_prefixed_names(resources: &mut [ManagedResource], state_file: &Option<StateFile>) {
+pub fn reconcile_prefixed_names(resources: &mut [Resource], state_file: &Option<StateFile>) {
     let state_file = match state_file {
         Some(sf) => sf,
         None => return,
@@ -420,7 +417,7 @@ fn identity_attributes_for_provider(ctx: &WiringContext, name: &str) -> Vec<Stri
 /// new binding name so the differ sees the resource under its new identity.
 pub fn apply_anonymous_to_named_renames(
     ctx: &WiringContext,
-    resources: &[ManagedResource],
+    resources: &[Resource],
     providers: &[ProviderConfig],
     current_states: &mut HashMap<ResourceId, State>,
     prev_explicit: &mut HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
@@ -485,7 +482,7 @@ pub fn apply_anonymous_to_named_renames(
 
 pub fn reconcile_anonymous_identifiers_with_ctx(
     ctx: &WiringContext,
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     state_file: &mut StateFile,
 ) {
     let renames = identifier::reconcile_anonymous_identifiers(
@@ -552,7 +549,7 @@ pub fn apply_provider_prefix_renames(renames: &[(String, String)], state_file: &
 
 pub fn compute_anonymous_identifiers_with_ctx(
     ctx: &WiringContext,
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     providers: &[ProviderConfig],
 ) -> Vec<AppError> {
     match identifier::compute_anonymous_identifiers(resources, providers, ctx.schemas(), &|name| {
@@ -587,7 +584,7 @@ impl<'a> PlanPreprocessor<'a> {
     /// Call after `resolve_refs_with_state_and_remote()` and before `create_plan()`.
     pub async fn prepare(
         &self,
-        resources: &mut [ManagedResource],
+        resources: &mut [Resource],
         current_states: &mut HashMap<ResourceId, State>,
         provider_configs: &[ProviderConfig],
     ) {
@@ -651,7 +648,7 @@ struct StrippedAttribute {
 ///   `core_to_wit_value` `_` debug-format fallback would silently
 ///   stringify the ref (#2387).
 fn strip_attributes_matching(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     predicate: &dyn Fn(&Value) -> bool,
 ) -> HashMap<ResourceId, Vec<StrippedAttribute>> {
     let mut out: HashMap<ResourceId, Vec<StrippedAttribute>> = HashMap::new();
@@ -698,7 +695,7 @@ fn strip_attributes_matching(
 /// provider-injected defaults) end up after the original entries,
 /// which matches behavior pre-#2377 for non-stripped attributes.
 fn restore_stripped_attributes(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     mut stripped: HashMap<ResourceId, Vec<StrippedAttribute>>,
 ) {
     for resource in resources.iter_mut() {
@@ -743,7 +740,7 @@ fn current_states_contain_unknown(states: &HashMap<ResourceId, State>) -> bool {
 /// `normalize_desired()` to the resources. This resolves enum identifiers
 /// (e.g., bare enum identifiers -> namespaced enum strings) without requiring
 /// actual provider instances or network access.
-pub fn normalize_desired_with_ctx(ctx: &WiringContext, resources: &mut [ManagedResource]) {
+pub fn normalize_desired_with_ctx(ctx: &WiringContext, resources: &mut [Resource]) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .build()
         .expect("failed to build tokio runtime for normalize_desired");
@@ -790,7 +787,7 @@ pub fn normalize_state_with_ctx(
 ///
 /// This must be called on both desired resources and current states to ensure
 /// the differ sees consistent values and produces no false diffs.
-pub fn resolve_enum_aliases_with_ctx(ctx: &WiringContext, resources: &mut [ManagedResource]) {
+pub fn resolve_enum_aliases_with_ctx(ctx: &WiringContext, resources: &mut [Resource]) {
     // Single source of truth shared with the apply path
     // (`executor::renormalize`) so plan and apply cannot diverge on the
     // enum-alias stage again (carina#3063). The core helper mutates
@@ -1161,10 +1158,7 @@ impl RefreshableChildIds {
     /// through this method — there is no other constructor for the
     /// refresh set, which is what makes the plan/apply parity a
     /// type-level invariant rather than a reviewer's responsibility.
-    pub fn select<'a>(
-        &'a self,
-        resources: &'a [ManagedResource],
-    ) -> impl Iterator<Item = &'a ManagedResource> {
+    pub fn select<'a>(&'a self, resources: &'a [Resource]) -> impl Iterator<Item = &'a Resource> {
         resources.iter().filter(move |r| self.0.contains(&r.id))
     }
 
@@ -1189,7 +1183,7 @@ pub struct DeferredForExpansion {
     /// The augmented, re-sorted resource set: every original resource
     /// plus the materialized loop children, topologically ordered.
     /// Equal in length to the input when no loop resolved.
-    pub sorted_resources: Vec<ManagedResource>,
+    pub sorted_resources: Vec<Resource>,
     /// Loops still unresolved (iterable genuinely unknowable at plan
     /// time) — rendered as the carina#3128 validate/plan placeholder.
     pub residual_deferred_for: Vec<carina_core::parser::DeferredForExpression>,
@@ -1247,7 +1241,7 @@ pub struct DeferredForExpansion {
 /// so the plan and apply paths cannot diverge.
 pub fn expand_same_config_deferred_for<E: Clone>(
     parsed: &carina_core::parser::File<E>,
-    sorted_resources: &[ManagedResource],
+    sorted_resources: &[Resource],
     current_states: &HashMap<ResourceId, State>,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
     wait_aliases: &[WaitAliasSpec],
@@ -1371,7 +1365,7 @@ pub fn expand_same_config_deferred_for<E: Clone>(
 /// is meant to close.
 #[non_exhaustive]
 pub struct ExpandedRefreshState {
-    pub sorted_resources: Vec<ManagedResource>,
+    pub sorted_resources: Vec<Resource>,
     pub residual_deferred_for: Vec<carina_core::parser::DeferredForExpression>,
     pub new_child_ids: HashSet<ResourceId>,
     pub refreshable_child_ids: RefreshableChildIds,
@@ -1386,7 +1380,7 @@ pub struct ExpandedRefreshState {
 pub struct ExpandRefreshAndLiftInputs<'a, E: Clone, P: Provider + ProviderNormalizer> {
     pub parsed: &'a carina_core::parser::File<E>,
     pub provider: &'a P,
-    pub sorted_resources: &'a [ManagedResource],
+    pub sorted_resources: &'a [Resource],
     pub current_states: &'a mut HashMap<ResourceId, State>,
     pub remote_bindings: &'a HashMap<String, HashMap<String, Value>>,
     pub wait_aliases: &'a [WaitAliasSpec],
@@ -2285,7 +2279,7 @@ pub async fn read_with_retry(
 pub(crate) async fn refresh_resource_set<'a>(
     provider: &dyn Provider,
     multi: &indicatif::MultiProgress,
-    resources: impl Iterator<Item = &'a ManagedResource>,
+    resources: impl Iterator<Item = &'a Resource>,
     state_file: &Option<StateFile>,
     saved_dep_bindings: &HashMap<ResourceId, BTreeSet<String>>,
     current_states: &mut HashMap<ResourceId, State>,
@@ -2392,7 +2386,7 @@ pub async fn read_data_source_with_retry(
 /// resolver builds its binding map from every managed resource with a
 /// `binding` — data sources reference those.
 pub(crate) fn resolve_data_source_refs_for_refresh(
-    managed: &[ManagedResource],
+    managed: &[Resource],
     virtuals: &[carina_core::resource::VirtualResource],
     data_sources: &[carina_core::resource::DataSource],
     current_states: &HashMap<ResourceId, State>,
@@ -2421,7 +2415,7 @@ pub(crate) fn resolve_data_source_refs_for_refresh(
 /// Convenience wrappers for tests. Each creates a fresh `WiringContext` internally,
 /// which is acceptable in test code where the overhead is negligible.
 #[cfg(test)]
-pub fn validate_resources(resources: &[ManagedResource]) -> Result<(), AppError> {
+pub fn validate_resources(resources: &[Resource]) -> Result<(), AppError> {
     use carina_core::parser::ParsedFile;
     let ctx = WiringContext::new(vec![]);
     let parsed = ParsedFile {
@@ -2436,20 +2430,20 @@ pub fn validate_resources(resources: &[ManagedResource]) -> Result<(), AppError>
 }
 
 #[cfg(test)]
-pub fn resolve_names(resources: &mut [ManagedResource]) -> Result<(), AppError> {
+pub fn resolve_names(resources: &mut [Resource]) -> Result<(), AppError> {
     let ctx = WiringContext::new(vec![]);
     errors_to_legacy_result(resolve_names_with_ctx(&ctx, resources))
 }
 
 #[cfg(test)]
-pub fn resolve_attr_prefixes(resources: &mut [ManagedResource]) -> Result<(), AppError> {
+pub fn resolve_attr_prefixes(resources: &mut [Resource]) -> Result<(), AppError> {
     let ctx = WiringContext::new(vec![]);
     errors_to_legacy_result(resolve_attr_prefixes_with_ctx(&ctx, resources))
 }
 
 #[cfg(test)]
 pub fn compute_anonymous_identifiers(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     providers: &[ProviderConfig],
 ) -> Result<(), AppError> {
     let ctx = WiringContext::new(vec![]);
@@ -2481,7 +2475,7 @@ fn errors_to_legacy_result(errors: Vec<AppError>) -> Result<(), AppError> {
 }
 
 #[cfg(test)]
-pub fn resolve_enum_aliases(resources: &mut [ManagedResource]) {
+pub fn resolve_enum_aliases(resources: &mut [Resource]) {
     let ctx = WiringContext::new(vec![]);
     resolve_enum_aliases_with_ctx(&ctx, resources)
 }

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -7,7 +7,7 @@ fn test_resolve_enum_aliases_ip_protocol_all() {
     // After normalize_desired, ip_protocol "all" becomes a namespaced DSL value.
     // resolve_enum_aliases should resolve the alias "all" -> "-1".
     let mut resource =
-        ManagedResource::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
+        Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
     resource.set_attr(
         "ip_protocol".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -30,7 +30,7 @@ fn test_resolve_enum_aliases_no_alias() {
     // "tcp" has no alias mapping, so it should be converted from DSL enum
     // to its raw form by convert_enum_value but not further changed.
     let mut resource =
-        ManagedResource::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
+        Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
     resource.set_attr(
         "ip_protocol".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -55,7 +55,7 @@ fn test_resolve_enum_aliases_no_alias() {
 fn test_resolve_enum_aliases_aws_provider() {
     // Same alias resolution should work for the aws provider
     let mut resource =
-        ManagedResource::with_provider("aws", "ec2.security_group_ingress", "test-rule", None);
+        Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule", None);
     resource.set_attr(
         "ip_protocol".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -101,8 +101,7 @@ fn test_resolve_enum_aliases_in_states() {
 #[ignore = "requires provider binary for enum alias resolution"]
 fn test_resolve_enum_aliases_in_struct_field() {
     // Aliases within struct fields (maps inside lists) should also be resolved
-    let mut resource =
-        ManagedResource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
     let mut egress_map = IndexMap::new();
     egress_map.insert(
         "ip_protocol".to_string(),
@@ -167,7 +166,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
     let ctx = WiringContext::new(vec![]);
 
     // Desired resource with normalized DSL enum value (after normalize_desired)
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
     resource.set_attr(
         "instance_tenancy".to_string(),
         Value::Concrete(ConcreteValue::String(
@@ -256,7 +255,7 @@ fn test_merge_default_tags_prevents_false_diff() {
     schemas.insert("awscc", schema);
 
     // Desired resource without explicit tags
-    let resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
 
     // State already has the default tags (from a previous apply)
     let id = resource.id.clone();
@@ -354,8 +353,7 @@ fn test_merge_default_tags_prevents_false_diff() {
 #[test]
 fn test_resolve_enum_aliases_non_enum_values_unchanged() {
     // Non-DSL-enum strings should not be affected
-    let mut resource =
-        ManagedResource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
     resource.set_attr(
         "group_description".to_string(),
         Value::Concrete(ConcreteValue::String("My security group".to_string())),
@@ -386,7 +384,7 @@ fn test_resolve_enum_aliases_non_enum_values_unchanged() {
 fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, Value};
+    use carina_core::resource::{ConcreteValue, Resource, ResourceId, Value};
     use carina_core::schema::ResourceSchema;
 
     // Schema with name_attribute = "bucket_name"
@@ -395,8 +393,7 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     schemas.insert("awscc", bucket_schema);
 
     // Anonymous resource with hash name but bucket_name = "carina-rs-state"
-    let mut resource =
-        ManagedResource::with_provider("awscc", "s3.Bucket", "s3_bucket_1d43a664", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "s3_bucket_1d43a664", None);
     resource.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
@@ -480,7 +477,7 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
     let identity_store_id = "d-9067c29a4b";
 
     // Managed resource with a binding — phase 1 would have refreshed it.
-    let mut sso = ManagedResource::with_provider("awscc", "sso.Instance", "carina-rs", None);
+    let mut sso = Resource::with_provider("awscc", "sso.Instance", "carina-rs", None);
     sso.binding = Some("sso".to_string());
 
     // Data source referencing `sso.identity_store_id`. carina#3181:
@@ -550,8 +547,8 @@ fn validate_resources_with_ctx_returns_each_error_as_app_error() {
     // Empty provider string sidesteps the "unknown provider, skip"
     // escape hatch (`known_providers` is empty), so each bad resource
     // produces its own "Unknown resource type" entry.
-    let r1 = ManagedResource::new("foo.nothing", "first");
-    let r2 = ManagedResource::new("bar.nothing", "second");
+    let r1 = Resource::new("foo.nothing", "first");
+    let r2 = Resource::new("bar.nothing", "second");
     let parsed = ParsedFile {
         resources: vec![r1, r2],
         ..ParsedFile::default()
@@ -571,7 +568,7 @@ fn validate_resources_with_ctx_returns_each_error_as_app_error() {
 #[test]
 fn dependency_chain_wrappers_return_vec_app_error() {
     let ctx = WiringContext::new(vec![]);
-    let mut resources: Vec<ManagedResource> = Vec::new();
+    let mut resources: Vec<Resource> = Vec::new();
     let providers: Vec<ProviderConfig> = Vec::new();
 
     let errors = resolve_names_with_ctx(&ctx, &mut resources);
@@ -617,7 +614,7 @@ fn strip_and_restore_unknown_attributes_round_trip() {
     use carina_core::resource::{AccessPath, ConcreteValue, DeferredValue, UnknownReason, Value};
     use indexmap::IndexMap;
 
-    let mut r = carina_core::resource::ManagedResource::new("test.t", "n");
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
     let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
     r.attributes.insert(
         "group_description".into(),
@@ -735,7 +732,7 @@ fn restore_unknown_attributes_after_normalize_injection() {
     // the originals when the post-normalize map has different length.
     use carina_core::resource::{AccessPath, ConcreteValue, DeferredValue, UnknownReason, Value};
 
-    let mut r = carina_core::resource::ManagedResource::new("test.t", "n");
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
     let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
     r.attributes.insert(
         "a".into(),
@@ -781,7 +778,7 @@ fn strip_and_restore_for_expression_unknowns_round_trip() {
     // `Value::Deferred(DeferredValue::Unknown)` of any reason.
     use carina_core::resource::{ConcreteValue, DeferredValue, UnknownReason, Value};
 
-    let mut r = carina_core::resource::ManagedResource::new("test.t", "n");
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
     r.attributes.insert(
         "name".into(),
         Value::Concrete(ConcreteValue::String("static".into())),
@@ -865,7 +862,7 @@ fn strip_and_restore_resource_ref_round_trip() {
     };
     use indexmap::IndexMap;
 
-    let mut r = carina_core::resource::ManagedResource::new("test.t", "n");
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
     let path = AccessPath::with_fields("admins", "group_id", vec![]);
     r.attributes.insert(
         "name".into(),
@@ -957,7 +954,7 @@ fn strip_unified_predicate_covers_unknown_and_ref() {
         AccessPath, ConcreteValue, DeferredValue, UnknownReason, Value, contains_resource_ref,
     };
 
-    let mut r = carina_core::resource::ManagedResource::new("test.t", "n");
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
     let path = AccessPath::with_fields("admins", "group_id", vec![]);
     r.attributes.insert(
         "name".into(),
@@ -1003,7 +1000,7 @@ fn strip_unified_predicate_covers_unknown_and_ref() {
 // =====================================================================
 
 fn parsed_with_attr(attr_name: &str, attr_value: Value) -> ParsedFile {
-    let mut r = ManagedResource::new("foo.bar", "x");
+    let mut r = Resource::new("foo.bar", "x");
     r.attributes.insert(attr_name.to_string(), attr_value);
     ParsedFile {
         resources: vec![r],
@@ -1425,14 +1422,14 @@ mod expand_same_config_deferred_for_tests {
     /// order, and nothing outside the set.
     #[test]
     fn refreshable_child_ids_select_yields_exactly_the_set() {
-        // `ManagedResource::new` gives each resource a distinct, concrete
+        // `Resource::new` gives each resource a distinct, concrete
         // `ResourceId` directly — no parse/ID-reconcile step, so the
         // test pins `select`'s set-membership logic in isolation
         // (anonymous ids are still pending right after `parse`, which is
         // a different concern covered by the expand_* tests).
-        let r_a = ManagedResource::new("aws.ec2.Vpc", "a");
-        let r_b = ManagedResource::new("aws.ec2.Vpc", "b");
-        let r_c = ManagedResource::new("aws.ec2.Vpc", "c");
+        let r_a = Resource::new("aws.ec2.Vpc", "a");
+        let r_b = Resource::new("aws.ec2.Vpc", "b");
+        let r_c = Resource::new("aws.ec2.Vpc", "c");
         let resources = vec![r_a.clone(), r_b.clone(), r_c.clone()];
 
         // Refreshable set = {a, c}; b must be skipped.

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -8,16 +8,16 @@
 //!   declaration kinds the parser tracks (resource, argument, module
 //!   call, upstream state, import alias, user function, variable,
 //!   structural binding from let-of-if/for/read).
-//! - [`BindingIndex`] — "what schema and which `ManagedResource` does this
+//! - [`BindingIndex`] — "what schema and which `Resource` does this
 //!   binding point at?" Schema-aware view. Used by validation and the
-//!   LSP. Each entry has both a `ManagedResource` and a `ResourceSchema`.
+//!   LSP. Each entry has both a `Resource` and a `ResourceSchema`.
 //! - [`ResolvedBindings`] — "what attribute values does this binding
 //!   actually carry?" Value-aware view. Used by the resolver and
-//!   executor. Includes upstream-state bindings that have no `ManagedResource`
+//!   executor. Includes upstream-state bindings that have no `Resource`
 //!   or `ResourceSchema`.
 //!
 //! The three are separate types rather than fields on one because their
-//! invariants differ — `BindingIndex` requires both `ManagedResource` and
+//! invariants differ — `BindingIndex` requires both `Resource` and
 //! `ResourceSchema`, `ResolvedBindings` requires only attribute values
 //! (no schema), `BindingNameSet` requires only the name and an origin
 //! tag. Callers that need more than one view hold them side by side.
@@ -40,7 +40,7 @@
 //! ```
 
 use crate::parser::{BindingName, ResourceRef};
-use crate::resource::{ManagedResource, ResourceId, State, Value, VirtualResource};
+use crate::resource::{Resource, ResourceId, State, Value, VirtualResource};
 use crate::schema::{ResourceSchema, SchemaRegistry};
 use std::collections::HashMap;
 
@@ -175,7 +175,7 @@ impl<'a> BindingIndex<'a> {
 #[non_exhaustive]
 pub enum BindingNameKind {
     /// `let <name> = ...` resource binding.
-    ManagedResource,
+    Resource,
     /// `argument <name> { ... }` module argument.
     Argument,
     /// `module <name> "..." { ... }` call site.
@@ -236,7 +236,7 @@ impl BindingNameSet {
     /// inserted in **most-specific-first** order and the first
     /// `insert` wins (later sources call `entry().or_insert`).
     ///
-    /// The order — `ManagedResource` → `ModuleCall` → `UpstreamState` →
+    /// The order — `Resource` → `ModuleCall` → `UpstreamState` →
     /// `Argument` → `Use` → `UserFunction` → `Structural` → `Variable`
     /// — keeps `Variable` last because `parsed.variables` is the
     /// catch-all "any `let`-RHS placeholder lives here" map, while the
@@ -246,15 +246,15 @@ impl BindingNameSet {
 
         // carina#3181: walk the typed top-level slices — managed
         // resources, data sources, and virtuals all register a
-        // `ManagedResource`-kind binding name (a data source declared as
+        // `Resource`-kind binding name (a data source declared as
         // `let x = read ...` is addressable by `ResourceRef`, and a
-        // virtual binding was a `ManagedResource`-kind name before the
+        // virtual binding was a `Resource`-kind name before the
         // typestate split too).
         for rref in parsed.iter_top_level_resources() {
             if let Some(name) = rref.binding() {
                 by_name
                     .entry(name.to_string())
-                    .or_insert(BindingNameKind::ManagedResource);
+                    .or_insert(BindingNameKind::Resource);
             }
         }
         // Wait bindings register right after resources: a wait binding
@@ -421,7 +421,7 @@ pub struct ResolvedBinding {
 /// why this is a separate type.
 ///
 /// Owned, not borrowed: building the merged map requires combining
-/// `ManagedResource.attributes` with `State.attributes`, and there is no single
+/// `Resource.attributes` with `State.attributes`, and there is no single
 /// upstream `HashMap<String, HashMap<String, Value>>` already on hand to
 /// borrow from. Owning the merged map avoids a self-referential
 /// structure.
@@ -442,7 +442,7 @@ pub struct ResolvedBindings {
 /// stores owned copies internally, so the caller retains ownership
 /// without forcing a clone at the API boundary.
 pub struct PreApplyInputs<'a> {
-    pub managed: &'a [ManagedResource],
+    pub managed: &'a [Resource],
     pub virtuals: &'a [VirtualResource],
     pub data_sources: &'a [crate::resource::DataSource],
     pub current_states: &'a HashMap<ResourceId, State>,
@@ -495,7 +495,7 @@ impl ResolvedBindings {
     /// caller after data sources / virtuals so a wait whose target is
     /// a data source or virtual still snapshots the resolved attrs.
     fn build_managed_core(
-        managed: &[ManagedResource],
+        managed: &[Resource],
         current_states: &HashMap<ResourceId, State>,
         remote_bindings: &HashMap<String, HashMap<String, Value>>,
     ) -> Self {
@@ -988,15 +988,11 @@ let vpc = aws.ec2.Vpc {
 #[cfg(test)]
 mod resolved_bindings_tests {
     use super::*;
-    use crate::resource::{ConcreteValue, DataSource, ManagedResource, ResourceId, State, Value};
+    use crate::resource::{ConcreteValue, DataSource, Resource, ResourceId, State, Value};
     use std::collections::BTreeSet;
 
-    fn make_resource(
-        name: &str,
-        binding: Option<&str>,
-        attrs: Vec<(&str, Value)>,
-    ) -> ManagedResource {
-        let mut r = ManagedResource::new("test.resource", name);
+    fn make_resource(name: &str, binding: Option<&str>, attrs: Vec<(&str, Value)>) -> Resource {
+        let mut r = Resource::new("test.resource", name);
         r.attributes = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
         r.binding = binding.map(|b| b.to_string());
         r
@@ -1098,9 +1094,9 @@ mod resolved_bindings_tests {
 
     #[test]
     fn upstream_state_binding_is_first_class() {
-        // Upstream-state bindings have no `ManagedResource` and no `ResourceSchema`,
+        // Upstream-state bindings have no `Resource` and no `ResourceSchema`,
         // which is the case `BindingIndex` cannot represent.
-        let resources: Vec<ManagedResource> = Vec::new();
+        let resources: Vec<Resource> = Vec::new();
         let states: HashMap<ResourceId, State> = HashMap::new();
         let mut remote: HashMap<String, HashMap<String, Value>> = HashMap::new();
         let mut network_attrs = HashMap::new();
@@ -1820,7 +1816,7 @@ let vpc = aws.ec2.Vpc {
         let names = BindingNameSet::from_parsed(&parsed);
 
         assert!(names.contains("vpc"));
-        assert_eq!(names.kind("vpc"), Some(&BindingNameKind::ManagedResource));
+        assert_eq!(names.kind("vpc"), Some(&BindingNameKind::Resource));
     }
 
     #[test]
@@ -2004,6 +2000,6 @@ let cert_issued = wait cert {
             "wait binding must carry its typed target edge"
         );
         // The target itself is still a plain resource binding.
-        assert_eq!(names.kind("cert"), Some(&BindingNameKind::ManagedResource));
+        assert_eq!(names.kind("cert"), Some(&BindingNameKind::Resource));
     }
 }

--- a/carina-core/src/binding_index_split_tests.rs
+++ b/carina-core/src/binding_index_split_tests.rs
@@ -13,18 +13,18 @@ use std::collections::{BTreeSet, HashMap};
 use indexmap::IndexMap;
 
 use crate::binding_index::ResolvedBindings;
-use crate::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value, VirtualResource};
+use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value, VirtualResource};
 
 fn s(s: &str) -> Value {
     Value::Concrete(ConcreteValue::String(s.into()))
 }
 
-fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> ManagedResource {
+fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> Resource {
     let mut attributes = IndexMap::new();
     for (k, v) in attrs {
         attributes.insert((*k).into(), v.clone());
     }
-    ManagedResource {
+    Resource {
         id: ResourceId::new("aws.s3.Bucket", binding),
         attributes,
         directives: Default::default(),

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::effect::Effect;
-use crate::resource::{ConcreteValue, DeferredValue, ManagedResource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
 
 /// Extract binding names that a resource depends on.
 ///
@@ -14,7 +14,7 @@ use crate::resource::{ConcreteValue, DeferredValue, ManagedResource, Value};
 ///
 /// Both sources are always merged because partial resolution can cause
 /// ResourceRef bindings to differ from the original direct dependencies.
-pub fn get_resource_dependencies(resource: &ManagedResource) -> HashSet<String> {
+pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
     let mut deps = HashSet::new();
     for value in resource.attributes.values() {
         collect_dependencies(value, &mut deps);
@@ -120,13 +120,13 @@ fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
 
 /// Like [`get_resource_dependencies`], but excludes `directives.depends_on`.
 ///
-/// The parser/resolver snapshots this into `ManagedResource.dependency_bindings`
+/// The parser/resolver snapshots this into `Resource.dependency_bindings`
 /// before reference resolution. Keeping the depends_on edges out of that
 /// snapshot is what lets the validation pass tell a redundant edge apart
 /// from a depends_on-only edge.
 ///
 /// Takes `&dyn ResourceLike` so the resolver can compute the snapshot for
-/// both managed [`ManagedResource`]s and [`DataSource`]s (carina#3181).
+/// both managed [`Resource`]s and [`DataSource`]s (carina#3181).
 pub fn get_resource_value_ref_dependencies(
     resource: &dyn crate::resource::ResourceLike,
 ) -> HashSet<String> {
@@ -148,9 +148,7 @@ pub fn get_resource_value_ref_dependencies(
 ///
 /// Returns an error if a circular dependency is detected, with a message
 /// showing the cycle path (e.g., "Circular dependency detected: a -> b -> c -> a").
-pub fn sort_resources_by_dependencies(
-    resources: &[ManagedResource],
-) -> Result<Vec<ManagedResource>, String> {
+pub fn sort_resources_by_dependencies(resources: &[Resource]) -> Result<Vec<Resource>, String> {
     topological_sort(resources, false)
 }
 
@@ -164,9 +162,7 @@ pub fn sort_resources_by_dependencies(
 /// The depth-based pre-sorting is only needed for destroy ordering. For apply
 /// (creation) ordering, the plain topological sort preserves the declaration
 /// order from the .crn file, which is the expected behavior (#1071).
-pub fn sort_resources_for_destroy(
-    resources: &[ManagedResource],
-) -> Result<Vec<ManagedResource>, String> {
+pub fn sort_resources_for_destroy(resources: &[Resource]) -> Result<Vec<Resource>, String> {
     let sorted = topological_sort(resources, true)?;
     Ok(sorted.into_iter().rev().collect())
 }
@@ -176,19 +172,16 @@ pub fn sort_resources_for_destroy(
 /// When `depth_presort` is true, resources are pre-sorted by dependency depth
 /// (ascending) before DFS traversal. This makes the sort input-order-independent,
 /// ensuring stable results for independent branches.
-fn topological_sort(
-    resources: &[ManagedResource],
-    depth_presort: bool,
-) -> Result<Vec<ManagedResource>, String> {
+fn topological_sort(resources: &[Resource], depth_presort: bool) -> Result<Vec<Resource>, String> {
     // Build binding name to resource mapping
-    let mut binding_to_resource: HashMap<String, &ManagedResource> = HashMap::new();
+    let mut binding_to_resource: HashMap<String, &Resource> = HashMap::new();
     for resource in resources {
         if let Some(ref binding_name) = resource.binding {
             binding_to_resource.insert(binding_name.clone(), resource);
         }
     }
 
-    let mut presorted: Vec<&ManagedResource> = resources.iter().collect();
+    let mut presorted: Vec<&Resource> = resources.iter().collect();
 
     if depth_presort {
         // Compute the dependency depth for each resource: the length of the longest
@@ -196,7 +189,7 @@ fn topological_sort(
         let mut depth_cache: HashMap<String, usize> = HashMap::new();
         fn compute_depth(
             binding: &str,
-            binding_to_resource: &HashMap<String, &ManagedResource>,
+            binding_to_resource: &HashMap<String, &Resource>,
             cache: &mut HashMap<String, usize>,
             visiting: &mut HashSet<String>,
         ) -> usize {
@@ -261,11 +254,11 @@ fn topological_sort(
     let mut visiting: Vec<String> = Vec::new();
 
     fn visit<'a>(
-        resource: &'a ManagedResource,
-        binding_to_resource: &HashMap<String, &'a ManagedResource>,
+        resource: &'a Resource,
+        binding_to_resource: &HashMap<String, &'a Resource>,
         visited: &mut HashSet<String>,
         visiting: &mut Vec<String>,
-        sorted: &mut Vec<ManagedResource>,
+        sorted: &mut Vec<Resource>,
     ) -> Result<(), String> {
         let binding_name = resource
             .binding
@@ -318,7 +311,7 @@ fn topological_sort(
 
 /// Build a reverse dependency map: for each binding, which bindings depend on it.
 /// If resource A depends on resource B, then `dependents_map["b"]` contains "a".
-pub fn build_dependents_map(resources: &[&ManagedResource]) -> HashMap<String, HashSet<String>> {
+pub fn build_dependents_map(resources: &[&Resource]) -> HashMap<String, HashSet<String>> {
     let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
     for resource in resources {
         let binding = resource
@@ -347,7 +340,7 @@ pub fn find_failed_dependency(
     // dependency set is assembled from the `ResourceLike` view (value
     // refs + `dependency_bindings`) plus the effect's explicit
     // `depends_on` edges — the same union `get_resource_dependencies`
-    // computes for a legacy `ManagedResource`.
+    // computes for a legacy `Resource`.
     let resource = effect.resource_like()?;
     let mut deps = get_resource_value_ref_dependencies(resource);
     deps.extend(effect.explicit_dependencies());
@@ -379,10 +372,10 @@ pub fn find_failed_dependent<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{Directives, ManagedResource, ResourceId, Value};
+    use crate::resource::{Directives, Resource, ResourceId, Value};
 
-    fn make_resource(binding: &str, deps: &[&str]) -> ManagedResource {
-        let mut r = ManagedResource::new("test", binding);
+    fn make_resource(binding: &str, deps: &[&str]) -> Resource {
+        let mut r = Resource::new("test", binding);
         r.binding = Some(binding.to_string());
         for dep in deps {
             r.set_attr(
@@ -441,7 +434,7 @@ mod tests {
     }
 
     // Closure-in-attribute regression test deleted: `Value::Closure` no
-    // longer exists, so a closure can never reach `ManagedResource.attributes`.
+    // longer exists, so a closure can never reach `Resource.attributes`.
     // The original concern (refs inside captured args getting silently
     // dropped from dependency walks) is now type-impossible.
 
@@ -456,7 +449,7 @@ mod tests {
     /// "tgw" makes deps non-empty, the fallback is skipped, and "tgw_attach" is lost.
     #[test]
     fn test_dependency_bindings_merged_when_resourceref_partially_resolved() {
-        let mut resource = ManagedResource::new("ec2.route", "my-route");
+        let mut resource = Resource::new("ec2.route", "my-route");
         // After partial resolution: transit_gateway_id resolved to a ResourceRef
         // pointing at "tgw" (the transitive target), not "tgw_attach" (the direct dep)
         resource.set_attr(
@@ -508,7 +501,7 @@ mod tests {
         // A depends on B
         let a = make_resource("a", &["b"]);
         let b = make_resource("b", &[]);
-        let resources: Vec<&ManagedResource> = vec![&a, &b];
+        let resources: Vec<&Resource> = vec![&a, &b];
 
         let map = build_dependents_map(&resources);
 
@@ -670,7 +663,7 @@ mod tests {
         //
         // Test with multiple input orderings to ensure the result is correct
         // regardless of declaration order in the .crn file.
-        let orderings: Vec<Vec<ManagedResource>> = vec![
+        let orderings: Vec<Vec<Resource>> = vec![
             // Original .crn order
             vec![
                 vpc.clone(),
@@ -960,7 +953,7 @@ mod tests {
 
     #[test]
     fn directives_depends_on_is_unioned_into_resource_dependencies() {
-        let mut bucket = ManagedResource::new("s3.Bucket", "bucket");
+        let mut bucket = Resource::new("s3.Bucket", "bucket");
         bucket.directives.depends_on = vec!["role".to_string()];
 
         let deps = get_resource_dependencies(&bucket);
@@ -973,7 +966,7 @@ mod tests {
 
     #[test]
     fn directives_depends_on_unions_with_value_refs() {
-        let mut bucket = ManagedResource::new("s3.Bucket", "bucket");
+        let mut bucket = Resource::new("s3.Bucket", "bucket");
         bucket.set_attr(
             "encryption_key".to_string(),
             Value::resource_ref("key", "arn", vec![]),

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -379,7 +379,7 @@ pub fn build_detail_rows(
     }
 
     // carina#3181: `Effect` payloads are typestate structs — the
-    // managed variants carry `ManagedResource`, `Read` carries a
+    // managed variants carry `Resource`, `Read` carries a
     // `DataSource`. Schema lookup routes through the matching
     // `get_for` / `get_for_data_source` registry method.
     match effect {
@@ -572,7 +572,7 @@ fn build_expanded_tags_row(
 
 fn build_update_rows(
     from: &crate::resource::State,
-    to: &crate::resource::ManagedResource,
+    to: &crate::resource::Resource,
     changed_attributes: &[String],
     schema: Option<&ResourceSchema>,
     detail: DetailLevel,
@@ -731,7 +731,7 @@ fn build_update_rows(
 #[allow(clippy::too_many_arguments)]
 fn build_replace_rows(
     from: &crate::resource::State,
-    to: &crate::resource::ManagedResource,
+    to: &crate::resource::Resource,
     changed_create_only: &[String],
     cascading_updates: &[crate::effect::CascadingUpdate],
     temporary_name: &Option<crate::effect::TemporaryName>,
@@ -1513,7 +1513,7 @@ fn value_references_binding(value: &Value, binding: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{ManagedResource, ResourceId, State};
+    use crate::resource::{Resource, ResourceId, State};
     use std::collections::HashSet;
 
     #[test]
@@ -1539,7 +1539,7 @@ mod tests {
 
     #[test]
     fn test_names_only_returns_empty() {
-        let resource = ManagedResource::new("s3.Bucket", "my-bucket");
+        let resource = Resource::new("s3.Bucket", "my-bucket");
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::NamesOnly, None, None);
         assert!(rows.is_empty());
@@ -1547,7 +1547,7 @@ mod tests {
 
     #[test]
     fn test_create_basic_attributes() {
-        let resource = ManagedResource::new("s3.Bucket", "my-bucket")
+        let resource = Resource::new("s3.Bucket", "my-bucket")
             .with_attribute(
                 "bucket",
                 Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -1574,7 +1574,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
+        let to = Resource::new("s3.Bucket", "my-bucket").with_attribute(
             "versioning",
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         );
@@ -1611,7 +1611,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("s3.Bucket", "my-bucket")
+        let to = Resource::new("s3.Bucket", "my-bucket")
             .with_attribute(
                 "name",
                 Value::Concrete(ConcreteValue::String("test".to_string())),
@@ -1665,7 +1665,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("s3.Bucket", "my-bucket")
+        let to = Resource::new("s3.Bucket", "my-bucket")
             .with_attribute(
                 "authored",
                 Value::Concrete(ConcreteValue::String("a".to_string())),
@@ -1765,7 +1765,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
+        let to = Resource::new("s3.Bucket", "my-bucket").with_attribute(
             "name",
             Value::Concrete(ConcreteValue::String("test".to_string())),
         );
@@ -1791,7 +1791,7 @@ mod tests {
             "Environment".to_string(),
             Value::Concrete(ConcreteValue::String("prod".to_string())),
         );
-        let resource = ManagedResource::new("s3.Bucket", "my-bucket")
+        let resource = Resource::new("s3.Bucket", "my-bucket")
             .with_attribute("tags", Value::Concrete(ConcreteValue::Map(tags)));
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -1854,7 +1854,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::Map(statement2.clone())),
             ])),
         );
-        let resource = ManagedResource::new("iam.RolePolicy", "test").with_attribute(
+        let resource = Resource::new("iam.RolePolicy", "test").with_attribute(
             "policy_document",
             Value::Concrete(ConcreteValue::Map(policy)),
         );
@@ -1999,7 +1999,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("ec2.Vpc", "my-vpc").with_attribute(
+        let to = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
@@ -2068,7 +2068,7 @@ mod tests {
             "effect".to_string(),
             Value::Concrete(ConcreteValue::String("Allow".to_string())),
         );
-        let resource = ManagedResource::new("iam.RolePolicy", "test").with_attribute(
+        let resource = Resource::new("iam.RolePolicy", "test").with_attribute(
             "statement",
             Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
                 ConcreteValue::Map(entry),
@@ -2096,7 +2096,7 @@ mod tests {
 
     #[test]
     fn create_row_scalar_attribute_unchanged() {
-        let resource = ManagedResource::new("iam.Role", "test").with_attribute(
+        let resource = Resource::new("iam.Role", "test").with_attribute(
             "role_name",
             Value::Concrete(ConcreteValue::String("foo".to_string())),
         );
@@ -2115,7 +2115,7 @@ mod tests {
     fn create_row_list_of_strings_emits_pretty_attribute() {
         // list-of-string must route through PrettyAttribute so
         // format_value_pretty's 80-col threshold can apply.
-        let resource = ManagedResource::new("iam.Role", "test").with_attribute(
+        let resource = Resource::new("iam.Role", "test").with_attribute(
             "managed_policy_arns",
             Value::Concrete(ConcreteValue::List(vec![
                 Value::Concrete(ConcreteValue::String(
@@ -2150,7 +2150,7 @@ mod tests {
         // Pins down `tags = []` behavior — a regression that re-introduces
         // an `!items.is_empty()` guard would silently bypass the routing
         // for empty lists, breaking the formatting-path uniformity.
-        let resource = ManagedResource::new("iam.Role", "test")
+        let resource = Resource::new("iam.Role", "test")
             .with_attribute("tags", Value::Concrete(ConcreteValue::List(vec![])));
         let effect = Effect::Create(resource);
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -2256,7 +2256,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("iam.Role", "r").with_attribute(
+        let to = Resource::new("iam.Role", "r").with_attribute(
             "policy",
             iam_policy_value(
                 ConcreteValue::String("Allow".to_string()),
@@ -2300,7 +2300,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("iam.Role", "r")
+        let to = Resource::new("iam.Role", "r")
             .with_attribute(
                 "policy",
                 iam_policy_value(
@@ -2349,7 +2349,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("iam.Role", "r").with_attribute(
+        let to = Resource::new("iam.Role", "r").with_attribute(
             "policy",
             iam_policy_value(
                 ConcreteValue::String("Allow".to_string()),
@@ -2389,7 +2389,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("iam.Role", "r").with_attribute(
+        let to = Resource::new("iam.Role", "r").with_attribute(
             "policy",
             iam_policy_value(
                 ConcreteValue::String("Allow".to_string()),
@@ -2458,7 +2458,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("x.Thing", "t")
+        let to = Resource::new("x.Thing", "t")
             .with_attribute("modes", mk(ConcreteValue::String("On".to_string())));
         let effect = Effect::Update {
             id: ResourceId::new("x.Thing", "t"),
@@ -2493,7 +2493,7 @@ mod tests {
         );
         // Desired flips effect to the API-canonical `Deny` — a real
         // change, not a spelling alias of `allow`.
-        let to = ManagedResource::new("iam.Role", "r").with_attribute(
+        let to = Resource::new("iam.Role", "r").with_attribute(
             "policy",
             iam_policy_value(
                 ConcreteValue::String("Deny".to_string()),
@@ -2545,7 +2545,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("iam.Role", "r")
+        let to = Resource::new("iam.Role", "r")
             .with_attribute(
                 "policy",
                 iam_policy_value(
@@ -2650,8 +2650,8 @@ mod tests {
                 .into_iter()
                 .collect(),
         );
-        let to = ManagedResource::new("x.Thing", "t")
-            .with_attribute("modes", enum_list(&["Allow", "Deny"]));
+        let to =
+            Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
         let effect = Effect::Update {
             id: ResourceId::new("x.Thing", "t"),
             from: Box::new(from),
@@ -2851,7 +2851,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("x.Thing", "t").with_attribute(
+        let to = Resource::new("x.Thing", "t").with_attribute(
             "tags",
             Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
                 ConcreteValue::String("only-one".to_string()),
@@ -2894,7 +2894,7 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let to = ManagedResource::new("x.Thing", "t").with_attribute(
+        let to = Resource::new("x.Thing", "t").with_attribute(
             "password",
             Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
                 ConcreteValue::String("new-secret".to_string()),
@@ -3105,8 +3105,8 @@ mod tests {
                 .into_iter()
                 .collect(),
         );
-        let to = ManagedResource::new("x.Thing", "t")
-            .with_attribute("modes", enum_list(&["Allow", "Deny"]));
+        let to =
+            Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
         let effect = Effect::Update {
             id: ResourceId::new("x.Thing", "t"),
             from: Box::new(from),

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -11,14 +11,14 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -115,14 +115,14 @@ fn cascade_skips_resources_already_in_plan() {
     let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -204,14 +204,14 @@ fn cascade_no_op_without_create_before_destroy() {
 
     let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
 
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -263,21 +263,21 @@ fn cascade_transitive_dependencies() {
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
     let instance_id = ResourceId::new("ec2.Instance", "my-instance");
 
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         );
 
-    let instance = ManagedResource::new("ec2.Instance", "my-instance")
+    let instance = Resource::new("ec2.Instance", "my-instance")
         .with_binding("instance")
         .with_attribute(
             "subnet_id",
@@ -362,7 +362,7 @@ fn cascade_anonymous_resource_dependent() {
     let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -370,7 +370,7 @@ fn cascade_anonymous_resource_dependent() {
         );
 
     // Anonymous subnet (no _binding) with a ResourceRef to the VPC
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet").with_attribute(
+    let subnet = Resource::new("ec2.Subnet", "my-subnet").with_attribute(
         "vpc_id",
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
@@ -449,14 +449,14 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -605,14 +605,14 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -762,14 +762,14 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -879,14 +879,14 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -1015,14 +1015,14 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
     let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let mut subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let mut subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -1134,14 +1134,14 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
     let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
     let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
 
-    let vpc = ManagedResource::new("ec2.Vpc", "my-vpc")
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let mut subnet = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let mut subnet = Resource::new("ec2.Subnet", "my-subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -133,7 +133,7 @@ fn type_aware_diff_no_change_with_schema() {
         AttributeSchema::new("port", AttributeType::Float),
     );
 
-    let desired = ManagedResource::new("test.resource", "test")
+    let desired = Resource::new("test.resource", "test")
         .with_attribute("port", Value::Concrete(ConcreteValue::Int(443)));
 
     let mut current_attrs = HashMap::new();
@@ -1079,7 +1079,7 @@ fn carina3080_principal_scalar_vs_singleton_is_no_change_via_pipeline() {
             "cloudfront.amazonaws.com".to_string(),
         )),
     );
-    let mut resources = vec![ManagedResource::new("iam.policy", "p1").with_attribute(
+    let mut resources = vec![Resource::new("iam.policy", "p1").with_attribute(
         "principal",
         Value::Concrete(ConcreteValue::Map(desired_inner)),
     )];
@@ -1261,7 +1261,7 @@ fn carina3122_cloudfront_allowed_methods_set_is_no_change_via_pipeline() {
         Value::Concrete(ConcreteValue::Map(desired_dcb)),
     );
     let mut resources = vec![
-        ManagedResource::new("cloudfront.Distribution", "d1").with_attribute(
+        Resource::new("cloudfront.Distribution", "d1").with_attribute(
             "distribution_config",
             Value::Concrete(ConcreteValue::Map(desired_dc)),
         ),
@@ -1468,7 +1468,7 @@ fn carina3122_cloudfront_allowed_methods_ordered_list_does_change_via_pipeline()
     };
 
     let mut resources = vec![
-        ManagedResource::new("cloudfront.Distribution", "d1")
+        Resource::new("cloudfront.Distribution", "d1")
             .with_attribute("distribution_config", dcb("get", "head")),
     ];
     resources[0].id.provider = "awscc".to_string();

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 
 #[test]
 fn diff_create_when_not_exists() {
-    let desired = ManagedResource::new("bucket", "test");
+    let desired = Resource::new("bucket", "test");
     let current = State::not_found(ResourceId::new("bucket", "test"));
 
     let result = diff(&desired, &current, None, None, None);
@@ -14,7 +14,7 @@ fn diff_create_when_not_exists() {
 
 #[test]
 fn diff_no_change_when_same() {
-    let desired = ManagedResource::new("bucket", "test").with_attribute(
+    let desired = Resource::new("bucket", "test").with_attribute(
         "region",
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
@@ -32,7 +32,7 @@ fn diff_no_change_when_same() {
 
 #[test]
 fn diff_update_when_different() {
-    let desired = ManagedResource::new("bucket", "test").with_attribute(
+    let desired = Resource::new("bucket", "test").with_attribute(
         "region",
         Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
     );
@@ -58,8 +58,8 @@ fn diff_update_when_different() {
 #[test]
 fn create_plan_from_resources() {
     let resources = vec![
-        ManagedResource::new("bucket", "new-bucket"),
-        ManagedResource::new("bucket", "existing-bucket")
+        Resource::new("bucket", "new-bucket"),
+        Resource::new("bucket", "existing-bucket")
             .with_attribute("versioning", Value::Concrete(ConcreteValue::Bool(true))),
     ];
 
@@ -101,7 +101,7 @@ fn create_plan_with_read_only_resource() {
             Value::Concrete(ConcreteValue::String("existing-bucket".to_string())),
         ),
     ];
-    let resources = vec![ManagedResource::new("bucket", "new-bucket")];
+    let resources = vec![Resource::new("bucket", "new-bucket")];
 
     let current_states = HashMap::new();
     let plan = create_plan(
@@ -152,7 +152,7 @@ fn diff_update_when_list_of_maps_changed() {
         Value::Concrete(ConcreteValue::Int(443)),
     );
 
-    let desired = ManagedResource::new("ec2_security_group", "test-sg").with_attribute(
+    let desired = Resource::new("ec2_security_group", "test-sg").with_attribute(
         "security_group_ingress",
         Value::Concrete(ConcreteValue::List(vec![
             Value::Concrete(ConcreteValue::Map(ingress1.clone())),
@@ -190,7 +190,7 @@ fn diff_update_when_list_of_maps_changed() {
 fn create_plan_detects_orphaned_resources_for_deletion() {
     // A resource exists in current_states but NOT in desired list
     // create_plan() should generate a Delete effect for it
-    let desired = vec![ManagedResource::new("bucket", "keep-this")];
+    let desired = vec![Resource::new("bucket", "keep-this")];
 
     let mut current_states = HashMap::new();
     // "keep-this" exists and matches
@@ -283,7 +283,7 @@ fn read_only_resource_always_generates_read_effect() {
 #[test]
 fn no_false_update_without_name_attribute() {
     // Simulate AWSCC resource: desired has cidr_block but no "name"
-    let desired = ManagedResource::new("ec2.Vpc", "vpc").with_attribute(
+    let desired = Resource::new("ec2.Vpc", "vpc").with_attribute(
         "cidr_block",
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
@@ -308,7 +308,7 @@ fn no_false_update_without_name_attribute() {
 fn replace_when_create_only_attr_changed() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let resources = vec![ManagedResource::new("ec2.Vpc", "my-vpc").with_attribute(
+    let resources = vec![Resource::new("ec2.Vpc", "my-vpc").with_attribute(
         "cidr_block",
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     )];
@@ -360,7 +360,7 @@ fn replace_when_create_only_attr_changed() {
 fn normal_update_when_non_create_only_attr_changed() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let resources = vec![ManagedResource::new("ec2.Vpc", "my-vpc").with_attribute(
+    let resources = vec![Resource::new("ec2.Vpc", "my-vpc").with_attribute(
         "enable_dns_support",
         Value::Concrete(ConcreteValue::Bool(true)),
     )];
@@ -412,9 +412,9 @@ fn normal_update_when_non_create_only_attr_changed() {
 fn replace_when_schema_force_replace() {
     use crate::schema::AttributeType;
 
-    // ManagedResource has changed attributes but NO create-only attributes
+    // Resource has changed attributes but NO create-only attributes
     let resources = vec![
-        ManagedResource::new("ec2.internet_gateway", "my-igw").with_attribute(
+        Resource::new("ec2.internet_gateway", "my-igw").with_attribute(
             "tags",
             Value::Concrete(ConcreteValue::Map(
                 vec![(
@@ -482,7 +482,7 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
     use crate::schema::{AttributeSchema, AttributeType};
 
     let resources = vec![
-        ManagedResource::new("ec2.Vpc", "my-vpc")
+        Resource::new("ec2.Vpc", "my-vpc")
             .with_attribute(
                 "cidr_block",
                 Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
@@ -547,7 +547,7 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
 fn replace_carries_create_before_destroy_directives() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let mut resource = ManagedResource::new("ec2.Vpc", "my-vpc").with_attribute(
+    let mut resource = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
         "cidr_block",
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     );
@@ -630,7 +630,7 @@ fn diff_no_change_when_list_of_maps_reordered() {
     );
 
     // Desired: [rule1, rule2]
-    let desired = ManagedResource::new("ec2_security_group", "test-sg").with_attribute(
+    let desired = Resource::new("ec2_security_group", "test-sg").with_attribute(
         "security_group_egress",
         Value::Concrete(ConcreteValue::List(vec![
             Value::Concrete(ConcreteValue::Map(rule1.clone())),
@@ -667,7 +667,7 @@ fn replace_with_provider_prefixed_schema_key() {
     // In production, schemas are keyed by "awscc.ec2.Vpc" but resource_type is "ec2.Vpc"
     // The resource must have provider set so the generic lookup works
     let resources = vec![
-        ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_attribute(
+        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         ),
@@ -719,7 +719,7 @@ fn replace_with_provider_prefixed_schema_key() {
 /// current (AWS) returns 3, saved state has 3. Should be NoChange.
 #[test]
 fn diff_no_change_when_struct_has_extra_fields_with_saved() {
-    let desired = ManagedResource::new("ec2.Subnet", "test-subnet").with_attribute(
+    let desired = Resource::new("ec2.Subnet", "test-subnet").with_attribute(
         "private_dns_name_options_on_launch",
         Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
@@ -782,7 +782,7 @@ fn diff_no_change_when_struct_has_extra_fields_with_saved() {
 /// When an unmanaged field drifts externally, diff should still detect the change.
 #[test]
 fn diff_detects_drift_on_unmanaged_field() {
-    let desired = ManagedResource::new("ec2.Subnet", "test-subnet").with_attribute(
+    let desired = Resource::new("ec2.Subnet", "test-subnet").with_attribute(
         "private_dns_name_options_on_launch",
         Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
@@ -848,7 +848,7 @@ fn diff_detects_drift_on_unmanaged_field() {
 /// After merge + semantic comparison, this should be NoChange.
 #[test]
 fn diff_no_change_when_bare_struct_with_extra_fields() {
-    let desired = ManagedResource::new("ec2.Subnet", "test-subnet").with_attribute(
+    let desired = Resource::new("ec2.Subnet", "test-subnet").with_attribute(
         "private_dns_name_options_on_launch",
         Value::Concrete(ConcreteValue::Map(IndexMap::from([
             (
@@ -915,7 +915,7 @@ fn diff_works_without_saved_state() {
     // Desired has 2 fields, current has 3 (extra field). Without saved state,
     // this should still be NoChange because find_changed_attributes only checks
     // desired keys against current (not the other direction).
-    let desired = ManagedResource::new("ec2.Subnet", "test-subnet").with_attribute(
+    let desired = Resource::new("ec2.Subnet", "test-subnet").with_attribute(
         "opts",
         Value::Concrete(ConcreteValue::Map(IndexMap::from([
             ("a".to_string(), Value::Concrete(ConcreteValue::Int(1))),
@@ -1053,7 +1053,7 @@ fn diff_no_change_for_struct_list_with_saved_state_egress_rules() {
 
     // Desired state (post-normalization, post-alias-resolution)
     // "all" -> "-1" (alias resolved), "tcp" stays as namespaced identifier
-    let desired = ManagedResource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None)
+    let desired = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None)
         .with_attribute(
             "security_group_egress",
             Value::Concrete(ConcreteValue::List(vec![
@@ -1303,7 +1303,7 @@ fn diff_false_positive_when_ordered_true_for_struct_list() {
         ),
     ])));
 
-    let desired = ManagedResource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None)
+    let desired = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None)
         .with_attribute(
             "security_group_egress",
             Value::Concrete(ConcreteValue::List(vec![item_a.clone(), item_b.clone()])),
@@ -1384,7 +1384,7 @@ fn diff_no_change_for_compound_word_dsl_alias() {
 
     // Desired: API-canonical bare spelling (output of pass-2 in
     // AwsNormalizer::resolve_enum_identifiers).
-    let desired = ManagedResource::with_provider("aws", "s3.BucketOwnershipControls", "test", None)
+    let desired = Resource::with_provider("aws", "s3.BucketOwnershipControls", "test", None)
         .with_attribute(
             "object_ownership",
             Value::Concrete(ConcreteValue::String("BucketOwnerEnforced".to_string())),

--- a/carina-core/src/differ/mod.rs
+++ b/carina-core/src/differ/mod.rs
@@ -8,7 +8,7 @@ mod plan;
 
 use std::collections::HashMap;
 
-use crate::resource::{ManagedResource, ResourceId, State, Value};
+use crate::resource::{Resource, ResourceId, State, Value};
 use crate::schema::ResourceSchema;
 
 pub use plan::{cascade_dependent_updates, create_plan};
@@ -34,18 +34,18 @@ pub(crate) use comparison::type_aware_equal;
 /// Result of a diff operation
 #[derive(Debug, Clone, PartialEq)]
 pub enum Diff {
-    /// ManagedResource does not exist -> needs creation
-    Create(ManagedResource),
-    /// ManagedResource exists with differences -> needs update
+    /// Resource does not exist -> needs creation
+    Create(Resource),
+    /// Resource exists with differences -> needs update
     Update {
         id: ResourceId,
         from: Box<State>,
-        to: ManagedResource,
+        to: Resource,
         changed_attributes: Vec<String>,
     },
-    /// ManagedResource exists with no differences -> no action needed
+    /// Resource exists with no differences -> no action needed
     NoChange(ResourceId),
-    /// ManagedResource exists but not in desired state -> needs deletion
+    /// Resource exists but not in desired state -> needs deletion
     Delete(ResourceId),
 }
 
@@ -67,7 +67,7 @@ impl Diff {
 /// If `schema` is provided, type-aware comparison is used (e.g., Int/Float coercion,
 /// case-insensitive enum matching).
 pub fn diff(
-    desired: &ManagedResource,
+    desired: &Resource,
     current: &State,
     saved: Option<&HashMap<String, Value>>,
     prev_explicit: Option<&crate::explicit::ExplicitFields>,

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -8,7 +8,7 @@ use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
 use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, Directives, ManagedResource, ResourceId, State, Value,
+    ConcreteValue, DataSource, DeferredValue, Directives, Resource, ResourceId, State, Value,
 };
 use crate::schema::{
     ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
@@ -51,7 +51,7 @@ fn find_changed_create_only(
 fn filter_non_removable_removals(
     provider: &str,
     resource_type: &str,
-    to: &ManagedResource,
+    to: &Resource,
     changed_attributes: Vec<String>,
     registry: &SchemaRegistry,
 ) -> Vec<String> {
@@ -85,7 +85,7 @@ fn filter_non_removable_removals(
 /// the resource already uses name_prefix for that attribute, or
 /// the name_attribute value changed between `from` and `to`).
 fn generate_temporary_name(
-    resource: &ManagedResource,
+    resource: &Resource,
     from: &State,
     schema: &ResourceSchema,
 ) -> Option<TemporaryName> {
@@ -130,7 +130,7 @@ fn generate_temporary_name(
 ///
 /// The `directives_map` provides Carina-side directives for orphaned
 /// resources (resources in state but not in desired). For desired
-/// resources, the directives are read directly from the `ManagedResource`
+/// resources, the directives are read directly from the `Resource`
 /// struct.
 ///
 /// The `saved_attrs` map provides the last-known attribute values from the state file.
@@ -171,7 +171,7 @@ fn generate_temporary_name(
 /// ```
 #[allow(clippy::too_many_arguments)]
 pub fn create_plan(
-    managed: &[ManagedResource],
+    managed: &[Resource],
     data_sources: &[DataSource],
     current_states: &HashMap<ResourceId, State>,
     directives_map: &HashMap<ResourceId, Directives>,
@@ -370,7 +370,7 @@ pub fn create_plan(
             let dependencies = if let Some(dep_bindings) = orphan_dependencies.get(id) {
                 dep_bindings.iter().cloned().collect()
             } else {
-                let temp_resource = ManagedResource {
+                let temp_resource = Resource {
                     id: id.clone(),
                     // `state.attributes` is `HashMap` — no source order
                     // survives round-tripping through the provider. The
@@ -551,14 +551,14 @@ pub fn create_plan(
 /// `registry` provides attribute metadata to detect create-only attributes.
 pub fn cascade_dependent_updates(
     plan: &mut Plan,
-    unresolved_managed: &[ManagedResource],
+    unresolved_managed: &[Resource],
     current_states: &HashMap<ResourceId, State>,
     registry: &SchemaRegistry,
 ) {
     // Build binding/key -> unresolved resource mapping.
     // Uses the same key logic as the dependent lookup below so anonymous resources
     // (without _binding) are also found.
-    let mut binding_to_unresolved: HashMap<String, &ManagedResource> = HashMap::new();
+    let mut binding_to_unresolved: HashMap<String, &Resource> = HashMap::new();
     for resource in unresolved_managed {
         let key = resource
             .binding

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -22,7 +22,7 @@ fn explicit_top_level(keys: &[&str]) -> ExplicitFields {
 fn create_before_destroy_generates_temporary_name_for_name_attribute() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let mut resource = ManagedResource::new("s3.Bucket", "my-bucket")
+    let mut resource = Resource::new("s3.Bucket", "my-bucket")
         .with_attribute(
             "bucket_name",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -107,7 +107,7 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
 fn create_before_destroy_generates_temporary_name_with_can_rename() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let mut resource = ManagedResource::new("logs.LogGroup", "my-log-group")
+    let mut resource = Resource::new("logs.LogGroup", "my-log-group")
         .with_attribute(
             "log_group_name".to_string(),
             Value::Concrete(ConcreteValue::String("my-log-group".to_string())),
@@ -178,7 +178,7 @@ fn no_temporary_name_without_create_before_destroy() {
 
     // Default directives (create_before_destroy = false)
     let resources = vec![
-        ManagedResource::new("s3.Bucket", "my-bucket")
+        Resource::new("s3.Bucket", "my-bucket")
             .with_attribute(
                 "bucket_name",
                 Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -243,7 +243,7 @@ fn no_temporary_name_without_create_before_destroy() {
 fn no_temporary_name_when_name_prefix_is_used() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let mut resource = ManagedResource::new("s3.Bucket", "my-bucket")
+    let mut resource = Resource::new("s3.Bucket", "my-bucket")
         .with_attribute(
             "bucket_name",
             Value::Concrete(ConcreteValue::String("my-app-abc12345".to_string())),
@@ -314,7 +314,7 @@ fn no_temporary_name_when_name_prefix_is_used() {
 fn no_temporary_name_without_name_attribute_in_schema() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let mut resource = ManagedResource::new("ec2.Vpc", "my-vpc").with_attribute(
+    let mut resource = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
         "cidr_block",
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     );
@@ -371,7 +371,7 @@ fn no_temporary_name_when_name_attribute_changes() {
 
     // name_attribute itself changed: old-bucket → new-bucket
     // No temporary name needed since names are already different
-    let mut resource = ManagedResource::new("s3.Bucket", "my-bucket")
+    let mut resource = Resource::new("s3.Bucket", "my-bucket")
         .with_attribute(
             "bucket_name",
             Value::Concrete(ConcreteValue::String("new-bucket".to_string())),
@@ -437,7 +437,7 @@ fn no_temporary_name_when_name_attribute_changes() {
 #[test]
 fn diff_detects_attribute_removal_with_prev_desired_keys() {
     // User previously had "region" and "tags" in .crn, now only has "region"
-    let desired = ManagedResource::new("s3.Bucket", "test").with_attribute(
+    let desired = Resource::new("s3.Bucket", "test").with_attribute(
         "region",
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
@@ -478,7 +478,7 @@ fn diff_detects_attribute_removal_with_prev_desired_keys() {
 fn diff_ignores_attributes_not_in_prev_desired_keys() {
     // Current state has "arn" and "region" from provider, but user only ever
     // specified "region" — "arn" was never in prev_desired_keys
-    let desired = ManagedResource::new("s3.Bucket", "test");
+    let desired = Resource::new("s3.Bucket", "test");
 
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
@@ -533,7 +533,7 @@ fn server_default_struct_field_does_not_appear_in_diff() {
             Value::Concrete(ConcreteValue::Map(rule))
         }])),
     );
-    let desired = ManagedResource::new("s3.Bucket", "test").with_attribute(
+    let desired = Resource::new("s3.Bucket", "test").with_attribute(
         "lifecycle_configuration",
         Value::Concrete(ConcreteValue::Map(desired_lc.clone())),
     );
@@ -586,7 +586,7 @@ fn explicit_top_level_removal_still_detected() {
     // gone from desired but still authored in prev_explicit) must
     // still produce an Update. This is the existing "explicit unset"
     // mechanism; the projection logic must not regress it.
-    let desired = ManagedResource::new("s3.Bucket", "test");
+    let desired = Resource::new("s3.Bucket", "test");
 
     let mut current_attrs = HashMap::new();
     current_attrs.insert(
@@ -618,7 +618,7 @@ fn explicit_top_level_removal_still_detected() {
 #[test]
 fn diff_no_change_without_prev_desired_keys() {
     // Without prev_desired_keys, removed attributes should NOT be detected
-    let desired = ManagedResource::new("s3.Bucket", "test").with_attribute(
+    let desired = Resource::new("s3.Bucket", "test").with_attribute(
         "region",
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
@@ -647,9 +647,9 @@ fn diff_no_change_without_prev_desired_keys() {
 
 #[test]
 fn create_plan_detects_attribute_removal() {
-    // ManagedResource in .crn has no "tags", but current state (from AWS) has tags.
+    // Resource in .crn has no "tags", but current state (from AWS) has tags.
     // prev_desired_keys indicates user previously had "region" and "tags".
-    let resources = vec![ManagedResource::new("s3.Bucket", "test").with_attribute(
+    let resources = vec![Resource::new("s3.Bucket", "test").with_attribute(
         "region",
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     )];
@@ -703,7 +703,7 @@ fn create_plan_filters_non_removable_attribute_removal() {
     use crate::schema::{AttributeSchema, AttributeType};
     // When schema is available, only removable attributes should trigger removal.
     // "region" is not removable, "tags" is removable.
-    let resources = vec![ManagedResource::new("s3.Bucket", "test").with_attribute(
+    let resources = vec![Resource::new("s3.Bucket", "test").with_attribute(
         "region",
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     )];
@@ -780,7 +780,7 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
     use crate::schema::{AttributeSchema, AttributeType};
     // When the only "change" is a non-removable attribute removal,
     // the plan should have no effects (no spurious Update).
-    let resources = vec![ManagedResource::new("s3.Bucket", "test").with_attribute(
+    let resources = vec![Resource::new("s3.Bucket", "test").with_attribute(
         "bucket",
         Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     )];
@@ -837,7 +837,7 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
 #[test]
 fn diff_skips_internal_attributes_in_removal_detection() {
     // prev_desired_keys includes "_internal" but it should be skipped
-    let desired = ManagedResource::new("s3.Bucket", "test").with_attribute(
+    let desired = Resource::new("s3.Bucket", "test").with_attribute(
         "region",
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
@@ -927,9 +927,9 @@ fn prevent_destroy_blocks_delete_for_orphaned_resource() {
 fn prevent_destroy_blocks_replace() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    // ManagedResource with prevent_destroy that has a create-only attribute change
+    // Resource with prevent_destroy that has a create-only attribute change
     // (which would normally trigger a Replace)
-    let mut resource = ManagedResource::new("ec2.Vpc", "my-vpc").with_attribute(
+    let mut resource = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
         "cidr_block",
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     );
@@ -989,9 +989,9 @@ fn prevent_destroy_blocks_replace() {
 
 #[test]
 fn prevent_destroy_does_not_block_update() {
-    // ManagedResource with prevent_destroy that has a normal (non-create-only) attribute change
+    // Resource with prevent_destroy that has a normal (non-create-only) attribute change
     // Updates don't destroy the resource, so they should be allowed
-    let mut resource = ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
+    let mut resource = Resource::new("s3.Bucket", "my-bucket").with_attribute(
         "versioning",
         Value::Concrete(ConcreteValue::String("Enabled".to_string())),
     );
@@ -1039,9 +1039,9 @@ fn prevent_destroy_does_not_block_update() {
 
 #[test]
 fn prevent_destroy_does_not_block_create() {
-    // ManagedResource with prevent_destroy that doesn't exist yet
+    // Resource with prevent_destroy that doesn't exist yet
     // Creates don't destroy anything, so they should be allowed
-    let mut resource = ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
+    let mut resource = Resource::new("s3.Bucket", "my-bucket").with_attribute(
         "bucket",
         Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
     );
@@ -1174,7 +1174,7 @@ fn prevent_destroy_collects_multiple_errors() {
 }
 
 // carina#3181: the former `virtual_resources_are_skipped_in_plan` test
-// is obsolete — `create_plan` now takes a `&[ManagedResource]` /
+// is obsolete — `create_plan` now takes a `&[Resource]` /
 // `&[DataSource]` pair, so a `VirtualResource` cannot be passed into the
 // plan input at all. The "virtuals produce no effect" invariant is now
 // enforced by the type system rather than a runtime skip.
@@ -1185,11 +1185,11 @@ fn wait_binding_lowers_to_wait_effect() {
     use crate::parser::{UntilPredicateAst, WaitBinding};
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
-    let cert = ManagedResource::new("acm.Certificate", "cert").with_binding("cert");
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
     // A downstream consumer that references the wait binding and is
     // itself a pending change (Create) — carina#3101: the wait is
     // emitted only when it gates a real downstream change.
-    let mut consumer = ManagedResource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    let mut consumer = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
     consumer
         .dependency_bindings
         .insert("cert_issued".to_string());
@@ -1265,10 +1265,10 @@ fn wait_uses_schema_default_timeout_when_omitted() {
     use crate::parser::{UntilPredicateAst, WaitBinding};
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let cert = ManagedResource::new("acm.Certificate", "cert").with_binding("cert");
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
     // Downstream consumer with a pending change so the wait gates
     // something (carina#3101).
-    let mut consumer = ManagedResource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    let mut consumer = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
     consumer
         .dependency_bindings
         .insert("cert_issued".to_string());
@@ -1325,7 +1325,7 @@ fn wait_uses_schema_default_timeout_when_omitted() {
 fn wait_with_unknown_target_emits_plan_error() {
     use crate::parser::{UntilPredicateAst, WaitBinding};
 
-    let resources: Vec<ManagedResource> = vec![];
+    let resources: Vec<Resource> = vec![];
 
     let wait = WaitBinding {
         binding: "cert_issued".into(),
@@ -1372,8 +1372,8 @@ fn wait_omitted_when_all_consumers_unchanged() {
     use crate::effect::Effect;
     use crate::parser::{UntilPredicateAst, WaitBinding};
 
-    let cert = ManagedResource::new("acm.Certificate", "cert").with_binding("cert");
-    let mut dist = ManagedResource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
+    let mut dist = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
     dist.dependency_bindings.insert("cert_issued".to_string());
     let resources = vec![cert, dist];
 
@@ -1437,9 +1437,9 @@ fn wait_emitted_when_a_consumer_has_a_pending_change() {
     use crate::effect::Effect;
     use crate::parser::{UntilPredicateAst, WaitBinding};
 
-    let cert = ManagedResource::new("acm.Certificate", "cert").with_binding("cert");
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
     // `dist` is new (absent from current_states) → Create → mutating.
-    let mut dist = ManagedResource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    let mut dist = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
     dist.dependency_bindings.insert("cert_issued".to_string());
     let resources = vec![cert, dist];
 

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::resource::{DataSource, Directives, ManagedResource, ResourceId, ResourceLike, State};
+use crate::resource::{DataSource, Directives, Resource, ResourceId, ResourceLike, State};
 use crate::wait::predicate::WaitPredicate;
 
 /// Temporary name used during create-before-destroy replacement.
@@ -37,7 +37,7 @@ pub struct TemporaryName {
 pub struct CascadingUpdate {
     pub id: ResourceId,
     pub from: Box<State>,
-    pub to: ManagedResource,
+    pub to: Resource,
 }
 
 /// How an [`Effect::Wait`] obtains the cloud provider identifier its
@@ -85,13 +85,13 @@ pub enum Effect {
     Read { resource: DataSource },
 
     /// Create a new resource
-    Create(ManagedResource),
+    Create(Resource),
 
     /// Update an existing resource
     Update {
         id: ResourceId,
         from: Box<State>,
-        to: ManagedResource,
+        to: Resource,
         /// Attribute names that changed (including removed attributes)
         changed_attributes: Vec<String>,
     },
@@ -100,7 +100,7 @@ pub enum Effect {
     Replace {
         id: ResourceId,
         from: Box<State>,
-        to: ManagedResource,
+        to: Resource,
         #[serde(default)]
         directives: Directives,
         /// Which create-only attributes forced the replacement
@@ -233,13 +233,13 @@ pub enum Effect {
 pub enum BasicEffect<'a> {
     Create {
         effect: &'a Effect,
-        resource: &'a ManagedResource,
+        resource: &'a Resource,
     },
     Update {
         effect: &'a Effect,
         id: &'a ResourceId,
         from: &'a State,
-        to: &'a ManagedResource,
+        to: &'a Resource,
         changed_attributes: &'a [String],
     },
     Delete {
@@ -284,8 +284,8 @@ impl Effect {
     ///
     /// ```compile_fail
     /// use carina_core::effect::{BasicEffect, Effect};
-    /// use carina_core::resource::ManagedResource;
-    /// let effect = Effect::Create(ManagedResource::new("test", "x"));
+    /// use carina_core::resource::Resource;
+    /// let effect = Effect::Create(Resource::new("test", "x"));
     /// // Was: a missed filter could pass a non-basic `&Effect` straight
     /// // into `execute_basic_effect` and trip `unreachable!()` at apply
     /// // time (carina#3164). The conversion no longer exists.
@@ -377,7 +377,7 @@ impl Effect {
     /// effects have no resource.
     ///
     /// carina#3181: the underlying payloads are typestate structs —
-    /// `Create`/`Update`/`Replace` carry a [`ManagedResource`], `Read`
+    /// `Create`/`Update`/`Replace` carry a [`Resource`], `Read`
     /// carries a [`DataSource`]. Callers that need a concrete type match
     /// the variant directly; this helper covers the shared
     /// id/attributes/binding/dependency_bindings accessors.
@@ -428,7 +428,7 @@ impl Effect {
     /// `directives { depends_on = [...] }` declarations**, as a snapshot
     /// (cloned).
     ///
-    /// For variants carrying a `ManagedResource` (Create, Update, Replace,
+    /// For variants carrying a `Resource` (Create, Update, Replace,
     /// Read), the answer is derived live from
     /// `resource.directives.depends_on`. For Delete the answer comes
     /// from a stored `explicit_dependencies` set captured by the differ
@@ -472,7 +472,7 @@ mod tests {
 
     #[test]
     fn create_is_mutating() {
-        let resource = ManagedResource::new("s3.Bucket", "my-bucket");
+        let resource = Resource::new("s3.Bucket", "my-bucket");
         let effect = Effect::Create(resource);
         assert!(effect.is_mutating());
     }
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn resource_returns_some_for_create() {
-        let resource = ManagedResource::new("s3.Bucket", "my-bucket");
+        let resource = Resource::new("s3.Bucket", "my-bucket");
         let effect = Effect::Create(resource.clone());
         assert_eq!(effect.resource_like().unwrap().id(), &resource.id);
     }
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn binding_name_returns_binding() {
-        let resource = ManagedResource::new("test", "my_binding").with_binding("my_binding");
+        let resource = Resource::new("test", "my_binding").with_binding("my_binding");
         let effect = Effect::Create(resource);
         assert_eq!(effect.binding_name(), Some("my_binding".to_string()));
     }
@@ -516,7 +516,7 @@ mod tests {
     #[test]
     fn binding_name_returns_none_without_binding() {
         use crate::resource::{ConcreteValue, Value};
-        let resource = ManagedResource::new("test", "no_binding").with_attribute(
+        let resource = Resource::new("test", "no_binding").with_attribute(
             "name",
             Value::Concrete(ConcreteValue::String("test".to_string())),
         );
@@ -530,7 +530,7 @@ mod tests {
         use std::collections::HashMap;
 
         let effects = vec![
-            Effect::Create(ManagedResource::new("s3.Bucket", "my-bucket")),
+            Effect::Create(Resource::new("s3.Bucket", "my-bucket")),
             Effect::Read {
                 resource: DataSource::new("s3.Bucket", "existing"),
             },
@@ -543,7 +543,7 @@ mod tests {
                         Value::Concrete(ConcreteValue::String("Disabled".to_string())),
                     )]),
                 )),
-                to: ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
+                to: Resource::new("s3.Bucket", "my-bucket").with_attribute(
                     "versioning",
                     Value::Concrete(ConcreteValue::String("Enabled".to_string())),
                 ),
@@ -558,18 +558,18 @@ mod tests {
                         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
                     )]),
                 )),
-                to: ManagedResource::new("ec2.Vpc", "my-vpc").with_attribute(
+                to: Resource::new("ec2.Vpc", "my-vpc").with_attribute(
                     "cidr_block",
                     Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
                 ),
                 directives: Directives::default(),
                 changed_create_only: vec!["cidr_block".to_string()],
                 // carina#3181 PR D: cover `CascadingUpdate.to:
-                // ManagedResource` in the serde round-trip.
+                // Resource` in the serde round-trip.
                 cascading_updates: vec![CascadingUpdate {
                     id: ResourceId::new("ec2.Subnet", "my-subnet"),
                     from: Box::new(State::not_found(ResourceId::new("ec2.Subnet", "my-subnet"))),
-                    to: ManagedResource::new("ec2.Subnet", "my-subnet").with_attribute(
+                    to: Resource::new("ec2.Subnet", "my-subnet").with_attribute(
                         "vpc_id",
                         Value::Concrete(ConcreteValue::String("vpc.id".to_string())),
                     ),
@@ -597,7 +597,7 @@ mod tests {
     #[test]
     fn explicit_dependencies_derived_from_resource_directives() {
         use crate::resource::Directives;
-        let mut bucket = ManagedResource::new("s3.Bucket", "b");
+        let mut bucket = Resource::new("s3.Bucket", "b");
         bucket.directives = Directives {
             depends_on: vec!["role".to_string(), "kms".to_string()],
             ..Directives::default()
@@ -779,7 +779,7 @@ mod tests {
         let rid = ResourceId::new("test", "x");
 
         // Basic variants must narrow.
-        let create = Effect::Create(ManagedResource::new("test", "x"));
+        let create = Effect::Create(Resource::new("test", "x"));
         assert!(matches!(
             create.as_basic(),
             Some(BasicEffect::Create { .. })
@@ -788,7 +788,7 @@ mod tests {
         let update = Effect::Update {
             id: rid.clone(),
             from: Box::new(ResState::not_found(rid.clone())),
-            to: ManagedResource::new("test", "x"),
+            to: Resource::new("test", "x"),
             changed_attributes: vec![],
         };
         assert!(matches!(
@@ -819,7 +819,7 @@ mod tests {
         let replace = Effect::Replace {
             id: rid.clone(),
             from: Box::new(ResState::not_found(rid.clone())),
-            to: ManagedResource::new("test", "x"),
+            to: Resource::new("test", "x"),
             directives: Directives::default(),
             changed_create_only: vec![],
             cascading_updates: vec![],

--- a/carina-core/src/eval_value.rs
+++ b/carina-core/src/eval_value.rs
@@ -1,7 +1,7 @@
 //! Evaluator-internal values.
 //!
 //! `Value` is the public, user-facing type that flows through `ParsedFile`,
-//! `ManagedResource.attributes`, plan display, state serialization, and the LSP.
+//! `Resource.attributes`, plan display, state serialization, and the LSP.
 //! Every variant of `Value` is something a `.crn` author can directly
 //! observe in their configuration.
 //!

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -12,7 +12,7 @@ use crate::provider::{
     build_update_patch,
 };
 use crate::resolver::resolve_ref_value;
-use crate::resource::{ConcreteValue, DeferredValue, ManagedResource, ResourceId, State, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};
 
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 
@@ -123,10 +123,10 @@ pub(super) async fn refresh_pending_states(
 /// that populate asynchronously (ACM `domain_validation_options`,
 /// CloudFront `domain_name`, etc.).
 pub(super) async fn resolve_resource(
-    resource: &ManagedResource,
+    resource: &Resource,
     bindings: &ResolvedBindings,
     pipeline: &RenormalizePipeline<'_>,
-) -> Result<ManagedResource, String> {
+) -> Result<Resource, String> {
     let mut resolved = resource.clone();
     for (key, expr) in &resource.attributes {
         let resolved_value = unwrap_secret(resolve_ref_value(expr, bindings)?);
@@ -142,11 +142,11 @@ pub(super) async fn resolve_resource(
 /// See [`resolve_resource`] for the fail-fast contract on
 /// still-deferred values.
 pub(super) async fn resolve_resource_with_source(
-    target: &ManagedResource,
-    source: &ManagedResource,
+    target: &Resource,
+    source: &Resource,
     bindings: &ResolvedBindings,
     pipeline: &RenormalizePipeline<'_>,
-) -> Result<ManagedResource, String> {
+) -> Result<Resource, String> {
     let mut resolved = target.clone();
     for (key, expr) in &source.attributes {
         let resolved_value = unwrap_secret(resolve_ref_value(expr, bindings)?);
@@ -203,9 +203,9 @@ pub(super) struct RenormalizePipeline<'a> {
 /// fail-fast earlier on still-`Deferred` values — so this stays the tail
 /// expression without forcing `Ok(...)` at every call site.
 async fn renormalize(
-    resolved: ManagedResource,
+    resolved: Resource,
     pipeline: &RenormalizePipeline<'_>,
-) -> Result<ManagedResource, String> {
+) -> Result<Resource, String> {
     let mut one = [resolved];
     crate::value::canonicalize_resources_with_schemas(&mut one, pipeline.schemas);
     pipeline.normalizer.normalize_desired(&mut one).await;
@@ -335,7 +335,7 @@ pub(super) fn count_actionable_effects(effects: &[Effect]) -> usize {
 pub(super) struct BasicEffectCtx<'a> {
     pub(super) provider: &'a dyn Provider,
     pub(super) bindings: &'a ResolvedBindings,
-    pub(super) unresolved: &'a HashMap<ResourceId, ManagedResource>,
+    pub(super) unresolved: &'a HashMap<ResourceId, Resource>,
     pub(super) pipeline: &'a RenormalizePipeline<'a>,
     pub(super) completed: &'a AtomicUsize,
     pub(super) total: usize,

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -31,7 +31,7 @@ use phased::{execute_effects_phased, has_interdependent_replaces};
 /// Input data required to execute a plan.
 pub struct ExecutionInput<'a> {
     pub plan: &'a crate::plan::Plan,
-    pub unresolved_resources: &'a HashMap<ResourceId, crate::resource::ManagedResource>,
+    pub unresolved_resources: &'a HashMap<ResourceId, crate::resource::Resource>,
     /// Virtual resources (module attribute containers). carina#3181:
     /// virtuals are a distinct typestate from managed resources, so the
     /// executor's dependency walk receives them as their own slice. A

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -9,7 +9,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use crate::deps::find_failed_dependency;
 use crate::effect::{Effect, WaitTarget};
 use crate::provider::Provider;
-use crate::resource::{ManagedResource, ResourceId, State, Value};
+use crate::resource::{Resource, ResourceId, State, Value};
 
 use super::basic::{
     BasicEffectCtx, ExecutionState, RenormalizePipeline, count_actionable_effects,
@@ -22,7 +22,7 @@ use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, 
 /// Build a dependency map: for each effect index, which other effect indices it depends on.
 pub(super) fn build_dependency_map(
     effects: &[Effect],
-    unresolved_resources: &HashMap<ResourceId, ManagedResource>,
+    unresolved_resources: &HashMap<ResourceId, Resource>,
     virtual_resources: &[crate::resource::VirtualResource],
 ) -> HashMap<usize, HashSet<usize>> {
     // Build binding -> effect index mapping
@@ -131,7 +131,7 @@ pub(super) fn build_dependency_map(
 #[cfg(test)]
 pub(super) fn build_dependency_levels(
     effects: &[Effect],
-    unresolved_resources: &HashMap<ResourceId, ManagedResource>,
+    unresolved_resources: &HashMap<ResourceId, Resource>,
     virtual_resources: &[crate::resource::VirtualResource],
 ) -> Vec<Vec<usize>> {
     let deps_of = build_dependency_map(effects, unresolved_resources, virtual_resources);
@@ -596,7 +596,7 @@ mod tests {
     /// underlying resources their attributes reference.
     #[test]
     fn build_dependency_map_follows_virtual_module_binding() {
-        let mut role = ManagedResource::with_provider("awscc", "iam.Role", "bootstrap.role", None);
+        let mut role = Resource::with_provider("awscc", "iam.Role", "bootstrap.role", None);
         role.binding = Some("bootstrap.role".to_string());
 
         // carina#3181: virtual resources are a distinct typestate.
@@ -615,7 +615,7 @@ mod tests {
             quoted_string_attrs: std::collections::HashSet::new(),
         };
 
-        let mut role_policy = ManagedResource::with_provider("awscc", "iam.RolePolicy", "rp", None);
+        let mut role_policy = Resource::with_provider("awscc", "iam.RolePolicy", "rp", None);
         role_policy.set_attr(
             "role_name",
             Value::resource_ref("bootstrap", "role_name", vec![]),
@@ -626,7 +626,7 @@ mod tests {
             Effect::Create(role_policy.clone()),
         ];
 
-        let mut unresolved: HashMap<ResourceId, ManagedResource> = HashMap::new();
+        let mut unresolved: HashMap<ResourceId, Resource> = HashMap::new();
         unresolved.insert(role.id.clone(), role.clone());
         unresolved.insert(role_policy.id.clone(), role_policy);
 

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -9,7 +9,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use crate::deps::{find_failed_dependency, get_resource_dependencies};
 use crate::effect::Effect;
 use crate::provider::{CreateRequest, DeleteRequest, Provider, UpdateRequest};
-use crate::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use super::basic::{
     BasicEffectCtx, BasicEffectResult, ExecutionState, RenormalizePipeline,
@@ -141,7 +141,7 @@ pub(super) fn topological_sort_replaces(
 pub(super) fn build_phase_dependency_map(
     effects: &[Effect],
     phase_indices: &[usize],
-    unresolved_resources: &HashMap<ResourceId, ManagedResource>,
+    unresolved_resources: &HashMap<ResourceId, Resource>,
     virtual_resources: &[crate::resource::VirtualResource],
 ) -> HashMap<usize, HashSet<usize>> {
     // Build binding -> effect index mapping for effects in this phase
@@ -213,11 +213,7 @@ impl<'a> DepResolver<'a> {
 
     /// Walk a resource's dependencies (via `get_resource_dependencies`) and
     /// merge the reached effect indices into `out`.
-    pub(super) fn collect_from_resource(
-        &self,
-        resource: &ManagedResource,
-        out: &mut HashSet<usize>,
-    ) {
+    pub(super) fn collect_from_resource(&self, resource: &Resource, out: &mut HashSet<usize>) {
         let dep_bindings = get_resource_dependencies(resource);
         let mut visited: HashSet<&str> = HashSet::new();
         for binding in &dep_bindings {
@@ -1387,7 +1383,7 @@ mod tests {
 
     #[test]
     fn build_phase_dependency_map_follows_virtual_module_binding() {
-        let mut role = ManagedResource::with_provider("awscc", "iam.Role", "bootstrap.role", None);
+        let mut role = Resource::with_provider("awscc", "iam.Role", "bootstrap.role", None);
         role.binding = Some("bootstrap.role".to_string());
 
         // carina#3181: the virtual exposes `role_name = role.role_name`,
@@ -1400,7 +1396,7 @@ mod tests {
             "role_name",
         );
 
-        let mut role_policy = ManagedResource::with_provider("awscc", "iam.RolePolicy", "rp", None);
+        let mut role_policy = Resource::with_provider("awscc", "iam.RolePolicy", "rp", None);
         role_policy.set_attr(
             "role_name",
             Value::resource_ref("bootstrap", "role_name", vec![]),
@@ -1412,7 +1408,7 @@ mod tests {
         ];
         let phase_indices: Vec<usize> = vec![0, 1];
 
-        let mut unresolved: HashMap<ResourceId, ManagedResource> = HashMap::new();
+        let mut unresolved: HashMap<ResourceId, Resource> = HashMap::new();
         unresolved.insert(role.id.clone(), role.clone());
         unresolved.insert(role_policy.id.clone(), role_policy.clone());
 
@@ -1430,8 +1426,7 @@ mod tests {
     /// through both layers to the underlying resource.
     #[test]
     fn build_phase_dependency_map_follows_nested_virtual_module_bindings() {
-        let mut role =
-            ManagedResource::with_provider("awscc", "iam.Role", "outer.inner.role", None);
+        let mut role = Resource::with_provider("awscc", "iam.Role", "outer.inner.role", None);
         role.binding = Some("outer.inner.role".to_string());
 
         let inner_virt = make_virtual(
@@ -1443,7 +1438,7 @@ mod tests {
         );
         let outer_virt = make_virtual("outer", "outer", "role_name", "outer.inner", "role_name");
 
-        let mut caller = ManagedResource::with_provider("awscc", "iam.RolePolicy", "rp", None);
+        let mut caller = Resource::with_provider("awscc", "iam.RolePolicy", "rp", None);
         caller.set_attr(
             "role_name",
             Value::resource_ref("outer", "role_name", vec![]),
@@ -1452,7 +1447,7 @@ mod tests {
         let effects = vec![Effect::Create(role.clone()), Effect::Create(caller.clone())];
         let phase_indices: Vec<usize> = vec![0, 1];
 
-        let mut unresolved: HashMap<ResourceId, ManagedResource> = HashMap::new();
+        let mut unresolved: HashMap<ResourceId, Resource> = HashMap::new();
         unresolved.insert(role.id.clone(), role);
         unresolved.insert(caller.id.clone(), caller);
 
@@ -1477,9 +1472,9 @@ mod tests {
     fn topological_sort_replaces_respects_depends_on() {
         use crate::resource::{Directives, State};
 
-        let mut role = ManagedResource::with_provider("test", "iam.Role", "role", None);
+        let mut role = Resource::with_provider("test", "iam.Role", "role", None);
         role.binding = Some("role".to_string());
-        let mut bucket = ManagedResource::with_provider("test", "s3.Bucket", "bucket", None);
+        let mut bucket = Resource::with_provider("test", "s3.Bucket", "bucket", None);
         bucket.binding = Some("bucket".to_string());
         bucket.directives = Directives {
             depends_on: vec!["role".to_string()],

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -9,7 +9,7 @@ use crate::provider::{
     CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, UpdatePatch, UpdateRequest,
     build_update_patch,
 };
-use crate::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 use super::basic::{
     BasicEffectResult, RenormalizePipeline, resolve_resource, resolve_resource_with_source,
@@ -21,7 +21,7 @@ use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 /// path of replacements (cascade has no precomputed
 /// `changed_attributes` list, so the patch is derived from the
 /// from/to comparison directly).
-pub(super) fn compute_full_diff_patch(from: &State, to: &ManagedResource) -> UpdatePatch {
+pub(super) fn compute_full_diff_patch(from: &State, to: &Resource) -> UpdatePatch {
     use std::collections::HashSet;
 
     let mut keys: HashSet<&str> = HashSet::new();
@@ -84,12 +84,12 @@ pub(super) struct ReplaceContext<'a> {
     pub(super) effect: &'a Effect,
     pub(super) id: &'a ResourceId,
     pub(super) from: &'a State,
-    pub(super) to: &'a ManagedResource,
+    pub(super) to: &'a Resource,
     pub(super) directives: &'a crate::resource::Directives,
     pub(super) cascading_updates: &'a [crate::effect::CascadingUpdate],
     pub(super) temporary_name: Option<&'a crate::effect::TemporaryName>,
     pub(super) bindings: &'a ResolvedBindings,
-    pub(super) unresolved: &'a HashMap<ResourceId, ManagedResource>,
+    pub(super) unresolved: &'a HashMap<ResourceId, Resource>,
     pub(super) pipeline: &'a RenormalizePipeline<'a>,
     pub(super) started: Instant,
     pub(super) progress: ProgressInfo,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -4,9 +4,7 @@ use crate::provider::{
     BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
     ReadRequest, UpdateRequest,
 };
-use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, Directives, ManagedResource, Value,
-};
+use crate::resource::{ConcreteValue, DataSource, DeferredValue, Directives, Resource, Value};
 use parallel::{build_dependency_levels, build_dependency_map};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -25,7 +23,7 @@ struct MockProvider {
     /// Resources passed in to `create()` in call order — lets a test
     /// assert that the executor handed the provider a fully-resolved
     /// resource (no remaining `Value::Deferred(ResourceRef)` etc.).
-    create_resources: Arc<Mutex<Vec<ManagedResource>>>,
+    create_resources: Arc<Mutex<Vec<Resource>>>,
     /// `UpdateRequest`s passed in to `update()` in call order — lets a
     /// test assert the patch carries re-normalized attribute values.
     update_requests: Arc<Mutex<Vec<UpdateRequest>>>,
@@ -64,7 +62,7 @@ impl MockProvider {
         self.call_log.lock().unwrap().clone()
     }
 
-    fn captured_create_resources(&self) -> Vec<ManagedResource> {
+    fn captured_create_resources(&self) -> Vec<Resource> {
         self.create_resources.lock().unwrap().clone()
     }
 
@@ -259,7 +257,7 @@ fn canonicalize_value(v: &Value) -> Option<Value> {
 impl crate::provider::ProviderNormalizer for CanonicalizingNormalizer {
     fn normalize_desired<'a>(
         &'a self,
-        resources: &'a mut [ManagedResource],
+        resources: &'a mut [Resource],
     ) -> crate::provider::BoxFuture<'a, ()> {
         Box::pin(async move {
             for r in resources.iter_mut() {
@@ -292,7 +290,7 @@ impl crate::provider::ProviderNormalizer for CanonicalizingNormalizer {
 
     fn merge_default_tags<'a>(
         &'a self,
-        _resources: &'a mut [ManagedResource],
+        _resources: &'a mut [Resource],
         _default_tags: &'a indexmap::IndexMap<String, Value>,
         _registry: &'a crate::schema::SchemaRegistry,
     ) -> crate::provider::BoxFuture<'a, ()> {
@@ -378,8 +376,8 @@ impl ProviderFactory for AliasFactory {
 // Helper functions
 // -----------------------------------------------------------------------
 
-fn make_resource(binding: &str, deps: &[&str]) -> ManagedResource {
-    let mut r = ManagedResource::new("test", binding);
+fn make_resource(binding: &str, deps: &[&str]) -> Resource {
+    let mut r = Resource::new("test", binding);
     r.binding = Some(binding.to_string());
     for dep in deps {
         r.set_attr(
@@ -512,7 +510,7 @@ async fn test_apply_reapplies_enum_alias_stage() {
     let provider = MockProvider::new();
     // `id.provider = "test"` so the per-resource factory lookup finds
     // `AliasFactory` (whose `name()` is `"test"`).
-    let mut resource = ManagedResource::with_provider("test", "sg", "a", None);
+    let mut resource = Resource::with_provider("test", "sg", "a", None);
     resource.binding = Some("a".to_string());
     // Post-normalize_desired shape: namespaced DSL enum identifier.
     resource.set_attr(
@@ -561,7 +559,7 @@ async fn test_apply_reapplies_enum_alias_stage() {
 #[tokio::test]
 async fn test_apply_reapplies_enum_alias_stage_update_path() {
     let provider = MockProvider::new();
-    let mut to_resource = ManagedResource::with_provider("test", "sg", "a", None);
+    let mut to_resource = Resource::with_provider("test", "sg", "a", None);
     to_resource.binding = Some("a".to_string());
     to_resource.set_attr(
         "ip_protocol",
@@ -628,7 +626,7 @@ async fn test_apply_reapplies_enum_alias_stage_update_path() {
 #[tokio::test]
 async fn test_apply_reapplies_canonicalize_stage() {
     let provider = MockProvider::new();
-    let mut resource = ManagedResource::with_provider("test", "sg", "a", None);
+    let mut resource = Resource::with_provider("test", "sg", "a", None);
     resource.binding = Some("a".to_string());
     resource.set_attr(
         "subject",
@@ -839,7 +837,7 @@ async fn test_async_normalizer_does_not_self_deadlock_on_apply_path() {
     impl crate::provider::ProviderNormalizer for LockHoldingNormalizer {
         fn normalize_desired<'a>(
             &'a self,
-            resources: &'a mut [ManagedResource],
+            resources: &'a mut [Resource],
         ) -> crate::provider::BoxFuture<'a, ()> {
             Box::pin(async move {
                 let mut guard = self.store.lock().await;
@@ -872,7 +870,7 @@ async fn test_async_normalizer_does_not_self_deadlock_on_apply_path() {
 
         fn merge_default_tags<'a>(
             &'a self,
-            _resources: &'a mut [ManagedResource],
+            _resources: &'a mut [Resource],
             _default_tags: &'a indexmap::IndexMap<String, Value>,
             _registry: &'a crate::schema::SchemaRegistry,
         ) -> crate::provider::BoxFuture<'a, ()> {
@@ -1022,7 +1020,7 @@ async fn test_cbd_creates_before_deletes() {
     let provider = MockProvider::new();
     let rid = ResourceId::new("test", "a");
     let from = State::existing(rid.clone(), HashMap::new()).with_identifier("old-id");
-    let to = ManagedResource::new("test", "a");
+    let to = Resource::new("test", "a");
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
@@ -1070,7 +1068,7 @@ async fn test_dbd_deletes_before_creates() {
     let provider = MockProvider::new();
     let rid = ResourceId::new("test", "a");
     let from = State::existing(rid.clone(), HashMap::new()).with_identifier("old-id");
-    let to = ManagedResource::new("test", "a");
+    let to = Resource::new("test", "a");
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
@@ -1121,12 +1119,12 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
     let subnet_id = ResourceId::new("test", "subnet");
 
     let vpc_from = State::existing(vpc_id.clone(), HashMap::new()).with_identifier("vpc-old");
-    let mut vpc_to = ManagedResource::new("test", "vpc");
+    let mut vpc_to = Resource::new("test", "vpc");
     vpc_to.binding = Some("vpc".to_string());
 
     let subnet_from =
         State::existing(subnet_id.clone(), HashMap::new()).with_identifier("subnet-old");
-    let mut subnet_to = ManagedResource::new("test", "subnet");
+    let mut subnet_to = Resource::new("test", "subnet");
     subnet_to.binding = Some("subnet".to_string());
     subnet_to.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
@@ -1202,12 +1200,12 @@ async fn test_phased_noncbd_creates_after_deletes() {
     let subnet_id = ResourceId::new("test", "subnet");
 
     let vpc_from = State::existing(vpc_id.clone(), HashMap::new()).with_identifier("vpc-old");
-    let mut vpc_to = ManagedResource::new("test", "vpc");
+    let mut vpc_to = Resource::new("test", "vpc");
     vpc_to.binding = Some("vpc".to_string());
 
     let subnet_from =
         State::existing(subnet_id.clone(), HashMap::new()).with_identifier("subnet-old");
-    let mut subnet_to = ManagedResource::new("test", "subnet");
+    let mut subnet_to = Resource::new("test", "subnet");
     subnet_to.binding = Some("subnet".to_string());
     subnet_to.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
@@ -1510,7 +1508,7 @@ fn test_build_dependency_levels_transitive_ref_preserves_direct_dep() {
     // but _dependency_bindings records the original direct dependencies.
 
     // tgw_attach depends on tgw, vpc, subnet
-    let mut tgw_attach = ManagedResource::new("ec2.transit_gateway_attachment", "tgw_attach");
+    let mut tgw_attach = Resource::new("ec2.transit_gateway_attachment", "tgw_attach");
     tgw_attach.binding = Some("tgw_attach".to_string());
     tgw_attach.dependency_bindings = std::collections::BTreeSet::from([
         "tgw".to_string(),
@@ -1520,7 +1518,7 @@ fn test_build_dependency_levels_transitive_ref_preserves_direct_dep() {
 
     // route depends on rt and tgw_attach (but after partial resolution,
     // transit_gateway_id points to ResourceRef { binding: "tgw" })
-    let mut route = ManagedResource::new("ec2.route", "my-route");
+    let mut route = Resource::new("ec2.route", "my-route");
     route.set_attr(
         "transit_gateway_id".to_string(),
         Value::resource_ref("tgw".to_string(), "id".to_string(), vec![]),
@@ -1529,17 +1527,17 @@ fn test_build_dependency_levels_transitive_ref_preserves_direct_dep() {
         std::collections::BTreeSet::from(["rt".to_string(), "tgw_attach".to_string()]);
 
     // Other resources
-    let mut vpc = ManagedResource::new("ec2.Vpc", "vpc");
+    let mut vpc = Resource::new("ec2.Vpc", "vpc");
     vpc.binding = Some("vpc".to_string());
 
-    let mut tgw = ManagedResource::new("ec2.transit_gateway", "tgw");
+    let mut tgw = Resource::new("ec2.transit_gateway", "tgw");
     tgw.binding = Some("tgw".to_string());
 
-    let mut subnet = ManagedResource::new("ec2.Subnet", "subnet");
+    let mut subnet = Resource::new("ec2.Subnet", "subnet");
     subnet.binding = Some("subnet".to_string());
     subnet.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
-    let mut rt = ManagedResource::new("ec2.RouteTable", "rt");
+    let mut rt = Resource::new("ec2.RouteTable", "rt");
     rt.binding = Some("rt".to_string());
     rt.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
@@ -1960,7 +1958,7 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     let provider = RecordingMockProvider::new();
 
     // VPC resource with binding "vpc"
-    let mut vpc = ManagedResource::new("test", "my-vpc");
+    let mut vpc = Resource::new("test", "my-vpc");
     vpc.binding = Some("vpc".to_string());
     vpc.set_attr(
         "cidr_block",
@@ -1969,7 +1967,7 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     let vpc_id = vpc.id.clone();
 
     // Subnet resource that references vpc.vpc_id
-    let mut subnet = ManagedResource::new("test", "my-subnet");
+    let mut subnet = Resource::new("test", "my-subnet");
     subnet.set_attr(
         "vpc_id",
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -2148,7 +2146,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
         .with_identifier("attach-old")
         .with_dependency_bindings(std::collections::BTreeSet::from(["tgw_a".to_string()]));
     // to: depends on tgw_b (different TGW — dependency changed)
-    let mut attachment_to = ManagedResource::new("test", "attachment");
+    let mut attachment_to = Resource::new("test", "attachment");
     attachment_to.binding = Some("attachment".to_string());
     attachment_to.dependency_bindings = std::collections::BTreeSet::from(["tgw_b".to_string()]);
 
@@ -2160,7 +2158,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
     let mut plan = Plan::new();
 
     // tgw_b: Create (new resource)
-    let mut tgw_b = ManagedResource::new("test", "tgw_b");
+    let mut tgw_b = Resource::new("test", "tgw_b");
     tgw_b.binding = Some("tgw_b".to_string());
     plan.add(Effect::Create(tgw_b));
 
@@ -2242,7 +2240,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
     let attachment_from = State::existing(attachment_id.clone(), HashMap::new())
         .with_identifier("attach-old")
         .with_dependency_bindings(std::collections::BTreeSet::from(["tgw_a".to_string()]));
-    let mut attachment_to = ManagedResource::new("test", "attachment");
+    let mut attachment_to = Resource::new("test", "attachment");
     attachment_to.binding = Some("attachment".to_string());
     attachment_to.dependency_bindings = std::collections::BTreeSet::from(["tgw_b".to_string()]);
 
@@ -2254,7 +2252,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
     let mut plan = Plan::new();
 
     // tgw_b: Create
-    let mut tgw_b = ManagedResource::new("test", "tgw_b");
+    let mut tgw_b = Resource::new("test", "tgw_b");
     tgw_b.binding = Some("tgw_b".to_string());
     plan.add(Effect::Create(tgw_b));
 
@@ -2437,7 +2435,7 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
     // `dist` references the wait binding from *inside a nested Map*,
     // mirroring `viewer_certificate = { acm_certificate_arn =
     // cert_issued.certificate_arn }`.
-    let mut dist = ManagedResource::new("test", "dist");
+    let mut dist = Resource::new("test", "dist");
     dist.binding = Some("dist".to_string());
     let mut viewer_certificate = indexmap::IndexMap::new();
     viewer_certificate.insert(
@@ -2657,7 +2655,7 @@ async fn test_chained_index_then_field_unresolved_at_apply_fails_with_clear_erro
     // attribute would be populated only by the create's read-back
     // state. Mirror the real ACM Certificate's user-facing shape.
     let cert = {
-        let mut r = ManagedResource::new("test", "cert");
+        let mut r = Resource::new("test", "cert");
         r.binding = Some("cert".to_string());
         r.set_attr(
             "domain_name",
@@ -2671,7 +2669,7 @@ async fn test_chained_index_then_field_unresolved_at_apply_fails_with_clear_erro
     // attributes from the issue:
     //   resource_records = [cert.domain_validation_options[0].resource_record_value]
     let record = {
-        let mut r = ManagedResource::new("test", "record");
+        let mut r = Resource::new("test", "record");
         r.binding = Some("record".to_string());
         r.dependency_bindings = ["cert".to_string()].into_iter().collect();
         let value_path = AccessPath::with_segments(
@@ -2800,7 +2798,7 @@ async fn test_chained_index_then_nested_field_resolves_from_post_create_state() 
     // as `carina-provider-aws::services::acm::certificate.rs::read_acm_certificate`
     // inserts it.
     let cert = {
-        let mut r = ManagedResource::new("test", "cert");
+        let mut r = Resource::new("test", "cert");
         r.binding = Some("cert".to_string());
         r.set_attr(
             "domain_name",
@@ -2814,7 +2812,7 @@ async fn test_chained_index_then_nested_field_resolves_from_post_create_state() 
     // chained-access path. Uses the post-aws#295 *nested* shape:
     // `resource_record` is a struct with `name`/`type`/`value`.
     let record = {
-        let mut r = ManagedResource::new("test", "record");
+        let mut r = Resource::new("test", "record");
         r.binding = Some("record".to_string());
         r.dependency_bindings = ["cert".to_string()].into_iter().collect();
         let chained_dvo = |leaf: &str| {
@@ -3069,7 +3067,7 @@ impl Provider for IdentifierAwareProvider {
 async fn wait_resolves_target_identifier_from_just_created_state() {
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
-    let mut cert = ManagedResource::new("test", "cert");
+    let mut cert = Resource::new("test", "cert");
     cert.binding = Some("cert".to_string());
     let cert_id = cert.id.clone();
 
@@ -3153,12 +3151,12 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
     let policy_new_id = ResourceId::new("test", "policy_new");
 
     let role_from = State::existing(role_id.clone(), HashMap::new()).with_identifier("role-old");
-    let mut role_to = ManagedResource::new("test", "role");
+    let mut role_to = Resource::new("test", "role");
     role_to.binding = Some("role".to_string());
 
     let policy_from =
         State::existing(policy_new_id.clone(), HashMap::new()).with_identifier("policy-old");
-    let mut policy_to = ManagedResource::new("test", "policy_new");
+    let mut policy_to = Resource::new("test", "policy_new");
     policy_to.dependency_bindings = std::collections::BTreeSet::from(["role".to_string()]);
 
     let mut plan = Plan::new();
@@ -3238,7 +3236,7 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
 /// `assume_role_policy_document.statement[].principal.aws = admin_access_roles.arns`
 /// on `carina-rs/infra@main`.
 #[tokio::test]
-async fn test_data_source_read_state_resolves_for_downstream_managed_resource() {
+async fn test_data_source_read_state_resolves_for_downstream_resource() {
     use crate::binding_index::{PreApplyInputs, ResolvedBindings};
     use crate::resource::{AccessPath, ResourceId};
 
@@ -3286,7 +3284,7 @@ async fn test_data_source_read_state_resolves_for_downstream_managed_resource() 
     // struct, but the resolve path is the same per-attribute one.)
     let role_id = ResourceId::with_provider("awscc", "iam.Role", "rd.role", None);
     let role = {
-        let mut r = ManagedResource::with_provider("awscc", "iam.Role", "rd.role", None);
+        let mut r = Resource::with_provider("awscc", "iam.Role", "rd.role", None);
         r.id = role_id.clone();
         r.binding = Some("role".to_string());
         // No `dependency_bindings` — the executor's dependency-graph

--- a/carina-core/src/explicit.rs
+++ b/carina-core/src/explicit.rs
@@ -7,7 +7,7 @@
 //!
 //! See `notes/specs/2026-05-10-explicit-fields-design.md`.
 
-use crate::resource::{ConcreteValue, ManagedResource, Value};
+use crate::resource::{ConcreteValue, Resource, Value};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -56,7 +56,7 @@ pub enum ExplicitFields {
 /// Build an `ExplicitFields::Struct` rooted at a resource's top-level
 /// attributes. Underscore-prefixed keys (internal attributes) are
 /// excluded.
-pub fn build_from_resource(resource: &ManagedResource) -> ExplicitFields {
+pub fn build_from_resource(resource: &Resource) -> ExplicitFields {
     ExplicitFields::Struct {
         children: resource
             .attributes
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn build_from_resource_skips_underscore_attrs() {
-        let mut r = ManagedResource::with_provider("aws", "s3.Bucket", "x", None);
+        let mut r = Resource::with_provider("aws", "s3.Bucket", "x", None);
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String("hi".into())),

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::parser::ProviderConfig;
-use crate::resource::{ConcreteValue, DeferredValue, ManagedResource, ResourceId, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, Value};
 use crate::schema::SchemaRegistry;
 use crate::validation::is_string_compatible_type;
 
@@ -27,7 +27,7 @@ pub fn generate_random_suffix() -> String {
 ///
 /// Errors if both `<attr>_prefix` and `<attr>` are specified, or if prefix is empty.
 pub fn resolve_attr_prefixes(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     registry: &SchemaRegistry,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
@@ -112,7 +112,7 @@ pub struct PrefixStateInfo {
 /// reuses the existing name from state instead of the temporarily generated one.
 /// If the prefix has changed or there's no state match, keeps the new generated name.
 pub fn reconcile_prefixed_names(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     find_state: &dyn Fn(&str, &str, &str) -> Option<PrefixStateInfo>,
 ) {
     for resource in resources.iter_mut() {
@@ -352,7 +352,7 @@ pub(crate) fn extract_hash_from_identifier(identifier: &str) -> Option<u64> {
 /// so the two always agree on what a resource's anonymous ID would be.
 fn simhash_from_identity_and_resource(
     identity_values: &BTreeMap<String, String>,
-    resource: &ManagedResource,
+    resource: &Resource,
 ) -> u64 {
     let mut simhash_values = identity_values.clone();
     for (key, value) in &resource.attributes {
@@ -368,7 +368,7 @@ fn simhash_from_identity_and_resource(
 /// single resource. Used by `detect_anonymous_to_named_renames` to recover the
 /// anonymous ID of a resource that has since been wrapped in a `let` binding.
 fn compute_resource_simhash(
-    resource: &ManagedResource,
+    resource: &Resource,
     providers: &[ProviderConfig],
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> u64 {
@@ -393,7 +393,7 @@ fn compute_resource_simhash(
 /// `identity_attributes_fn` takes a provider name and returns the list of identity attribute names
 /// for that provider (e.g., `["region"]`).
 pub fn compute_anonymous_identifiers(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     providers: &[ProviderConfig],
     registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
@@ -573,7 +573,7 @@ pub struct AnonymousIdStateInfo {
 /// resource keeps its freshly-computed new-format name and the wiring layer
 /// re-keys the state entry instead of destroy+recreate.
 pub fn reconcile_anonymous_identifiers(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     registry: &SchemaRegistry,
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
 ) -> Vec<(String, String)> {
@@ -716,7 +716,7 @@ pub fn reconcile_anonymous_identifiers(
 /// An "orphaned" state entry is one whose name is not used by any current DSL
 /// resource (so it would otherwise appear as a Delete in the plan).
 pub fn detect_anonymous_to_named_renames(
-    resources: &[ManagedResource],
+    resources: &[Resource],
     registry: &SchemaRegistry,
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
     providers: &[ProviderConfig],

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::resource::ManagedResource;
+use crate::resource::Resource;
 use crate::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
 use indexmap::IndexMap;
 
@@ -23,7 +23,7 @@ fn test_generate_random_suffix_format() {
 
 #[test]
 fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -53,7 +53,7 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
 
 #[test]
 fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "nonexistent_attr_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("some-value".to_string())),
@@ -74,7 +74,7 @@ fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
 
 #[test]
 fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("my-app-".to_string())),
@@ -93,7 +93,7 @@ fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
 
 #[test]
 fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource.set_attr(
         "bucket_name_prefix".to_string(),
         Value::Concrete(ConcreteValue::String("".to_string())),
@@ -108,7 +108,7 @@ fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
 
 #[test]
 fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -140,7 +140,7 @@ fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
 
 #[test]
 fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "new-prefix-".to_string());
@@ -175,7 +175,7 @@ fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
 
 #[test]
 fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket", None);
     resource
         .prefixes
         .insert("bucket_name".to_string(), "my-app-".to_string());
@@ -219,7 +219,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     // Step 1: compute identifier with path="/"
-    let mut r1 = ManagedResource::with_provider("awscc", "iam.role", "", None);
+    let mut r1 = Resource::with_provider("awscc", "iam.role", "", None);
     r1.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-role".to_string())),
@@ -233,7 +233,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with path="/carina/" (changed create-only)
-    let mut r2 = ManagedResource::with_provider("awscc", "iam.role", "", None);
+    let mut r2 = Resource::with_provider("awscc", "iam.role", "", None);
     r2.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-role".to_string())),
@@ -276,8 +276,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let mut resource =
-        ManagedResource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
+    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("new-role".to_string())),
@@ -318,8 +317,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let mut resource =
-        ManagedResource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
+    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-role".to_string())),
@@ -360,7 +358,7 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "ec2_vpc_aabbccdd", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "ec2_vpc_aabbccdd", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
@@ -414,7 +412,7 @@ fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
-    let mut r = ManagedResource::with_provider("awscc", "iam.RolePolicy", "", None);
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "", None);
     r.set_attr(
         "policy_name".to_string(),
         Value::Concrete(ConcreteValue::String("inline".to_string())),
@@ -469,7 +467,7 @@ fn test_anonymous_resource_no_create_only_properties() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
-    let mut r = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r = Resource::with_provider("awscc", "ec2.eip", "", None);
     r.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -509,7 +507,7 @@ fn test_anonymous_resource_no_create_only_deterministic() {
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
     let make_resource = || {
-        let mut r = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+        let mut r = Resource::with_provider("awscc", "ec2.eip", "", None);
         r.set_attr(
             "domain".to_string(),
             Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -545,13 +543,13 @@ fn test_anonymous_resource_no_create_only_collision() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r1 = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r1.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
     );
 
-    let mut r2 = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r2.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -594,7 +592,7 @@ fn test_identity_attribute_prevents_collision() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r1 = ManagedResource::with_provider("awscc", "route53.record_set", "", None);
+    let mut r1 = Resource::with_provider("awscc", "route53.record_set", "", None);
     r1.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs.dev".to_string())),
@@ -608,7 +606,7 @@ fn test_identity_attribute_prevents_collision() {
         Value::Concrete(ConcreteValue::String("A".to_string())),
     );
 
-    let mut r2 = ManagedResource::with_provider("awscc", "route53.record_set", "", None);
+    let mut r2 = Resource::with_provider("awscc", "route53.record_set", "", None);
     r2.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs.dev".to_string())),
@@ -726,7 +724,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
     // Step 1: compute identifier with tag_env="production"
-    let mut r1 = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r1.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -744,7 +742,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     let old_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with tag_env="staging" (one attribute changed)
-    let mut r2 = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r2.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -791,9 +789,9 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    // ManagedResource with a computed identifier
+    // Resource with a computed identifier
     let mut resource =
-        ManagedResource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344", None);
+        Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344", None);
     resource.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -838,7 +836,7 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     // Compute identifier without setting the create-only property
-    let mut r1 = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r1.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1026,7 +1024,7 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
 
     // Compute 3 identifiers with different attributes
     let make_resource = |env: &str, team: &str| {
-        let mut r = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+        let mut r = Resource::with_provider("awscc", "ec2.eip", "", None);
         r.set_attr(
             "domain".to_string(),
             Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1080,13 +1078,13 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
             state_entries.clone()
         });
 
-    // ManagedResource keeps its freshly-computed identifier; the rename pair (if any)
+    // Resource keeps its freshly-computed identifier; the rename pair (if any)
     // points from the closest state entry to the new identifier so the wiring
     // layer can re-key the legacy state row.
     assert_eq!(
         resources_current[0].id.name_str(),
         current_id_before,
-        "ManagedResource should retain its freshly-computed identifier",
+        "Resource should retain its freshly-computed identifier",
     );
 
     let current_hash = extract_hash_from_identifier(&current_id_before).unwrap();
@@ -1134,7 +1132,7 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r = Resource::with_provider("awscc", "ec2.eip", "", None);
     r.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1165,7 +1163,7 @@ fn test_reconcile_no_create_only_empty_state() {
     schemas.insert("awscc", schema);
 
     let mut resource =
-        ManagedResource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344", None);
+        Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344", None);
     resource.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1201,7 +1199,7 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     let make_resource = |env: &str| {
-        let mut r = ManagedResource::with_provider("awscc", "ec2.internet_gateway", "", None);
+        let mut r = Resource::with_provider("awscc", "ec2.internet_gateway", "", None);
         r.set_attr(
             "tag_name".to_string(),
             Value::Concrete(ConcreteValue::String("my-igw".to_string())),
@@ -1263,7 +1261,7 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut vpc = ManagedResource::with_provider("awscc", "ec2.Vpc", "", None);
+    let mut vpc = Resource::with_provider("awscc", "ec2.Vpc", "", None);
     vpc.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -1273,7 +1271,7 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
         Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
     );
 
-    let mut eip = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut eip = Resource::with_provider("awscc", "ec2.eip", "", None);
     eip.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1307,9 +1305,8 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    // ManagedResource with both create-only props set
-    let mut resource =
-        ManagedResource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
+    // Resource with both create-only props set
+    let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd", None);
     resource.set_attr(
         "role_name".to_string(),
         Value::Concrete(ConcreteValue::String("my-role".to_string())),
@@ -1366,7 +1363,7 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
 
     // Simulate two runs with different random suffixes but same prefix
     let make_resource = |generated_name: &str| {
-        let mut r = ManagedResource::with_provider("awscc", "s3.Bucket", "", None);
+        let mut r = Resource::with_provider("awscc", "s3.Bucket", "", None);
         r.set_attr(
             "bucket_name".to_string(),
             Value::Concrete(ConcreteValue::String(generated_name.to_string())),
@@ -1410,7 +1407,7 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     let make_resource = |prefix: &str, generated_name: &str| {
-        let mut r = ManagedResource::with_provider("awscc", "s3.Bucket", "", None);
+        let mut r = Resource::with_provider("awscc", "s3.Bucket", "", None);
         r.set_attr(
             "bucket_name".to_string(),
             Value::Concrete(ConcreteValue::String(generated_name.to_string())),
@@ -1446,7 +1443,7 @@ fn test_reconcile_skips_let_bound_resources() {
 
     // A let-bound resource whose name does NOT exist in state
     let mut ingress_new =
-        ManagedResource::with_provider("aws", "ec2.security_group_ingress", "ingress_new", None);
+        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_new", None);
     ingress_new.binding = Some("ingress_new".to_string());
     ingress_new.set_attr(
         "cidr_ip".to_string(),
@@ -1501,7 +1498,7 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
     schemas.insert("aws", schema);
 
     // Anonymous resource with a new hash-derived identifier
-    let mut new_rule = ManagedResource::with_provider(
+    let mut new_rule = Resource::with_provider(
         "aws",
         "ec2.security_group_ingress",
         "ec2_security_group_ingress_deadbeef",
@@ -1601,7 +1598,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
     // Step 1: Create EIP with tags Environment=acceptance-test
-    let mut r1 = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r1 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r1.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1625,7 +1622,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: Change tag Environment=staging (only tags changed)
-    let mut r2 = ManagedResource::with_provider("awscc", "ec2.eip", "", None);
+    let mut r2 = Resource::with_provider("awscc", "ec2.eip", "", None);
     r2.set_attr(
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
@@ -1667,7 +1664,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     assert_eq!(
         resources2[0].id.name_str(),
         step2_id,
-        "ManagedResource should retain its freshly-computed identifier"
+        "Resource should retain its freshly-computed identifier"
     );
     assert_eq!(
         renames,
@@ -1693,7 +1690,7 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
 
     // Two named ingress resources with overlapping create-only attributes
     let mut ingress_http =
-        ManagedResource::with_provider("aws", "ec2.security_group_ingress", "ingress_http", None);
+        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_http", None);
     ingress_http.set_attr(
         "cidr_ip".to_string(),
         Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
@@ -1708,7 +1705,7 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
     );
 
     let mut ingress_https =
-        ManagedResource::with_provider("aws", "ec2.security_group_ingress", "ingress_https", None);
+        Resource::with_provider("aws", "ec2.security_group_ingress", "ingress_https", None);
     ingress_https.set_attr(
         "cidr_ip".to_string(),
         Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
@@ -1781,7 +1778,7 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
     // anonymous hash name to the binding name.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     resource.binding = Some("sso".to_string());
     resource.set_attr(
         "name".to_string(),
@@ -1814,7 +1811,7 @@ fn test_detect_rename_skips_when_binding_already_in_state() {
     // If state already has an entry for the binding name, nothing to rename.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     resource.binding = Some("sso".to_string());
     resource.set_attr(
         "name".to_string(),
@@ -1844,8 +1841,7 @@ fn test_detect_rename_ignores_anonymous_resources() {
     // Anonymous resources (binding=None) are not candidates for this rename.
     let schemas = make_sso_instance_registry();
 
-    let mut resource =
-        ManagedResource::with_provider("awscc", "sso.Instance", "sso_instance_new", None);
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso_instance_new", None);
     // No binding set
     resource.set_attr(
         "name".to_string(),
@@ -1875,7 +1871,7 @@ fn test_detect_rename_skips_ambiguous_matches() {
     // Two orphan state entries match — skip to avoid rebinding the wrong one.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     resource.binding = Some("sso".to_string());
     resource.set_attr(
         "name".to_string(),
@@ -1914,7 +1910,7 @@ fn test_detect_rename_ignores_non_hash_state_names() {
     // treated as an anonymous candidate and must not be silently renamed.
     let schemas = make_sso_instance_registry();
 
-    let mut resource = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     resource.binding = Some("sso".to_string());
     resource.set_attr(
         "name".to_string(),
@@ -1961,7 +1957,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
 
     // Step 1: generate the anonymous ID the previous `apply` would have
     // written to state, using the same inputs and the same code path.
-    let mut anon = ManagedResource::with_provider("awscc", "sso.Instance", "", None);
+    let mut anon = Resource::with_provider("awscc", "sso.Instance", "", None);
     anon.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
@@ -1975,7 +1971,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     );
 
     // Step 2: user wraps the same resource in a `let` binding.
-    let mut let_bound = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2014,7 +2010,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
     // Anonymous snapshot with many attributes.
-    let mut anon = ManagedResource::with_provider("awscc", "sso.Instance", "", None);
+    let mut anon = Resource::with_provider("awscc", "sso.Instance", "", None);
     anon.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("old-name".to_string())),
@@ -2037,7 +2033,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     let anonymous_name = anon_vec[0].id.name_str().to_string();
 
     // Let-bound resource with wildly different attributes.
-    let mut let_bound = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2091,7 +2087,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
     // Compute the exact-match name.
-    let mut anon = ManagedResource::with_provider("awscc", "sso.Instance", "", None);
+    let mut anon = Resource::with_provider("awscc", "sso.Instance", "", None);
     anon.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
@@ -2122,7 +2118,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
         },
     ];
 
-    let mut let_bound = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2155,7 +2151,7 @@ fn test_detect_rename_no_create_only_skips_8_char_hash_entries() {
     let providers: Vec<ProviderConfig> = Vec::new();
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
-    let mut let_bound = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2192,7 +2188,7 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
     // Compute the target SimHash.
-    let mut anon = ManagedResource::with_provider("awscc", "sso.Instance", "", None);
+    let mut anon = Resource::with_provider("awscc", "sso.Instance", "", None);
     anon.set_attr(
         "name".to_string(),
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
@@ -2213,7 +2209,7 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
         },
     ];
 
-    let mut let_bound = ManagedResource::with_provider("awscc", "sso.Instance", "sso", None);
+    let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
     let_bound.binding = Some("sso".to_string());
     let_bound.set_attr(
         "name".to_string(),
@@ -2254,7 +2250,7 @@ fn anonymous_identifier_includes_provider_prefix() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r = ManagedResource::with_provider("awscc", "iam.RolePolicy", "", None);
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "", None);
     r.set_attr(
         "policy_name".to_string(),
         Value::Concrete(ConcreteValue::String("foo".to_string())),
@@ -2292,7 +2288,7 @@ fn anonymous_identifier_provider_prefix_for_aws_provider() {
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let mut r = ManagedResource::with_provider("aws", "s3.Bucket", "", None);
+    let mut r = Resource::with_provider("aws", "s3.Bucket", "", None);
     r.set_attr(
         "bucket_name".to_string(),
         Value::Concrete(ConcreteValue::String("example".to_string())),
@@ -2328,7 +2324,7 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
 
     // Build a resource and let compute_anonymous_identifiers assign its
     // freshly-computed new-format name.
-    let mut r = ManagedResource::with_provider("awscc", "iam.RolePolicy", "", None);
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "", None);
     r.set_attr(
         "policy_name".to_string(),
         Value::Concrete(ConcreteValue::String("inline".to_string())),

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -21,7 +21,7 @@ pub struct Dependency {
 /// Dependency graph for resources within a module
 #[derive(Debug, Clone, Default)]
 pub struct DependencyGraph {
-    /// ManagedResource binding name -> list of dependencies
+    /// Resource binding name -> list of dependencies
     pub edges: HashMap<String, Vec<Dependency>>,
     /// Reverse edges: target -> list of resources that depend on it
     pub reverse_edges: HashMap<String, Vec<String>>,
@@ -211,7 +211,7 @@ pub struct TypedArgument {
     pub description: Option<String>,
 }
 
-/// ManagedResource creation entry in module signature
+/// Resource creation entry in module signature
 #[derive(Debug, Clone)]
 pub struct ResourceCreation {
     /// Binding name for this resource
@@ -249,7 +249,7 @@ pub struct TypedDependency {
 /// Typed dependency graph with resource type information
 #[derive(Debug, Clone, Default)]
 pub struct TypedDependencyGraph {
-    /// ManagedResource binding name -> list of typed dependencies
+    /// Resource binding name -> list of typed dependencies
     pub edges: HashMap<String, Vec<TypedDependency>>,
 }
 

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -9,7 +9,7 @@ use crate::parser::{
     ArgumentParameter, BindingName, DeferredForExpression, ModuleCall, ParsedFile, WaitBinding,
 };
 use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, ManagedResource, ResourceId, ResourceName, Value,
+    ConcreteValue, DataSource, DeferredValue, Resource, ResourceId, ResourceName, Value,
     VirtualResource,
 };
 
@@ -228,9 +228,9 @@ impl ModuleResolver<'_> {
             .collect();
 
         // Expand managed resources with substituted values.
-        let mut managed_resources: Vec<ManagedResource> = Vec::new();
+        let mut resources: Vec<Resource> = Vec::new();
         for resource in &module.resources {
-            managed_resources.push(prefix_module_resource(
+            resources.push(prefix_module_resource(
                 resource,
                 instance_prefix,
                 &call.module_name,
@@ -326,7 +326,7 @@ impl ModuleResolver<'_> {
 
         // carina#3181: managed resources, data sources, and virtual
         // resources are collected into separate typed `Vec`s above —
-        // `managed_resources` from `module.resources`, `data_sources`
+        // `resources` from `module.resources`, `data_sources`
         // from `module.data_sources`, and `virtual_resources` from
         // `module.virtual_resources` plus the `_virtual` attribute
         // resource built above.
@@ -339,7 +339,7 @@ impl ModuleResolver<'_> {
         // reason — never silently absent (the carina#3126 fix).
         Ok(ParsedFile {
             // Populated from the module, instance-prefixed:
-            resources: managed_resources,
+            resources,
             data_sources,
             virtual_resources,
             wait_bindings: expanded_wait_bindings,
@@ -484,12 +484,12 @@ fn prefix_attr_value(
 /// `template_resource` so a loop body inside a module is prefixed
 /// identically to a top-level module resource (carina#3126 PR-B).
 fn prefix_module_resource(
-    resource: &ManagedResource,
+    resource: &Resource,
     instance_prefix: &str,
     module_name: &str,
     intra_module_bindings: &HashSet<String>,
     argument_values: &HashMap<String, Value>,
-) -> ManagedResource {
+) -> Resource {
     let mut new_resource = resource.clone();
 
     // Only Bound names take the prefix here. Pending names stay
@@ -629,7 +629,7 @@ fn prefix_module_virtual_resource(
 /// field:
 /// - `binding_name` (the generated-resource address prefix, e.g.
 ///   `_domain_validation_options`) → instance-prefixed
-///   unconditionally, exactly like `ManagedResource.binding`, so each module
+///   unconditionally, exactly like `Resource.binding`, so each module
 ///   instance's loop resources are uniquely addressed.
 /// - `iterable_binding` (the iterable's root binding, e.g. `cert`) →
 ///   instance-prefixed **only when it is a module-internal binding**,
@@ -691,7 +691,7 @@ fn prefix_deferred_for_expression(
         // `_domain_validation_options`), NOT a reference to a
         // pre-existing binding, so the caller-collision concern does
         // not apply: prefix it unconditionally (same as
-        // `ManagedResource.binding`) to isolate each module instance's loop
+        // `Resource.binding`) to isolate each module instance's loop
         // resources.
         binding_name: apply_instance_prefix(instance_prefix, binding_name),
         // Iterable root binding — this IS a reference to an existing
@@ -924,7 +924,7 @@ pub(super) fn split_instance_prefix(name: &str) -> Option<(&str, &str)> {
 /// `(provider, resource_type)` — the reconciler uses them to discover which
 /// instance prefixes already exist in state.
 pub fn reconcile_anonymous_module_instances(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     find_state_names_by_type: &dyn Fn(&str, &str) -> Vec<String>,
 ) {
     use std::collections::{HashMap, HashSet};

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -13,9 +13,7 @@ use indexmap::IndexMap;
 
 use super::*;
 use crate::parser::{ArgumentParameter, ModuleCall, ParsedFile, ProviderContext, TypeExpr};
-use crate::resource::{
-    ConcreteValue, DeferredValue, Directives, ManagedResource, ResourceId, Value,
-};
+use crate::resource::{ConcreteValue, DeferredValue, Directives, Resource, ResourceId, Value};
 use crate::schema::TypeIdentity;
 
 fn create_test_module() -> ParsedFile {
@@ -23,7 +21,7 @@ fn create_test_module() -> ParsedFile {
         providers: vec![],
         data_sources: vec![],
         virtual_resources: vec![],
-        resources: vec![ManagedResource {
+        resources: vec![Resource {
             id: ResourceId::new("security_group", "sg"),
             attributes: {
                 let mut attrs = HashMap::new();
@@ -140,7 +138,7 @@ fn create_test_module_with_anonymous_resource() -> ParsedFile {
         providers: vec![],
         data_sources: vec![],
         virtual_resources: vec![],
-        resources: vec![ManagedResource {
+        resources: vec![Resource {
             id: ResourceId::with_provider("awscc", "iam.RolePolicy", "", None),
             attributes: {
                 let mut attrs = IndexMap::new();
@@ -272,7 +270,7 @@ fn test_expand_module_call() {
 /// `(id.provider, id.provider_instance)`, so the lost binding made
 /// `create` dispatch to the kind's default instance even though
 /// state-writeback (which reads `directives.provider_instance` from
-/// the `ManagedResource`, not the `id`) still recorded the routing
+/// the `Resource`, not the `id`) still recorded the routing
 /// correctly. Net effect for users: an ACM cert that should live in
 /// `us-east-1` (where CloudFront viewer certs *must* live) lands in
 /// the default region instead, and subsequent `read` against the
@@ -282,7 +280,7 @@ fn create_module_with_named_provider_instance() -> ParsedFile {
         providers: vec![],
         data_sources: vec![],
         virtual_resources: vec![],
-        resources: vec![ManagedResource {
+        resources: vec![Resource {
             id: ResourceId::with_provider("aws", "acm.Certificate", "cert", Some("us".to_string())),
             attributes: {
                 let mut attrs = IndexMap::new();
@@ -367,13 +365,13 @@ fn test_reconcile_anonymous_module_instances_preserves_provider_instance() {
     // `provider_instance` before carina#3038. A close-but-different
     // SimHash in state triggers a name rewrite, so this test must
     // assert that the named-instance routing survives the rewrite.
-    use crate::resource::{ConcreteValue, ManagedResource, ResourceId, Value};
+    use crate::resource::{ConcreteValue, Resource, ResourceId, Value};
 
     let current_prefix = format!("thing_{:016x}", 0xABCDu64);
     let state_hash = 0xABCDu64 ^ 1; // flip one bit — within SimHash threshold
     let state_name = format!("thing_{:016x}.role", state_hash);
 
-    let mut resources = vec![ManagedResource {
+    let mut resources = vec![Resource {
         id: ResourceId::with_provider(
             "aws",
             "iam.Role",
@@ -426,7 +424,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
         data_sources: vec![],
         virtual_resources: vec![],
         resources: vec![
-            ManagedResource {
+            Resource {
                 id: ResourceId::new("ec2.Vpc", "main_vpc"),
                 attributes: {
                     let mut attrs = HashMap::new();
@@ -445,7 +443,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
                 module_source: None,
                 quoted_string_attrs: std::collections::HashSet::new(),
             },
-            ManagedResource {
+            Resource {
                 id: ResourceId::new("ec2.Subnet", "sub"),
                 attributes: {
                     let mut attrs = HashMap::new();
@@ -572,7 +570,7 @@ fn test_multiple_module_instances_no_collision() {
         "Instance B subnet should reference staging.vpc, not bare vpc"
     );
 
-    // ManagedResource names should also be distinct (dot notation)
+    // Resource names should also be distinct (dot notation)
     assert_eq!(expanded_a[0].id.name_str(), "prod.main_vpc");
     assert_eq!(expanded_b[0].id.name_str(), "staging.main_vpc");
 }
@@ -585,7 +583,7 @@ fn create_module_with_attributes() -> ParsedFile {
         providers: vec![],
         data_sources: vec![],
         virtual_resources: vec![],
-        resources: vec![ManagedResource {
+        resources: vec![Resource {
             id: ResourceId::new("security_group", "sg"),
             attributes: {
                 let mut attrs = HashMap::new();
@@ -1242,7 +1240,7 @@ fn test_expand_module_call_uses_dot_path_addressing() {
     assert_eq!(expanded.len(), 1);
 
     let sg = &expanded[0];
-    // ManagedResource name should use dot notation, not underscore
+    // Resource name should use dot notation, not underscore
     assert_eq!(sg.id.name_str(), "my_instance.sg");
 }
 
@@ -1273,7 +1271,7 @@ fn test_module_dot_path_bindings_and_refs() {
         .unwrap()
         .resources;
 
-    // ManagedResource names should use dot notation
+    // Resource names should use dot notation
     assert_eq!(expanded[0].id.name_str(), "prod.main_vpc");
     assert_eq!(expanded[1].id.name_str(), "prod.sub");
 
@@ -1304,7 +1302,7 @@ fn test_expand_module_call_propagates_and_prefixes_wait_bindings() {
         let mut m = create_module_with_intra_refs();
         // A resource that consumes the wait binding the same way the
         // real CloudFront Distribution consumes `cert_issued`.
-        m.resources.push(ManagedResource {
+        m.resources.push(Resource {
             id: ResourceId::new("cloudfront.Distribution", "distribution"),
             attributes: {
                 let mut attrs = HashMap::new();
@@ -1540,7 +1538,7 @@ fn create_module_with_interpolation() -> ParsedFile {
         providers: vec![],
         data_sources: vec![],
         virtual_resources: vec![],
-        resources: vec![ManagedResource {
+        resources: vec![Resource {
             id: ResourceId::new("ec2.Vpc", "vpc"),
             attributes: {
                 let mut attrs = HashMap::new();
@@ -4083,7 +4081,7 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
         // intra-module-conditional prefix to apply (same condition as
         // `rewrite_intra_module_refs`). Add it so this unit faithfully
         // models the real `let cert = aws.acm.Certificate { … }` case.
-        m.resources.push(ManagedResource {
+        m.resources.push(Resource {
             id: ResourceId::new("acm.Certificate", "cert"),
             attributes: HashMap::new().into_iter().collect(),
             directives: Directives::default(),
@@ -4103,7 +4101,7 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
             iterable_binding: "cert".to_string(),
             iterable_attr: "domain_validation_options".to_string(),
             binding: ForBinding::Map("_".to_string(), "opt".to_string()),
-            template_resource: ManagedResource {
+            template_resource: Resource {
                 id: ResourceId::new("route53.RecordSet", "placeholder"),
                 attributes: {
                     // The loop body references the module-internal
@@ -4170,7 +4168,7 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
     // resource. Call instance is "r".
     //
     // `binding_name` is the generated-resource address prefix →
-    // prefixed unconditionally (mirrors `ManagedResource.binding`).
+    // prefixed unconditionally (mirrors `Resource.binding`).
     assert_eq!(
         d.binding_name, "r._domain_validation_options",
         "PR-B must instance-prefix binding_name"
@@ -4243,7 +4241,7 @@ fn deferred_for_iterable_binding_not_prefixed_when_not_module_internal() {
             iterable_binding: "accounts".to_string(),
             iterable_attr: "list".to_string(),
             binding: ForBinding::Map("_".to_string(), "a".to_string()),
-            template_resource: ManagedResource {
+            template_resource: Resource {
                 id: ResourceId::new("sso.Assignment", "placeholder"),
                 attributes: HashMap::new().into_iter().collect(),
                 directives: Directives::default(),

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -8,8 +8,8 @@ use super::expressions::validate_expr::CompareOp;
 use super::util::snake_to_pascal;
 use crate::binding_index::IterableBindings;
 use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, Directives, ManagedResource, ResourceId,
-    ResourceLike, UnknownReason, Value, VirtualResource,
+    ConcreteValue, DataSource, DeferredValue, Directives, Resource, ResourceId, ResourceLike,
+    UnknownReason, Value, VirtualResource,
 };
 use crate::version_constraint::VersionConstraint;
 use indexmap::IndexMap;
@@ -44,7 +44,7 @@ pub struct DeferredForExpression {
     /// correct variable(s).
     pub binding: ForBinding,
     /// Template resource for expansion (the for body parsed with placeholders).
-    pub template_resource: ManagedResource,
+    pub template_resource: Resource,
 }
 
 /// Origin of a resource yielded by [`ParsedFile::iter_all_resources`].
@@ -67,7 +67,7 @@ pub enum ResourceContext<'a> {
 /// arms borrow from `File`'s typed slices ([`File::resources`] managed
 /// rows, [`File::virtual_resources`], [`File::data_sources`]); the
 /// `Deferred` arm is a `for`-expression template body that still lives
-/// as a legacy [`ManagedResource`] in [`File::deferred_for_expressions`].
+/// as a legacy [`Resource`] in [`File::deferred_for_expressions`].
 ///
 /// Read-only consumers reach the shared accessors via
 /// [`ResourceRef::as_resource_like`] (or the `id` / `attributes` /
@@ -76,7 +76,7 @@ pub enum ResourceContext<'a> {
 #[derive(Debug, Clone, Copy)]
 pub enum ResourceRef<'a> {
     /// A top-level managed resource.
-    Managed(&'a ManagedResource),
+    Managed(&'a Resource),
     /// A top-level virtual resource (module-expansion synthetic node).
     Virtual(&'a VirtualResource),
     /// A top-level data source (`read`-keyword resource).
@@ -84,7 +84,7 @@ pub enum ResourceRef<'a> {
     /// The template body of a deferred `for` expression — always a
     /// managed resource (`for` bodies never carry `read` / virtual).
     Deferred {
-        resource: &'a ManagedResource,
+        resource: &'a Resource,
         deferred: &'a DeferredForExpression,
     },
 }
@@ -794,7 +794,7 @@ impl ExportParamLike for InferredExportParam {
 pub struct File<E> {
     pub providers: Vec<ProviderConfig>,
     /// Top-level managed infrastructure resources.
-    pub resources: Vec<ManagedResource>,
+    pub resources: Vec<Resource>,
     /// Read-only data-source resources (`read`-keyword resources).
     pub data_sources: Vec<DataSource>,
     /// Virtual resources synthesized by module-call expansion.
@@ -979,7 +979,7 @@ impl<E> File<E> {
         resource_type: &str,
         attr_name: &str,
         attr_value: &str,
-    ) -> Option<&ManagedResource> {
+    ) -> Option<&Resource> {
         self.resources.iter().find(|r| {
             r.id.resource_type == resource_type
                 && matches!(r.get_attr(attr_name), Some(Value::Concrete(ConcreteValue::String(n))) if n == attr_value)
@@ -1131,7 +1131,7 @@ impl<E> File<E> {
         }
 
         // carina#3181: a deferred for-expression's `template_resource` is
-        // a `ManagedResource`, so every expansion of it is managed — they
+        // a `Resource`, so every expansion of it is managed — they
         // go straight into the managed `resources` slice. (A `read` /
         // virtual for-body never reaches the deferred path.)
         self.resources.extend(expanded_resources);
@@ -1145,7 +1145,7 @@ impl<E> File<E> {
 /// with concrete scalars, surrounding `Interpolation` shapes can collapse
 /// to a `String` (#2227).
 fn substitute_attrs(
-    resource: &mut crate::resource::ManagedResource,
+    resource: &mut crate::resource::Resource,
     index: Option<i64>,
     key: Option<&str>,
     value: &Value,

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -12,7 +12,7 @@ use crate::parser::expressions::string_literal::parse_string_value;
 use crate::parser::expressions::validate_expr::parse_validate_expr;
 use crate::parser::parse_expression;
 use crate::parser::types::parse_type_expr;
-use crate::resource::{ConcreteValue, DeferredValue, Directives, ManagedResource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Directives, Resource, Value};
 use indexmap::IndexMap;
 
 /// Parse arguments block. See `register_argument_binding` for the
@@ -149,7 +149,7 @@ fn register_argument_binding(ctx: &mut ParseContext, name: &str) {
         binding: name.to_string(),
     });
     ctx.set_variable(name.to_string(), placeholder_ref);
-    let placeholder = ManagedResource::new("_argument", name);
+    let placeholder = Resource::new("_argument", name);
     ctx.set_resource_binding(name.to_string(), placeholder);
     // The local declaration is the real one for this file; drop the
     // seed mark (if any) so a later real duplicate (`let <name> = ...`

--- a/carina-core/src/parser/blocks/resource.rs
+++ b/carina-core/src/parser/blocks/resource.rs
@@ -1,4 +1,4 @@
-//! ManagedResource-expression parsers (`provider.service.Type "name" { ... }`,
+//! Resource-expression parsers (`provider.service.Type "name" { ... }`,
 //! anonymous resources, `read` data sources) and the shared
 //! `parse_block_contents` traversal that backs both resources and the
 //! map-literal primary.
@@ -11,14 +11,14 @@ use crate::parser::context::{ParseContext, extract_key_string, first_inner, next
 use crate::parser::error::ParseError;
 use crate::parser::parse_expression;
 use crate::parser::util::expression_is_plain_string_literal;
-use crate::resource::{ConcreteValue, DataSource, ManagedResource, ResourceId, Value};
+use crate::resource::{ConcreteValue, DataSource, Resource, ResourceId, Value};
 use indexmap::IndexMap;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 pub(in crate::parser) fn parse_anonymous_resource(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
-) -> Result<ManagedResource, ParseError> {
+) -> Result<Resource, ParseError> {
     let inner = pair.into_inner();
 
     let mut iter = inner;
@@ -59,7 +59,7 @@ pub(in crate::parser) fn parse_anonymous_resource(
         directives.provider_instance.clone(),
     );
 
-    Ok(ManagedResource {
+    Ok(Resource {
         id,
         attributes: attributes.into_iter().collect(),
         directives,
@@ -85,7 +85,7 @@ pub(crate) fn parse_block_contents(
 /// As [`parse_block_contents`], but if `quoted_out` is `Some`, populate it
 /// with the names of top-level attributes whose value is a plain quoted
 /// string literal (`attr = "..."`). Used by resource-level callers to
-/// build `ManagedResource.quoted_string_attrs` for enum-attribute diagnostics
+/// build `Resource.quoted_string_attrs` for enum-attribute diagnostics
 /// (#2094 / #2229) without re-walking the pest tree.
 pub(in crate::parser) fn parse_block_contents_with_quoted(
     pairs: pest::iterators::Pairs<Rule>,
@@ -93,7 +93,7 @@ pub(in crate::parser) fn parse_block_contents_with_quoted(
     quoted_out: &mut Option<HashSet<String>>,
 ) -> Result<IndexMap<String, Value>, ParseError> {
     // `IndexMap` so the order in which the user wrote attributes in the
-    // .crn file flows all the way to `ManagedResource.attributes` and to
+    // .crn file flows all the way to `Resource.attributes` and to
     // `Value::Concrete(ConcreteValue::Map)` payloads — anything that re-renders attributes
     // (formatter, plan display, diagnostics) sees a stable order.
     let mut attributes: IndexMap<String, Value> = IndexMap::new();
@@ -191,7 +191,7 @@ pub(crate) fn parse_resource_expr(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
     binding_name: &str,
-) -> Result<ManagedResource, ParseError> {
+) -> Result<Resource, ParseError> {
     let mut inner = pair.into_inner();
 
     let namespaced_type = next_pair(&mut inner, "resource type", "resource expression")?
@@ -230,7 +230,7 @@ pub(crate) fn parse_resource_expr(
         directives.provider_instance.clone(),
     );
 
-    Ok(ManagedResource {
+    Ok(Resource {
         id,
         attributes: attributes.into_iter().collect(),
         directives,

--- a/carina-core/src/parser/context.rs
+++ b/carina-core/src/parser/context.rs
@@ -8,7 +8,7 @@ use super::ast::{DeferredForExpression, ProviderConfig, UpstreamState, UserFunct
 use super::error::{ParseError, ParseWarning};
 use super::{ProviderContext, Rule};
 use crate::eval_value::EvalValue;
-use crate::resource::ManagedResource;
+use crate::resource::Resource;
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 
@@ -22,8 +22,8 @@ pub(crate) struct ParseContext<'cfg> {
     /// end of `parse(...)`; an unfinished closure surfaces as a
     /// parse-time error.
     pub(super) variables: IndexMap<String, EvalValue>,
-    /// Resource bindings (binding_name -> ManagedResource)
-    pub(super) resource_bindings: HashMap<String, ManagedResource>,
+    /// Resource bindings (binding_name -> Resource)
+    pub(super) resource_bindings: HashMap<String, Resource>,
     /// Imported modules (alias -> path)
     pub(super) imported_modules: HashMap<String, String>,
     /// User-defined functions
@@ -99,7 +99,7 @@ impl<'cfg> ParseContext<'cfg> {
         self.variables.get(name)
     }
 
-    pub(super) fn set_resource_binding(&mut self, name: String, resource: ManagedResource) {
+    pub(super) fn set_resource_binding(&mut self, name: String, resource: Resource) {
         self.resource_bindings.insert(name, resource);
     }
 

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -27,7 +27,7 @@ use super::resolve::{
     resolve_resource_refs,
 };
 use crate::eval_value::EvalValue;
-use crate::resource::{DataSource, DeferredValue, ManagedResource, Value};
+use crate::resource::{DataSource, DeferredValue, Resource, Value};
 use indexmap::IndexMap;
 use pest::Parser;
 
@@ -53,7 +53,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
 /// Each name in `seeds` is registered in the per-file [`ParseContext`]
 /// the same way `register_argument_binding` does: a placeholder
 /// `Value::Deferred(DeferredValue::ResourceRef{ binding: <name>, attribute: "", … })` is
-/// installed in `ctx.variables`, and a placeholder `ManagedResource` is
+/// installed in `ctx.variables`, and a placeholder `Resource` is
 /// installed in `ctx.resource_bindings`. This means subsequent
 /// expressions resolve the name via the normal `ctx.get_variable` /
 /// `ctx.is_resource_binding` paths instead of degrading to the literal-
@@ -290,12 +290,11 @@ pub fn parse_with_seeded_bindings(
                                     if !is_discard {
                                         // Register the binding name so `name.attr`
                                         // resolves as a `ResourceRef`. Data sources
-                                        // are a distinct type from `ManagedResource`,
+                                        // are a distinct type from `Resource`,
                                         // so a placeholder managed binding stands in
                                         // for resolution purposes — same shape as the
                                         // `_module_binding` / `_wait` placeholders.
-                                        let placeholder =
-                                            ManagedResource::new("_data_source", &name);
+                                        let placeholder = Resource::new("_data_source", &name);
                                         ctx.set_resource_binding(name.clone(), placeholder);
                                     }
                                     data_sources.extend(expanded_data_sources);
@@ -310,14 +309,12 @@ pub fn parse_with_seeded_bindings(
                                     if !is_discard {
                                         // Register as a resource binding so that
                                         // `name.attr` resolves as ResourceRef
-                                        let placeholder =
-                                            ManagedResource::new("_module_binding", &name);
+                                        let placeholder = Resource::new("_module_binding", &name);
                                         ctx.set_resource_binding(name.clone(), placeholder);
                                     }
                                 }
                                 if is_upstream_state && !is_discard {
-                                    let placeholder =
-                                        ManagedResource::new("_upstream_state", &name);
+                                    let placeholder = Resource::new("_upstream_state", &name);
                                     ctx.set_resource_binding(name.clone(), placeholder);
                                     upstream_states.push(ctx.upstream_states[&name].clone());
                                 }
@@ -327,7 +324,7 @@ pub fn parse_with_seeded_bindings(
                                     // `<wait-binding>.<attr>` parses as `ResourceRef`.
                                     // Downstream resolution (Phase 4 of #2825) treats
                                     // it as passthrough of the target's snapshot.
-                                    let placeholder = ManagedResource::new("_wait", &name);
+                                    let placeholder = Resource::new("_wait", &name);
                                     ctx.set_resource_binding(name.clone(), placeholder);
                                     wait_bindings.push(ctx.wait_bindings[&name].clone());
                                 }
@@ -447,7 +444,7 @@ fn seed_bindings(ctx: &mut ParseContext<'_>, seeds: &[&str]) {
             binding: name.to_string(),
         });
         ctx.set_variable(name.to_string(), placeholder_ref);
-        let placeholder = ManagedResource::new("_seeded", name);
+        let placeholder = Resource::new("_seeded", name);
         ctx.set_resource_binding(name.to_string(), placeholder);
         ctx.seeded_bindings.insert(name.to_string());
     }

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -13,9 +13,7 @@ use crate::parser::{
     evaluate_static_value, first_inner, next_pair, parse_expression, parse_module_call,
     parse_read_resource_expr, parse_resource_expr,
 };
-use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, ManagedResource, UnknownReason, Value,
-};
+use crate::resource::{ConcreteValue, DataSource, DeferredValue, Resource, UnknownReason, Value};
 
 /// Binding pattern for a for expression
 #[derive(Debug, Clone, PartialEq)]
@@ -81,7 +79,7 @@ fn is_bare_identifier(s: &str) -> bool {
 /// Result of parsing a for expression body: a managed resource, a data
 /// source, or a module call.
 pub(crate) enum ForBodyResult {
-    ManagedResource(Box<ManagedResource>),
+    Resource(Box<Resource>),
     DataSource(Box<DataSource>),
     ModuleCall(ModuleCall),
 }
@@ -130,7 +128,7 @@ pub(crate) fn parse_for_expr(
     pair: pest::iterators::Pair<Rule>,
     ctx: &mut ParseContext,
     binding_name: &str,
-) -> Result<(Vec<ManagedResource>, Vec<DataSource>, Vec<ModuleCall>), ParseError> {
+) -> Result<(Vec<Resource>, Vec<DataSource>, Vec<ModuleCall>), ParseError> {
     let for_line = pair.as_span().start_pos().line_col().0;
     let mut inner = pair.into_inner();
 
@@ -169,11 +167,11 @@ pub(crate) fn parse_for_expr(
     let mut module_calls = Vec::new();
 
     let collect = |result: ForBodyResult,
-                   resources: &mut Vec<ManagedResource>,
+                   resources: &mut Vec<Resource>,
                    data_sources: &mut Vec<DataSource>,
                    module_calls: &mut Vec<ModuleCall>| {
         match result {
-            ForBodyResult::ManagedResource(r) => resources.push(*r),
+            ForBodyResult::Resource(r) => resources.push(*r),
             ForBodyResult::DataSource(d) => data_sources.push(*d),
             ForBodyResult::ModuleCall(c) => module_calls.push(c),
         }
@@ -280,7 +278,7 @@ pub(crate) fn parse_for_expr(
             }
 
             let address = format!("{}[?]", binding_name);
-            if let Ok(ForBodyResult::ManagedResource(resource)) =
+            if let Ok(ForBodyResult::Resource(resource)) =
                 parse_for_body(body_pair, &template_ctx, &address)
             {
                 let attrs: Vec<(String, Value)> = resource
@@ -365,7 +363,7 @@ pub(crate) fn parse_for_expr(
                     }
                 }
                 let address = format!("{}[?]", binding_name);
-                if let Ok(ForBodyResult::ManagedResource(resource)) =
+                if let Ok(ForBodyResult::Resource(resource)) =
                     parse_for_body(body_pair, &template_ctx, &address)
                 {
                     let attrs: Vec<(String, Value)> = resource
@@ -528,7 +526,7 @@ pub(crate) fn parse_for_body(
             }
             Rule::resource_expr => {
                 let resource = parse_resource_expr(inner, &local_ctx, address)?;
-                return Ok(ForBodyResult::ManagedResource(Box::new(resource)));
+                return Ok(ForBodyResult::Resource(Box::new(resource)));
             }
             Rule::read_resource_expr => {
                 let data_source = parse_read_resource_expr(inner, &local_ctx, address)?;

--- a/carina-core/src/parser/expressions/if_expr.rs
+++ b/carina-core/src/parser/expressions/if_expr.rs
@@ -15,12 +15,12 @@ use crate::parser::{
     is_static_value, next_pair, parse_expression, parse_module_call, parse_read_resource_expr,
     parse_resource_expr,
 };
-use crate::resource::{ConcreteValue, DataSource, ManagedResource, Value};
+use crate::resource::{ConcreteValue, DataSource, Resource, Value};
 
 /// Result of parsing an if expression body: a managed resource, a data
 /// source, a module call, or a value.
 pub(crate) enum IfBodyResult {
-    ManagedResource(Box<ManagedResource>),
+    Resource(Box<Resource>),
     DataSource(Box<DataSource>),
     ModuleCall(ModuleCall),
     Value(Value),
@@ -100,7 +100,7 @@ pub(crate) fn parse_if_body_to_rhs(
 ) -> Result<LetBindingRhs, ParseError> {
     let result = parse_if_body(pair, ctx, binding_name)?;
     match result {
-        IfBodyResult::ManagedResource(r) => {
+        IfBodyResult::Resource(r) => {
             let ref_value =
                 Value::Concrete(ConcreteValue::String(format!("${{{}}}", binding_name)));
             Ok((
@@ -156,7 +156,7 @@ pub(crate) fn parse_if_body(
             }
             Rule::resource_expr => {
                 let resource = parse_resource_expr(inner, &local_ctx, binding_name)?;
-                return Ok(IfBodyResult::ManagedResource(Box::new(resource)));
+                return Ok(IfBodyResult::Resource(Box::new(resource)));
             }
             Rule::read_resource_expr => {
                 let data_source = parse_read_resource_expr(inner, &local_ctx, binding_name)?;

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -266,10 +266,10 @@ pub(crate) fn parse_primary_eval(
 
     match inner.as_rule() {
         Rule::resource_expr => {
-            // ManagedResource expressions cannot be used as attribute values (only valid in top-level let bindings)
+            // Resource expressions cannot be used as attribute values (only valid in top-level let bindings)
             Err(ParseError::InvalidExpression {
                 line: 0,
-                message: "ManagedResource expressions can only be used in let bindings".to_string(),
+                message: "Resource expressions can only be used in let bindings".to_string(),
             })
         }
         Rule::list => {

--- a/carina-core/src/parser/let_binding.rs
+++ b/carina-core/src/parser/let_binding.rs
@@ -22,7 +22,7 @@ use super::parse_expression;
 use super::static_eval::is_static_value;
 use super::util::eval_type_name;
 use crate::eval_value::EvalValue;
-use crate::resource::{ConcreteValue, DataSource, DeferredValue, ManagedResource, Value};
+use crate::resource::{ConcreteValue, DataSource, DeferredValue, Resource, Value};
 
 /// Tuple returned by the let-binding parser. The RHS is `EvalValue`
 /// rather than `Value` so partial applications (closures) can survive
@@ -34,7 +34,7 @@ use crate::resource::{ConcreteValue, DataSource, DeferredValue, ManagedResource,
 /// [`ParsedFile`](super::ast::ParsedFile) (carina#3181).
 pub(crate) type LetBindingRhs = (
     EvalValue,
-    Vec<ManagedResource>,
+    Vec<Resource>,
     Vec<DataSource>,
     Vec<ModuleCall>,
     Option<UseStatement>,
@@ -53,7 +53,7 @@ pub(super) fn parse_let_binding_extended(
     (
         String,
         EvalValue,
-        Vec<ManagedResource>,
+        Vec<Resource>,
         Vec<DataSource>,
         Vec<ModuleCall>,
         Option<UseStatement>,

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -7,15 +7,13 @@ use super::ast::{AttributeParameter, ExportParameter, ModuleCall, ParsedFile};
 use super::error::{ParseError, undefined_identifier_error};
 use super::static_eval::is_static_value;
 use crate::eval_value::EvalValue;
-use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, ManagedResource, ResourceLike, Value,
-};
+use crate::resource::{ConcreteValue, DataSource, DeferredValue, Resource, ResourceLike, Value};
 use indexmap::IndexMap;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 /// Mutable pre-apply traversal — the resolver mutates `attributes` and
 /// `dependency_bindings` of every resource whose references are resolved
-/// **before** apply: managed [`ManagedResource`]s and [`DataSource`]s.
+/// **before** apply: managed [`Resource`]s and [`DataSource`]s.
 ///
 /// `VirtualResource` is excluded on purpose — a virtual resource's
 /// attributes may carry refs whose resolution is deferred to the
@@ -26,7 +24,7 @@ trait PreApplyResourceMut: ResourceLike {
     fn dependency_bindings_mut(&mut self) -> &mut BTreeSet<String>;
 }
 
-impl PreApplyResourceMut for ManagedResource {
+impl PreApplyResourceMut for Resource {
     fn attributes_mut(&mut self) -> &mut IndexMap<String, Value> {
         &mut self.attributes
     }
@@ -71,7 +69,7 @@ fn iter_pre_apply_resources_mut(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn resolve_forward_references(
     resource_bindings: &HashSet<String>,
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     data_sources: &mut [DataSource],
     attribute_params: &mut [AttributeParameter],
     module_calls: &mut [ModuleCall],
@@ -395,7 +393,7 @@ pub fn check_identifier_scope(parsed: &ParsedFile) -> Vec<ParseError> {
 /// - `provider = <binding>` whose binding's kind does not match the
 ///   resource's kind (e.g. `aws.s3.Bucket { directives { provider =
 ///   <awscc-binding> } }`).
-/// - ManagedResource that omits `directives { provider = ... }` but whose
+/// - Resource that omits `directives { provider = ... }` but whose
 ///   kind has no default instance (the kind was registered via a
 ///   top-level `provider <kind> { source = ..., version = ... }`
 ///   block with no instance attributes, and every instance of that

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::binding_index::IterableBindings;
-use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, ManagedResource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, Resource, Value};
 use crate::schema::TypeIdentity;
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -7505,7 +7505,7 @@ fn expand_deferred_for_map_binding_substitutes_key_and_value() {
     assert_eq!(parsed.resources.len(), 2); // allow: direct — fixture test inspection
 
     // Verify both key and value are substituted.
-    let mut by_name: HashMap<String, &ManagedResource> = HashMap::new();
+    let mut by_name: HashMap<String, &Resource> = HashMap::new();
     for r in &parsed.resources {
         if let Some(Value::Concrete(ConcreteValue::String(s))) = r.get_attr("target_name") {
             by_name.insert(s.clone(), r);
@@ -8285,7 +8285,7 @@ fn reference_to_upstream_state_binding_is_allowed() {
 /// Anonymous resources start with an empty name; the post-parse
 /// identifier pass rewrites that name. A side-table keyed by
 /// `ResourceId` would silently miss after the rename. Co-locating
-/// the bit on the `ManagedResource` (the same struct that carries the
+/// the bit on the `Resource` (the same struct that carries the
 /// attributes) makes it impossible to lose.
 #[test]
 fn quoted_literal_marker_survives_anonymous_resource_rename() {
@@ -8317,8 +8317,8 @@ fn quoted_literal_marker_survives_anonymous_resource_rename() {
 /// bare identifiers and namespaced identifiers at the parser level,
 /// so downstream enum diagnostics can report shape mismatches
 /// ("got a string literal") vs. variant mismatches ("invalid enum
-/// variant"). After #2229 the marker lives on the `ManagedResource` that
-/// owns the attributes (`ManagedResource.quoted_string_attrs`); the
+/// variant"). After #2229 the marker lives on the `Resource` that
+/// owns the attributes (`Resource.quoted_string_attrs`); the
 /// previous `string_literal_paths` side-table is gone.
 #[test]
 fn quoted_string_attrs_distinguish_quoted_from_bare_and_namespaced() {

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -166,7 +166,7 @@ pub(crate) fn extract_string_from_pair(
 
 /// True if a parsed expression is exactly a plain (uninterpolated)
 /// quoted string literal — no operators, no interpolation, no
-/// list / map wrapping. Used to populate `ManagedResource.quoted_string_attrs`
+/// list / map wrapping. Used to populate `Resource.quoted_string_attrs`
 /// so enum-attribute diagnostics can distinguish a shape mismatch
 /// (`attr = "AWS_ACCOUNT"`) from a variant mismatch
 /// (`attr = AWS_ACCOUNT`); see #2094 / #2229.

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -142,7 +142,7 @@ impl Plan {
                     // Take ownership of the Update fields and upgrade to Replace.
                     // The `Create` here is a throwaway placeholder overwritten
                     // on the next line.
-                    let placeholder = crate::resource::ManagedResource::new("", "");
+                    let placeholder = crate::resource::Resource::new("", "");
                     let old = std::mem::replace(effect, Effect::Create(placeholder));
                     if let Effect::Update { id, from, to, .. } = old {
                         *effect = Effect::Replace {
@@ -429,7 +429,7 @@ fn format_effect_brief(effect: &Effect) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::ManagedResource;
+    use crate::resource::Resource;
 
     #[test]
     fn empty_plan() {
@@ -464,10 +464,7 @@ mod tests {
     #[test]
     fn plan_with_create_has_mutations() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(ManagedResource::new(
-            "acm.Certificate",
-            "cert",
-        )));
+        plan.add(Effect::Create(Resource::new("acm.Certificate", "cert")));
         assert!(plan.has_mutations());
         assert_eq!(plan.mutation_count(), 1);
     }
@@ -504,10 +501,7 @@ mod tests {
         use std::time::Duration;
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(ManagedResource::new(
-            "acm.Certificate",
-            "cert",
-        )));
+        plan.add(Effect::Create(Resource::new("acm.Certificate", "cert")));
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
@@ -529,8 +523,8 @@ mod tests {
     #[test]
     fn plan_summary() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
-        plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
+        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+        plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
         plan.add(Effect::Delete {
             id: crate::resource::ResourceId::new("s3.Bucket", "c"),
             identifier: String::new(),
@@ -550,15 +544,14 @@ mod tests {
         let mut plan = Plan::new();
 
         // Root resource
-        plan.add(Effect::Create(ManagedResource::new("vpc", "main")));
+        plan.add(Effect::Create(Resource::new("vpc", "main")));
 
         // Module resource
-        let module_resource = ManagedResource::new("security_group", "web_sg").with_module_source(
-            ModuleSource::Module {
+        let module_resource =
+            Resource::new("security_group", "web_sg").with_module_source(ModuleSource::Module {
                 name: "web_tier".to_string(),
                 instance: "web".to_string(),
-            },
-        );
+            });
         plan.add(Effect::Create(module_resource));
 
         let modular = ModularPlan::from_plan(plan);
@@ -578,16 +571,15 @@ mod tests {
         let mut plan = Plan::new();
 
         // Two root resources
-        plan.add(Effect::Create(ManagedResource::new("vpc", "main")));
-        plan.add(Effect::Create(ManagedResource::new("subnet", "public")));
+        plan.add(Effect::Create(Resource::new("vpc", "main")));
+        plan.add(Effect::Create(Resource::new("subnet", "public")));
 
         // Module resource
-        let module_resource = ManagedResource::new("security_group", "web_sg").with_module_source(
-            ModuleSource::Module {
+        let module_resource =
+            Resource::new("security_group", "web_sg").with_module_source(ModuleSource::Module {
                 name: "web_tier".to_string(),
                 instance: "web".to_string(),
-            },
-        );
+            });
         plan.add(Effect::Create(module_resource));
 
         let modular = ModularPlan::from_plan(plan);
@@ -613,14 +605,14 @@ mod tests {
 
         // A Replace effect with one cascading update
         let from = State::not_found(ResourceId::new("ec2.Vpc", "vpc")).with_identifier("vpc-123");
-        let to = ManagedResource::new("ec2.Vpc", "vpc");
+        let to = Resource::new("ec2.Vpc", "vpc");
         let cascading = CascadingUpdate {
             id: ResourceId::new("ec2.Subnet", "subnet"),
             from: Box::new(
                 State::not_found(ResourceId::new("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
             ),
-            to: (ManagedResource::new("ec2.Subnet", "subnet")),
+            to: (Resource::new("ec2.Subnet", "subnet")),
         };
         plan.add(Effect::Replace {
             id: ResourceId::new("ec2.Vpc", "vpc"),
@@ -649,14 +641,14 @@ mod tests {
         let mut plan = Plan::new();
 
         let from = State::not_found(ResourceId::new("ec2.Vpc", "vpc")).with_identifier("vpc-123");
-        let to = ManagedResource::new("ec2.Vpc", "vpc");
+        let to = Resource::new("ec2.Vpc", "vpc");
         let cascading = CascadingUpdate {
             id: ResourceId::new("ec2.Subnet", "subnet"),
             from: Box::new(
                 State::not_found(ResourceId::new("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
             ),
-            to: (ManagedResource::new("ec2.Subnet", "subnet")),
+            to: (Resource::new("ec2.Subnet", "subnet")),
         };
         plan.add(Effect::Replace {
             id: ResourceId::new("ec2.Vpc", "vpc"),
@@ -687,7 +679,7 @@ mod tests {
         use crate::resource::ResourceId;
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
+        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
         plan.add(Effect::Delete {
             id: ResourceId::new("s3.Bucket", "b"),
             identifier: "b-id".to_string(),

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -373,13 +373,12 @@ pub fn shorten_service_name<'a>(attr_name: &str, value: &'a str) -> Cow<'a, str>
 mod tests {
     use super::*;
     use crate::plan::Plan;
-    use crate::resource::ManagedResource;
+    use crate::resource::Resource;
 
     #[test]
     fn explicit_only_depends_on_edge_is_in_dependency_graph() {
-        let role = ManagedResource::new("iam.Role", "role").with_binding("role".to_string());
-        let mut bucket =
-            ManagedResource::new("s3.Bucket", "bucket").with_binding("bucket".to_string());
+        let role = Resource::new("iam.Role", "role").with_binding("role".to_string());
+        let mut bucket = Resource::new("s3.Bucket", "bucket").with_binding("bucket".to_string());
         bucket.directives.depends_on = vec!["role".to_string()];
 
         let mut plan = Plan::new();

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -9,9 +9,7 @@ use indexmap::IndexMap;
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::resource::{
-    ConcreteValue, DataSource, Directives, ManagedResource, ResourceId, State, Value,
-};
+use crate::resource::{ConcreteValue, DataSource, Directives, Resource, ResourceId, State, Value};
 use crate::schema::{SchemaRegistry, TypeIdentity};
 
 /// Contextual metadata attached to every [`ProviderError`] variant.
@@ -349,7 +347,7 @@ pub type ProviderResult<T> = Result<T, ProviderError>;
 #[derive(Debug, Clone)]
 pub struct CreateRequest {
     /// Full desired state for the new resource.
-    pub resource: ManagedResource,
+    pub resource: Resource,
 }
 
 /// Per-operation request record for [`Provider::read`].
@@ -366,7 +364,7 @@ pub struct ReadRequest;
 /// Mirrors `update-request` in `wit/types.wit`. `from` is the current
 /// provider-side state; `patch` carries only the user's intended
 /// changes. The patch is the sole source of truth for what the
-/// provider should write — there is no separate `to: ManagedResource`
+/// provider should write — there is no separate `to: Resource`
 /// because exposing the full desired resource invites providers to
 /// touch fields the user never specified (the root cause of
 /// `carina-rs/carina#2559`).
@@ -441,7 +439,7 @@ pub enum PatchOpKind {
 /// value from `to`.
 pub fn build_update_patch(
     changed_attributes: &[String],
-    to: &ManagedResource,
+    to: &Resource,
     from: &State,
 ) -> UpdatePatch {
     let ops = changed_attributes
@@ -623,7 +621,7 @@ pub trait ProviderNormalizer: Send + Sync {
     /// `Tier.advanced` into fully-qualified DSL format like
     /// `awscc.ec2_ipam.Tier.advanced` based on schema definitions.
     /// Providers without enum types return [`ready_noop`].
-    fn normalize_desired<'a>(&'a self, resources: &'a mut [ManagedResource]) -> BoxFuture<'a, ()>;
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()>;
 
     /// Normalize current state values before diffing.
     ///
@@ -667,7 +665,7 @@ pub trait ProviderNormalizer: Send + Sync {
     /// merge, or [`ready_noop`]'s deliberate no-op.
     fn merge_default_tags<'a>(
         &'a self,
-        resources: &'a mut [ManagedResource],
+        resources: &'a mut [Resource],
         default_tags: &'a IndexMap<String, Value>,
         registry: &'a SchemaRegistry,
     ) -> BoxFuture<'a, ()>;
@@ -677,7 +675,7 @@ pub trait ProviderNormalizer: Send + Sync {
 #[derive(Debug, Clone, Copy)]
 pub struct NoopNormalizer;
 impl ProviderNormalizer for NoopNormalizer {
-    fn normalize_desired<'a>(&'a self, _resources: &'a mut [ManagedResource]) -> BoxFuture<'a, ()> {
+    fn normalize_desired<'a>(&'a self, _resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
         ready_noop()
     }
 
@@ -698,7 +696,7 @@ impl ProviderNormalizer for NoopNormalizer {
 
     fn merge_default_tags<'a>(
         &'a self,
-        _resources: &'a mut [ManagedResource],
+        _resources: &'a mut [Resource],
         _default_tags: &'a IndexMap<String, Value>,
         _registry: &'a SchemaRegistry,
     ) -> BoxFuture<'a, ()> {
@@ -716,7 +714,7 @@ impl ProviderNormalizer for NoopNormalizer {
 /// metadata attribute.
 pub fn merge_default_tags_for_provider(
     provider_name: &str,
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     default_tags: &IndexMap<String, Value>,
     registry: &SchemaRegistry,
 ) {
@@ -905,7 +903,7 @@ impl Provider for ProviderRouter {
 }
 
 impl ProviderNormalizer for ProviderRouter {
-    fn normalize_desired<'a>(&'a self, resources: &'a mut [ManagedResource]) -> BoxFuture<'a, ()> {
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
         Box::pin(async move {
             // Sequential, never concurrent: normalizers are not
             // commutative, and `resources` is re-borrowed per iteration
@@ -941,7 +939,7 @@ impl ProviderNormalizer for ProviderRouter {
 
     fn merge_default_tags<'a>(
         &'a self,
-        resources: &'a mut [ManagedResource],
+        resources: &'a mut [Resource],
         default_tags: &'a IndexMap<String, Value>,
         registry: &'a SchemaRegistry,
     ) -> BoxFuture<'a, ()> {
@@ -1341,7 +1339,7 @@ mod tests {
         assert!(!state.exists);
     }
 
-    /// A provider that only accepts a data source when the full `ManagedResource`
+    /// A provider that only accepts a data source when the full `Resource`
     /// carrying its input attributes is delivered. Exercises the new
     /// `read_data_source` path introduced to enable resources like
     /// `identitystore.user` that look themselves up by user-provided inputs.
@@ -1360,7 +1358,7 @@ mod tests {
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let id = id.clone();
             // Intentionally fails if the data source path doesn't deliver
-            // the full ManagedResource — the regular `read` route has no access
+            // the full Resource — the regular `read` route has no access
             // to input attributes.
             Box::pin(async move {
                 Err(ProviderError::internal("read cannot see inputs").for_resource(id))
@@ -1493,7 +1491,7 @@ mod tests {
     #[tokio::test]
     async fn mock_provider_create_returns_existing() {
         let provider = MockProvider;
-        let resource = ManagedResource::new("test", "example");
+        let resource = Resource::new("test", "example");
         let id = resource.id.clone();
         let state = provider
             .create(&id, CreateRequest { resource })
@@ -1518,7 +1516,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let resource = ManagedResource::with_provider("mock", "test", "example", None);
+        let resource = Resource::with_provider("mock", "test", "example", None);
         let id = resource.id.clone();
         let state = router
             .create(&id, CreateRequest { resource })
@@ -1931,7 +1929,7 @@ mod tests {
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = ManagedResource::new("test", "example");
+        let mut to = Resource::new("test", "example");
         to.set_attr(
             "a".to_string(),
             Value::Concrete(ConcreteValue::String("new".into())),
@@ -2255,10 +2253,7 @@ mod tests {
         struct SchemaOnlyProvider;
 
         impl ProviderNormalizer for SchemaOnlyProvider {
-            fn normalize_desired<'a>(
-                &'a self,
-                resources: &'a mut [ManagedResource],
-            ) -> BoxFuture<'a, ()> {
+            fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
                 Box::pin(async move {
                     // Prefix all string attribute values with "normalized:"
                     for resource in resources.iter_mut() {
@@ -2299,7 +2294,7 @@ mod tests {
 
             fn merge_default_tags<'a>(
                 &'a self,
-                _resources: &'a mut [ManagedResource],
+                _resources: &'a mut [Resource],
                 _default_tags: &'a IndexMap<String, Value>,
                 _registry: &'a SchemaRegistry,
             ) -> BoxFuture<'a, ()> {
@@ -2309,7 +2304,7 @@ mod tests {
 
         // Test normalize_desired
         let ext = SchemaOnlyProvider;
-        let mut resources = vec![ManagedResource::new("test", "example").with_attribute(
+        let mut resources = vec![Resource::new("test", "example").with_attribute(
             "key",
             Value::Concrete(ConcreteValue::String("value".to_string())),
         )];
@@ -2400,10 +2395,7 @@ mod tests {
         // Separate schema ext struct for the router
         struct TestNormalizer;
         impl ProviderNormalizer for TestNormalizer {
-            fn normalize_desired<'a>(
-                &'a self,
-                resources: &'a mut [ManagedResource],
-            ) -> BoxFuture<'a, ()> {
+            fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
                 Box::pin(async move {
                     for resource in resources.iter_mut() {
                         if resource.id.provider == "normalizing" {
@@ -2434,7 +2426,7 @@ mod tests {
 
             fn merge_default_tags<'a>(
                 &'a self,
-                _resources: &'a mut [ManagedResource],
+                _resources: &'a mut [Resource],
                 _default_tags: &'a IndexMap<String, Value>,
                 _registry: &'a SchemaRegistry,
             ) -> BoxFuture<'a, ()> {
@@ -2447,7 +2439,7 @@ mod tests {
         router.add_normalizer(Box::new(TestNormalizer));
 
         let mut resources = vec![
-            ManagedResource::with_provider("normalizing", "test", "example", None).with_attribute(
+            Resource::with_provider("normalizing", "test", "example", None).with_attribute(
                 "key",
                 Value::Concrete(ConcreteValue::String("val".to_string())),
             ),

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -9,8 +9,8 @@ use indexmap::IndexMap;
 
 use crate::binding_index::ResolvedBindings;
 use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, InterpolationPart, ManagedResource, ResourceId,
-    State, Value, VirtualResource, contains_resource_ref, peel_secrets, rewrap_secrets,
+    ConcreteValue, DataSource, DeferredValue, InterpolationPart, Resource, ResourceId, State,
+    Value, VirtualResource, contains_resource_ref, peel_secrets, rewrap_secrets,
 };
 
 /// Resolve all ResourceRef values in resources using current state.
@@ -26,7 +26,7 @@ use crate::resource::{
 /// Each entry maps an upstream_state binding name to a map of resource binding names
 /// to their attributes. For example, `network -> { vpc -> { vpc_id -> "vpc-123" } }`.
 pub fn resolve_refs_with_state(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     current_states: &HashMap<ResourceId, State>,
 ) -> Result<(), String> {
     let bindings =
@@ -55,7 +55,7 @@ pub fn resolve_refs_with_state(
 /// display can render it as `(known after upstream apply: <ref>)`
 /// instead of the raw dot-form.
 pub fn resolve_refs_with_state_and_remote(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     bindings: &ResolvedBindings,
 ) -> Result<(), String> {
     resolve_refs_inner(resources, bindings, &std::collections::HashSet::new())
@@ -68,7 +68,7 @@ pub fn resolve_refs_with_state_and_remote(
 /// `Value::Unknown(UnknownReason::UpstreamRef { path })` for display.
 /// `apply` continues to call the strict variant. See #2366 / RFC #2371.
 pub fn resolve_refs_for_plan(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     bindings: &ResolvedBindings,
     unresolved_upstream_bindings: &std::collections::HashSet<&str>,
 ) -> Result<(), String> {
@@ -76,7 +76,7 @@ pub fn resolve_refs_for_plan(
 }
 
 fn resolve_refs_inner(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     bindings: &ResolvedBindings,
     unresolved_upstream_bindings: &std::collections::HashSet<&str>,
 ) -> Result<(), String> {
@@ -116,7 +116,7 @@ fn resolve_refs_inner(
 // ---------------------------------------------------------------------------
 
 /// Pre-apply path: resolve `ResourceRef` values across a slice of
-/// `ManagedResource`s.
+/// `Resource`s.
 ///
 /// carina#3248: virtuals and data sources are first-class binding
 /// sources on the pre-apply path. `bindings` must therefore include
@@ -129,7 +129,7 @@ fn resolve_refs_inner(
 /// to same-stack module attribute references — those resolve through
 /// the in-process virtual binding directly.
 pub fn resolve_managed_refs_with_state_and_remote(
-    managed: &mut [ManagedResource],
+    managed: &mut [Resource],
     bindings: &ResolvedBindings,
 ) -> Result<(), String> {
     resolve_refs_inner(managed, bindings, &std::collections::HashSet::new())
@@ -491,12 +491,8 @@ mod tests {
     use super::*;
     use crate::resource::ResourceId;
 
-    fn make_resource(
-        name: &str,
-        binding: Option<&str>,
-        attrs: Vec<(&str, Value)>,
-    ) -> ManagedResource {
-        let mut r = ManagedResource::new("test.resource", name);
+    fn make_resource(name: &str, binding: Option<&str>, attrs: Vec<(&str, Value)>) -> Resource {
+        let mut r = Resource::new("test.resource", name);
         r.attributes = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
         r.binding = binding.map(|b| b.to_string());
         r
@@ -507,7 +503,7 @@ mod tests {
     /// view is identical to what production code constructs — there is
     /// no test-only back door into the type.
     fn bindings_from(entries: Vec<(&str, Vec<(&str, Value)>)>) -> ResolvedBindings {
-        let resources: Vec<ManagedResource> = entries
+        let resources: Vec<Resource> = entries
             .into_iter()
             .map(|(binding, attrs)| {
                 make_resource(&format!("{}-resource", binding), Some(binding), attrs)
@@ -528,7 +524,7 @@ mod tests {
     /// Builds the bindings view here, then delegates to the new
     /// signature.
     fn resolve_refs_with_state_and_remote_legacy(
-        resources: &mut [ManagedResource],
+        resources: &mut [Resource],
         current_states: &HashMap<ResourceId, State>,
         remote_bindings: &HashMap<String, HashMap<String, Value>>,
         wait_aliases: &[crate::binding_index::WaitAliasSpec],
@@ -547,7 +543,7 @@ mod tests {
     /// Test-only adapter for the plan-path resolver (mirrors
     /// `resolve_refs_with_state_and_remote_legacy`).
     fn resolve_refs_for_plan_legacy(
-        resources: &mut [ManagedResource],
+        resources: &mut [Resource],
         current_states: &HashMap<ResourceId, State>,
         remote_bindings: &HashMap<String, HashMap<String, Value>>,
         wait_aliases: &[crate::binding_index::WaitAliasSpec],

--- a/carina-core/src/resolver_split_tests.rs
+++ b/carina-core/src/resolver_split_tests.rs
@@ -1,13 +1,13 @@
 //! Tests for #3175: typed resolver entry points.
 //!
-//! - `resolve_managed_refs_with_state_and_remote(&mut [ManagedResource], ...)`
-//!   — pre-apply path, accepts only `ManagedResource` slices.
+//! - `resolve_managed_refs_with_state_and_remote(&mut [Resource], ...)`
+//!   — pre-apply path, accepts only `Resource` slices.
 //! - `resolve_virtual_refs_post_apply(&mut [VirtualResource], &ResolvedBindings)`
 //!   — post-apply path, takes a pre-built bindings view.
 //!
 //! Both are new entry points layered over the existing
 //! `resolve_refs_inner` logic; the legacy
-//! `resolve_refs_with_state_and_remote(&mut [ManagedResource], …)` shim is
+//! `resolve_refs_with_state_and_remote(&mut [Resource], …)` shim is
 //! unchanged.
 
 use std::collections::{BTreeSet, HashMap};
@@ -19,8 +19,7 @@ use crate::resolver::{
     resolve_managed_refs_with_state_and_remote, resolve_virtual_refs_post_apply,
 };
 use crate::resource::{
-    AccessPath, ConcreteValue, DeferredValue, ManagedResource, ResourceId, State, Value,
-    VirtualResource,
+    AccessPath, ConcreteValue, DeferredValue, Resource, ResourceId, State, Value, VirtualResource,
 };
 
 fn s(s: &str) -> Value {
@@ -33,12 +32,12 @@ fn ref_to(binding: &str, attr: &str) -> Value {
     })
 }
 
-fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> ManagedResource {
+fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> Resource {
     let mut attributes = IndexMap::new();
     for (k, v) in attrs {
         attributes.insert((*k).into(), v.clone());
     }
-    ManagedResource {
+    Resource {
         id: ResourceId::new("aws.s3.Bucket", binding),
         attributes,
         directives: Default::default(),
@@ -231,7 +230,7 @@ fn resolve_virtual_refs_post_apply_leaves_non_ref_values_intact() {
 
 #[test]
 fn resolve_managed_refs_with_empty_slice_is_ok() {
-    let mut managed: Vec<ManagedResource> = Vec::new();
+    let mut managed: Vec<Resource> = Vec::new();
     {
         let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
             managed: &managed,
@@ -266,7 +265,7 @@ fn resolve_virtual_refs_post_apply_with_empty_slice_is_ok() {
 #[test]
 fn resolve_managed_refs_legacy_shim_produces_identical_result() {
     // Equivalence guard: feeding the same managed-only inputs through
-    // the new typed entry and the legacy `&mut [ManagedResource]` shim must
+    // the new typed entry and the legacy `&mut [Resource]` shim must
     // produce identical attributes.
     let a_new = make_managed("a", &[("value", s("hi"))]);
     let b_new = make_managed("b", &[("dep", ref_to("a", "value"))]);
@@ -285,7 +284,7 @@ fn resolve_managed_refs_legacy_shim_produces_identical_result() {
     }
     .expect("resolve managed");
 
-    let mut legacy: Vec<ManagedResource> = vec![a_new.clone(), b_new.clone()];
+    let mut legacy: Vec<Resource> = vec![a_new.clone(), b_new.clone()];
     {
         let bindings = ResolvedBindings::pre_apply(crate::binding_index::PreApplyInputs {
             managed: &legacy,

--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -2,7 +2,7 @@
 //! managed.
 //!
 //! Part of the resource typestate split (#3169). A `DataSource`
-//! carries the same fields as a [`ManagedResource`](super::ManagedResource)
+//! carries the same fields as a [`Resource`](super::Resource)
 //! minus `prefixes` (auto-generated names do not apply to read-only
 //! lookups). `directives` is retained because `depends_on` and
 //! `provider_instance` are still meaningful when ordering reads
@@ -48,7 +48,7 @@ pub struct DataSource {
     pub module_source: Option<ModuleSource>,
     /// Parser-level: attributes whose value was written as a quoted
     /// string literal. Parse-time only; `#[serde(skip)]` keeps it out
-    /// of state — mirrors [`ManagedResource::quoted_string_attrs`](super::ManagedResource).
+    /// of state — mirrors [`Resource::quoted_string_attrs`](super::Resource).
     #[serde(default, skip)]
     pub quoted_string_attrs: HashSet<String>,
 }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1,4 +1,4 @@
-//! ManagedResource - Representing resources and their state
+//! Resource - Representing resources and their state
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -79,7 +79,7 @@ pub struct ResourceId {
     pub provider: String,
     /// Resource type (e.g., "s3.Bucket", "ec2.Instance")
     pub resource_type: String,
-    /// ManagedResource name (identifier specified in DSL).
+    /// Resource name (identifier specified in DSL).
     ///
     /// `Pending` means the resource is anonymous and the `name`
     /// attribute has not yet been promoted into the `ResourceId`.
@@ -1131,11 +1131,11 @@ impl Value {
     }
 }
 
-/// Project an `IndexMap<String, Value>` (the shape `ManagedResource.attributes`
+/// Project an `IndexMap<String, Value>` (the shape `Resource.attributes`
 /// uses since #2222) into a plain `HashMap<String, Value>` for callers
 /// that only need key-based lookup (state merging, ResourceRef
 /// resolution, provider trait inputs). Source-order is dropped on
-/// purpose at this boundary — keep it on `ManagedResource.attributes` itself
+/// purpose at this boundary — keep it on `Resource.attributes` itself
 /// when iteration order matters.
 ///
 /// Despite the historical name (the helper used to operate on the now-removed
@@ -1573,9 +1573,9 @@ pub struct Directives {
 /// Source of a resource (root or from a module)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ModuleSource {
-    /// ManagedResource defined at the root level
+    /// Resource defined at the root level
     Root,
-    /// ManagedResource from a module instantiation
+    /// Resource from a module instantiation
     Module {
         /// Module name (e.g., "web_tier")
         name: String,
@@ -1601,7 +1601,7 @@ impl ModuleSource {
 
 /// A managed infrastructure resource declared in DSL.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ManagedResource {
+pub struct Resource {
     pub id: ResourceId,
     /// Source-order preserving map of attribute name → expression.
     ///
@@ -1636,7 +1636,7 @@ pub struct ManagedResource {
     /// Top-level attribute names whose value was written as a quoted
     /// string literal (`attr = "..."`) in the source `.crn`.
     ///
-    /// **Why on `ManagedResource`, not on `Value`:** the alternative is a
+    /// **Why on `Resource`, not on `Value`:** the alternative is a
     /// `Value::QuotedString` variant, but that ripples through every
     /// `match` arm in the codebase. Co-locating the bit with the
     /// owning resource is enough for the only consumer that needs it
@@ -1644,14 +1644,14 @@ pub struct ManagedResource {
     /// radius. Sharing a struct with the attributes also makes the
     /// lookup rename-proof: there is no separate identifier keying
     /// the metadata, so `compute_anonymous_identifiers` can rewrite
-    /// `ManagedResource.id.name` freely (#2229).
+    /// `Resource.id.name` freely (#2229).
     ///
     /// Parse-time only; `#[serde(skip)]` keeps it out of state.
     #[serde(default, skip)]
     pub quoted_string_attrs: HashSet<String>,
 }
 
-impl ManagedResource {
+impl Resource {
     pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             id: ResourceId::new(resource_type, name),
@@ -1748,7 +1748,7 @@ pub struct State {
     /// Binding names this resource depended on when it was last applied.
     /// Used by the executor to determine delete ordering during replace operations.
     ///
-    /// Set semantics (BTreeSet) — see ManagedResource::dependency_bindings (#2228).
+    /// Set semantics (BTreeSet) — see Resource::dependency_bindings (#2228).
     pub dependency_bindings: BTreeSet<String>,
 }
 

--- a/carina-core/src/resource/resource_like.rs
+++ b/carina-core/src/resource/resource_like.rs
@@ -3,7 +3,7 @@
 //!
 //! Lets read-only consumers — plan tree builders, formatters,
 //! diagnostics — stay generic over the three sibling types
-//! ([`ManagedResource`](super::ManagedResource),
+//! ([`Resource`](super::Resource),
 //! [`VirtualResource`](super::VirtualResource),
 //! [`DataSource`](super::DataSource)). Write-side callers (resolver,
 //! effect-executor, writeback) continue to take a concrete type and
@@ -13,7 +13,7 @@ use std::collections::BTreeSet;
 
 use indexmap::IndexMap;
 
-use super::{DataSource, ManagedResource, ResourceId, Value, VirtualResource};
+use super::{DataSource, Resource, ResourceId, Value, VirtualResource};
 
 /// Read-only accessors shared by all resource representations.
 ///
@@ -51,7 +51,7 @@ impl<T: ResourceLike + ?Sized> ResourceLike for &T {
     }
 }
 
-impl ResourceLike for ManagedResource {
+impl ResourceLike for Resource {
     fn id(&self) -> &ResourceId {
         &self.id
     }

--- a/carina-core/src/resource/resource_like_tests.rs
+++ b/carina-core/src/resource/resource_like_tests.rs
@@ -1,5 +1,5 @@
 //! Tests for #3174: `ResourceLike` trait — shared read-only
-//! accessors implemented for `ManagedResource`, `VirtualResource`, and
+//! accessors implemented for `Resource`, `VirtualResource`, and
 //! `DataSource`.
 
 use std::collections::{BTreeSet, HashSet};
@@ -7,8 +7,8 @@ use std::collections::{BTreeSet, HashSet};
 use indexmap::IndexMap;
 
 use crate::resource::{
-    ConcreteValue, DataSource, Directives, ManagedResource, ModuleSource, ResourceId, ResourceLike,
-    Value, VirtualResource,
+    ConcreteValue, DataSource, Directives, ModuleSource, Resource, ResourceId, ResourceLike, Value,
+    VirtualResource,
 };
 
 fn sample_value(s: &str) -> Value {
@@ -19,8 +19,8 @@ fn deps() -> BTreeSet<String> {
     ["dep_binding".into()].into_iter().collect()
 }
 
-fn make_managed() -> ManagedResource {
-    ManagedResource::new("aws.s3.Bucket", "b")
+fn make_managed() -> Resource {
+    Resource::new("aws.s3.Bucket", "b")
         .with_attribute("k", sample_value("v"))
         .with_binding("b")
         .with_dependency_bindings(deps())
@@ -74,7 +74,7 @@ fn assert_resource_like<R: ResourceLike>(
 }
 
 #[test]
-fn managed_resource_implements_resource_like() {
+fn resource_implements_resource_like() {
     let managed = make_managed();
     let expected_id = managed.id.clone();
     assert_resource_like(&managed, &expected_id, "k", Some("b"), &deps());
@@ -96,9 +96,9 @@ fn data_source_implements_resource_like() {
 
 #[test]
 fn binding_none_covers_all_arms() {
-    // ManagedResource::new() leaves binding = None by default.
-    let managed = ManagedResource::new("aws.s3.Bucket", "b");
-    assert_eq!(<ManagedResource as ResourceLike>::binding(&managed), None);
+    // Resource::new() leaves binding = None by default.
+    let managed = Resource::new("aws.s3.Bucket", "b");
+    assert_eq!(<Resource as ResourceLike>::binding(&managed), None);
 
     let mut v = make_virtual();
     v.binding = None;

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -714,7 +714,7 @@ fn canonical_hash_consistency() {
 
 #[test]
 fn resource_typed_binding_field() {
-    let resource = ManagedResource::new("s3.Bucket", "my-bucket").with_binding("my_bucket");
+    let resource = Resource::new("s3.Bucket", "my-bucket").with_binding("my_bucket");
     assert_eq!(resource.binding, Some("my_bucket".to_string()));
     // binding should NOT be in attributes
     assert!(!resource.attributes.contains_key("_binding"));
@@ -722,7 +722,7 @@ fn resource_typed_binding_field() {
 
 #[test]
 fn resource_typed_dependency_bindings_field() {
-    let resource = ManagedResource::new("ec2.Subnet", "my-subnet")
+    let resource = Resource::new("ec2.Subnet", "my-subnet")
         .with_dependency_bindings(["vpc".to_string()].into_iter().collect());
     assert!(resource.dependency_bindings.contains("vpc"));
     assert_eq!(resource.dependency_bindings.len(), 1);
@@ -734,7 +734,7 @@ fn resource_typed_dependency_bindings_field() {
 /// entry (#2228).
 #[test]
 fn resource_dependency_bindings_dedup_on_duplicate_insert() {
-    let mut resource = ManagedResource::new("ec2.Subnet", "my-subnet");
+    let mut resource = Resource::new("ec2.Subnet", "my-subnet");
     resource.dependency_bindings.insert("vpc".to_string());
     resource.dependency_bindings.insert("vpc".to_string());
     assert_eq!(resource.dependency_bindings.len(), 1);
@@ -745,7 +745,7 @@ fn resource_dependency_bindings_dedup_on_duplicate_insert() {
 /// order (#2228).
 #[test]
 fn resource_dependency_bindings_iteration_is_sorted() {
-    let mut resource = ManagedResource::new("ec2.Route", "my-route");
+    let mut resource = Resource::new("ec2.Route", "my-route");
     resource.dependency_bindings.insert("rt".to_string());
     resource
         .dependency_bindings
@@ -767,14 +767,14 @@ fn state_dependency_bindings_dedup_on_duplicate_insert() {
 
 #[test]
 fn resource_default_metadata_fields() {
-    let resource = ManagedResource::new("s3.Bucket", "my-bucket");
+    let resource = Resource::new("s3.Bucket", "my-bucket");
     assert_eq!(resource.binding, None);
     assert!(resource.dependency_bindings.is_empty());
 }
 
 #[test]
 fn resource_attributes_use_value_type() {
-    let resource = ManagedResource::new("s3.Bucket", "test")
+    let resource = Resource::new("s3.Bucket", "test")
         .with_attribute(
             "name",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
@@ -816,12 +816,11 @@ fn attrs_to_hashmap_clones_values() {
 fn resource_module_source_typed_field() {
     // Real resources that belong to modules should use the typed module_source field
     // instead of storing _module/_module_instance as hidden attributes
-    let resource = ManagedResource::new("ec2.SecurityGroup", "web_sg").with_module_source(
-        ModuleSource::Module {
+    let resource =
+        Resource::new("ec2.SecurityGroup", "web_sg").with_module_source(ModuleSource::Module {
             name: "web_tier".to_string(),
             instance: "web".to_string(),
-        },
-    );
+        });
 
     // Module source info should be in the typed field
     assert_eq!(

--- a/carina-core/src/resource/virtual_resource.rs
+++ b/carina-core/src/resource/virtual_resource.rs
@@ -8,7 +8,7 @@
 //! The typestate split encodes that invariant: a `VirtualResource`
 //! is never accepted by the pre-apply resolver.
 //!
-//! Unlike [`ManagedResource`](super::ManagedResource), this struct
+//! Unlike [`Resource`](super::Resource), this struct
 //! does not carry `directives` (no `prevent_destroy` applies to a
 //! synthetic node) or `prefixes` (no auto-generated names on a
 //! non-provider resource). `module_source` is flattened to
@@ -75,7 +75,7 @@ pub struct VirtualResource {
     pub instance: String,
     /// Parser-level: attributes whose value was written as a quoted
     /// string literal. Parse-time only; `#[serde(skip)]` keeps it out
-    /// of state — mirrors [`ManagedResource::quoted_string_attrs`](super::ManagedResource).
+    /// of state — mirrors [`Resource::quoted_string_attrs`](super::Resource).
     #[serde(default, skip)]
     pub quoted_string_attrs: HashSet<String>,
 }

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 
-use crate::resource::{ConcreteValue, ConcreteValueRef, DeferredValue, ManagedResource, Value};
+use crate::resource::{ConcreteValue, ConcreteValueRef, DeferredValue, Resource, Value};
 use crate::utils::{extract_enum_value_with_values, validate_enum_namespace};
 use crate::value::format_value_with_key;
 
@@ -2065,7 +2065,7 @@ pub enum TypeError {
     #[error("Validation failed: {message}")]
     ValidationFailed { message: String },
 
-    #[error("ManagedResource validation failed: {message}")]
+    #[error("Resource validation failed: {message}")]
     ResourceValidationFailed {
         message: String,
         /// Optional attribute name for precise diagnostic positioning.
@@ -2476,7 +2476,7 @@ pub enum SchemaKind {
     DataSource,
 }
 
-/// ManagedResource schema
+/// Resource schema
 #[derive(Debug, Clone)]
 pub struct ResourceSchema {
     pub resource_type: String,
@@ -2767,7 +2767,7 @@ impl ResourceSchema {
         for (name, value) in attributes {
             // Skip parser-internal attributes (leading `_`, e.g.
             // `_type`, `_default_tag_keys`); they have no schema entry.
-            // Prefer a typed field on `ManagedResource` for new internal state
+            // Prefer a typed field on `Resource` for new internal state
             // — see #2224.
             if name.starts_with('_') {
                 continue;
@@ -2950,7 +2950,7 @@ fn resolve_block_names_in_map(
 ///
 /// Also recursively resolves block names in nested struct values.
 pub fn resolve_block_names(
-    resources: &mut [ManagedResource],
+    resources: &mut [Resource],
     registry: &SchemaRegistry,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
@@ -3482,8 +3482,8 @@ impl SchemaRegistry {
         }
     }
 
-    /// Look up the `Managed` schema for a given [`ManagedResource`].
-    pub fn get_for(&self, resource: &crate::resource::ManagedResource) -> Option<&ResourceSchema> {
+    /// Look up the `Managed` schema for a given [`Resource`].
+    pub fn get_for(&self, resource: &crate::resource::Resource) -> Option<&ResourceSchema> {
         self.get(
             &resource.id.provider,
             &resource.id.resource_type,

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2006,7 +2006,7 @@ fn block_name_map_empty_when_no_block_names() {
 #[test]
 fn resolve_block_names_renames_key() {
     let mut resources = vec![{
-        let mut r = ManagedResource::new("ec2.ipam", "my-ipam");
+        let mut r = Resource::new("ec2.ipam", "my-ipam");
         // Block syntax produces Value::Concrete(ConcreteValue::List)
         r.set_attr(
             "operating_region".to_string(),
@@ -2042,7 +2042,7 @@ fn resolve_block_names_renames_key() {
 #[test]
 fn resolve_block_names_noop_when_no_match() {
     let mut resources = vec![{
-        let mut r = ManagedResource::new("ec2.ipam", "my-ipam");
+        let mut r = Resource::new("ec2.ipam", "my-ipam");
         r.set_attr(
             "name".to_string(),
             Value::Concrete(ConcreteValue::String("test".to_string())),
@@ -2065,7 +2065,7 @@ fn resolve_block_names_noop_when_no_match() {
 #[test]
 fn resolve_block_names_errors_on_mixed_syntax() {
     let mut resources = vec![{
-        let mut r = ManagedResource::new("ec2.ipam", "my-ipam");
+        let mut r = Resource::new("ec2.ipam", "my-ipam");
         // Block syntax produces Value::Concrete(ConcreteValue::List)
         r.set_attr(
             "operating_region".to_string(),
@@ -2116,7 +2116,7 @@ fn resolve_block_names_errors_on_mixed_syntax() {
 #[test]
 fn resolve_block_names_skips_unknown_schema() {
     let mut resources = vec![{
-        let mut r = ManagedResource::new("unknown.type", "test");
+        let mut r = Resource::new("unknown.type", "test");
         r.set_attr(
             "operating_region".to_string(),
             Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
@@ -2166,7 +2166,7 @@ fn resolve_block_names_nested_struct() {
     );
 
     let mut resources = vec![{
-        let mut r = ManagedResource::new("s3.Bucket", "my-bucket");
+        let mut r = Resource::new("s3.Bucket", "my-bucket");
         r.set_attr(
             "lifecycle_configuration".to_string(),
             Value::Concrete(ConcreteValue::Map(inner_map)),
@@ -2234,7 +2234,7 @@ fn resolve_block_names_singular_field_not_renamed_when_assigned() {
     );
 
     let mut resources = vec![{
-        let mut r = ManagedResource::new("s3.Bucket", "my-bucket");
+        let mut r = Resource::new("s3.Bucket", "my-bucket");
         r.set_attr(
             "lifecycle_configuration".to_string(),
             Value::Concrete(ConcreteValue::Map(inner_map)),
@@ -2308,7 +2308,7 @@ fn resolve_block_names_block_syntax_renamed_when_singular_field_exists() {
     );
 
     let mut resources = vec![{
-        let mut r = ManagedResource::new("s3.Bucket", "my-bucket");
+        let mut r = Resource::new("s3.Bucket", "my-bucket");
         r.set_attr(
             "lifecycle_configuration".to_string(),
             Value::Concrete(ConcreteValue::Map(inner_map)),
@@ -2367,7 +2367,7 @@ fn resolve_block_names_same_block_and_canonical_name() {
     // without triggering a false "cannot use both" error.
     // This regression was introduced in PR #913 and fixed in PR #917.
     let mut resources = vec![{
-        let mut r = ManagedResource::new("ec2.SecurityGroup", "my-sg");
+        let mut r = Resource::new("ec2.SecurityGroup", "my-sg");
         // Block syntax produces Value::Concrete(ConcreteValue::List)
         r.set_attr(
             "ingress".to_string(),
@@ -2419,7 +2419,7 @@ fn resolve_block_names_same_block_and_canonical_name_multiple_items() {
     // The key already exists (it IS the canonical key), so the `continue`
     // path handles it. This test verifies all items are preserved.
     let mut resources = vec![{
-        let mut r = ManagedResource::new("ec2.SecurityGroup", "my-sg");
+        let mut r = Resource::new("ec2.SecurityGroup", "my-sg");
         r.set_attr(
             "ingress".to_string(),
             Value::Concrete(ConcreteValue::List(vec![
@@ -2493,7 +2493,7 @@ fn resolve_block_names_nested_same_block_and_canonical_name() {
     );
 
     let mut resources = vec![{
-        let mut r = ManagedResource::new("test.resource", "my-resource");
+        let mut r = Resource::new("test.resource", "my-resource");
         r.set_attr(
             "config".to_string(),
             Value::Concrete(ConcreteValue::Map(inner_map)),
@@ -3946,13 +3946,13 @@ fn schema_registry_routes_lookup_by_typestate() {
     // carina#3181: schema lookup routes by the resource typestate —
     // `get_for` for managed resources, `get_for_data_source` for data
     // sources.
-    use crate::resource::{DataSource, ManagedResource};
+    use crate::resource::{DataSource, Resource};
 
     let mut registry = SchemaRegistry::new();
     registry.insert("aws", ResourceSchema::new("s3.Bucket"));
     registry.insert("aws", ResourceSchema::new("s3.Bucket").as_data_source());
 
-    let managed_res = ManagedResource::with_provider("aws", "s3.Bucket", "new", None);
+    let managed_res = Resource::with_provider("aws", "s3.Bucket", "new", None);
     let data_res = DataSource::with_provider("aws", "s3.Bucket", "existing", None);
 
     let m = registry

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -835,7 +835,7 @@ pub fn lift_saved_state_string_enums(
         crate::resource::ResourceId,
         std::collections::HashMap<String, Value>,
     >,
-    resources: &[crate::resource::ManagedResource],
+    resources: &[crate::resource::Resource],
     registry: &crate::schema::SchemaRegistry,
 ) {
     for resource in resources {
@@ -871,7 +871,7 @@ pub fn lift_current_state_string_enums(
         crate::resource::ResourceId,
         crate::resource::State,
     >,
-    resources: &[crate::resource::ManagedResource],
+    resources: &[crate::resource::Resource],
     registry: &crate::schema::SchemaRegistry,
 ) {
     for resource in resources {
@@ -2377,7 +2377,7 @@ mod tests {
     /// absent from the registry is skipped without panic.
     #[test]
     fn lift_saved_state_string_enums_resolves_schema_per_resource() {
-        use crate::resource::{ConcreteValue, ManagedResource, ResourceId, Value};
+        use crate::resource::{ConcreteValue, Resource, ResourceId, Value};
         use crate::schema::{
             AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField,
         };
@@ -2403,8 +2403,8 @@ mod tests {
                 .attribute(AttributeSchema::new("policy_document", policy_struct)),
         );
 
-        let known = ManagedResource::with_provider("awscc", "iam.RolePolicy", "rp", None);
-        let unknown = ManagedResource::with_provider("awscc", "iam.Unknown", "x", None);
+        let known = Resource::with_provider("awscc", "iam.RolePolicy", "rp", None);
+        let unknown = Resource::with_provider("awscc", "iam.Unknown", "x", None);
 
         let mut pd = indexmap::IndexMap::new();
         pd.insert(
@@ -2450,7 +2450,7 @@ mod tests {
     /// failed the strict validator.
     #[test]
     fn lift_current_state_string_enums_lifts_provider_read_state() {
-        use crate::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+        use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
         use crate::schema::{
             AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField,
         };
@@ -2478,7 +2478,7 @@ mod tests {
             )),
         );
 
-        let role = ManagedResource::with_provider("awscc", "iam.Role", "bs.bootstrap.role", None);
+        let role = Resource::with_provider("awscc", "iam.Role", "bs.bootstrap.role", None);
 
         let mut pd = indexmap::IndexMap::new();
         pd.insert(

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -301,8 +301,8 @@ mod tests {
     use super::*;
     use crate::parser::{ParsedFile, WaitBinding};
     use crate::resource::{
-        AccessPath, ConcreteValue, DeferredValue, ManagedResource, PathSegment, ResourceId,
-        Subscript, Value,
+        AccessPath, ConcreteValue, DeferredValue, PathSegment, Resource, ResourceId, Subscript,
+        Value,
     };
     use crate::schema::{
         AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField,
@@ -350,12 +350,12 @@ mod tests {
     /// Build a `ParsedFile` with a cert binding + a route53 RecordSet
     /// that references the deferred field.
     fn parsed_with_unsynchronized_chained_ref() -> ParsedFile {
-        let mut cert = ManagedResource::new("acm.Certificate", "cert");
+        let mut cert = Resource::new("acm.Certificate", "cert");
         cert.id = ResourceId::new("acm.Certificate", "cert");
         cert.id.provider = "aws".to_string();
         cert.binding = Some("cert".to_string());
 
-        let mut record = ManagedResource::new("route53.RecordSet", "record");
+        let mut record = Resource::new("route53.RecordSet", "record");
         record.id = ResourceId::new("route53.RecordSet", "record");
         record.id.provider = "aws".to_string();
         record.binding = Some("record".to_string());
@@ -419,13 +419,13 @@ mod tests {
 
     #[test]
     fn chained_ref_to_non_deferred_inner_field_is_not_flagged() {
-        let mut record = ManagedResource::new("route53.RecordSet", "record");
+        let mut record = Resource::new("route53.RecordSet", "record");
         record.id = ResourceId::new("route53.RecordSet", "record");
         record.id.provider = "aws".to_string();
         record.binding = Some("record".to_string());
         record.set_attr("name", dvo_chained_ref("domain_name"));
 
-        let mut cert = ManagedResource::new("acm.Certificate", "cert");
+        let mut cert = Resource::new("acm.Certificate", "cert");
         cert.id = ResourceId::new("acm.Certificate", "cert");
         cert.id.provider = "aws".to_string();
         cert.binding = Some("cert".to_string());
@@ -442,7 +442,7 @@ mod tests {
     fn unknown_target_binding_does_not_emit_double_diagnostic() {
         // A typo in the binding name produces an undefined-identifier
         // error elsewhere; this pass must not pile on.
-        let mut record = ManagedResource::new("route53.RecordSet", "record");
+        let mut record = Resource::new("route53.RecordSet", "record");
         record.id = ResourceId::new("route53.RecordSet", "record");
         record.id.provider = "aws".to_string();
         record.binding = Some("record".to_string());
@@ -493,12 +493,12 @@ mod tests {
         r.insert("aws", schema);
         r.insert("aws", consumer);
 
-        let mut db = ManagedResource::new("rds.DBInstance", "db");
+        let mut db = Resource::new("rds.DBInstance", "db");
         db.id = ResourceId::new("rds.DBInstance", "db");
         db.id.provider = "aws".to_string();
         db.binding = Some("db".to_string());
 
-        let mut inst = ManagedResource::new("ec2.Instance", "i");
+        let mut inst = Resource::new("ec2.Instance", "i");
         inst.id = ResourceId::new("ec2.Instance", "i");
         inst.id.provider = "aws".to_string();
         inst.binding = Some("i".to_string());
@@ -527,7 +527,7 @@ mod tests {
     fn schema_lookup_miss_does_not_panic_or_emit() {
         // Resource type not in the registry — pass should bail
         // silently. Other passes report unknown resource types.
-        let mut record = ManagedResource::new("unknown.thing", "x");
+        let mut record = Resource::new("unknown.thing", "x");
         record.id = ResourceId::new("unknown.thing", "x");
         record.id.provider = "aws".to_string();
         record.binding = Some("x".to_string());

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -115,7 +115,7 @@ impl std::fmt::Display for InferenceError {
 /// failing with `unknown binding` (#2493).
 #[derive(Debug, Clone)]
 pub enum InferenceBinding {
-    ManagedResource {
+    Resource {
         provider: String,
         resource_type: String,
     },
@@ -187,7 +187,7 @@ pub fn bindings_from_parsed(parsed: &crate::parser::ParsedFile) -> InferenceBind
 /// semantics; the duplicate-binding check elsewhere is the gate that
 /// reports it to the user.
 pub fn bindings_from_parts(
-    resources: &[crate::resource::ManagedResource],
+    resources: &[crate::resource::Resource],
     data_sources: &[crate::resource::DataSource],
     virtual_resources: &[crate::resource::VirtualResource],
     upstream_states: &[crate::parser::UpstreamState],
@@ -197,7 +197,7 @@ pub fn bindings_from_parts(
         out.insert(us.binding.clone(), InferenceBinding::UpstreamState);
     }
     // carina#3181: managed resources and data sources both carry a
-    // provider identity, so each maps to `InferenceBinding::ManagedResource`
+    // provider identity, so each maps to `InferenceBinding::Resource`
     // (a `read`-bound `${data_source.attr}` still resolves its type via
     // a schema lookup). Virtual resources synthesised by module-call
     // expansion (`expand_module_call`) carry no provider identity — their
@@ -211,7 +211,7 @@ pub fn bindings_from_parts(
         };
         out.insert(
             name.clone(),
-            InferenceBinding::ManagedResource {
+            InferenceBinding::Resource {
                 provider: resource.id.provider.clone(),
                 resource_type: resource.id.resource_type.clone(),
             },
@@ -223,7 +223,7 @@ pub fn bindings_from_parts(
         };
         out.insert(
             name.clone(),
-            InferenceBinding::ManagedResource {
+            InferenceBinding::Resource {
                 provider: data_source.id.provider.clone(),
                 resource_type: data_source.id.resource_type.clone(),
             },
@@ -414,7 +414,7 @@ fn infer_resource_ref_with_visiting(
     visiting: &mut indexmap::IndexSet<String>,
 ) -> Result<TypeExpr, InferenceError> {
     let target = match bindings.get(binding) {
-        Some(InferenceBinding::ManagedResource {
+        Some(InferenceBinding::Resource {
             provider,
             resource_type,
         }) => (provider.as_str(), resource_type.as_str()),
@@ -779,7 +779,7 @@ mod tests {
         let mut b = InferenceBindings::new();
         b.insert(
             name.to_string(),
-            InferenceBinding::ManagedResource {
+            InferenceBinding::Resource {
                 provider: "awscc".to_string(),
                 resource_type: "ec2.Vpc".to_string(),
             },
@@ -1164,9 +1164,8 @@ mod tests {
         // resource wins, so `x.attr` infers precisely instead of
         // degrading to `NonInferableBinding`.
         use crate::parser::UpstreamState;
-        use crate::resource::ManagedResource;
-        let resource =
-            ManagedResource::with_provider("awscc", "ec2.Vpc", "main", None).with_binding("x");
+        use crate::resource::Resource;
+        let resource = Resource::with_provider("awscc", "ec2.Vpc", "main", None).with_binding("x");
         let upstream = UpstreamState {
             binding: "x".to_string(),
             source: std::path::PathBuf::from("../other"),
@@ -1174,7 +1173,7 @@ mod tests {
         let bindings = bindings_from_parts(&[resource], &[], &[], &[upstream]);
         assert!(matches!(
             bindings.get("x"),
-            Some(InferenceBinding::ManagedResource { .. })
+            Some(InferenceBinding::Resource { .. })
         ));
     }
 
@@ -1225,7 +1224,7 @@ mod tests {
         let mut bindings = InferenceBindings::new();
         bindings.insert(
             "policy".to_string(),
-            InferenceBinding::ManagedResource {
+            InferenceBinding::Resource {
                 provider: "awscc".to_string(),
                 resource_type: "iam.Policy".to_string(),
             },
@@ -1284,7 +1283,7 @@ mod tests {
     #[test]
     fn apply_inference_fills_inferable_export_with_inferred_type() {
         let mut parsed = crate::parser::ParsedFile::default();
-        let res = crate::resource::ManagedResource::with_provider("awscc", "ec2.Vpc", "main", None)
+        let res = crate::resource::Resource::with_provider("awscc", "ec2.Vpc", "main", None)
             .with_binding("main");
         parsed.resources.push(res); // allow: direct — fixture test inspection
         parsed.export_params.push(crate::parser::ParsedExportParam {
@@ -1363,7 +1362,7 @@ mod tests {
         // "unknown binding" diagnostic.
         let mut parsed = crate::parser::ParsedFile::default();
         // Concrete role resource with prefixed binding (post-expansion shape).
-        let role = crate::resource::ManagedResource::with_provider(
+        let role = crate::resource::Resource::with_provider(
             "awscc",
             "ec2.Vpc",
             "github_actions_carina.role",

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -11,7 +11,7 @@ use indexmap::IndexMap;
 use crate::binding_index::BindingIndex;
 use crate::parser::{ModuleCall, ProviderContext, ResourceRef, TypeExpr, validate_custom_type};
 use crate::provider::ProviderFactory;
-use crate::resource::{ConcreteValue, DeferredValue, ManagedResource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
 /// Render the trailing `" Did you mean 'X'?"` segment for an unknown
@@ -276,10 +276,10 @@ pub fn validate_resource_ref_types<E>(
 /// be rejected because `role_name` is `String`, not `IamRoleArn`.
 pub fn validate_attribute_param_ref_types(
     attribute_params: &[crate::parser::AttributeParameter],
-    resources: &[ManagedResource],
+    resources: &[Resource],
     registry: &SchemaRegistry,
 ) -> Result<(), String> {
-    let mut binding_map: HashMap<String, &ManagedResource> = HashMap::new();
+    let mut binding_map: HashMap<String, &Resource> = HashMap::new();
     for resource in resources {
         if let Some(ref binding_name) = resource.binding {
             binding_map.insert(binding_name.clone(), resource);
@@ -347,10 +347,10 @@ pub fn validate_attribute_param_ref_types(
 /// `vpc_id` is a string attribute but the export declares `bool`.
 pub fn validate_export_param_ref_types(
     export_params: &[crate::parser::InferredExportParam],
-    resources: &[ManagedResource],
+    resources: &[Resource],
     registry: &SchemaRegistry,
 ) -> Result<(), String> {
-    let mut binding_map: HashMap<String, &ManagedResource> = HashMap::new();
+    let mut binding_map: HashMap<String, &Resource> = HashMap::new();
     for resource in resources {
         if let Some(ref binding_name) = resource.binding {
             binding_map.insert(binding_name.clone(), resource);
@@ -392,7 +392,7 @@ fn collect_ref_type_errors(
     type_expr: &crate::parser::TypeExpr,
     value: &Value,
     param_name: &str,
-    binding_map: &HashMap<String, &ManagedResource>,
+    binding_map: &HashMap<String, &Resource>,
     registry: &SchemaRegistry,
     errors: &mut Vec<String>,
 ) {

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::parser::{ParsedFile, ProviderContext};
-use crate::resource::ManagedResource;
+use crate::resource::Resource;
 use crate::schema::{ResourceSchema, SchemaRegistry, TypeIdentity, noop_validator};
 
 fn empty_parsed() -> ParsedFile {
@@ -60,8 +60,8 @@ fn no_bindings_no_warnings() {
 fn used_binding_no_warning() {
     let mut parsed = empty_parsed();
 
-    // ManagedResource with a binding
-    let vpc = ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
+    // Resource with a binding
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -69,12 +69,11 @@ fn used_binding_no_warning() {
         );
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
-    // ManagedResource that references the binding
-    let subnet = ManagedResource::with_provider("awscc", "ec2.Subnet", "web-subnet", None)
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        );
+    // Resource that references the binding
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
+        "vpc_id",
+        Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+    );
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
 
     assert!(check_unused_bindings(&parsed).is_empty());
@@ -84,7 +83,7 @@ fn used_binding_no_warning() {
 fn unused_binding_warns() {
     let mut parsed = empty_parsed();
 
-    let vpc = ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -101,11 +100,10 @@ fn anonymous_resource_no_warning() {
     let mut parsed = empty_parsed();
 
     // Anonymous resource (no _binding attribute)
-    let bucket = ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None)
-        .with_attribute(
-            "bucket_name",
-            Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
-        );
+    let bucket = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None).with_attribute(
+        "bucket_name",
+        Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
+    );
     parsed.resources.push(bucket); // allow: direct — fixture test inspection
 
     assert!(check_unused_bindings(&parsed).is_empty());
@@ -115,8 +113,7 @@ fn anonymous_resource_no_warning() {
 fn binding_referenced_in_nested_value() {
     let mut parsed = empty_parsed();
 
-    let vpc =
-        ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     // Reference inside a Map inside a List
@@ -125,13 +122,12 @@ fn binding_referenced_in_nested_value() {
         "vpc_id".to_string(),
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
-    let sg = ManagedResource::with_provider("awscc", "ec2.SecurityGroup", "web-sg", None)
-        .with_attribute(
-            "tags",
-            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
-                ConcreteValue::Map(map),
-            )])),
-        );
+    let sg = Resource::with_provider("awscc", "ec2.SecurityGroup", "web-sg", None).with_attribute(
+        "tags",
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(map),
+        )])),
+    );
     parsed.resources.push(sg); // allow: direct — fixture test inspection
 
     assert!(check_unused_bindings(&parsed).is_empty());
@@ -141,8 +137,7 @@ fn binding_referenced_in_nested_value() {
 fn binding_referenced_in_module_call() {
     let mut parsed = empty_parsed();
 
-    let vpc =
-        ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     let mut args = HashMap::new();
@@ -163,20 +158,18 @@ fn binding_referenced_in_module_call() {
 fn multiple_bindings_some_unused() {
     let mut parsed = empty_parsed();
 
-    let vpc =
-        ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
-    let sg = ManagedResource::with_provider("awscc", "ec2.SecurityGroup", "web-sg", None)
+    let sg = Resource::with_provider("awscc", "ec2.SecurityGroup", "web-sg", None)
         .with_binding("web_sg");
     parsed.resources.push(sg); // allow: direct — fixture test inspection
 
     // Only vpc is referenced
-    let subnet = ManagedResource::with_provider("awscc", "ec2.Subnet", "web-subnet", None)
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        );
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
+        "vpc_id",
+        Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+    );
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
 
     let unused = check_unused_bindings(&parsed);
@@ -187,8 +180,7 @@ fn multiple_bindings_some_unused() {
 fn binding_referenced_in_attributes_not_warned() {
     let mut parsed = empty_parsed();
 
-    let vpc =
-        ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     parsed
@@ -210,8 +202,7 @@ fn binding_referenced_in_attributes_not_warned() {
 fn binding_referenced_in_exports_not_warned() {
     let mut parsed = empty_parsed();
 
-    let vpc =
-        ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
     parsed.export_params.push(crate::parser::ExportParameter {
@@ -453,11 +444,10 @@ fn unknown_binding_reference_reports_error() {
     );
 
     // Subnet references "vpc" binding which doesn't exist
-    let subnet = ManagedResource::with_provider("awscc", "ec2.Subnet", "web-subnet", None)
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        );
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
+        "vpc_id",
+        Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+    );
 
     let mut parsed = empty_parsed();
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
@@ -481,7 +471,7 @@ fn unknown_attribute_reference_reports_error() {
     );
 
     // VPC resource with binding
-    let vpc = ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
@@ -489,11 +479,10 @@ fn unknown_attribute_reference_reports_error() {
         );
 
     // Subnet references vpc.nonexistent_attr which doesn't exist on the VPC schema
-    let subnet = ManagedResource::with_provider("awscc", "ec2.Subnet", "web-subnet", None)
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "nonexistent_attr".to_string(), vec![]),
-        );
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
+        "vpc_id",
+        Value::resource_ref("vpc".to_string(), "nonexistent_attr".to_string(), vec![]),
+    );
 
     let mut parsed = empty_parsed();
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
@@ -526,19 +515,18 @@ fn unknown_attribute_reference_suggests_similar_name() {
         ),
     );
 
-    let igw = ManagedResource::with_provider("awscc", "ec2.internet_gateway", "igw", None)
-        .with_binding("igw");
+    let igw =
+        Resource::with_provider("awscc", "ec2.internet_gateway", "igw", None).with_binding("igw");
 
     // Typo: internet_gateway_idd instead of internet_gateway_id
-    let route = ManagedResource::with_provider("awscc", "ec2.route", "main-route", None)
-        .with_attribute(
-            "gateway_id",
-            Value::resource_ref(
-                "igw".to_string(),
-                "internet_gateway_idd".to_string(),
-                vec![],
-            ),
-        );
+    let route = Resource::with_provider("awscc", "ec2.route", "main-route", None).with_attribute(
+        "gateway_id",
+        Value::resource_ref(
+            "igw".to_string(),
+            "internet_gateway_idd".to_string(),
+            vec![],
+        ),
+    );
 
     let mut parsed = empty_parsed();
     parsed.resources.push(igw); // allow: direct — fixture test inspection
@@ -564,19 +552,17 @@ fn unknown_attribute_reference_no_suggestion_when_too_different() {
         make_schema("ec2.Subnet", vec![("vpc_id", AttributeType::String)]),
     );
 
-    let vpc =
-        ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None).with_binding("vpc");
 
     // Completely unrelated attribute name - no suggestion expected
-    let subnet = ManagedResource::with_provider("awscc", "ec2.Subnet", "web-subnet", None)
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref(
-                "vpc".to_string(),
-                "completely_wrong_name".to_string(),
-                vec![],
-            ),
-        );
+    let subnet = Resource::with_provider("awscc", "ec2.Subnet", "web-subnet", None).with_attribute(
+        "vpc_id",
+        Value::resource_ref(
+            "vpc".to_string(),
+            "completely_wrong_name".to_string(),
+            vec![],
+        ),
+    );
 
     let mut parsed = empty_parsed();
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
@@ -1114,9 +1100,8 @@ fn validate_type_expr_value_schema_type_rejects_int() {
 fn discard_binding_no_warning() {
     let mut parsed = empty_parsed();
 
-    let caller =
-        ManagedResource::with_provider("aws", "sts.caller_identity", "caller_identity", None)
-            .with_binding("_");
+    let caller = Resource::with_provider("aws", "sts.caller_identity", "caller_identity", None)
+        .with_binding("_");
     parsed.resources.push(caller); // allow: direct — fixture test inspection
 
     assert!(check_unused_bindings(&parsed).is_empty());
@@ -1588,7 +1573,7 @@ fn attribute_param_ref_type_mismatch_detected() {
     use crate::schema::{AttributeSchema, ResourceSchema};
 
     // Build a resource with schema: role_name is String, arn is IamRoleArn (Custom)
-    let role = ManagedResource::with_provider("awscc", "iam.role", "github-role", None)
+    let role = Resource::with_provider("awscc", "iam.role", "github-role", None)
         .with_binding("role")
         .with_attribute(
             "role_name",
@@ -2025,13 +2010,12 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
         ),
     );
 
-    let registry_prod =
-        ManagedResource::with_provider("awscc", "organizations.account", "prod", None)
-            .with_binding("registry_prod")
-            .with_attribute(
-                "account_id",
-                Value::Concrete(ConcreteValue::String("111".to_string())),
-            );
+    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod", None)
+        .with_binding("registry_prod")
+        .with_attribute(
+            "account_id",
+            Value::Concrete(ConcreteValue::String("111".to_string())),
+        );
 
     let mut map_value = IndexMap::new();
     map_value.insert(
@@ -2071,13 +2055,12 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
         ),
     );
 
-    let registry_prod =
-        ManagedResource::with_provider("awscc", "organizations.account", "prod", None)
-            .with_binding("registry_prod")
-            .with_attribute(
-                "account_id",
-                Value::Concrete(ConcreteValue::String("111".to_string())),
-            );
+    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod", None)
+        .with_binding("registry_prod")
+        .with_attribute(
+            "account_id",
+            Value::Concrete(ConcreteValue::String("111".to_string())),
+        );
 
     let mut map_value = IndexMap::new();
     map_value.insert(
@@ -2138,13 +2121,12 @@ fn validate_export_param_ref_types_against_inferred_inputs() {
     // Smoke test: a happy-path post-inference shape (bare TypeExpr,
     // matching attribute type) typechecks cleanly through the new
     // signature.
-    let registry_prod =
-        ManagedResource::with_provider("awscc", "organizations.account", "prod", None)
-            .with_binding("registry_prod")
-            .with_attribute(
-                "account_id",
-                Value::Concrete(ConcreteValue::String("111".to_string())),
-            );
+    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod", None)
+        .with_binding("registry_prod")
+        .with_attribute(
+            "account_id",
+            Value::Concrete(ConcreteValue::String("111".to_string())),
+        );
 
     let mut schemas = SchemaRegistry::new();
     schemas.insert(
@@ -2194,7 +2176,7 @@ fn validate_resources_accepts_resource_ref_in_list_position() {
         ),
     );
 
-    let record_set = ManagedResource::with_provider("aws", "route53.RecordSet", "ns", None)
+    let record_set = Resource::with_provider("aws", "route53.RecordSet", "ns", None)
         .with_attribute(
             "resource_records",
             Value::resource_ref(
@@ -2249,7 +2231,7 @@ fn validate_resources_accepts_resource_ref_in_struct_field_position() {
         Value::resource_ref("vpc".to_string(), "name".to_string(), vec![]),
     );
 
-    let holder = ManagedResource::with_provider("aws", "test.StructHolder", "h", None)
+    let holder = Resource::with_provider("aws", "test.StructHolder", "h", None)
         .with_attribute("config", Value::Concrete(ConcreteValue::Map(config)));
 
     let mut known = HashSet::new();
@@ -2284,7 +2266,7 @@ fn validate_resources_accepts_resource_ref_in_map_position() {
         ),
     );
 
-    let holder = ManagedResource::with_provider("aws", "test.MapHolder", "h", None).with_attribute(
+    let holder = Resource::with_provider("aws", "test.MapHolder", "h", None).with_attribute(
         "tags",
         Value::resource_ref("orgs".to_string(), "tag_map".to_string(), vec![]),
     );
@@ -2320,7 +2302,7 @@ fn validate_resources_rejects_missing_exclusive_required() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
 
-    let vpc = ManagedResource::with_provider("awscc", "ec2.Vpc", "main-vpc", None);
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None);
 
     let mut known = HashSet::new();
     known.insert("awscc".to_string());
@@ -2630,8 +2612,7 @@ fn ref_with_chained_subscript_then_field_narrows_through_list() {
         make_schema("route53.RecordSet", vec![("name", AttributeType::String)]),
     );
 
-    let cert =
-        ManagedResource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
+    let cert = Resource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
 
     // `cert.domain_validation_options[0].resource_record_name`
     let path = AccessPath::with_segments(
@@ -2646,7 +2627,7 @@ fn ref_with_chained_subscript_then_field_narrows_through_list() {
             },
         ],
     );
-    let record = ManagedResource::with_provider("aws", "route53.RecordSet", "validation", None)
+    let record = Resource::with_provider("aws", "route53.RecordSet", "validation", None)
         .with_attribute(
             "name",
             Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
@@ -2694,8 +2675,7 @@ fn ref_with_chained_subscript_then_field_rejects_real_mismatch() {
         make_schema("route53.RecordSet", vec![("name", AttributeType::String)]),
     );
 
-    let cert =
-        ManagedResource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
+    let cert = Resource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
 
     let path = AccessPath::with_segments(
         "cert",
@@ -2709,7 +2689,7 @@ fn ref_with_chained_subscript_then_field_rejects_real_mismatch() {
             },
         ],
     );
-    let record = ManagedResource::with_provider("aws", "route53.RecordSet", "validation", None)
+    let record = Resource::with_provider("aws", "route53.RecordSet", "validation", None)
         .with_attribute(
             "name",
             Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),
@@ -2779,8 +2759,7 @@ fn ref_with_chained_field_on_struct_flags_unknown_field() {
         make_schema("route53.RecordSet", vec![("name", AttributeType::String)]),
     );
 
-    let cert =
-        ManagedResource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
+    let cert = Resource::with_provider("aws", "acm.Certificate", "main", None).with_binding("cert");
 
     // User wrote `cert.domain_validation_options[0].resource_record_name`
     // — the old flat spelling that the nested-shape migration replaced
@@ -2797,7 +2776,7 @@ fn ref_with_chained_field_on_struct_flags_unknown_field() {
             },
         ],
     );
-    let record = ManagedResource::with_provider("aws", "route53.RecordSet", "validation", None)
+    let record = Resource::with_provider("aws", "route53.RecordSet", "validation", None)
         .with_attribute(
             "name",
             Value::Deferred(crate::resource::DeferredValue::ResourceRef { path }),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -706,34 +706,34 @@ pub fn redact_secrets_in_attributes(
         .collect()
 }
 
-/// Redact all secrets in a `ManagedResource`, returning a new ManagedResource with secrets replaced by hashes.
+/// Redact all secrets in a `Resource`, returning a new Resource with secrets replaced by hashes.
 pub fn redact_secrets_in_resource(
-    resource: &crate::resource::ManagedResource,
-) -> Result<crate::resource::ManagedResource, SerializationError> {
+    resource: &crate::resource::Resource,
+) -> Result<crate::resource::Resource, SerializationError> {
     let attributes: Result<_, _> = resource
         .attributes
         .iter()
         .map(|(k, e)| redact_secrets_in_value(e).map(|rv| (k.clone(), rv)))
         .collect();
-    Ok(crate::resource::ManagedResource {
+    Ok(crate::resource::Resource {
         attributes: attributes?,
         ..resource.clone()
     })
 }
 
-/// Redact all secrets in a [`ManagedResource`](crate::resource::ManagedResource).
+/// Redact all secrets in a [`Resource`](crate::resource::Resource).
 ///
 /// carina#3181 PR D: `Effect` payloads are typestate structs, so the
 /// redaction pass needs a typed entry point per arm.
 pub fn redact_secrets_in_managed(
-    resource: &crate::resource::ManagedResource,
-) -> Result<crate::resource::ManagedResource, SerializationError> {
+    resource: &crate::resource::Resource,
+) -> Result<crate::resource::Resource, SerializationError> {
     let attributes: Result<_, _> = resource
         .attributes
         .iter()
         .map(|(k, e)| redact_secrets_in_value(e).map(|rv| (k.clone(), rv)))
         .collect();
-    Ok(crate::resource::ManagedResource {
+    Ok(crate::resource::Resource {
         attributes: attributes?,
         ..resource.clone()
     })
@@ -1363,10 +1363,10 @@ fn canonicalize_to_string_list(value: Value) -> Value {
 /// validation surfaces the mismatch elsewhere.
 ///
 /// Call this once after `resolver::resolve_refs_*` and before the
-/// differ runs, so every `ManagedResource` flowing into the plan / state /
+/// differ runs, so every `Resource` flowing into the plan / state /
 /// provider boundary carries the canonical shape. See #2481, #2511.
 pub fn canonicalize_resources_with_schemas(
-    resources: &mut [crate::resource::ManagedResource],
+    resources: &mut [crate::resource::Resource],
     registry: &crate::schema::SchemaRegistry,
 ) {
     for resource in resources.iter_mut() {
@@ -1497,7 +1497,7 @@ pub fn resolve_value_alias(
 /// path (`executor::renormalize`) so the two cannot diverge on this
 /// stage again (carina#3063).
 pub fn resolve_enum_aliases_for_resources(
-    resources: &mut [crate::resource::ManagedResource],
+    resources: &mut [crate::resource::Resource],
     factories: &[Box<dyn crate::provider::ProviderFactory>],
 ) {
     for resource in resources.iter_mut() {
@@ -3508,14 +3508,14 @@ mod tests {
         reg
     }
 
-    fn make_resource(attrs: Vec<(&str, Value)>) -> crate::resource::ManagedResource {
-        use crate::resource::{ManagedResource, ResourceId, ResourceName};
+    fn make_resource(attrs: Vec<(&str, Value)>) -> crate::resource::Resource {
+        use crate::resource::{Resource, ResourceId, ResourceName};
         use std::collections::{BTreeSet, HashMap, HashSet};
         let mut attributes = IndexMap::new();
         for (k, v) in attrs {
             attributes.insert(k.to_string(), v);
         }
-        ManagedResource {
+        Resource {
             id: ResourceId {
                 provider: "aws".to_string(),
                 resource_type: "iam.policy".to_string(),

--- a/carina-core/tests/carina3122_live_phantom.rs
+++ b/carina-core/tests/carina3122_live_phantom.rs
@@ -46,7 +46,7 @@ use std::collections::HashMap;
 
 use carina_core::differ::{Diff, diff};
 use carina_core::explicit::ExplicitFields;
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
 fn load_dc(name: &str) -> Value {
     let path = format!(
@@ -93,7 +93,7 @@ fn carina3122_live_distribution_readback_defaults_are_projected_away() {
     let mut id = ResourceId::new("cloudfront.Distribution", "r.distribution");
     id.provider = "awscc".to_string();
 
-    let mut desired = ManagedResource::new("cloudfront.Distribution", "r.distribution")
+    let mut desired = Resource::new("cloudfront.Distribution", "r.distribution")
         .with_attribute("distribution_config", desired_dc);
     desired.id.provider = "awscc".to_string();
 

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -10,7 +10,7 @@
 //!         viewer_certificate = { acm_certificate_arn =
 //!                                cert_issued.certificate_arn } }
 //!
-//! Pre-fix: `expand_module_call` returns only `Vec<ManagedResource>`, so the
+//! Pre-fix: `expand_module_call` returns only `Vec<Resource>`, so the
 //! module's `wait_bindings` are silently dropped and the module
 //! resources' references to the wait binding are never instance-
 //! prefixed. `create_plan` emits no `Effect::Wait`, the Distribution

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -764,7 +764,7 @@ let igw_attachment = awscc.ec2.vpc_gateway_attachment {
     // so that "igw." gets replaced with "igw.internet_gateway_id".
     assert!(
         igw_completion.text_edit.is_some(),
-        "ManagedResource reference completion should use text_edit to avoid prefix duplication. \
+        "Resource reference completion should use text_edit to avoid prefix duplication. \
          Got insert_text: {:?}",
         igw_completion.insert_text
     );
@@ -2687,7 +2687,7 @@ exports {
     }
 }
 
-/// ManagedResource-ref candidates: a binding whose resource schema exposes an
+/// Resource-ref candidates: a binding whose resource schema exposes an
 /// attribute of the target type should appear as `<binding>.<attr>`
 /// at the value position. Guards the "offer matching refs" half of
 /// the issue spec.

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -236,7 +236,7 @@ impl CompletionProvider {
             let description = schema
                 .description
                 .as_deref()
-                .unwrap_or("ManagedResource")
+                .unwrap_or("Resource")
                 .to_string();
 
             // Build snippet with required attributes

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -1651,7 +1651,7 @@ impl CompletionProvider {
                 let description = schema
                     .description
                     .as_deref()
-                    .unwrap_or("ManagedResource reference");
+                    .unwrap_or("Resource reference");
                 type_completion_item(key, format!("{} reference", description), replacement_range)
             });
 

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -8,7 +8,7 @@ use crate::document::Document;
 use crate::position;
 use carina_core::builtins;
 use carina_core::parser::{ArgumentParameter, ParsedFile, TypeExpr};
-use carina_core::resource::{ConcreteValue, DeferredValue, ManagedResource, Value};
+use carina_core::resource::{ConcreteValue, DeferredValue, Resource, Value};
 use carina_core::schema::{ResourceSchema, suggest_similar_name};
 use carina_core::upstream_exports::UpstreamRefDiagnostic;
 
@@ -1111,7 +1111,7 @@ impl DiagnosticEngine {
         type_expr: &TypeExpr,
         path: &carina_core::resource::AccessPath,
         param_name: &str,
-        resources: &[carina_core::resource::ManagedResource],
+        resources: &[carina_core::resource::Resource],
     ) -> Option<String> {
         let expected_type = match type_expr {
             TypeExpr::Simple(name) => name.as_str(),
@@ -1377,7 +1377,7 @@ impl DiagnosticEngine {
         doc: &Document,
         parsed: &ParsedFile,
         merged: Option<&ParsedFile>,
-        all_resources: Option<&[ManagedResource]>,
+        all_resources: Option<&[Resource]>,
         sibling_bindings: &HashMap<String, String>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -3277,7 +3277,7 @@ fn exports_type_check_resolves_resource_binding_from_sibling_file() {
     let tmp = tempfile::tempdir().unwrap();
     let base = tmp.path().join("downstream");
     std::fs::create_dir_all(&base).unwrap();
-    // ManagedResource binding lives in main.crn.
+    // Resource binding lives in main.crn.
     std::fs::write(
         base.join("main.crn"),
         "let registry_prod = awscc.organizations.account {\n  name = 'prod'\n}\n",

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -10,8 +10,7 @@ use carina_core::provider::{
 };
 use carina_core::resource::{
     ConcreteValue, DataSource as CoreDataSource, DeferredValue, Directives,
-    ManagedResource as CoreResource, ResourceId as CoreResourceId, State as CoreState,
-    Value as CoreValue,
+    Resource as CoreResource, ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -24,7 +24,7 @@ use carina_core::provider::{
     BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderFactory,
     ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
 };
-use carina_core::resource::{DataSource, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{DataSource, Resource, ResourceId, State, Value};
 use carina_core::schema::{CompletionValue, ResourceSchema, TypeIdentity};
 use carina_core::value::SerializationError;
 
@@ -1952,7 +1952,7 @@ unsafe impl Sync for WasmProviderNormalizer {}
 impl ProviderNormalizer for WasmProviderNormalizer {
     fn normalize_desired<'a>(
         &'a self,
-        resources: &'a mut [ManagedResource],
+        resources: &'a mut [Resource],
     ) -> carina_core::provider::BoxFuture<'a, ()> {
         Box::pin(async move {
             let wit_resources: Vec<_> = expect_unresolvable_absent(
@@ -2093,7 +2093,7 @@ impl ProviderNormalizer for WasmProviderNormalizer {
 
     fn merge_default_tags<'a>(
         &'a self,
-        resources: &'a mut [ManagedResource],
+        resources: &'a mut [Resource],
         default_tags: &'a IndexMap<String, Value>,
         _registry: &'a carina_core::schema::SchemaRegistry,
     ) -> carina_core::provider::BoxFuture<'a, ()> {

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -7,7 +7,7 @@ use carina_core::provider::{
     CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, ProviderFactory, ReadRequest,
     UpdatePatch, UpdateRequest,
 };
-use carina_core::resource::{ConcreteValue, DataSource, ManagedResource, ResourceId, Value};
+use carina_core::resource::{ConcreteValue, DataSource, Resource, ResourceId, Value};
 use carina_plugin_host::WasmProviderFactory;
 
 fn wasm_path() -> Option<PathBuf> {
@@ -86,7 +86,7 @@ async fn test_wasm_mock_provider_create_and_read() {
     assert!(state.attributes.is_empty());
 
     // Create a resource
-    let mut resource = ManagedResource::with_provider("mock", "test.resource", "my-resource", None);
+    let mut resource = Resource::with_provider("mock", "test.resource", "my-resource", None);
     resource.attributes = indexmap::IndexMap::from([
         (
             "name".into(),
@@ -158,7 +158,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
     let id = ResourceId::with_provider("mock", "test.resource", "updatable", None);
 
     // Create first
-    let mut resource = ManagedResource::with_provider("mock", "test.resource", "updatable", None);
+    let mut resource = Resource::with_provider("mock", "test.resource", "updatable", None);
     resource.attributes = indexmap::IndexMap::from([
         (
             "color".into(),
@@ -273,7 +273,7 @@ async fn test_wasm_mock_provider_normalizer() {
 
     // normalize_desired: mock provider returns resources unchanged
     let mut resources = vec![{
-        let mut r = ManagedResource::with_provider("mock", "test.resource", "norm-test", None);
+        let mut r = Resource::with_provider("mock", "test.resource", "norm-test", None);
         r.attributes = indexmap::IndexMap::from([(
             "key".into(),
             Value::Concrete(ConcreteValue::String("value".into())),
@@ -316,7 +316,7 @@ async fn test_wasm_mock_provider_merge_default_tags_dispatches_through_wit() {
         .await;
 
     let registry = carina_core::schema::SchemaRegistry::new();
-    let mut resources = vec![ManagedResource::with_provider(
+    let mut resources = vec![Resource::with_provider(
         "mock",
         "test.resource",
         "tag-test",
@@ -357,7 +357,7 @@ async fn test_wasm_mock_provider_merge_default_tags_empty_short_circuits() {
         .await;
 
     let registry = carina_core::schema::SchemaRegistry::new();
-    let mut resources = vec![ManagedResource::with_provider(
+    let mut resources = vec![Resource::with_provider(
         "mock",
         "test.resource",
         "no-tags",
@@ -389,9 +389,9 @@ async fn test_wasm_mock_provider_merge_default_tags_preserves_order() {
 
     let registry = carina_core::schema::SchemaRegistry::new();
     let mut resources = vec![
-        ManagedResource::with_provider("mock", "test.resource", "alpha", None),
-        ManagedResource::with_provider("mock", "test.resource", "beta", None),
-        ManagedResource::with_provider("mock", "test.resource", "gamma", None),
+        Resource::with_provider("mock", "test.resource", "alpha", None),
+        Resource::with_provider("mock", "test.resource", "beta", None),
+        Resource::with_provider("mock", "test.resource", "gamma", None),
     ];
     let default_tags = indexmap::IndexMap::from([(
         "Env".to_string(),

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -2,7 +2,7 @@
 
 use carina_core::deps::get_resource_dependencies;
 use carina_core::explicit::{self, ExplicitFields};
-use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::value::{
     SecretHashContext, contains_secret, json_to_dsl_value, merge_secrets_into_provider_json,
     value_to_json,
@@ -160,7 +160,7 @@ impl StateFile {
     }
 
     /// Get the identifier for a resource from state.
-    pub fn get_identifier_for_resource(&self, resource: &ManagedResource) -> Option<String> {
+    pub fn get_identifier_for_resource(&self, resource: &Resource) -> Option<String> {
         if let Some(resource_state) = self.find_resource(
             &resource.id.provider,
             &resource.id.resource_type,
@@ -585,7 +585,7 @@ pub fn check_and_migrate_bytes(bytes: &[u8]) -> Result<MigratedStateFile, Backen
 pub struct ResourceState {
     /// Resource type (e.g., "s3.Bucket", "ec2.Vpc")
     pub resource_type: String,
-    /// ManagedResource name (from the `name` attribute in DSL)
+    /// Resource name (from the `name` attribute in DSL)
     pub name: String,
     /// Provider name (e.g., "aws")
     pub provider: String,
@@ -628,7 +628,7 @@ pub struct ResourceState {
     /// Binding names of resources this resource depends on (via ResourceRef).
     /// Stored so orphan Delete effects can have tree structure.
     ///
-    /// Set semantics (BTreeSet) — see ManagedResource::dependency_bindings (#2228).
+    /// Set semantics (BTreeSet) — see Resource::dependency_bindings (#2228).
     /// Old state files persisted as JSON arrays continue to deserialize
     /// (serde transparently coerces array → BTreeSet, deduping any
     /// duplicates and re-serializing in sorted order on next write).
@@ -733,11 +733,7 @@ impl ResourceState {
     ///
     /// `write_only_keys` is the set of attribute names that are marked write-only
     /// in the resource schema.
-    pub fn merge_write_only_attributes(
-        &mut self,
-        resource: &ManagedResource,
-        write_only_keys: &[String],
-    ) {
+    pub fn merge_write_only_attributes(&mut self, resource: &Resource, write_only_keys: &[String]) {
         let mut merged = Vec::new();
         for key in write_only_keys {
             // Only merge if the user specified this attribute and it's not already
@@ -754,14 +750,14 @@ impl ResourceState {
         self.write_only_attributes = merged;
     }
 
-    /// Build a ResourceState from a ManagedResource and its provider-returned State.
+    /// Build a ResourceState from a Resource and its provider-returned State.
     ///
     /// If `existing` is provided, the `protected` flag is preserved from it.
     ///
     /// Returns an error if any attribute value cannot be converted to JSON
     /// (e.g., non-finite float values).
     pub fn from_provider_state(
-        resource: &ManagedResource,
+        resource: &Resource,
         state: &State,
         existing: Option<&ResourceState>,
     ) -> Result<Self, String> {
@@ -812,7 +808,7 @@ impl ResourceState {
         // carina#3280: when `build_from_resource` would produce an
         // empty top-level `Struct` (the user authored no attributes —
         // bodyless resource like `aws.sts.CallerIdentity {}`, or the
-        // `carina state import` path that constructs a `ManagedResource`
+        // `carina state import` path that constructs a `Resource`
         // with no DSL attributes), emit `Unrecorded` instead. The
         // empty-Struct-at-top-level shape used to double as the
         // legacy-corruption marker, which forced callers to

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -150,14 +150,14 @@ fn test_resource_state_prefixes_serialization() {
 
 #[test]
 fn test_get_identifier_for_resource_from_state() {
-    use carina_core::resource::ManagedResource;
+    use carina_core::resource::Resource;
 
     let mut state = StateFile::new();
     let rs =
         ResourceState::new("s3.Bucket", "my-bucket", "awscc").with_identifier("my-bucket-abcd1234");
     state.upsert_resource(rs);
 
-    let resource = ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     assert_eq!(
         state.get_identifier_for_resource(&resource),
         Some("my-bucket-abcd1234".to_string())
@@ -166,10 +166,10 @@ fn test_get_identifier_for_resource_from_state() {
 
 #[test]
 fn test_get_identifier_for_resource_returns_none() {
-    use carina_core::resource::ManagedResource;
+    use carina_core::resource::Resource;
 
     let state = StateFile::new();
-    let resource = ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     assert_eq!(state.get_identifier_for_resource(&resource), None);
 }
 
@@ -254,9 +254,9 @@ fn test_resource_state_deserialization_without_v3_fields() {
 
 #[test]
 fn test_from_provider_state() {
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let mut resource = ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     resource.directives.force_delete = true;
     resource
         .prefixes
@@ -292,9 +292,9 @@ fn test_from_provider_state() {
 
 #[test]
 fn test_from_provider_state_without_existing() {
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let resource = ManagedResource::with_provider("aws", "s3.Bucket", "test", None);
+    let resource = Resource::with_provider("aws", "s3.Bucket", "test", None);
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("test-id".to_string()),
@@ -322,9 +322,9 @@ fn test_from_provider_state_repairs_unrecorded_from_state_attrs() {
     // `state.attributes` is populated, rebuild `explicit` from the
     // fresh state so the next write replaces the corrupt row.
     use carina_core::explicit::ExplicitFields;
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let resource = ManagedResource::with_provider("awscc", "sso.Assignment", "x", None);
+    let resource = Resource::with_provider("awscc", "sso.Assignment", "x", None);
     // resource.attributes intentionally left empty — this is the buggy
     // input the old expansion path delivered to state writeback.
     let provider_state = ProviderState {
@@ -375,9 +375,9 @@ fn test_from_provider_state_emits_unrecorded_for_fresh_empty_body_resource() {
     // authored an empty struct, drop every server-side attribute".
     // The typed signal removes the ambiguity at the source.
     use carina_core::explicit::ExplicitFields;
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let resource = ManagedResource::with_provider("aws", "sts.CallerIdentity", "caller", None);
+    let resource = Resource::with_provider("aws", "sts.CallerIdentity", "caller", None);
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("identifier".to_string()),
@@ -411,9 +411,9 @@ fn test_from_provider_state_preserves_populated_struct_when_resource_attrs_empty
     // with `Unrecorded`, flip-flopping the row on every apply and
     // churning state `serial`. Preserve the existing populated Struct.
     use carina_core::explicit::ExplicitFields;
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let resource = ManagedResource::with_provider("aws", "sts.CallerIdentity", "caller", None);
+    let resource = Resource::with_provider("aws", "sts.CallerIdentity", "caller", None);
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("id".to_string()),
@@ -452,9 +452,9 @@ fn test_from_provider_state_no_repair_when_state_attrs_also_empty() {
     // repair cannot rebuild authoring from nothing — emit `Unrecorded`
     // (stable fixed point), do not crash, do not invent attributes.
     use carina_core::explicit::ExplicitFields;
-    use carina_core::resource::{ManagedResource, State as ProviderState};
+    use carina_core::resource::{Resource, State as ProviderState};
 
-    let resource = ManagedResource::with_provider("awscc", "sso.Assignment", "x", None);
+    let resource = Resource::with_provider("awscc", "sso.Assignment", "x", None);
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("id".to_string()),
@@ -618,7 +618,7 @@ fn test_migrate_v6_does_not_rewrite_nested_empty_struct() {
 
 #[test]
 fn test_multi_provider_resources_do_not_collide() {
-    use carina_core::resource::ManagedResource;
+    use carina_core::resource::Resource;
 
     let mut state = StateFile::new();
 
@@ -642,13 +642,13 @@ fn test_multi_provider_resources_do_not_collide() {
     assert_eq!(found_awscc.identifier, Some("awscc-bucket-id".to_string()));
 
     // get_identifier_for_resource should return provider-scoped identifiers
-    let aws_res = ManagedResource::with_provider("aws", "s3.Bucket", "main", None);
+    let aws_res = Resource::with_provider("aws", "s3.Bucket", "main", None);
     assert_eq!(
         state.get_identifier_for_resource(&aws_res),
         Some("aws-bucket-id".to_string())
     );
 
-    let awscc_res = ManagedResource::with_provider("awscc", "s3.Bucket", "main", None);
+    let awscc_res = Resource::with_provider("awscc", "s3.Bucket", "main", None);
     assert_eq!(
         state.get_identifier_for_resource(&awscc_res),
         Some("awscc-bucket-id".to_string())
@@ -738,7 +738,7 @@ fn test_build_saved_attrs_provider_scoped() {
 
 #[test]
 fn test_build_state_for_resource_existing() {
-    use carina_core::resource::{ConcreteValue, ManagedResource, Value};
+    use carina_core::resource::{ConcreteValue, Resource, Value};
 
     let mut state = StateFile::new();
     state.upsert_resource(
@@ -747,7 +747,7 @@ fn test_build_state_for_resource_existing() {
             .with_attribute("region".to_string(), serde_json::json!("ap-northeast-1")),
     );
 
-    let resource = ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     let result = state.build_state_for_resource(&resource.id);
 
     assert!(result.exists);
@@ -763,12 +763,8 @@ fn test_build_state_for_resource_existing() {
 #[test]
 fn test_build_state_for_resource_not_found() {
     let state = StateFile::new();
-    let resource = carina_core::resource::ManagedResource::with_provider(
-        "awscc",
-        "s3.Bucket",
-        "missing",
-        None,
-    );
+    let resource =
+        carina_core::resource::Resource::with_provider("awscc", "s3.Bucket", "missing", None);
     let result = state.build_state_for_resource(&resource.id);
 
     assert!(!result.exists);
@@ -779,18 +775,14 @@ fn test_build_state_for_resource_not_found() {
 #[test]
 fn test_build_state_for_resource_without_identifier() {
     let mut state = StateFile::new();
-    // ManagedResource in state but without identifier (not yet created)
+    // Resource in state but without identifier (not yet created)
     state.upsert_resource(
         ResourceState::new("s3.Bucket", "pending", "awscc")
             .with_attribute("region".to_string(), serde_json::json!("us-east-1")),
     );
 
-    let resource = carina_core::resource::ManagedResource::with_provider(
-        "awscc",
-        "s3.Bucket",
-        "pending",
-        None,
-    );
+    let resource =
+        carina_core::resource::Resource::with_provider("awscc", "s3.Bucket", "pending", None);
     let result = state.build_state_for_resource(&resource.id);
 
     assert!(!result.exists);
@@ -799,9 +791,9 @@ fn test_build_state_for_resource_without_identifier() {
 
 #[test]
 fn test_from_provider_state_stores_binding_and_dependencies() {
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Subnet", "my-subnet", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None);
     resource.binding = Some("my_subnet".to_string());
     resource.set_attr(
         "vpc_id".to_string(),
@@ -1088,10 +1080,10 @@ fn check_and_migrate_drops_artifact_rows_with_null_identifier_3266() {
 
 #[test]
 fn test_merge_write_only_attributes() {
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
     // Simulate a VPC resource with a write-only attribute (ipv4_netmask_length)
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -1137,10 +1129,10 @@ fn test_merge_write_only_attributes() {
 
 #[test]
 fn test_merge_write_only_attributes_not_in_desired() {
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    // ManagedResource without write-only attribute specified
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
+    // Resource without write-only attribute specified
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -1172,10 +1164,10 @@ fn test_merge_write_only_attributes_not_in_desired() {
 
 #[test]
 fn test_merge_write_only_skips_if_already_in_provider_state() {
-    use carina_core::resource::{ConcreteValue, ManagedResource, State as ProviderState, Value};
+    use carina_core::resource::{ConcreteValue, Resource, State as ProviderState, Value};
 
-    // ManagedResource with a write-only attribute
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
+    // Resource with a write-only attribute
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     resource.set_attr(
         "some_attr".to_string(),
         Value::Concrete(ConcreteValue::String("desired".to_string())),
@@ -1245,11 +1237,11 @@ fn test_write_only_attributes_omitted_when_empty() {
 #[test]
 fn test_from_provider_state_secret_stored_as_hash() {
     use carina_core::resource::{
-        ConcreteValue, DeferredValue, ManagedResource, State as ProviderState, Value,
+        ConcreteValue, DeferredValue, Resource, State as ProviderState, Value,
     };
     use carina_core::value::SECRET_PREFIX;
 
-    let mut resource = ManagedResource::with_provider("awscc", "rds.db_instance", "my-db", None);
+    let mut resource = Resource::with_provider("awscc", "rds.db_instance", "my-db", None);
     resource.set_attr(
         "master_password".to_string(),
         Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
@@ -1294,11 +1286,11 @@ fn test_from_provider_state_secret_stored_as_hash() {
 #[test]
 fn test_from_provider_state_secret_in_map_stored_as_hash() {
     use carina_core::resource::{
-        ConcreteValue, DeferredValue, ManagedResource, State as ProviderState, Value,
+        ConcreteValue, DeferredValue, Resource, State as ProviderState, Value,
     };
     use carina_core::value::SECRET_PREFIX;
 
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     let mut tags_map = IndexMap::new();
     tags_map.insert(
         "Name".to_string(),
@@ -1363,12 +1355,12 @@ fn test_from_provider_state_secret_in_map_stored_as_hash() {
 #[test]
 fn test_from_provider_state_secret_in_map_preserves_provider_extra_keys() {
     use carina_core::resource::{
-        ConcreteValue, DeferredValue, ManagedResource, State as ProviderState, Value,
+        ConcreteValue, DeferredValue, Resource, State as ProviderState, Value,
     };
     use carina_core::value::SECRET_PREFIX;
 
     // User specifies only SecretTag in tags
-    let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
+    let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None);
     let mut tags_map = IndexMap::new();
     tags_map.insert(
         "SecretTag".to_string(),
@@ -1437,11 +1429,11 @@ fn test_from_provider_state_secret_in_map_preserves_provider_extra_keys() {
 #[test]
 fn test_from_provider_state_secret_in_list_stored_as_hash() {
     use carina_core::resource::{
-        ConcreteValue, DeferredValue, ManagedResource, State as ProviderState, Value,
+        ConcreteValue, DeferredValue, Resource, State as ProviderState, Value,
     };
     use carina_core::value::SECRET_PREFIX;
 
-    let mut resource = ManagedResource::with_provider("awscc", "test.resource", "my-res", None);
+    let mut resource = Resource::with_provider("awscc", "test.resource", "my-res", None);
     resource.set_attr(
         "values".to_string(),
         Value::Concrete(ConcreteValue::List(vec![
@@ -1582,10 +1574,10 @@ fn check_and_migrate_canonicalizes_legacy_map_key_addresses() {
 #[test]
 fn from_provider_state_rejects_resource_ref_in_provider_attributes() {
     use carina_core::resource::{
-        AccessPath, DeferredValue, ManagedResource, State as ProviderState, Value,
+        AccessPath, DeferredValue, Resource, State as ProviderState, Value,
     };
 
-    let resource = ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None);
     let provider_state = ProviderState {
         id: resource.id.clone(),
         identifier: Some("my-bucket".to_string()),

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::value::format_value;
 
 #[test]
@@ -13,10 +13,7 @@ fn app_from_empty_plan() {
 #[test]
 fn app_from_plan_with_effects() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ManagedResource::new(
-        "s3.Bucket",
-        "my-bucket",
-    )));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
     plan.add(Effect::Delete {
         id: ResourceId::new("s3.Bucket", "old-bucket"),
         identifier: "old-bucket-id".to_string(),
@@ -37,9 +34,9 @@ fn app_from_plan_with_effects() {
 #[test]
 fn navigation() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "c")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "c")));
 
     let mut app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.selected, 0);
@@ -79,7 +76,7 @@ fn update_effect_has_detail_rows() {
             .into_iter()
             .collect(),
         )),
-        to: ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
+        to: Resource::new("s3.Bucket", "my-bucket").with_attribute(
             "versioning",
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         ),
@@ -101,7 +98,7 @@ fn update_effect_has_detail_rows() {
 fn internal_attributes_filtered() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::new("s3.Bucket", "my-bucket")
+        Resource::new("s3.Bucket", "my-bucket")
             .with_attribute(
                 "name",
                 Value::Concrete(ConcreteValue::String("test".to_string())),
@@ -158,7 +155,7 @@ fn replace_effect_symbols() {
     plan.add(Effect::Replace {
         id: ResourceId::new("ec2.Vpc", "my-vpc"),
         from: from.clone(),
-        to: ManagedResource::new("ec2.Vpc", "my-vpc"),
+        to: Resource::new("ec2.Vpc", "my-vpc"),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -173,7 +170,7 @@ fn replace_effect_symbols() {
     plan.add(Effect::Replace {
         id: ResourceId::new("ec2.Vpc", "my-vpc2"),
         from,
-        to: ManagedResource::new("ec2.Vpc", "my-vpc2"),
+        to: Resource::new("ec2.Vpc", "my-vpc2"),
         directives: Directives::default(),
         changed_create_only: vec!["cidr".to_string()],
         cascading_updates: vec![],
@@ -191,7 +188,7 @@ fn tree_structure_with_dependencies() {
     // Create a plan where subnet depends on vpc via ResourceRef
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.Vpc", "my-vpc")
+        Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -199,7 +196,7 @@ fn tree_structure_with_dependencies() {
             ),
     ));
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.Subnet", "my-subnet")
+        Resource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
                 "vpc_id",
@@ -224,7 +221,7 @@ fn tree_structure_with_dependencies() {
 fn selected_node_returns_correct_node() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::new("s3.Bucket", "my-bucket").with_attribute(
+        Resource::new("s3.Bucket", "my-bucket").with_attribute(
             "name",
             Value::Concrete(ConcreteValue::String("test".to_string())),
         ),
@@ -240,7 +237,7 @@ fn selected_node_returns_correct_node() {
 #[test]
 fn toggle_focus_switches_panels() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     assert_eq!(app.focused_panel, FocusedPanel::Tree);
@@ -253,7 +250,7 @@ fn toggle_focus_switches_panels() {
 #[test]
 fn detail_scroll_up_down() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     assert_eq!(app.detail_scroll, 0);
@@ -273,8 +270,8 @@ fn detail_scroll_up_down() {
 #[test]
 fn detail_scroll_resets_on_navigation() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     app.detail_scroll = 5;
@@ -291,7 +288,7 @@ fn tree_scroll_cursor_moves_within_visible_area_before_scrolling() {
     // Create a plan with 10 items
     let mut plan = Plan::new();
     for i in 0..10 {
-        plan.add(Effect::Create(ManagedResource::new(
+        plan.add(Effect::Create(Resource::new(
             "s3.Bucket",
             format!("bucket-{}", i),
         )));
@@ -350,8 +347,8 @@ fn tree_scroll_cursor_moves_within_visible_area_before_scrolling() {
 fn tree_scroll_zero_height_does_not_scroll_on_move_down() {
     // When tree_area_height is 0 (before first render), move_down should not scroll
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.tree_area_height, 0);
 
@@ -364,7 +361,7 @@ fn tree_scroll_zero_height_does_not_scroll_on_move_down() {
 fn make_tree_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.Vpc", "my-vpc")
+        Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -372,7 +369,7 @@ fn make_tree_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.Subnet", "my-subnet")
+        Resource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
                 "vpc_id",
@@ -380,7 +377,7 @@ fn make_tree_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Create(
-        ManagedResource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
+        Resource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
     ));
     plan
 }
@@ -567,11 +564,10 @@ fn tab_complete_with_provider_prefix() {
     // Resource types with provider prefix (e.g., "awscc.ec2.Vpc")
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
+        Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
     ));
     plan.add(Effect::Create(
-        ManagedResource::with_provider("awscc", "ec2.Subnet", "my-subnet", None)
-            .with_binding("subnet"),
+        Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None).with_binding("subnet"),
     ));
     let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
@@ -636,7 +632,7 @@ fn format_value_resolves_dsl_enum_identifiers() {
 fn create_effect_attributes_resolve_enum_values() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.vpc_endpoint", "my-endpoint")
+        Resource::new("ec2.vpc_endpoint", "my-endpoint")
             .with_attribute(
                 "vpc_endpoint_type",
                 Value::Concrete(ConcreteValue::String(
@@ -689,7 +685,7 @@ fn move_suppressed_when_update_exists_for_same_target() {
             .into_iter()
             .collect(),
         )),
-        to: ManagedResource::new("s3.Bucket", "new-name").with_attribute(
+        to: Resource::new("s3.Bucket", "new-name").with_attribute(
             "versioning",
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         ),
@@ -720,7 +716,7 @@ fn move_suppressed_when_replace_exists_for_same_target() {
             .into_iter()
             .collect(),
         )),
-        to: ManagedResource::new("ec2.Vpc", "new-vpc"),
+        to: Resource::new("ec2.Vpc", "new-vpc"),
         directives: Directives::default(),
         changed_create_only: vec!["cidr".to_string()],
         cascading_updates: vec![],

--- a/carina-tui/src/lib.rs
+++ b/carina-tui/src/lib.rs
@@ -226,12 +226,12 @@ fn run_tui<A>(
 mod tests {
     use super::*;
     use carina_core::effect::Effect;
-    use carina_core::resource::ManagedResource;
+    use carina_core::resource::Resource;
 
     fn make_app() -> App {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "a")));
-        plan.add(Effect::Create(ManagedResource::new("s3.Bucket", "b")));
+        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+        plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
         App::new(&plan, &SchemaRegistry::new())
     }
 
@@ -275,13 +275,13 @@ mod tests {
     fn make_search_app() -> App {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            ManagedResource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
+            Resource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
         ));
         plan.add(Effect::Create(
-            ManagedResource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
+            Resource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
         ));
         plan.add(Effect::Create(
-            ManagedResource::new("ec2.Subnet", "my-subnet")
+            Resource::new("ec2.Subnet", "my-subnet")
                 .with_binding("subnet")
                 .with_attribute(
                     "vpc_id",
@@ -483,15 +483,14 @@ mod tests {
     fn make_provider_prefixed_app() -> App {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            ManagedResource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
+            Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
         ));
         plan.add(Effect::Create(
-            ManagedResource::with_provider("awscc", "ec2.Subnet", "my-subnet", None)
+            Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None)
                 .with_binding("subnet"),
         ));
         plan.add(Effect::Create(
-            ManagedResource::with_provider("awscc", "s3.Bucket", "my-bucket", None)
-                .with_binding("bucket"),
+            Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None).with_binding("bucket"),
         ));
         App::new(&plan, &SchemaRegistry::new())
     }

--- a/carina-tui/src/module_info_app.rs
+++ b/carina-tui/src/module_info_app.rs
@@ -10,7 +10,7 @@ use crate::app::FocusedPanel;
 pub enum SectionKind {
     Header,
     Argument,
-    ManagedResource,
+    Resource,
     Attribute,
     Import,
     ModuleCall,
@@ -274,7 +274,7 @@ impl InfoRow {
             type_info: resource_type.to_string(),
             detail: dep_detail,
             depth: 1,
-            kind: SectionKind::ManagedResource,
+            kind: SectionKind::Resource,
             required: false,
             default_value: None,
             description: None,

--- a/carina-tui/src/module_info_ui.rs
+++ b/carina-tui/src/module_info_ui.rs
@@ -99,7 +99,7 @@ fn build_list_item(row: &crate::module_info_app::InfoRow, is_selected: bool) -> 
             }
             s
         }
-        SectionKind::ManagedResource => {
+        SectionKind::Resource => {
             vec![
                 Span::raw(indent),
                 Span::styled(row.label.clone(), Style::default().fg(Color::White)),

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -10,7 +10,7 @@ use ratatui::backend::TestBackend;
 
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
-use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 
 use crate::app::App;
@@ -46,7 +46,7 @@ fn render_tui_with_schemas(
 fn build_all_create_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.Vpc", "my-vpc")
+        Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -54,7 +54,7 @@ fn build_all_create_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.RouteTable", "my-rt")
+        Resource::new("ec2.RouteTable", "my-rt")
             .with_binding("rt")
             .with_attribute(
                 "vpc_id",
@@ -62,7 +62,7 @@ fn build_all_create_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.Subnet", "my-subnet")
+        Resource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
                 "cidr_block",
@@ -96,7 +96,7 @@ fn build_mixed_operations_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: ManagedResource::new("ec2.Vpc", "my-vpc")
+        to: Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -109,7 +109,7 @@ fn build_mixed_operations_plan() -> Plan {
         changed_attributes: vec!["enable_dns_support".to_string()],
     });
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.SecurityGroup", "my-sg")
+        Resource::new("ec2.SecurityGroup", "my-sg")
             .with_binding("sg")
             .with_attribute(
                 "group_description",
@@ -190,7 +190,7 @@ fn build_map_key_diff_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: ManagedResource::new("ec2.Vpc", "my-vpc")
+        to: Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -235,7 +235,7 @@ fn snapshot_map_key_diff() {
 fn snapshot_create_with_schema() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.Vpc", "my-vpc")
+        Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
                 "cidr_block",
@@ -361,7 +361,7 @@ fn build_moved_with_changes_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: ManagedResource::new("ec2.Vpc", "new_vpc")
+        to: Resource::new("ec2.Vpc", "new_vpc")
             .with_binding("new_vpc")
             .with_attribute(
                 "cidr_block",
@@ -381,7 +381,7 @@ fn build_moved_with_changes_plan() -> Plan {
         changed_attributes: vec!["tags".to_string()],
     });
     plan.add(Effect::Create(
-        ManagedResource::new("ec2.Subnet", "my-subnet")
+        Resource::new("ec2.Subnet", "my-subnet")
             .with_attribute(
                 "cidr_block",
                 Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),

--- a/carina-tui/src/ui/tree.rs
+++ b/carina-tui/src/ui/tree.rs
@@ -156,16 +156,13 @@ mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{ConcreteValue, ManagedResource, Value};
+    use carina_core::resource::{ConcreteValue, Resource, Value};
     use carina_core::schema::SchemaRegistry;
 
     #[test]
     fn tree_connector_root_has_no_prefix() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(ManagedResource::new(
-            "s3.Bucket",
-            "my-bucket",
-        )));
+        plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
         let app = App::new(&plan, &SchemaRegistry::new());
         assert_eq!(build_tree_connector(0, &app), "");
     }
@@ -174,7 +171,7 @@ mod tests {
     fn tree_connector_single_child() {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            ManagedResource::new("ec2.Vpc", "my-vpc")
+            Resource::new("ec2.Vpc", "my-vpc")
                 .with_binding("vpc")
                 .with_attribute(
                     "cidr_block",
@@ -182,7 +179,7 @@ mod tests {
                 ),
         ));
         plan.add(Effect::Create(
-            ManagedResource::new("ec2.Subnet", "my-subnet")
+            Resource::new("ec2.Subnet", "my-subnet")
                 .with_binding("subnet")
                 .with_attribute(
                     "vpc_id",
@@ -200,10 +197,10 @@ mod tests {
     fn tree_connector_multiple_children() {
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            ManagedResource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
+            Resource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
         ));
         plan.add(Effect::Create(
-            ManagedResource::new("ec2.Subnet", "subnet-a")
+            Resource::new("ec2.Subnet", "subnet-a")
                 .with_binding("subnet_a")
                 .with_attribute(
                     "vpc_id",
@@ -211,7 +208,7 @@ mod tests {
                 ),
         ));
         plan.add(Effect::Create(
-            ManagedResource::new("ec2.Subnet", "subnet-b")
+            Resource::new("ec2.Subnet", "subnet-b")
                 .with_binding("subnet_b")
                 .with_attribute(
                     "vpc_id",


### PR DESCRIPTION
## Summary

PR A of the #3287 series. Reclaims the `Resource` name (vacated by #3181) for the CRUD variant. Mechanical rename across 87 files; no semantic changes.

- `carina_provider_protocol::types::Resource` (WIT boundary) untouched
- `wasm_convert.rs` keeps its `Resource as CoreResource` alias
- Historical design notes (`notes/specs/2026-05-21-*.md` etc.) preserve their `ManagedResource` text as `#3181`-era descriptions

Closes #3288

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3620 passed
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-*.sh` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
