### PR TITLE
wasi_http: call outgoing-handler.handle before writing the body

### DIFF
--- a/carina-plugin-sdk/src/wasi_http.rs
+++ b/carina-plugin-sdk/src/wasi_http.rs
@@ -250,25 +250,39 @@ fn make_request(
 
     let t_setup_done = req_start.map(|s| s.elapsed());
 
-    // Write the request body. `body` was classified above so the
-    // wasi:http `OutgoingBody` only ever sees a known-sized payload
-    // (Empty → no stream write; Sized → exactly `body.content_length()`
-    // bytes, matching the `content-length` header we injected).
+    // Acquire the `OutgoingBody` resource **before** handing the
+    // request to `outgoing_handler::handle`. `outgoing_request.body()`
+    // constructs the host-side mpsc channel that backs the body, and
+    // the `OutgoingBody` resource is allowed to outlive the request
+    // (see `wasmtime_wasi_http::p2::types_impl`: "we could be still
+    // writing to the stream after `outgoing-handler.handle` is
+    // called").
     let body_len = body.content_length();
     let outgoing_body = outgoing_req
         .body()
         .map_err(|()| ConnectorError::other("Failed to get outgoing body".into(), None))?;
+
+    // Hand the request off to the host *first* so the hyper task that
+    // consumes the body channel is spawned before we start writing.
+    // If we wrote the body first, the host channel (default capacity
+    // `outgoing_body_buffer_chunks + 1 = 2`) would fill up with no
+    // reader on the other side, and the trailing `write_ready().await`
+    // inside `wasmtime-wasi-io`'s `blocking_write_and_flush` default
+    // impl would block forever — the carina-rs/carina#3320 20-minute
+    // host I/O hang.
+    let future_response = outgoing_handler::handle(outgoing_req, options).map_err(|e| {
+        ConnectorError::other(format!("outgoing-handler error: {e:?}").into(), None)
+    })?;
+    let t_handle_done = req_start.map(|s| s.elapsed());
+
+    // Now ship the body. The hyper consumer is live, so each
+    // `blocking_write_and_flush` chunk drains as it goes and the
+    // channel stays well below its capacity bound.
     write_body(&outgoing_body, body.as_bytes())?;
     let t_write_body_done = req_start.map(|s| s.elapsed());
     OutgoingBody::finish(outgoing_body, None)
         .map_err(|e| ConnectorError::other(format!("Failed to finish body: {e:?}").into(), None))?;
     let t_body_finish_done = req_start.map(|s| s.elapsed());
-
-    // Send the request (with timeout options if provided)
-    let future_response = outgoing_handler::handle(outgoing_req, options).map_err(|e| {
-        ConnectorError::other(format!("outgoing-handler error: {e:?}").into(), None)
-    })?;
-    let t_handle_done = req_start.map(|s| s.elapsed());
 
     // Wait for the response by polling
     let pollable = future_response.subscribe();
@@ -309,9 +323,15 @@ fn make_request(
         // pollable.block) are the ones that flag a host-side stall when they
         // grow.
         let ms = |d: Option<Duration>| d.map(|x| x.as_millis()).unwrap_or(0);
+        // Columns are emitted in execution order so a reader can scan
+        // left-to-right and see where the wall-clock went. The order
+        // is: setup → handle (hand request off so the hyper consumer
+        // is live before we write — see carina-rs/carina#3320) →
+        // write_body → body_finish → pollable_block → get_response →
+        // read_body.
         eprintln!(
             "carina-wasi-http-trace method={} uri={} status={} body_in={} body_out={} \
-             setup_ms={} write_body_ms={} body_finish_ms={} handle_ms={} \
+             setup_ms={} handle_ms={} write_body_ms={} body_finish_ms={} \
              pollable_block_ms={} get_response_ms={} read_body_ms={}",
             trace_method,
             trace_uri,
@@ -319,9 +339,9 @@ fn make_request(
             body_len,
             response_bytes.len(),
             ms(t_setup_done),
+            ms(t_handle_done),
             ms(t_write_body_done),
             ms(t_body_finish_done),
-            ms(t_handle_done),
             ms(t_pollable_block_done),
             ms(t_get_response_done),
             ms(t_read_body_done),


### PR DESCRIPTION
## Summary

- After carina-rs/carina#3318 chunked `write_body` to fit the wasi:io 4096-byte per-call cap, multi-chunk requests started **hanging for the full 20-minute carina hard timeout** instead of trapping. A 4157-byte CloudControl `UpdateResource` body (the `awscc.iam.RolePolicy` update case) was the trigger.
- Root cause: `wasi_http::make_request` was writing the request body **before** calling `outgoing_handler::handle`. With no hyper task spawned yet, the host-side mpsc channel that backs the body (capacity `outgoing_body_buffer_chunks + 1 = 2`) never drained, and the trailing `write_ready().await` inside `wasmtime-wasi-io`'s `blocking_write_and_flush` default impl blocked on the second chunk forever.
- Fix: hand the request to `outgoing_handler::handle` first; ship the body afterwards. wasmtime-wasi-http documents this ordering explicitly:

> The output stream will necessarily outlive the request, because we could be still writing to the stream after `outgoing-handler.handle` is called.

Single-chunk bodies (4096 bytes or less) hid the bug because the loop left one channel slot free for the trailing `write_ready` reservation. Anything over 4096 bytes tripped it.

## Why this is the root cause

The wasi:http guest contract is "you may write to the stream after `outgoing-handler.handle` is called" — but the previous code wrote to the stream **before** ever calling `handle`. That works only as long as the entire body fits in the channel-1 reserve slot, which is the special case `wasi_http_body::BLOCKING_WRITE_AND_FLUSH_MAX_BYTES` (4096 bytes). The instant we started chunking, we exposed the latent ordering bug that the single-chunk path had been hiding.

`outgoing_handler::handle` consumes the `outgoing_request`, but the `outgoing_body` resource the guest holds is allowed to outlive the request (see `wasmtime_wasi_http::p2::types_impl`), so the natural call order is `body()` → `handle(req)` → `write` → `finish(body)` → `subscribe()` → `block()`. That is what this PR encodes.

The trace columns are reordered to match the new execution order (setup → handle → write_body → body_finish → pollable_block) so the cumulative-ms breakdown reads left-to-right in time. Otherwise, no behavior change for in-spec single-chunk requests.

## Reproduction

`carina-rs/infra@0fae933, envs/registry/dev/infra-deploy/`, `awscc.iam.RolePolicy` 4157-byte `UpdateResource`. With current main + new awscc:

```
Applying changes...
  ✗ Update awscc.iam.RolePolicy ... [20m 0.0s] 1/1
      → WASM plugin operation 'update' exceeded 1200s (host-side I/O wait
        that epoch interruption cannot reach; check network/AWS connectivity)
```

`CARINA_WASI_HTTP_TRACE=1` shows the request hangs *between* `carina-wasi-http-trace-headers` and the host-side `carina-host-http-trace-phases` line — i.e. before `outgoing_handler::handle` ever fires. AWS-side checks (`aws iam get-role-policy`) return in 1 s; no traffic reaches AWS during the 20-minute hang.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3660 passed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check -p carina-plugin-sdk --target wasm32-wasip2` — compiles
- [x] All `scripts/check-*.sh` — passed
- [ ] Real-AWS confirmation against `carina-rs/infra@0fae933, envs/registry/dev/infra-deploy/` (needs the awscc rev bump that follows this PR to pull this carina-plugin-sdk into the provider WASM artifact — same flow as #3319 / awscc#278).

Closes #3320