### PR TITLE
wasi_http: chunk write_body to fit wasi:io blocking-write-and-flush 4096-byte cap

### DIFF
--- a/carina-plugin-sdk/src/wasi_http.rs
+++ b/carina-plugin-sdk/src/wasi_http.rs
@@ -27,7 +27,10 @@ use wasi::http::types::{
 };
 use wasi::io::streams::StreamError;
 
-use crate::wasi_http_body::{RequestBody, inject_content_length_header};
+use crate::wasi_http_body::{
+    BLOCKING_WRITE_AND_FLUSH_MAX_BYTES, RequestBody, chunks_for_blocking_write,
+    inject_content_length_header,
+};
 
 /// When `CARINA_WASI_HTTP_TRACE=1` is set in the host environment, emit a
 /// per-phase wall-clock breakdown of each request to stderr.
@@ -343,14 +346,25 @@ fn make_request(
     Ok(sdk_response)
 }
 
-/// Write bytes to an outgoing body.
+/// Write bytes to an outgoing body, respecting the wasi:io
+/// `blocking-write-and-flush` per-call byte limit.
+///
+/// `blocking_write_and_flush` in `wasmtime-wasi-io` traps the
+/// component instance when the guest passes more than
+/// [`BLOCKING_WRITE_AND_FLUSH_MAX_BYTES`] bytes at once
+/// (carina-rs/carina#3318). The cap is part of the wasi:io WIT
+/// contract; a trap there poisons the instance, so the next guest
+/// entry fails with `cannot enter component instance`. Splitting via
+/// [`chunks_for_blocking_write`] keeps every call inside the
+/// contract, regardless of how large the SDK-buffered body is.
 fn write_body(body: &OutgoingBody, data: &[u8]) -> Result<(), ConnectorError> {
     let stream = body
         .write()
         .map_err(|()| ConnectorError::other("Failed to get output stream".into(), None))?;
-    if !data.is_empty() {
+    for chunk in chunks_for_blocking_write(data) {
+        debug_assert!(chunk.len() <= BLOCKING_WRITE_AND_FLUSH_MAX_BYTES);
         stream
-            .blocking_write_and_flush(data)
+            .blocking_write_and_flush(chunk)
             .map_err(|e| ConnectorError::other(format!("Write error: {e:?}").into(), None))?;
     }
     drop(stream);

--- a/carina-plugin-sdk/src/wasi_http_body.rs
+++ b/carina-plugin-sdk/src/wasi_http_body.rs
@@ -1,5 +1,19 @@
 //! Body framing for wasi:http outgoing requests.
 //!
+//! # Two invariants enforced here
+//!
+//! 1. **Every buffered body crosses the wasi:http boundary with an explicit
+//!    `Content-Length`** — see `RequestBody` / `inject_content_length_header`
+//!    below (carina-rs/carina#3254).
+//! 2. **Every call into `wasi:io::OutputStream::blocking_write_and_flush`
+//!    carries at most `BLOCKING_WRITE_AND_FLUSH_MAX_BYTES` bytes** — see
+//!    `chunks_for_blocking_write` below (carina-rs/carina#3318). The
+//!    wasi:io contract caps a single `blocking-write-and-flush` at
+//!    4096 bytes; the host `wasmtime-wasi-io` returns a *trap* (not a
+//!    recoverable error) on overflow, which leaves the WASM instance
+//!    re-entry-locked. A 4157-byte CloudControl `UpdateResource` body
+//!    triggered this; the splitter restores the contract.
+//!
 //! # Why this exists
 //!
 //! `wasi:http` and the host-side `wasmtime_wasi_http` bridge let the guest
@@ -94,6 +108,32 @@ impl RequestBody {
     }
 }
 
+/// Maximum bytes accepted by a single
+/// `wasi:io::OutputStream::blocking_write_and_flush` call.
+///
+/// Pinned by the wasi:io WIT contract; the host implementation
+/// (`wasmtime-wasi-io::impls::OutputStream::blocking_write_and_flush`)
+/// returns a `StreamError::trap` — not a recoverable error — when the
+/// guest passes more than this. A trap on the wasi:io path poisons the
+/// component instance from wasmtime's point of view, so the very next
+/// guest entry fails with `cannot enter component instance` (the
+/// cascade observed in carina-rs/carina#3318). Always feed bodies
+/// through [`chunks_for_blocking_write`] before handing them to the
+/// stream.
+pub(crate) const BLOCKING_WRITE_AND_FLUSH_MAX_BYTES: usize = 4096;
+
+/// Split `data` into chunks no larger than
+/// [`BLOCKING_WRITE_AND_FLUSH_MAX_BYTES`], in order, so each chunk can
+/// be passed to `wasi:io::OutputStream::blocking_write_and_flush`
+/// without tripping the host-side trap.
+///
+/// Empty input yields no chunks (the caller must skip the stream write
+/// entirely, the same as before the splitter existed). Concatenating
+/// the returned chunks in order reproduces the input exactly.
+pub(crate) fn chunks_for_blocking_write(data: &[u8]) -> impl Iterator<Item = &[u8]> {
+    data.chunks(BLOCKING_WRITE_AND_FLUSH_MAX_BYTES)
+}
+
 /// Add a `content-length` header to `headers` if not already present.
 ///
 /// Headers come in as the `(name, value-bytes)` list that
@@ -183,6 +223,65 @@ mod tests {
             .collect();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].1, b"42".to_vec());
+    }
+
+    #[test]
+    fn chunks_empty_yields_nothing() {
+        let chunks: Vec<&[u8]> = chunks_for_blocking_write(&[]).collect();
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn chunks_under_limit_yields_single_chunk() {
+        let data = vec![0xAB; BLOCKING_WRITE_AND_FLUSH_MAX_BYTES - 1];
+        let chunks: Vec<&[u8]> = chunks_for_blocking_write(&data).collect();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), BLOCKING_WRITE_AND_FLUSH_MAX_BYTES - 1);
+    }
+
+    #[test]
+    fn chunks_exactly_at_limit_yields_single_chunk() {
+        let data = vec![0xCD; BLOCKING_WRITE_AND_FLUSH_MAX_BYTES];
+        let chunks: Vec<&[u8]> = chunks_for_blocking_write(&data).collect();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), BLOCKING_WRITE_AND_FLUSH_MAX_BYTES);
+    }
+
+    #[test]
+    fn chunks_over_limit_yields_multiple_bounded_chunks() {
+        // 4157-byte body — the size of the CloudControl `UpdateResource`
+        // call that triggered carina-rs/carina#3318 on the real
+        // `awscc.iam.RolePolicy` update.
+        let data = vec![0xEF; 4157];
+        let chunks: Vec<&[u8]> = chunks_for_blocking_write(&data).collect();
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), BLOCKING_WRITE_AND_FLUSH_MAX_BYTES);
+        assert_eq!(chunks[1].len(), 4157 - BLOCKING_WRITE_AND_FLUSH_MAX_BYTES);
+        // Reassembled, the chunks must equal the input.
+        let mut joined: Vec<u8> = Vec::new();
+        for c in &chunks {
+            joined.extend_from_slice(c);
+        }
+        assert_eq!(joined, data);
+        // Every chunk is within the wasi:io limit.
+        for c in &chunks {
+            assert!(c.len() <= BLOCKING_WRITE_AND_FLUSH_MAX_BYTES);
+        }
+    }
+
+    #[test]
+    fn chunks_far_over_limit_yields_only_bounded_chunks() {
+        // Stress: ten-times the limit plus a tail.
+        let total = BLOCKING_WRITE_AND_FLUSH_MAX_BYTES * 10 + 123;
+        let data = vec![0x42u8; total];
+        let chunks: Vec<&[u8]> = chunks_for_blocking_write(&data).collect();
+        let mut sum = 0;
+        for c in &chunks {
+            assert!(c.len() <= BLOCKING_WRITE_AND_FLUSH_MAX_BYTES);
+            sum += c.len();
+        }
+        assert_eq!(sum, total);
+        assert_eq!(chunks.len(), 11);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `wasi:io::OutputStream::blocking_write_and_flush` is contracted to accept at most 4096 bytes per call; the host (`wasmtime-wasi-io`) returns `StreamError::trap` on overflow, which **traps the component instance** (not a recoverable error) and leaves it re-entry-locked. The next guest entry fails with `cannot enter component instance`.
- `wasi_http::write_body` was passing the **whole SDK-buffered body** in one call. Bodies ≤4096 bytes (the GetResource/STS/IAM calls in #3318's trace) worked; a 4157-byte CloudControl `UpdateResource` body — the size of the real `awscc.iam.RolePolicy` update — tripped the cap, trapping the awscc instance and cascading into `WASM trap in read: cannot enter component instance` on the post-apply refresh.
- Fix: split the body into ≤4096-byte chunks via `chunks_for_blocking_write` (a pure helper in `wasi_http_body`) and write one chunk per call. The chunk invariants (≤4096 per chunk, order-preserving, concat reproduces input, empty→no chunks) are unit-tested directly.

## Root cause vs. symptoms

The 4096B cap is the **single upstream invariant** — every `blocking_write_and_flush` site must respect it. `write_body` is the only such site in `carina-plugin-sdk` (`blocking_read` in `read_body` has no equivalent host cap; the `len` parameter is a *maximum*, not a contract). Putting the chunk splitter on the body path closes the invariant for every body shape the SDK buffers, including any future caller in the same file.

## Reproduction (before this PR)

Against `carina-rs/infra@0fae933, envs/registry/dev/infra-deploy/`:

```
Applying changes...

  ✗ Update awscc.iam.RolePolicy registry_infra_deploy.awscc_iam_role_policy_d88bef72 [0.0s] 1/1
      → WASM trap in update: error while executing at wasm backtrace:
    1: 0x4bd4bf - ...!wasip2::imports::wasi::io::streams::OutputStream::blocking_write_and_flush
    2: 0x471d39 - ...!carina_plugin_sdk::wasi_http::write_body
    ...

Refreshing uncertain resource states...
  ! Refresh awscc.iam.RolePolicy ... - WASM trap in read: wasm trap: cannot enter component instance

Error: Apply failed. 0 succeeded, 1 failed.
```

`CARINA_WASI_HTTP_TRACE=1` shows the trapping call:

```
method=POST uri=https://cloudcontrolapi.ap-northeast-1.amazonaws.com/
body_in=4157
content-length=4157
x-amz-target=CloudApiService.UpdateResource
```

All earlier requests in the same apply (GetResource 73/115 bytes, STS 43 bytes, IAM 85 bytes) completed normally — every one of them was ≤ 4096 bytes.

The host wasi:io contract is the explicit source of the cap (`wasmtime-wasi-io::impls::OutputStream::blocking_write_and_flush`):

```rust
if bytes.len() > 4096 {
    return Err(StreamError::trap(
        "Buffer too large for blocking-write-and-flush (expected at most 4096)",
    ));
}
```

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3655 passed, 0 failed.
- [x] `cargo test --workspace --doc` — passed.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo check -p carina-plugin-sdk --target wasm32-wasip2` — compiles.
- [x] All `scripts/check-*.sh` — passed.
- [x] New unit tests cover: empty input, under limit, exactly at limit, over limit (the 4157B case from this issue), and a 10×-limit stress case.
- [ ] Real-AWS confirmation against `carina-rs/infra@0fae933, envs/registry/dev/infra-deploy/` (needs provider-side rev bump to pull this carina-plugin-sdk into the awscc/aws WASM artifacts — same shape as past WIT/SDK changes).

Closes #3318