### PR TITLE
resource: Signature struct on Composition (#3292)

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1210,7 +1210,10 @@ fn resolve_exports_resolves_module_call_attribute_via_composition() {
     );
     let composition = Composition {
         id: carina_core::resource::ResourceId::new("_virtual", "github_actions_carina"),
-        attributes: virt_attrs,
+        signature: carina_core::resource::Signature {
+            arguments: indexmap::IndexMap::new(),
+            attributes: virt_attrs,
+        },
         binding: Some("github_actions_carina".to_string()),
         dependency_bindings: std::collections::BTreeSet::new(),
         module_name: "github_module".to_string(),
@@ -1303,7 +1306,10 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_compositions()
         );
         Composition {
             id: carina_core::resource::ResourceId::new("_virtual", id_name),
-            attributes,
+            signature: carina_core::resource::Signature {
+                arguments: indexmap::IndexMap::new(),
+                attributes,
+            },
             binding: Some(binding.to_string()),
             dependency_bindings: std::collections::BTreeSet::new(),
             module_name: "mod".to_string(),
@@ -1474,7 +1480,10 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
     );
     let composition = Composition {
         id: ResourceId::new("_virtual", "carina_module"),
-        attributes: virt_attrs,
+        signature: carina_core::resource::Signature {
+            arguments: indexmap::IndexMap::new(),
+            attributes: virt_attrs,
+        },
         binding: Some("carina_module".to_string()),
         dependency_bindings: std::collections::BTreeSet::new(),
         module_name: "carina_module".to_string(),

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -604,7 +604,7 @@ impl ResolvedBindings {
             self.by_name.insert(
                 binding_name.clone(),
                 ResolvedBinding {
-                    attributes: crate::resource::attrs_to_hashmap(&v.attributes),
+                    attributes: crate::resource::attrs_to_hashmap(&v.signature.attributes),
                     source: BindingValueSource::Local,
                 },
             );

--- a/carina-core/src/binding_index_split_tests.rs
+++ b/carina-core/src/binding_index_split_tests.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeSet, HashMap};
 use indexmap::IndexMap;
 
 use crate::binding_index::ResolvedBindings;
-use crate::resource::{Composition, ConcreteValue, Resource, ResourceId, State, Value};
+use crate::resource::{Composition, ConcreteValue, Resource, ResourceId, Signature, State, Value};
 
 fn s(s: &str) -> Value {
     Value::Concrete(ConcreteValue::String(s.into()))
@@ -43,7 +43,10 @@ fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> Composition {
     }
     Composition {
         id: ResourceId::new("_virtual.module", binding),
-        attributes,
+        signature: Signature {
+            arguments: IndexMap::new(),
+            attributes,
+        },
         binding: Some(binding.into()),
         dependency_bindings: BTreeSet::new(),
         module_name: "m".into(),

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -43,7 +43,7 @@ pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
 /// same first-two-thirds of [`get_resource_dependencies`].
 pub fn get_composition_dependencies(virt: &crate::resource::Composition) -> HashSet<String> {
     let mut deps = HashSet::new();
-    for value in virt.attributes.values() {
+    for value in virt.signature.attributes.values() {
         collect_dependencies(value, &mut deps);
     }
     for name in &virt.dependency_bindings {
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn test_get_composition_dependencies_collects_attrs_and_deps() {
-        use crate::resource::Composition;
+        use crate::resource::{Composition, Signature};
         use indexmap::IndexMap;
         use std::collections::BTreeSet;
 
@@ -411,7 +411,10 @@ mod tests {
         dep_bindings.insert("explicit_dep".to_string());
         let virt = Composition {
             id: ResourceId::new("_virtual.module", "v"),
-            attributes,
+            signature: Signature {
+                arguments: IndexMap::new(),
+                attributes,
+            },
             binding: Some("v".to_string()),
             dependency_bindings: dep_bindings,
             module_name: "m".to_string(),

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -606,7 +606,10 @@ mod tests {
         );
         let virt = Composition {
             id: ResourceId::with_provider("_virtual", "_virtual", "bootstrap", None),
-            attributes: virt_attrs,
+            signature: crate::resource::Signature {
+                arguments: indexmap::IndexMap::new(),
+                attributes: virt_attrs,
+            },
             binding: Some("bootstrap".to_string()),
             dependency_bindings: std::collections::BTreeSet::new(),
             module_name: "github-oidc".to_string(),

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1371,7 +1371,10 @@ mod tests {
         );
         Composition {
             id: ResourceId::with_provider("_virtual", "_virtual", id_name, None),
-            attributes,
+            signature: crate::resource::Signature {
+                arguments: indexmap::IndexMap::new(),
+                attributes,
+            },
             binding: Some(binding.to_string()),
             dependency_bindings: std::collections::BTreeSet::new(),
             module_name: "mod".to_string(),

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -283,9 +283,24 @@ impl ModuleResolver<'_> {
                 }
             }
 
+            // Preserve the resolved call-site arguments on the
+            // expanded composition itself (#3292). `argument_values`
+            // is a HashMap (look-up keyed); we record them on the
+            // composition in `module.arguments` declaration order so
+            // the trace is stable across runs.
+            let mut signature_arguments: IndexMap<String, Value> = IndexMap::new();
+            for arg in &module.arguments {
+                if let Some(value) = argument_values.get(&arg.name) {
+                    signature_arguments.insert(arg.name.clone(), value.clone());
+                }
+            }
+
             let composition = Composition {
                 id: ResourceId::new("_virtual", binding_name),
-                attributes: composition_attrs,
+                signature: crate::resource::Signature {
+                    arguments: signature_arguments,
+                    attributes: composition_attrs,
+                },
                 binding: Some(binding_name.clone()),
                 dependency_bindings: BTreeSet::new(),
                 module_name: call.module_name.clone(),
@@ -596,7 +611,7 @@ fn prefix_module_composition(
     }
 
     let mut substituted_attrs: IndexMap<String, Value> = IndexMap::new();
-    for (key, expr) in &new_virtual.attributes {
+    for (key, expr) in &new_virtual.signature.attributes {
         substituted_attrs.insert(
             key.clone(),
             prefix_attr_value(
@@ -607,7 +622,7 @@ fn prefix_module_composition(
             ),
         );
     }
-    new_virtual.attributes = substituted_attrs;
+    new_virtual.signature.attributes = substituted_attrs;
 
     new_virtual
 }

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -656,12 +656,17 @@ fn test_expand_module_call_creates_composition() {
     // Module info lives in the flattened module_name / instance fields.
     assert_eq!(composition_res.module_name, "web_tier");
     assert_eq!(composition_res.instance, "web");
-    assert!(!composition_res.attributes.contains_key("_module"));
-    assert!(!composition_res.attributes.contains_key("_module_instance"));
+    assert!(!composition_res.signature.attributes.contains_key("_module"));
+    assert!(
+        !composition_res
+            .signature
+            .attributes
+            .contains_key("_module_instance")
+    );
     // The security_group attribute should be a rewritten ResourceRef
     // pointing to the dot-path binding (web.sg)
     assert_eq!(
-        composition_res.attributes.get("security_group"),
+        composition_res.signature.attributes.get("security_group"),
         Some(&Value::resource_ref(
             "web.sg".to_string(),
             "id".to_string(),
@@ -702,6 +707,115 @@ fn test_expand_module_call_populates_compositions_slice() {
 
     // This module declares no data sources.
     assert!(expanded.data_sources.is_empty());
+}
+
+/// PR E (#3292) acceptance: a composition's `signature.arguments`
+/// preserves the resolved call-site arguments. The pre-#3292 expander
+/// dropped this information with the `ModuleCall`; with `Signature`
+/// on `Composition`, the call boundary is now inspectable on the
+/// expanded node itself.
+#[test]
+fn test_expand_module_call_preserves_arguments_on_composition_signature() {
+    use crate::parser::{ArgumentParameter, AttributeParameter, TypeExpr};
+
+    // A small module that declares two `argument` parameters and one
+    // `attribute` output, used to verify both halves of the signature.
+    let module = ParsedFile {
+        providers: vec![],
+        resources: vec![],
+        data_sources: vec![],
+        compositions: vec![],
+        variables: IndexMap::new(),
+        uses: vec![],
+        module_calls: vec![],
+        arguments: vec![
+            ArgumentParameter {
+                name: "region".to_string(),
+                type_expr: TypeExpr::String,
+                default: None,
+                description: None,
+                validations: vec![],
+            },
+            ArgumentParameter {
+                name: "instance_count".to_string(),
+                type_expr: TypeExpr::Int,
+                default: None,
+                description: None,
+                validations: vec![],
+            },
+        ],
+        attribute_params: vec![AttributeParameter {
+            name: "endpoint".to_string(),
+            type_expr: None,
+            value: Some(Value::Concrete(ConcreteValue::String(
+                "fixed-endpoint".to_string(),
+            ))),
+        }],
+        export_params: vec![],
+        backend: None,
+        state_blocks: vec![],
+        user_functions: HashMap::new(),
+        upstream_states: vec![],
+        wait_bindings: vec![],
+        requires: vec![],
+        structural_bindings: HashSet::new(),
+        warnings: vec![],
+        deferred_for_expressions: vec![],
+    };
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert("svc".to_string(), module);
+        r
+    };
+
+    let mut call_arguments: HashMap<String, Value> = HashMap::new();
+    call_arguments.insert(
+        "region".to_string(),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    );
+    call_arguments.insert(
+        "instance_count".to_string(),
+        Value::Concrete(ConcreteValue::Int(3)),
+    );
+
+    let call = ModuleCall {
+        module_name: "svc".to_string(),
+        binding_name: Some("api".to_string()),
+        arguments: call_arguments,
+    };
+
+    let expanded = resolver.expand_module_call(&call, "api", None).unwrap();
+    assert_eq!(expanded.compositions.len(), 1);
+    let composition = &expanded.compositions[0];
+
+    // The composition's signature.arguments must contain BOTH values
+    // passed at the call site, keyed by argument name.
+    assert_eq!(
+        composition.signature.arguments.get("region"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "ap-northeast-1".to_string()
+        ))),
+        "region argument must be recorded on the composition signature",
+    );
+    assert_eq!(
+        composition.signature.arguments.get("instance_count"),
+        Some(&Value::Concrete(ConcreteValue::Int(3))),
+        "instance_count argument must be recorded on the composition signature",
+    );
+
+    // Arguments are recorded in module.arguments declaration order so
+    // the trace is stable across runs.
+    let keys: Vec<&String> = composition.signature.arguments.keys().collect();
+    assert_eq!(keys, vec!["region", "instance_count"]);
+
+    // The attribute half remains populated as before.
+    assert_eq!(
+        composition.signature.attributes.get("endpoint"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "fixed-endpoint".to_string()
+        ))),
+    );
 }
 
 #[test]
@@ -1418,7 +1532,7 @@ fn test_module_composition_dot_path_refs() {
 
     // The security_group attribute should reference dot-notation binding
     assert_eq!(
-        composition_res.attributes.get("security_group"),
+        composition_res.signature.attributes.get("security_group"),
         Some(&Value::resource_ref(
             "web.sg".to_string(),
             "id".to_string(),

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -115,7 +115,7 @@ impl<'a> ResourceRef<'a> {
     pub fn attributes(&self) -> &'a IndexMap<String, Value> {
         match self {
             ResourceRef::Resource(r) => &r.attributes,
-            ResourceRef::Composition(v) => &v.attributes,
+            ResourceRef::Composition(v) => &v.signature.attributes,
             ResourceRef::DataSource(d) => &d.attributes,
             ResourceRef::Deferred { resource, .. } => &resource.attributes,
         }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -211,10 +211,10 @@ pub fn resolve_virtual_refs_post_apply(
 ) -> Result<(), String> {
     for v in compositions.iter_mut() {
         let mut resolved_attrs: IndexMap<String, Value> = IndexMap::new();
-        for (key, value) in &v.attributes {
+        for (key, value) in &v.signature.attributes {
             resolved_attrs.insert(key.clone(), resolve_ref_value(value, bindings)?);
         }
-        v.attributes = resolved_attrs;
+        v.signature.attributes = resolved_attrs;
     }
     Ok(())
 }

--- a/carina-core/src/resolver_split_tests.rs
+++ b/carina-core/src/resolver_split_tests.rs
@@ -19,7 +19,8 @@ use crate::resolver::{
     resolve_managed_refs_with_state_and_remote, resolve_virtual_refs_post_apply,
 };
 use crate::resource::{
-    AccessPath, Composition, ConcreteValue, DeferredValue, Resource, ResourceId, State, Value,
+    AccessPath, Composition, ConcreteValue, DeferredValue, Resource, ResourceId, Signature, State,
+    Value,
 };
 
 fn s(s: &str) -> Value {
@@ -56,7 +57,10 @@ fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> Composition {
     }
     Composition {
         id: ResourceId::new("_virtual.module", binding),
-        attributes,
+        signature: Signature {
+            arguments: IndexMap::new(),
+            attributes,
+        },
         binding: Some(binding.into()),
         dependency_bindings: BTreeSet::new(),
         module_name: "m".into(),
@@ -168,6 +172,7 @@ fn resolve_virtual_refs_post_apply_uses_provided_bindings() {
     resolve_virtual_refs_post_apply(&mut compositions, &bindings).expect("resolve compositions");
 
     let forwarded = compositions[0]
+        .signature
         .attributes
         .get("forwarded")
         .expect("forwarded present");
@@ -196,6 +201,7 @@ fn resolve_virtual_refs_post_apply_picks_post_apply_value_not_pre_apply() {
         .expect("resolve compositions");
 
     let role_arn = compositions[0]
+        .signature
         .attributes
         .get("role_arn")
         .expect("role_arn present");
@@ -223,6 +229,7 @@ fn resolve_virtual_refs_post_apply_leaves_non_ref_values_intact() {
     resolve_virtual_refs_post_apply(&mut compositions, &bindings).expect("resolve compositions");
 
     let literal = compositions[0]
+        .signature
         .attributes
         .get("literal")
         .expect("literal present");

--- a/carina-core/src/resource/composition.rs
+++ b/carina-core/src/resource/composition.rs
@@ -2,11 +2,12 @@
 //! resolver to expose module `attributes` values.
 //!
 //! Part of the resource typestate split (#3169). Virtual resources
-//! are not sent to providers; they exist only in the IR. Their
-//! `attributes` may contain unresolved `ResourceRef` / `BindingRef`
-//! values whose resolution is **deferred to the post-apply path**.
-//! The typestate split encodes that invariant: a `Composition`
-//! is never accepted by the pre-apply resolver.
+//! are not sent to providers; they exist only in the IR. The
+//! `signature.attributes` map may contain unresolved
+//! `ResourceRef` / `BindingRef` values whose resolution is **deferred
+//! to the post-apply path**. The typestate split encodes that
+//! invariant: a `Composition` is never accepted by the pre-apply
+//! resolver.
 //!
 //! Unlike [`Resource`](super::Resource), this struct
 //! does not carry `directives` (no `prevent_destroy` applies to a
@@ -20,6 +21,42 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use super::{ResourceId, Value};
+
+/// The function-shaped I/O surface of a [`Composition`].
+///
+/// Carries both halves of the module-call boundary on the expanded
+/// node itself:
+///
+/// - **`arguments`**: resolved call-site values, populated from
+///   `ModuleCall.arguments` at expansion time. Today these are read
+///   for substitution and then dropped with the `ModuleCall`;
+///   keeping them on the composition makes "what was passed in"
+///   inspectable post-expansion.
+/// - **`attributes`**: resolved module-output values (the
+///   `attribute_params` resolved against `arguments`). May still
+///   carry unresolved `ResourceRef` / `BindingRef` values whose
+///   resolution is deferred until post-apply.
+///
+/// `Signature` is intentionally *only* on `Composition`: the DSL
+/// gives `Resource` and `DataSource` a single user-written
+/// `attributes` namespace with no `arguments` concept, so embedding a
+/// `Signature` on those structs would be a pretextual abstraction
+/// with one populated half. See the rescoped design note
+/// (`notes/specs/2026-05-25-composition-graph-node-design.md`, PR
+/// #3301) for the rationale.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Signature {
+    /// Resolved call-site arguments. Empty when the composition was
+    /// produced by a module that does not declare any `argument`
+    /// parameters, or when the call site passed no arguments.
+    #[serde(default)]
+    pub arguments: IndexMap<String, Value>,
+    /// Resolved module-output values. May contain unresolved
+    /// `ResourceRef` / `BindingRef` values; resolution is deferred to
+    /// the post-apply path.
+    #[serde(default)]
+    pub attributes: IndexMap<String, Value>,
+}
 
 /// A composition resource created by module-call expansion.
 ///
@@ -56,12 +93,28 @@ use super::{ResourceId, Value};
 ///     &v.module_source
 /// }
 /// ```
+///
+/// The bare `attributes` field is dropped — the I/O surface lives on
+/// `signature` (PR #3292). Direct access through `&v.attributes` must
+/// no longer compile; consumers should use `&v.signature.attributes`
+/// or, where polymorphism is needed, the
+/// [`ResourceLike::attributes`](super::ResourceLike::attributes)
+/// accessor.
+///
+/// ```compile_fail
+/// use carina_core::resource::Composition;
+/// use indexmap::IndexMap;
+/// fn _f(v: &Composition) -> &IndexMap<String, carina_core::resource::Value> {
+///     &v.attributes
+/// }
+/// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Composition {
     pub id: ResourceId,
-    /// Attributes that may contain unresolved `ResourceRef` /
-    /// `BindingRef` values. Resolution is deferred until post-apply.
-    pub attributes: IndexMap<String, Value>,
+    /// I/O surface of this composition: resolved call-site arguments
+    /// + resolved module-output attributes. See [`Signature`].
+    #[serde(default, flatten)]
+    pub signature: Signature,
     /// Binding name from `let` bindings in DSL.
     #[serde(default)]
     pub binding: Option<String>,

--- a/carina-core/src/resource/graph_node.rs
+++ b/carina-core/src/resource/graph_node.rs
@@ -146,7 +146,10 @@ mod tests {
         use std::collections::{BTreeSet, HashSet};
         let c = Composition {
             id: ResourceId::new("_virtual", "m"),
-            attributes: IndexMap::new(),
+            signature: super::super::Signature {
+                arguments: IndexMap::new(),
+                attributes: IndexMap::new(),
+            },
             binding: None,
             dependency_bindings: BTreeSet::new(),
             module_name: "m".to_string(),

--- a/carina-core/src/resource/leaf_node.rs
+++ b/carina-core/src/resource/leaf_node.rs
@@ -164,7 +164,10 @@ mod tests {
         use std::collections::{BTreeSet, HashSet};
         Composition {
             id: ResourceId::new("_virtual", "m"),
-            attributes: IndexMap::new(),
+            signature: super::super::Signature {
+                arguments: IndexMap::new(),
+                attributes: IndexMap::new(),
+            },
             binding: None,
             dependency_bindings: BTreeSet::new(),
             module_name: "m".to_string(),
@@ -237,12 +240,15 @@ mod tests {
     /// is the core guarantee of this enum.
     ///
     /// ```compile_fail
-    /// use carina_core::resource::{LeafNode, Composition, ResourceId};
+    /// use carina_core::resource::{LeafNode, Composition, ResourceId, Signature};
     /// use indexmap::IndexMap;
     /// use std::collections::{BTreeSet, HashSet};
     /// let c = Composition {
     ///     id: ResourceId::new("_virtual", "m"),
-    ///     attributes: IndexMap::new(),
+    ///     signature: Signature {
+    ///         arguments: IndexMap::new(),
+    ///         attributes: IndexMap::new(),
+    ///     },
     ///     binding: None,
     ///     dependency_bindings: BTreeSet::new(),
     ///     module_name: "m".to_string(),

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1796,7 +1796,7 @@ pub mod graph_node;
 pub mod leaf_node;
 pub mod resource_like;
 
-pub use composition::Composition;
+pub use composition::{Composition, Signature};
 pub use data_source::DataSource;
 pub use graph_node::GraphNode;
 pub use leaf_node::{CompositionNotALeaf, LeafNode, expand_to_leaves};

--- a/carina-core/src/resource/resource_like.rs
+++ b/carina-core/src/resource/resource_like.rs
@@ -70,8 +70,16 @@ impl ResourceLike for Composition {
     fn id(&self) -> &ResourceId {
         &self.id
     }
+    /// Reads the I/O surface's `attributes` half.
+    ///
+    /// `Composition` is the only sibling that carries a [`Signature`]
+    /// (#3292). The `arguments` half is not exposed through
+    /// `ResourceLike` — the trait abstracts over the *output* surface
+    /// that `Resource` and `DataSource` also expose, while
+    /// `arguments` is composition-only and reached via
+    /// `c.signature.arguments` directly.
     fn attributes(&self) -> &IndexMap<String, Value> {
-        &self.attributes
+        &self.signature.attributes
     }
     fn binding(&self) -> Option<&str> {
         self.binding.as_deref()

--- a/carina-core/src/resource/resource_like_tests.rs
+++ b/carina-core/src/resource/resource_like_tests.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 
 use crate::resource::{
     Composition, ConcreteValue, DataSource, Directives, ModuleSource, Resource, ResourceId,
-    ResourceLike, Value,
+    ResourceLike, Signature, Value,
 };
 
 fn sample_value(s: &str) -> Value {
@@ -32,7 +32,10 @@ fn make_virtual() -> Composition {
     attributes.insert("k".to_string(), sample_value("v"));
     Composition {
         id: ResourceId::new("aws.s3.Bucket", "b"),
-        attributes,
+        signature: Signature {
+            arguments: IndexMap::new(),
+            attributes,
+        },
         binding: Some("b".to_string()),
         dependency_bindings: deps(),
         module_name: "m".to_string(),

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -240,7 +240,7 @@ pub fn bindings_from_parts(
         out.insert(
             name.clone(),
             InferenceBinding::Virtual {
-                attributes: composition.attributes.clone(),
+                attributes: composition.signature.attributes.clone(),
             },
         );
     }
@@ -1389,7 +1389,10 @@ mod tests {
         );
         let virt = crate::resource::Composition {
             id: crate::resource::ResourceId::new("_virtual", "github_actions_carina"),
-            attributes: virt_attrs,
+            signature: crate::resource::Signature {
+                arguments: indexmap::IndexMap::new(),
+                attributes: virt_attrs,
+            },
             binding: Some("github_actions_carina".to_string()),
             dependency_bindings: std::collections::BTreeSet::new(),
             module_name: "github_module".to_string(),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -771,14 +771,14 @@ pub fn redact_secrets_in_virtual(
     resource: &crate::resource::Composition,
 ) -> Result<crate::resource::Composition, SerializationError> {
     let attributes: Result<indexmap::IndexMap<String, Value>, _> = resource
+        .signature
         .attributes
         .iter()
         .map(|(k, e)| redact_secrets_in_value(e).map(|rv| (k.clone(), rv)))
         .collect();
-    Ok(crate::resource::Composition {
-        attributes: attributes?,
-        ..resource.clone()
-    })
+    let mut out = resource.clone();
+    out.signature.attributes = attributes?;
+    Ok(out)
 }
 
 /// Redact all secrets in a `State`, returning a new State with secrets replaced by hashes.
@@ -2364,7 +2364,7 @@ mod tests {
         // block (which lands as a `Value::Secret` in the composition's
         // attribute map) must be redacted before serialization, the
         // same way managed-resource attributes are redacted.
-        use crate::resource::{Composition, ResourceId};
+        use crate::resource::{Composition, ResourceId, Signature};
         use std::collections::{BTreeSet, HashSet};
         let mut attrs = indexmap::IndexMap::new();
         attrs.insert(
@@ -2379,7 +2379,10 @@ mod tests {
         );
         let virt = Composition {
             id: ResourceId::new("_virtual", "module_instance"),
-            attributes: attrs,
+            signature: Signature {
+                arguments: indexmap::IndexMap::new(),
+                attributes: attrs,
+            },
             binding: Some("module_instance".to_string()),
             dependency_bindings: BTreeSet::new(),
             module_name: "m".to_string(),
@@ -2391,13 +2394,13 @@ mod tests {
 
         // The non-secret attribute survives verbatim.
         assert_eq!(
-            redacted.attributes.get("non_secret"),
+            redacted.signature.attributes.get("non_secret"),
             Some(&Value::Concrete(ConcreteValue::String("kept".to_string()))),
         );
 
         // The secret attribute is replaced with the hash prefix, not the
         // plaintext.
-        match redacted.attributes.get("secret_field") {
+        match redacted.signature.attributes.get("secret_field") {
             Some(Value::Concrete(ConcreteValue::String(s))) => {
                 assert!(
                     s.starts_with(SECRET_PREFIX),


### PR DESCRIPTION
## Summary

PR E of the #3287 series, implementing the rescoped design from #3301.

Introduces `Signature { arguments, attributes }` as a field on `Composition` only:

```rust
pub struct Signature {
    pub arguments:  IndexMap<String, Value>,
    pub attributes: IndexMap<String, Value>,
}

pub struct Composition {
    pub id: ResourceId,
    pub signature: Signature,
    ...
}
```

Key changes:
- `Composition.attributes` is moved into `signature.attributes`; the bare field is removed (compile_fail doctest guards it).
- `signature.arguments` captures resolved call-site arguments at expansion time. Pre-PR, `ModuleCall.arguments` was consumed for substitution then dropped — now the boundary is recorded on the expanded composition itself.
- `Resource` and `DataSource` are not touched. Their DSL syntax has no `arguments` concept.
- `ResourceLike::attributes()` on `Composition` reads `signature.attributes`; other arms unchanged. Trait retires in PR H.
- `#[serde(flatten)]` keeps in-memory shape unchanged (no state-schema impact; compositions aren't persisted).

Closes #3292

## Test plan

- [x] New boundary-preservation test `test_expand_module_call_preserves_arguments_on_composition_signature` verifies arguments passed at `ModuleCall` land on `signature.arguments`, in declaration order
- [x] `cargo nextest run --workspace --all-features` — 3631 passed (was 3630, +1 boundary test)
- [x] `cargo test --workspace --doc` — green (compile_fail doctests for dropped fields and Composition-not-a-leaf both enforced)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-*.sh` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
