### PR TITLE
resource: PersistentId / EphemeralId / NodeId newtypes (#3293)

### DIFF
--- a/carina-core/src/resource/composition.rs
+++ b/carina-core/src/resource/composition.rs
@@ -132,3 +132,15 @@ pub struct Composition {
     #[serde(default, skip)]
     pub quoted_string_attrs: HashSet<String>,
 }
+
+impl Composition {
+    /// The composition's id wrapped as an [`EphemeralId`](super::EphemeralId).
+    ///
+    /// `Composition` is plan-scoped and never persists in state, so its
+    /// id is `EphemeralId`-typed. By construction this id cannot enter
+    /// state-load APIs that take `&PersistentId` — that mismatch is a
+    /// compile error.
+    pub fn ephemeral_id(&self) -> super::EphemeralId {
+        super::EphemeralId::new(self.id.clone())
+    }
+}

--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -67,6 +67,15 @@ impl DataSource {
         }
     }
 
+    /// The data source's id wrapped as a [`PersistentId`] — i.e., an
+    /// id that may legally enter state-load APIs.
+    ///
+    /// `DataSource` is a leaf node and persists in state (as a
+    /// snapshot), so its id is `PersistentId`-typed.
+    pub fn persistent_id(&self) -> super::PersistentId {
+        super::PersistentId::new(self.id.clone())
+    }
+
     /// Create a data source with a provider-qualified id.
     pub fn with_provider(
         provider: impl Into<String>,

--- a/carina-core/src/resource/graph_node.rs
+++ b/carina-core/src/resource/graph_node.rs
@@ -55,6 +55,23 @@ impl GraphNode {
         }
     }
 
+    /// The id of the underlying node, wrapped in the appropriate
+    /// [`NodeId`](super::NodeId) variant: `Persistent` for `Resource`
+    /// / `DataSource`, `Ephemeral` for `Composition`.
+    ///
+    /// Use this when a caller needs an id whose typestate reflects
+    /// "may be looked up in state" — and the caller does not already
+    /// know which variant it holds. State-load APIs should still take
+    /// `&PersistentId` directly so passing an `Ephemeral` is a compile
+    /// error rather than a runtime branch.
+    pub fn node_id(&self) -> super::NodeId {
+        match self {
+            GraphNode::Resource(r) => super::NodeId::Persistent(r.persistent_id()),
+            GraphNode::DataSource(d) => super::NodeId::Persistent(d.persistent_id()),
+            GraphNode::Composition(c) => super::NodeId::Ephemeral(c.ephemeral_id()),
+        }
+    }
+
     /// Whether this node is a [`Resource`] (CRUD variant).
     pub fn is_resource(&self) -> bool {
         matches!(self, GraphNode::Resource(_))

--- a/carina-core/src/resource/leaf_node.rs
+++ b/carina-core/src/resource/leaf_node.rs
@@ -62,6 +62,16 @@ impl LeafNode {
         }
     }
 
+    /// The id of the underlying node wrapped as a [`PersistentId`](super::PersistentId).
+    ///
+    /// `LeafNode` is by construction a leaf — never a composition —
+    /// so its id is always `Persistent`. APIs that take
+    /// `&PersistentId` can be fed from a `LeafNode` without further
+    /// discrimination.
+    pub fn persistent_id(&self) -> super::PersistentId {
+        super::PersistentId::new(self.id().clone())
+    }
+
     /// Whether this leaf is a [`Resource`] (CRUD variant).
     pub fn is_resource(&self) -> bool {
         matches!(self, LeafNode::Resource(_))

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1665,6 +1665,16 @@ impl Resource {
         }
     }
 
+    /// The resource's id wrapped as a [`PersistentId`] — i.e., an id
+    /// that may legally enter state-load APIs.
+    ///
+    /// `Resource` is a leaf node and persists in state, so its id is
+    /// `PersistentId`-typed. The wrapper is created by cloning the
+    /// inner `ResourceId`; for owned consumption use `PersistentId::new(r.id.clone())`.
+    pub fn persistent_id(&self) -> persistent_id::PersistentId {
+        persistent_id::PersistentId::new(self.id.clone())
+    }
+
     pub fn with_provider(
         provider: impl Into<String>,
         resource_type: impl Into<String>,
@@ -1794,10 +1804,12 @@ pub mod composition;
 pub mod data_source;
 pub mod graph_node;
 pub mod leaf_node;
+pub mod persistent_id;
 pub mod resource_like;
 
 pub use composition::{Composition, Signature};
 pub use data_source::DataSource;
 pub use graph_node::GraphNode;
 pub use leaf_node::{CompositionNotALeaf, LeafNode, expand_to_leaves};
+pub use persistent_id::{EphemeralId, NodeId, PersistentId};
 pub use resource_like::ResourceLike;

--- a/carina-core/src/resource/persistent_id.rs
+++ b/carina-core/src/resource/persistent_id.rs
@@ -1,0 +1,220 @@
+//! `PersistentId` / `EphemeralId` — typed wrappers over [`ResourceId`]
+//! that record whether the id is allowed to enter state lookups.
+//!
+//! ## What problem these solve
+//!
+//! Pre-#3293 every node in the IR carried a `ResourceId`. The state
+//! layer's lookup APIs (`current_states: HashMap<ResourceId, State>`,
+//! `StateBackend::load`, etc.) accepted any `&ResourceId`, including
+//! one from a [`Composition`](super::Composition) — which never
+//! persists. A composition id passed to a state lookup is guaranteed
+//! to miss, but the type system gave no static signal of that.
+//!
+//! The post-#3169 typestate split already encodes "compositions do
+//! not enter the pre-apply differ" structurally (PR D). This PR
+//! mirrors that for state-load callers: a `PersistentId` can only
+//! be constructed from a leaf node ([`Resource`](super::Resource) or
+//! [`DataSource`](super::DataSource)); a `Composition` exposes only
+//! `EphemeralId`. No `From<EphemeralId> for PersistentId` impl
+//! exists, and no `Deref<Target = ResourceId>` is provided, so a
+//! state API that takes `&PersistentId` cannot be handed a
+//! composition id by accident.
+//!
+//! ## Migration scope
+//!
+//! This PR is **boundary-only**: the wrappers exist, accessor
+//! methods on [`Resource`](super::Resource) / [`DataSource`](super::DataSource) /
+//! [`Composition`](super::Composition) make them reachable, but the
+//! existing `current_states: HashMap<ResourceId, State>` maps and
+//! the ~1130 sites that touch `ResourceId` are *not* migrated in
+//! this PR. The wrappers become the canonical type at every new
+//! state-touching boundary going forward; existing boundaries can
+//! be widened one at a time without large mechanical diffs.
+//!
+//! `into_inner()` is provided as an explicit escape hatch (the wrapper
+//! around `ResourceId` is content-equal, so peeling it is safe — the
+//! caller is just opting out of the static guarantee on that site).
+
+use serde::{Deserialize, Serialize};
+
+use super::ResourceId;
+
+/// An id of a node that **persists** in state — i.e., a leaf node
+/// ([`Resource`](super::Resource) or
+/// [`DataSource`](super::DataSource)).
+///
+/// State-load APIs that take `&PersistentId` are statically prevented
+/// from being passed an [`EphemeralId`] (composition id), which would
+/// always miss. Construct via [`Resource::persistent_id`](super::Resource::persistent_id)
+/// or [`DataSource::persistent_id`](super::DataSource::persistent_id),
+/// or via [`PersistentId::new`] when you already have an owned
+/// `ResourceId` and know the node it came from is leaf-kind.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct PersistentId(ResourceId);
+
+impl PersistentId {
+    /// Wrap an owned [`ResourceId`] as a `PersistentId`.
+    ///
+    /// The caller asserts the id came from a leaf node. The wrapper
+    /// is content-equal to its inner `ResourceId`, so this is purely
+    /// a type-system declaration.
+    pub fn new(id: ResourceId) -> Self {
+        Self(id)
+    }
+
+    /// Borrow the wrapped [`ResourceId`].
+    ///
+    /// Returned as a borrow so callers cannot accidentally clone the
+    /// inner id and pass it to APIs that would otherwise reject a
+    /// `PersistentId` — there is only one path back to a bare
+    /// `ResourceId`, and that is [`into_inner`](Self::into_inner).
+    pub fn inner(&self) -> &ResourceId {
+        &self.0
+    }
+
+    /// Unwrap into the inner [`ResourceId`].
+    ///
+    /// Explicit escape hatch for boundaries that have not yet
+    /// migrated to typed-id APIs. Each call site that uses this is a
+    /// candidate for a follow-up that takes `&PersistentId` directly.
+    pub fn into_inner(self) -> ResourceId {
+        self.0
+    }
+}
+
+/// An id of a node that **never persists** in state — i.e., a
+/// [`Composition`](super::Composition).
+///
+/// `EphemeralId` cannot convert to a [`PersistentId`] (no `From` impl
+/// exists), so passing it to a state-load API that takes
+/// `&PersistentId` is a compile error. Construct via
+/// [`Composition::ephemeral_id`](super::Composition::ephemeral_id) or
+/// via [`EphemeralId::new`] when you already have the id and know it
+/// came from a composition.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct EphemeralId(ResourceId);
+
+impl EphemeralId {
+    /// Wrap an owned [`ResourceId`] as an `EphemeralId`.
+    ///
+    /// The caller asserts the id came from a composition.
+    pub fn new(id: ResourceId) -> Self {
+        Self(id)
+    }
+
+    /// Borrow the wrapped [`ResourceId`].
+    pub fn inner(&self) -> &ResourceId {
+        &self.0
+    }
+
+    /// Unwrap into the inner [`ResourceId`].
+    ///
+    /// Explicit escape hatch for boundaries that have not yet
+    /// migrated to typed-id APIs.
+    pub fn into_inner(self) -> ResourceId {
+        self.0
+    }
+}
+
+/// A node identifier in either flavour — persistent (leaf) or
+/// ephemeral (composition).
+///
+/// Used by APIs that need to refer to **any** node by id without
+/// committing to leaf or composition statically. The chief consumer
+/// is the upcoming `CompositionAttribute::Forwarded(NodeId, AttrPath)`
+/// (#3294), where a forwarded composition attribute may alias either
+/// a leaf attribute (`PersistentId`) or another composition's attribute
+/// (`EphemeralId`).
+///
+/// `NodeId` is **not** a substitute for the typed-id newtypes at
+/// state-load boundaries. APIs that genuinely require leaf-only ids
+/// should still take `&PersistentId` directly so that handing them an
+/// `EphemeralId` is a compile error rather than a runtime branch.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum NodeId {
+    Persistent(PersistentId),
+    Ephemeral(EphemeralId),
+}
+
+impl NodeId {
+    /// Borrow the underlying [`ResourceId`].
+    ///
+    /// Discriminates the variant internally; callers that care about
+    /// which kind they have should pattern-match instead of using this.
+    pub fn inner(&self) -> &ResourceId {
+        match self {
+            NodeId::Persistent(p) => p.inner(),
+            NodeId::Ephemeral(e) => e.inner(),
+        }
+    }
+}
+
+impl From<PersistentId> for NodeId {
+    fn from(p: PersistentId) -> Self {
+        NodeId::Persistent(p)
+    }
+}
+
+impl From<EphemeralId> for NodeId {
+    fn from(e: EphemeralId) -> Self {
+        NodeId::Ephemeral(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persistent_id_round_trip() {
+        let id = ResourceId::new("aws.s3.Bucket", "b");
+        let pid = PersistentId::new(id.clone());
+        assert_eq!(pid.inner(), &id);
+        assert_eq!(pid.into_inner(), id);
+    }
+
+    #[test]
+    fn ephemeral_id_round_trip() {
+        let id = ResourceId::new("_virtual", "m");
+        let eid = EphemeralId::new(id.clone());
+        assert_eq!(eid.inner(), &id);
+        assert_eq!(eid.into_inner(), id);
+    }
+
+    /// The whole point of the typestate split: `EphemeralId` and
+    /// `PersistentId` are not interconvertible. A function that takes
+    /// `&PersistentId` cannot accept an `&EphemeralId`.
+    ///
+    /// ```compile_fail
+    /// use carina_core::resource::{EphemeralId, PersistentId, ResourceId};
+    /// fn loads_from_state(_pid: &PersistentId) {}
+    /// let eid = EphemeralId::new(ResourceId::new("_virtual", "m"));
+    /// loads_from_state(&eid);
+    /// ```
+    ///
+    /// ```compile_fail
+    /// use carina_core::resource::{EphemeralId, PersistentId, ResourceId};
+    /// let eid = EphemeralId::new(ResourceId::new("_virtual", "m"));
+    /// let _pid: PersistentId = eid.into();
+    /// ```
+    #[allow(dead_code)]
+    fn _doctest_anchor() {}
+
+    #[test]
+    fn node_id_from_persistent_id() {
+        let pid = PersistentId::new(ResourceId::new("aws.s3.Bucket", "b"));
+        let nid: NodeId = pid.clone().into();
+        assert!(matches!(nid, NodeId::Persistent(_)));
+        assert_eq!(nid.inner(), pid.inner());
+    }
+
+    #[test]
+    fn node_id_from_ephemeral_id() {
+        let eid = EphemeralId::new(ResourceId::new("_virtual", "m"));
+        let nid: NodeId = eid.clone().into();
+        assert!(matches!(nid, NodeId::Ephemeral(_)));
+        assert_eq!(nid.inner(), eid.inner());
+    }
+}


### PR DESCRIPTION
## Summary

PR F of the #3287 series. Introduces three typed wrappers over `ResourceId`:

```rust
pub struct PersistentId(ResourceId);   // Resource, DataSource
pub struct EphemeralId(ResourceId);    // Composition
pub enum NodeId {
    Persistent(PersistentId),
    Ephemeral(EphemeralId),
}
```

Opaque by design (no `Deref<Target = ResourceId>`, no `From<EphemeralId> for PersistentId`) so a state-load API that takes `&PersistentId` cannot be handed a composition id. Two `compile_fail` doctests pin the exclusions.

Accessor methods on every node + umbrella expose the typed ids:
- `Resource::persistent_id()`, `DataSource::persistent_id()`, `LeafNode::persistent_id()` → `PersistentId`
- `Composition::ephemeral_id()` → `EphemeralId`
- `GraphNode::node_id()` → `NodeId`

`into_inner()` is an explicit escape hatch for sites that have not yet migrated to typed-id APIs.

`NodeId` is included here (rather than deferred to PR G) because the upcoming `CompositionAttribute::Forwarded(NodeId, AttrPath)` (#3294) needs the key type ready.

Scope is **boundary-only**: ~1130 `ResourceId` sites are not migrated in this PR. Existing boundaries can be widened to `&PersistentId` one at a time without large mechanical diffs.

Closes #3293

## Test plan

- [x] Round-trip tests for `PersistentId` / `EphemeralId` / `NodeId`
- [x] Two `compile_fail` doctests guard the leaf-only-into-state invariant
- [x] `cargo nextest run --workspace --all-features` — 3635 passed (+4 from PR E)
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-*.sh` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
