### PR TITLE
wiring: unify "Using <provider>" log shape across default and named instances

### DIFF
--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -912,7 +912,8 @@ pub async fn get_provider_with_ctx<E>(
     // instance (`let <name> = provider <kind> { ... }`), reusing the
     // factory the default instance already brought in.
     for provider_config in parsed.providers.iter().filter(|p| p.is_default) {
-        instantiate_provider_into_router(ctx, &mut router, provider_config, base_dir, None).await?;
+        instantiate_provider_into_router(ctx, &mut router, provider_config, base_dir, None, None)
+            .await?;
     }
 
     for provider_config in parsed.providers.iter().filter(|p| !p.is_default) {
@@ -920,12 +921,14 @@ pub async fn get_provider_with_ctx<E>(
             .binding
             .clone()
             .expect("named instance must carry its binding name (parser invariant)");
+        let inherited_source = kind_default_source(&parsed.providers, &provider_config.name);
         instantiate_provider_into_router(
             ctx,
             &mut router,
             provider_config,
             base_dir,
             Some(binding),
+            inherited_source,
         )
         .await?;
     }
@@ -941,6 +944,54 @@ pub async fn get_provider_with_ctx<E>(
     Ok(router)
 }
 
+/// Look up the `source` declared on the kind's default instance for a
+/// given kind name. Named instances inherit `source` from the kind's
+/// default — the parser rejects `source` on `let <name> = provider
+/// <kind>` — so this is the only way to get the source URL while
+/// processing a named instance's wiring.
+fn kind_default_source<'a>(configs: &'a [ProviderConfig], kind: &str) -> Option<&'a str> {
+    configs
+        .iter()
+        .find(|p| p.is_default && p.name == kind)
+        .and_then(|p| p.source.as_deref())
+}
+
+/// Format the "Using <provider>" announcement emitted by both the
+/// default-instance and named-instance wiring paths (carina#3067).
+///
+/// One helper, one shape — the rule is that there is no other place
+/// in the codebase that builds this line. Both code paths
+/// (`try_add_source_provider` for the kind's default, the
+/// `find_factory` branch of `instantiate_provider_into_router` for
+/// named instances) call this function, so a future "third caller"
+/// physically cannot emit a divergent shape without touching this
+/// function.
+///
+/// - `kind` is the kind name (`aws`, `awscc`) — what the user writes
+///   in `provider <kind> {}` and routes to via `directives.provider`.
+///   Use `ProviderFactory::name()`, not `display_name()`.
+/// - `binding = None` is the kind's default instance and is rendered
+///   as `instance=default`. Explicit, not omitted: the omission is
+///   exactly what made the old shape ambiguous.
+/// - `source = None` is omitted from the rendered line. In practice
+///   both call paths feed a `Some(...)`: the source-loading path has
+///   it directly, and the find_factory path threads in the kind
+///   default's source. `None` is only reachable if a kind default
+///   never declared a `source`, which currently only happens in
+///   mock/test wiring that doesn't pass through this helper.
+fn format_provider_using_line(
+    kind: &str,
+    region: &str,
+    binding: Option<&str>,
+    source: Option<&str>,
+) -> String {
+    let instance = binding.unwrap_or("default");
+    match source {
+        Some(src) => format!("Using {kind} (region: {region}, instance={instance}, source: {src})"),
+        None => format!("Using {kind} (region: {region}, instance={instance})"),
+    }
+}
+
 /// Register a single provider instance into `router`. `binding = None`
 /// is the kind's default instance; `binding = Some(name)` is a named
 /// instance and routes resources tagged `directives { provider = name }`.
@@ -954,6 +1005,7 @@ async fn instantiate_provider_into_router(
     provider_config: &ProviderConfig,
     base_dir: &Path,
     binding: Option<String>,
+    inherited_source: Option<&str>,
 ) -> Result<(), AppError> {
     // Named instances inherit `source`/`version`/`revision` from the
     // kind's default — these fields are rejected by the parser when set
@@ -968,17 +1020,18 @@ async fn instantiate_provider_into_router(
 
     if let Some(factory) = provider_mod::find_factory(ctx.factories(), &provider_config.name) {
         let region = factory.extract_region(&provider_config.attributes);
-        let instance_label = match &binding {
-            Some(name) => format!(" instance={}", name),
-            None => String::new(),
-        };
+        // Reaching this branch implies `provider_config.source` is None:
+        // the early-return above handles `binding.is_none() && source.is_some()`,
+        // and the parser rejects `source` on named instances. So the only
+        // candidate for the log line is the kind default's source, threaded
+        // in by the caller as `inherited_source`.
         println!(
             "{}",
-            format!(
-                "Using {} (region: {}{})",
-                factory.display_name(),
-                region,
-                instance_label
+            format_provider_using_line(
+                factory.name(),
+                &region,
+                binding.as_deref(),
+                inherited_source,
             )
             .cyan()
         );
@@ -1023,7 +1076,7 @@ async fn try_add_source_provider(
             let region = factory.extract_region(&config.attributes);
             println!(
                 "{}",
-                format!("Using {} (region: {}, source: {})", name, region, source).cyan()
+                format_provider_using_line(&name, &region, None, Some(source)).cyan()
             );
             router.add_provider(name, provider);
             router.add_normalizer(factory.create_normalizer(None, &config.attributes).await);
@@ -1118,15 +1171,23 @@ pub async fn create_providers_from_configs(
     // first (they may load the WASM plugin), then named instances reuse
     // the factory that was just loaded.
     for config in configs.iter().filter(|p| p.is_default) {
-        instantiate_provider_into_router(&ctx, &mut router, config, base_dir, None).await?;
+        instantiate_provider_into_router(&ctx, &mut router, config, base_dir, None, None).await?;
     }
     for config in configs.iter().filter(|p| !p.is_default) {
         let binding = config
             .binding
             .clone()
             .expect("named instance must carry its binding name (parser invariant)");
-        instantiate_provider_into_router(&ctx, &mut router, config, base_dir, Some(binding))
-            .await?;
+        let inherited_source = kind_default_source(configs, &config.name);
+        instantiate_provider_into_router(
+            &ctx,
+            &mut router,
+            config,
+            base_dir,
+            Some(binding),
+            inherited_source,
+        )
+        .await?;
     }
 
     if router.is_empty() {

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -2341,3 +2341,175 @@ mod expand_same_config_deferred_for_tests {
         );
     }
 }
+
+/// Tests for the unified "Using <provider>" announcement format
+/// (carina#3067). The default-instance and named-instance code paths
+/// must emit the same shape so that CI logs are unambiguous about
+/// which kind / instance / region was wired up.
+#[cfg(test)]
+mod using_line_format_tests {
+    use super::super::format_provider_using_line;
+
+    #[test]
+    fn default_instance_with_source() {
+        // Default instance (no binding). Source is always known on this
+        // path because the default instance is the only one that
+        // load-sources a factory.
+        assert_eq!(
+            format_provider_using_line(
+                "awscc",
+                "ap-northeast-1",
+                None,
+                Some("github.com/carina-rs/carina-provider-awscc"),
+            ),
+            "Using awscc (region: ap-northeast-1, instance=default, \
+             source: github.com/carina-rs/carina-provider-awscc)",
+        );
+    }
+
+    #[test]
+    fn named_instance_with_source() {
+        // Named instance. Source belongs to the kind, not the instance,
+        // and is still included so that one log line is enough to
+        // identify what got wired up.
+        assert_eq!(
+            format_provider_using_line(
+                "aws",
+                "us-east-1",
+                Some("us"),
+                Some("github.com/carina-rs/carina-provider-aws"),
+            ),
+            "Using aws (region: us-east-1, instance=us, \
+             source: github.com/carina-rs/carina-provider-aws)",
+        );
+    }
+
+    #[test]
+    fn instance_label_uses_default_marker_when_unbound() {
+        // The kind's default instance must be labeled "instance=default"
+        // explicitly, not omitted — the omission is what made the old
+        // default-line and named-line shapes diverge.
+        let line = format_provider_using_line("aws", "ap-northeast-1", None, None);
+        assert!(
+            line.contains("instance=default"),
+            "default instance must surface as 'instance=default'; got: {line}",
+        );
+    }
+
+    #[test]
+    fn kind_label_is_kind_name_not_display_name() {
+        // The label must be the kind name ("aws") — what the user
+        // writes in `provider <kind> {}` and routes to via
+        // `directives.provider` — not the factory's display_name
+        // ("AWS provider"). The old named-instance path used
+        // display_name, which made the two log lines disagree on
+        // what to call the same construct.
+        let line = format_provider_using_line("aws", "us-east-1", Some("us"), None);
+        assert!(
+            line.starts_with("Using aws "),
+            "kind label must be the kind name, not a display name; got: {line}",
+        );
+    }
+}
+
+#[cfg(test)]
+mod kind_default_source_tests {
+    use super::super::kind_default_source;
+    use carina_core::parser::ProviderConfig;
+    use indexmap::IndexMap;
+
+    fn config(name: &str, is_default: bool, source: Option<&str>) -> ProviderConfig {
+        ProviderConfig {
+            name: name.to_string(),
+            attributes: IndexMap::new(),
+            default_tags: IndexMap::new(),
+            source: source.map(str::to_string),
+            version: None,
+            revision: None,
+            unresolved_attributes: IndexMap::new(),
+            binding: if is_default {
+                None
+            } else {
+                Some("named".to_string())
+            },
+            is_default,
+        }
+    }
+
+    #[test]
+    fn returns_source_of_matching_kind_default() {
+        let configs = vec![
+            config(
+                "aws",
+                true,
+                Some("github.com/carina-rs/carina-provider-aws"),
+            ),
+            config("aws", false, None),
+        ];
+        assert_eq!(
+            kind_default_source(&configs, "aws"),
+            Some("github.com/carina-rs/carina-provider-aws"),
+        );
+    }
+
+    #[test]
+    fn ignores_named_instances_with_same_kind() {
+        // Named instance comes first in the slice. The function must
+        // still pick the default, not the named — otherwise it would
+        // return the named instance's (always-None) source.
+        let configs = vec![
+            config("aws", false, None),
+            config(
+                "aws",
+                true,
+                Some("github.com/carina-rs/carina-provider-aws"),
+            ),
+        ];
+        assert_eq!(
+            kind_default_source(&configs, "aws"),
+            Some("github.com/carina-rs/carina-provider-aws"),
+        );
+    }
+
+    #[test]
+    fn different_kinds_do_not_cross_leak() {
+        // Two kinds, each with their own default + source. Asking for
+        // one kind must never return the other's source.
+        let configs = vec![
+            config(
+                "aws",
+                true,
+                Some("github.com/carina-rs/carina-provider-aws"),
+            ),
+            config(
+                "awscc",
+                true,
+                Some("github.com/carina-rs/carina-provider-awscc"),
+            ),
+        ];
+        assert_eq!(
+            kind_default_source(&configs, "aws"),
+            Some("github.com/carina-rs/carina-provider-aws"),
+        );
+        assert_eq!(
+            kind_default_source(&configs, "awscc"),
+            Some("github.com/carina-rs/carina-provider-awscc"),
+        );
+    }
+
+    #[test]
+    fn returns_none_when_kind_default_has_no_source() {
+        let configs = vec![config("mock", true, None)];
+        assert_eq!(kind_default_source(&configs, "mock"), None);
+    }
+
+    #[test]
+    fn returns_none_when_kind_is_absent() {
+        let configs = vec![config(
+            "aws",
+            true,
+            Some("github.com/carina-rs/carina-provider-aws"),
+        )];
+        assert_eq!(kind_default_source(&configs, "awscc"), None);
+    }
+}


### PR DESCRIPTION
## Summary

The default-instance and named-instance wiring paths in `carina-cli/src/wiring/mod.rs` were rendering the same "provider instance wired up" announcement in three inconsistent ways:

| Field            | Default-instance line (`awscc` / `aws`) | Named-instance line (`us`) |
|------------------|-----------------------------------------|---------------------------|
| Kind label       | Kind name (`awscc`, `aws`)              | Display name (`AWS provider`) |
| Source URL       | Printed                                 | Omitted |
| Instance binding | Absent                                  | ` instance=<binding>` suffix |

After this PR all three lines use one shape:

```
Using awscc (region: ap-northeast-1, instance=default, source: github.com/carina-rs/carina-provider-awscc)
Using aws (region: ap-northeast-1, instance=default, source: github.com/carina-rs/carina-provider-aws)
Using aws (region: us-east-1, instance=us, source: github.com/carina-rs/carina-provider-aws)
```

## Approach

This is issue #3067's option (2): extract `format_provider_using_line(kind, region, binding, source) -> String` and call it from both paths. One helper, one shape — a future "third caller" physically cannot emit a divergent line without touching this function.

- **Kind label** is `ProviderFactory::name()` (`aws`, `awscc`) — what users write in `provider <kind> {}` and route to via `directives.provider` — never `display_name()`.
- **`instance=default`** is now always rendered explicitly for kind defaults. The previous "omit when default" behavior was exactly what made the two shapes diverge.
- **Source URL** is now on every line. Named instances inherit `source` from the kind's default (parser invariant: `let <name> = provider <kind>` is rejected when it sets `source`), so a small `kind_default_source(configs, kind)` lookup threads the kind default's `source` into the named-instance log line.

## Test plan

- [x] `cargo nextest run -p carina-cli` — 524 tests pass (4 new `using_line_format_tests` + 5 new `kind_default_source_tests`)
- [x] `cargo clippy -p carina-cli --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `bash scripts/check-docs-use-new-spellings.sh`, `check-no-direct-resources-access.sh`, `check-provider-boundaries.sh` — clean
- [ ] Real-infra smoke (multi-instance providers in `carina-rs/infra`) — left to the user; the source of the issue is multi-instance wiring in `usecases/registry/`.

Closes #3067