### PR TITLE
fix(apply,plan): drop x+red from state-only Remove output

### DIFF
--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -68,21 +68,31 @@ pub(crate) async fn execute_import_effects(
     }
 }
 
+/// Format a single state-only effect line for `apply` output.
+///
+/// Extracted so the rendering can be asserted without intercepting
+/// stdout. carina#3332: the `Remove` arm previously led with a red
+/// lowercase `x`, which is visually indistinguishable from the `✗`
+/// failure indicator used elsewhere in the apply output. The leading
+/// token here is now a neutral `~` and the operation name
+/// (`removed-from-state`) carries the meaning, so a state-only
+/// success line can never be misread as a failure.
+fn format_state_only_effect_line(effect: &Effect) -> Option<String> {
+    match effect {
+        Effect::Remove { id } => Some(format!("  {} removed-from-state {}", "~".yellow(), id)),
+        Effect::Move { from, to } => Some(format!("  {} Moving {} -> {}", "->".yellow(), from, to)),
+        _ => None,
+    }
+}
+
 /// Execute state-only effects (remove, move) with user feedback.
 ///
 /// These effects only modify state and don't call the provider.
 pub(crate) fn execute_state_only_effects(plan: &Plan, result: &mut ExecutionResult) {
     for effect in plan.effects() {
-        match effect {
-            Effect::Remove { id } => {
-                println!("  {} Removing {} from state", "x".red(), id);
-                result.success_count += 1;
-            }
-            Effect::Move { from, to } => {
-                println!("  {} Moving {} -> {}", "->".yellow(), from, to);
-                result.success_count += 1;
-            }
-            _ => {}
+        if let Some(line) = format_state_only_effect_line(effect) {
+            println!("{}", line);
+            result.success_count += 1;
         }
     }
 }
@@ -247,5 +257,61 @@ mod tests {
         let reads = recorder.reads.lock().unwrap();
         assert_eq!(reads.len(), 1);
         assert_eq!(reads[0].1.as_deref(), Some("my-bucket"));
+    }
+
+    /// carina#3332: the state-only `Remove` line must not shape-collide
+    /// with the `✗` failure indicator. The previous output led with a
+    /// red lowercase `x`, which in monospace terminals reads as
+    /// failure. The fix moves the meaning into a word
+    /// (`removed-from-state`) and uses a non-cross leading token, so
+    /// the rendered line contains no `x` / `✗` glyph at all.
+    #[test]
+    fn remove_effect_line_has_no_failure_shaped_glyph() {
+        colored::control::set_override(true);
+        let id = ResourceId::new("aws.route53.RecordSet", "aws_route53_record_set_7059de08");
+        let line = format_state_only_effect_line(&Effect::Remove { id: id.clone() })
+            .expect("Remove must render a line");
+        colored::control::unset_override();
+
+        // No literal `x` or `✗` anywhere — the leading token and the
+        // word `removed-from-state` are both x-free.
+        assert!(
+            !line.contains('x'),
+            "rendered Remove line must contain no lowercase `x` glyph \
+             (it shape-collides with the failure indicator); got: {line:?}"
+        );
+        assert!(
+            !line.contains('✗'),
+            "rendered Remove line must contain no `✗`; got: {line:?}"
+        );
+        // The operation name and the id are both present in plain form
+        // so the user can read what happened to which resource.
+        assert!(
+            line.contains("removed-from-state"),
+            "rendered Remove line must name the operation; got: {line:?}"
+        );
+        assert!(
+            line.contains(&id.to_string()),
+            "rendered Remove line must include the resource id; got: {line:?}"
+        );
+    }
+
+    /// The Move arm is out of scope for #3332 (its leading `->` does
+    /// not collide with `✗`), so its rendering must stay byte-identical.
+    /// This pins the format so a future sweep of state-only output
+    /// does not change it by accident.
+    #[test]
+    fn move_effect_line_format_is_unchanged() {
+        colored::control::set_override(false);
+        let from = ResourceId::new("aws.s3.Bucket", "old");
+        let to = ResourceId::new("aws.s3.Bucket", "new");
+        let line = format_state_only_effect_line(&Effect::Move {
+            from: from.clone(),
+            to: to.clone(),
+        })
+        .expect("Move must render a line");
+        colored::control::unset_override();
+
+        assert_eq!(line, format!("  -> Moving {} -> {}", from, to));
     }
 }

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -329,9 +329,12 @@ pub fn format_plan(
     }
     parts.push(format!("{} to destroy", summary.delete.to_string().red()));
     if summary.remove > 0 {
+        // carina#3332: state-only removal is not a destructive failure;
+        // color the count yellow to agree with the `~` Remove row in
+        // the tree above instead of red (which pairs with `✗`/Delete).
         parts.push(format!(
             "{} to remove from state",
-            summary.remove.to_string().red()
+            summary.remove.to_string().yellow()
         ));
     }
     if summary.moved > 0 {
@@ -464,7 +467,12 @@ impl<'a> TreeRenderContext<'a> {
             Effect::Delete { .. } => "-".red().bold(),
             Effect::Read { .. } => "<=".cyan().bold(),
             Effect::Import { .. } => "<-".cyan().bold(),
-            Effect::Remove { .. } => "x".red().bold(),
+            // carina#3332: the previous `x` (red, bold) shape-collides
+            // with the `✗` failure indicator used in apply output.
+            // Use `~` (yellow, bold) — the same family as Move's `->`
+            // and the trailing `(remove from state)` annotation
+            // disambiguates from Update's `~` line.
+            Effect::Remove { .. } => "~".yellow().bold(),
             Effect::Move { .. } => "->".yellow().bold(),
             Effect::Wait { .. } => ">".magenta().bold(),
         };
@@ -671,7 +679,12 @@ impl<'a> TreeRenderContext<'a> {
                     connector,
                     colored_symbol,
                     id.display_type().cyan().bold(),
-                    id.name_str().red().bold(),
+                    // carina#3332: name was previously `red().bold()`,
+                    // which pairs with `✗`/Delete and re-introduces the
+                    // "state-only success looks like failure" misread
+                    // even after the leading `x` glyph fix. Yellow
+                    // matches the `~` symbol family and Move's row.
+                    id.name_str().yellow().bold(),
                     "(remove from state)".dimmed()
                 )
                 .unwrap();

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_state_blocks.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_state_blocks.snap
@@ -5,7 +5,7 @@ expression: output
 Execution Plan:
 
   -> awscc.ec2.SecurityGroup renamed-sg (moved from: old-sg)
-  x awscc.ec2.Subnet legacy-subnet (remove from state)
+  ~ awscc.ec2.Subnet legacy-subnet (remove from state)
   <- awscc.ec2.Vpc imported-vpc (import: vpc-0abc123def456)
       id: vpc-0abc123def456
 

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -420,7 +420,11 @@ fn format_effect_brief(effect: &Effect) -> String {
             id,
             crate::effect::format_import_identifier(identifier)
         ),
-        Effect::Remove { id } => format!("x {}", id),
+        // carina#3332: leading `x` shape-collides with the `✗` failure
+        // indicator used elsewhere in apply output. Use `~` here too —
+        // matches the `display`/TUI plan-tree Remove symbol and the
+        // operation word disambiguates from Update.
+        Effect::Remove { id } => format!("~ {} (remove from state)", id),
         Effect::Move { from, to } => format!("-> {} (from: {})", to, from),
         Effect::Wait {
             binding,
@@ -471,6 +475,28 @@ mod tests {
         plan.add(Effect::Create(Resource::new("acm.Certificate", "cert")));
         assert!(plan.has_mutations());
         assert_eq!(plan.mutation_count(), 1);
+    }
+
+    /// carina#3332: `Effect::Remove` in the brief renderer must not
+    /// lead with `x` (shape-collides with the `✗` failure indicator
+    /// used in apply output). Pin the new `~ ... (remove from state)`
+    /// shape so a future tweak does not silently re-introduce the
+    /// confusing glyph.
+    #[test]
+    fn format_effect_brief_remove_has_no_failure_shaped_glyph() {
+        use crate::resource::ResourceId;
+        let id = ResourceId::new("aws.route53.RecordSet", "aws_route53_record_set_7059de08");
+        let s = format_effect_brief(&Effect::Remove { id: id.clone() });
+        assert!(!s.contains('x'), "must not contain `x`; got: {s:?}");
+        assert!(!s.contains('✗'), "must not contain `✗`; got: {s:?}");
+        assert!(
+            s.contains("(remove from state)"),
+            "must name the operation; got: {s:?}"
+        );
+        assert!(
+            s.contains(&id.to_string()),
+            "must include the resource id; got: {s:?}"
+        );
     }
 
     #[test]

--- a/carina-tui/src/app/mod.rs
+++ b/carina-tui/src/app/mod.rs
@@ -765,8 +765,16 @@ fn effect_to_node(effect: &Effect, schemas: Option<&SchemaRegistry>) -> TreeNode
             effect_label: format!("{}", id.human()),
             resource_type: id.display_type(),
             name_part: id.name_str().to_string(),
-            symbol: "x".to_string(),
-            kind: EffectKind::Delete,
+            // carina#3332: avoid the `x` glyph that shape-collides with
+            // the `✗` failure indicator. `~` matches the CLI plan
+            // tree's Remove symbol; `(remove from state)` annotation
+            // disambiguates from Update lines. Mirror Move below in
+            // using `EffectKind::Update` so the row renders yellow —
+            // `EffectKind::Delete` would color the whole row red and
+            // re-introduce the misread the symbol fix was meant to
+            // remove.
+            symbol: "~".to_string(),
+            kind: EffectKind::Update,
             detail_rows,
             children: Vec::new(),
             depth: 0,

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -31,6 +31,34 @@ fn app_from_plan_with_effects() {
     assert_eq!(app.nodes[1].kind, EffectKind::Delete);
 }
 
+/// carina#3332: a state-only `Remove` node must NOT use the `x`
+/// symbol (shape-collision with `✗`) and must NOT use
+/// `EffectKind::Delete` (which renders the row red — same family as
+/// the failure indicator). Pinned shape: `~` + `EffectKind::Update`
+/// so the row colors yellow, matching the CLI plan-tree fix.
+#[test]
+fn remove_effect_uses_non_failure_symbol_and_kind() {
+    let mut plan = Plan::new();
+    plan.add(Effect::Remove {
+        id: ResourceId::new("aws.route53.RecordSet", "aws_route53_record_set_7059de08"),
+    });
+
+    let app = App::new(&plan, &SchemaRegistry::new());
+    assert_eq!(app.nodes.len(), 1);
+    assert_ne!(
+        app.nodes[0].symbol, "x",
+        "Remove must not use the `x` glyph — it shape-collides with `✗`"
+    );
+    assert_eq!(app.nodes[0].symbol, "~");
+    assert_ne!(
+        app.nodes[0].kind,
+        EffectKind::Delete,
+        "Remove must not use EffectKind::Delete — that paints the row red \
+         and re-introduces the misread the symbol fix removed"
+    );
+    assert_eq!(app.nodes[0].kind, EffectKind::Update);
+}
+
 #[test]
 fn navigation() {
     let mut plan = Plan::new();


### PR DESCRIPTION
## Summary

`carina apply` and `carina plan` rendered state-only "removed from state" success using a red lowercase `x` glyph that visually shape-collides with the `✗` failure indicator. In monospace terminals with bold-disabled themes the two glyphs are essentially indistinguishable — operators trained to react fast to apparent failures could trigger unwarranted intervention (force-unlock, manual rollback, re-apply with destructive flag) on a successful state detach.

Issue #3332 chose Option 1 (drop the glyph as a meaning-carrier; let a word do the work). This PR sweeps **every** site that renders a state-only `Effect::Remove`, not just the headline apply line, so a future caller cannot re-introduce the misread.

## Before / after

**Before (apply runtime):**
```
  x Removing aws.route53.RecordSet.foo from state    ← success (red x)
  ✗ Update awscc.iam.RolePolicy ...                  ← failure (red ✗)
```

**After:**
```
  ~ removed-from-state aws.route53.RecordSet.foo     ← success (yellow ~)
  ✗ Update awscc.iam.RolePolicy ...                  ← failure (red ✗)
```

## Sites swept

| Site | Old | New |
| ---- | --- | --- |
| `carina-cli/.../effect_execution.rs` (apply runtime line) | `x Removing X from state` (red) | `~ removed-from-state X` (yellow) |
| `carina-cli/.../display/mod.rs` (plan tree symbol) | `x` (red bold) | `~` (yellow bold) |
| `carina-cli/.../display/mod.rs` (plan tree name color) | `red().bold()` | `yellow().bold()` |
| `carina-cli/.../display/mod.rs` (summary count color) | `red()` | `yellow()` |
| `carina-tui/.../app/mod.rs` (TUI symbol + kind) | `"x"` + `EffectKind::Delete` (red row) | `"~"` + `EffectKind::Update` (yellow row) |
| `carina-core/.../plan.rs::format_effect_brief` | `x <id>` | `~ <id> (remove from state)` |

Color **and** glyph both moved off the red/`✗` family — fixing only the glyph still leaves the row painted red, which pairs visually with Delete and re-introduces the misread.

Move (`->`, yellow) is intentionally untouched — its token does not shape-collide with `✗` and its row already uses yellow.

## Regression tests

Three property-style tests pin "no `x` / no `✗` glyph + operation named" so the invariant survives future format tweaks:

- `effect_execution.rs::remove_effect_line_has_no_failure_shaped_glyph` (apply runtime)
- `plan.rs::format_effect_brief_remove_has_no_failure_shaped_glyph` (brief renderer)
- `app/tests.rs::remove_effect_uses_non_failure_symbol_and_kind` (TUI symbol + kind)

Plus `move_effect_line_format_is_unchanged` pins the Move output byte-identical so a future sweep cannot collateral-damage it. Snapshot `snapshot_state_blocks.snap` was updated to reflect the new `~` glyph.

## Test plan

- [x] `cargo nextest run --workspace` — 3692 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 pass)
- [ ] Real-infra eyeball: run `carina-rs/infra/aws/management/route53/` apply after merge; confirm the `removed.crn` line renders as `~ removed-from-state ...` and the row is yellow, not red.

Closes #3332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
