### PR TITLE
wasi_http: inject Content-Length so body-less DELETE is sized, not chunked

### DIFF
--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -13,6 +13,14 @@ pub mod wasm_guest;
 #[cfg(target_arch = "wasm32")]
 pub mod wasi_http;
 
+// `wasi_http_body` is compiled for every target so its pure-Rust
+// classification helpers can be unit-tested on the host. The only
+// non-test caller (`wasi_http::make_request`) is wasm32-only, so on
+// host builds the items are dead from the lib's point of view —
+// silence the warning rather than guard the module on every fn.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+mod wasi_http_body;
+
 /// Parse a ResourceId string (provider.resource_type.name) into a ResourceId.
 ///
 /// Format: "provider.service.type.name" where provider is the first segment,

--- a/carina-plugin-sdk/src/wasi_http.rs
+++ b/carina-plugin-sdk/src/wasi_http.rs
@@ -27,6 +27,8 @@ use wasi::http::types::{
 };
 use wasi::io::streams::StreamError;
 
+use crate::wasi_http_body::{RequestBody, inject_content_length_header};
+
 /// When `CARINA_WASI_HTTP_TRACE=1` is set in the host environment, emit a
 /// per-phase wall-clock breakdown of each request to stderr.
 ///
@@ -178,12 +180,21 @@ fn make_request(
         .parse::<http::Uri>()
         .map_err(|e| ConnectorError::other(e.into(), None))?;
 
-    // Build headers
-    let headers_list: Vec<(String, Vec<u8>)> = request
+    // Classify the SDK body into Empty / Sized so the wire framing is
+    // explicit. Without this, AWS SDK-emitted body-less DELETEs lose
+    // their length signal at the wasi:http boundary, the host falls
+    // back to `Transfer-Encoding: chunked`, and S3 sits for ~20s
+    // (carina-rs/carina#3254) waiting for chunked-body bytes that
+    // hyper never produces.
+    let body = RequestBody::from_sdk_body(request.body().bytes().unwrap_or(&[]));
+
+    // Build headers, injecting `content-length` if the SDK omitted it.
+    let mut headers_list: Vec<(String, Vec<u8>)> = request
         .headers()
         .iter()
         .map(|(k, v)| (k.to_string(), v.as_bytes().to_vec()))
         .collect();
+    inject_content_length_header(&mut headers_list, &body);
     let fields = Fields::from_list(&headers_list).map_err(|e| {
         ConnectorError::other(format!("Failed to create headers: {e:?}").into(), None)
     })?;
@@ -236,13 +247,15 @@ fn make_request(
 
     let t_setup_done = req_start.map(|s| s.elapsed());
 
-    // Write the request body
-    let body_bytes = request.body().bytes().unwrap_or(&[]).to_vec();
-    let body_len = body_bytes.len();
+    // Write the request body. `body` was classified above so the
+    // wasi:http `OutgoingBody` only ever sees a known-sized payload
+    // (Empty → no stream write; Sized → exactly `body.content_length()`
+    // bytes, matching the `content-length` header we injected).
+    let body_len = body.content_length();
     let outgoing_body = outgoing_req
         .body()
         .map_err(|()| ConnectorError::other("Failed to get outgoing body".into(), None))?;
-    write_body(&outgoing_body, &body_bytes)?;
+    write_body(&outgoing_body, body.as_bytes())?;
     let t_write_body_done = req_start.map(|s| s.elapsed());
     OutgoingBody::finish(outgoing_body, None)
         .map_err(|e| ConnectorError::other(format!("Failed to finish body: {e:?}").into(), None))?;

--- a/carina-plugin-sdk/src/wasi_http_body.rs
+++ b/carina-plugin-sdk/src/wasi_http_body.rs
@@ -1,0 +1,208 @@
+//! Body framing for wasi:http outgoing requests.
+//!
+//! # Why this exists
+//!
+//! `wasi:http` and the host-side `wasmtime_wasi_http` bridge let the guest
+//! emit only two body shapes to hyper:
+//!
+//! - **Sized**: a `Content-Length` header is present in the request, so the
+//!   host constructs a `HostOutgoingBody` with `size = Some(n)` and hyper
+//!   serializes it with an explicit `Content-Length` framing.
+//! - **Unknown-size**: no `Content-Length` is present, so the host
+//!   constructs a `HostOutgoingBody` with `size = None`, and hyper's
+//!   HTTP/1.1 client falls back to `Transfer-Encoding: chunked`.
+//!
+//! The AWS SDK Rust does **not** consistently emit `Content-Length: 0` for
+//! body-less DELETE operations. When such a request crosses the
+//! wasi:http boundary, the host has no length signal and hyper sends the
+//! DELETE with `Transfer-Encoding: chunked`. S3 rejects body-less DELETE
+//! framed this way — it sits on the socket until the 20s server-side
+//! idle cutoff fires (`HTTP 400 RequestTimeout`). Every body-less DELETE
+//! the WASM provider makes pays the same 20s penalty.
+//!
+//! That's the chain pinned by the diagnosis in carina-rs/carina#3254
+//! (PRs #3257 / #3261 / #3264 / #3268 all merged). The bytes never reach
+//! S3 on time because hyper waits for a chunked terminator that the
+//! body never produces.
+//!
+//! # The fix
+//!
+//! Restore the invariant at the wasi:http boundary: **every outgoing
+//! request body that the SDK has fully buffered (which is every body the
+//! current `WasiHttpConnector` ever sees) crosses the boundary with an
+//! explicit `Content-Length`**. The header is added when missing and
+//! left alone when already present.
+//!
+//! The classification is encoded as a tagged union so the broken state
+//! ("body bytes known but Content-Length missing") is unrepresentable
+//! after `RequestBody::from_sdk_body` runs: every constructor of
+//! `RequestBody` produces a value that, when handed to
+//! `inject_content_length_header`, emits a sized framing on the wire.
+
+/// The body of an outgoing request, classified by what we know about its
+/// size at the wasi:http boundary.
+///
+/// The AWS SDK Rust's `HttpRequest` body is always fully buffered by the
+/// time `WasiHttpConnector` sees it (the smithy runtime collects it
+/// before calling the connector), so only the `Empty` and `Sized`
+/// variants are reachable from the current connector. A `Streaming`
+/// variant would be added if/when the connector grows to handle
+/// chunked-upload paths — encoded explicitly so the wasi:http bridge
+/// knows when *not* to inject `Content-Length`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RequestBody {
+    /// No request body. The SDK either passed no bytes or passed a
+    /// zero-length buffer. Either way the wire framing must be
+    /// `Content-Length: 0` so hyper does not fall back to
+    /// `Transfer-Encoding: chunked`.
+    Empty,
+    /// A fully-buffered, non-empty body. The wire framing must carry
+    /// `Content-Length: <bytes.len()>`.
+    Sized(Vec<u8>),
+}
+
+impl RequestBody {
+    /// Classify a buffered SDK body into `Empty` / `Sized`.
+    ///
+    /// The input is the byte slice the AWS SDK handed down through
+    /// `request.body().bytes().unwrap_or(&[])`. Empty buffers — the
+    /// case that triggers carina-rs/carina#3254 — collapse to
+    /// `RequestBody::Empty`.
+    pub(crate) fn from_sdk_body(bytes: &[u8]) -> Self {
+        if bytes.is_empty() {
+            RequestBody::Empty
+        } else {
+            RequestBody::Sized(bytes.to_vec())
+        }
+    }
+
+    /// The number of bytes the receiver should expect on the wire.
+    pub(crate) fn content_length(&self) -> usize {
+        match self {
+            RequestBody::Empty => 0,
+            RequestBody::Sized(bytes) => bytes.len(),
+        }
+    }
+
+    /// The bytes to feed into the wasi:http `OutgoingBody` output
+    /// stream. Returns an empty slice for `Empty`.
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        match self {
+            RequestBody::Empty => &[],
+            RequestBody::Sized(bytes) => bytes,
+        }
+    }
+}
+
+/// Add a `content-length` header to `headers` if not already present.
+///
+/// Headers come in as the `(name, value-bytes)` list that
+/// `wasi::http::types::Fields::from_list` accepts. Matching is
+/// case-insensitive on the header name to handle the AWS SDK's
+/// historical mix of `Content-Length` / `content-length` spellings.
+///
+/// If a `content-length` header is already present we leave it alone —
+/// either the SDK already framed the request correctly, or there is a
+/// genuine mismatch and we want it to surface (e.g. as an HTTP error)
+/// rather than silently overwriting.
+pub(crate) fn inject_content_length_header(
+    headers: &mut Vec<(String, Vec<u8>)>,
+    body: &RequestBody,
+) {
+    let already_present = headers
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case("content-length"));
+    if already_present {
+        return;
+    }
+    headers.push((
+        "content-length".to_string(),
+        body.content_length().to_string().into_bytes(),
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_sdk_body_empty_slice_is_empty() {
+        assert_eq!(RequestBody::from_sdk_body(&[]), RequestBody::Empty);
+    }
+
+    #[test]
+    fn from_sdk_body_non_empty_is_sized() {
+        let bytes = b"hello".to_vec();
+        assert_eq!(
+            RequestBody::from_sdk_body(b"hello"),
+            RequestBody::Sized(bytes)
+        );
+    }
+
+    #[test]
+    fn content_length_matches_byte_count() {
+        assert_eq!(RequestBody::Empty.content_length(), 0);
+        assert_eq!(RequestBody::Sized(vec![0; 7]).content_length(), 7);
+    }
+
+    #[test]
+    fn empty_body_injects_content_length_zero() {
+        let mut headers: Vec<(String, Vec<u8>)> = vec![
+            ("host".to_string(), b"example.com".to_vec()),
+            ("x-amz-date".to_string(), b"20260526T000000Z".to_vec()),
+        ];
+        inject_content_length_header(&mut headers, &RequestBody::Empty);
+        let cl = headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case("content-length"))
+            .expect("content-length must be present after injection");
+        assert_eq!(cl.1, b"0".to_vec());
+    }
+
+    #[test]
+    fn sized_body_injects_content_length_matching_bytes() {
+        let mut headers: Vec<(String, Vec<u8>)> = vec![];
+        inject_content_length_header(&mut headers, &RequestBody::Sized(b"hello world".to_vec()));
+        let cl = headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case("content-length"))
+            .expect("content-length must be present after injection");
+        assert_eq!(cl.1, b"11".to_vec());
+    }
+
+    #[test]
+    fn existing_content_length_is_left_untouched() {
+        // SDK already framed the body. Don't second-guess it.
+        let mut headers: Vec<(String, Vec<u8>)> =
+            vec![("Content-Length".to_string(), b"42".to_vec())];
+        inject_content_length_header(&mut headers, &RequestBody::Empty);
+        // Still exactly one entry, original value preserved.
+        let entries: Vec<_> = headers
+            .iter()
+            .filter(|(n, _)| n.eq_ignore_ascii_case("content-length"))
+            .collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].1, b"42".to_vec());
+    }
+
+    #[test]
+    fn case_insensitive_existing_content_length_is_detected() {
+        // The AWS SDK has historically emitted both `Content-Length`
+        // and `content-length`; either spelling must inhibit injection.
+        for existing_name in ["content-length", "Content-Length", "CONTENT-LENGTH"] {
+            let mut headers: Vec<(String, Vec<u8>)> =
+                vec![(existing_name.to_string(), b"5".to_vec())];
+            inject_content_length_header(&mut headers, &RequestBody::Sized(b"world".to_vec()));
+            let entries: Vec<_> = headers
+                .iter()
+                .filter(|(n, _)| n.eq_ignore_ascii_case("content-length"))
+                .collect();
+            assert_eq!(
+                entries.len(),
+                1,
+                "duplicate content-length when existing spelling was {existing_name}",
+            );
+            assert_eq!(entries[0].1, b"5".to_vec());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Pin AWS SDK-emitted requests to a sized wire framing at the wasi:http boundary, removing the ~20s S3 socket-idle stall on every body-less DELETE that the WASM provider makes.

## Root cause

The diagnosis chain (#3257, #3261, #3264, #3268, all merged) pinned the 20s wait inside `hyper::client::conn::http1::SendRequest::send_request().await`. Phase decomposition showed TCP/TLS/HTTP-handshake all healthy at tens of ms; the body-less DELETE then sits inside hyper's send_request for ~20s until S3 closes the socket with `400 RequestTimeout`.

Reading `wasmtime-wasi-http` 43.0.0 confirms why:

- `outgoing_request_body()` calls `get_content_length(&req.headers)` and passes the result as `size: Option<u64>` into `HostOutgoingBody::new` (`p2/types_impl.rs:256-262`).
- When `Content-Length` is missing the body becomes `size = None`, the resulting `HyperOutgoingBody` carries no length signal, and hyper's HTTP/1.1 client falls back to `Transfer-Encoding: chunked`.
- AWS SDK Rust does not consistently emit `Content-Length: 0` for body-less DELETE; on the native hyper path the chunked fallback is invisible because hyper ends the stream immediately, but the wasi:http bridge breaks that round-trip.
- S3 receives a chunked body-less DELETE and waits for chunk bytes that never arrive, then times out at its documented ~20s server-side idle cutoff. The same shape happens for GET/POST/PUT when the SDK omits `Content-Length`, but only DELETE is observed because the others carry a body or a length.

## Fix shape

One seam in `carina-plugin-sdk/src/wasi_http.rs::make_request`:

- Classify the buffered SDK body into `RequestBody { Empty, Sized(Vec<u8>) }` (tagged union, broken "buffered but unsized" state unrepresentable).
- Inject `content-length` into the outgoing headers if (and only if) the SDK didn't already supply one. Case-insensitive on the existing header name to handle the SDK's mix of `Content-Length` / `content-length`.
- The wasi:http `OutgoingBody` write path now reads from the classified body, so it never sees a length mismatch with the header we set.

The fix is per-method-agnostic — every body-less request gets sized framing, not just DELETE — because the broken invariant ("buffered body should cross the wasi:http boundary with a length") was per-method-agnostic too.

## Type safety

The new `RequestBody` enum makes "size unknown but body buffered" unrepresentable after classification. `from_sdk_body` is the only constructor and routes empty buffers through `Empty` (the carina#3254 path) rather than `Sized(vec![])`. A future `Streaming` variant for chunked uploads would extend the enum and the matching arms; the current connector only ever has buffered bodies, so it would be dead code today.

## Test plan

- [x] Unit tests on the new `wasi_http_body` module (7 tests, run on host):
  - empty/sized classification
  - empty -> `content-length: 0` (carina#3254 regression case)
  - sized -> `content-length: <bytes.len()>`
  - existing `Content-Length` not overwritten
  - case-insensitive (`Content-Length` / `content-length` / `CONTENT-LENGTH`) detection
- [x] `cargo nextest run -p carina-plugin-sdk --all-features` — 13/13 pass
- [x] `cargo test -p carina-plugin-sdk --doc`
- [x] `cargo clippy -p carina-plugin-sdk --all-targets -- -D warnings`
- [x] `cargo check -p carina-plugin-sdk --target wasm32-wasip2`
- [x] `scripts/check-*.sh` (5 scripts, all clean)
- [ ] Acceptance test verification on real S3 (`s3_bucket_replication_configuration/basic`, `s3_bucket_public_access_block/basic`, etc. — the five suites currently 20s-stalled per carina#3254). This requires rebuilding `carina-provider-aws` against this branch's `carina-plugin-sdk` rev and running `run-tests.sh full` with `CARINA_WASI_HTTP_TRACE=1`. Expected: `send_request_ms` for DELETE drops from ~20000 to tens of ms.

Closes #3254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
