### PR TITLE
parser, effect: type import.id and Effect::Import.identifier as Value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ plan-fixtures:
 	@$(MAKE) plan-upstream-state-map-dot-notation
 	@echo "---"
 	@$(MAKE) plan-deferred-for
+	@echo "---"
+	@$(MAKE) plan-import-deferred-interpolation
 	@echo ""
 	@echo "=== policy_pretty ==="
 	@$(MAKE) plan-policy-pretty
@@ -212,6 +214,8 @@ plan-upstream-state-map-dot-notation:
 	$(PLAN_FIXTURE) upstream_state_map_dot_notation
 plan-deferred-for:
 	$(PLAN_FIXTURE) deferred_for
+plan-import-deferred-interpolation:
+	$(PLAN_FIXTURE) import_deferred_interpolation
 plan-exports:
 	$(PLAN_FIXTURE) exports
 plan-exports-multifile:
@@ -236,7 +240,7 @@ plan-multi-instance-create:
 	$(PLAN_FIXTURE) multi_instance_create
 plan-multi-instance-module:
 	$(PLAN_FIXTURE) multi_instance_module
-.PHONY: plan-all-create plan-no-changes plan-empty-explicit-children-no-changes plan-no-changes-enum plan-mixed plan-delete plan-delete-list-of-maps plan-compact \
+.PHONY: plan-all-create plan-no-changes plan-empty-explicit-children-no-changes plan-no-changes-enum plan-mixed plan-delete plan-delete-list-of-maps plan-compact plan-import-deferred-interpolation \
         plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
         plan-list-diff-modified-with-unchanged \
         plan-list-diff-modified-with-unchanged-nested \

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1219,13 +1219,26 @@ async fn run_apply_locked(
     // Uses unresolved resources (sorted_resources) so dependents retain ResourceRef values.
     cascade_dependent_updates(&mut plan, &sorted_resources, &current_states, schemas);
 
-    // Add state block effects (import/removed/moved) to the plan
+    // Add state block effects (import/removed/moved) to the plan.
+    // carina#3329: resolve `import { id = "${…}|…" }` interpolations
+    // against the same binding view the resource-attribute resolver
+    // uses. The empty `unresolved_upstream_bindings` set here just
+    // skips the plan-time "stamp upstream refs as
+    // `(known after upstream apply: …)`" pass — apply does not need
+    // that display marker. The hard-fail on a still-deferred
+    // identifier is enforced one layer down in
+    // `execute_import_effects` via [`carina_core::effect::resolve_import_identifier`],
+    // which rejects any non-Concrete `Value` before it can reach the
+    // provider's `read()`.
+    let no_unresolved_upstreams: std::collections::HashSet<&str> = std::collections::HashSet::new();
     crate::wiring::add_state_block_effects(
         &mut plan,
         &parsed.state_blocks,
         &state_file,
         &moved_pairs,
         schemas,
+        &bindings,
+        &no_unresolved_upstreams,
     );
 
     // Check for prevent_destroy violations
@@ -1462,16 +1475,24 @@ pub async fn run_apply_from_plan(
     let plan_file: PlanFile =
         serde_json::from_str(&content).map_err(|e| format!("Failed to parse plan file: {}", e))?;
 
-    // Validate version compatibility. Plan-file version 4
-    // (carina#3248) persists `compositions` so the saved-plan
-    // apply path can rebuild the same `ResolvedBindings` view as the
-    // live-apply path (carina#3246). Older plans (version 3 and
-    // below) lack the `compositions` field and cannot be applied
-    // by the post-#3248 binding-construction path, so they are
+    // Validate version compatibility. Plan-file version 5
+    // (carina#3329) changed `Effect::Import.identifier`'s on-disk shape
+    // from a plain string to a tagged `Value`, so a deferred upstream-
+    // state reference inside the import id can survive plan→apply as
+    // a `Value::Deferred(Interpolation)` rather than being silently
+    // substituted to empty. Pre-#3329 plans (version 4) serialise
+    // `identifier` as a raw string and would otherwise hit an opaque
+    // serde error at deserialisation; the explicit version check
+    // produces a clean "re-run plan" message instead.
+    //
+    // Plan-file version 4 (carina#3248) persists `compositions` so the
+    // saved-plan apply path can rebuild the same `ResolvedBindings`
+    // view as the live-apply path (carina#3246). Older plans cannot be
+    // applied by the post-#3248 binding-construction path and are
     // rejected outright per the repo's no-backward-compat policy.
-    if plan_file.version != 4 {
+    if plan_file.version != 5 {
         return Err(AppError::Config(format!(
-            "Unsupported plan file version: {} (expected 4). \
+            "Unsupported plan file version: {} (expected 5). \
              Re-run 'carina plan' to produce a plan in the current format.",
             plan_file.version
         )));

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -2024,7 +2024,7 @@ mod saved_plan_version_tests {
             "error must name the rejected version, got: {msg}",
         );
         assert!(
-            msg.contains("expected 4"),
+            msg.contains("expected 5"),
             "error must name the expected version, got: {msg}",
         );
         assert!(

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -159,12 +159,18 @@ fn build_plan_file<E>(
     ctx: &crate::wiring::PlanContext,
 ) -> Result<PlanFile, carina_core::value::SerializationError> {
     Ok(PlanFile {
+        // carina#3329: bumped 4→5 — `Effect::Import.identifier` is now
+        // a tagged `Value`, not a plain string, so a pre-#3329 v4 plan
+        // would otherwise fail to deserialize with an opaque serde
+        // error. The version check at apply time produces a clean
+        // "re-run plan" message instead.
+        //
         // carina#3248: bumped 3→4 — saved plans now persist
         // `compositions` so the saved-plan apply path can rebuild
         // the same `ResolvedBindings` view as the live-apply path.
-        // Older plans (version `3` and below) are rejected with a
+        // Older plans (version below current) are rejected with a
         // clear message pointing the user at re-running `plan`.
-        version: 4,
+        version: 5,
         carina_version: env!("CARGO_PKG_VERSION").to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
         source_path: path.display().to_string(),

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -1,6 +1,6 @@
 //! Helpers for executing import and state-only effects with user feedback.
 
-use carina_core::effect::Effect;
+use carina_core::effect::{Effect, resolve_import_identifier};
 use carina_core::executor::ExecutionResult;
 use carina_core::plan::Plan;
 use carina_core::provider::{Provider, ReadRequest};
@@ -18,9 +18,30 @@ pub(crate) async fn execute_import_effects(
 ) {
     for effect in plan.effects() {
         if let Effect::Import { id, identifier } = effect {
-            println!("  {} Importing {} (id: {})...", "<-".cyan(), id, identifier);
+            // carina#3329: the identifier is a `Value` so an
+            // interpolation referencing a deferred upstream-state ref
+            // can survive plan-time display as `(known after upstream
+            // apply: …)`. The apply path requires a concrete string;
+            // `resolve_import_identifier` is the single entry point
+            // that performs this check, so any future caller is forced
+            // to handle the deferred case explicitly via its `Result`
+            // contract rather than rolling its own ad-hoc match.
+            let identifier_str = match resolve_import_identifier(identifier) {
+                Ok(s) => s.to_string(),
+                Err(e) => {
+                    println!("  {} Import failed for {}: {}", "✗".red(), id, e);
+                    result.failure_count += 1;
+                    continue;
+                }
+            };
+            println!(
+                "  {} Importing {} (id: {})...",
+                "<-".cyan(),
+                id,
+                identifier_str
+            );
             match provider
-                .read(id, Some(identifier.as_str()), ReadRequest)
+                .read(id, Some(identifier_str.as_str()), ReadRequest)
                 .await
             {
                 Ok(state) => {
@@ -33,7 +54,7 @@ pub(crate) async fn execute_import_effects(
                             "  {} Import failed: resource {} with id {} not found",
                             "✗".red(),
                             id,
-                            identifier
+                            identifier_str
                         );
                         result.failure_count += 1;
                     }
@@ -63,5 +84,168 @@ pub(crate) fn execute_state_only_effects(plan: &Plan, result: &mut ExecutionResu
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_core::executor::ExecutionResult;
+    use carina_core::plan::Plan;
+    use carina_core::provider::{
+        CreateRequest, DeleteRequest, Provider, ProviderResult, ReadRequest, UpdateRequest,
+    };
+    use carina_core::resource::{
+        ConcreteValue, DataSource, DeferredValue, InterpolationPart, ResourceId, State,
+        UnknownReason, Value,
+    };
+    use futures::future::BoxFuture;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::Mutex;
+
+    fn empty_result() -> ExecutionResult {
+        ExecutionResult {
+            success_count: 0,
+            failure_count: 0,
+            skip_count: 0,
+            applied_states: HashMap::new(),
+            successfully_deleted: HashSet::new(),
+            permanent_name_overrides: HashMap::new(),
+            current_states: HashMap::new(),
+            failed_refreshes: HashSet::new(),
+        }
+    }
+
+    /// Mock provider that records every `read` call so the test can
+    /// assert apply *never* invokes the provider when the import
+    /// identifier is still deferred.
+    struct ReadRecorder {
+        reads: Mutex<Vec<(ResourceId, Option<String>)>>,
+    }
+
+    impl ReadRecorder {
+        fn new() -> Self {
+            Self {
+                reads: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn read_count(&self) -> usize {
+            self.reads.lock().unwrap().len()
+        }
+    }
+
+    impl Provider for ReadRecorder {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        fn read(
+            &self,
+            id: &ResourceId,
+            identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            self.reads
+                .lock()
+                .unwrap()
+                .push((id.clone(), identifier.map(str::to_string)));
+            let id = id.clone();
+            Box::pin(async move { Ok(State::not_found(id)) })
+        }
+
+        fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+            self.read(&resource.id, None, ReadRequest)
+        }
+
+        fn create(
+            &self,
+            _id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            unreachable!("import path must not call create")
+        }
+
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            unreachable!("import path must not call update")
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            unreachable!("import path must not call delete")
+        }
+    }
+
+    /// carina#3329: an `Effect::Import` whose `identifier` is still a
+    /// `Value::Deferred(Interpolation)` at apply time MUST be rejected
+    /// before reaching the provider. Pre-#3329 the identifier was a
+    /// plain `String`, so a partially-substituted "|literal|literal"
+    /// would be passed straight to `provider.read()` with no warning.
+    /// The `Value`-typed field plus `resolve_import_identifier` now
+    /// gates that path.
+    #[tokio::test]
+    async fn execute_import_effects_rejects_deferred_identifier_without_calling_provider() {
+        let id = ResourceId::new("aws.route53.RecordSet", "r");
+        let deferred = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
+                UnknownReason::UpstreamBareRef {
+                    binding: "management_route53".into(),
+                },
+            ))),
+            InterpolationPart::Literal("|registry-dev.carina-rs.dev|NS".into()),
+        ]));
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Import {
+            id: id.clone(),
+            identifier: deferred,
+        });
+
+        let recorder = ReadRecorder::new();
+        let mut result = empty_result();
+        execute_import_effects(&plan, &recorder, &mut result).await;
+
+        assert_eq!(
+            recorder.read_count(),
+            0,
+            "provider.read() must NOT be called when the import identifier \
+             is still deferred — that is the regression #3329 is preventing"
+        );
+        assert_eq!(
+            result.failure_count, 1,
+            "the deferred import must count as a failure"
+        );
+        assert_eq!(result.success_count, 0);
+    }
+
+    /// Companion check: a concrete-string identifier still flows
+    /// through to the provider unchanged. Guards against an overly-
+    /// aggressive future tweak to `resolve_import_identifier` that
+    /// would block the happy path.
+    #[tokio::test]
+    async fn execute_import_effects_passes_concrete_identifier_through() {
+        let id = ResourceId::new("aws.s3.Bucket", "b");
+        let mut plan = Plan::new();
+        plan.add(Effect::Import {
+            id: id.clone(),
+            identifier: Value::Concrete(ConcreteValue::String("my-bucket".into())),
+        });
+
+        let recorder = ReadRecorder::new();
+        let mut result = empty_result();
+        execute_import_effects(&plan, &recorder, &mut result).await;
+
+        let reads = recorder.reads.lock().unwrap();
+        assert_eq!(reads.len(), 1);
+        assert_eq!(reads[0].1.as_deref(), Some("my-bucket"));
     }
 }

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -644,6 +644,13 @@ impl<'a> TreeRenderContext<'a> {
                 }
             }
             Effect::Import { id, identifier } => {
+                // carina#3329: render the identifier through
+                // `format_import_identifier` so a concrete cloud
+                // identifier prints bare (`vpc-0abc…`) while a
+                // deferred-upstream interpolation keeps its
+                // `(known after upstream apply: …)` marker rather than
+                // being silently substituted to empty.
+                let identifier_str = carina_core::effect::format_import_identifier(identifier);
                 writeln!(
                     self.out,
                     "{}{}{} {} {} {}",
@@ -652,7 +659,7 @@ impl<'a> TreeRenderContext<'a> {
                     colored_symbol,
                     id.display_type().cyan().bold(),
                     id.name_str().cyan().bold(),
-                    format!("(import: {})", identifier).dimmed()
+                    format!("(import: {})", identifier_str).dimmed()
                 )
                 .unwrap();
             }
@@ -1859,7 +1866,11 @@ pub fn format_effect(effect: &Effect) -> String {
             format!("Read {}", resource.id.human())
         }
         Effect::Import { id, identifier } => {
-            format!("Import {} (id: {})", id.human(), identifier)
+            format!(
+                "Import {} (id: {})",
+                id.human(),
+                carina_core::effect::format_import_identifier(identifier)
+            )
         }
         Effect::Remove { id } => {
             format!("Remove {} from state", id.human())

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1363,7 +1363,9 @@ fn format_effect_replace_separates_type_and_name_with_space() {
 fn format_effect_import_separates_type_and_name_with_space() {
     let effect = Effect::Import {
         id: ResourceId::with_provider("aws", "s3.Bucket", "logs", None),
-        identifier: "my-logs-bucket".to_string(),
+        identifier: carina_core::resource::Value::Concrete(
+            carina_core::resource::ConcreteValue::String("my-logs-bucket".to_string()),
+        ),
     };
     assert_eq!(
         format_effect(&effect),

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -281,6 +281,8 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &state_file,
         &moved_pairs,
         wiring.schemas(),
+        &plan_bindings,
+        &upstream_binding_names,
     );
 
     let moved_origins: HashMap<ResourceId, ResourceId> = moved_pairs

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -983,6 +983,51 @@ fn plan_snapshot_upstream_state_unresolved() {
     insta::assert_snapshot!(stripped);
 }
 
+/// carina#3329 regression: an `import { id = "${X.attr}|…" }` whose
+/// `${X.attr}` references a deferred upstream-state value must render
+/// the interpolation through plan display as a `(known after upstream
+/// apply: …)` placeholder around the literal segments rather than
+/// silently substituting the `${…}` to empty.
+///
+/// Pre-#3329 the parser stored `id` as a plain `String` and discarded
+/// every `${…}` segment, so the plan showed `id: |literal|literal` —
+/// a malformed-looking identifier presented as if it were the cloud
+/// API's real value. Operators reviewing the diff had no way to tell
+/// whether apply would re-resolve the reference or ship the partial
+/// string to AWS as-is.
+#[test]
+fn plan_snapshot_import_deferred_interpolation() {
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("import_deferred_interpolation");
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &[],
+        &[],
+        None,
+        None,
+    );
+    let stripped = strip_ansi(&output);
+    assert!(
+        stripped.contains("(known after upstream apply: management_route53.apex_zone_id)"),
+        "expected the import id's `${{management_route53.apex_zone_id}}` segment to render \
+         as `(known after upstream apply: management_route53.apex_zone_id)`, got:\n{}",
+        stripped
+    );
+    assert!(
+        !stripped.lines().any(|line| line.contains("id:")
+            && line.contains("|registry-dev")
+            && !line.contains("known after upstream apply")),
+        "expected the leading `|` (caused by a silently-substituted ${{…}}) to be gone — \
+         no `id:` line should show a bare `|registry-dev…` without the deferred marker. \
+         Got:\n{}",
+        stripped
+    );
+    insta::assert_snapshot!(stripped);
+}
+
 /// Companion to `plan_snapshot_upstream_state_unresolved`: state file is
 /// present but `exports` is empty (upstream module declared but not yet
 /// applied). The same `(known after upstream apply: <ref>)` rendering

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_import_deferred_interpolation.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_import_deferred_interpolation.snap
@@ -1,0 +1,10 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: stripped
+---
+Execution Plan:
+
+  <- aws.route53.RecordSet r.delegation_ns (import: (known after upstream apply: management_route53.apex_zone_id)|registry-dev.carina-rs.dev|NS)
+      id: (known after upstream apply: management_route53.apex_zone_id)|registry-dev.carina-rs.dev|NS
+
+Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -302,7 +302,7 @@ fn plan_file_serde_round_trip() {
     }];
 
     let plan_file = PlanFile {
-        version: 4,
+        version: 5,
         carina_version: "0.1.0".to_string(),
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         source_path: "example.crn".to_string(),
@@ -350,7 +350,7 @@ fn plan_file_serde_round_trip() {
     let json = serde_json::to_string_pretty(&plan_file).unwrap();
     let deserialized: PlanFile = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(deserialized.version, 4);
+    assert_eq!(deserialized.version, 5);
     assert_eq!(deserialized.carina_version, "0.1.0");
     assert_eq!(deserialized.source_path, "example.crn");
     assert_eq!(deserialized.state_lineage, Some("test-lineage".to_string()));
@@ -2510,7 +2510,7 @@ fn import_effect_preserves_resource_metadata_in_state() {
     let mut plan = Plan::new();
     plan.add(Effect::Import {
         id: id.clone(),
-        identifier: identifier.to_string(),
+        identifier: Value::Concrete(ConcreteValue::String(identifier.to_string())),
     });
 
     let saved = build_state_after_apply(ApplyStateSave {
@@ -2749,7 +2749,7 @@ fn plan_file_serialization_redacts_secrets() {
 
     // Redact before building PlanFile (same as production code does)
     let plan_file = PlanFile {
-        version: 4,
+        version: 5,
         carina_version: "0.1.0".to_string(),
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         source_path: "example.crn".to_string(),

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1968,13 +1968,21 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // retain ResourceRef values for re-resolution at apply time.
     cascade_dependent_updates(&mut plan, &sorted_resources, &current_states, ctx.schemas());
 
-    // Add state block effects (import/removed/moved) to the plan
+    // Add state block effects (import/removed/moved) to the plan.
+    // carina#3329: pass the same plan_bindings + upstream_binding_names
+    // the resource-attribute resolver uses so an `import { id = "${…}|…" }`
+    // expression is folded into a concrete cloud identifier (when the
+    // referenced binding is in scope) or stamped for display as
+    // `(known after upstream apply: …)` when the referenced upstream
+    // state has not been published yet.
     add_state_block_effects(
         &mut plan,
         &parsed.state_blocks,
         state_file,
         &moved_pairs,
         ctx.schemas(),
+        &plan_bindings,
+        &upstream_binding_names,
     );
 
     let moved_origins: HashMap<ResourceId, ResourceId> = moved_pairs
@@ -2125,6 +2133,17 @@ pub fn add_state_block_effects(
     state_file: &Option<StateFile>,
     moved_pairs: &[(ResourceId, ResourceId)],
     registry: &SchemaRegistry,
+    // carina#3329: resolved bindings + the set of upstream-state
+    // binding names whose surviving refs are stamped as
+    // `Value::Deferred(DeferredValue::Unknown(UpstreamRef { … }))`.
+    // The `id = "${X.attr}|…"` interpolation inside an `import` block
+    // is resolved here against the same view that the differ uses for
+    // resource attributes (`resolve_refs_for_plan`), so a deferred
+    // upstream-state ref carries through as a `(known after upstream
+    // apply: …)` placeholder instead of being silently substituted to
+    // empty.
+    bindings: &carina_core::binding_index::ResolvedBindings,
+    unresolved_upstream_bindings: &std::collections::HashSet<&str>,
 ) {
     // Collect resource IDs that are covered by removed blocks
     // to suppress orphan Delete effects
@@ -2154,10 +2173,26 @@ pub fn add_state_block_effects(
                     .is_some()
                 });
                 if !already_in_state {
+                    // carina#3329: resolve any `${binding.attr}` segments
+                    // in `id` against the same binding view the resource
+                    // attribute resolver uses. If the referenced binding
+                    // is a same-stack `let`, this folds the interpolation
+                    // to a `Value::Concrete(ConcreteValue::String)`; if
+                    // it is an `upstream_state` binding whose state has
+                    // not been published yet, it is stamped as
+                    // `Value::Deferred(DeferredValue::Unknown(UpstreamRef))`
+                    // for display. The pre-#3329 path stored a partially-
+                    // substituted `String` and dropped the deferred-ref
+                    // signal entirely.
+                    let resolved_id = carina_core::resolver::resolve_value_for_plan(
+                        id,
+                        bindings,
+                        unresolved_upstream_bindings,
+                    );
                     suppress_create.insert(effective_to.clone());
                     new_effects.push(Effect::Import {
                         id: effective_to,
-                        identifier: id.clone(),
+                        identifier: resolved_id,
                     });
                 }
             }

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -404,10 +404,20 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     // Import block with the logical name (not the hash)
     let state_blocks = vec![StateBlock::Import {
         to: StateBlockAddress::new("awscc", "s3.Bucket", "carina-rs-state"),
-        id: "carina-rs-state".to_string(),
+        id: Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
     }];
 
-    add_state_block_effects(&mut plan, &state_blocks, &None, &[], &schemas);
+    let bindings = carina_core::binding_index::ResolvedBindings::default();
+    let no_upstreams: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    add_state_block_effects(
+        &mut plan,
+        &state_blocks,
+        &None,
+        &[],
+        &schemas,
+        &bindings,
+        &no_upstreams,
+    );
 
     // Expect only an Import effect (no Create) targeting the anonymous hash name
     let effects = plan.effects();
@@ -423,7 +433,10 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
                 "s3_bucket_1d43a664",
                 "Import should target the anonymous hash name"
             );
-            assert_eq!(identifier, "carina-rs-state");
+            assert_eq!(
+                identifier,
+                &Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
+            );
         }
         other => panic!("Expected Import effect, got {other:?}"),
     }
@@ -549,7 +562,17 @@ fn removed_block_suppresses_delete_when_state_resource_is_routed_to_named_instan
         from: StateBlockAddress::new("aws", "route53.RecordSet", "r.delegation_ns"),
     }];
 
-    add_state_block_effects(&mut plan, &state_blocks, &Some(state_file), &[], &schemas);
+    let bindings = carina_core::binding_index::ResolvedBindings::default();
+    let no_upstreams: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    add_state_block_effects(
+        &mut plan,
+        &state_blocks,
+        &Some(state_file),
+        &[],
+        &schemas,
+        &bindings,
+        &no_upstreams,
+    );
 
     let effects = plan.effects();
     assert_eq!(
@@ -605,10 +628,22 @@ fn import_suppresses_create_when_target_resource_is_routed_to_named_instance() {
     // is responsible for lifting routing from the matched Create.
     let state_blocks = vec![StateBlock::Import {
         to: StateBlockAddress::new("aws", "route53.RecordSet", "r.delegation_ns"),
-        id: "|hosted-zone-id|registry-dev.carina-rs.dev|NS".to_string(),
+        id: Value::Concrete(ConcreteValue::String(
+            "|hosted-zone-id|registry-dev.carina-rs.dev|NS".to_string(),
+        )),
     }];
 
-    add_state_block_effects(&mut plan, &state_blocks, &None, &[], &schemas);
+    let bindings = carina_core::binding_index::ResolvedBindings::default();
+    let no_upstreams: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    add_state_block_effects(
+        &mut plan,
+        &state_blocks,
+        &None,
+        &[],
+        &schemas,
+        &bindings,
+        &no_upstreams,
+    );
 
     let effects = plan.effects();
     assert_eq!(
@@ -653,10 +688,20 @@ fn import_fallback_skips_when_already_in_state_by_name_attribute() {
     let mut plan = Plan::new();
     let state_blocks = vec![StateBlock::Import {
         to: StateBlockAddress::new("awscc", "s3.Bucket", "carina-rs-state"),
-        id: "carina-rs-state".to_string(),
+        id: Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
     }];
 
-    add_state_block_effects(&mut plan, &state_blocks, &Some(state_file), &[], &schemas);
+    let bindings = carina_core::binding_index::ResolvedBindings::default();
+    let no_upstreams: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    add_state_block_effects(
+        &mut plan,
+        &state_blocks,
+        &Some(state_file),
+        &[],
+        &schemas,
+        &bindings,
+        &no_upstreams,
+    );
 
     // Already in state (via fallback match) — no Import effect should be emitted
     assert_eq!(

--- a/carina-cli/tests/fixtures/plan_display/import_deferred_interpolation/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/import_deferred_interpolation/main.crn
@@ -1,0 +1,23 @@
+# Regression fixture for carina#3329.
+#
+# An `import { id = "${X.attr}|literal|literal" }` whose `${X.attr}` is
+# a deferred upstream-state reference (the upstream's state file has not
+# published the export yet) must render its interpolation through the
+# plan-display path that emits `(known after upstream apply: …)` for
+# every other deferred ref site. Before #3329 the parser dropped the
+# `${…}` segment entirely and the plan showed `id: |literal|literal` —
+# a partially-substituted string presented as if it were the real cloud
+# identifier.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let management_route53 = upstream_state {
+  source = "./network"
+}
+
+import {
+  to = aws.route53.RecordSet "r.delegation_ns"
+  id = "${management_route53.apex_zone_id}|registry-dev.carina-rs.dev|NS"
+}

--- a/carina-cli/tests/fixtures/plan_display/import_deferred_interpolation/network/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/import_deferred_interpolation/network/main.crn
@@ -1,0 +1,7 @@
+backend local { path = "carina.state.json" }
+
+# Upstream declares the binding but has not been applied yet — `exports`
+# is empty, so `management_route53.apex_zone_id` is a deferred upstream
+# ref at plan time.
+exports {
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -426,9 +426,16 @@ pub fn build_detail_rows(
             build_create_rows(&resource.attributes, schema, detail)
         }
         Effect::Import { identifier, .. } => {
+            // carina#3329: the identifier is carried as a `Value` so a
+            // deferred upstream-state reference inside a `"${X.attr}|…"`
+            // interpolation renders as `(known after upstream apply: …)`
+            // instead of being silently substituted to empty.
+            // `format_import_identifier` prints concrete identifiers bare
+            // and falls back to the structured `format_value_with_key`
+            // shape only for the deferred / interpolation case.
             vec![DetailRow::Attribute {
                 key: "id".to_string(),
-                value: identifier.clone(),
+                value: crate::effect::format_import_identifier(identifier),
                 ref_binding: None,
                 annotation: None,
             }]

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -145,8 +145,17 @@ pub enum Effect {
     Import {
         /// Target resource address
         id: ResourceId,
-        /// Cloud provider identifier (e.g., "vpc-0abc123def456")
-        identifier: String,
+        /// Cloud provider identifier (e.g., `"vpc-0abc123def456"`).
+        ///
+        /// Carried as a [`Value`] so an interpolation like
+        /// `"${upstream.attr}|literal"` whose `upstream.attr` is still
+        /// deferred at plan-time remains a
+        /// `Value::Deferred(DeferredValue::Interpolation)` for display
+        /// rather than being silently substituted to empty (carina#3329).
+        /// The executor calls `assert_fully_resolved` before passing the
+        /// identifier to the provider, so by apply time this is always
+        /// a `Value::Concrete(ConcreteValue::String)`.
+        identifier: crate::resource::Value,
     },
 
     /// Remove a resource from state without destroying it
@@ -460,9 +469,155 @@ impl Effect {
     }
 }
 
+/// Render an [`Effect::Import`] identifier for plan display.
+///
+/// Three shapes matter:
+///
+/// 1. **Concrete `String` / `EnumIdentifier`**: print the bare
+///    identifier text (no DSL string quoting — operators read this as
+///    the cloud-API identifier, not as a DSL literal).
+/// 2. **`Value::Deferred(Interpolation)`**: walk the parts and emit
+///    each one inline — `Literal` segments verbatim, `Expr` segments
+///    through [`crate::value::format_value_with_key`]. Concrete `Expr`
+///    parts therefore render as bare text and a deferred upstream ref
+///    renders as `(known after upstream apply: …)` *without* the
+///    surrounding `${…}` syntax, so the operator sees the full
+///    composite identifier exactly as it will look after apply with
+///    the deferred slot called out.
+/// 3. **Other deferred shapes**: fall through to
+///    [`crate::value::format_value_with_key`].
+///
+/// Carina#3329.
+pub fn format_import_identifier(identifier: &crate::resource::Value) -> String {
+    use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, Value};
+    match identifier {
+        Value::Concrete(ConcreteValue::String(s))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => s.clone(),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
+            let mut out = String::new();
+            for part in parts {
+                match part {
+                    InterpolationPart::Literal(s) => out.push_str(s),
+                    // Recurse so a nested `Value::Deferred(Interpolation)`
+                    // produced by canonicalization stays unquoted and
+                    // un-`${…}`-wrapped at every level. Falling through
+                    // to `format_value_with_key` here would re-introduce
+                    // the wrapping the outer level was designed to
+                    // strip.
+                    InterpolationPart::Expr(v) => out.push_str(&format_import_identifier(v)),
+                }
+            }
+            out
+        }
+        other => crate::value::format_value_with_key(other, Some("id")),
+    }
+}
+
+/// Resolve an [`Effect::Import`] identifier to the concrete string the
+/// provider's `read()` needs, or return a structured error describing
+/// which deferred segment prevented resolution.
+///
+/// Centralizing the check means a future apply-side caller cannot
+/// silently ship a `Value::Deferred(…)` to the provider by rolling its
+/// own incomplete `match`: the only public path from a `Value` import
+/// identifier to a provider-ready `&str` goes through this helper.
+/// Plan-time display still calls
+/// [`crate::value::format_value_with_key`] on the same field, so a
+/// deferred upstream-state ref renders as
+/// `(known after upstream apply: …)` rather than being silently
+/// substituted to empty — see carina#3329.
+pub fn resolve_import_identifier(identifier: &crate::resource::Value) -> Result<&str, String> {
+    use crate::resource::{ConcreteValue, Value};
+    match identifier {
+        Value::Concrete(ConcreteValue::String(s)) => Ok(s.as_str()),
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Ok(s.as_str()),
+        other => Err(format!(
+            "import identifier did not resolve to a concrete string at apply time \
+             (got {}). A referenced upstream value has not been published yet — \
+             apply the upstream stack first, then re-run apply here.",
+            crate::value::format_value_with_key(other, Some("id"))
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn format_import_identifier_recurses_into_nested_interpolation() {
+        // Carina#3329 (round-2): if canonicalization or a future
+        // resolver pass produces a `Value::Deferred(Interpolation)`
+        // *inside* an `Expr` part of the outer interpolation, the
+        // helper must stay in its inline-string mode at every level
+        // rather than falling back to `format_value_with_key` (which
+        // would wrap the nested value as a DSL string literal with
+        // surrounding `"…"` quotes and `${…}` syntax).
+        use crate::resource::{
+            ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
+        };
+        let inner = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
+                UnknownReason::UpstreamBareRef {
+                    binding: "u".into(),
+                },
+            ))),
+            InterpolationPart::Literal("-suffix".into()),
+        ]));
+        let outer = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("prefix-".into()),
+            InterpolationPart::Expr(inner),
+            InterpolationPart::Literal("-tail".into()),
+        ]));
+        let rendered = format_import_identifier(&outer);
+        assert_eq!(
+            rendered, "prefix-(known after upstream apply: u)-suffix-tail",
+            "nested interpolation must render inline with no `${{…}}` wrapping or quoting"
+        );
+        // Sanity: a bare concrete still renders bare.
+        assert_eq!(
+            format_import_identifier(&Value::Concrete(ConcreteValue::String("plain".into()))),
+            "plain"
+        );
+    }
+
+    #[test]
+    fn resolve_import_identifier_accepts_concrete_string() {
+        use crate::resource::{ConcreteValue, Value};
+        let v = Value::Concrete(ConcreteValue::String("vpc-0abc".into()));
+        assert_eq!(resolve_import_identifier(&v).unwrap(), "vpc-0abc");
+    }
+
+    #[test]
+    fn resolve_import_identifier_rejects_deferred_interpolation() {
+        // carina#3329: an apply-time `Effect::Import.identifier` carrying
+        // an unresolved interpolation must surface a structured error,
+        // not be silently shipped to the provider as the
+        // partially-substituted literal. Pre-#3329 the field was a
+        // `String` so the same shape would land at the provider as
+        // `|literal|literal` with no way to detect the dropped
+        // interpolation; the helper now gates that path through the
+        // `Value` type.
+        use crate::resource::{
+            ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
+        };
+        let v = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
+                UnknownReason::UpstreamBareRef {
+                    binding: "upstream".into(),
+                },
+            ))),
+            InterpolationPart::Literal("|tail".into()),
+        ]));
+        let err = resolve_import_identifier(&v).unwrap_err();
+        assert!(
+            err.contains("did not resolve to a concrete string"),
+            "unexpected error message: {err}"
+        );
+        // Sanity: still passes for a concrete String/EnumIdentifier.
+        let s = Value::Concrete(ConcreteValue::EnumIdentifier("ENUM_X".into()));
+        assert_eq!(resolve_import_identifier(&s).unwrap(), "ENUM_X");
+    }
 
     #[test]
     fn read_is_not_mutating() {
@@ -627,7 +782,9 @@ mod tests {
     fn explicit_dependencies_empty_for_state_only_effects() {
         let imp = Effect::Import {
             id: ResourceId::new("s3.Bucket", "b"),
-            identifier: "x".to_string(),
+            identifier: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(
+                "x".to_string(),
+            )),
         };
         let rem = Effect::Remove {
             id: ResourceId::new("s3.Bucket", "b"),
@@ -829,7 +986,9 @@ mod tests {
         };
         let import = Effect::Import {
             id: rid.clone(),
-            identifier: "x-1".to_string(),
+            identifier: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(
+                "x-1".to_string(),
+            )),
         };
         let remove = Effect::Remove { id: rid.clone() };
         let mov = Effect::Move {

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -626,8 +626,16 @@ pub enum StateBlock {
         /// Target resource address (routing-agnostic — see
         /// [`StateBlockAddress`]).
         to: StateBlockAddress,
-        /// Cloud provider identifier (e.g., "vpc-0abc123def456")
-        id: String,
+        /// Cloud provider identifier (e.g., `"vpc-0abc123def456"`).
+        ///
+        /// Carried as a [`Value`] (not `String`) so a `"${X.attr}|..."`
+        /// interpolation referencing a deferred upstream-state value
+        /// stays a `Value::Deferred(DeferredValue::Interpolation)` from
+        /// parse through plan-time resolution and display. The pre-#3329
+        /// `String` shape silently dropped `${...}` segments at parse
+        /// time and presented a partially-substituted literal as if it
+        /// were a real cloud identifier. See carina#3329.
+        id: Value,
     },
     /// Remove a resource from state without destroying it
     Removed {

--- a/carina-core/src/parser/blocks/state.rs
+++ b/carina-core/src/parser/blocks/state.rs
@@ -2,19 +2,21 @@
 //!
 //! Extracted from `parser/mod.rs` per #2263 (part 2/2).
 
+use crate::parser::ParseContext;
 use crate::parser::Rule;
 use crate::parser::ast::{StateBlock, StateBlockAddress};
 use crate::parser::context::first_inner;
 use crate::parser::error::ParseError;
-use crate::parser::expressions::string_literal::parse_string_literal;
+use crate::parser::expressions::string_literal::parse_string_value;
 use crate::parser::util::parse_state_block_address;
 
 /// Parse an import state block
 pub(in crate::parser) fn parse_import_state_block(
     pair: pest::iterators::Pair<Rule>,
+    ctx: &ParseContext,
 ) -> Result<StateBlock, ParseError> {
     let mut to: Option<StateBlockAddress> = None;
-    let mut id: Option<String> = None;
+    let mut id: Option<crate::resource::Value> = None;
 
     for attr in pair.into_inner() {
         if attr.as_rule() == Rule::import_state_attr {
@@ -25,8 +27,17 @@ pub(in crate::parser) fn parse_import_state_block(
                     to = Some(parse_state_block_address(addr)?);
                 }
                 Rule::import_id_attr => {
+                    // carina#3329: parse via `parse_string_value` (not
+                    // `parse_string_literal`) so `"${binding.attr}|..."`
+                    // keeps its `${...}` segments as deferred `Expr`
+                    // parts. The pre-#3329 path called
+                    // `parse_string_literal`, which concatenated only the
+                    // raw literal segments and silently dropped every
+                    // interpolation — yielding a partially-substituted
+                    // string that the plan displayed as if it were the
+                    // real cloud identifier.
                     let str_pair = first_inner(inner, "string", "import id")?;
-                    id = Some(parse_string_literal(str_pair)?);
+                    id = Some(parse_string_value(str_pair, ctx)?);
                 }
                 _ => {}
             }

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -152,7 +152,7 @@ pub fn parse_with_seeded_bindings(
                                 export_params.extend(parsed_export_params);
                             }
                             Rule::import_state_block => {
-                                state_blocks.push(parse_import_state_block(stmt)?);
+                                state_blocks.push(parse_import_state_block(stmt, &ctx)?);
                             }
                             Rule::removed_block => {
                                 state_blocks.push(parse_removed_block(stmt)?);

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -4087,8 +4087,70 @@ fn parse_import_block() {
             assert_eq!(to.provider, "awscc");
             assert_eq!(to.resource_type, "ec2.Vpc");
             assert_eq!(to.name_str(), "main-vpc");
-            assert_eq!(id, "vpc-0abc123def456");
+            assert_eq!(
+                id,
+                &Value::Concrete(ConcreteValue::String("vpc-0abc123def456".to_string()))
+            );
         }
+        other => panic!("Expected Import, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_import_block_preserves_interpolation_segments() {
+    // carina#3329: a `"${X.attr}|literal"`-shaped `id` in an `import`
+    // block must keep the `${...}` segment as a deferred `Expr` part,
+    // so the plan-time resolver can either resolve it to a concrete
+    // string (when the referenced binding is in scope) or stamp it
+    // as `(known after upstream apply: ...)` for display. Pre-#3329
+    // the parser collapsed the `id` to a `String` and silently
+    // dropped every `${...}` segment, presenting a partially-
+    // substituted literal (`"|literal"`) as if it were a real cloud
+    // identifier.
+    let input = r#"
+        let management_route53 = upstream_state {
+            source = "../management/route53"
+        }
+
+        import {
+            to = aws.route53.RecordSet "r.delegation_ns"
+            id = "${management_route53.apex_zone_id}|registry-dev.carina-rs.dev|NS"
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(result.state_blocks.len(), 1);
+    match &result.state_blocks[0] {
+        StateBlock::Import { id, .. } => match id {
+            Value::Deferred(DeferredValue::Interpolation(parts)) => {
+                // Three parts expected: ${...} expr, "|registry-dev.carina-rs.dev|" literal, "NS" literal.
+                // After canonicalization adjacent literals may merge, so check structurally:
+                let has_expr = parts
+                    .iter()
+                    .any(|p| matches!(p, InterpolationPart::Expr(_)));
+                assert!(
+                    has_expr,
+                    "expected an `Expr` part for `${{management_route53.apex_zone_id}}`, got {:?}",
+                    parts
+                );
+                let literal_concat: String = parts
+                    .iter()
+                    .filter_map(|p| match p {
+                        InterpolationPart::Literal(s) => Some(s.as_str()),
+                        InterpolationPart::Expr(_) => None,
+                    })
+                    .collect();
+                assert!(
+                    literal_concat.contains("|registry-dev.carina-rs.dev|NS"),
+                    "expected literal segments to retain `|registry-dev.carina-rs.dev|NS`, got {:?}",
+                    parts
+                );
+            }
+            other => panic!(
+                "expected Value::Deferred(Interpolation) for interpolated import id, got {:?}",
+                other
+            ),
+        },
         other => panic!("Expected Import, got {:?}", other),
     }
 }

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -415,7 +415,11 @@ fn format_effect_brief(effect: &Effect) -> String {
         }
         Effect::Delete { id, .. } => format!("- {}", id),
         Effect::Read { resource } => format!("<= {} (data source)", resource.id),
-        Effect::Import { id, identifier } => format!("<- {} (import: {})", id, identifier),
+        Effect::Import { id, identifier } => format!(
+            "<- {} (import: {})",
+            id,
+            crate::effect::format_import_identifier(identifier)
+        ),
         Effect::Remove { id } => format!("x {}", id),
         Effect::Move { from, to } => format!("-> {} (from: {})", to, from),
         Effect::Wait {

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -303,6 +303,36 @@ fn stamp_unresolved_upstream(
     }
 }
 
+/// Plan-only single-value counterpart of [`resolve_refs_for_plan`].
+///
+/// Resolves `ResourceRef` segments against `bindings` and then stamps
+/// any surviving ref whose root binding is in
+/// `unresolved_upstream_bindings` as
+/// `Value::Deferred(DeferredValue::Unknown(UpstreamRef { path }))` so
+/// plan display renders it as `(known after upstream apply: …)`.
+///
+/// Used by `carina_cli::wiring::add_state_block_effects` for the `id`
+/// value of an `import { … }` block: a `"${X.attr}|…"`
+/// interpolation that references a deferred upstream-state value must
+/// either fold to a concrete cloud identifier (when `X.attr` is in
+/// scope) or carry the deferred marker through plan display (carina#3329).
+/// Errors are converted into the input value untouched — same shape as
+/// the resource-attribute path, where a non-evaluable interpolation
+/// stays a `Value::Deferred(DeferredValue::Interpolation)` rather than
+/// aborting the plan.
+pub fn resolve_value_for_plan(
+    value: &Value,
+    bindings: &ResolvedBindings,
+    unresolved_upstream_bindings: &std::collections::HashSet<&str>,
+) -> Value {
+    let resolved = resolve_ref_value(value, bindings).unwrap_or_else(|_| value.clone());
+    if unresolved_upstream_bindings.is_empty() {
+        resolved
+    } else {
+        stamp_unresolved_upstream(resolved, unresolved_upstream_bindings)
+    }
+}
+
 /// Recursively resolve a single Value, replacing ResourceRef with the referenced value.
 ///
 /// If the referenced binding or attribute is not found, the value is returned as-is.

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -664,6 +664,65 @@ pub fn merge_secrets_into_provider_json(
 /// secret plaintext is ever written. The hash uses Argon2id with the fallback
 /// salt (not context-aware). This is suitable for plan file serialization where
 /// the goal is redaction, not state comparison.
+/// Secret-only redactor used inside deferred wrappers (`Interpolation`,
+/// `FunctionCall`) where a `Value::Deferred(Unknown(UpstreamRef))` is a
+/// load-bearing plan-time placeholder, not an error.
+///
+/// Hashes every `Secret(_)` leaf — matching `redact_secrets_in_value`
+/// for that case — but, unlike the top-level redactor, passes
+/// `Unknown` and other deferred shapes through verbatim. This is the
+/// Unknown-tolerant counterpart introduced by carina#3329 so that
+/// `plan --out` on an `import { id = "${upstream.attr}|tail" }`
+/// (where the upstream is not yet applied) does not fail with
+/// `UnknownNotAllowed`. The apply-side enforcement still happens:
+/// `resolve_import_identifier` rejects any non-concrete identifier
+/// before the provider is called.
+fn redact_secrets_only(value: &Value) -> Result<Value, SerializationError> {
+    match value {
+        Value::Deferred(DeferredValue::Secret(inner)) => {
+            let inner_json = value_to_json(inner)?;
+            let json_str = serde_json::to_string(&inner_json)
+                .expect("serde_json::Value -> String is infallible");
+            let hash_hex = argon2id_hash(json_str.as_bytes(), None);
+            Ok(Value::Concrete(ConcreteValue::String(format!(
+                "{SECRET_PREFIX}{hash_hex}"
+            ))))
+        }
+        Value::Concrete(ConcreteValue::Map(map)) => {
+            let redacted: Result<IndexMap<String, Value>, _> = map
+                .iter()
+                .map(|(k, v)| redact_secrets_only(v).map(|rv| (k.clone(), rv)))
+                .collect();
+            Ok(Value::Concrete(ConcreteValue::Map(redacted?)))
+        }
+        Value::Concrete(ConcreteValue::List(items)) => {
+            let redacted: Result<Vec<_>, _> = items.iter().map(redact_secrets_only).collect();
+            Ok(Value::Concrete(ConcreteValue::List(redacted?)))
+        }
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
+            let redacted: Result<Vec<InterpolationPart>, _> = parts
+                .iter()
+                .map(|p| match p {
+                    InterpolationPart::Literal(s) => Ok(InterpolationPart::Literal(s.clone())),
+                    InterpolationPart::Expr(v) => {
+                        redact_secrets_only(v).map(InterpolationPart::Expr)
+                    }
+                })
+                .collect();
+            Ok(Value::Deferred(DeferredValue::Interpolation(redacted?)))
+        }
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
+            let redacted: Result<Vec<Value>, _> = args.iter().map(redact_secrets_only).collect();
+            Ok(Value::Deferred(DeferredValue::FunctionCall {
+                name: name.clone(),
+                args: redacted?,
+            }))
+        }
+        // `Unknown` and every other deferred / concrete shape pass through.
+        other => Ok(other.clone()),
+    }
+}
+
 pub fn redact_secrets_in_value(value: &Value) -> Result<Value, SerializationError> {
     match value {
         Value::Deferred(DeferredValue::Secret(inner)) => {
@@ -685,6 +744,39 @@ pub fn redact_secrets_in_value(value: &Value) -> Result<Value, SerializationErro
         Value::Concrete(ConcreteValue::List(items)) => {
             let redacted: Result<Vec<_>, _> = items.iter().map(redact_secrets_in_value).collect();
             Ok(Value::Concrete(ConcreteValue::List(redacted?)))
+        }
+        // carina#3329: an `Interpolation` can carry a secret under an
+        // `Expr` part (e.g. `id = "${secret_let.value}|tail"`). Walk
+        // the parts via the secret-only redactor — a generic
+        // `redact_secrets_in_value` recurse would reject the deferred
+        // `Unknown(UpstreamRef)` produced by plan-time stamping (RFC
+        // #2371 stage-4 invariant), even though the supported scenario
+        // here is exactly "deferred upstream ref inside import id".
+        // The dedicated `redact_secrets_only` walker only hashes
+        // `Secret` leaves and passes every other shape through
+        // unchanged, so `Unknown` survives saved-plan write to the
+        // apply side where the version-5 contract is enforced.
+        Value::Deferred(DeferredValue::Interpolation(parts)) => {
+            let redacted: Result<Vec<InterpolationPart>, _> = parts
+                .iter()
+                .map(|p| match p {
+                    InterpolationPart::Literal(s) => Ok(InterpolationPart::Literal(s.clone())),
+                    InterpolationPart::Expr(v) => {
+                        redact_secrets_only(v).map(InterpolationPart::Expr)
+                    }
+                })
+                .collect();
+            Ok(Value::Deferred(DeferredValue::Interpolation(redacted?)))
+        }
+        // Sibling shape: a deferred function-call carries `Value` args
+        // that could equally hide a `Secret`. Same Unknown-tolerant
+        // recursion via `redact_secrets_only`.
+        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
+            let redacted: Result<Vec<Value>, _> = args.iter().map(redact_secrets_only).collect();
+            Ok(Value::Deferred(DeferredValue::FunctionCall {
+                name: name.clone(),
+                args: redacted?,
+            }))
         }
         Value::Deferred(DeferredValue::Unknown(reason)) => {
             Err(SerializationError::UnknownNotAllowed {
@@ -871,7 +963,14 @@ pub fn redact_secrets_in_effect(
         },
         Effect::Import { id, identifier } => Effect::Import {
             id: id.clone(),
-            identifier: identifier.clone(),
+            // carina#3329: `identifier` is a `Value` (not the legacy
+            // `String`), so a `"${secret_let.value}|tail"` interpolation
+            // can carry a `DeferredValue::Secret(...)` segment under an
+            // `Expr` part. Route through `redact_secrets_in_value` so
+            // the saved-plan / persisted form replaces the secret with
+            // its hash; without this, the plain `clone()` would persist
+            // the in-memory plaintext.
+            identifier: redact_secrets_in_value(identifier)?,
         },
         Effect::Remove { id } => Effect::Remove { id: id.clone() },
         Effect::Move { from, to } => Effect::Move {
@@ -3926,5 +4025,106 @@ mod tests {
             big.contains('\n'),
             "oversize list must render vertically, got: {big:?}"
         );
+    }
+
+    /// Carina#3329 (round-4): `plan --out` on the supported scenario
+    /// — `import { id = "${upstream.attr}|tail" }` where `upstream.attr`
+    /// is still deferred at plan time — must succeed and persist the
+    /// deferred `Unknown` placeholder through `redact_secrets_in_plan`.
+    /// A previous iteration of the fix routed through
+    /// `redact_secrets_in_value` directly and tripped its strict
+    /// "Unknown is not serializable" guard (RFC #2371 stage 4),
+    /// causing `plan --out` to fail on the exact scenario the PR
+    /// targets. The dedicated `redact_secrets_only` walker keeps the
+    /// Secret-redaction behavior while passing `Unknown` through.
+    #[test]
+    fn redact_secrets_in_effect_passes_unknown_through_import_identifier() {
+        use crate::effect::Effect;
+        use crate::resource::{
+            AccessPath, DeferredValue, InterpolationPart, ResourceId, UnknownReason, Value,
+        };
+        let path =
+            AccessPath::with_fields("management_route53", "apex_zone_id", Vec::<String>::new());
+        let identifier = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
+                UnknownReason::UpstreamRef { path },
+            ))),
+            InterpolationPart::Literal("|registry-dev.carina-rs.dev|NS".to_string()),
+        ]));
+        let effect = Effect::Import {
+            id: ResourceId::new("aws.route53.RecordSet", "r.delegation_ns"),
+            identifier,
+        };
+        let redacted = redact_secrets_in_effect(&effect)
+            .expect("redaction must not error on a deferred Unknown inside an import identifier");
+        match redacted {
+            Effect::Import { identifier, .. } => {
+                // Round-trip preserves the Unknown placeholder verbatim
+                // for the saved-plan apply path to encounter.
+                assert!(
+                    matches!(identifier, Value::Deferred(DeferredValue::Interpolation(_))),
+                    "identifier shape must survive redaction, got: {identifier:?}",
+                );
+            }
+            other => panic!("expected Effect::Import, got {other:?}"),
+        }
+    }
+
+    /// Carina#3329: a secret value reaching `Effect::Import.identifier`
+    /// — possible when the import id is `"${secret_let.value}|tail"` —
+    /// must be redacted in the saved-plan / persisted form just like
+    /// every other secret-bearing leaf. The pre-#3329 clone() bypassed
+    /// the redactor entirely because the field was a plain `String`;
+    /// now that it carries a `Value`, the redactor walks the
+    /// interpolation parts and replaces the secret with its hash.
+    #[test]
+    fn redact_secrets_in_effect_walks_import_identifier_interpolation() {
+        use crate::effect::Effect;
+        use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, ResourceId, Value};
+        let secret_inner = Value::Concrete(ConcreteValue::String("super-secret".to_string()));
+        let identifier = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Expr(Value::Deferred(DeferredValue::Secret(Box::new(
+                secret_inner,
+            )))),
+            InterpolationPart::Literal("|tail".to_string()),
+        ]));
+        let effect = Effect::Import {
+            id: ResourceId::new("aws.s3.Bucket", "b"),
+            identifier,
+        };
+        let redacted = redact_secrets_in_effect(&effect).expect("redaction succeeds");
+        match redacted {
+            Effect::Import { identifier, .. } => {
+                // The secret must no longer be reachable as plaintext.
+                let rendered = format_value_with_key(&identifier, None);
+                assert!(
+                    !rendered.contains("super-secret"),
+                    "redacted import identifier must not contain plaintext secret, got: {rendered}",
+                );
+                // The redactor emits a `_carina_secret_` hash prefix
+                // for the secret's leaf; that prefix must be present
+                // somewhere in the redacted Value tree.
+                fn walk(v: &Value) -> bool {
+                    use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, Value};
+                    match v {
+                        Value::Concrete(ConcreteValue::String(s)) => {
+                            s.starts_with(crate::value::SECRET_PREFIX)
+                        }
+                        Value::Deferred(DeferredValue::Interpolation(parts)) => {
+                            parts.iter().any(|p| match p {
+                                InterpolationPart::Expr(inner) => walk(inner),
+                                InterpolationPart::Literal(_) => false,
+                            })
+                        }
+                        _ => false,
+                    }
+                }
+                assert!(
+                    walk(&identifier),
+                    "redacted identifier must carry the secret-prefix marker, got: {identifier:?}",
+                );
+            }
+            other => panic!("expected Effect::Import, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fix the silent drop of `\${…}` interpolation segments inside an
`import { id = "…" }` block.

Pre-#3329, `parse_string_literal` only concatenated raw literal tokens
and discarded every `\${…}` segment, so an `id = "\${X.attr}|literal|NS"`
referencing a deferred upstream-state value ended up as the plain
string `|literal|NS`. The plan displayed `id: |literal|NS` — a
partially-substituted string presented as if it were the real cloud
identifier. Operators could not tell whether apply would re-resolve the
reference or ship the malformed string to AWS as-is.

## Approach (root-cause + type-safe)

Carry the identifier as a `Value` at every layer so the deferred
interpolation survives parse → plan-time resolution → display:

- `StateBlock::Import.id`, `Effect::Import.identifier`: `String → Value`.
- Parser switches to `parse_string_value` (preserves interpolation).
- `add_state_block_effects` resolves the identifier against the same
  plan-time binding view the resource-attribute resolver uses, via a
  new `carina_core::resolver::resolve_value_for_plan` helper. A deferred
  upstream-state ref ends up stamped as
  `Value::Deferred(Unknown(UpstreamRef))` for display.
- Two carina-core helpers gate the consumer concerns through a single
  entry point each, so a future caller cannot bypass the deferred check:
  - `format_import_identifier(&Value) -> String` — bare for concrete,
    inlined for deferred (`(known after upstream apply: …)|tail`).
  - `resolve_import_identifier(&Value) -> Result<&str, String>` —
    apply-time gate.
- `redact_secrets_in_value` now recurses into `Interpolation` /
  `FunctionCall` via a new `redact_secrets_only` walker that hashes
  `Secret` leaves while tolerating `Unknown` placeholders, so
  `plan --out` on the supported "deferred upstream ref in import id"
  scenario serialises cleanly without violating the RFC #2371 stage-4
  invariant for the surrounding contexts.
- `PlanFile::version` bumped 4 → 5 (`Effect::Import` wire format
  changed). Older plans are rejected with the existing clean message.

## Long-term + type-safety self-check

- **Root cause restored**: the parser no longer throws away
  interpolation segments; the AST and `Effect` types carry the deferred
  shape end-to-end.
- **New caller tomorrow**: `Effect::Import.identifier` is a `Value`, so
  every consumer must dispatch on the variant. The two idiomatic entry
  points (`format_import_identifier`, `resolve_import_identifier`) are
  the only paths from a `Value` identifier to user-facing display or
  to a provider-ready `&str`. A new consumer that rolls its own
  incomplete match still cannot bypass `resolve_import_identifier` for
  the apply path because the field is no longer `String` — the
  `Result<&str, String>` signature forces explicit handling of the
  deferred case.
- A full typestate split (`Effect::Import.identifier` as a newtype
  separating plan-time vs apply-time variants) would create asymmetry
  with the surrounding `Value`-typed resource-attribute sites, which
  also use the runtime `assert_fully_resolved` pattern. That refactor
  is genuinely workspace-wide and is out of scope per CLAUDE.md.

## Coverage

- Parser: `parse_import_block_preserves_interpolation_segments` —
  `\${…}` survives as `InterpolationPart::Expr`.
- carina-core/effect: `format_import_identifier` recurses into nested
  interpolation; `resolve_import_identifier` rejects deferred input.
- carina-core/value: redaction passes `Unknown` through and hashes
  `Secret` inside import-id interpolation.
- carina-cli/effect_execution: apply path never calls `provider.read()`
  when the identifier is still deferred (mock provider asserts zero
  reads); concrete identifier still flows through unchanged.
- Snapshot + fixture
  `tests/fixtures/plan_display/import_deferred_interpolation/` pins
  the display:

  ```
  <- aws.route53.RecordSet r.delegation_ns \
      (import: (known after upstream apply: management_route53.apex_zone_id)|registry-dev.carina-rs.dev|NS)
      id: (known after upstream apply: management_route53.apex_zone_id)|registry-dev.carina-rs.dev|NS
  ```

Closes #3329

## Test plan

- [x] `cargo nextest run --workspace --all-features` (3679 tests, all pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `bash scripts/check-*.sh` (all four)
- [x] `cargo build --release`
- [x] `make plan-import-deferred-interpolation` visually confirms the new display

🤖 Generated with [Claude Code](https://claude.com/claude-code)