### PR TITLE
plan: stop double-counting import/removed/moved blocks targeting routed resources

### DIFF
--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -2016,36 +2016,89 @@ pub fn materialize_moved_states(
 
     for block in state_blocks {
         if let StateBlock::Moved { from, to } = block {
-            let old_in_state = state_file.as_ref().is_some_and(|sf| {
+            // carina#3324: `from`/`to` are parsed from
+            // `moved { from = X 'a', to = X 'b' }`, which has no
+            // syntax for `provider_instance`. The state-resident
+            // `from` may carry routing from its original
+            // `directives { provider = ... }`, and the desired-state
+            // `to` may similarly carry routing from the new let-bound
+            // resource's directives. Resolve both to their full ids
+            // so map lookups (which include `provider_instance` in
+            // `Hash`/`Eq`) hit the right keys and the emitted
+            // `(from, to)` pair matches every downstream consumer's
+            // address shape.
+            let resolved_from = state_file.as_ref().and_then(|sf| {
                 sf.find_resource(&from.provider, &from.resource_type, from.name_str())
-                    .is_some()
+                    .map(|rs| {
+                        ResourceId::with_provider(
+                            &rs.provider,
+                            &rs.resource_type,
+                            &rs.name,
+                            rs.directives.provider_instance.clone(),
+                        )
+                    })
             });
-            if old_in_state {
-                // Transfer state from the old name to the new name so the
-                // differ compares desired(to) against actual(from).
-                if let Some(mut state) = current_states.remove(from) {
-                    state.id = to.clone();
-                    current_states.insert(to.clone(), state);
-                }
+            let Some(resolved_from) = resolved_from else {
+                continue;
+            };
+            // For `to`, look up the destination key by
+            // `(provider, resource_type, name)` across the desired
+            // state maps. `current_states` / `prev_explicit` /
+            // `saved_attrs` may already have an entry under the
+            // routed id; without resolving, `insert(to.clone(), ...)`
+            // would create a second entry under the None-routing id
+            // and the routed id would be left as an orphan.
+            //
+            // Consult all three maps (not just `current_states`) so
+            // the resolution is independent of map-population
+            // ordering — a routed entry in any of the three is the
+            // right routing for the destination.
+            let resolved_to = find_desired_id(to, current_states)
+                .or_else(|| find_desired_id(to, prev_explicit))
+                .or_else(|| find_desired_id(to, saved_attrs))
+                .unwrap_or_else(|| to.clone());
 
-                // Transfer prev_explicit so the differ detects attribute
-                // removals under the new resource name.
-                if let Some(keys) = prev_explicit.remove(from) {
-                    prev_explicit.insert(to.clone(), keys);
-                }
-
-                // Transfer saved_attrs so create_plan can look up saved
-                // attributes under the new resource name.
-                if let Some(attrs) = saved_attrs.remove(from) {
-                    saved_attrs.insert(to.clone(), attrs);
-                }
-
-                moved_pairs.push((from.clone(), to.clone()));
+            // Transfer state from the old name to the new name so the
+            // differ compares desired(to) against actual(from).
+            if let Some(mut state) = current_states.remove(&resolved_from) {
+                state.id = resolved_to.clone();
+                current_states.insert(resolved_to.clone(), state);
             }
+
+            // Transfer prev_explicit so the differ detects attribute
+            // removals under the new resource name.
+            if let Some(keys) = prev_explicit.remove(&resolved_from) {
+                prev_explicit.insert(resolved_to.clone(), keys);
+            }
+
+            // Transfer saved_attrs so create_plan can look up saved
+            // attributes under the new resource name.
+            if let Some(attrs) = saved_attrs.remove(&resolved_from) {
+                saved_attrs.insert(resolved_to.clone(), attrs);
+            }
+
+            moved_pairs.push((resolved_from, resolved_to));
         }
     }
 
     moved_pairs
+}
+
+/// Look up `to`'s full id (with any routed `provider_instance`) in
+/// `desired` by matching on `(provider, resource_type, name)` —
+/// `provider_instance` is intentionally not part of the match key,
+/// since `moved { to = X 'name' }` has no syntax for routing. Returns
+/// `None` when no matching key exists, so callers can chain across
+/// multiple maps with `.or_else(...)` (carina#3324).
+fn find_desired_id<V>(to: &ResourceId, desired: &HashMap<ResourceId, V>) -> Option<ResourceId> {
+    desired
+        .keys()
+        .find(|k| {
+            k.provider == to.provider
+                && k.resource_type == to.resource_type
+                && k.name_str() == to.name_str()
+        })
+        .cloned()
 }
 
 /// Add state block effects (import/removed/moved) to the plan.
@@ -2105,14 +2158,29 @@ pub fn add_state_block_effects(
                 }
             }
             StateBlock::Removed { from } => {
-                // Skip if resource is not in state
-                let in_state = state_file.as_ref().is_some_and(|sf| {
+                // `from` is parsed from `removed { from = X 'addr' }`,
+                // which has no syntax for `provider_instance`. The
+                // resource in state may still carry a routed instance
+                // from its original `directives { provider = ... }`.
+                // Resolve to the full state id (inheriting the
+                // routing) so the emitted Remove effect and the
+                // `suppress_delete` HashSet key match the orphan
+                // Delete effect's id exactly — same root fix as the
+                // Import arm above (carina#3324).
+                let resolved_from = state_file.as_ref().and_then(|sf| {
                     sf.find_resource(&from.provider, &from.resource_type, from.name_str())
-                        .is_some()
+                        .map(|rs| {
+                            ResourceId::with_provider(
+                                &rs.provider,
+                                &rs.resource_type,
+                                &rs.name,
+                                rs.directives.provider_instance.clone(),
+                            )
+                        })
                 });
-                if in_state {
-                    suppress_delete.insert(from.clone());
-                    new_effects.push(Effect::Remove { id: from.clone() });
+                if let Some(id) = resolved_from {
+                    suppress_delete.insert(id.clone());
+                    new_effects.push(Effect::Remove { id });
                 }
             }
             StateBlock::Moved { .. } => {
@@ -2153,13 +2221,32 @@ pub fn add_state_block_effects(
 
 /// Resolve an import block's `to` address to a matching resource in the plan or state.
 ///
-/// Tries exact match first (by provider, resource_type, name). If no exact match
-/// exists, falls back to matching `to.name` against the `name_attribute` values of:
-/// 1. Anonymous resources in the plan's Create effects (pre-apply case)
-/// 2. Resources in the state file (already-imported case)
+/// Match keys on `(provider, resource_type, name)`. **`provider_instance`
+/// is intentionally not part of the address** — `to = X 'addr'` in DSL
+/// has no syntax for specifying a routed instance, so the parsed `to`
+/// always has `provider_instance = None`. The let-bound resource it
+/// targets may carry `directives { provider = <name> }`, which the
+/// parser stamps as `provider_instance = Some(<name>)`. Treating the
+/// instance as part of the address would falsely make these addresses
+/// non-equal and silently emit both an Import and a Create for the
+/// same infrastructure (carina#3324).
 ///
-/// This lets users write `to = awscc.s3.Bucket 'carina-rs-state'` without needing
-/// the auto-generated hash name, matching against `bucket_name = 'carina-rs-state'`.
+/// The function returns the matched resource's full id (inheriting
+/// its `provider_instance`), so:
+/// - The Import effect carries the routing the operator's directives
+///   selected — apply-time routing sends the import to the right
+///   provider instance.
+/// - The `suppress_create` set in [`add_state_block_effects`] keys on
+///   exactly the same id as the Create's resource, so the Create is
+///   suppressed.
+///
+/// Match precedence:
+/// 1. Exact `(provider, resource_type, name)` against a Create effect.
+/// 2. `name_attribute` fallback against a Create effect's anonymous
+///    resource (so `to = X 'carina-rs-state'` matches against
+///    `bucket_name = 'carina-rs-state'` on a `s3_bucket_1d43a664`).
+/// 3. `name_attribute` fallback against the state file
+///    (already-imported case).
 fn resolve_import_target(
     to: &ResourceId,
     plan: &Plan,
@@ -2174,14 +2261,24 @@ fn resolve_import_target(
         )
         .and_then(|s| s.name_attribute.as_deref());
 
+    // Address-equality test that ignores `provider_instance` — the
+    // import-block surface form has no routing slot, so two ids with
+    // the same `(provider, resource_type, name)` are the same address
+    // regardless of routing.
+    let same_address = |id: &ResourceId| {
+        id.provider == to.provider
+            && id.resource_type == to.resource_type
+            && id.name_str() == to.name_str()
+    };
+
     // Single pass: prefer exact id match, otherwise remember the first name_attribute match.
     let mut fallback_id: Option<ResourceId> = None;
     for effect in plan.effects() {
         let Effect::Create(resource) = effect else {
             continue;
         };
-        if resource.id == *to {
-            return to.clone();
+        if same_address(&resource.id) {
+            return resource.id.clone();
         }
         if fallback_id.is_some() {
             continue;

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -429,6 +429,207 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     }
 }
 
+/// Sibling of the Import/Removed routing fix:
+/// `moved { from = X 'a', to = X 'b' }` faces the same address-
+/// equality bug when the state-resident `a` carries
+/// `provider_instance = Some("X")`. Without the root fix
+/// `current_states.remove(from)` misses (since the key in the map has
+/// the routed id), the moved state is never transferred, and the
+/// orphan Delete for `a` is never suppressed — the operator sees both
+/// `<- moved` and `- delete` for the same address.
+///
+/// Coverage shape: state has `a` under routed id; `materialize_moved_states`
+/// must (a) actually move the entry under `b`'s routed id, and (b)
+/// return a `(from, to)` pair whose ids carry the routing so the
+/// downstream `suppress_delete` set in `add_state_block_effects`
+/// keys correctly.
+#[test]
+fn moved_block_resolves_routed_instance_on_from_and_to() {
+    use carina_core::resource::{ResourceId, State};
+    use carina_state::state::{ResourceState, StateFile};
+
+    // State has the source resource under a routed id.
+    let mut state_file = StateFile::new();
+    let mut rs = ResourceState::new("route53.RecordSet", "old_record", "aws");
+    rs.directives.provider_instance = Some("management".to_string());
+    state_file.resources.push(rs);
+
+    // Pre-populate `current_states` with the routed `from` id (mirrors
+    // what `build_state_for_resource` would produce).
+    let routed_from = ResourceId::with_provider(
+        "aws",
+        "route53.RecordSet",
+        "old_record",
+        Some("management".to_string()),
+    );
+    let mut current_states = HashMap::new();
+    current_states.insert(routed_from.clone(), State::not_found(routed_from.clone()));
+
+    let mut prev_explicit = HashMap::new();
+    let mut saved_attrs = HashMap::new();
+
+    // `moved` block addresses are parsed without routing.
+    let state_blocks = vec![StateBlock::Moved {
+        from: ResourceId::with_provider("aws", "route53.RecordSet", "old_record", None),
+        to: ResourceId::with_provider("aws", "route53.RecordSet", "new_record", None),
+    }];
+
+    let moved_pairs = materialize_moved_states(
+        &mut current_states,
+        &mut prev_explicit,
+        &mut saved_attrs,
+        &state_blocks,
+        &Some(state_file),
+    );
+
+    // The pair must inherit `from`'s routing so the downstream
+    // `suppress_delete` lookup matches the orphan Delete's id.
+    assert_eq!(moved_pairs.len(), 1);
+    let (from, _to) = &moved_pairs[0];
+    assert_eq!(
+        from.provider_instance.as_deref(),
+        Some("management"),
+        "moved.from must inherit routing from the matched state row, got {from:?}",
+    );
+
+    // And `current_states` must no longer carry the old key — the
+    // state was actually transferred (not silently left under the
+    // routed id while a None-routing key was inserted).
+    assert!(
+        !current_states.contains_key(&routed_from),
+        "old routed key must be removed after move",
+    );
+}
+
+/// Sibling of `import_suppresses_create_when_target_resource_is_routed_to_named_instance`:
+/// `removed { from = X 'addr' }` faces the same address-equality
+/// mismatch when the state-resident resource has
+/// `provider_instance = Some("X")` (originally created via
+/// `directives { provider = X }`) but the user-typed `from` parses as
+/// `provider_instance = None`. Without the root fix the orphan Delete
+/// stays in the plan and the operator sees both `<- removed` and
+/// `- delete` for the same address (carina#3324 root cause class).
+#[test]
+fn removed_block_suppresses_delete_when_state_resource_is_routed_to_named_instance() {
+    use carina_core::effect::Effect;
+    use carina_core::plan::Plan;
+    use carina_core::resource::ResourceId;
+    use carina_state::state::{ResourceState, StateFile};
+
+    let schemas = SchemaRegistry::new();
+
+    // State has a resource that was originally created via
+    // `directives { provider = management }` — `provider_instance =
+    // Some("management")`.
+    let mut state_file = StateFile::new();
+    let mut rs = ResourceState::new("route53.RecordSet", "r.delegation_ns", "aws");
+    rs.directives.provider_instance = Some("management".to_string());
+    state_file.resources.push(rs);
+
+    // The orphan Delete effect carries the same routed instance.
+    let mut plan = Plan::new();
+    plan.add(Effect::Delete {
+        id: ResourceId::with_provider(
+            "aws",
+            "route53.RecordSet",
+            "r.delegation_ns",
+            Some("management".to_string()),
+        ),
+        identifier: String::new(),
+        directives: carina_core::resource::Directives::default(),
+        binding: None,
+        dependencies: std::collections::HashSet::new(),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+
+    // `removed` block was written without routing — `from` has
+    // `provider_instance = None`.
+    let state_blocks = vec![StateBlock::Removed {
+        from: ResourceId::with_provider("aws", "route53.RecordSet", "r.delegation_ns", None),
+    }];
+
+    add_state_block_effects(&mut plan, &state_blocks, &Some(state_file), &[], &schemas);
+
+    let effects = plan.effects();
+    assert_eq!(
+        effects.len(),
+        1,
+        "expected only the Remove effect (orphan Delete must be suppressed \
+         when the same address is being removed), got {effects:?}",
+    );
+    match &effects[0] {
+        Effect::Remove { id } => {
+            assert_eq!(
+                id.provider_instance.as_deref(),
+                Some("management"),
+                "the remove effect must inherit the routed instance from the \
+                 state row so apply-time routing sends the state-removal call \
+                 to the correct provider instance",
+            );
+        }
+        other => panic!("expected Remove effect, got {other:?}"),
+    }
+}
+
+/// carina#3324 regression: an import block targeting a let-bound
+/// resource whose `directives { provider = <name> }` routes it to a
+/// named provider instance must still suppress the resource's Create
+/// effect. Before the fix, the import target was carrying the user-
+/// typed `provider_instance = None` while the Create's resource had
+/// the directive-routed `provider_instance = Some("management")`, so
+/// the `suppress_create` set never matched and the same address
+/// appeared as both `<- import` and `+ add` in the plan.
+#[test]
+fn import_suppresses_create_when_target_resource_is_routed_to_named_instance() {
+    use carina_core::effect::Effect;
+    use carina_core::plan::Plan;
+    use carina_core::resource::{Resource, ResourceId};
+
+    let schemas = SchemaRegistry::new();
+
+    // Let-bound resource with `directives { provider = management }`:
+    // the parser stamps `provider_instance = Some("management")` on
+    // its ResourceId.
+    let resource = Resource::with_provider(
+        "aws",
+        "route53.RecordSet",
+        "r.delegation_ns",
+        Some("management".to_string()),
+    );
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(resource));
+
+    // The import block was written without a routing hint
+    // (`to = aws.route53.RecordSet 'r.delegation_ns'`), so the parsed
+    // `to` carries `provider_instance = None`. Same address otherwise.
+    let state_blocks = vec![StateBlock::Import {
+        to: ResourceId::with_provider("aws", "route53.RecordSet", "r.delegation_ns", None),
+        id: "|hosted-zone-id|registry-dev.carina-rs.dev|NS".to_string(),
+    }];
+
+    add_state_block_effects(&mut plan, &state_blocks, &None, &[], &schemas);
+
+    let effects = plan.effects();
+    assert_eq!(
+        effects.len(),
+        1,
+        "expected only the Import effect (Create must be suppressed when \
+         the same address is being imported), got {effects:?}",
+    );
+    match &effects[0] {
+        Effect::Import { id, .. } => {
+            assert_eq!(
+                id.provider_instance.as_deref(),
+                Some("management"),
+                "the import effect must inherit the routed instance from the \
+                 matched resource so apply-time routing sends the import call \
+                 to the correct provider instance",
+            );
+        }
+        other => panic!("expected Import effect, got {other:?}"),
+    }
+}
+
 #[test]
 fn import_fallback_skips_when_already_in_state_by_name_attribute() {
     use carina_core::plan::Plan;


### PR DESCRIPTION
## Summary

`carina plan` was emitting BOTH a state-block effect AND the auto-generated `+ add` / `- delete` on the **same address** when the user targeted a let-bound resource whose `directives { provider = ... }` routed it to a named provider instance:

```
  <- aws.route53.RecordSet r.delegation_ns (import: |...|NS)
+ module \"r\" (./modules/route53)
  + aws.route53.RecordSet r.delegation_ns
      ...

Plan: 1 to import, 1 to add, 0 to change, 0 to destroy.
```

Only the import should fire — apply would then try to create something the import had just claimed, failing with `already exists`.

## Root cause

`ResourceId` includes `provider_instance` in `Hash`/`Eq`. State-block addresses (`import { to }`, `removed { from }`, `moved { from, to }`) are parsed without routing — there is no DSL syntax for it — so they always carry `provider_instance = None`. The target resource (or state row) may carry `provider_instance = Some(<name>)` from its `directives`. The suppress-set lookups and map removes therefore missed:

- `suppress_create.insert(to.clone())` vs `Effect::Create(resource)` — set keyed on None, plan had Some → Create stayed → double-count.
- `suppress_delete.insert(from.clone())` vs orphan `Effect::Delete` — same shape → Delete stayed alongside the Remove.
- `current_states.remove(from)` keyed on None vs map key with Some → miss → moved state never transferred → orphan Delete persists.

## Fix (root cause, all three sibling sites)

- `resolve_import_target` matches on `(provider, resource_type, name)` only via a `same_address` closure and returns the **matched resource's full id** — Import inherits the routed instance, `suppress_create` keys on the same id as the Create's `resource.id`.
- The `Removed` arm resolves `from` to the state row's full id via `find_resource`, then keys `suppress_delete` and emits Remove on that routed id.
- `materialize_moved_states` resolves `from` via state lookup and `to` via a new `find_desired_id` helper that scans `current_states` / `prev_explicit` / `saved_attrs` in order, independent of which map a caller populates first.

Per CLAUDE.md \"Root-cause fixes only\": all three sibling arms share the same broken invariant (\"state-block address surface has no routing slot — the resolver must lift routing from the matched row\"), so all three are fixed in this PR rather than carving out one.

## Test plan

- [x] `import_suppresses_create_when_target_resource_is_routed_to_named_instance` — directly mirrors the real-world `r.delegation_ns` + `provider = management` repro from the issue.
- [x] `removed_block_suppresses_delete_when_state_resource_is_routed_to_named_instance` — same shape for the Removed arm.
- [x] `moved_block_resolves_routed_instance_on_from_and_to` — pins the map-removal + pair-routing for Moved.
- [x] All 512 carina-cli tests pass.
- [x] `cargo test --workspace --doc` — pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass.
- [x] `bash scripts/check-*.sh` — all pass.

Closes #3324