### PR TITLE
expander: wire ExpansionTrace through module-call expansion (#3306)

### DIFF
--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -745,6 +745,7 @@ fn test_find_state_bucket_resource_matching_type() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: carina_core::resource::ExpansionTrace::new(),
     };
 
     // Matching resource type

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -345,6 +345,7 @@ pub(crate) fn merge_parsed_file<E>(target: &mut File<E>, source: File<E>) {
         structural_bindings,
         warnings,
         deferred_for_expressions,
+        expansion_trace,
     } = source;
 
     target.providers.extend(providers);
@@ -367,6 +368,13 @@ pub(crate) fn merge_parsed_file<E>(target: &mut File<E>, source: File<E>) {
     target
         .deferred_for_expressions
         .extend(deferred_for_expressions);
+    // `expansion_trace`: merge every (leaf, chain) entry. Different
+    // sources never produce the same leaf id (the expander prefixes
+    // leaf ids with the call-site instance), so the merge is just a
+    // disjoint-set union; the iteration order does not matter.
+    for (leaf, call_sites) in expansion_trace.leaf_to_call_sites {
+        target.expansion_trace.record(leaf, call_sites);
+    }
     // `backend` is config, not accumulated content: last file wins.
     if let Some(backend) = backend {
         target.backend = Some(backend);

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -353,6 +353,16 @@ impl ModuleResolver<'_> {
         // `module.compositions` plus the `_virtual` attribute
         // resource built above.
 
+        // #3306: build the expansion trace from this call's leaves +
+        // nested-expansion traces inherited from `module`, *before*
+        // the struct literal moves `resources` / `data_sources`.
+        let expansion_trace = build_expansion_trace(
+            instance_prefix,
+            &module.expansion_trace,
+            &resources,
+            &data_sources,
+        );
+
         // The contribution is a full `ParsedFile` built with an
         // **exhaustive struct literal** (no `..Default::default()`):
         // adding a `File<E>` field breaks this until someone decides
@@ -398,8 +408,54 @@ impl ModuleResolver<'_> {
             requires: Vec::new(),
             structural_bindings: HashSet::new(),
             warnings: Vec::new(),
+
+            // ExpansionTrace (#3306): pre-built above against the
+            // call's leaves before the struct literal moved them.
+            expansion_trace,
         })
     }
+}
+
+/// Build an [`ExpansionTrace`](crate::resource::ExpansionTrace) for one
+/// `expand_module_call` invocation.
+///
+/// Records the call site (derived from `instance_prefix`) against
+/// every leaf produced at this level, and prepends the same call site
+/// to every chain inherited from the module's own
+/// `expansion_trace` (so nested expansions surface a full outermost-
+/// first chain in the merged plan).
+pub(crate) fn build_expansion_trace(
+    instance_prefix: &str,
+    inner_trace: &crate::resource::ExpansionTrace,
+    leaf_resources: &[Resource],
+    leaf_data_sources: &[DataSource],
+) -> crate::resource::ExpansionTrace {
+    let this_call_site = crate::resource::EphemeralId::new(crate::resource::ResourceId::new(
+        "_virtual",
+        instance_prefix,
+    ));
+
+    let mut out = crate::resource::ExpansionTrace::new();
+
+    // Direct leaves at this expansion level: chain is `[this_call_site]`.
+    for r in leaf_resources {
+        out.record(r.persistent_id(), vec![this_call_site.clone()]);
+    }
+    for d in leaf_data_sources {
+        out.record(d.persistent_id(), vec![this_call_site.clone()]);
+    }
+
+    // Leaves from nested expansions inside `module` already have an
+    // inner chain; prepend the current call site to mark this level as
+    // their outer-most container.
+    for (leaf, inner_chain) in inner_trace.iter() {
+        let mut chain = Vec::with_capacity(inner_chain.len() + 1);
+        chain.push(this_call_site.clone());
+        chain.extend(inner_chain.iter().cloned());
+        out.record(leaf.clone(), chain);
+    }
+
+    out
 }
 
 /// Join a module-call `instance_prefix` to an intra-module binding name

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -78,6 +78,7 @@ fn create_test_module() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 
@@ -170,6 +171,7 @@ fn create_test_module_with_anonymous_resource() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 
@@ -315,6 +317,7 @@ fn create_module_with_named_provider_instance() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 
@@ -482,6 +485,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 
@@ -627,6 +631,7 @@ fn create_module_with_attributes() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 
@@ -713,6 +718,85 @@ fn test_expand_module_call_populates_compositions_slice() {
     assert!(expanded.data_sources.is_empty());
 }
 
+/// #3306 acceptance: a single-level module call records each leaf
+/// resource it produces in the `ExpansionTrace`, with the call-site
+/// `EphemeralId` as the only chain element.
+#[test]
+fn test_expand_module_call_populates_expansion_trace_single_level() {
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules
+            .insert("web_tier".to_string(), create_module_with_attributes());
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "web_tier".to_string(),
+        binding_name: Some("web".to_string()),
+        arguments: HashMap::new(),
+    };
+
+    let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
+
+    // One leaf produced (the security_group resource).
+    assert_eq!(expanded.resources.len(), 1);
+    let leaf = &expanded.resources[0];
+
+    // The trace records the leaf against a one-element chain.
+    let chain = expanded
+        .expansion_trace
+        .call_sites_of(&leaf.persistent_id());
+    assert_eq!(
+        chain.len(),
+        1,
+        "single-level expansion must yield a one-element chain, got {chain:?}",
+    );
+
+    // The chain element points at this call site's instance prefix
+    // (`_virtual.<instance_prefix>`).
+    let expected_call_site =
+        crate::resource::EphemeralId::new(crate::resource::ResourceId::new("_virtual", "web"));
+    assert_eq!(chain[0], expected_call_site);
+}
+
+/// #3306 acceptance: when an outer expansion absorbs leaves from a
+/// previously-expanded inner module, the trace prepends the outer
+/// call site to the inner chain — outermost-first overall.
+#[test]
+fn test_build_expansion_trace_prepends_outer_call_site_to_inner_chain() {
+    use crate::resource::{EphemeralId, ExpansionTrace, PersistentId, ResourceId};
+
+    // Simulate an inner module that already finished its own
+    // expansion: one leaf nested one level deep (inner_call_site).
+    let mut inner_trace = ExpansionTrace::new();
+    let inner_leaf = PersistentId::new(ResourceId::new("aws.s3.Bucket", "outer.inner.logs"));
+    let inner_call_site = EphemeralId::new(ResourceId::new("_virtual", "outer.inner"));
+    inner_trace.record(inner_leaf.clone(), vec![inner_call_site.clone()]);
+
+    // Build the outer trace: no direct leaves at this level, only
+    // inherited ones. The outer call-site is `outer`.
+    let outer_trace =
+        crate::module_resolver::expander::build_expansion_trace("outer", &inner_trace, &[], &[]);
+
+    // The inner leaf is still recorded, but its chain now leads with
+    // the outer call site.
+    let chain = outer_trace.call_sites_of(&inner_leaf);
+    assert_eq!(
+        chain.len(),
+        2,
+        "two-level expansion must produce a two-element chain, got {chain:?}",
+    );
+    let expected_outer = EphemeralId::new(ResourceId::new("_virtual", "outer"));
+    assert_eq!(
+        chain[0], expected_outer,
+        "outermost element must be the outer call site",
+    );
+    assert_eq!(
+        chain[1], inner_call_site,
+        "inner element must follow the outer one",
+    );
+}
+
 /// PR E (#3292) acceptance: a composition's `signature.arguments`
 /// preserves the resolved call-site arguments. The pre-#3292 expander
 /// dropped this information with the `ModuleCall`; with `Signature`
@@ -765,6 +849,7 @@ fn test_expand_module_call_preserves_arguments_on_composition_signature() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     };
 
     let resolver = {
@@ -1725,6 +1810,7 @@ fn create_module_with_interpolation() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 
@@ -2108,6 +2194,7 @@ fn create_module_with_port_validation() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 
@@ -2286,6 +2373,7 @@ fn test_argument_validation_no_message_uses_default() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     };
 
     let resolver = {
@@ -2354,6 +2442,7 @@ fn test_argument_validation_len_with_list() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     };
 
     let resolver = {
@@ -2455,6 +2544,7 @@ fn test_require_block_passes() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     };
 
     let resolver = {
@@ -2532,6 +2622,7 @@ fn test_require_block_fails_with_not_expr() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     };
 
     let resolver = {
@@ -2607,6 +2698,7 @@ fn test_require_block_len_function() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     };
 
     let resolver = {
@@ -2704,6 +2796,7 @@ fn test_require_block_multiple_constraints() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     };
 
     let resolver = {
@@ -3996,6 +4089,7 @@ fn create_module_with_environment_union() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -847,6 +847,18 @@ pub struct File<E> {
     pub warnings: Vec<ParseWarning>,
     /// For-expressions whose iterables are unresolved; displayed as deferred in plan.
     pub deferred_for_expressions: Vec<DeferredForExpression>,
+    /// Plan-scoped lineage of leaf nodes back to the composition call
+    /// sites that produced them (#3306).
+    ///
+    /// Populated by `ModuleResolver::expand_module_call`: every leaf
+    /// resource added to the expanded `File` records its originating
+    /// call-site chain (outermost first). Leaves declared at the DSL
+    /// root are absent from the map.
+    ///
+    /// Not serialized to state — the trace is plan-scoped and rebuilt
+    /// from DSL on every parse. (`File` itself does not derive Serde,
+    /// so no annotation is required.)
+    pub expansion_trace: crate::resource::ExpansionTrace,
 }
 
 /// Parse-phase file: exports retain their `Option<TypeExpr>` shape.
@@ -878,6 +890,7 @@ impl<E> Default for File<E> {
             structural_bindings: HashSet::new(),
             warnings: Vec::new(),
             deferred_for_expressions: Vec::new(),
+            expansion_trace: crate::resource::ExpansionTrace::new(),
         }
     }
 }
@@ -917,6 +930,7 @@ impl<E> File<E> {
             structural_bindings,
             warnings,
             deferred_for_expressions,
+            expansion_trace,
         } = self;
 
         File {
@@ -939,6 +953,7 @@ impl<E> File<E> {
             structural_bindings,
             warnings,
             deferred_for_expressions,
+            expansion_trace,
         }
     }
 

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -419,6 +419,10 @@ pub fn parse_with_seeded_bindings(
         structural_bindings: ctx.structural_bindings,
         warnings: ctx.warnings,
         deferred_for_expressions: ctx.deferred_for_expressions,
+        // The parser never synthesizes composition resources, so it
+        // never records lineage — the trace starts empty here and is
+        // populated by `module_resolver::expander` (#3306).
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     })
 }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -24,6 +24,7 @@ fn empty_parsed() -> ParsedFile {
         structural_bindings: HashSet::new(),
         warnings: Vec::new(),
         deferred_for_expressions: Vec::new(),
+        expansion_trace: crate::resource::ExpansionTrace::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #3306. Wires `ExpansionTrace` (#3305) into the module-call expander so every leaf produced by composition expansion records its call-site chain.

```rust
// New field on File<E>
pub expansion_trace: ExpansionTrace,
```

- `merge_parsed_file` destructures and merges the trace (disjoint-set union).
- `expand_module_call` derives `_virtual.<instance_prefix>` as this call's `EphemeralId`, records direct leaves with a one-element chain, and prepends it to chains inherited from the module's own trace — outermost-first overall.
- Factored as `pub(crate) build_expansion_trace(...)` so the prepend logic is unit-testable.

## Test plan

- [x] `test_expand_module_call_populates_expansion_trace_single_level` — single-level call → one-element chain
- [x] `test_build_expansion_trace_prepends_outer_call_site_to_inner_chain` — nested expansion → outermost-first chain
- [x] `cargo nextest run --workspace --all-features` — 3649 passed
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-*.sh` — all green

## Refs

- Foundation: #3305 (trace type)
- Tracker: #3287
- Next: #3307 (display folding consumer), #3308 (ResourceLike retire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
