### PR TITLE
display: plan-tree composition folding via ExpansionTrace (#3307)

### DIFF
--- a/carina-cli/examples/plan-fixture.rs
+++ b/carina-cli/examples/plan-fixture.rs
@@ -112,6 +112,7 @@ fn main() -> ExitCode {
             &[],
             &fp.deferred_for_expressions,
             Some(&fp.prev_explicit),
+            None,
         );
     }
 

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1239,6 +1239,7 @@ async fn run_apply_locked(
             &export_changes,
             &residual_deferred_for,
             None,
+            None,
         );
 
         let stdin = tokio::io::BufReader::new(tokio::io::stdin());
@@ -1322,6 +1323,7 @@ async fn run_apply_locked(
         &export_changes,
         &residual_deferred_for,
         Some(&prev_explicit),
+        None,
     );
 
     let stdin = tokio::io::BufReader::new(tokio::io::stdin());
@@ -1638,6 +1640,7 @@ async fn run_apply_from_plan_locked(
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     );
 

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -646,6 +646,7 @@ pub async fn run_plan(
             &export_changes,
             &ctx.residual_deferred_for,
             Some(&ctx.prev_explicit),
+            Some(&ctx.expansion_trace),
         );
     }
 

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -225,6 +225,7 @@ pub fn print_plan(
     export_changes: &[crate::commands::plan::ExportChange],
     deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
     prev_explicit: Option<&HashMap<ResourceId, carina_core::explicit::ExplicitFields>>,
+    expansion_trace: Option<&carina_core::resource::ExpansionTrace>,
 ) {
     print!(
         "{}",
@@ -237,6 +238,7 @@ pub fn print_plan(
             export_changes,
             deferred_for_expressions,
             prev_explicit,
+            expansion_trace,
         )
     );
 }
@@ -260,6 +262,7 @@ pub fn format_plan(
     export_changes: &[crate::commands::plan::ExportChange],
     deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
     prev_explicit: Option<&HashMap<ResourceId, carina_core::explicit::ExplicitFields>>,
+    expansion_trace: Option<&carina_core::resource::ExpansionTrace>,
 ) -> String {
     let mut out = String::new();
 
@@ -289,6 +292,7 @@ pub fn format_plan(
         schemas,
         moved_origins,
         prev_explicit,
+        expansion_trace,
     ));
 
     // Show deferred for-expressions
@@ -404,6 +408,7 @@ pub fn format_destroy_plan(
         None,
         &HashMap::new(),
         None,
+        None, // ExpansionTrace doesn't apply to destroy plans (no compositions in state)
     ));
 
     out
@@ -803,6 +808,7 @@ impl<'a> TreeRenderContext<'a> {
 ///
 /// `delete_attributes` optionally provides current state attributes for Delete
 /// effects, allowing the display to show what will be deleted.
+#[allow(clippy::too_many_arguments)]
 fn format_plan_tree<'a>(
     plan: &Plan,
     detail: DetailLevel,
@@ -810,6 +816,7 @@ fn format_plan_tree<'a>(
     schemas: Option<&'a SchemaRegistry>,
     moved_origins: &'a HashMap<ResourceId, ResourceId>,
     prev_explicit: Option<&'a HashMap<ResourceId, carina_core::explicit::ExplicitFields>>,
+    expansion_trace: Option<&carina_core::resource::ExpansionTrace>,
 ) -> String {
     // Build dependency graph from effects
     let graph = build_dependency_graph(plan);
@@ -840,9 +847,38 @@ fn format_plan_tree<'a>(
         update_or_replace_targets,
     };
 
-    // Print from roots
-    for (i, root_idx) in roots.iter().enumerate() {
-        ctx.format_effect_tree(*root_idx, 0, i == roots.len() - 1, "", None);
+    // #3307: when an ExpansionTrace is supplied AND it actually
+    // records lineage for the plan's leaves, group root rows by their
+    // outermost composition call site. Within each composition group,
+    // a `Composition "<binding>"` header is printed first, followed by
+    // the leaf rows. Roots with no lineage entry render at the
+    // top level as before.
+    let composition_groups = group_roots_by_outermost_composition(plan, &roots, expansion_trace);
+
+    if composition_groups.has_any_grouping() {
+        // First: render ungrouped roots (declared at the DSL root).
+        for (i, root_idx) in composition_groups.ungrouped.iter().enumerate() {
+            let last = i == composition_groups.ungrouped.len() - 1
+                && composition_groups.grouped.is_empty();
+            ctx.format_effect_tree(*root_idx, 0, last, "", None);
+        }
+        // Then: each composition group with its header. Each leaf
+        // renders as a top-level row (indent 0, no prefix) — the
+        // composition header marks the group, and the per-line `Composition`
+        // header visually separates groups.
+        for group in &composition_groups.grouped {
+            writeln!(ctx.out, "{}", format_composition_header(&group.binding)).unwrap();
+            for (li, leaf_idx) in group.leaves.iter().enumerate() {
+                let leaf_last = li == group.leaves.len() - 1;
+                ctx.format_effect_tree(*leaf_idx, 0, leaf_last, "  ", None);
+            }
+        }
+    } else {
+        // No trace, or trace empty for this plan's leaves — use the
+        // pre-#3307 flat layout so existing snapshots remain valid.
+        for (i, root_idx) in roots.iter().enumerate() {
+            ctx.format_effect_tree(*root_idx, 0, i == roots.len() - 1, "", None);
+        }
     }
 
     // Print any remaining effects that weren't reachable from roots
@@ -855,6 +891,88 @@ fn format_plan_tree<'a>(
     }
 
     ctx.out
+}
+
+/// Header row for a composition group in the folded plan layout.
+fn format_composition_header(binding: &str) -> String {
+    use colored::Colorize;
+    format!("{} Composition \"{}\"", "+".cyan(), binding.cyan().bold())
+}
+
+/// Bucket of root effects, partitioned into the ones nested inside a
+/// composition (grouped under their outermost call site) and the ones
+/// declared at the DSL root (ungrouped).
+struct CompositionGroups {
+    ungrouped: Vec<usize>,
+    grouped: Vec<CompositionGroup>,
+}
+
+impl CompositionGroups {
+    fn has_any_grouping(&self) -> bool {
+        !self.grouped.is_empty()
+    }
+}
+
+struct CompositionGroup {
+    /// Display label — the call site's binding (instance prefix), e.g. `cluster`.
+    binding: String,
+    /// Root indices in `plan.effects()` that belong to this group.
+    leaves: Vec<usize>,
+}
+
+/// Partition `roots` into composition-grouped vs ungrouped buckets
+/// using the `ExpansionTrace`. A root whose effect's resource has an
+/// outermost composition in the trace lands in the grouped bucket
+/// under that call site; everything else stays ungrouped.
+fn group_roots_by_outermost_composition(
+    plan: &Plan,
+    roots: &[usize],
+    expansion_trace: Option<&carina_core::resource::ExpansionTrace>,
+) -> CompositionGroups {
+    let trace = match expansion_trace {
+        Some(t) if !t.is_empty() => t,
+        _ => {
+            return CompositionGroups {
+                ungrouped: roots.to_vec(),
+                grouped: Vec::new(),
+            };
+        }
+    };
+
+    // Map: outermost call-site name → group leaves (preserves first
+    // appearance order).
+    let mut order: Vec<String> = Vec::new();
+    let mut by_call_site: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut ungrouped: Vec<usize> = Vec::new();
+
+    for &root_idx in roots {
+        let effect = &plan.effects()[root_idx];
+        let outer = effect
+            .as_resource_ref()
+            .map(|rref| carina_core::resource::PersistentId::new(rref.id().clone()))
+            .and_then(|pid| trace.call_sites_of(&pid).first().cloned());
+
+        match outer {
+            Some(eid) => {
+                let key = eid.inner().name.as_str().to_string();
+                if !by_call_site.contains_key(&key) {
+                    order.push(key.clone());
+                }
+                by_call_site.entry(key).or_default().push(root_idx);
+            }
+            None => ungrouped.push(root_idx),
+        }
+    }
+
+    let grouped: Vec<CompositionGroup> = order
+        .into_iter()
+        .map(|binding| {
+            let leaves = by_call_site.remove(&binding).unwrap_or_default();
+            CompositionGroup { binding, leaves }
+        })
+        .collect();
+
+    CompositionGroups { grouped, ungrouped }
 }
 
 /// Split a string by `, ` at the top level, respecting nested brackets, braces, and quotes.

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -38,6 +38,7 @@ fn test_print_plan_with_external_dependency_does_not_panic() {
         &[],
         &[],
         None,
+        None,
     );
 }
 
@@ -60,6 +61,7 @@ fn test_print_plan_with_internal_dependency_does_not_panic() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     );
 }
@@ -605,6 +607,7 @@ fn test_print_plan_compact_does_not_panic() {
         &[],
         &[],
         None,
+        None,
     );
 }
 
@@ -634,6 +637,7 @@ fn test_print_plan_compact_with_anonymous_resources() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     );
 }
@@ -801,6 +805,7 @@ fn test_cascading_update_shows_attribute_diffs() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     );
 }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -61,6 +61,7 @@ fn snapshot_depends_on() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -86,6 +87,7 @@ fn snapshot_wait_cert() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -101,6 +103,7 @@ fn snapshot_all_create() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -126,6 +129,7 @@ fn snapshot_multi_instance_create() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -218,6 +222,7 @@ fn snapshot_module_anonymous_resource() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -234,6 +239,7 @@ fn snapshot_policy_pretty() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -249,6 +255,7 @@ fn snapshot_policy_pretty_nested() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -272,6 +279,7 @@ fn snapshot_policy_pretty_dynamic_key_list() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -287,6 +295,7 @@ fn snapshot_pretty_long_string_list() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -304,6 +313,7 @@ fn snapshot_pretty_short_string_list() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -319,6 +329,7 @@ fn snapshot_no_changes() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -346,6 +357,7 @@ fn snapshot_empty_explicit_children_no_changes() {
         &[],
         &[],
         Some(&fp.prev_explicit),
+        None,
     ));
     assert!(
         output.contains("No changes"),
@@ -367,6 +379,7 @@ fn snapshot_mixed_operations() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -398,6 +411,7 @@ fn snapshot_delete_orphan() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -435,6 +449,7 @@ fn snapshot_delete_orphan_list_of_maps() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -451,6 +466,7 @@ fn snapshot_compact() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -466,6 +482,7 @@ fn snapshot_map_key_diff() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -485,6 +502,7 @@ fn snapshot_map_added_from_none() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -507,6 +525,7 @@ fn snapshot_map_attribute_removed() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -523,6 +542,7 @@ fn snapshot_enum_display() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -538,6 +558,7 @@ fn snapshot_no_changes_enum() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -591,6 +612,7 @@ fn snapshot_default_values() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -606,6 +628,7 @@ fn snapshot_read_only_attrs() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -623,6 +646,7 @@ fn snapshot_explicit() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -639,6 +663,7 @@ fn snapshot_default_tags() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -654,6 +679,7 @@ fn snapshot_state_blocks() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -686,6 +712,7 @@ fn snapshot_secret_values() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -701,6 +728,7 @@ fn snapshot_moved_with_changes() {
         &moved_origins,
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -731,6 +759,7 @@ fn snapshot_moved_prev_keys() {
         &moved_origins,
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -768,6 +797,7 @@ fn snapshot_moved_pure() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -791,6 +821,7 @@ fn snapshot_moved_with_changes_compact() {
         &moved_origins,
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -920,6 +951,7 @@ fn plan_snapshot_upstream_state() {
         &[],
         &[],
         None,
+        None,
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -939,6 +971,7 @@ fn plan_snapshot_upstream_state_unresolved() {
         &moved_origins,
         &[],
         &[],
+        None,
         None,
     );
     let stripped = strip_ansi(&output);
@@ -967,6 +1000,7 @@ fn plan_snapshot_upstream_state_empty_exports() {
         &[],
         &[],
         None,
+        None,
     );
     let stripped = strip_ansi(&output);
     assert!(
@@ -992,6 +1026,7 @@ fn plan_snapshot_upstream_state_map_subscript() {
         &moved_origins,
         &[],
         &[],
+        None,
         None,
     );
     let stripped = strip_ansi(&output);
@@ -1039,6 +1074,7 @@ fn plan_snapshot_upstream_state_map_dot_notation() {
         &moved_origins,
         &[],
         &[],
+        None,
         None,
     );
     let stripped = strip_ansi(&output);
@@ -1097,6 +1133,7 @@ fn plan_snapshot_exports() {
         &export_changes,
         &[],
         None,
+        None,
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -1132,6 +1169,7 @@ fn plan_snapshot_exports_multifile() {
         &fp.moved_origins,
         &export_changes,
         &[],
+        None,
         None,
     );
     insta::assert_snapshot!(strip_ansi(&output));
@@ -1170,6 +1208,7 @@ fn plan_snapshot_export_changes_mixed() {
         &export_changes,
         &[],
         None,
+        None,
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -1185,6 +1224,7 @@ fn snapshot_nested_map_diff() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -1206,6 +1246,7 @@ fn snapshot_list_diff_added_struct() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     assert!(
@@ -1234,6 +1275,7 @@ fn snapshot_list_diff_modified_with_unchanged() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     assert!(
@@ -1265,6 +1307,7 @@ fn snapshot_list_diff_string_list_grew() {
         &[],
         &[],
         None,
+        None,
     ));
     assert!(
         !output.lines().any(|l| l.len() > 200),
@@ -1291,6 +1334,7 @@ fn snapshot_map_field_string_list_grew() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     assert!(
@@ -1320,6 +1364,7 @@ fn snapshot_list_diff_modified_with_unchanged_nested() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     assert!(
@@ -1352,6 +1397,7 @@ fn snapshot_list_diff_paired_all_unchanged_dropped() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -1374,6 +1420,7 @@ fn snapshot_nested_list_of_maps_all_dropped() {
         &[],
         &[],
         None,
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -1390,6 +1437,7 @@ fn snapshot_list_diff_removed_struct() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     assert!(
@@ -1417,6 +1465,7 @@ fn snapshot_deferred_for() {
         &[],
         &fp.deferred_for_expressions,
         Some(&fp.prev_explicit),
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -1436,6 +1485,7 @@ fn snapshot_provider_prefix() {
         &HashMap::new(),
         &[],
         &[],
+        None,
         None,
     ));
     insta::assert_snapshot!(output);
@@ -1460,6 +1510,7 @@ fn snapshot_server_default_struct_leaf() {
         &[],
         &[],
         Some(&fp.prev_explicit),
+        None,
     ));
     insta::assert_snapshot!(output);
 
@@ -1468,6 +1519,70 @@ fn snapshot_server_default_struct_leaf() {
     assert!(
         !output.contains("Name"),
         "rendered plan must not surface the unauthored 'Name' leaf, got:\n{}",
+        output
+    );
+}
+
+/// #3307 acceptance: when an `ExpansionTrace` records two leaf resources
+/// under a composition call site, the rendered plan groups them under a
+/// `Composition "<binding>"` header. The third leaf, declared at the
+/// DSL root with no trace entry, stays at the top level.
+#[test]
+fn snapshot_composition_folding() {
+    use carina_core::effect::Effect;
+    use carina_core::plan::Plan;
+    use carina_core::resource::{EphemeralId, ExpansionTrace, PersistentId, Resource, ResourceId};
+    use carina_core::schema::SchemaRegistry;
+
+    let mut plan = Plan::new();
+
+    // Two leaves under the composition `cluster`.
+    let inner = Resource::new("aws.eks.Cluster", "cluster/inner");
+    let inner_role = Resource::new("aws.iam.Role", "cluster/inner-role");
+    // One leaf at the DSL root.
+    let logs = Resource::new("aws.s3.Bucket", "logs");
+
+    let inner_id = inner.id.clone();
+    let inner_role_id = inner_role.id.clone();
+
+    plan.add(Effect::Create(inner));
+    plan.add(Effect::Create(inner_role));
+    plan.add(Effect::Create(logs));
+
+    let mut trace = ExpansionTrace::new();
+    let cluster_site = EphemeralId::new(ResourceId::new("_virtual", "cluster"));
+    trace.record(PersistentId::new(inner_id), vec![cluster_site.clone()]);
+    trace.record(PersistentId::new(inner_role_id), vec![cluster_site]);
+
+    let schemas = SchemaRegistry::new();
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::None,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        Some(&trace),
+    ));
+    insta::assert_snapshot!(output);
+
+    // Acceptance: the composition header must appear, with both leaves
+    // following it in the output.
+    assert!(
+        output.contains("Composition \"cluster\""),
+        "expected `Composition \"cluster\"` header in:\n{}",
+        output
+    );
+    assert!(
+        output.contains("cluster/inner"),
+        "expected inner leaf row in:\n{}",
+        output
+    );
+    assert!(
+        output.contains("logs"),
+        "expected ungrouped `logs` leaf row in:\n{}",
         output
     );
 }

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
@@ -1,0 +1,13 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+assertion_line: 1571
+expression: output
+---
+Execution Plan:
+
+  + aws.s3.Bucket logs
++ Composition "cluster"
+  + aws.eks.Cluster cluster/inner
+  + aws.iam.Role cluster/inner-role
+
+Plan: 3 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -60,6 +60,10 @@ pub struct PlanContext {
     /// `parsed.deferred_for_expressions` the caller used to pass to
     /// `print_plan` — expansion no longer mutates `parsed`.
     pub residual_deferred_for: Vec<carina_core::parser::DeferredForExpression>,
+    /// Plan-scoped lineage of leaves back to the composition call sites
+    /// that produced them (#3306, #3307). Forwarded to the display
+    /// layer so the rendered tree folds leaves under composition rows.
+    pub expansion_trace: carina_core::resource::ExpansionTrace,
 }
 
 /// Cached provider factories and schemas, constructed once per CLI invocation.
@@ -1986,6 +1990,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         upstream_snapshot: remote_bindings.clone(),
         prev_explicit,
         residual_deferred_for,
+        expansion_trace: parsed.expansion_trace.clone(),
     })
 }
 

--- a/carina-cli/tests/plan_fixture_example.rs
+++ b/carina-cli/tests/plan_fixture_example.rs
@@ -29,6 +29,7 @@ fn render_plan(fixture: &str, detail: DetailLevel) -> String {
         &[],
         &fp.deferred_for_expressions,
         Some(&fp.prev_explicit),
+        None,
     )
 }
 


### PR DESCRIPTION
## Summary

Closes #3307. Plan-tree composition folding via `ExpansionTrace` (#3306).

When an `ExpansionTrace` records leaves under composition call sites, the rendered plan groups them under a `Composition "<binding>"` header:

```
+ Composition "cluster"
  + aws.eks.Cluster cluster/inner
  + aws.iam.Role    cluster/inner-role
+ aws.s3.Bucket     logs
```

## Changes

- `format_plan` / `print_plan` gain `Option<&ExpansionTrace>` at the end. `None` → byte-identical pre-#3307 output (snapshot tests, destroy plan, examples).
- `format_plan_tree` partitions roots into `(ungrouped, grouped_by_outermost_call_site)` and emits a header before each group.
- `PlanContext.expansion_trace` field carries the trace from `create_plan_from_parsed_with_upstream` into the production `print_plan` call path.
- `format_destroy_plan` passes `None` — destroy plans only see state-resident leaves, never compositions.

## Test

- New snapshot test `snapshot_composition_folding` constructs a 3-effect plan (2 leaves under `cluster` + 1 root-level `logs`) with synthetic `ExpansionTrace`, asserts both the header presence and the rendered shape via insta.
- ~50 existing snapshot callers updated to pass `None` for the new arg; their snapshots remain unchanged (the trace branch is opt-in).

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3643 passed (+1)
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-*.sh` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
