### PR TITLE
differ: schema-aware equality for CustomEnum attributes (closes #3312)

### DIFF
--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -200,6 +200,82 @@ pub(crate) fn type_aware_equal(
                 canonical(va).eq_ignore_ascii_case(&canonical(vb))
             }
 
+            // CustomEnum: a namespaced enum carrying a `to_dsl` callback,
+            // not an `Aliases` table (StringEnum's shape). The differ sees
+            // both shapes in the wild: the provider-read side stores the
+            // AWS-canonical value (e.g. `String("ap-northeast-1a")` for
+            // `aws.AvailabilityZone`), while the DSL side flows through
+            // `resolve_enum_value_recursive` and arrives as the
+            // fully-qualified namespaced spelling
+            // (`String("aws.AvailabilityZone.ap_northeast_1a")` /
+            // `EnumIdentifier(...)` of the same). Without this arm the
+            // post-apply plan reports a phantom `forces replacement`
+            // diff on every `CustomEnum`-typed attribute — see
+            // carina-rs/carina#3312 and the closed carina-rs/carina-provider-aws#363.
+            (
+                a,
+                b,
+                AttributeType::CustomEnum {
+                    identity: _,
+                    to_dsl,
+                    ..
+                },
+            ) if matches!(
+                a,
+                Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
+            ) && matches!(
+                b,
+                Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
+            ) =>
+            {
+                let text = |v: &Value| -> Option<String> {
+                    match v {
+                        Value::Concrete(ConcreteValue::String(s))
+                        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.clone()),
+                        _ => None,
+                    }
+                };
+                let (Some(sa), Some(sb)) = (text(a), text(b)) else {
+                    return a.semantically_equal(b);
+                };
+                if sa == sb {
+                    return true;
+                }
+                // Normalize both sides to the trailing enum-value spelling,
+                // then map through `to_dsl` if available. Each side may
+                // arrive in any of these shapes:
+                //
+                //   - AWS-canonical:     `ap-northeast-1a`
+                //   - Dotted namespace:  `aws.AvailabilityZone.ap_northeast_1a`
+                //   - With `kind` tail:  `aws.AvailabilityZone.ZoneName.ap_northeast_1a`
+                //     (the WIT-bridged identity, where the original
+                //     `("aws.AvailabilityZone", "ZoneName")` axis split
+                //     does not round-trip and `kind` carries the full
+                //     dotted form — see carina#3312)
+                //   - Or any of the above with `EnumIdentifier` shape
+                //
+                // Stripping is greedy: take the segment after the last `.`,
+                // since the trailing enum value never contains a `.` in
+                // any AWS namespace (`ap_northeast_1a`, `dedicated`, etc.).
+                // The `to_dsl` mapping then aligns hyphenated AWS spellings
+                // with underscored DSL spellings (`ap-northeast-1a` ↔
+                // `ap_northeast_1a`); when `to_dsl` is `None` (the WIT
+                // bridge currently drops the function pointer), text
+                // equality after stripping is still sufficient for the
+                // identical-segment case.
+                let canonical = |s: &str| -> String {
+                    let trailing = match s.rsplit_once('.') {
+                        Some((_, tail)) => tail,
+                        None => s,
+                    };
+                    match to_dsl {
+                        Some(f) => f(trailing),
+                        None => trailing.to_string(),
+                    }
+                };
+                canonical(&sa) == canonical(&sb)
+            }
+
             // Custom types with base type: delegate to base
             (_, _, AttributeType::Custom { base, .. }) => {
                 type_aware_equal(a, b, Some(base), secret_ctx)

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -292,6 +292,105 @@ fn type_aware_string_enum_namespaced_vs_raw() {
     );
 }
 
+/// Regression for carina#3312: `CustomEnum` attributes with a `to_dsl`
+/// callback (e.g. `aws.AvailabilityZone`, where `to_dsl = |s|
+/// s.replace('-', '_')`) must compare equal across the `String("ap-northeast-1a")`
+/// vs `String("aws.AvailabilityZone.ap_northeast_1a")` / `EnumIdentifier(...)`
+/// pairs that arise naturally between provider-read state (AWS canonical)
+/// and DSL-side desired (fully-qualified identifier). Without this arm
+/// the differ reports a phantom replacement on every post-apply plan.
+#[test]
+fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
+    let az_type = AttributeType::CustomEnum {
+        identity: TypeIdentity::new(Some("aws"), ["AvailabilityZone"], "ZoneName"),
+        base: Box::new(AttributeType::String),
+        validate: noop_validator(),
+        to_dsl: Some(|s: &str| s.replace('-', "_")),
+    };
+
+    // Provider-read AWS canonical form vs DSL fully-qualified identifier.
+    // State side stores `String("ap-northeast-1a")`; the DSL parser turns
+    // `aws.AvailabilityZone.ap_northeast_1a` into an `EnumIdentifier` and
+    // `resolve_enum_value_recursive` rewrites it to a `String` carrying
+    // the same dotted form. Both shapes need to compare equal.
+    assert!(
+        type_aware_equal(
+            &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
+            &Value::Concrete(ConcreteValue::String(
+                "aws.AvailabilityZone.ap_northeast_1a".to_string()
+            )),
+            Some(&az_type),
+            None,
+        ),
+        "AWS-canonical hyphenated form must equal the fully-qualified DSL identifier"
+    );
+    assert!(
+        type_aware_equal(
+            &Value::Concrete(ConcreteValue::String(
+                "aws.AvailabilityZone.ap_northeast_1a".to_string()
+            )),
+            &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
+            Some(&az_type),
+            None,
+        ),
+        "Equality must be symmetric"
+    );
+
+    // Same dotted DSL form on both sides — identical strings, trivially equal.
+    assert!(
+        type_aware_equal(
+            &Value::Concrete(ConcreteValue::String(
+                "aws.AvailabilityZone.ap_northeast_1a".to_string()
+            )),
+            &Value::Concrete(ConcreteValue::String(
+                "aws.AvailabilityZone.ap_northeast_1a".to_string()
+            )),
+            Some(&az_type),
+            None,
+        ),
+        "Identical fully-qualified forms must be equal"
+    );
+
+    // Bare canonical form on both sides — identical strings, trivially equal.
+    assert!(
+        type_aware_equal(
+            &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
+            &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
+            Some(&az_type),
+            None,
+        ),
+        "Identical AWS-canonical forms must be equal"
+    );
+
+    // Cross-shape: state String vs DSL EnumIdentifier (the parser
+    // produces this for the `aws.AvailabilityZone.ap_northeast_1a` literal
+    // before resolve_enum_value_recursive rewrites it).
+    assert!(
+        type_aware_equal(
+            &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
+            &Value::Concrete(ConcreteValue::EnumIdentifier(
+                "aws.AvailabilityZone.ap_northeast_1a".to_string()
+            )),
+            Some(&az_type),
+            None,
+        ),
+        "AWS-canonical String must equal the matching EnumIdentifier shape"
+    );
+
+    // Different values must still produce a real diff (don't over-fold).
+    assert!(
+        !type_aware_equal(
+            &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
+            &Value::Concrete(ConcreteValue::String(
+                "aws.AvailabilityZone.ap_northeast_1c".to_string()
+            )),
+            Some(&az_type),
+            None,
+        ),
+        "Different enum values must not be folded as equal"
+    );
+}
+
 #[test]
 fn type_aware_struct_ignores_default_string_enum_empty() {
     use crate::schema::StructField;


### PR DESCRIPTION
## Summary

`type_aware_equal` had no arm for `AttributeType::CustomEnum`. Any `CustomEnum`-typed attribute whose state side and DSL side carried the same enum value in *different shapes* — e.g. `String("ap-northeast-1a")` from the provider read vs `String("aws.AvailabilityZone.ap_northeast_1a")` produced by `resolve_enum_value_recursive` on the DSL side — compared unequal, fell through to `semantically_equal`, and the differ marked the attribute as changed. Because `availability_zone` is create-only, the diff cascaded into a `forces replacement` on every post-apply plan, taking every dependent resource (NAT gateway, transit-gateway attachment, subnet–RT association) with it. Six acceptance tests reproduced it on every run.

Mirror the existing `StringEnum` arm for `CustomEnum`: strip to the trailing enum-value spelling (the segment after the last `.`) and map each side through `to_dsl` when present. Equal trailing spellings → equal. Different values still produce a real diff.

## Why this is the root-cause fix, not another bandaid

The previous attempt (carina-rs/carina-provider-aws#364) deleted a read-path AZ override in `subnet.rs`, masking one shape of the divergence. As soon as carina-core started lifting provider-read state via `lift_current_state_string_enums` and `resolve_enum_value_recursive` (the awscc#251 / carina#3075 / #3222 chain), the divergence came back through a different path — exactly the bandaid regression `~/.claude/CLAUDE.md` warns against. The fix has to live in the differ so it covers every `CustomEnum` attribute in every provider, not in any one read-path or write-path consumer.

Sibling-symptom check: the issue body lists 6 affected tests across 4 resource types (subnet, NAT gateway, TGW attachment, subnet–RT association), all rooted in one `CustomEnum` attribute (`availability_zone`). One arm-level fix dissolves the entire class. If a new `CustomEnum` attribute lands tomorrow, it inherits the fix automatically — no remembered filter, no per-site carve-out.

## Shapes covered

Each side may arrive as any of:

- AWS canonical: `ap-northeast-1a`
- Dotted namespace: `aws.AvailabilityZone.ap_northeast_1a`
- With `kind` tail: `aws.AvailabilityZone.ZoneName.ap_northeast_1a` (the WIT-bridged identity, where the original `("aws.AvailabilityZone", "ZoneName")` axis split does not round-trip and `kind` carries the full dotted form)
- Or any of the above with `EnumIdentifier` shape

Stripping is greedy: take the segment after the last `.`. Trailing enum values never contain `.` in any AWS namespace, so this is sound. `to_dsl` then aligns hyphenated AWS spellings with underscored DSL spellings (`ap-northeast-1a` ↔ `ap_northeast_1a`); when `to_dsl` is `None` (the WIT bridge currently drops `fn` pointers), text equality after stripping is still sufficient for the identical-segment case observed in production.

## Test plan

- [x] `cargo nextest run -p carina-core` — 2221/2221 pass (new unit test `type_aware_custom_enum_canonical_vs_namespaced_identifier` covers symmetry, identical, EnumIdentifier shape, and a negative case to keep real diffs from being folded)
- [x] `cargo nextest run --workspace --all-features` — 3644/3644 pass
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] All `scripts/check-*.sh` — clean
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2` — clean
- [x] **Acceptance**: `./acceptance-tests/run-tests.sh full --accounts 0-0 ec2_subnet/basic` against `carina-test-000` — **1 passed, 0 failed** (was failing plan-verify with `availability_zone: "ap_northeast_1a" → "ap_northeast_1a" (forces replacement)` on `main`)

Closes #3312, refs carina-rs/carina-provider-aws#363.
