### PR TITLE
parser: introduce StateBlockAddress newtype so routing mismatch is unrepresentable

### DIFF
--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -16,7 +16,7 @@ use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
 use carina_core::identifier::{self, AnonymousIdStateInfo, PrefixStateInfo};
 use carina_core::module_resolver;
-use carina_core::parser::{ProviderConfig, StateBlock};
+use carina_core::parser::{ProviderConfig, StateBlock, StateBlockAddress};
 use carina_core::plan::Plan;
 use carina_core::provider::{
     self as provider_mod, Provider, ProviderError, ProviderFactory, ProviderNormalizer,
@@ -2056,7 +2056,7 @@ pub fn materialize_moved_states(
             let resolved_to = find_desired_id(to, current_states)
                 .or_else(|| find_desired_id(to, prev_explicit))
                 .or_else(|| find_desired_id(to, saved_attrs))
-                .unwrap_or_else(|| to.clone());
+                .unwrap_or_else(|| to.to_unrouted_resource_id());
 
             // Transfer state from the old name to the new name so the
             // differ compares desired(to) against actual(from).
@@ -2085,12 +2085,16 @@ pub fn materialize_moved_states(
 }
 
 /// Look up `to`'s full id (with any routed `provider_instance`) in
-/// `desired` by matching on `(provider, resource_type, name)` —
-/// `provider_instance` is intentionally not part of the match key,
-/// since `moved { to = X 'name' }` has no syntax for routing. Returns
+/// `desired` by matching a [`StateBlockAddress`] against the routed
+/// `ResourceId` keys. `StateBlockAddress` is routing-agnostic by
+/// construction, so this is the only place the routing for the
+/// destination of a `moved { ... }` block can be derived. Returns
 /// `None` when no matching key exists, so callers can chain across
 /// multiple maps with `.or_else(...)` (carina#3324).
-fn find_desired_id<V>(to: &ResourceId, desired: &HashMap<ResourceId, V>) -> Option<ResourceId> {
+fn find_desired_id<V>(
+    to: &StateBlockAddress,
+    desired: &HashMap<ResourceId, V>,
+) -> Option<ResourceId> {
     desired
         .keys()
         .find(|k| {
@@ -2248,7 +2252,7 @@ pub fn add_state_block_effects(
 /// 3. `name_attribute` fallback against the state file
 ///    (already-imported case).
 fn resolve_import_target(
-    to: &ResourceId,
+    to: &StateBlockAddress,
     plan: &Plan,
     state_file: &Option<StateFile>,
     registry: &SchemaRegistry,
@@ -2261,10 +2265,9 @@ fn resolve_import_target(
         )
         .and_then(|s| s.name_attribute.as_deref());
 
-    // Address-equality test that ignores `provider_instance` — the
-    // import-block surface form has no routing slot, so two ids with
-    // the same `(provider, resource_type, name)` are the same address
-    // regardless of routing.
+    // Address-equality test: `StateBlockAddress` has no
+    // `provider_instance`, so equality is naturally the 3-tuple match
+    // we want — no risk of `Eq` silently including routing.
     let same_address = |id: &ResourceId| {
         id.provider == to.provider
             && id.resource_type == to.resource_type
@@ -2315,7 +2318,7 @@ fn resolve_import_target(
         }
     }
 
-    to.clone()
+    to.to_unrouted_resource_id()
 }
 
 /// Check whether a `ProviderError` is an AWS throttling error that should be retried.

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -384,7 +384,7 @@ fn test_resolve_enum_aliases_non_enum_values_unchanged() {
 fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{ConcreteValue, Resource, ResourceId, Value};
+    use carina_core::resource::{ConcreteValue, Resource, Value};
     use carina_core::schema::ResourceSchema;
 
     // Schema with name_attribute = "bucket_name"
@@ -403,7 +403,7 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
 
     // Import block with the logical name (not the hash)
     let state_blocks = vec![StateBlock::Import {
-        to: ResourceId::with_provider("awscc", "s3.Bucket", "carina-rs-state", None),
+        to: StateBlockAddress::new("awscc", "s3.Bucket", "carina-rs-state"),
         id: "carina-rs-state".to_string(),
     }];
 
@@ -468,10 +468,11 @@ fn moved_block_resolves_routed_instance_on_from_and_to() {
     let mut prev_explicit = HashMap::new();
     let mut saved_attrs = HashMap::new();
 
-    // `moved` block addresses are parsed without routing.
+    // `moved` block addresses are routing-agnostic by construction
+    // (the type makes routing unrepresentable here).
     let state_blocks = vec![StateBlock::Moved {
-        from: ResourceId::with_provider("aws", "route53.RecordSet", "old_record", None),
-        to: ResourceId::with_provider("aws", "route53.RecordSet", "new_record", None),
+        from: StateBlockAddress::new("aws", "route53.RecordSet", "old_record"),
+        to: StateBlockAddress::new("aws", "route53.RecordSet", "new_record"),
     }];
 
     let moved_pairs = materialize_moved_states(
@@ -542,10 +543,10 @@ fn removed_block_suppresses_delete_when_state_resource_is_routed_to_named_instan
         explicit_dependencies: std::collections::HashSet::new(),
     });
 
-    // `removed` block was written without routing — `from` has
-    // `provider_instance = None`.
+    // `removed` block addresses are routing-agnostic by construction
+    // — the newtype makes routing unrepresentable here.
     let state_blocks = vec![StateBlock::Removed {
-        from: ResourceId::with_provider("aws", "route53.RecordSet", "r.delegation_ns", None),
+        from: StateBlockAddress::new("aws", "route53.RecordSet", "r.delegation_ns"),
     }];
 
     add_state_block_effects(&mut plan, &state_blocks, &Some(state_file), &[], &schemas);
@@ -583,7 +584,7 @@ fn removed_block_suppresses_delete_when_state_resource_is_routed_to_named_instan
 fn import_suppresses_create_when_target_resource_is_routed_to_named_instance() {
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{Resource, ResourceId};
+    use carina_core::resource::Resource;
 
     let schemas = SchemaRegistry::new();
 
@@ -599,11 +600,11 @@ fn import_suppresses_create_when_target_resource_is_routed_to_named_instance() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(resource));
 
-    // The import block was written without a routing hint
-    // (`to = aws.route53.RecordSet 'r.delegation_ns'`), so the parsed
-    // `to` carries `provider_instance = None`. Same address otherwise.
+    // The import block address has no routing slot (`StateBlockAddress`
+    // is routing-agnostic by construction). The downstream resolver
+    // is responsible for lifting routing from the matched Create.
     let state_blocks = vec![StateBlock::Import {
-        to: ResourceId::with_provider("aws", "route53.RecordSet", "r.delegation_ns", None),
+        to: StateBlockAddress::new("aws", "route53.RecordSet", "r.delegation_ns"),
         id: "|hosted-zone-id|registry-dev.carina-rs.dev|NS".to_string(),
     }];
 
@@ -633,7 +634,6 @@ fn import_suppresses_create_when_target_resource_is_routed_to_named_instance() {
 #[test]
 fn import_fallback_skips_when_already_in_state_by_name_attribute() {
     use carina_core::plan::Plan;
-    use carina_core::resource::ResourceId;
     use carina_core::schema::ResourceSchema;
     use carina_state::state::{ResourceState, StateFile};
 
@@ -652,7 +652,7 @@ fn import_fallback_skips_when_already_in_state_by_name_attribute() {
 
     let mut plan = Plan::new();
     let state_blocks = vec![StateBlock::Import {
-        to: ResourceId::with_provider("awscc", "s3.Bucket", "carina-rs-state", None),
+        to: StateBlockAddress::new("awscc", "s3.Bucket", "carina-rs-state"),
         id: "carina-rs-state".to_string(),
     }];
 

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -486,27 +486,160 @@ impl ExportParamLike for ParsedExportParam {
     }
 }
 
+/// An address as written in a state block (`import { to = X 'addr' }`,
+/// `removed { from = X 'addr' }`, `moved { from = X 'a', to = X 'b' }`).
+///
+/// The DSL surface form for these blocks has **no syntax for routing**
+/// — there is no slot to specify which `provider_instance` the address
+/// targets. The `provider_instance` of the matched resource (or state
+/// row) is decided downstream by looking at the let-bound resource's
+/// `directives { provider = ... }`.
+///
+/// This type is the **routing-agnostic** counterpart to
+/// [`crate::resource::ResourceId`]:
+///
+/// - Its `Eq`/`Hash` includes only `(provider, resource_type, name)`.
+///   Comparing two state-block addresses cannot silently mismatch on
+///   a routing field that the DSL never specified.
+/// - It does **not** implement `PartialEq<ResourceId>` and there is no
+///   `From<&StateBlockAddress>` / `From<&ResourceId>` shortcut. The
+///   only way to produce a `ResourceId` from a `StateBlockAddress` is
+///   via a routing-lifting lookup against the plan / state (see
+///   `resolve_import_target` and `find_desired_id` in
+///   `carina-cli/src/wiring/mod.rs`), or — only when no match
+///   exists — via the explicit
+///   [`to_unrouted_resource_id`](Self::to_unrouted_resource_id)
+///   escape hatch documented on the method itself.
+///
+/// This shape makes the carina#3324 bug class — comparing a
+/// None-routed parsed address against a routed `ResourceId` and
+/// silently missing — unrepresentable: the type signature forces every
+/// consumer to perform the resolution step explicitly. A new consumer
+/// added tomorrow cannot reach the buggy path; the compiler rejects
+/// the comparison.
+///
+/// The cross-type equality guard is enforced by the type system:
+///
+/// ```compile_fail
+/// use carina_core::parser::StateBlockAddress;
+/// use carina_core::resource::ResourceId;
+///
+/// let addr = StateBlockAddress::new("aws", "route53.RecordSet", "r");
+/// let routed = ResourceId::with_provider(
+///     "aws",
+///     "route53.RecordSet",
+///     "r",
+///     Some("management".to_string()),
+/// );
+///
+/// // The compiler rejects this — `StateBlockAddress` does not
+/// // implement `PartialEq<ResourceId>`. A new consumer cannot
+/// // silently miss a routed-vs-unrouted match the way carina#3324
+/// // did before the newtype existed.
+/// let _ = addr == routed;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct StateBlockAddress {
+    pub provider: String,
+    pub resource_type: String,
+    pub name: crate::resource::ResourceName,
+}
+
+impl StateBlockAddress {
+    /// Construct a `StateBlockAddress`. The `name` is canonicalized
+    /// through [`crate::utils::canonicalize_map_key_address`] so all
+    /// three DSL surface forms (`binding.key`, `binding['key']`,
+    /// `binding["key"]`) collapse to the same value — the parser's
+    /// `parse_state_block_address` does the same, and the type's
+    /// `Eq`/`Hash` only match when the canonical form does. Without
+    /// canonicalization at the constructor, a programmatic caller
+    /// could build an address that silently fails to match a parsed
+    /// one (the same class of bug the newtype exists to prevent).
+    pub fn new(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        let raw_name = name.into();
+        let canonical = crate::utils::canonicalize_map_key_address(&raw_name);
+        Self {
+            provider: provider.into(),
+            resource_type: resource_type.into(),
+            name: crate::resource::ResourceName::from_string(canonical),
+        }
+    }
+
+    /// Borrow the address's name as `&str`.
+    pub fn name_str(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// Returns the display type including provider prefix, matching
+    /// [`ResourceId::display_type`] so plan/error output reads the
+    /// same for both routing-agnostic and routed addresses.
+    pub fn display_type(&self) -> String {
+        if self.provider.is_empty() {
+            self.resource_type.clone()
+        } else {
+            format!("{}.{}", self.provider, self.resource_type)
+        }
+    }
+
+    /// Last-resort lift to a [`ResourceId`] with no routing.
+    ///
+    /// Use this **only** when the address resolved against no plan or
+    /// state entry (e.g. the user wrote `import { to = X 'addr' }` for
+    /// a resource that does not exist anywhere). The resulting
+    /// `ResourceId` carries `provider_instance = None`, which is the
+    /// best the type system can do when there is no row to inherit
+    /// routing from.
+    ///
+    /// Normal resolution paths must instead inherit routing from the
+    /// matched plan Create or state row — they should never call this
+    /// method as a shortcut. Doing so re-introduces the carina#3324
+    /// bug class.
+    pub fn to_unrouted_resource_id(&self) -> crate::resource::ResourceId {
+        crate::resource::ResourceId::with_provider(
+            &self.provider,
+            &self.resource_type,
+            self.name_str(),
+            None,
+        )
+    }
+}
+
+impl std::fmt::Display for StateBlockAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.provider.is_empty() {
+            write!(f, "{}.{}", self.resource_type, self.name)
+        } else {
+            write!(f, "{}.{}.{}", self.provider, self.resource_type, self.name)
+        }
+    }
+}
+
 /// State manipulation block (import, removed, moved)
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum StateBlock {
     /// Import existing infrastructure into Carina management
     Import {
-        /// Target resource address
-        to: ResourceId,
+        /// Target resource address (routing-agnostic — see
+        /// [`StateBlockAddress`]).
+        to: StateBlockAddress,
         /// Cloud provider identifier (e.g., "vpc-0abc123def456")
         id: String,
     },
     /// Remove a resource from state without destroying it
     Removed {
-        /// Resource address to remove from state
-        from: ResourceId,
+        /// Resource address to remove from state (routing-agnostic).
+        from: StateBlockAddress,
     },
     /// Rename/move a resource in state without destroy/recreate
     Moved {
-        /// Old resource address
-        from: ResourceId,
-        /// New resource address
-        to: ResourceId,
+        /// Old resource address (routing-agnostic).
+        from: StateBlockAddress,
+        /// New resource address (routing-agnostic).
+        to: StateBlockAddress,
     },
 }
 

--- a/carina-core/src/parser/blocks/state.rs
+++ b/carina-core/src/parser/blocks/state.rs
@@ -3,18 +3,17 @@
 //! Extracted from `parser/mod.rs` per #2263 (part 2/2).
 
 use crate::parser::Rule;
-use crate::parser::ast::StateBlock;
+use crate::parser::ast::{StateBlock, StateBlockAddress};
 use crate::parser::context::first_inner;
 use crate::parser::error::ParseError;
 use crate::parser::expressions::string_literal::parse_string_literal;
-use crate::parser::util::parse_resource_address;
-use crate::resource::ResourceId;
+use crate::parser::util::parse_state_block_address;
 
 /// Parse an import state block
 pub(in crate::parser) fn parse_import_state_block(
     pair: pest::iterators::Pair<Rule>,
 ) -> Result<StateBlock, ParseError> {
-    let mut to: Option<ResourceId> = None;
+    let mut to: Option<StateBlockAddress> = None;
     let mut id: Option<String> = None;
 
     for attr in pair.into_inner() {
@@ -23,7 +22,7 @@ pub(in crate::parser) fn parse_import_state_block(
             match inner.as_rule() {
                 Rule::import_to_attr => {
                     let addr = first_inner(inner, "resource address", "import to")?;
-                    to = Some(parse_resource_address(addr)?);
+                    to = Some(parse_state_block_address(addr)?);
                 }
                 Rule::import_id_attr => {
                     let str_pair = first_inner(inner, "string", "import id")?;
@@ -50,12 +49,12 @@ pub(in crate::parser) fn parse_import_state_block(
 pub(in crate::parser) fn parse_removed_block(
     pair: pest::iterators::Pair<Rule>,
 ) -> Result<StateBlock, ParseError> {
-    let mut from: Option<ResourceId> = None;
+    let mut from: Option<StateBlockAddress> = None;
 
     for attr in pair.into_inner() {
         if attr.as_rule() == Rule::removed_attr {
             let addr = first_inner(attr, "resource address", "removed from")?;
-            from = Some(parse_resource_address(addr)?);
+            from = Some(parse_state_block_address(addr)?);
         }
     }
 
@@ -71,8 +70,8 @@ pub(in crate::parser) fn parse_removed_block(
 pub(in crate::parser) fn parse_moved_block(
     pair: pest::iterators::Pair<Rule>,
 ) -> Result<StateBlock, ParseError> {
-    let mut from: Option<ResourceId> = None;
-    let mut to: Option<ResourceId> = None;
+    let mut from: Option<StateBlockAddress> = None;
+    let mut to: Option<StateBlockAddress> = None;
 
     for attr in pair.into_inner() {
         if attr.as_rule() == Rule::moved_attr {
@@ -80,11 +79,11 @@ pub(in crate::parser) fn parse_moved_block(
             match inner.as_rule() {
                 Rule::moved_from_attr => {
                     let addr = first_inner(inner, "resource address", "moved from")?;
-                    from = Some(parse_resource_address(addr)?);
+                    from = Some(parse_state_block_address(addr)?);
                 }
                 Rule::moved_to_attr => {
                     let addr = first_inner(inner, "resource address", "moved to")?;
-                    to = Some(parse_resource_address(addr)?);
+                    to = Some(parse_state_block_address(addr)?);
                 }
                 _ => {}
             }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -20,8 +20,8 @@ pub use ast::{
     ArgumentParameter, AttributeParameter, BackendConfig, BindingName, DeferredForExpression,
     ExportParamLike, ExportParameter, File, FnParam, InferredExportParam, InferredFile, ModuleCall,
     ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock, ResourceContext, ResourceRef,
-    ResourceTypePath, StateBlock, TypeExpr, UntilPredicateAst, UpstreamState, UseStatement,
-    UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock, WaitBinding,
+    ResourceTypePath, StateBlock, StateBlockAddress, TypeExpr, UntilPredicateAst, UpstreamState,
+    UseStatement, UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock, WaitBinding,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub(crate) use entry::parse_with_seeded_bindings;

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -7,7 +7,7 @@ use super::context::next_pair;
 use super::error::ParseError;
 use super::expressions::string_literal::{parse_string_literal, unescape_single_quoted};
 use crate::eval_value::EvalValue;
-use crate::resource::{ConcreteValue, DeferredValue, ResourceId, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 
 /// Convert PascalCase to snake_case (e.g., "VpcId" → "vpc_id", "AwsAccountId" → "aws_account_id").
 pub fn pascal_to_snake(s: &str) -> String {
@@ -87,32 +87,32 @@ pub(crate) fn split_namespaced_id(namespaced: &str) -> (String, String) {
     }
 }
 
-/// Parse a resource address: `provider.service.type "name"`
-pub(crate) fn parse_resource_address(
+/// Parse a resource address into a [`StateBlockAddress`] — the
+/// routing-agnostic newtype used by `import`/`removed`/`moved` blocks.
+///
+/// The DSL `resource_address` rule (`provider.service.type "name"`)
+/// has no syntax for `provider_instance`, so the returned type
+/// deliberately has no routing field at all. A downstream consumer
+/// cannot accidentally compare the address against a routed
+/// [`ResourceId`] — the carina#3324 bug class is unrepresentable at
+/// the type level.
+pub(crate) fn parse_state_block_address(
     pair: pest::iterators::Pair<Rule>,
-) -> Result<ResourceId, ParseError> {
+) -> Result<crate::parser::ast::StateBlockAddress, ParseError> {
     let mut inner = pair.into_inner();
     let namespaced = next_pair(&mut inner, "namespaced id", "resource address")?
         .as_str()
         .to_string();
     let name_pair = next_pair(&mut inner, "resource name", "resource address")?;
-    // The name is a string literal - extract value from quotes
     let raw_name = parse_string_literal(name_pair)?;
-    // Normalize map-key trailing segment so all three input shapes
-    // (`binding.key`, `binding['key']`, `binding["key"]`) collapse
-    // to the canonical form before state lookup. See #1903.
-    let name = crate::utils::canonicalize_map_key_address(&raw_name);
-
-    // Split namespaced id into provider and resource_type
+    // Name canonicalization lives in `StateBlockAddress::new` so the
+    // invariant holds for every constructor, not just this parser
+    // path. A future programmatic caller can't bypass it.
     let (provider, resource_type) = split_namespaced_id(&namespaced);
-
-    // `to`/`moved` addresses don't carry instance routing — the resolved
-    // resource supplies its own `provider_instance` from the DSL.
-    Ok(ResourceId::with_provider(
+    Ok(crate::parser::ast::StateBlockAddress::new(
         provider,
         resource_type,
-        name,
-        None,
+        raw_name,
     ))
 }
 

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -195,7 +195,7 @@ impl ResourceName {
     /// `Pending`; any other input becomes `Bound`. Used by
     /// `ResourceId::new` / `with_provider` to keep the legacy
     /// `String` constructors compatible.
-    fn from_string(s: String) -> Self {
+    pub fn from_string(s: String) -> Self {
         if s.is_empty() {
             Self::Pending
         } else {


### PR DESCRIPTION
## Summary

PR #3325 (carina#3324) fixed the symptom of state-block addresses silently mismatching against routed `ResourceId`s by adding runtime `find_*` lookups at three consumer sites. That worked, but the type system still permitted the bug — a future fourth consumer that compared a parsed state-block address directly against a routed `ResourceId` would re-introduce the same silent miss. CLAUDE.md "Long-term view alongside root-cause" demands a type-level guarantee, not just a runtime convention.

This PR makes the bug class unrepresentable at the type level.

## Mechanism

New type `StateBlockAddress { provider, resource_type, name }`:

- `Eq` / `Hash` includes only the 3-tuple — there is no `provider_instance` field on the type. Two state-block addresses with the same `(provider, resource_type, name)` are equal, regardless of any routing in the world.
- Does **not** implement `PartialEq<ResourceId>`, and there are no `From` / `Into` shortcuts. The only way to produce a `ResourceId` is via the routing-lifting lookups (`resolve_import_target`, `find_desired_id`) or the explicit `to_unrouted_resource_id()` escape hatch (documented as last-resort with a warning against misuse).
- A `compile_fail` doctest pins the guarantee: `addr == routed_id` is rejected by the compiler. The "new caller tomorrow" check is now type-shaped, not behavioral.
- `StateBlockAddress::new` canonicalizes the name through `canonicalize_map_key_address` so all three DSL surface forms (`binding.key`, `binding['key']`, `binding["key"]`) collapse to the same value at every constructor — not just the parser path. A programmatic test caller cannot construct an address that silently fails to match a parsed one (this gap was caught by review round 3).

## Wiring

- `StateBlock::Import { to }`, `Removed { from }`, `Moved { from, to }` now hold `StateBlockAddress` (`carina-core/src/parser/ast.rs`).
- Parser produces the newtype via `parse_state_block_address`. The obsolete `parse_resource_address` (which silently set `provider_instance = None`) is removed.
- The three consumer paths (`carina-cli/src/wiring/mod.rs` — `resolve_import_target`, `find_desired_id`, `materialize_moved_states`, `Removed` arm) take `&StateBlockAddress` and produce `ResourceId` via lookup. Same runtime behavior as PR #3325, but now driven by the type signature.

## Blast radius measurement

Per CLAUDE.md "Long-term view alongside root-cause", I stubbed the newtype and measured before deciding scope:

- Initial stub: 4 errors (carina-core parser only).
- After parser fix: 11 errors (5 in carina-cli/src/wiring/mod.rs, 6 in carina-cli/src/wiring/tests.rs).
- All errors are mechanical `ResourceId::with_provider(... None)` → `StateBlockAddress::new(...)` rewrites.

Total: small enough to land in-PR (no follow-up needed). The "blast radius is wide" intuition that delayed this in PR #3325 was wrong.

## Test plan

- [x] Three carina#3325 tests now construct addresses via `StateBlockAddress::new` and continue to pass.
- [x] `compile_fail` doctest pins cross-type equality rejection.
- [x] 3670 workspace tests pass.
- [x] `cargo test --workspace --doc` — pass (including the `compile_fail` doctest).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass.
- [x] `bash scripts/check-*.sh` — all pass.

Closes #3326

Refs #3324, PR #3325, PR #3327 (CLAUDE.md "Long-term view alongside root-cause").
