### PR TITLE
feat(state): add --state-url for direct state access without .crn config

### DIFF
--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -15,7 +15,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, LockInfo, ResourceState, StateBackend,
-    StateFile, create_backend, resolve_backend,
+    StateFile, StateUrl, create_backend, load_state_from_url, resolve_backend,
 };
 
 use super::validate_and_resolve_with_config;
@@ -131,9 +131,15 @@ pub enum StateCommands {
     },
     /// List all managed resources from the state file
     List {
-        /// Path to directory containing .crn files
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Path to directory containing .crn files (defaults to ".").
+        /// Mutually exclusive with --state-url.
+        path: Option<PathBuf>,
+
+        /// Read state directly from a URL, bypassing .crn / backend
+        /// resolution. Accepts s3://bucket/key, file://path, or a bare
+        /// local path. Mutually exclusive with [PATH].
+        #[arg(long, conflicts_with = "path")]
+        state_url: Option<String>,
     },
     /// Look up resource attributes from the state file
     Lookup {
@@ -141,9 +147,15 @@ pub enum StateCommands {
         #[arg(add = ArgValueCompleter::new(complete_state_lookup))]
         query: String,
 
-        /// Path to directory containing .crn files
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Path to directory containing .crn files (defaults to ".").
+        /// Mutually exclusive with --state-url.
+        path: Option<PathBuf>,
+
+        /// Read state directly from a URL, bypassing .crn / backend
+        /// resolution. Accepts s3://bucket/key, file://path, or a bare
+        /// local path. Mutually exclusive with [PATH].
+        #[arg(long, conflicts_with = "path")]
+        state_url: Option<String>,
 
         /// Always output as JSON
         #[arg(long)]
@@ -151,9 +163,15 @@ pub enum StateCommands {
     },
     /// Show all managed resources with full attributes
     Show {
-        /// Path to directory containing .crn files
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Path to directory containing .crn files (defaults to ".").
+        /// Mutually exclusive with --state-url.
+        path: Option<PathBuf>,
+
+        /// Read state directly from a URL, bypassing .crn / backend
+        /// resolution. Accepts s3://bucket/key, file://path, or a bare
+        /// local path. Mutually exclusive with [PATH].
+        #[arg(long, conflicts_with = "path")]
+        state_url: Option<String>,
 
         /// Display state in interactive TUI mode
         #[arg(long)]
@@ -179,12 +197,38 @@ pub async fn run_state_command(
         StateCommands::Refresh { path, lock } => {
             run_state_refresh(&path, lock, provider_context).await
         }
-        StateCommands::List { path } => run_state_list(&path, provider_context).await,
-        StateCommands::Lookup { query, path, json } => {
-            run_state_lookup(&query, &path, json, provider_context).await
+        StateCommands::List { path, state_url } => {
+            run_state_list(path.as_deref(), state_url.as_deref(), provider_context).await
         }
-        StateCommands::Show { path, tui, json } => {
-            run_state_show(&path, tui, json, provider_context).await
+        StateCommands::Lookup {
+            query,
+            path,
+            state_url,
+            json,
+        } => {
+            run_state_lookup(
+                &query,
+                path.as_deref(),
+                state_url.as_deref(),
+                json,
+                provider_context,
+            )
+            .await
+        }
+        StateCommands::Show {
+            path,
+            state_url,
+            tui,
+            json,
+        } => {
+            run_state_show(
+                path.as_deref(),
+                state_url.as_deref(),
+                tui,
+                json,
+                provider_context,
+            )
+            .await
         }
     }
 }
@@ -226,11 +270,26 @@ pub async fn run_force_unlock(
     }
 }
 
-/// Load the state file from the backend (or local file), without acquiring a lock.
+/// Load the state file, either from a configured backend (resolved via
+/// the .crn at `path`) or from a direct URL.
+///
+/// `path` and `state_url` are mutually exclusive at the clap layer
+/// (`conflicts_with = "path"`), so this helper trusts that at most one
+/// is `Some`. When both are `None`, the existing behavior applies and
+/// the path defaults to `.`.
 async fn load_state_file(
-    path: &Path,
+    path: Option<&Path>,
+    state_url: Option<&str>,
     provider_context: &ProviderContext,
 ) -> Result<StateFile, AppError> {
+    if let Some(raw) = state_url {
+        let url = StateUrl::parse(raw).map_err(AppError::Backend)?;
+        return load_state_from_url(&url).await.map_err(AppError::Backend);
+    }
+
+    let default_path = PathBuf::from(".");
+    let path = path.unwrap_or(&default_path);
+
     let loaded = load_configuration_with_config(
         path,
         provider_context,
@@ -274,8 +333,12 @@ fn format_state_list(state: &StateFile) -> Vec<String> {
 }
 
 /// Run state list command
-async fn run_state_list(path: &Path, provider_context: &ProviderContext) -> Result<(), AppError> {
-    let state = load_state_file(path, provider_context).await?;
+async fn run_state_list(
+    path: Option<&Path>,
+    state_url: Option<&str>,
+    provider_context: &ProviderContext,
+) -> Result<(), AppError> {
+    let state = load_state_file(path, state_url, provider_context).await?;
 
     if state.resources.is_empty() {
         println!("No resources in state.");
@@ -331,11 +394,12 @@ fn format_state_lookup(
 /// Run state lookup command
 async fn run_state_lookup(
     query: &str,
-    path: &Path,
+    path: Option<&Path>,
+    state_url: Option<&str>,
     json_output: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let state = load_state_file(path, provider_context).await?;
+    let state = load_state_file(path, state_url, provider_context).await?;
     let output = format_state_lookup(&state, query, json_output)?;
     println!("{}", output);
     Ok(())
@@ -403,12 +467,13 @@ fn format_state_show(state: &StateFile) -> String {
 
 /// Run state show command
 async fn run_state_show(
-    path: &Path,
+    path: Option<&Path>,
+    state_url: Option<&str>,
     tui: bool,
     json: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let state = load_state_file(path, provider_context).await?;
+    let state = load_state_file(path, state_url, provider_context).await?;
 
     if json {
         let json_str = serde_json::to_string_pretty(&state)

--- a/carina-cli/tests/state_url_e2e.rs
+++ b/carina-cli/tests/state_url_e2e.rs
@@ -1,0 +1,171 @@
+//! End-to-end coverage for `--state-url` on `carina state {lookup,list,show}`.
+//!
+//! Covers carina#3336:
+//! - The clap-level `conflicts_with` between `[PATH]` and `--state-url`
+//!   surfaces as a usage error when both are explicitly supplied.
+//! - `lookup` resolves a query directly from a bare-path state URL with
+//!   no `.crn` in cwd.
+//! - `list` and `show` accept `file://` URLs.
+
+use std::fs;
+use std::process::Command;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+fn carina(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_carina"))
+        .args(args)
+        .output()
+        .expect("failed to execute carina")
+}
+
+/// Write a minimal v7 state file with a single ec2.Vpc resource bound
+/// to `vpc` and return its path.
+fn write_minimal_state(dir: &std::path::Path) -> std::path::PathBuf {
+    let path = dir.join("carina.state.json");
+    let state = json!({
+        "version": 7,
+        "serial": 1,
+        "lineage": "test-state-url-e2e",
+        "carina_version": "0.1.0",
+        "resources": [
+            {
+                "resource_type": "ec2.Vpc",
+                "name": "my-vpc",
+                "binding": "vpc",
+                "provider": "awscc",
+                "identifier": "vpc-deadbeef",
+                "attributes": {
+                    "vpc_id": "vpc-deadbeef",
+                    "cidr_block": "10.0.0.0/16"
+                },
+                "protected": false,
+                "directives": {},
+                "prefixes": {},
+                "name_overrides": {},
+                "dependency_bindings": []
+            }
+        ],
+        "exports": {}
+    });
+    fs::write(&path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+    path
+}
+
+#[test]
+fn state_lookup_state_url_and_path_conflict() {
+    let tmp = TempDir::new().unwrap();
+    let state = write_minimal_state(tmp.path());
+
+    let output = carina(&[
+        "state",
+        "lookup",
+        "vpc",
+        "--state-url",
+        state.to_str().unwrap(),
+        "/some/dir",
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "expected the conflicting-args invocation to fail.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--state-url") && stderr.contains("[PATH]"),
+        "expected clap conflict error mentioning both flags, got:\n{}",
+        stderr,
+    );
+}
+
+#[test]
+fn state_lookup_bare_path_url_returns_attribute() {
+    let tmp = TempDir::new().unwrap();
+    let state = write_minimal_state(tmp.path());
+
+    let output = carina(&[
+        "state",
+        "lookup",
+        "vpc.vpc_id",
+        "--state-url",
+        state.to_str().unwrap(),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "lookup failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "vpc-deadbeef");
+}
+
+#[test]
+fn state_list_file_url_lists_resources() {
+    let tmp = TempDir::new().unwrap();
+    let state = write_minimal_state(tmp.path());
+    let url = format!("file://{}", state.display());
+
+    let output = carina(&["state", "list", "--state-url", &url]);
+
+    assert!(
+        output.status.success(),
+        "list failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("awscc.ec2.Vpc vpc"),
+        "expected list output to mention the vpc resource, got:\n{}",
+        stdout,
+    );
+}
+
+#[test]
+fn state_show_json_file_url_emits_state_json() {
+    let tmp = TempDir::new().unwrap();
+    let state = write_minimal_state(tmp.path());
+    let url = format!("file://{}", state.display());
+
+    let output = carina(&["state", "show", "--state-url", &url, "--json"]);
+
+    assert!(
+        output.status.success(),
+        "show failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("show --json must emit valid JSON");
+    assert_eq!(parsed["lineage"], "test-state-url-e2e");
+}
+
+#[test]
+fn state_lookup_unsupported_scheme_errors() {
+    let output = carina(&[
+        "state",
+        "lookup",
+        "vpc",
+        "--state-url",
+        "https://example.com/state.json",
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "expected unsupported-scheme invocation to fail.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Unsupported URL scheme"),
+        "expected unsupported-scheme error, got:\n{}",
+        stderr,
+    );
+}

--- a/carina-state/src/backends/mod.rs
+++ b/carina-state/src/backends/mod.rs
@@ -2,9 +2,11 @@
 
 mod local;
 mod s3;
+mod url;
 
 pub use local::LocalBackend;
 pub use s3::S3Backend;
+pub use url::{StateUrl, load_state_from_url};
 
 use crate::backend::{BackendConfig, BackendError, BackendResult, StateBackend};
 

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -81,6 +81,24 @@ impl S3Backend {
         ))
     }
 
+    /// Construct an `S3Backend` from a bucket + key pair, resolving the
+    /// region through the AWS SDK default chain.
+    ///
+    /// This is the URL-addressed entry point (carina#3336): it goes
+    /// through the same region resolution and SDK client construction
+    /// as [`Self::from_config`] but skips the `BackendConfig` round-trip
+    /// that callers without a DSL `backend { ... }` block would otherwise
+    /// have to fabricate. `auto_create` is forced off — a read-only URL
+    /// lookup must never create infrastructure as a side effect.
+    /// `encrypt` is left at the production default (`true`) so any future
+    /// fallback write would match `from_config`'s behavior.
+    pub async fn from_url_parts(bucket: String, key: String) -> BackendResult<Self> {
+        let sdk_region = sdk_chain_region().await;
+        let region = resolve_region(None, sdk_region.as_deref())?;
+        let client = build_s3_client(&region).await;
+        Ok(Self::from_client(client, bucket, key, region, true, false))
+    }
+
     /// Construct an `S3Backend` over a caller-supplied `aws_sdk_s3::Client`.
     ///
     /// `from_config` is the production entry point — it resolves the

--- a/carina-state/src/backends/url.rs
+++ b/carina-state/src/backends/url.rs
@@ -1,0 +1,358 @@
+//! Direct URL-addressed state loading.
+//!
+//! `carina state lookup`, `state list`, and `state show` accept a
+//! `--state-url <URL>` flag that bypasses the `.crn` + `backend { ... }`
+//! resolution path entirely (carina#3336). This module owns the URL
+//! parsing and the read-only state loader that backs that flag.
+//!
+//! Three URL forms are accepted:
+//!
+//! | Form | Example | Resolution |
+//! | ---- | ------- | ---------- |
+//! | `s3://bucket/key` | `s3://my-states/prod/state.json` | Constructs an `S3Backend` via the shared region + SDK-client helpers in `s3.rs`. |
+//! | `file://path` | `file:///tmp/state.json` | Reads the absolute path after the scheme. |
+//! | Bare path | `./state.json`, `/abs/state.json` | Read directly from the local filesystem. |
+//!
+//! The parser surface is a [`StateUrl`] tagged enum, not a free
+//! `&str`-taking function — every loader call must therefore go through
+//! `StateUrl::parse`, which is the seam where the "bare path vs
+//! scheme-prefixed" classification lives. The loader cannot be reached
+//! with an unclassified raw string.
+
+use std::path::PathBuf;
+
+use crate::backend::{BackendError, BackendResult, StateBackend};
+use crate::state::StateFile;
+
+/// A parsed `--state-url` argument.
+///
+/// Constructable **only** via [`Self::parse`]: each variant is
+/// `#[non_exhaustive]`, so external code cannot fabricate a `StateUrl`
+/// with an unvalidated bucket / key / path. Combined with
+/// `load_state_from_url` taking `&StateUrl` (not `&str`), a raw user
+/// string can never reach the backend layer without going through the
+/// parser's scheme + emptiness checks first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateUrl {
+    /// `s3://bucket/key` — bucket is the URL host, key is the path
+    /// (leading `/` stripped). Region / credentials come from the AWS
+    /// SDK default chain at load time.
+    #[non_exhaustive]
+    S3 { bucket: String, key: String },
+    /// `file://path` or a bare local path. The path is taken verbatim
+    /// (no normalization) — relative paths resolve against the process
+    /// CWD at read time.
+    #[non_exhaustive]
+    File { path: PathBuf },
+}
+
+impl StateUrl {
+    /// Classify a `--state-url` argument.
+    ///
+    /// `s3://` requires a non-empty host and a non-empty key.
+    /// `file://` requires a path starting with `/` (RFC 8089
+    /// `file:///path` — host-form `file://host/path` is rejected because
+    /// only the local-file form is meaningful for state lookup).
+    /// Anything else is treated as a bare filesystem path.
+    pub fn parse(raw: &str) -> BackendResult<Self> {
+        if let Some(rest) = raw.strip_prefix("s3://") {
+            let (bucket, key) = rest.split_once('/').ok_or_else(|| {
+                BackendError::configuration(format!(
+                    "Invalid s3:// URL '{}': expected s3://<bucket>/<key>",
+                    raw
+                ))
+            })?;
+            if bucket.is_empty() {
+                return Err(BackendError::configuration(format!(
+                    "Invalid s3:// URL '{}': bucket is empty",
+                    raw
+                )));
+            }
+            if key.is_empty() {
+                return Err(BackendError::configuration(format!(
+                    "Invalid s3:// URL '{}': key is empty",
+                    raw
+                )));
+            }
+            Ok(StateUrl::S3 {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            })
+        } else if let Some(rest) = raw.strip_prefix("file://") {
+            if rest.is_empty() {
+                return Err(BackendError::configuration(format!(
+                    "Invalid file:// URL '{}': path is empty",
+                    raw
+                )));
+            }
+            // Reject `file://host/path` (RFC 8089 host form) and
+            // `file://./relative` style inputs — silently treating
+            // `file://localhost/foo` as the relative path
+            // `localhost/foo` is the kind of bug operators only catch
+            // after the lookup returns "No state at localhost/foo".
+            // Require the local-file form `file:///abs/path`.
+            if !rest.starts_with('/') {
+                return Err(BackendError::configuration(format!(
+                    "Invalid file:// URL '{}': use file:///<absolute-path> \
+                     (host form file://host/path is not supported)",
+                    raw
+                )));
+            }
+            Ok(StateUrl::File {
+                path: PathBuf::from(rest),
+            })
+        } else if raw.contains("://") {
+            // Reject other URL schemes explicitly rather than silently
+            // treating them as bare paths — the user almost certainly
+            // meant something else.
+            Err(BackendError::configuration(format!(
+                "Unsupported URL scheme in '{}': only s3://, file://, or a bare path are accepted",
+                raw
+            )))
+        } else {
+            if raw.is_empty() {
+                return Err(BackendError::configuration(
+                    "Empty --state-url is not allowed",
+                ));
+            }
+            Ok(StateUrl::File {
+                path: PathBuf::from(raw),
+            })
+        }
+    }
+
+    /// Human-readable form, suitable for migration-warning display
+    /// targets and error messages.
+    pub fn display_target(&self) -> String {
+        match self {
+            StateUrl::S3 { bucket, key } => format!("s3://{}/{}", bucket, key),
+            StateUrl::File { path } => path.display().to_string(),
+        }
+    }
+}
+
+/// Load a [`StateFile`] from a parsed `--state-url`.
+///
+/// Read-only: never acquires a lock, never persists migrations. If the
+/// on-disk state needs a schema migration, the lift happens in memory
+/// via the underlying backend (`S3Backend` / `LocalBackend`), which
+/// emits the per-backend migration warning to stderr through
+/// [`crate::state::log_state_migration_once`]. The lifted state is
+/// returned but the on-disk file is not rewritten — same shape as the
+/// existing read-only `state lookup`/`list`/`show` backend path.
+///
+/// Returns an error if the URL resolves to a missing object/file.
+pub async fn load_state_from_url(url: &StateUrl) -> BackendResult<StateFile> {
+    let loaded = match url {
+        StateUrl::S3 { bucket, key } => {
+            crate::backends::S3Backend::from_url_parts(bucket.clone(), key.clone())
+                .await?
+                .read_state()
+                .await?
+        }
+        StateUrl::File { path } => {
+            crate::backends::LocalBackend::with_path(path.clone())
+                .read_state()
+                .await?
+        }
+    };
+
+    loaded
+        .map(|l| l.into_state())
+        .ok_or_else(|| BackendError::InvalidState(format!("No state at {}", url.display_target())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- StateUrl::parse ----
+
+    #[test]
+    fn parse_s3_url() {
+        let url = StateUrl::parse("s3://my-bucket/path/to/state.json").unwrap();
+        assert_eq!(
+            url,
+            StateUrl::S3 {
+                bucket: "my-bucket".to_string(),
+                key: "path/to/state.json".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_s3_url_with_single_segment_key() {
+        let url = StateUrl::parse("s3://b/state.json").unwrap();
+        assert_eq!(
+            url,
+            StateUrl::S3 {
+                bucket: "b".to_string(),
+                key: "state.json".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_s3_url_missing_key_errors() {
+        let err = StateUrl::parse("s3://just-a-bucket").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("s3://"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn parse_s3_url_empty_bucket_errors() {
+        let err = StateUrl::parse("s3:///key.json").unwrap_err();
+        assert!(err.to_string().contains("bucket is empty"));
+    }
+
+    #[test]
+    fn parse_s3_url_empty_key_errors() {
+        let err = StateUrl::parse("s3://bucket/").unwrap_err();
+        assert!(err.to_string().contains("key is empty"));
+    }
+
+    #[test]
+    fn parse_file_url_absolute() {
+        let url = StateUrl::parse("file:///tmp/state.json").unwrap();
+        assert_eq!(
+            url,
+            StateUrl::File {
+                path: PathBuf::from("/tmp/state.json"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_file_url_empty_path_errors() {
+        let err = StateUrl::parse("file://").unwrap_err();
+        assert!(err.to_string().contains("path is empty"));
+    }
+
+    #[test]
+    fn parse_file_url_host_form_rejected() {
+        // RFC 8089 `file://host/path` would silently parse to the
+        // relative path `host/path` if not rejected — guard against
+        // `file://localhost/foo` looking like it worked but actually
+        // reading a non-existent `./localhost/foo`.
+        let err = StateUrl::parse("file://localhost/tmp/state.json").unwrap_err();
+        assert!(
+            err.to_string().contains("file:///"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_file_url_relative_after_scheme_rejected() {
+        let err = StateUrl::parse("file://./carina.state.json").unwrap_err();
+        assert!(
+            err.to_string().contains("file:///"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_bare_relative_path() {
+        let url = StateUrl::parse("./carina.state.json").unwrap();
+        assert_eq!(
+            url,
+            StateUrl::File {
+                path: PathBuf::from("./carina.state.json"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_bare_absolute_path() {
+        let url = StateUrl::parse("/var/state.json").unwrap();
+        assert_eq!(
+            url,
+            StateUrl::File {
+                path: PathBuf::from("/var/state.json"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_bare_simple_name() {
+        let url = StateUrl::parse("state.json").unwrap();
+        assert_eq!(
+            url,
+            StateUrl::File {
+                path: PathBuf::from("state.json"),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_https_scheme_is_rejected() {
+        let err = StateUrl::parse("https://example.com/state.json").unwrap_err();
+        assert!(err.to_string().contains("Unsupported URL scheme"));
+    }
+
+    #[test]
+    fn parse_gcs_scheme_is_rejected() {
+        let err = StateUrl::parse("gs://bucket/key.json").unwrap_err();
+        assert!(err.to_string().contains("Unsupported URL scheme"));
+    }
+
+    #[test]
+    fn parse_empty_string_errors() {
+        let err = StateUrl::parse("").unwrap_err();
+        assert!(err.to_string().contains("Empty"));
+    }
+
+    // ---- display_target ----
+
+    #[test]
+    fn display_target_s3() {
+        let url = StateUrl::parse("s3://b/k.json").unwrap();
+        assert_eq!(url.display_target(), "s3://b/k.json");
+    }
+
+    #[test]
+    fn display_target_file() {
+        let url = StateUrl::parse("/tmp/state.json").unwrap();
+        assert_eq!(url.display_target(), "/tmp/state.json");
+    }
+
+    // ---- load_state_from_url (file path) ----
+
+    #[tokio::test]
+    async fn load_local_file_url_returns_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("carina.state.json");
+        let mut state = StateFile::new();
+        state.increment_serial();
+        let bytes = serde_json::to_vec_pretty(&state).unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+
+        let url = StateUrl::parse(path.to_str().unwrap()).unwrap();
+        let loaded = load_state_from_url(&url).await.unwrap();
+        assert_eq!(loaded.serial, state.serial);
+    }
+
+    #[tokio::test]
+    async fn load_file_url_with_scheme_returns_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s.json");
+        let state = StateFile::new();
+        let bytes = serde_json::to_vec_pretty(&state).unwrap();
+        std::fs::write(&path, &bytes).unwrap();
+
+        let url = StateUrl::parse(&format!("file://{}", path.display())).unwrap();
+        let loaded = load_state_from_url(&url).await.unwrap();
+        assert_eq!(loaded.serial, state.serial);
+    }
+
+    #[tokio::test]
+    async fn load_missing_local_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        let url = StateUrl::parse(path.to_str().unwrap()).unwrap();
+        let err = load_state_from_url(&url).await.unwrap_err();
+        assert!(
+            err.to_string().contains("No state"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -53,8 +53,8 @@ pub mod state;
 pub use backend::{BackendConfig, BackendError, BackendResult, LOCAL_BACKEND_TYPE, StateBackend};
 pub use backend_lock::BackendLock;
 pub use backends::{
-    LocalBackend, anchored_local_path, create_backend, create_local_backend, resolve_backend,
-    resolve_backend_anchored,
+    LocalBackend, StateUrl, anchored_local_path, create_backend, create_local_backend,
+    load_state_from_url, resolve_backend, resolve_backend_anchored,
 };
 pub use lock::LockInfo;
 pub use state::{

--- a/carina-state/tests/s3_backend_winterbaume.rs
+++ b/carina-state/tests/s3_backend_winterbaume.rs
@@ -101,6 +101,46 @@ async fn init_auto_creates_bucket_and_seeds_empty_state() {
     );
 }
 
+// carina#3336: end-to-end exercise of `--state-url s3://...`'s
+// happy path. Seeds an object into the in-process mock S3, reads it
+// back through the same `S3Backend::read_state` + LoadedState→StateFile
+// path that `load_state_from_url` walks for the `StateUrl::S3` arm. The
+// only difference between this test's setup and the production URL
+// loader is which `aws_sdk_s3::Client` is in the backend
+// (winterbaume-mocked here, SDK-default-chain-built in production —
+// the URL parsing + region/SDK resolution are covered by url.rs's
+// unit tests). Together they pin the full S3 read path.
+#[tokio::test]
+async fn url_loader_s3_path_reads_seeded_state() {
+    let (backend, raw_client) = mock_backend_with_client().await;
+    backend.init().await.unwrap();
+
+    let mut seeded = StateFile::new();
+    seeded.increment_serial();
+    seeded.lineage = "test-state-url-s3-loader".to_string();
+    let bytes = carina_core::utils::pretty_with_newline_bytes(&seeded).unwrap();
+
+    raw_client
+        .put_object()
+        .bucket(TEST_BUCKET)
+        .key(TEST_KEY)
+        .body(ByteStream::from(bytes))
+        .send()
+        .await
+        .unwrap();
+
+    // Replicates the body of `load_state_from_url` for the `StateUrl::S3`
+    // arm: read_state, unwrap into_state, error on None.
+    let loaded = backend
+        .read_state()
+        .await
+        .unwrap()
+        .expect("seeded object should be readable")
+        .into_state();
+    assert_eq!(loaded.serial, seeded.serial);
+    assert_eq!(loaded.lineage, seeded.lineage);
+}
+
 #[tokio::test]
 async fn write_then_read_state_round_trips() {
     let backend = mock_backend().await;


### PR DESCRIPTION
Closes #3336.

## Summary

Adds `--state-url <URL>` to `carina state {lookup, list, show}`, so users can peek at a state file via a direct URL without needing a `.crn` directory and `backend { ... }` block in cwd.

```bash
# Read attribute directly from S3
carina state lookup vpc.vpc_id --state-url s3://my-states/prod/state.json

# Read from a local file
carina state lookup vpc.vpc_id --state-url ./carina.state.json

# List resources from a file URL
carina state list --state-url file:///tmp/state.json

# Show as JSON
carina state show --state-url s3://bucket/key.json --json
```

## Design highlights

- **Type-sealed URL parser.** `StateUrl` is a `pub enum` whose variants are `#[non_exhaustive]`, so the only way to obtain one outside the crate is `StateUrl::parse(&str)`. `load_state_from_url(&StateUrl)` takes the typed value (not a raw `&str`), so a future caller cannot accidentally route an unvalidated string into the backend layer. (Long-term + type-safety lens per `CLAUDE.md`.)
- **Reuses the existing S3 client construction path.** A new `S3Backend::from_url_parts(bucket, key)` constructor goes through the same `sdk_chain_region` → `resolve_region` → `build_s3_client` → `from_client` chain as `from_config`; only the `BackendConfig` round-trip is skipped. `auto_create` is forced off — a read-only URL lookup must never create infrastructure as a side effect.
- **`[PATH]` and `--state-url` are mutex.** Wired via clap `conflicts_with = \"path\"`, so explicitly supplying both surfaces a usage error before any state work happens.
- **`file:///` only, not `file://host/path`.** RFC 8089's host form would silently parse to a relative path (e.g. `file://localhost/foo` → `./localhost/foo`); we reject it with a clear message pointing at `file:///<absolute-path>`.

## Acceptance criteria coverage

| Criterion | Coverage |
|---|---|
| `state lookup foo.id --state-url s3://...` works | `s3_backend_winterbaume::url_loader_s3_path_reads_seeded_state` (in-process S3 mock) + URL parse unit tests |
| `state lookup foo.id --state-url ./local-state.json` works | `state_url_e2e::state_lookup_bare_path_url_returns_attribute` |
| `state list --state-url file:///abs/path/state.json` works | `state_url_e2e::state_list_file_url_lists_resources` |
| `state show --state-url s3://...` works (incl. `--json`) | `state_url_e2e::state_show_json_file_url_emits_state_json` (file://+--json — the format path doesn't branch on scheme) |
| Both `[PATH]` and `--state-url` explicit → clear error | `state_url_e2e::state_lookup_state_url_and_path_conflict` |
| Only `--state-url` (no `[PATH]`) succeeds | All e2e tests run this shape |
| URL scheme parsing tests | `carina-state/src/backends/url.rs` unit tests (20) |
| Both-specified error | as above |
| S3 happy path (mock/fixture) | `url_loader_s3_path_reads_seeded_state` |
| Local file happy path | `load_local_file_url_returns_state`, `load_file_url_with_scheme_returns_state` + e2e tests |

## Out of scope (deliberate)

- `state refresh` / `state bucket-delete`: they mutate and need the full backend config.
- `https://` and other URL schemes.
- A JSON-path query language (lookup stays one-level `binding.attribute`).
- Writes via URL.
- Shell completion for `--state-url s3://...` (the existing `complete_state_lookup` still reads from cwd's `carina.state.json`; not regressed, just not aware of URL context).

## Test plan

- [x] `cargo nextest run -p carina-state -p carina-cli` — 693 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `bash scripts/check-*.sh` — all pass
- [x] Manual: `carina state lookup vpc.vpc_id --state-url <local-fixture>` returns `vpc-…`
- [x] Manual: `--state-url + [PATH]` shows clap conflict error
- [x] Manual: `--state-url https://...` shows unsupported-scheme error

5-round self-review completed: rounds 1-2 produced fixes (S3 happy-path test, doc-comment correctness, `file://localhost` rejection, sealed variants); rounds 3-5 LGTM with only stylistic polish absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)