### PR TITLE
resource: CompositionAttribute = Forwarded | Derived (#3294)

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1201,12 +1201,15 @@ fn resolve_exports_resolves_module_call_attribute_via_composition() {
     // Virtual resource as `expand_module_call` produces it: binding is
     // the module-call alias, and each attribute is a ResourceRef into
     // an expanded sub-resource. carina#3181: compositions are their own type.
-    let mut virt_attrs = indexmap::IndexMap::new();
+    let mut virt_attrs: indexmap::IndexMap<String, carina_core::resource::CompositionAttribute> =
+        indexmap::IndexMap::new();
     virt_attrs.insert(
         "role_arn".to_string(),
-        Value::Deferred(DeferredValue::ResourceRef {
-            path: AccessPath::new("github_actions_carina.role", "arn"),
-        }),
+        carina_core::resource::CompositionAttribute::from_value(Value::Deferred(
+            DeferredValue::ResourceRef {
+                path: AccessPath::new("github_actions_carina.role", "arn"),
+            },
+        )),
     );
     let composition = Composition {
         id: carina_core::resource::ResourceId::new("_virtual", "github_actions_carina"),
@@ -1297,12 +1300,17 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_compositions()
 
     // carina#3181: compositions are a distinct typestate.
     let make_virtual = |id_name: &str, binding: &str, attr: &str, ref_b: &str, ref_a: &str| {
-        let mut attributes = indexmap::IndexMap::new();
+        let mut attributes: indexmap::IndexMap<
+            String,
+            carina_core::resource::CompositionAttribute,
+        > = indexmap::IndexMap::new();
         attributes.insert(
             attr.to_string(),
-            Value::Deferred(DeferredValue::ResourceRef {
-                path: AccessPath::new(ref_b, ref_a),
-            }),
+            carina_core::resource::CompositionAttribute::from_value(Value::Deferred(
+                DeferredValue::ResourceRef {
+                    path: AccessPath::new(ref_b, ref_a),
+                },
+            )),
         );
         Composition {
             id: carina_core::resource::ResourceId::new("_virtual", id_name),
@@ -1471,12 +1479,15 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
     let mut role_managed = Resource::with_provider("awscc", "iam.Role", "carina_role", None);
     role_managed.binding = Some("role".to_string());
 
-    let mut virt_attrs = indexmap::IndexMap::new();
+    let mut virt_attrs: indexmap::IndexMap<String, carina_core::resource::CompositionAttribute> =
+        indexmap::IndexMap::new();
     virt_attrs.insert(
         "role_arn".to_string(),
-        Value::Deferred(DeferredValue::ResourceRef {
-            path: AccessPath::new("role", "arn"),
-        }),
+        carina_core::resource::CompositionAttribute::from_value(Value::Deferred(
+            DeferredValue::ResourceRef {
+                path: AccessPath::new("role", "arn"),
+            },
+        )),
     );
     let composition = Composition {
         id: ResourceId::new("_virtual", "carina_module"),

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -303,7 +303,8 @@ where
     // composition — so an empty interpolation in a `read` resource's
     // attribute is still caught.
     for rref in parsed.iter_top_level_resources() {
-        for (attr_name, value) in rref.attributes() {
+        let attrs = rref.attributes();
+        for (attr_name, value) in attrs.iter() {
             if value_contains_empty_interpolation(value) {
                 errors.push(AppError::Validation(format!(
                     "{}: attribute `{}`: empty interpolation `${{}}` — fill in the expression or remove it",

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -601,10 +601,16 @@ impl ResolvedBindings {
             let Some(binding_name) = v.binding.as_ref() else {
                 continue;
             };
+            let value_attrs: indexmap::IndexMap<String, crate::resource::Value> = v
+                .signature
+                .attributes
+                .iter()
+                .map(|(k, attr)| (k.clone(), attr.to_value()))
+                .collect();
             self.by_name.insert(
                 binding_name.clone(),
                 ResolvedBinding {
-                    attributes: crate::resource::attrs_to_hashmap(&v.signature.attributes),
+                    attributes: crate::resource::attrs_to_hashmap(&value_attrs),
                     source: BindingValueSource::Local,
                 },
             );

--- a/carina-core/src/binding_index_split_tests.rs
+++ b/carina-core/src/binding_index_split_tests.rs
@@ -37,9 +37,12 @@ fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> Resource {
 }
 
 fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> Composition {
-    let mut attributes = IndexMap::new();
+    let mut attributes: IndexMap<String, crate::resource::CompositionAttribute> = IndexMap::new();
     for (k, v) in attrs {
-        attributes.insert((*k).into(), v.clone());
+        attributes.insert(
+            (*k).into(),
+            crate::resource::CompositionAttribute::from_value(v.clone()),
+        );
     }
     Composition {
         id: ResourceId::new("_virtual.module", binding),

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -43,8 +43,11 @@ pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
 /// same first-two-thirds of [`get_resource_dependencies`].
 pub fn get_composition_dependencies(virt: &crate::resource::Composition) -> HashSet<String> {
     let mut deps = HashSet::new();
-    for value in virt.signature.attributes.values() {
-        collect_dependencies(value, &mut deps);
+    for attr in virt.signature.attributes.values() {
+        // The Forwarded/Derived split (#3294) is a typed
+        // classification; dependency collection still walks the
+        // underlying `Value` shape, so reify and recurse.
+        collect_dependencies(&attr.to_value(), &mut deps);
     }
     for name in &virt.dependency_bindings {
         deps.insert(name.clone());
@@ -402,10 +405,15 @@ mod tests {
         // Build a composition whose attributes carry a ResourceRef and
         // whose `dependency_bindings` carries a separate entry.
         // Both must end up in the merged set.
-        let mut attributes = IndexMap::new();
+        let mut attributes: IndexMap<String, crate::resource::CompositionAttribute> =
+            IndexMap::new();
         attributes.insert(
             "role_arn".to_string(),
-            Value::resource_ref("role".to_string(), "arn", vec![]),
+            crate::resource::CompositionAttribute::from_value(Value::resource_ref(
+                "role".to_string(),
+                "arn",
+                vec![],
+            )),
         );
         let mut dep_bindings = BTreeSet::new();
         dep_bindings.insert("explicit_dep".to_string());

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -599,10 +599,15 @@ mod tests {
         role.binding = Some("bootstrap.role".to_string());
 
         // carina#3181: composition resources are a distinct typestate.
-        let mut virt_attrs = indexmap::IndexMap::new();
+        let mut virt_attrs: indexmap::IndexMap<String, crate::resource::CompositionAttribute> =
+            indexmap::IndexMap::new();
         virt_attrs.insert(
             "role_name".to_string(),
-            Value::resource_ref("bootstrap.role", "role_name", vec![]),
+            crate::resource::CompositionAttribute::from_value(Value::resource_ref(
+                "bootstrap.role",
+                "role_name",
+                vec![],
+            )),
         );
         let virt = Composition {
             id: ResourceId::with_provider("_virtual", "_virtual", "bootstrap", None),

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1367,7 +1367,11 @@ mod tests {
         let mut attributes = indexmap::IndexMap::new();
         attributes.insert(
             attr.to_string(),
-            Value::resource_ref(ref_binding, ref_attr, vec![]),
+            crate::resource::CompositionAttribute::from_value(Value::resource_ref(
+                ref_binding,
+                ref_attr,
+                vec![],
+            )),
         );
         Composition {
             id: ResourceId::with_provider("_virtual", "_virtual", id_name, None),

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -267,9 +267,13 @@ impl ModuleResolver<'_> {
         if !module.attribute_params.is_empty()
             && let Some(binding_name) = &call.binding_name
         {
-            let mut composition_attrs: IndexMap<String, Value> = IndexMap::new();
+            let mut composition_attrs: IndexMap<String, crate::resource::CompositionAttribute> =
+                IndexMap::new();
 
-            // Copy attribute values from the module definition
+            // Copy attribute values from the module definition.
+            // Each value is classified into `Forwarded` (single-hop
+            // alias) vs `Derived` (multi-source expression) via
+            // `CompositionAttribute::from_value` (#3294).
             for attr_param in &module.attribute_params {
                 if let Some(value) = &attr_param.value {
                     // Rewrite intra-module refs and substitute arguments
@@ -279,7 +283,10 @@ impl ModuleResolver<'_> {
                     // Same post-substitution canonicalize as the
                     // resource-attribute path above (#2815 / #2817).
                     substituted.canonicalize_in_place();
-                    composition_attrs.insert(attr_param.name.clone(), substituted);
+                    composition_attrs.insert(
+                        attr_param.name.clone(),
+                        crate::resource::CompositionAttribute::from_value(substituted),
+                    );
                 }
             }
 
@@ -610,16 +617,21 @@ fn prefix_module_composition(
         new_virtual.binding = Some(apply_instance_prefix(instance_prefix, binding));
     }
 
-    let mut substituted_attrs: IndexMap<String, Value> = IndexMap::new();
-    for (key, expr) in &new_virtual.signature.attributes {
+    let mut substituted_attrs: IndexMap<String, crate::resource::CompositionAttribute> =
+        IndexMap::new();
+    for (key, attr) in &new_virtual.signature.attributes {
+        // Round-trip through `Value` so the existing `prefix_attr_value`
+        // helper (which knows about every nested `Value` shape) can
+        // run unmodified, then re-classify the result. A bare
+        // `Forwarded` may transform into another `Forwarded`
+        // (same shape, instance-prefixed binding) or stay `Derived`
+        // depending on what `prefix_attr_value` did.
+        let v = attr.to_value();
+        let prefixed =
+            prefix_attr_value(&v, instance_prefix, intra_module_bindings, argument_values);
         substituted_attrs.insert(
             key.clone(),
-            prefix_attr_value(
-                expr,
-                instance_prefix,
-                intra_module_bindings,
-                argument_values,
-            ),
+            crate::resource::CompositionAttribute::from_value(prefixed),
         );
     }
     new_virtual.signature.attributes = substituted_attrs;

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -666,8 +666,12 @@ fn test_expand_module_call_creates_composition() {
     // The security_group attribute should be a rewritten ResourceRef
     // pointing to the dot-path binding (web.sg)
     assert_eq!(
-        composition_res.signature.attributes.get("security_group"),
-        Some(&Value::resource_ref(
+        composition_res
+            .signature
+            .attributes
+            .get("security_group")
+            .map(|a| a.to_value()),
+        Some(Value::resource_ref(
             "web.sg".to_string(),
             "id".to_string(),
             vec![]
@@ -811,8 +815,12 @@ fn test_expand_module_call_preserves_arguments_on_composition_signature() {
 
     // The attribute half remains populated as before.
     assert_eq!(
-        composition.signature.attributes.get("endpoint"),
-        Some(&Value::Concrete(ConcreteValue::String(
+        composition
+            .signature
+            .attributes
+            .get("endpoint")
+            .map(|a| a.to_value()),
+        Some(Value::Concrete(ConcreteValue::String(
             "fixed-endpoint".to_string()
         ))),
     );
@@ -1532,8 +1540,12 @@ fn test_module_composition_dot_path_refs() {
 
     // The security_group attribute should reference dot-notation binding
     assert_eq!(
-        composition_res.signature.attributes.get("security_group"),
-        Some(&Value::resource_ref(
+        composition_res
+            .signature
+            .attributes
+            .get("security_group")
+            .map(|a| a.to_value()),
+        Some(Value::resource_ref(
             "web.sg".to_string(),
             "id".to_string(),
             vec![]

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -111,13 +111,30 @@ impl<'a> ResourceRef<'a> {
         }
     }
 
-    /// Source-order preserving attribute map.
-    pub fn attributes(&self) -> &'a IndexMap<String, Value> {
+    /// Source-order preserving attribute map as `Value`s.
+    ///
+    /// Returned as a [`Cow`](std::borrow::Cow) because
+    /// [`Composition`] stores its attributes typed as
+    /// [`CompositionAttribute`](crate::resource::CompositionAttribute)
+    /// since #3294, and must materialize a `Value`-typed view on
+    /// demand. The other three variants ([`Resource`],
+    /// [`DataSource`], [`Deferred`](Self::Deferred)) return a borrowed
+    /// reference. Callers `.iter()` / `.contains_key()` / `.get()`
+    /// through the `Cow` directly via `Deref`.
+    pub fn attributes(&self) -> std::borrow::Cow<'a, IndexMap<String, Value>> {
         match self {
-            ResourceRef::Resource(r) => &r.attributes,
-            ResourceRef::Composition(v) => &v.signature.attributes,
-            ResourceRef::DataSource(d) => &d.attributes,
-            ResourceRef::Deferred { resource, .. } => &resource.attributes,
+            ResourceRef::Resource(r) => std::borrow::Cow::Borrowed(&r.attributes),
+            ResourceRef::Composition(v) => std::borrow::Cow::Owned(
+                v.signature
+                    .attributes
+                    .iter()
+                    .map(|(k, attr)| (k.clone(), attr.to_value()))
+                    .collect(),
+            ),
+            ResourceRef::DataSource(d) => std::borrow::Cow::Borrowed(&d.attributes),
+            ResourceRef::Deferred { resource, .. } => {
+                std::borrow::Cow::Borrowed(&resource.attributes)
+            }
         }
     }
 
@@ -166,7 +183,7 @@ impl<'a> ResourceRef<'a> {
     /// Attributes projected to a `HashMap<String, Value>` — the
     /// lookup-shaped view consumed by schema validation.
     pub fn resolved_attributes(&self) -> HashMap<String, Value> {
-        crate::resource::attrs_to_hashmap(self.attributes())
+        crate::resource::attrs_to_hashmap(&self.attributes())
     }
 }
 

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -288,16 +288,13 @@ pub fn extract_compact_hint(
     resource: &dyn crate::resource::ResourceLike,
     parent_binding: Option<&str>,
 ) -> Option<String> {
-    let mut keys: Vec<_> = resource
-        .attributes()
-        .keys()
-        .filter(|k| !k.starts_with('_'))
-        .collect();
+    let attrs = resource.attributes();
+    let mut keys: Vec<&String> = attrs.keys().filter(|k| !k.starts_with('_')).collect();
     keys.sort();
 
     // Priority 1: First distinguishing string attribute (most identifying)
     for key in &keys {
-        if let Some(Value::Concrete(ConcreteValue::String(s))) = resource.attributes().get(*key)
+        if let Some(Value::Concrete(ConcreteValue::String(s))) = attrs.get(*key)
             && !s.is_empty()
         {
             let short_key = shorten_attr_name(key);
@@ -314,7 +311,7 @@ pub fn extract_compact_hint(
 
     // Priority 2: First non-parent ResourceRef attribute (direct or inside a List)
     for key in &keys {
-        match resource.attributes().get(*key) {
+        match attrs.get(*key) {
             Some(Value::Deferred(DeferredValue::ResourceRef { path })) => {
                 if parent_binding == Some(path.binding()) {
                     continue;

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -210,9 +210,19 @@ pub fn resolve_virtual_refs_post_apply(
     bindings: &ResolvedBindings,
 ) -> Result<(), String> {
     for v in compositions.iter_mut() {
-        let mut resolved_attrs: IndexMap<String, Value> = IndexMap::new();
-        for (key, value) in &v.signature.attributes {
-            resolved_attrs.insert(key.clone(), resolve_ref_value(value, bindings)?);
+        let mut resolved_attrs: IndexMap<String, crate::resource::CompositionAttribute> =
+            IndexMap::new();
+        for (key, attr) in &v.signature.attributes {
+            // Reify the typed attribute back into a `Value`, resolve
+            // it the same way as before, then re-classify the
+            // resolved result. A `Forwarded` that resolves to a
+            // literal becomes a `Derived(Concrete(...))`; a one that
+            // resolves into another `ResourceRef` stays `Forwarded`.
+            let resolved = resolve_ref_value(&attr.to_value(), bindings)?;
+            resolved_attrs.insert(
+                key.clone(),
+                crate::resource::CompositionAttribute::from_value(resolved),
+            );
         }
         v.signature.attributes = resolved_attrs;
     }

--- a/carina-core/src/resolver_split_tests.rs
+++ b/carina-core/src/resolver_split_tests.rs
@@ -51,9 +51,12 @@ fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> Resource {
 }
 
 fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> Composition {
-    let mut attributes = IndexMap::new();
+    let mut attributes: IndexMap<String, crate::resource::CompositionAttribute> = IndexMap::new();
     for (k, v) in attrs {
-        attributes.insert((*k).into(), v.clone());
+        attributes.insert(
+            (*k).into(),
+            crate::resource::CompositionAttribute::from_value(v.clone()),
+        );
     }
     Composition {
         id: ResourceId::new("_virtual.module", binding),
@@ -176,7 +179,7 @@ fn resolve_virtual_refs_post_apply_uses_provided_bindings() {
         .attributes
         .get("forwarded")
         .expect("forwarded present");
-    assert_eq!(*forwarded, s("post_apply_value"));
+    assert_eq!(forwarded.to_value(), s("post_apply_value"));
 }
 
 #[test]
@@ -206,7 +209,7 @@ fn resolve_virtual_refs_post_apply_picks_post_apply_value_not_pre_apply() {
         .get("role_arn")
         .expect("role_arn present");
     assert_eq!(
-        *role_arn,
+        role_arn.to_value(),
         s("post_apply_arn"),
         "expected post-apply ARN, got {role_arn:?}",
     );
@@ -233,7 +236,7 @@ fn resolve_virtual_refs_post_apply_leaves_non_ref_values_intact() {
         .attributes
         .get("literal")
         .expect("literal present");
-    assert_eq!(*literal, s("kept"));
+    assert_eq!(literal.to_value(), s("kept"));
 }
 
 #[test]

--- a/carina-core/src/resource/composition.rs
+++ b/carina-core/src/resource/composition.rs
@@ -20,7 +20,86 @@ use std::collections::{BTreeSet, HashSet};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use super::{ResourceId, Value};
+use super::{AccessPath, DeferredValue, ResourceId, Value};
+
+/// How a [`Composition`]'s attribute is produced from the rest of the
+/// IR.
+///
+/// Pre-#3294 every composition attribute was a single `Value`, and the
+/// resolver had to inspect the variant at runtime to decide whether it
+/// was a single-hop alias (`Value::Deferred(DeferredValue::ResourceRef
+/// { path })`) or a multi-source expression
+/// (`Value::Deferred(DeferredValue::Interpolation { ... })`,
+/// `FunctionCall`, etc.). Splitting that decision into a tagged enum
+/// removes the runtime classification and matches the way the
+/// post-apply resolver actually consumes them.
+///
+/// - **`Forwarded(path)`**: this attribute is the same value as the
+///   attribute reachable through `path` on another node. The resolver
+///   evaluates the path one hop at post-apply time; display can fold
+///   the alias under its target; dependency analysis adds one edge.
+/// - **`Derived(value)`**: this attribute is a multi-source expression
+///   (interpolation, function call, arithmetic, literal). The
+///   resolver evaluates the `Value` against post-apply state, which
+///   may itself contain nested refs.
+///
+/// `AccessPath` is used in `Forwarded` rather than `NodeId` because at
+/// expansion time the `NodeId` of the target may not yet be bound —
+/// the path carries a binding name + attribute path that the resolver
+/// already knows how to look up. A future PR can lift this to
+/// `Forwarded(NodeId, AttrPath)` once a name → `NodeId` index is
+/// available at expansion time.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CompositionAttribute {
+    /// Single-hop alias to another node's attribute, by path.
+    Forwarded(AccessPath),
+    /// Multi-source expression: a literal, interpolation, function
+    /// call, or any other `Value` shape that is not a bare
+    /// single-hop reference.
+    Derived(Value),
+}
+
+impl CompositionAttribute {
+    /// Classify a `Value` into the appropriate
+    /// [`CompositionAttribute`] variant.
+    ///
+    /// `Value::Deferred(DeferredValue::ResourceRef { path })` is a
+    /// single-hop alias and lifts into [`Forwarded`](Self::Forwarded).
+    /// Every other `Value` shape is multi-source (literal,
+    /// interpolation, function call, etc.) and lifts into
+    /// [`Derived`](Self::Derived).
+    pub fn from_value(value: Value) -> Self {
+        match value {
+            Value::Deferred(DeferredValue::ResourceRef { path }) => {
+                CompositionAttribute::Forwarded(path)
+            }
+            other => CompositionAttribute::Derived(other),
+        }
+    }
+
+    /// Reify back into a [`Value`] for callers that have not yet been
+    /// migrated to the new typed-variant dispatch.
+    ///
+    /// The post-apply resolver, plan display, and exporters consume
+    /// composition attributes as `Value`s today; this lets PR G ship
+    /// the type-level split without rewriting every consumer in one
+    /// commit. Each subsequent migration replaces a `.to_value()` site
+    /// with a direct match on `CompositionAttribute`.
+    pub fn to_value(&self) -> Value {
+        match self {
+            CompositionAttribute::Forwarded(path) => {
+                Value::Deferred(DeferredValue::ResourceRef { path: path.clone() })
+            }
+            CompositionAttribute::Derived(v) => v.clone(),
+        }
+    }
+}
+
+impl From<Value> for CompositionAttribute {
+    fn from(v: Value) -> Self {
+        Self::from_value(v)
+    }
+}
 
 /// The function-shaped I/O surface of a [`Composition`].
 ///
@@ -51,11 +130,13 @@ pub struct Signature {
     /// parameters, or when the call site passed no arguments.
     #[serde(default)]
     pub arguments: IndexMap<String, Value>,
-    /// Resolved module-output values. May contain unresolved
-    /// `ResourceRef` / `BindingRef` values; resolution is deferred to
-    /// the post-apply path.
+    /// Module-output values classified by how they are produced
+    /// (#3294): [`Forwarded`](CompositionAttribute::Forwarded) for
+    /// single-hop aliases, [`Derived`](CompositionAttribute::Derived)
+    /// for multi-source expressions. The resolver dispatches on the
+    /// variant at post-apply time.
     #[serde(default)]
-    pub attributes: IndexMap<String, Value>,
+    pub attributes: IndexMap<String, CompositionAttribute>,
 }
 
 /// A composition resource created by module-call expansion.
@@ -142,5 +223,87 @@ impl Composition {
     /// compile error.
     pub fn ephemeral_id(&self) -> super::EphemeralId {
         super::EphemeralId::new(self.id.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::ConcreteValue;
+
+    #[test]
+    fn from_value_resource_ref_classifies_as_forwarded() {
+        let path = AccessPath::new("role", "arn");
+        let v = Value::Deferred(DeferredValue::ResourceRef { path: path.clone() });
+        let attr = CompositionAttribute::from_value(v);
+        match attr {
+            CompositionAttribute::Forwarded(p) => assert_eq!(p, path),
+            CompositionAttribute::Derived(_) => panic!("ResourceRef must lift to Forwarded"),
+        }
+    }
+
+    #[test]
+    fn from_value_concrete_string_classifies_as_derived() {
+        let v = Value::Concrete(ConcreteValue::String("literal".to_string()));
+        let attr = CompositionAttribute::from_value(v.clone());
+        match attr {
+            CompositionAttribute::Derived(d) => assert_eq!(d, v),
+            CompositionAttribute::Forwarded(_) => panic!("literal must lift to Derived"),
+        }
+    }
+
+    #[test]
+    fn from_value_interpolation_classifies_as_derived() {
+        use crate::resource::InterpolationPart;
+        let v = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("prefix-".to_string()),
+            InterpolationPart::Expr(Value::Deferred(DeferredValue::ResourceRef {
+                path: AccessPath::new("svc", "id"),
+            })),
+        ]));
+        let attr = CompositionAttribute::from_value(v.clone());
+        match attr {
+            CompositionAttribute::Derived(d) => assert_eq!(d, v),
+            CompositionAttribute::Forwarded(_) => {
+                panic!("multi-source interpolation must lift to Derived")
+            }
+        }
+    }
+
+    #[test]
+    fn forwarded_to_value_is_resource_ref() {
+        let path = AccessPath::new("svc", "endpoint");
+        let attr = CompositionAttribute::Forwarded(path.clone());
+        let v = attr.to_value();
+        assert_eq!(
+            v,
+            Value::Deferred(DeferredValue::ResourceRef { path: path.clone() }),
+        );
+    }
+
+    #[test]
+    fn derived_to_value_returns_inner() {
+        let inner = Value::Concrete(ConcreteValue::String("kept".to_string()));
+        let attr = CompositionAttribute::Derived(inner.clone());
+        assert_eq!(attr.to_value(), inner);
+    }
+
+    /// Round-trip: a `Value` → `CompositionAttribute` → `Value` is
+    /// lossless for both `Forwarded`-lifted refs and `Derived`-wrapped
+    /// expressions. This is the invariant the resolver / display
+    /// layers rely on while migrating to per-variant dispatch.
+    #[test]
+    fn from_value_to_value_round_trip() {
+        let cases = vec![
+            Value::Deferred(DeferredValue::ResourceRef {
+                path: AccessPath::new("a", "b"),
+            }),
+            Value::Concrete(ConcreteValue::String("literal".to_string())),
+            Value::Concrete(ConcreteValue::Int(42)),
+        ];
+        for original in cases {
+            let lifted = CompositionAttribute::from_value(original.clone());
+            assert_eq!(lifted.to_value(), original);
+        }
     }
 }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1807,7 +1807,7 @@ pub mod leaf_node;
 pub mod persistent_id;
 pub mod resource_like;
 
-pub use composition::{Composition, Signature};
+pub use composition::{Composition, CompositionAttribute, Signature};
 pub use data_source::DataSource;
 pub use graph_node::GraphNode;
 pub use leaf_node::{CompositionNotALeaf, LeafNode, expand_to_leaves};

--- a/carina-core/src/resource/resource_like.rs
+++ b/carina-core/src/resource/resource_like.rs
@@ -9,6 +9,7 @@
 //! effect-executor, writeback) continue to take a concrete type and
 //! benefit from the typed dispatch.
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 use indexmap::IndexMap;
@@ -22,8 +23,17 @@ pub trait ResourceLike {
     /// Stable identifier of this resource.
     fn id(&self) -> &ResourceId;
 
-    /// Source-order preserving attribute map.
-    fn attributes(&self) -> &IndexMap<String, Value>;
+    /// Source-order preserving attribute map as `Value`s.
+    ///
+    /// Returned as a [`Cow`] because [`Composition`](super::Composition)
+    /// stores its attributes as
+    /// [`CompositionAttribute`](super::CompositionAttribute) (#3294)
+    /// and must materialize a `Value`-typed view on demand; the other
+    /// two siblings return a borrowed reference into their owned
+    /// `IndexMap<String, Value>`. Callers can `.iter()` /
+    /// `.contains_key()` / `.get()` through the `Cow` directly via
+    /// `Deref`.
+    fn attributes(&self) -> Cow<'_, IndexMap<String, Value>>;
 
     /// `let` binding name if any.
     fn binding(&self) -> Option<&str>;
@@ -40,7 +50,7 @@ impl<T: ResourceLike + ?Sized> ResourceLike for &T {
     fn id(&self) -> &ResourceId {
         (**self).id()
     }
-    fn attributes(&self) -> &IndexMap<String, Value> {
+    fn attributes(&self) -> Cow<'_, IndexMap<String, Value>> {
         (**self).attributes()
     }
     fn binding(&self) -> Option<&str> {
@@ -55,8 +65,8 @@ impl ResourceLike for Resource {
     fn id(&self) -> &ResourceId {
         &self.id
     }
-    fn attributes(&self) -> &IndexMap<String, Value> {
-        &self.attributes
+    fn attributes(&self) -> Cow<'_, IndexMap<String, Value>> {
+        Cow::Borrowed(&self.attributes)
     }
     fn binding(&self) -> Option<&str> {
         self.binding.as_deref()
@@ -70,16 +80,27 @@ impl ResourceLike for Composition {
     fn id(&self) -> &ResourceId {
         &self.id
     }
-    /// Reads the I/O surface's `attributes` half.
+    /// Materializes the I/O surface's `attributes` half as a
+    /// `Value`-typed map.
     ///
-    /// `Composition` is the only sibling that carries a [`Signature`]
-    /// (#3292). The `arguments` half is not exposed through
-    /// `ResourceLike` — the trait abstracts over the *output* surface
-    /// that `Resource` and `DataSource` also expose, while
+    /// `Composition.signature.attributes` is
+    /// `IndexMap<String, CompositionAttribute>` since #3294 — the
+    /// typed variant carries the same information as the pre-#3294
+    /// `Value` form (cf. `CompositionAttribute::to_value`), so this
+    /// materialization is lossless and used only by callers that
+    /// haven't yet been ported to dispatch on the variant. Direct
+    /// consumers can read `c.signature.attributes` instead.
+    ///
     /// `arguments` is composition-only and reached via
     /// `c.signature.arguments` directly.
-    fn attributes(&self) -> &IndexMap<String, Value> {
-        &self.signature.attributes
+    fn attributes(&self) -> Cow<'_, IndexMap<String, Value>> {
+        Cow::Owned(
+            self.signature
+                .attributes
+                .iter()
+                .map(|(k, attr)| (k.clone(), attr.to_value()))
+                .collect(),
+        )
     }
     fn binding(&self) -> Option<&str> {
         self.binding.as_deref()
@@ -93,8 +114,8 @@ impl ResourceLike for DataSource {
     fn id(&self) -> &ResourceId {
         &self.id
     }
-    fn attributes(&self) -> &IndexMap<String, Value> {
-        &self.attributes
+    fn attributes(&self) -> Cow<'_, IndexMap<String, Value>> {
+        Cow::Borrowed(&self.attributes)
     }
     fn binding(&self) -> Option<&str> {
         self.binding.as_deref()

--- a/carina-core/src/resource/resource_like_tests.rs
+++ b/carina-core/src/resource/resource_like_tests.rs
@@ -28,8 +28,11 @@ fn make_managed() -> Resource {
 }
 
 fn make_virtual() -> Composition {
-    let mut attributes = IndexMap::new();
-    attributes.insert("k".to_string(), sample_value("v"));
+    let mut attributes: IndexMap<String, crate::resource::CompositionAttribute> = IndexMap::new();
+    attributes.insert(
+        "k".to_string(),
+        crate::resource::CompositionAttribute::from_value(sample_value("v")),
+    );
     Composition {
         id: ResourceId::new("aws.s3.Bucket", "b"),
         signature: Signature {
@@ -113,15 +116,15 @@ fn binding_none_covers_all_arms() {
 
 #[test]
 fn resource_like_supports_generic_dispatch() {
-    fn first_attribute_key<R: ResourceLike>(r: &R) -> Option<&String> {
-        r.attributes().keys().next()
+    fn first_attribute_key<R: ResourceLike>(r: &R) -> Option<String> {
+        r.attributes().keys().next().cloned()
     }
 
-    assert_eq!(first_attribute_key(&make_managed()), Some(&"k".to_string()));
-    assert_eq!(first_attribute_key(&make_virtual()), Some(&"k".to_string()));
+    assert_eq!(first_attribute_key(&make_managed()), Some("k".to_string()));
+    assert_eq!(first_attribute_key(&make_virtual()), Some("k".to_string()));
     assert_eq!(
         first_attribute_key(&make_data_source()),
-        Some(&"k".to_string()),
+        Some("k".to_string()),
     );
 }
 

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -97,7 +97,8 @@ pub fn validate_deferred_populate_refs<E>(
 
     let mut out: Vec<DeferredPopulateDiagnostic> = Vec::new();
     for rref in parsed.iter_all_resources() {
-        for (key, value) in rref.attributes() {
+        let attrs = rref.attributes();
+        for (key, value) in attrs.iter() {
             collect_unsynchronized_refs(
                 value,
                 key,

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -240,7 +240,12 @@ pub fn bindings_from_parts(
         out.insert(
             name.clone(),
             InferenceBinding::Virtual {
-                attributes: composition.signature.attributes.clone(),
+                attributes: composition
+                    .signature
+                    .attributes
+                    .iter()
+                    .map(|(k, attr)| (k.clone(), attr.to_value()))
+                    .collect(),
             },
         );
     }
@@ -1378,14 +1383,15 @@ mod tests {
         // `vpc_id` here stands in for the module-exposed attribute that
         // points at the inner role's schema attribute. carina#3181:
         // compositions are a distinct typestate in `compositions`.
-        let mut virt_attrs = indexmap::IndexMap::new();
+        let mut virt_attrs: indexmap::IndexMap<String, crate::resource::CompositionAttribute> =
+            indexmap::IndexMap::new();
         virt_attrs.insert(
             "role_id".to_string(),
-            Value::resource_ref(
+            crate::resource::CompositionAttribute::from_value(Value::resource_ref(
                 "github_actions_carina.role".to_string(),
                 "vpc_id".to_string(),
                 vec![],
-            ),
+            )),
         );
         let virt = crate::resource::Composition {
             id: crate::resource::ResourceId::new("_virtual", "github_actions_carina"),

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -155,7 +155,8 @@ pub fn validate_resource_ref_types<E>(
         };
         let resource_id = rref.id();
 
-        for (attr_name, attr_value) in rref.attributes() {
+        let attrs = rref.attributes();
+        for (attr_name, attr_value) in attrs.iter() {
             if attr_name.starts_with('_') {
                 continue;
             }
@@ -979,7 +980,8 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     // `principals = [binding.attr]` would otherwise be missed.
     let mut referenced: HashSet<String> = HashSet::new();
     for rref in parsed.iter_all_resources() {
-        for (attr_name, value) in rref.attributes() {
+        let attrs = rref.attributes();
+        for (attr_name, value) in attrs.iter() {
             if attr_name.starts_with('_') {
                 continue;
             }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -770,12 +770,23 @@ pub fn redact_secrets_in_data_source(
 pub fn redact_secrets_in_virtual(
     resource: &crate::resource::Composition,
 ) -> Result<crate::resource::Composition, SerializationError> {
-    let attributes: Result<indexmap::IndexMap<String, Value>, _> = resource
-        .signature
-        .attributes
-        .iter()
-        .map(|(k, e)| redact_secrets_in_value(e).map(|rv| (k.clone(), rv)))
-        .collect();
+    // Reify each `CompositionAttribute` to a `Value`, redact secrets,
+    // then re-classify with `CompositionAttribute::from_value` so
+    // single-hop alias structure is preserved across the round-trip.
+    let attributes: Result<indexmap::IndexMap<String, crate::resource::CompositionAttribute>, _> =
+        resource
+            .signature
+            .attributes
+            .iter()
+            .map(|(k, attr)| {
+                redact_secrets_in_value(&attr.to_value()).map(|rv| {
+                    (
+                        k.clone(),
+                        crate::resource::CompositionAttribute::from_value(rv),
+                    )
+                })
+            })
+            .collect();
     let mut out = resource.clone();
     out.signature.attributes = attributes?;
     Ok(out)
@@ -2364,17 +2375,20 @@ mod tests {
         // block (which lands as a `Value::Secret` in the composition's
         // attribute map) must be redacted before serialization, the
         // same way managed-resource attributes are redacted.
+        use crate::resource::CompositionAttribute;
         use crate::resource::{Composition, ResourceId, Signature};
         use std::collections::{BTreeSet, HashSet};
-        let mut attrs = indexmap::IndexMap::new();
+        let mut attrs: indexmap::IndexMap<String, CompositionAttribute> = indexmap::IndexMap::new();
         attrs.insert(
             "non_secret".to_string(),
-            Value::Concrete(ConcreteValue::String("kept".to_string())),
+            CompositionAttribute::from_value(Value::Concrete(ConcreteValue::String(
+                "kept".to_string(),
+            ))),
         );
         attrs.insert(
             "secret_field".to_string(),
-            Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
-                ConcreteValue::String("plaintext-must-not-leak".to_string()),
+            CompositionAttribute::from_value(Value::Deferred(DeferredValue::Secret(Box::new(
+                Value::Concrete(ConcreteValue::String("plaintext-must-not-leak".to_string())),
             )))),
         );
         let virt = Composition {
@@ -2394,13 +2408,23 @@ mod tests {
 
         // The non-secret attribute survives verbatim.
         assert_eq!(
-            redacted.signature.attributes.get("non_secret"),
-            Some(&Value::Concrete(ConcreteValue::String("kept".to_string()))),
+            redacted
+                .signature
+                .attributes
+                .get("non_secret")
+                .map(|a| a.to_value()),
+            Some(Value::Concrete(ConcreteValue::String("kept".to_string()))),
         );
 
         // The secret attribute is replaced with the hash prefix, not the
         // plaintext.
-        match redacted.signature.attributes.get("secret_field") {
+        match redacted
+            .signature
+            .attributes
+            .get("secret_field")
+            .map(|a| a.to_value())
+            .as_ref()
+        {
             Some(Value::Concrete(ConcreteValue::String(s))) => {
                 assert!(
                     s.starts_with(SECRET_PREFIX),

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1761,7 +1761,8 @@ impl DiagnosticEngine {
         let mut diagnostics = Vec::new();
 
         for rref in parsed.iter_all_resources() {
-            for (attr_name, attr_value) in rref.attributes() {
+            let attrs = rref.attributes();
+            for (attr_name, attr_value) in attrs.iter() {
                 if attr_name.starts_with('_') {
                     continue;
                 }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -464,7 +464,7 @@ impl DiagnosticEngine {
                     // Build block_name -> canonical_name map for this schema
                     let bn_map = schema.block_name_map();
 
-                    for (attr_name, attr_value) in resource_attributes {
+                    for (attr_name, attr_value) in resource_attributes.iter() {
                         if attr_name.starts_with('_') {
                             continue; // Skip internal attributes
                         }


### PR DESCRIPTION
## Summary

PR G of the #3287 series. Lifts the value type of `Signature.attributes` from `Value` to a tagged enum:

```rust
pub enum CompositionAttribute {
    Forwarded(AccessPath),   // single-hop alias
    Derived(Value),          // multi-source expression
}

pub struct Signature {
    pub arguments:  IndexMap<String, Value>,
    pub attributes: IndexMap<String, CompositionAttribute>,  // ← lifted
}
```

The classification removes the runtime decision the resolver did on every composition attribute and encodes it in the type. The variant is built at expansion via `CompositionAttribute::from_value`.

`AccessPath` is used in `Forwarded` (not `NodeId` from the original design sketch) because expand-time targets aren't yet bound; `AccessPath` carries the same binding-name + attribute path that the post-apply resolver already looks up.

`to_value()` materializes back to the pre-PR `Value` form for sites not yet ported to per-variant dispatch. Round-trip is lossless.

`ResourceLike::attributes()` and `ResourceRef::attributes()` now return `Cow<'_, IndexMap<String, Value>>`. Bare-attributes siblings borrow; `Composition` returns `Cow::Owned`. Six iteration sites updated to bind the `Cow` locally before `.iter()`. The trait retires in PR H.

Closes #3294

## Test plan

- [x] Six new unit tests cover `from_value` / `to_value` classification (`Forwarded` for ResourceRef, `Derived` for everything else, round-trip)
- [x] `cargo nextest run --workspace --all-features` — 3635 passed
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-*.sh` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
