### PR TITLE
state: persist v6→v7 migration through apply/destroy/refresh

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -353,6 +353,42 @@ pub async fn save_state_unlocked(
     backend.write_state(state).await.map_err(AppError::Backend)
 }
 
+/// Read state from the backend and, if `check_and_migrate` lifted the
+/// on-disk schema in memory, persist the upgraded shape immediately
+/// under the current lock.
+///
+/// This is the lock-held entry-point used by `apply`, `destroy`, and
+/// `state refresh`. Without it, the no-op short-circuits inside those
+/// commands (e.g. "No changes needed." when no resource diff exists)
+/// would skip the writer entirely and leave the on-disk version
+/// stuck at the older schema — which is the bug reported in
+/// carina#3315 and which makes carina#3283's "Disk state will be
+/// rewritten on the next `carina apply` or `carina state refresh`"
+/// warning text a lie.
+///
+/// Persistence happens exactly once per state file's schema lifetime:
+/// after the first successful run under this helper the on-disk
+/// version matches `StateFile::CURRENT_VERSION`, so subsequent
+/// `read_state` calls produce a pristine `LoadedState` and this
+/// helper is a no-op write-wise.
+pub async fn load_state_persist_if_migrated(
+    backend: &dyn StateBackend,
+    lock: Option<&LockInfo>,
+) -> Result<Option<StateFile>, AppError> {
+    match backend.read_state().await.map_err(AppError::Backend)? {
+        None => Ok(None),
+        Some(carina_state::LoadedState::Pristine(state)) => Ok(Some(state)),
+        Some(carina_state::LoadedState::Migrated { mut state, .. }) => {
+            if let Some(lk) = lock {
+                save_state_locked(backend, lk, &mut state).await?;
+            } else {
+                save_state_unlocked(backend, &mut state).await?;
+            }
+            Ok(Some(state))
+        }
+    }
+}
+
 /// Persist export changes when the plan has no mutating effects.
 ///
 /// Used when `!plan.has_mutations()` short-circuits apply: no
@@ -778,8 +814,12 @@ async fn run_apply_locked(
     base_dir: &std::path::Path,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    // Read current state from backend
-    let mut state_file = backend.read_state().await.map_err(AppError::Backend)?;
+    // Read current state from backend. carina#3315: if `check_and_migrate`
+    // lifted an older on-disk schema in memory, persist the upgrade
+    // under the current lock before any short-circuit path can return
+    // — otherwise the carina#3283 warning text ("Disk state will be
+    // rewritten on the next `carina apply`...") becomes a lie.
+    let mut state_file = load_state_persist_if_migrated(backend, lock).await?;
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
     if let Some(sf) = state_file.as_ref() {
@@ -1519,8 +1559,19 @@ async fn run_apply_from_plan_locked(
     lock: Option<&LockInfo>,
     base_dir: &std::path::Path,
 ) -> Result<(), AppError> {
-    // Read current state and validate lineage
-    let state_file = backend.read_state().await.map_err(AppError::Backend)?;
+    // Read current state and validate lineage. carina#3315: a
+    // pending in-memory schema migration must be persisted under
+    // the apply lock so the carina#3283 warning text matches
+    // reality — but we run that *after* the saved-plan
+    // lineage/serial check below, so the operator sees the original
+    // on-disk serial (the one the saved plan was diffed against)
+    // rather than a +1 bump caused by our own migration persist.
+    let (mut state_file, pending_migration) =
+        match backend.read_state().await.map_err(AppError::Backend)? {
+            None => (None, None),
+            Some(carina_state::LoadedState::Pristine(state)) => (Some(state), None),
+            Some(carina_state::LoadedState::Migrated { state, info }) => (Some(state), Some(info)),
+        };
 
     if let Some(ref state) = state_file {
         // Validate state lineage
@@ -1546,6 +1597,20 @@ async fn run_apply_from_plan_locked(
                 )
                 .yellow()
             );
+        }
+    }
+
+    // Now that the saved-plan integrity checks have run against the
+    // pristine on-disk view, persist any pending schema migration so
+    // the next short-circuit (`!plan.has_mutations()`) cannot leave
+    // the disk at the older version (carina#3315).
+    if pending_migration.is_some()
+        && let Some(state) = state_file.as_mut()
+    {
+        if let Some(lk) = lock {
+            save_state_locked(backend, lk, state).await?;
+        } else {
+            save_state_unlocked(backend, state).await?;
         }
     }
 

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -145,8 +145,12 @@ async fn run_destroy_locked(
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let ctx = WiringContext::new(factories);
 
-    // Read current state from backend
-    let mut state_file = backend.read_state().await.map_err(AppError::Backend)?;
+    // Read current state from backend. carina#3315: persist any v6→v7
+    // schema migration under the destroy lock before any short-circuit
+    // (e.g. "No resources to destroy.") returns — see
+    // `apply::load_state_persist_if_migrated`.
+    let mut state_file =
+        crate::commands::apply::load_state_persist_if_migrated(backend, lock).await?;
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
     if let Some(sf) = state_file.as_ref() {

--- a/carina-cli/src/commands/export.rs
+++ b/carina-cli/src/commands/export.rs
@@ -37,10 +37,14 @@ pub async fn run_export(
         .await
         .map_err(AppError::Backend)?;
 
+    // `carina export` is read-only; drop the pending-migration token
+    // — lock-held callers (apply/destroy/state refresh) persist
+    // schema migrations (carina#3315).
     let state_file = backend
         .read_state()
         .await
         .map_err(AppError::Backend)?
+        .map(|loaded| loaded.into_state())
         .ok_or_else(|| {
             AppError::Config("No state file found. Run 'carina apply' first.".to_string())
         })?;

--- a/carina-cli/src/commands/migrate_state.rs
+++ b/carina-cli/src/commands/migrate_state.rs
@@ -76,10 +76,18 @@ async fn perform_state_migration(
     target: &dyn StateBackend,
     force: bool,
 ) -> Result<StateFile, AppError> {
+    // `carina init --migrate-state` copies the source state into the
+    // target backend verbatim. The pending-migration token is
+    // discarded here: `target.write_state(&state)` will re-emit the
+    // state at `StateFile::CURRENT_VERSION` on disk regardless, and
+    // the `--migrate-state` command is itself the backend-relocation
+    // path (carina#3315 — schema-migration persistence is handled by
+    // apply/destroy/state-refresh in the source-or-target directory).
     let state = source
         .read_state()
         .await
         .map_err(AppError::Backend)?
+        .map(|loaded| loaded.into_state())
         .ok_or_else(|| {
             AppError::Config(
                 "The locked backend holds no state. There is nothing to migrate; \
@@ -91,7 +99,11 @@ async fn perform_state_migration(
 
     // Target guard: refuse to clobber a populated, differently-lineaged
     // target unless the operator explicitly opted in with --force.
-    if let Some(existing) = target.read_state().await.map_err(AppError::Backend)?
+    if let Some(existing) = target
+        .read_state()
+        .await
+        .map_err(AppError::Backend)?
+        .map(|loaded| loaded.into_state())
         && (existing.lineage != state.lineage || !existing.resources.is_empty())
         && !force
     {
@@ -117,6 +129,7 @@ async fn perform_state_migration(
         .read_state()
         .await
         .map_err(AppError::Backend)?
+        .map(|loaded| loaded.into_state())
         .ok_or_else(|| {
             AppError::Config(
                 "Failed to read state back from the configured backend after \
@@ -279,7 +292,7 @@ mod tests {
         let state = perform_state_migration(&src, &dst, false).await.unwrap();
         assert_eq!(state.resources.len(), 3);
 
-        let migrated = dst.read_state().await.unwrap().unwrap();
+        let migrated = dst.read_state().await.unwrap().unwrap().into_state();
         assert_eq!(migrated.lineage, "lin-1");
         assert_eq!(migrated.resources.len(), 3);
     }
@@ -300,7 +313,7 @@ mod tests {
             "got: {err:?}"
         );
         // Target must be untouched on refusal.
-        let dst_state = dst.read_state().await.unwrap().unwrap();
+        let dst_state = dst.read_state().await.unwrap().unwrap().into_state();
         assert_eq!(dst_state.lineage, "lin-dst");
     }
 
@@ -313,7 +326,7 @@ mod tests {
         dst.write_state(&state_with("lin-dst", 2)).await.unwrap();
 
         perform_state_migration(&src, &dst, true).await.unwrap();
-        let dst_state = dst.read_state().await.unwrap().unwrap();
+        let dst_state = dst.read_state().await.unwrap().unwrap().into_state();
         assert_eq!(dst_state.lineage, "lin-src");
         assert_eq!(dst_state.resources.len(), 1);
     }
@@ -391,7 +404,8 @@ mod tests {
             .read_state()
             .await
             .unwrap()
-            .unwrap();
+            .unwrap()
+            .into_state();
         assert_eq!(migrated.resources.len(), 2);
 
         // Lock now reflects the configured backend ⇒ a second run is a no-op.

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -396,8 +396,16 @@ pub async fn run_plan(
         let bucket_exists = backend.bucket_exists().await.map_err(AppError::Backend)?;
 
         if bucket_exists {
-            // Try to load state from backend
-            state_file = backend.read_state().await.map_err(AppError::Backend)?;
+            // Try to load state from backend. `plan` is read-only and
+            // already warns when an in-memory migration was applied,
+            // so it drops the migration token via `into_state()` —
+            // carina#3315 routes persistence through the lock-held
+            // `apply` / `destroy` / `state refresh` paths.
+            state_file = backend
+                .read_state()
+                .await
+                .map_err(AppError::Backend)?
+                .map(|loaded| loaded.into_state());
         } else {
             // Check if there's a matching s3_bucket resource defined
             let bucket_name = config
@@ -443,9 +451,15 @@ pub async fn run_plan(
         }
         backend
     } else {
-        // Use local backend by default
+        // Use local backend by default. Plan is read-only; drop any
+        // pending-migration token (carina#3315 — lock-held callers
+        // persist instead).
         let backend = create_local_backend();
-        state_file = backend.read_state().await.map_err(AppError::Backend)?;
+        state_file = backend
+            .read_state()
+            .await
+            .map_err(AppError::Backend)?
+            .map(|loaded| loaded.into_state());
         backend
     };
 
@@ -554,6 +568,7 @@ pub async fn run_plan(
         drift_detection_test_barrier().await;
         match plan_backend.read_state().await {
             Ok(state_t1) => {
+                let state_t1 = state_t1.map(|loaded| loaded.into_state());
                 if let Some(drift) = detect_state_drift(Some(snapshot_t0), state_t1.as_ref()) {
                     eprintln!("{}", drift.warning().yellow());
                 }
@@ -922,7 +937,14 @@ pub(crate) async fn load_upstream_states(
         cycle_guard.remove(&source_abs);
         let backend = backend_result?;
 
-        let state_file = backend.read_state().await.map_err(AppError::Backend)?;
+        // Upstream-state reads are read-only; drop any pending-migration
+        // token (carina#3315 — only the owning directory's lock-held
+        // apply / destroy / refresh persists).
+        let state_file = backend
+            .read_state()
+            .await
+            .map_err(AppError::Backend)?
+            .map(|loaded| loaded.into_state());
         let bindings = match (state_file, policy) {
             (Some(sf), _) => sf.build_remote_bindings(),
             (None, UpstreamMissingStatePolicy::Strict) => {

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -243,7 +243,9 @@ async fn load_state_file(
         .map_err(AppError::Backend)?;
 
     let state_file = backend.read_state().await.map_err(AppError::Backend)?;
-    state_file.ok_or_else(|| AppError::Config("No state file found.".to_string()))
+    state_file
+        .map(|loaded| loaded.into_state())
+        .ok_or_else(|| AppError::Config("No state file found.".to_string()))
 }
 
 /// Find a resource by binding name first, then fall back to resource name.
@@ -642,8 +644,13 @@ pub(crate) async fn run_state_refresh_locked(
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let ctx = WiringContext::new(factories);
 
-    // Read current state from backend
-    let mut state_file = backend.read_state().await.map_err(AppError::Backend)?;
+    // Read current state from backend. carina#3315: persist any v6→v7
+    // schema migration under the refresh lock before the "no
+    // resources" short-circuit returns — see
+    // `apply::load_state_persist_if_migrated`. The on-disk version
+    // must advance so the carina#3283 warning text matches reality.
+    let mut state_file =
+        crate::commands::apply::load_state_persist_if_migrated(backend, lock).await?;
 
     if state_file.as_ref().is_none_or(|s| s.resources.is_empty()) {
         let msg = if state_file.is_none() {

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -14,7 +14,7 @@ use carina_core::resource::{
     ConcreteValue, DataSource, DeferredValue, Directives, Resource, ResourceId, State, Value,
 };
 use carina_core::schema::{ResourceSchema, SchemaRegistry};
-use carina_state::{BackendError, LockInfo, ResourceState, StateBackend, StateFile};
+use carina_state::{BackendError, LoadedState, LockInfo, ResourceState, StateBackend, StateFile};
 
 use crate::commands::apply::{
     ApplyResult, detect_drift, execute_effects, finalize_apply, refresh_pending_states,
@@ -1358,8 +1358,8 @@ struct MockBackend {
 
 #[async_trait::async_trait]
 impl StateBackend for MockBackend {
-    async fn read_state(&self) -> carina_state::BackendResult<Option<StateFile>> {
-        Ok(Some(StateFile::new()))
+    async fn read_state(&self) -> carina_state::BackendResult<Option<LoadedState>> {
+        Ok(Some(LoadedState::Pristine(StateFile::new())))
     }
     async fn write_state(&self, _state: &StateFile) -> carina_state::BackendResult<()> {
         if self.write_state_fails {
@@ -1480,8 +1480,8 @@ impl LockTrackingBackend {
 
 #[async_trait::async_trait]
 impl StateBackend for LockTrackingBackend {
-    async fn read_state(&self) -> carina_state::BackendResult<Option<StateFile>> {
-        Ok(Some(StateFile::new()))
+    async fn read_state(&self) -> carina_state::BackendResult<Option<LoadedState>> {
+        Ok(Some(LoadedState::Pristine(StateFile::new())))
     }
     async fn write_state(&self, _state: &StateFile) -> carina_state::BackendResult<()> {
         self.write_state_called.store(true, Ordering::SeqCst);
@@ -2019,8 +2019,8 @@ impl RefreshTestBackend {
 
 #[async_trait::async_trait]
 impl StateBackend for RefreshTestBackend {
-    async fn read_state(&self) -> carina_state::BackendResult<Option<StateFile>> {
-        Ok(self.initial_state.clone())
+    async fn read_state(&self) -> carina_state::BackendResult<Option<LoadedState>> {
+        Ok(self.initial_state.clone().map(LoadedState::Pristine))
     }
     async fn write_state(&self, state: &StateFile) -> carina_state::BackendResult<()> {
         *self.written_state.lock().unwrap() = Some(state.clone());
@@ -2797,8 +2797,8 @@ struct CapturingBackend {
 
 #[async_trait::async_trait]
 impl StateBackend for CapturingBackend {
-    async fn read_state(&self) -> carina_state::BackendResult<Option<StateFile>> {
-        Ok(Some(StateFile::new()))
+    async fn read_state(&self) -> carina_state::BackendResult<Option<LoadedState>> {
+        Ok(Some(LoadedState::Pristine(StateFile::new())))
     }
     async fn write_state(&self, state: &StateFile) -> carina_state::BackendResult<()> {
         *self.captured.lock().unwrap() = Some(state.clone());

--- a/carina-cli/tests/apply_persists_state_migration.rs
+++ b/carina-cli/tests/apply_persists_state_migration.rs
@@ -1,0 +1,231 @@
+//! Regression test for carina#3315.
+//!
+//! After carina#3283 improved the v6→v7 migration warning to promise
+//! the operator that the upgrade "will be rewritten on the next
+//! `carina apply` or `carina state refresh`", an apply with no
+//! resource diff still left the on-disk state at v6: the no-op path
+//! returned without calling the state writer. The warning then
+//! re-emitted forever on every subsequent plan.
+//!
+//! The fix routes a migrated state load through a persist-on-load
+//! step at the lock-held entry of `apply` / `destroy` /
+//! `state refresh`, so the disk is upgraded the first time a
+//! mutating command runs under the lock — independent of whether
+//! that command has any resource or export work to do.
+//!
+//! This test pins the real binary behavior so a future refactor that
+//! re-introduces a no-op short-circuit ahead of the persist step
+//! fails loudly.
+
+use std::fs;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn plain_text_command(bin: &str) -> Command {
+    let mut cmd = Command::new(bin);
+    cmd.env("NO_COLOR", "1").env_remove("CLICOLOR_FORCE");
+    cmd
+}
+
+fn write_v6_state(dir: &std::path::Path) {
+    fs::write(
+        dir.join("main.crn"),
+        r#"backend local { path = "carina.state.json" }
+exports { region: String = "ap-northeast-1" }"#,
+    )
+    .unwrap();
+
+    let state = serde_json::json!({
+        "version": 6,
+        "serial": 1,
+        "lineage": "11111111-1111-1111-1111-111111111111",
+        "carina_version": "0.0.0-test",
+        "resources": [],
+        "exports": { "region": "ap-northeast-1" }
+    });
+    fs::write(
+        dir.join("carina.state.json"),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let status = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .args(["init", dir.to_str().unwrap()])
+        .status()
+        .expect("failed to execute carina init");
+    assert!(status.success(), "carina init failed");
+}
+
+fn read_state_version_and_serial(path: &std::path::Path) -> (u32, u64) {
+    let content = fs::read_to_string(path).expect("state file must exist");
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let version = v["version"].as_u64().expect("version field") as u32;
+    let serial = v["serial"].as_u64().expect("serial field");
+    (version, serial)
+}
+
+#[test]
+fn apply_persists_v6_to_v7_with_no_resource_diff() {
+    let dir = TempDir::new().unwrap();
+    write_v6_state(dir.path());
+
+    let state_path = dir.path().join("carina.state.json");
+    let (before_version, _before_serial) = read_state_version_and_serial(&state_path);
+    assert_eq!(before_version, 6, "test setup: state must start at v6");
+
+    // Run apply --auto-approve against a project with no source-side
+    // resources and a v6 state with no resources. The plan should be
+    // "0 to add, 0 to change, 0 to destroy" (no resource diff, no
+    // export diff), but the migrated state must still be persisted.
+    let output = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .current_dir(dir.path())
+        .args(["apply", "--auto-approve", "."])
+        .output()
+        .expect("failed to run carina apply");
+    assert!(
+        output.status.success(),
+        "carina apply failed: stderr=\n{}\nstdout=\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let (after_version, after_serial) = read_state_version_and_serial(&state_path);
+    assert_eq!(
+        after_version,
+        carina_state::StateFile::CURRENT_VERSION,
+        "apply must rewrite the on-disk state at the current schema version \
+         after a v6→v{} in-memory migration. \
+         stderr:\n{}\nstdout:\n{}",
+        carina_state::StateFile::CURRENT_VERSION,
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        after_serial > 1,
+        "apply must advance serial when persisting a migration (was 1, now {after_serial})"
+    );
+
+    // A second apply against the now-current state must NOT emit the
+    // migration warning (the disk is already at the current version).
+    let output2 = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .current_dir(dir.path())
+        .args(["apply", "--auto-approve", "."])
+        .output()
+        .expect("failed to run second carina apply");
+    assert!(output2.status.success());
+    let stderr2 = String::from_utf8_lossy(&output2.stderr);
+    assert!(
+        !stderr2.contains("is v6 on disk"),
+        "second apply must not re-emit the migration warning. stderr:\n{stderr2}"
+    );
+}
+
+#[test]
+fn apply_persists_v6_to_v7_under_no_lock_flag() {
+    // Same scenario as `apply_persists_v6_to_v7_with_no_resource_diff`
+    // but with `--lock=false`. The dispatch in
+    // `load_state_persist_if_migrated` must pick the unlocked writer
+    // (`save_state_unlocked`) when no `LockInfo` is held, and the
+    // disk still has to advance to the current schema. Caught the
+    // round-2 review gap that the locked-mode tests alone did not
+    // exercise the `lock: None` branch of the helper.
+    let dir = TempDir::new().unwrap();
+    write_v6_state(dir.path());
+
+    let state_path = dir.path().join("carina.state.json");
+    let (before_version, _) = read_state_version_and_serial(&state_path);
+    assert_eq!(before_version, 6);
+
+    let output = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .current_dir(dir.path())
+        .args(["apply", "--auto-approve", "--lock=false", "."])
+        .output()
+        .expect("failed to run carina apply --lock=false");
+    assert!(
+        output.status.success(),
+        "carina apply --lock=false failed: stderr=\n{}\nstdout=\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let (after_version, _) = read_state_version_and_serial(&state_path);
+    assert_eq!(
+        after_version,
+        carina_state::StateFile::CURRENT_VERSION,
+        "apply --lock=false must still rewrite a migrated state"
+    );
+}
+
+#[test]
+fn destroy_persists_v6_to_v7_when_state_has_no_resources() {
+    // Sibling path of `apply`: `destroy` also takes the apply lock
+    // and short-circuits ("No resources to destroy.") when the
+    // state has no managed resources. The migration must still be
+    // persisted before that short-circuit returns — otherwise an
+    // operator that runs `apply` then `destroy` on a v6 directory
+    // sees the warning re-emit forever from the destroy side too.
+    let dir = TempDir::new().unwrap();
+    write_v6_state(dir.path());
+
+    let state_path = dir.path().join("carina.state.json");
+    let (before_version, _) = read_state_version_and_serial(&state_path);
+    assert_eq!(before_version, 6);
+
+    let output = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .current_dir(dir.path())
+        .args(["destroy", "--auto-approve", "."])
+        .output()
+        .expect("failed to run carina destroy");
+    assert!(
+        output.status.success(),
+        "carina destroy failed: stderr=\n{}\nstdout=\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let (after_version, _) = read_state_version_and_serial(&state_path);
+    assert_eq!(
+        after_version,
+        carina_state::StateFile::CURRENT_VERSION,
+        "destroy must rewrite the on-disk state at the current schema \
+         version even when the no-resources short-circuit fires"
+    );
+}
+
+#[test]
+fn state_refresh_persists_v6_to_v7_when_state_has_no_resources() {
+    // `state refresh` returns early when the state has no resources
+    // ("No resources in state. Nothing to refresh."). The migration
+    // persistence must still happen on that path — otherwise a v6
+    // state with empty resources would never be upgraded by
+    // `carina state refresh` either, and the migration warning
+    // would persist forever on directories that legitimately have
+    // no managed resources yet.
+    let dir = TempDir::new().unwrap();
+    write_v6_state(dir.path());
+
+    let state_path = dir.path().join("carina.state.json");
+    let (before_version, _) = read_state_version_and_serial(&state_path);
+    assert_eq!(before_version, 6);
+
+    let output = plain_text_command(env!("CARGO_BIN_EXE_carina"))
+        .current_dir(dir.path())
+        .args(["state", "refresh", "."])
+        .output()
+        .expect("failed to run carina state refresh");
+    assert!(
+        output.status.success(),
+        "carina state refresh failed: stderr=\n{}\nstdout=\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let (after_version, _) = read_state_version_and_serial(&state_path);
+    assert_eq!(
+        after_version,
+        carina_state::StateFile::CURRENT_VERSION,
+        "state refresh must rewrite the on-disk state at the current \
+         schema version even when the empty-resource short-circuit fires"
+    );
+}

--- a/carina-state/src/backend.rs
+++ b/carina-state/src/backend.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use thiserror::Error;
 
 use crate::lock::LockInfo;
-use crate::state::StateFile;
+use crate::state::{LoadedState, StateFile};
 
 /// Errors that can occur when interacting with a state backend
 #[derive(Debug, Error)]
@@ -366,10 +366,18 @@ pub type BackendResult<T> = Result<T, BackendError>;
 /// as well as managing locks for concurrent access control.
 #[async_trait]
 pub trait StateBackend: Send + Sync {
-    /// Read the current state from the backend
+    /// Read the current state from the backend.
     ///
-    /// Returns `None` if no state exists (first-time use)
-    async fn read_state(&self) -> BackendResult<Option<StateFile>>;
+    /// Returns `None` if no state exists (first-time use). When the
+    /// on-disk schema is older than [`StateFile::CURRENT_VERSION`],
+    /// `check_and_migrate` lifts it in memory and the result is
+    /// returned as the [`LoadedState::Migrated`] variant carrying the
+    /// migration info; otherwise [`LoadedState::Pristine`].
+    /// Lock-held callers (`apply`, `destroy`, `state refresh`)
+    /// destructure the `Migrated` arm and persist `state` so the
+    /// carina#3283 warning text matches reality — otherwise the
+    /// warning re-emits forever (carina#3315).
+    async fn read_state(&self) -> BackendResult<Option<LoadedState>>;
 
     /// Write the state to the backend
     ///

--- a/carina-state/src/backends/local.rs
+++ b/carina-state/src/backends/local.rs
@@ -13,7 +13,7 @@ use tokio::time::sleep as async_sleep;
 
 use crate::backend::{BackendConfig, BackendError, BackendResult, StateBackend};
 use crate::lock::LockInfo;
-use crate::state::{self, MigrationInfo, StateFile, log_state_migration_once};
+use crate::state::{self, LoadedState, MigrationInfo, StateFile, log_state_migration_once};
 
 /// Local file backend for development and simple use cases
 pub struct LocalBackend {
@@ -233,7 +233,7 @@ impl Default for LocalBackend {
 
 #[async_trait]
 impl StateBackend for LocalBackend {
-    async fn read_state(&self) -> BackendResult<Option<StateFile>> {
+    async fn read_state(&self) -> BackendResult<Option<LoadedState>> {
         let content = match tokio::fs::read_to_string(&self.state_path).await {
             Ok(content) => content,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -252,8 +252,13 @@ impl StateBackend for LocalBackend {
                 info,
                 &self.state_path.display().to_string(),
             );
+            Ok(Some(LoadedState::Migrated {
+                state: outcome.state,
+                info,
+            }))
+        } else {
+            Ok(Some(LoadedState::Pristine(outcome.state)))
         }
-        Ok(Some(outcome.state))
     }
 
     async fn write_state(&self, state: &StateFile) -> BackendResult<()> {
@@ -581,7 +586,7 @@ mod tests {
         // Read back
         let read_state = backend.read_state().await.unwrap();
         assert!(read_state.is_some());
-        let read_state = read_state.unwrap();
+        let read_state = read_state.unwrap().into_state();
         assert_eq!(read_state.serial, 1);
     }
 
@@ -857,7 +862,7 @@ mod tests {
             .await
             .unwrap();
 
-        let read_state = backend.read_state().await.unwrap().unwrap();
+        let read_state = backend.read_state().await.unwrap().unwrap().into_state();
         assert_eq!(read_state.serial, 1);
 
         backend.release_lock(&lock).await.unwrap();

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -13,7 +13,7 @@ use carina_core::utils::convert_region_value;
 
 use crate::backend::{AwsError, BackendConfig, BackendError, BackendResult, StateBackend};
 use crate::lock::LockInfo;
-use crate::state::{self, MigrationInfo, StateFile, log_state_migration_once};
+use crate::state::{self, LoadedState, MigrationInfo, StateFile, log_state_migration_once};
 
 const REGION_UNRESOLVED_MESSAGE: &str = "S3 backend has no region: set `region` in the backend block, or configure AWS_REGION / a profile region";
 
@@ -254,7 +254,7 @@ impl S3Backend {
 
 #[async_trait]
 impl StateBackend for S3Backend {
-    async fn read_state(&self) -> BackendResult<Option<StateFile>> {
+    async fn read_state(&self) -> BackendResult<Option<LoadedState>> {
         let result = self
             .client
             .get_object()
@@ -272,14 +272,20 @@ impl StateBackend for S3Backend {
                     .map_err(|e| BackendError::Io(e.to_string()))?;
                 let bytes = body.into_bytes();
                 let outcome = state::check_and_migrate_bytes(&bytes)?;
-                if let Some(info) = outcome.migration {
+                let loaded = if let Some(info) = outcome.migration {
                     log_state_migration_once(
                         &self.migration_logged,
                         info,
                         &format!("s3://{}/{}", self.bucket, self.key.trim_start_matches('/')),
                     );
-                }
-                Ok(Some(outcome.state))
+                    LoadedState::Migrated {
+                        state: outcome.state,
+                        info,
+                    }
+                } else {
+                    LoadedState::Pristine(outcome.state)
+                };
+                Ok(Some(loaded))
             }
             Err(err) => {
                 if is_not_found_error(&err) {

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -58,6 +58,6 @@ pub use backends::{
 };
 pub use lock::LockInfo;
 pub use state::{
-    MigratedStateFile, MigrationInfo, ResourceState, StateFile, check_and_migrate,
+    LoadedState, MigratedStateFile, MigrationInfo, ResourceState, StateFile, check_and_migrate,
     check_and_migrate_bytes, log_state_migration_once,
 };

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -443,6 +443,59 @@ impl MigratedStateFile {
     }
 }
 
+/// A state file just read from a backend, tagged with whether
+/// `check_and_migrate` had to lift the on-disk schema in memory.
+/// Returned from [`crate::backend::StateBackend::read_state`].
+///
+/// The two-variant shape (rather than `StateFile + Option<MigrationInfo>`)
+/// forces every consumer to `match` on the pristine vs. migrated case
+/// at the boundary. Lock-held call sites (`apply`, `destroy`,
+/// `state refresh`) bind the `Migrated { state, info }` arm and
+/// persist the upgraded shape before any short-circuit return, so the
+/// carina#3283 warning ("Disk state will be rewritten on the next
+/// `carina apply` or `carina state refresh`") matches reality —
+/// carina#3315. Read-only call sites (`plan`, exports, `state
+/// list/show/lookup`, etc.) bind both arms identically and discard
+/// `info` explicitly — the discard is visible in the source rather
+/// than hidden inside an `Option::None`.
+///
+/// Intentionally not `Clone`: a [`StateFile`] can hold every resource
+/// in the deployment, so accidentally cloning the wrapper would clone
+/// the full state. Consume the wrapper at the call site via
+/// [`Self::into_state`] (read-only paths) or by destructuring the
+/// enum directly (lock-held paths that need the `MigrationInfo`).
+#[derive(Debug)]
+#[must_use = "a loaded state must be either persisted (lock-held paths) or \
+              explicitly consumed via .into_state() (read-only paths); \
+              see LoadedState docs for the carina#3315 invariant"]
+pub enum LoadedState {
+    /// The on-disk state already matched [`StateFile::CURRENT_VERSION`];
+    /// no in-memory migration was applied.
+    Pristine(StateFile),
+    /// `check_and_migrate` lifted the on-disk state to
+    /// [`StateFile::CURRENT_VERSION`] in memory. Lock-held callers
+    /// must persist `state` so the disk reflects the new schema.
+    Migrated {
+        state: StateFile,
+        info: MigrationInfo,
+    },
+}
+
+impl LoadedState {
+    /// Consume the wrapper, returning the state and dropping any
+    /// pending-migration indicator. Use this for read-only paths
+    /// (`plan`, exports, `state list/show/lookup`) where the on-disk
+    /// version is reported via a separate warning and not persisted.
+    /// Lock-held paths destructure the enum directly so the
+    /// `MigrationInfo` is a named binding rather than a hidden drop.
+    pub fn into_state(self) -> StateFile {
+        match self {
+            Self::Pristine(s) => s,
+            Self::Migrated { state, .. } => state,
+        }
+    }
+}
+
 /// Emit the state-schema migration warning to stderr at most once for
 /// the given `OnceLock`-protected slot. Backends call this from
 /// `read_state` so a single `carina plan` run — which reads state

--- a/carina-state/tests/s3_backend_winterbaume.rs
+++ b/carina-state/tests/s3_backend_winterbaume.rs
@@ -87,7 +87,8 @@ async fn init_auto_creates_bucket_and_seeds_empty_state() {
         .read_state()
         .await
         .unwrap()
-        .expect("init should seed a state file");
+        .expect("init should seed a state file")
+        .into_state();
     assert_eq!(
         state.version,
         StateFile::CURRENT_VERSION,
@@ -128,7 +129,8 @@ async fn write_then_read_state_round_trips() {
         .read_state()
         .await
         .unwrap()
-        .expect("state written above should be readable");
+        .expect("state written above should be readable")
+        .into_state();
     // `StateFile` has no `PartialEq`; compare the fields that prove the
     // bytes round-tripped through S3 unchanged. `lineage` is preserved
     // (not regenerated) so it pins identity across the write/read.
@@ -227,7 +229,7 @@ async fn write_state_locked_succeeds_for_held_lock() {
     state.increment_serial();
     backend.write_state_locked(&state, &lock).await.unwrap();
 
-    let read_back = backend.read_state().await.unwrap().unwrap();
+    let read_back = backend.read_state().await.unwrap().unwrap().into_state();
     assert_eq!(
         read_back.lineage, state.lineage,
         "locked write must persist the state we passed in",


### PR DESCRIPTION
## Summary

After carina#3283 improved the in-memory-migration warning text to promise the operator that the upgrade would be "rewritten on the next `carina apply` or `carina state refresh`," the implementation never actually wrote: the no-op short-circuits in those commands (`No changes needed.`, `No resources in state. Nothing to refresh.`, `No resources to destroy.`) returned without calling the state writer. A v6 state file with no resource diff sat on disk as v6 forever and the migration warning re-emitted on every subsequent plan/apply/refresh.

## Root cause

`StateBackend::read_state()` returned `Option<StateFile>` and silently dropped the in-memory `check_and_migrate` outcome, so no consumer could tell that a schema upgrade was pending. Every short-circuit in apply/destroy/state-refresh then chose "skip the writer" based purely on resource/export diff, missing the schema-version delta. Filtering at each short-circuit site is the bandaid; the type-level fix is to make the migration outcome visible at the backend boundary.

## Fix

- New tagged enum `LoadedState::{ Pristine(StateFile), Migrated { state, info } }` in `carina-state`. Consumers must `match` or call `.into_state()` — there is no `Option` to silently drop. `#[must_use]` on the type makes accidental discards even noisier.
- `StateBackend::read_state()` now returns `Option<LoadedState>`; both production backends (`LocalBackend`, `S3Backend`) and the four CLI mocks updated.
- New helper `apply::load_state_persist_if_migrated(backend, lock)` called from `run_apply_locked`, `run_destroy_locked`, and `run_state_refresh_locked`. When the read returns `Migrated` it persists the upgraded shape under the held lock immediately, before any short-circuit can return. After the first run the disk reads as `Pristine` forever, so the extra write is a one-time cost per state file.
- `run_apply_from_plan_locked` does the same persist but reorders: the saved-plan lineage/serial check runs against the pre-persist on-disk view, so the operator does not see a spurious "serial changed" warning caused by our own migration write.
- Read-only callers (`plan`, `export`, `state list/show/lookup`, `init --migrate-state`, upstream-state reads) call `loaded.into_state()` to discard the migration token explicitly — the discard is visible in source, not hidden inside an `Option`.

## Test plan

- [x] `carina-cli/tests/apply_persists_state_migration.rs` (new) — drives the real `carina` binary against a hand-authored v6 state and asserts the disk is rewritten at the current schema version for four short-circuit paths: `apply` no-resource-diff, `apply --lock=false`, `destroy` no-resources, and `state refresh` no-resources. First test additionally runs `apply` a second time and verifies the migration warning is gone.
- [x] `cargo nextest run --workspace --all-features` — 3655 tests pass.
- [x] `cargo test --workspace --doc` — passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all 5 invariant scripts pass.

Closes #3315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
