### PR TITLE
plan: rebadge composition group header to `module "<binding>" (<source_path>)`

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -850,9 +850,12 @@ fn format_plan_tree<'a>(
     // #3307: when an ExpansionTrace is supplied AND it actually
     // records lineage for the plan's leaves, group root rows by their
     // outermost composition call site. Within each composition group,
-    // a `Composition "<binding>"` header is printed first, followed by
-    // the leaf rows. Roots with no lineage entry render at the
-    // top level as before.
+    // a `module "<binding>" (<source_path>)` header is printed first,
+    // followed by the leaf rows. Roots with no lineage entry render
+    // at the top level as before. (carina#3307 introduced the
+    // grouping; carina#3322 renamed the user-facing label from
+    // `Composition "<binding>"` to the DSL-visible
+    // `module "<binding>" (<source_path>)` shape.)
     let composition_groups = group_roots_by_outermost_composition(plan, &roots, expansion_trace);
 
     if composition_groups.has_any_grouping() {
@@ -867,7 +870,12 @@ fn format_plan_tree<'a>(
         // composition header marks the group, and the per-line `Composition`
         // header visually separates groups.
         for group in &composition_groups.grouped {
-            writeln!(ctx.out, "{}", format_composition_header(&group.binding)).unwrap();
+            writeln!(
+                ctx.out,
+                "{}",
+                format_composition_header(&group.binding, group.source_path.as_deref())
+            )
+            .unwrap();
             for (li, leaf_idx) in group.leaves.iter().enumerate() {
                 let leaf_last = li == group.leaves.len() - 1;
                 ctx.format_effect_tree(*leaf_idx, 0, leaf_last, "  ", None);
@@ -894,9 +902,25 @@ fn format_plan_tree<'a>(
 }
 
 /// Header row for a composition group in the folded plan layout.
-fn format_composition_header(binding: &str) -> String {
+///
+/// Renders `+ module "<binding>" (<source_path>)`, dropping the
+/// parenthesized suffix when the call site has no recorded
+/// `source_path` (hand-built traces, test fixtures). The keyword
+/// `module` matches the DSL `module_call` construct the operator
+/// wrote (`let r = infra { ... }`), so it is something they can
+/// trace back to their own `.crn` — unlike the previous internal
+/// `Composition` label (carina#3322).
+fn format_composition_header(binding: &str, source_path: Option<&str>) -> String {
     use colored::Colorize;
-    format!("{} Composition \"{}\"", "+".cyan(), binding.cyan().bold())
+    match source_path {
+        None => format!("{} module \"{}\"", "+".cyan(), binding.cyan().bold()),
+        Some(path) => format!(
+            "{} module \"{}\" {}",
+            "+".cyan(),
+            binding.cyan().bold(),
+            format!("({})", path).dimmed(),
+        ),
+    }
 }
 
 /// Bucket of root effects, partitioned into the ones nested inside a
@@ -916,6 +940,11 @@ impl CompositionGroups {
 struct CompositionGroup {
     /// Display label — the call site's binding (instance prefix), e.g. `cluster`.
     binding: String,
+    /// `use { source = "..." }` path the module was loaded from.
+    /// `None` when the trace was built without a recorded path (test
+    /// fixtures, hand-built traces); the renderer drops the
+    /// parenthesized suffix then.
+    source_path: Option<String>,
     /// Root indices in `plan.effects()` that belong to this group.
     leaves: Vec<usize>,
 }
@@ -940,9 +969,11 @@ fn group_roots_by_outermost_composition(
     };
 
     // Map: outermost call-site name → group leaves (preserves first
-    // appearance order).
+    // appearance order). `source_path` is recorded on first sight; the
+    // expander stamps every leaf of the same call site with the same
+    // path, so later sightings can be ignored.
     let mut order: Vec<String> = Vec::new();
-    let mut by_call_site: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut by_call_site: HashMap<String, (Option<String>, Vec<usize>)> = HashMap::new();
     let mut ungrouped: Vec<usize> = Vec::new();
 
     for &root_idx in roots {
@@ -953,12 +984,16 @@ fn group_roots_by_outermost_composition(
             .and_then(|pid| trace.call_sites_of(&pid).first().cloned());
 
         match outer {
-            Some(eid) => {
-                let key = eid.inner().name.as_str().to_string();
+            Some(site) => {
+                let key = site.binding().to_string();
                 if !by_call_site.contains_key(&key) {
                     order.push(key.clone());
                 }
-                by_call_site.entry(key).or_default().push(root_idx);
+                by_call_site
+                    .entry(key)
+                    .or_insert_with(|| (site.source_path.clone(), Vec::new()))
+                    .1
+                    .push(root_idx);
             }
             None => ungrouped.push(root_idx),
         }
@@ -967,8 +1002,12 @@ fn group_roots_by_outermost_composition(
     let grouped: Vec<CompositionGroup> = order
         .into_iter()
         .map(|binding| {
-            let leaves = by_call_site.remove(&binding).unwrap_or_default();
-            CompositionGroup { binding, leaves }
+            let (source_path, leaves) = by_call_site.remove(&binding).unwrap_or_default();
+            CompositionGroup {
+                binding,
+                source_path,
+                leaves,
+            }
         })
         .collect();
 

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1677,3 +1677,25 @@ fn test_refresh_plan_separator_emits_blank_line_after_refresh() {
 fn test_refresh_plan_separator_no_blank_line_without_refresh() {
     assert_eq!(refresh_plan_separator(false), "");
 }
+
+/// carina#3322: the composition group header reads
+/// `+ module "<binding>" (<source_path>)`. The keyword is `module`,
+/// not the internal `Composition`; the binding name is the user's
+/// `let` LHS, and the parenthesized suffix surfaces the DSL `use`
+/// path so the operator can trace the group back to a real `.crn`
+/// file.
+#[test]
+fn test_composition_header_renders_module_with_source_path() {
+    let header = strip_ansi(&format_composition_header("r", Some("./modules/infra")));
+    assert_eq!(header, r#"+ module "r" (./modules/infra)"#);
+}
+
+/// Fallback shape when no `use` path was recorded for the call site
+/// (test fixtures, hand-built traces). The parenthesized suffix is
+/// dropped so the header still reads as a clean `+ module "<binding>"`
+/// line — never as a literal "None" or an empty `()`.
+#[test]
+fn test_composition_header_drops_parens_for_none_source_path() {
+    let header = strip_ansi(&format_composition_header("r", None));
+    assert_eq!(header, r#"+ module "r""#);
+}

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -39,6 +39,11 @@ pub struct FixturePlan {
     /// default fields the user never wrote do not surface in plan
     /// output (refs awscc#206).
     pub prev_explicit: HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
+    /// Plan-scoped lineage of leaf nodes back to their composition
+    /// call sites — surfaced here so fixture-based snapshot tests
+    /// can render the composition-group header the same way the
+    /// real `carina plan` command does (carina#3322).
+    pub expansion_trace: carina_core::resource::ExpansionTrace,
 }
 
 /// Build a plan from a fixture directory name (e.g. "all_create"). Resolves
@@ -291,6 +296,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         deferred_for_expressions: parsed.deferred_for_expressions,
         export_params: parsed.export_params,
         prev_explicit,
+        expansion_trace: parsed.expansion_trace,
     }
 }
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -1523,15 +1523,20 @@ fn snapshot_server_default_struct_leaf() {
     );
 }
 
-/// #3307 acceptance: when an `ExpansionTrace` records two leaf resources
-/// under a composition call site, the rendered plan groups them under a
-/// `Composition "<binding>"` header. The third leaf, declared at the
-/// DSL root with no trace entry, stays at the top level.
+/// carina#3307 + carina#3322 acceptance: when an `ExpansionTrace`
+/// records two leaf resources under a composition call site, the
+/// rendered plan groups them under a
+/// `module "<binding>" (<source_path>)` header. The third leaf,
+/// declared at the DSL root with no trace entry, stays at the top
+/// level. The header label was rebadged from the internal
+/// `Composition "<binding>"` term in carina#3322.
 #[test]
 fn snapshot_composition_folding() {
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{EphemeralId, ExpansionTrace, PersistentId, Resource, ResourceId};
+    use carina_core::resource::{
+        CallSite, EphemeralId, ExpansionTrace, PersistentId, Resource, ResourceId,
+    };
     use carina_core::schema::SchemaRegistry;
 
     let mut plan = Plan::new();
@@ -1550,7 +1555,13 @@ fn snapshot_composition_folding() {
     plan.add(Effect::Create(logs));
 
     let mut trace = ExpansionTrace::new();
-    let cluster_site = EphemeralId::new(ResourceId::new("_virtual", "cluster"));
+    // carina#3322: the call site carries the `use { source = "..." }`
+    // path so the rendered header reads
+    // `module "cluster" (./modules/cluster)`.
+    let cluster_site = CallSite::new(
+        EphemeralId::new(ResourceId::new("_virtual", "cluster")),
+        "./modules/cluster",
+    );
     trace.record(PersistentId::new(inner_id), vec![cluster_site.clone()]);
     trace.record(PersistentId::new(inner_role_id), vec![cluster_site]);
 
@@ -1568,11 +1579,17 @@ fn snapshot_composition_folding() {
     ));
     insta::assert_snapshot!(output);
 
-    // Acceptance: the composition header must appear, with both leaves
-    // following it in the output.
+    // Acceptance: the rebadged module header must appear, with the
+    // DSL-visible source path in parens, and the two leaves following
+    // it in the output (carina#3322).
     assert!(
-        output.contains("Composition \"cluster\""),
-        "expected `Composition \"cluster\"` header in:\n{}",
+        output.contains("module \"cluster\" (./modules/cluster)"),
+        "expected `module \"cluster\" (./modules/cluster)` header in:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("Composition"),
+        "must not leak internal `Composition` term in:\n{}",
         output
     );
     assert!(
@@ -1584,5 +1601,46 @@ fn snapshot_composition_folding() {
         output.contains("logs"),
         "expected ungrouped `logs` leaf row in:\n{}",
         output
+    );
+}
+
+/// carina#3322 end-to-end: loading a real multi-file fixture
+/// (`module_anonymous_resource` — main.crn + an `oidc-module/`
+/// subdirectory referenced as `use { source = './oidc-module' }`)
+/// must render the composition group with `module "<binding>"
+/// (./oidc-module)`. This exercises the full pipeline:
+/// `process_imports` records `module_paths`, `expand_module_call`
+/// stamps each `CallSite`, the renderer reads `source_path`. Without
+/// this test the rebadge could regress silently for any input the
+/// hand-built `snapshot_composition_folding` doesn't cover.
+///
+/// Also obeys the CLAUDE.md "directory-scoped, never single-file"
+/// policy: the fixture is a real two-directory module shape, not a
+/// bare string.
+#[test]
+fn snapshot_module_header_renders_use_source_path_for_real_fixture() {
+    let fp = build_plan_from_fixture_name("module_anonymous_resource");
+    let output = strip_ansi(&format_plan(
+        &fp.plan,
+        DetailLevel::None,
+        &HashMap::new(),
+        Some(&fp.schemas),
+        &fp.moved_origins,
+        &[],
+        &[],
+        None,
+        Some(&fp.expansion_trace),
+    ));
+
+    assert!(
+        output.contains(r#"module "bootstrap" (./oidc-module)"#),
+        "expected `module \"bootstrap\" (./oidc-module)` header from real \
+         fixture in:\n{}",
+        output,
+    );
+    assert!(
+        !output.contains("Composition"),
+        "internal `Composition` term must not surface to operators in:\n{}",
+        output,
     );
 }

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
@@ -1,12 +1,11 @@
 ---
 source: carina-cli/src/plan_snapshot_tests.rs
-assertion_line: 1571
 expression: output
 ---
 Execution Plan:
 
   + aws.s3.Bucket logs
-+ Composition "cluster"
++ module "cluster" (./modules/cluster)
   + aws.eks.Cluster cluster/inner
   + aws.iam.Role cluster/inner-role
 

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -356,8 +356,17 @@ impl ModuleResolver<'_> {
         // #3306: build the expansion trace from this call's leaves +
         // nested-expansion traces inherited from `module`, *before*
         // the struct literal moves `resources` / `data_sources`.
+        // carina#3322: stamp the call site with the DSL `use` path
+        // so plan rendering can label the group with a DSL-visible
+        // name (`module "<binding>" (<source_path>)`). `None` falls
+        // back to a path-less header — only relevant in test harnesses
+        // that bypass `process_imports`; real expansions always have
+        // a recorded path.
+        let source_path: Option<&str> =
+            self.module_paths.get(&call.module_name).map(String::as_str);
         let expansion_trace = build_expansion_trace(
             instance_prefix,
+            source_path,
             &module.expansion_trace,
             &resources,
             &data_sources,
@@ -426,14 +435,19 @@ impl ModuleResolver<'_> {
 /// first chain in the merged plan).
 pub(crate) fn build_expansion_trace(
     instance_prefix: &str,
+    source_path: Option<&str>,
     inner_trace: &crate::resource::ExpansionTrace,
     leaf_resources: &[Resource],
     leaf_data_sources: &[DataSource],
 ) -> crate::resource::ExpansionTrace {
-    let this_call_site = crate::resource::EphemeralId::new(crate::resource::ResourceId::new(
+    let id = crate::resource::EphemeralId::new(crate::resource::ResourceId::new(
         "_virtual",
         instance_prefix,
     ));
+    let this_call_site = match source_path {
+        Some(p) => crate::resource::CallSite::new(id, p),
+        None => crate::resource::CallSite::without_source(id),
+    };
 
     let mut out = crate::resource::ExpansionTrace::new();
 

--- a/carina-core/src/module_resolver/resolver.rs
+++ b/carina-core/src/module_resolver/resolver.rs
@@ -20,6 +20,11 @@ pub struct ModuleResolver<'cfg> {
     pub(super) resolving: HashSet<PathBuf>,
     /// Imported module definitions by alias
     pub(super) imported_modules: HashMap<String, ParsedFile>,
+    /// `use { source = "..." }` paths by alias — the DSL-visible
+    /// source location for each imported module. Threaded into the
+    /// `ExpansionTrace` so plan rendering can label a composition
+    /// group with `module "<binding>" (<source_path>)` (carina#3322).
+    pub(super) module_paths: HashMap<String, String>,
     /// Parser configuration (decryptor, custom validators)
     pub(super) config: &'cfg ProviderContext,
 }
@@ -39,6 +44,7 @@ impl<'cfg> ModuleResolver<'cfg> {
             module_cache: HashMap::new(),
             resolving: HashSet::new(),
             imported_modules: HashMap::new(),
+            module_paths: HashMap::new(),
             config,
         }
     }
@@ -151,6 +157,8 @@ impl<'cfg> ModuleResolver<'cfg> {
         for import in imports {
             let module = self.load_module(&import.path)?;
             self.imported_modules.insert(import.alias.clone(), module);
+            self.module_paths
+                .insert(import.alias.clone(), import.path.clone());
         }
         Ok(())
     }
@@ -172,6 +180,7 @@ impl<'cfg> ModuleResolver<'cfg> {
         // Save and temporarily replace the base_dir and imported_modules
         let original_base_dir = std::mem::replace(&mut self.base_dir, base_dir.to_path_buf());
         let original_imported = std::mem::take(&mut self.imported_modules);
+        let original_paths = std::mem::take(&mut self.module_paths);
 
         // Process the module's own imports
         let imports = parsed.uses.clone();
@@ -181,6 +190,7 @@ impl<'cfg> ModuleResolver<'cfg> {
             // Restore state on error
             self.base_dir = original_base_dir;
             self.imported_modules = original_imported;
+            self.module_paths = original_paths;
             return Err(e);
         }
 
@@ -215,6 +225,7 @@ impl<'cfg> ModuleResolver<'cfg> {
                 Err(e) => {
                     self.base_dir = original_base_dir;
                     self.imported_modules = original_imported;
+                    self.module_paths = original_paths;
                     return Err(e);
                 }
             }
@@ -223,6 +234,7 @@ impl<'cfg> ModuleResolver<'cfg> {
         // Restore original state
         self.base_dir = original_base_dir;
         self.imported_modules = original_imported;
+        self.module_paths = original_paths;
 
         Ok(())
     }

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -756,7 +756,76 @@ fn test_expand_module_call_populates_expansion_trace_single_level() {
     // (`_virtual.<instance_prefix>`).
     let expected_call_site =
         crate::resource::EphemeralId::new(crate::resource::ResourceId::new("_virtual", "web"));
-    assert_eq!(chain[0], expected_call_site);
+    assert_eq!(chain[0].id, expected_call_site);
+}
+
+/// carina#3322 acceptance: when `process_imports` recorded a
+/// `use { source = "..." }` path for the module alias, the call site
+/// stamped onto each leaf in the `ExpansionTrace` must carry that
+/// path verbatim. The plan renderer reads it to label a composition
+/// group with `module "<binding>" (<source_path>)` — without this,
+/// the group label silently falls back to the path-less form.
+#[test]
+fn test_expand_module_call_records_use_source_path_on_call_site() {
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules
+            .insert("web_tier".to_string(), create_module_with_attributes());
+        // Simulates what `process_imports` records for
+        // `use { source = "./modules/web_tier", alias = "web_tier" }`.
+        r.module_paths
+            .insert("web_tier".to_string(), "./modules/web_tier".to_string());
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "web_tier".to_string(),
+        binding_name: Some("web".to_string()),
+        arguments: HashMap::new(),
+    };
+
+    let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
+    let leaf = &expanded.resources[0];
+    let chain = expanded
+        .expansion_trace
+        .call_sites_of(&leaf.persistent_id());
+
+    assert_eq!(
+        chain[0].source_path.as_deref(),
+        Some("./modules/web_tier"),
+        "the call site must carry the DSL `use` source path so the \
+         renderer can emit `module \"<binding>\" (./modules/web_tier)`",
+    );
+}
+
+/// Absence-of-path fallback: when no `module_paths` entry exists for
+/// the alias (e.g. hand-built test resolvers, or a module synthesized
+/// without going through `process_imports`), the call site falls back
+/// to `source_path = None`. The renderer treats that as
+/// "drop the parenthesized suffix" — never a panic, never the literal
+/// string "None".
+#[test]
+fn test_expand_module_call_call_site_source_path_none_when_unmapped() {
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules
+            .insert("web_tier".to_string(), create_module_with_attributes());
+        // Deliberately no `module_paths` entry.
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "web_tier".to_string(),
+        binding_name: Some("web".to_string()),
+        arguments: HashMap::new(),
+    };
+
+    let expanded = resolver.expand_module_call(&call, "web", None).unwrap();
+    let leaf = &expanded.resources[0];
+    let chain = expanded
+        .expansion_trace
+        .call_sites_of(&leaf.persistent_id());
+    assert_eq!(chain[0].source_path, None);
 }
 
 /// #3306 acceptance: when an outer expansion absorbs leaves from a
@@ -764,19 +833,27 @@ fn test_expand_module_call_populates_expansion_trace_single_level() {
 /// call site to the inner chain — outermost-first overall.
 #[test]
 fn test_build_expansion_trace_prepends_outer_call_site_to_inner_chain() {
-    use crate::resource::{EphemeralId, ExpansionTrace, PersistentId, ResourceId};
+    use crate::resource::{CallSite, EphemeralId, ExpansionTrace, PersistentId, ResourceId};
 
     // Simulate an inner module that already finished its own
     // expansion: one leaf nested one level deep (inner_call_site).
     let mut inner_trace = ExpansionTrace::new();
     let inner_leaf = PersistentId::new(ResourceId::new("aws.s3.Bucket", "outer.inner.logs"));
-    let inner_call_site = EphemeralId::new(ResourceId::new("_virtual", "outer.inner"));
+    let inner_call_site = CallSite::new(
+        EphemeralId::new(ResourceId::new("_virtual", "outer.inner")),
+        "./modules/inner",
+    );
     inner_trace.record(inner_leaf.clone(), vec![inner_call_site.clone()]);
 
     // Build the outer trace: no direct leaves at this level, only
     // inherited ones. The outer call-site is `outer`.
-    let outer_trace =
-        crate::module_resolver::expander::build_expansion_trace("outer", &inner_trace, &[], &[]);
+    let outer_trace = crate::module_resolver::expander::build_expansion_trace(
+        "outer",
+        Some("./modules/outer"),
+        &inner_trace,
+        &[],
+        &[],
+    );
 
     // The inner leaf is still recorded, but its chain now leads with
     // the outer call site.
@@ -788,8 +865,13 @@ fn test_build_expansion_trace_prepends_outer_call_site_to_inner_chain() {
     );
     let expected_outer = EphemeralId::new(ResourceId::new("_virtual", "outer"));
     assert_eq!(
-        chain[0], expected_outer,
+        chain[0].id, expected_outer,
         "outermost element must be the outer call site",
+    );
+    assert_eq!(
+        chain[0].source_path.as_deref(),
+        Some("./modules/outer"),
+        "outer call site must carry the outer module's source path",
     );
     assert_eq!(
         chain[1], inner_call_site,

--- a/carina-core/src/resource/expansion_trace.rs
+++ b/carina-core/src/resource/expansion_trace.rs
@@ -8,15 +8,18 @@
 //! it can fold leaf rows under their originating composition row:
 //!
 //! ```text
-//! + Composition "cluster"
+//! + module "cluster" (./modules/cluster)
 //!     + aws.eks.Cluster      cluster/inner
 //!     + aws.iam.Role         cluster/inner-role
 //! + aws.s3.Bucket            logs
 //! ```
 //!
 //! `ExpansionTrace` records that relationship as a sidecar map keyed
-//! by leaf [`PersistentId`] → an outermost-first chain of
-//! [`EphemeralId`]s for the composition(s) that nest the leaf.
+//! by leaf [`PersistentId`] → an outermost-first chain of [`CallSite`]
+//! entries for the composition(s) that nest the leaf. Each entry
+//! carries the call-site id (binding name) plus the module's
+//! `use { source = "..." }` path so the renderer can label the group
+//! with a DSL-visible name (carina#3322).
 //!
 //! The trace is **plan-scoped, not persisted**. State files do not
 //! carry it; every plan rebuilds it from DSL at parse time. This keeps
@@ -41,6 +44,54 @@ use super::{EphemeralId, PersistentId};
 // iterator output by `leaf.inner().name.as_str()` itself rather than
 // relying on map iteration order.
 
+/// One composition call site in an expansion chain: the `EphemeralId`
+/// that identifies the call (its instance binding) plus the module's
+/// `use { source = "..." }` path, so the display layer can label the
+/// group with a DSL-visible name like `module "r" (./modules/infra)`.
+///
+/// `source_path` is the path the user wrote in the `use` statement
+/// (verbatim, not canonicalized) — the same surface form that appears
+/// in the DSL. `None` means "no recorded path" (hand-built test
+/// traces, or a synthesized call site that never went through
+/// `process_imports`); the renderer drops the parenthesized suffix
+/// in that case. Using `Option` here, not an empty `String`, keeps
+/// "absent" syntactically distinct from "an empty user-written path"
+/// — making the broken state of accidentally treating one as the
+/// other unrepresentable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CallSite {
+    pub id: EphemeralId,
+    #[serde(default)]
+    pub source_path: Option<String>,
+}
+
+impl CallSite {
+    /// Create a call site with a recorded source path (the typical
+    /// production shape: `use { source = "..." }` resolved into the
+    /// expander).
+    pub fn new(id: EphemeralId, source_path: impl Into<String>) -> Self {
+        Self {
+            id,
+            source_path: Some(source_path.into()),
+        }
+    }
+
+    /// Create a call site without a source path. Used by test
+    /// fixtures and any caller that synthesizes a `CallSite` outside
+    /// the `process_imports` → `expand_module_call` flow.
+    pub fn without_source(id: EphemeralId) -> Self {
+        Self {
+            id,
+            source_path: None,
+        }
+    }
+
+    /// The call site's binding name (instance prefix), e.g. `cluster`.
+    pub fn binding(&self) -> &str {
+        self.id.inner().name.as_str()
+    }
+}
+
 /// Plan-scoped lineage of leaf nodes back to the composition call
 /// sites that produced them.
 ///
@@ -59,7 +110,7 @@ pub struct ExpansionTrace {
     /// For each persistent (leaf) id, the chain of composition call
     /// sites that nest it — outermost first. An empty `Vec` means the
     /// leaf was declared at the DSL root, outside any composition.
-    pub leaf_to_call_sites: HashMap<PersistentId, Vec<EphemeralId>>,
+    pub leaf_to_call_sites: HashMap<PersistentId, Vec<CallSite>>,
 }
 
 impl ExpansionTrace {
@@ -76,7 +127,7 @@ impl ExpansionTrace {
     /// Calling `record` again with the same `leaf` overwrites the
     /// previous chain — this matches the expander's contract that
     /// each leaf has exactly one originating call chain.
-    pub fn record(&mut self, leaf: PersistentId, call_sites: Vec<EphemeralId>) {
+    pub fn record(&mut self, leaf: PersistentId, call_sites: Vec<CallSite>) {
         self.leaf_to_call_sites.insert(leaf, call_sites);
     }
 
@@ -86,13 +137,13 @@ impl ExpansionTrace {
     /// level leaf, no composition nesting"). Callers that always want
     /// a slice can use [`call_sites_of`](Self::call_sites_of) which
     /// returns an empty slice for the not-recorded case.
-    pub fn get(&self, leaf: &PersistentId) -> Option<&[EphemeralId]> {
+    pub fn get(&self, leaf: &PersistentId) -> Option<&[CallSite]> {
         self.leaf_to_call_sites.get(leaf).map(Vec::as_slice)
     }
 
     /// Look up the composition chain for `leaf`, returning an empty
     /// slice if the leaf has no recorded chain (root-level).
-    pub fn call_sites_of(&self, leaf: &PersistentId) -> &[EphemeralId] {
+    pub fn call_sites_of(&self, leaf: &PersistentId) -> &[CallSite] {
         self.leaf_to_call_sites
             .get(leaf)
             .map(Vec::as_slice)
@@ -110,7 +161,7 @@ impl ExpansionTrace {
     }
 
     /// Iterate `(leaf, call_sites)` pairs in `HashMap` order.
-    pub fn iter(&self) -> impl Iterator<Item = (&PersistentId, &Vec<EphemeralId>)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&PersistentId, &Vec<CallSite>)> {
         self.leaf_to_call_sites.iter()
     }
 }
@@ -124,8 +175,11 @@ mod tests {
         PersistentId::new(ResourceId::new("aws.s3.Bucket", name))
     }
 
-    fn eid(name: &str) -> EphemeralId {
-        EphemeralId::new(ResourceId::new("_virtual", name))
+    fn site(name: &str, source_path: &str) -> CallSite {
+        CallSite::new(
+            EphemeralId::new(ResourceId::new("_virtual", name)),
+            source_path,
+        )
     }
 
     #[test]
@@ -139,7 +193,10 @@ mod tests {
     fn record_and_get_round_trip() {
         let mut t = ExpansionTrace::new();
         let leaf = pid("inner");
-        let chain = vec![eid("outer"), eid("inner_comp")];
+        let chain = vec![
+            site("outer", "./modules/outer"),
+            site("inner_comp", "./modules/inner_comp"),
+        ];
         t.record(leaf.clone(), chain.clone());
         assert_eq!(t.get(&leaf), Some(chain.as_slice()));
         assert_eq!(t.call_sites_of(&leaf), chain.as_slice());
@@ -147,10 +204,32 @@ mod tests {
     }
 
     #[test]
+    fn call_site_carries_source_path_for_display() {
+        // carina#3322: the renderer needs the `use { source = "..." }`
+        // path so it can label a composition group with a
+        // DSL-visible name like `module "r" (./modules/infra)`.
+        let s = site("r", "./modules/infra");
+        assert_eq!(s.binding(), "r");
+        assert_eq!(s.source_path.as_deref(), Some("./modules/infra"));
+    }
+
+    #[test]
+    fn call_site_without_source_has_none_path() {
+        // A call site synthesized outside `process_imports` (test
+        // harness, hand-built trace) keeps `source_path = None`.
+        // The renderer drops the parenthesized `(<path>)` suffix in
+        // that case — `None` is syntactically distinct from a real
+        // user-supplied empty path.
+        let s = CallSite::without_source(EphemeralId::new(ResourceId::new("_virtual", "r")));
+        assert_eq!(s.binding(), "r");
+        assert_eq!(s.source_path, None);
+    }
+
+    #[test]
     fn call_sites_of_unrecorded_leaf_is_empty() {
         let t = ExpansionTrace::new();
         let leaf = pid("never_recorded");
-        assert_eq!(t.call_sites_of(&leaf), &[] as &[EphemeralId]);
+        assert_eq!(t.call_sites_of(&leaf), &[] as &[CallSite]);
         assert!(t.get(&leaf).is_none());
     }
 
@@ -161,16 +240,16 @@ mod tests {
         // replaces, not appends.
         let mut t = ExpansionTrace::new();
         let leaf = pid("inner");
-        t.record(leaf.clone(), vec![eid("outer1")]);
-        t.record(leaf.clone(), vec![eid("outer2")]);
-        assert_eq!(t.call_sites_of(&leaf), &[eid("outer2")]);
+        t.record(leaf.clone(), vec![site("outer1", "./a")]);
+        t.record(leaf.clone(), vec![site("outer2", "./b")]);
+        assert_eq!(t.call_sites_of(&leaf), &[site("outer2", "./b")]);
     }
 
     #[test]
     fn iter_yields_every_recorded_leaf_exactly_once() {
         let mut t = ExpansionTrace::new();
-        t.record(pid("b_leaf"), vec![eid("c1")]);
-        t.record(pid("a_leaf"), vec![eid("c2")]);
+        t.record(pid("b_leaf"), vec![site("c1", "./c1")]);
+        t.record(pid("a_leaf"), vec![site("c2", "./c2")]);
         // `HashMap`-backed iteration order is not guaranteed; only
         // the *set* of keys is observable. Verify every recorded leaf
         // shows up exactly once.
@@ -188,9 +267,9 @@ mod tests {
         // empty Vec is also legal and useful for display passes that
         // want every leaf accounted for.
         t.record(leaf.clone(), vec![]);
-        assert_eq!(t.call_sites_of(&leaf), &[] as &[EphemeralId]);
+        assert_eq!(t.call_sites_of(&leaf), &[] as &[CallSite]);
         // `get` returns `Some(&[])` here, not `None` — both forms are
         // semantically equivalent for the display layer.
-        assert_eq!(t.get(&leaf), Some(&[] as &[EphemeralId]));
+        assert_eq!(t.get(&leaf), Some(&[] as &[CallSite]));
     }
 }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1806,7 +1806,7 @@ pub mod persistent_id;
 
 pub use composition::{Composition, CompositionAttribute, Signature};
 pub use data_source::DataSource;
-pub use expansion_trace::ExpansionTrace;
+pub use expansion_trace::{CallSite, ExpansionTrace};
 pub use graph_node::GraphNode;
 pub use leaf_node::{CompositionNotALeaf, LeafNode, expand_to_leaves};
 pub use persistent_id::{EphemeralId, NodeId, PersistentId};


### PR DESCRIPTION
## Summary

`carina plan` was leaking the internal `Composition` data-type name into operator-facing output:

```
+ Composition "r"
  + aws.route53.RecordSet r.delegation_ns
      ...
```

Operators have no anchor for the word "Composition" — the DSL has no `composition { ... }` construct, so the line stalled first-read of the plan without adding information they could trace back to a `.crn` file.

This PR rebadges the header to use the DSL-visible `module` keyword and surfaces the `use { source = "..." }` path so the group label points at a real file path:

```
+ module "r" (./modules/route53)
  + aws.route53.RecordSet r.delegation_ns
      ...
```

A multi-module stack now reads as `module "r" (./modules/route53) ... module "s" (./modules/sg) ...` instead of repeated, anonymous `Composition "X"` headers.

## Root-cause fix (not a display-layer band-aid)

- `ExpansionTrace`'s call-site chain becomes `Vec<CallSite>` where `CallSite = { id: EphemeralId, source_path: Option<String> }`. `Option<String>` (not an empty-string sentinel) makes "absent path" syntactically distinct from "empty path" — accidentally treating one as the other is unrepresentable.
- `ModuleResolver` gains a `module_paths` map (alias -> use path), populated alongside `imported_modules` in `process_imports`. Save/restore lifecycle in `resolve_nested_modules` mirrors `imported_modules` on every success and error path.
- `expand_module_call` reads the alias's source path and threads it into `build_expansion_trace`, which stamps every direct + inherited leaf's call site with the path. **A new caller of `build_expansion_trace` cannot forget the path — the signature forces it.**
- `carina-cli` display reads `CallSite.source_path` to compose the header; `None` falls back to the path-less form.

## Test plan

- [x] `ExpansionTrace` unit tests pin `CallSite::new` (Some) vs `without_source` (None) at the model layer.
- [x] `module_resolver` tests assert the source path propagates through single-level and nested-level `expand_module_call`, plus the `None`-fallback when `module_paths` lacks the alias.
- [x] `format_composition_header` unit tests pin both the with-path (`+ module "r" (./modules/infra)`) and no-path (`+ module "r"`) render shapes.
- [x] New end-to-end snapshot test loads the real multi-file `module_anonymous_resource` fixture, threads the trace through `FixturePlan`, and asserts the header reads `module "bootstrap" (./oidc-module)` — and that the literal `Composition` term never surfaces.
- [x] `cargo nextest run --workspace --all-features` — 3667 passed
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass
- [x] `bash scripts/check-*.sh` — all pass

Closes #3322