### PR TITLE
schema: support cyclic struct definitions via AttributeType::Ref (carina#3340)

### DIFF
--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -12,7 +12,7 @@ use crate::diff_helpers::{compute_map_diff, compute_unchanged_count, schema_awar
 use crate::effect::Effect;
 use crate::non_empty::NonEmptyVec;
 use crate::resource::{ConcreteValue, DeferredValue, ResourceId, Value};
-use crate::schema::{AttributeType, ResourceSchema, SchemaRegistry};
+use crate::schema::{AttributeType, ResourceSchema, SchemaRegistry, empty_defs};
 use crate::value::{format_value, format_value_with_key, is_list_of_maps, map_similarity};
 
 /// Controls how much detail is shown in plan output.
@@ -586,6 +586,7 @@ fn build_update_rows(
     explicit: Option<&crate::explicit::ExplicitFields>,
 ) -> Vec<DetailRow> {
     let mut rows = Vec::new();
+    let defs = schema.map(|s| &s.defs).unwrap_or(empty_defs());
 
     // Project `from.attributes` through the user-authoring tree so
     // server-side default fields the user never wrote don't inflate
@@ -630,7 +631,7 @@ fn build_update_rows(
         // Struct/List/Map internally and returns true, so no row is
         // built at all and sites 3/4/5 never run for this attribute.
         let is_same = old_value
-            .map(|ov| schema_aware_equal(ov, new_value, attr_type))
+            .map(|ov| schema_aware_equal(ov, new_value, attr_type, defs))
             .unwrap_or(false);
 
         if is_same {
@@ -638,12 +639,12 @@ fn build_update_rows(
         }
 
         if is_list_of_maps(new_value) {
-            match build_list_of_maps_diff_row(key, old_value, new_value, attr_type, detail) {
+            match build_list_of_maps_diff_row(key, old_value, new_value, attr_type, defs, detail) {
                 Some(row) => rows.push(row),
                 None => effectively_unchanged += 1,
             }
         } else if should_render_as_map_diff(old_value, new_value) {
-            match build_map_diff_row(key, old_value, new_value, attr_type, detail) {
+            match build_map_diff_row(key, old_value, new_value, attr_type, defs, detail) {
                 Some(row) => rows.push(row),
                 None => effectively_unchanged += 1,
             }
@@ -748,6 +749,7 @@ fn build_replace_rows(
     explicit: Option<&crate::explicit::ExplicitFields>,
 ) -> Vec<DetailRow> {
     let mut rows = Vec::new();
+    let defs = schema.map(|s| &s.defs).unwrap_or(empty_defs());
 
     // Show changed create-only attributes
     let mut keys: Vec<_> = changed_create_only
@@ -764,7 +766,7 @@ fn build_replace_rows(
             .map(|a| &a.attr_type);
         // Site 2 (carina#3073): schema-aware, mirrors site 1.
         let is_same = old_value
-            .map(|ov| schema_aware_equal(ov, new_value, attr_type))
+            .map(|ov| schema_aware_equal(ov, new_value, attr_type, defs))
             .unwrap_or(false);
 
         if is_same {
@@ -784,7 +786,7 @@ fn build_replace_rows(
             });
         } else if is_list_of_maps(new_value) {
             let (unchanged, modified, added, removed) =
-                compute_list_of_maps_diff_parts(old_value, new_value, attr_type, detail);
+                compute_list_of_maps_diff_parts(old_value, new_value, attr_type, defs, detail);
             rows.push(DetailRow::ReplaceListOfMapsDiff {
                 key: key.to_string(),
                 unchanged,
@@ -793,7 +795,7 @@ fn build_replace_rows(
                 removed,
             });
         } else if should_render_as_map_diff(old_value, new_value) {
-            let entries = compute_map_diff_entries(old_value, new_value, attr_type, detail);
+            let entries = compute_map_diff_entries(old_value, new_value, attr_type, defs, detail);
             rows.push(DetailRow::ReplaceMapDiff {
                 key: key.to_string(),
                 entries,
@@ -982,10 +984,11 @@ fn build_map_diff_row(
     old_value: Option<&Value>,
     new_value: &Value,
     attr_type: Option<&AttributeType>,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
     detail: DetailLevel,
 ) -> Option<DetailRow> {
     let entries = NonEmptyVec::from_vec(compute_map_diff_entries(
-        old_value, new_value, attr_type, detail,
+        old_value, new_value, attr_type, defs, detail,
     ))?;
     Some(DetailRow::MapDiff {
         key: key.to_string(),
@@ -997,6 +1000,7 @@ fn compute_map_diff_entries(
     old_value: Option<&Value>,
     new_value: &Value,
     attr_type: Option<&AttributeType>,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
     detail: DetailLevel,
 ) -> Vec<MapDiffEntryIR> {
     let new_map = match new_value {
@@ -1041,7 +1045,7 @@ fn compute_map_diff_entries(
                     matches!(&e.new_value, Value::Concrete(ConcreteValue::Map(_)))
                         || is_list_of_maps(&e.new_value);
                 if !is_recursed_container
-                    && schema_aware_equal(&e.old_value, &e.new_value, entry_type)
+                    && schema_aware_equal(&e.old_value, &e.new_value, entry_type, defs)
                 {
                     continue;
                 }
@@ -1053,6 +1057,7 @@ fn compute_map_diff_entries(
                         Some(&e.old_value),
                         &e.new_value,
                         entry_type,
+                        defs,
                         detail,
                     );
                     // #2910: `from_vec` returns None for the all-empty
@@ -1071,6 +1076,7 @@ fn compute_map_diff_entries(
                         Some(&e.old_value),
                         &e.new_value,
                         entry_type,
+                        defs,
                         detail,
                     );
                     // #2910: `from_parts` returns None when every
@@ -1146,10 +1152,11 @@ fn build_list_of_maps_diff_row(
     old_value: Option<&Value>,
     new_value: &Value,
     attr_type: Option<&AttributeType>,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
     detail: DetailLevel,
 ) -> Option<DetailRow> {
     let (unchanged, modified, added, removed) =
-        compute_list_of_maps_diff_parts(old_value, new_value, attr_type, detail);
+        compute_list_of_maps_diff_parts(old_value, new_value, attr_type, defs, detail);
     if unchanged.is_empty() && modified.is_empty() && added.is_empty() && removed.is_empty() {
         return None;
     }
@@ -1166,6 +1173,7 @@ fn compute_list_of_maps_diff_parts(
     old_value: Option<&Value>,
     new_value: &Value,
     attr_type: Option<&AttributeType>,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
     detail: DetailLevel,
 ) -> (
     Vec<String>,
@@ -1200,7 +1208,7 @@ fn compute_list_of_maps_diff_parts(
     // being reported as removed+added.
     for (ni, new_item) in new_items.iter().enumerate() {
         for (oi, old_item) in old_items.iter().enumerate() {
-            if !old_matched[oi] && schema_aware_equal(old_item, new_item, item_type) {
+            if !old_matched[oi] && schema_aware_equal(old_item, new_item, item_type, defs) {
                 old_matched[oi] = true;
                 new_matched[ni] = true;
                 break;
@@ -1295,7 +1303,7 @@ fn compute_list_of_maps_diff_parts(
                 let field_type = map_entry_subtype(item_type, k);
                 let field_same = old_map
                     .get(k)
-                    .map(|ov| schema_aware_equal(ov, &new_map[k], field_type))
+                    .map(|ov| schema_aware_equal(ov, &new_map[k], field_type, defs))
                     .unwrap_or(false);
                 if field_same {
                     // #2881: drop unchanged fields from the IR; renderers
@@ -1308,7 +1316,8 @@ fn compute_list_of_maps_diff_parts(
                 if matches!(old_val, Some(Value::Concrete(ConcreteValue::Map(_))))
                     && matches!(&new_map[k], Value::Concrete(ConcreteValue::Map(_)))
                 {
-                    let nested = compute_map_diff_entries(old_val, &new_map[k], field_type, detail);
+                    let nested =
+                        compute_map_diff_entries(old_val, &new_map[k], field_type, defs, detail);
                     // carina#3258: when every nested entry was
                     // suppressed (display-equal phantom or
                     // schema-aware leaf-skip), the parent header alone
@@ -1502,7 +1511,23 @@ fn string_list_inner_type(attr_type: &AttributeType) -> Option<&AttributeType> {
     match attr_type {
         AttributeType::List { inner, .. } => Some(inner),
         AttributeType::Union(members) => members.iter().find_map(string_list_inner_type),
-        _ => None,
+        // `AttributeType::Ref` (carina#3340): in CFN-derived schemas
+        // the resolved target is a `Struct`, never a `List<String>`.
+        // Returning `None` is the safe answer and keeps the helper
+        // free of a `defs` dependency. A future schema that uses
+        // `Ref` for list shapes would need to thread `&defs` and
+        // resolve here.
+        AttributeType::Ref(_) => None,
+        AttributeType::String
+        | AttributeType::Int
+        | AttributeType::Float
+        | AttributeType::Bool
+        | AttributeType::Duration
+        | AttributeType::StringEnum { .. }
+        | AttributeType::Custom { .. }
+        | AttributeType::CustomEnum { .. }
+        | AttributeType::Map { .. }
+        | AttributeType::Struct { .. } => None,
     }
 }
 
@@ -2763,8 +2788,13 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(new_admin)),
         ]));
 
-        let (_unchanged, modified, _added, _removed) =
-            compute_list_of_maps_diff_parts(Some(&old_value), &new_value, None, DetailLevel::Full);
+        let (_unchanged, modified, _added, _removed) = compute_list_of_maps_diff_parts(
+            Some(&old_value),
+            &new_value,
+            None,
+            crate::schema::empty_defs(),
+            DetailLevel::Full,
+        );
 
         // The paired OIDC element must NOT report `action` as Changed:
         // both sides render to the same `["sts:AssumeRoleWithWebIdentity"]`
@@ -2822,8 +2852,13 @@ mod tests {
         let old_value = Value::Concrete(ConcreteValue::Map(old_principal));
         let new_value = Value::Concrete(ConcreteValue::Map(new_principal));
 
-        let entries =
-            compute_map_diff_entries(Some(&old_value), &new_value, None, DetailLevel::Full);
+        let entries = compute_map_diff_entries(
+            Some(&old_value),
+            &new_value,
+            None,
+            crate::schema::empty_defs(),
+            DetailLevel::Full,
+        );
 
         for entry in &entries {
             if let MapDiffEntryIR::Changed { key, old, new } = entry {
@@ -2987,8 +3022,13 @@ mod tests {
             ConcreteValue::Map(new_stmt),
         )]));
 
-        let (_unchanged, modified, _added, _removed) =
-            compute_list_of_maps_diff_parts(Some(&old_value), &new_value, None, DetailLevel::Full);
+        let (_unchanged, modified, _added, _removed) = compute_list_of_maps_diff_parts(
+            Some(&old_value),
+            &new_value,
+            None,
+            crate::schema::empty_defs(),
+            DetailLevel::Full,
+        );
 
         for m in &modified {
             for field in m.fields.as_slice() {
@@ -3026,8 +3066,13 @@ mod tests {
         );
         let old_value = Value::Concrete(ConcreteValue::Map(old_map));
         let new_value = Value::Concrete(ConcreteValue::Map(new_map));
-        let entries =
-            compute_map_diff_entries(Some(&old_value), &new_value, None, DetailLevel::Full);
+        let entries = compute_map_diff_entries(
+            Some(&old_value),
+            &new_value,
+            None,
+            crate::schema::empty_defs(),
+            DetailLevel::Full,
+        );
         assert!(
             entries.iter().any(|e| matches!(
                 e,
@@ -3083,8 +3128,13 @@ mod tests {
             ConcreteValue::Map(new_stmt),
         )]));
 
-        let (_unchanged, modified, _added, _removed) =
-            compute_list_of_maps_diff_parts(Some(&old_value), &new_value, None, DetailLevel::Full);
+        let (_unchanged, modified, _added, _removed) = compute_list_of_maps_diff_parts(
+            Some(&old_value),
+            &new_value,
+            None,
+            crate::schema::empty_defs(),
+            DetailLevel::Full,
+        );
 
         let password_changed = modified.iter().any(|m| {
             m.fields

--- a/carina-core/src/diff_helpers.rs
+++ b/carina-core/src/diff_helpers.rs
@@ -3,12 +3,12 @@
 //! These helpers extract the pure computation logic (no formatting/coloring)
 //! that is shared between CLI and TUI frontends.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use indexmap::IndexMap;
 
 use crate::resource::Value;
-use crate::schema::{AttributeType, ResourceSchema};
+use crate::schema::{AttributeType, ResourceSchema, empty_defs};
 
 /// Schema-aware value equality shared by the plan renderer
 /// (`detail_rows`) and the unchanged-count helper below (carina#3073).
@@ -28,9 +28,10 @@ pub(crate) fn schema_aware_equal(
     old: &Value,
     new: &Value,
     attr_type: Option<&AttributeType>,
+    defs: &BTreeMap<String, AttributeType>,
 ) -> bool {
     match attr_type {
-        Some(t) => crate::differ::type_aware_equal(old, new, Some(t), None),
+        Some(t) => crate::differ::type_aware_equal(old, new, Some(t), defs, None),
         None => old.semantically_equal(new),
     }
 }
@@ -56,6 +57,7 @@ pub fn compute_unchanged_count(
     exclude: Option<&std::collections::HashSet<&str>>,
     schema: Option<&ResourceSchema>,
 ) -> usize {
+    let defs: &BTreeMap<String, AttributeType> = schema.map(|s| &s.defs).unwrap_or(empty_defs());
     from_attrs
         .iter()
         .filter(|(k, v)| {
@@ -67,7 +69,7 @@ pub fn compute_unchanged_count(
                         let attr_type = schema
                             .and_then(|s| s.attributes.get(k.as_str()))
                             .map(|a| &a.attr_type);
-                        schema_aware_equal(nv, v, attr_type)
+                        schema_aware_equal(nv, v, attr_type, defs)
                     })
                     .unwrap_or(false)
         })

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -1,12 +1,12 @@
 //! Type-aware comparison logic for diffing resource attributes.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use indexmap::IndexMap;
 
 use crate::explicit::{self, ExplicitFields};
 use crate::resource::{ConcreteValue, DeferredValue, ResourceId, Value, merge_with_saved};
-use crate::schema::{AttributeType, ResourceSchema};
+use crate::schema::{AttributeType, ResourceSchema, empty_defs};
 use crate::value::{SECRET_PREFIX, SecretHashContext, argon2id_hash, value_to_json_with_context};
 
 /// Type-aware semantic comparison of two Values.
@@ -54,6 +54,7 @@ pub(crate) fn type_aware_equal(
     a: &Value,
     b: &Value,
     attr_type: Option<&AttributeType>,
+    defs: &BTreeMap<String, AttributeType>,
     secret_ctx: Option<&SecretHashContext>,
 ) -> bool {
     // Secret comparison: compare the hash of the desired secret with the state hash string.
@@ -65,6 +66,10 @@ pub(crate) fn type_aware_equal(
         return secret_matches_state(inner, a, secret_ctx);
     }
 
+    // Resolve any top-level `AttributeType::Ref` chain BEFORE matching,
+    // so the wildcard arm below cannot silently swallow a `Ref` (carina#3340).
+    let attr_type = attr_type.map(|t| t.resolve_refs(defs));
+
     match attr_type {
         None => {
             // Even without type info, use type_aware_maps_equal / type_aware_lists_equal
@@ -74,11 +79,11 @@ pub(crate) fn type_aware_equal(
                 (
                     Value::Concrete(ConcreteValue::Map(ma)),
                     Value::Concrete(ConcreteValue::Map(mb)),
-                ) => type_aware_maps_equal(ma, mb, |_key| None, secret_ctx),
+                ) => type_aware_maps_equal(ma, mb, |_key| None, defs, secret_ctx),
                 (
                     Value::Concrete(ConcreteValue::List(la)),
                     Value::Concrete(ConcreteValue::List(lb)),
-                ) => type_aware_lists_equal(la, lb, None, false, secret_ctx),
+                ) => type_aware_lists_equal(la, lb, None, defs, false, secret_ctx),
                 _ => a.semantically_equal(b),
             }
         }
@@ -100,21 +105,21 @@ pub(crate) fn type_aware_equal(
                 Value::Concrete(ConcreteValue::List(la)),
                 Value::Concrete(ConcreteValue::List(lb)),
                 AttributeType::List { inner, ordered },
-            ) => type_aware_lists_equal(la, lb, Some(inner), *ordered, secret_ctx),
+            ) => type_aware_lists_equal(la, lb, Some(inner), defs, *ordered, secret_ctx),
 
             // Maps: recursive comparison with inner value type
             (
                 Value::Concrete(ConcreteValue::Map(ma)),
                 Value::Concrete(ConcreteValue::Map(mb)),
                 AttributeType::Map { value: inner, .. },
-            ) => type_aware_maps_equal(ma, mb, |_key| Some(inner.as_ref()), secret_ctx),
+            ) => type_aware_maps_equal(ma, mb, |_key| Some(inner.as_ref()), defs, secret_ctx),
 
             // Struct: per-field type-aware comparison with default-value tolerance
             (
                 Value::Concrete(ConcreteValue::Map(ma)),
                 Value::Concrete(ConcreteValue::Map(mb)),
                 AttributeType::Struct { fields, .. },
-            ) => type_aware_struct_equal(ma, mb, fields, secret_ctx),
+            ) => type_aware_struct_equal(ma, mb, fields, defs, secret_ctx),
 
             // Union: try each member type; if any says equal, they're equal
             (_, _, AttributeType::Union(types)) => {
@@ -135,7 +140,7 @@ pub(crate) fn type_aware_equal(
                     }
                     _ => types
                         .iter()
-                        .any(|t| type_aware_equal(a, b, Some(t), secret_ctx)),
+                        .any(|t| type_aware_equal(a, b, Some(t), defs, secret_ctx)),
                 }
             }
 
@@ -278,8 +283,17 @@ pub(crate) fn type_aware_equal(
 
             // Custom types with base type: delegate to base
             (_, _, AttributeType::Custom { base, .. }) => {
-                type_aware_equal(a, b, Some(base), secret_ctx)
+                type_aware_equal(a, b, Some(base), defs, secret_ctx)
             }
+
+            // `AttributeType::Ref` cannot reach this point: `resolve_refs`
+            // above peeled any `Ref` chain at the function entry. A
+            // `Ref` here would be a schema invariant violation handled
+            // by `resolve_refs`' panic. Documented explicitly so the
+            // wildcard below is provably Ref-free (carina#3340).
+            (_, _, AttributeType::Ref(_)) => unreachable!(
+                "AttributeType::Ref must be resolved by resolve_refs before reaching the match"
+            ),
 
             // All other cases: fall back to semantic equality
             _ => a.semantically_equal(b),
@@ -294,6 +308,7 @@ fn type_aware_lists_equal(
     a: &[Value],
     b: &[Value],
     inner: Option<&AttributeType>,
+    defs: &BTreeMap<String, AttributeType>,
     ordered: bool,
     secret_ctx: Option<&SecretHashContext>,
 ) -> bool {
@@ -304,14 +319,14 @@ fn type_aware_lists_equal(
         // Sequential comparison: element order matters
         a.iter()
             .zip(b.iter())
-            .all(|(va, vb)| type_aware_equal(va, vb, inner, secret_ctx))
+            .all(|(va, vb)| type_aware_equal(va, vb, inner, defs, secret_ctx))
     } else {
         // Multiset comparison: order-insensitive
         let mut matched = vec![false; b.len()];
         for item_a in a {
             let mut found = false;
             for (j, item_b) in b.iter().enumerate() {
-                if !matched[j] && type_aware_equal(item_a, item_b, inner, secret_ctx) {
+                if !matched[j] && type_aware_equal(item_a, item_b, inner, defs, secret_ctx) {
                     matched[j] = true;
                     found = true;
                     break;
@@ -330,6 +345,7 @@ fn type_aware_maps_equal<'a, F>(
     a: &IndexMap<String, Value>,
     b: &IndexMap<String, Value>,
     get_type: F,
+    defs: &BTreeMap<String, AttributeType>,
     secret_ctx: Option<&SecretHashContext>,
 ) -> bool
 where
@@ -340,7 +356,7 @@ where
     }
     a.iter().all(|(k, va)| {
         b.get(k)
-            .map(|vb| type_aware_equal(va, vb, get_type(k), secret_ctx))
+            .map(|vb| type_aware_equal(va, vb, get_type(k), defs, secret_ctx))
             .unwrap_or(false)
     })
 }
@@ -355,6 +371,7 @@ fn type_aware_struct_equal(
     a: &IndexMap<String, Value>,
     b: &IndexMap<String, Value>,
     fields: &[crate::schema::StructField],
+    defs: &BTreeMap<String, AttributeType>,
     secret_ctx: Option<&SecretHashContext>,
 ) -> bool {
     let field_types: HashMap<&str, &AttributeType> = fields
@@ -366,14 +383,20 @@ fn type_aware_struct_equal(
     for (k, va) in a {
         match b.get(k) {
             Some(vb) => {
-                if !type_aware_equal(va, vb, field_types.get(k.as_str()).copied(), secret_ctx) {
+                if !type_aware_equal(
+                    va,
+                    vb,
+                    field_types.get(k.as_str()).copied(),
+                    defs,
+                    secret_ctx,
+                ) {
                     return false;
                 }
             }
             None => {
                 // Key only in `a` — must be a type default to be tolerated
                 let ft = field_types.get(k.as_str()).copied();
-                if !is_type_default(va, ft) {
+                if !is_type_default(va, ft, defs) {
                     return false;
                 }
             }
@@ -386,7 +409,7 @@ fn type_aware_struct_equal(
             continue; // Already checked above
         }
         let ft = field_types.get(k.as_str()).copied();
-        if !is_type_default(vb, ft) {
+        if !is_type_default(vb, ft, defs) {
             return false;
         }
     }
@@ -403,7 +426,14 @@ fn type_aware_struct_equal(
 /// - List: empty list
 /// - Map / Struct: empty map
 /// - Custom: delegates to the base type
-fn is_type_default(value: &Value, attr_type: Option<&AttributeType>) -> bool {
+fn is_type_default(
+    value: &Value,
+    attr_type: Option<&AttributeType>,
+    defs: &BTreeMap<String, AttributeType>,
+) -> bool {
+    // Resolve top-level `Ref` chain so the wildcard arm cannot
+    // silently miss a default-value classification (carina#3340).
+    let attr_type = attr_type.map(|t| t.resolve_refs(defs));
     match (value, attr_type) {
         (Value::Concrete(ConcreteValue::Bool(false)), Some(AttributeType::Bool) | None) => true,
         (Value::Concrete(ConcreteValue::Int(0)), Some(AttributeType::Int)) => true,
@@ -432,7 +462,7 @@ fn is_type_default(value: &Value, attr_type: Option<&AttributeType>) -> bool {
             Some(AttributeType::Map { .. } | AttributeType::Struct { .. }),
         ) if m.is_empty() => true,
         // Custom types: delegate to the base type
-        (_, Some(AttributeType::Custom { base, .. })) => is_type_default(value, Some(base)),
+        (_, Some(AttributeType::Custom { base, .. })) => is_type_default(value, Some(base), defs),
         _ => false,
     }
 }
@@ -505,6 +535,11 @@ pub(super) fn find_changed_attributes(
 ) -> Vec<String> {
     let mut changed = Vec::new();
 
+    // Pull the cyclic-struct definition map (`Ref` targets) from the
+    // resource schema if available, otherwise an empty map. Walk-sites
+    // resolve `Ref` against this map (carina#3340).
+    let defs: &BTreeMap<String, AttributeType> = schema.map(|s| &s.defs).unwrap_or(empty_defs());
+
     // Project `current` through `prev_explicit` so server-side defaults
     // the user never authored disappear before any comparison runs.
     // The projection is idempotent and shape-preserving for keys the
@@ -555,13 +590,19 @@ pub(super) fn find_changed_attributes(
                 projected_current
                     .get(key)
                     .map(|cv| {
-                        type_aware_equal(cv, &effective_desired, attr_type, secret_ctx.as_ref())
+                        type_aware_equal(
+                            cv,
+                            &effective_desired,
+                            attr_type,
+                            defs,
+                            secret_ctx.as_ref(),
+                        )
                     })
                     .unwrap_or(false)
             }
             None => projected_current
                 .get(key)
-                .map(|cv| type_aware_equal(cv, desired_value, attr_type, secret_ctx.as_ref()))
+                .map(|cv| type_aware_equal(cv, desired_value, attr_type, defs, secret_ctx.as_ref()))
                 .unwrap_or(false),
         };
 

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -10,12 +10,14 @@ fn type_aware_int_float_coercion() {
         &Value::Concrete(ConcreteValue::Int(42)),
         &Value::Concrete(ConcreteValue::Float(42.0)),
         Some(&AttributeType::Float),
+        crate::schema::empty_defs(),
         None,
     ));
     assert!(type_aware_equal(
         &Value::Concrete(ConcreteValue::Float(42.0)),
         &Value::Concrete(ConcreteValue::Int(42)),
         Some(&AttributeType::Float),
+        crate::schema::empty_defs(),
         None,
     ));
     // Non-exact conversion should not be equal
@@ -23,6 +25,7 @@ fn type_aware_int_float_coercion() {
         &Value::Concrete(ConcreteValue::Int(42)),
         &Value::Concrete(ConcreteValue::Float(42.5)),
         Some(&AttributeType::Float),
+        crate::schema::empty_defs(),
         None,
     ));
     // Without type info, Int and Float are not equal
@@ -30,6 +33,7 @@ fn type_aware_int_float_coercion() {
         &Value::Concrete(ConcreteValue::Int(42)),
         &Value::Concrete(ConcreteValue::Float(42.0)),
         None,
+        crate::schema::empty_defs(),
         None,
     ));
 }
@@ -41,6 +45,7 @@ fn type_aware_int_float_coercion_for_int_type() {
         &Value::Concrete(ConcreteValue::Int(10)),
         &Value::Concrete(ConcreteValue::Float(10.0)),
         Some(&AttributeType::Int),
+        crate::schema::empty_defs(),
         None,
     ));
 }
@@ -59,6 +64,7 @@ fn type_aware_list_with_inner_type() {
             Value::Concrete(ConcreteValue::Float(1.0))
         ])),
         Some(&list_type),
+        crate::schema::empty_defs(),
         None,
     ));
 }
@@ -91,7 +97,13 @@ fn type_aware_struct_per_field() {
             Value::Concrete(ConcreteValue::String("test".to_string())),
         ),
     ])));
-    assert!(type_aware_equal(&a, &b, Some(&struct_type), None));
+    assert!(type_aware_equal(
+        &a,
+        &b,
+        Some(&struct_type),
+        crate::schema::empty_defs(),
+        None
+    ));
 }
 
 #[test]
@@ -101,6 +113,7 @@ fn type_aware_union_numeric() {
         &Value::Concrete(ConcreteValue::Int(7)),
         &Value::Concrete(ConcreteValue::Float(7.0)),
         Some(&union_type),
+        crate::schema::empty_defs(),
         None,
     ));
 }
@@ -119,6 +132,7 @@ fn type_aware_custom_delegates_to_base() {
         &Value::Concrete(ConcreteValue::Int(8080)),
         &Value::Concrete(ConcreteValue::Float(8080.0)),
         Some(&custom_type),
+        crate::schema::empty_defs(),
         None,
     ));
 }
@@ -192,7 +206,13 @@ fn type_aware_struct_ignores_default_bool_false() {
     ])));
 
     assert!(
-        type_aware_equal(&desired, &current, Some(&struct_type), None),
+        type_aware_equal(
+            &desired,
+            &current,
+            Some(&struct_type),
+            crate::schema::empty_defs(),
+            None
+        ),
         "Struct with extra default Bool(false) should be considered equal"
     );
 }
@@ -228,7 +248,13 @@ fn type_aware_struct_does_not_ignore_non_default_bool() {
     ])));
 
     assert!(
-        !type_aware_equal(&desired, &current, Some(&struct_type), None),
+        !type_aware_equal(
+            &desired,
+            &current,
+            Some(&struct_type),
+            crate::schema::empty_defs(),
+            None
+        ),
         "Struct with non-default Bool(true) should NOT be considered equal"
     );
 }
@@ -258,6 +284,7 @@ fn type_aware_string_enum_namespaced_vs_raw() {
             )),
             &Value::Concrete(ConcreteValue::String("AES256".to_string())),
             Some(&enum_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "Namespaced enum and raw value should be considered equal"
@@ -273,6 +300,7 @@ fn type_aware_string_enum_namespaced_vs_raw() {
                 "awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256".to_string()
             )),
             Some(&enum_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "Both namespaced should be equal"
@@ -286,6 +314,7 @@ fn type_aware_string_enum_namespaced_vs_raw() {
             )),
             &Value::Concrete(ConcreteValue::String("aws:kms".to_string())),
             Some(&enum_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "Different enum values should not be equal"
@@ -320,6 +349,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
                 "aws.AvailabilityZone.ap_northeast_1a".to_string()
             )),
             Some(&az_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "AWS-canonical hyphenated form must equal the fully-qualified DSL identifier"
@@ -331,6 +361,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
             )),
             &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
             Some(&az_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "Equality must be symmetric"
@@ -346,6 +377,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
                 "aws.AvailabilityZone.ap_northeast_1a".to_string()
             )),
             Some(&az_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "Identical fully-qualified forms must be equal"
@@ -357,6 +389,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
             &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
             &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
             Some(&az_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "Identical AWS-canonical forms must be equal"
@@ -372,6 +405,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
                 "aws.AvailabilityZone.ap_northeast_1a".to_string()
             )),
             Some(&az_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "AWS-canonical String must equal the matching EnumIdentifier shape"
@@ -385,6 +419,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
                 "aws.AvailabilityZone.ap_northeast_1c".to_string()
             )),
             Some(&az_type),
+            crate::schema::empty_defs(),
             None,
         ),
         "Different enum values must not be folded as equal"
@@ -430,7 +465,13 @@ fn type_aware_struct_ignores_default_string_enum_empty() {
     ])));
 
     assert!(
-        type_aware_equal(&desired, &current, Some(&struct_type), None),
+        type_aware_equal(
+            &desired,
+            &current,
+            Some(&struct_type),
+            crate::schema::empty_defs(),
+            None
+        ),
         "Struct with extra default StringEnum empty string should be considered equal"
     );
 }
@@ -473,7 +514,13 @@ fn type_aware_struct_ignores_default_custom_type() {
     ])));
 
     assert!(
-        type_aware_equal(&desired, &current, Some(&struct_type), None),
+        type_aware_equal(
+            &desired,
+            &current,
+            Some(&struct_type),
+            crate::schema::empty_defs(),
+            None
+        ),
         "Struct with extra default Custom(Int) zero should be considered equal"
     );
 }
@@ -515,7 +562,13 @@ fn type_aware_struct_ignores_default_nested_struct_empty() {
     ])));
 
     assert!(
-        type_aware_equal(&desired, &current, Some(&struct_type), None),
+        type_aware_equal(
+            &desired,
+            &current,
+            Some(&struct_type),
+            crate::schema::empty_defs(),
+            None
+        ),
         "Struct with extra default nested Struct empty map should be considered equal"
     );
 }
@@ -539,7 +592,13 @@ fn type_aware_ordered_list_detects_reorder() {
     ]));
 
     assert!(
-        !type_aware_equal(&a, &b, Some(&ordered_list_type), None),
+        !type_aware_equal(
+            &a,
+            &b,
+            Some(&ordered_list_type),
+            crate::schema::empty_defs(),
+            None
+        ),
         "Ordered list should detect reorder as NOT equal"
     );
 
@@ -549,7 +608,13 @@ fn type_aware_ordered_list_detects_reorder() {
         Value::Concrete(ConcreteValue::String("b".to_string())),
     ]));
     assert!(
-        type_aware_equal(&a, &c, Some(&ordered_list_type), None),
+        type_aware_equal(
+            &a,
+            &c,
+            Some(&ordered_list_type),
+            crate::schema::empty_defs(),
+            None
+        ),
         "Ordered list with same order should be equal"
     );
 }
@@ -572,7 +637,13 @@ fn type_aware_unordered_list_ignores_reorder() {
     ]));
 
     assert!(
-        type_aware_equal(&a, &b, Some(&unordered_list_type), None),
+        type_aware_equal(
+            &a,
+            &b,
+            Some(&unordered_list_type),
+            crate::schema::empty_defs(),
+            None
+        ),
         "Unordered list should treat reorder as equal"
     );
 }
@@ -730,6 +801,7 @@ fn secret_unchanged_same_hash() {
         &secret_value,
         &Value::Concrete(ConcreteValue::String(hash_str.clone())),
         None,
+        crate::schema::empty_defs(),
         None,
     ));
     // Reversed order should also work
@@ -737,6 +809,7 @@ fn secret_unchanged_same_hash() {
         &Value::Concrete(ConcreteValue::String(hash_str)),
         &secret_value,
         None,
+        crate::schema::empty_defs(),
         None,
     ));
 }
@@ -760,6 +833,7 @@ fn secret_changed_different_hash() {
         &new_secret,
         &Value::Concrete(ConcreteValue::String(old_hash_str)),
         None,
+        crate::schema::empty_defs(),
         None,
     ));
 }
@@ -981,11 +1055,11 @@ fn secret_matches_plain_text_state_value() {
     ))));
     let plain = Value::Concrete(ConcreteValue::String("my-password".to_string()));
     assert!(
-        type_aware_equal(&secret, &plain, None, None),
+        type_aware_equal(&secret, &plain, None, crate::schema::empty_defs(), None),
         "Secret should match plain-text state when inner values are equal"
     );
     assert!(
-        type_aware_equal(&plain, &secret, None, None),
+        type_aware_equal(&plain, &secret, None, crate::schema::empty_defs(), None),
         "Plain-text state should match secret when inner values are equal"
     );
 }
@@ -998,7 +1072,7 @@ fn secret_does_not_match_different_plain_text() {
     ))));
     let plain = Value::Concrete(ConcreteValue::String("other-password".to_string()));
     assert!(
-        !type_aware_equal(&secret, &plain, None, None),
+        !type_aware_equal(&secret, &plain, None, crate::schema::empty_defs(), None),
         "Secret should not match different plain-text state"
     );
 }
@@ -1084,7 +1158,13 @@ fn union_string_or_list_canonical_string_list_equal_to_self() {
     let union = string_or_list_of_strings_type();
     let a = Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]));
     let b = Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]));
-    assert!(type_aware_equal(&a, &b, Some(&union), None));
+    assert!(type_aware_equal(
+        &a,
+        &b,
+        Some(&union),
+        crate::schema::empty_defs(),
+        None
+    ));
 }
 
 #[test]
@@ -1092,7 +1172,13 @@ fn union_string_or_list_canonical_string_list_diff_on_different_content() {
     let union = string_or_list_of_strings_type();
     let a = Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]));
     let b = Value::Concrete(ConcreteValue::StringList(vec!["repo:bar:*".to_string()]));
-    assert!(!type_aware_equal(&a, &b, Some(&union), None));
+    assert!(!type_aware_equal(
+        &a,
+        &b,
+        Some(&union),
+        crate::schema::empty_defs(),
+        None
+    ));
 }
 
 #[test]
@@ -1106,7 +1192,13 @@ fn union_string_or_list_non_canonical_mixed_shapes_fail_to_equal() {
     let union = string_or_list_of_strings_type();
     let scalar = Value::Concrete(ConcreteValue::String("repo:foo:*".to_string()));
     let canonical = Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]));
-    assert!(!type_aware_equal(&scalar, &canonical, Some(&union), None));
+    assert!(!type_aware_equal(
+        &scalar,
+        &canonical,
+        Some(&union),
+        crate::schema::empty_defs(),
+        None
+    ));
 
     let legacy_list = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
         ConcreteValue::String("repo:foo:*".to_string()),
@@ -1115,6 +1207,7 @@ fn union_string_or_list_non_canonical_mixed_shapes_fail_to_equal() {
         &legacy_list,
         &canonical,
         Some(&union),
+        crate::schema::empty_defs(),
         None
     ));
 }
@@ -1134,7 +1227,13 @@ fn union_string_or_list_through_custom_wrapper() {
     };
     let a = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
     let b = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
-    assert!(type_aware_equal(&a, &b, Some(&custom), None));
+    assert!(type_aware_equal(
+        &a,
+        &b,
+        Some(&custom),
+        crate::schema::empty_defs(),
+        None
+    ));
 }
 
 /// carina#3080 differ parity (design Test plan item 2+3): the

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -1104,6 +1104,16 @@ pub fn collect_custom_type_validators(
         for attr_schema in schema.attributes.values() {
             collect_validators_from_type(&attr_schema.attr_type, &mut validators);
         }
+        // Visit cyclic-struct definitions directly so any
+        // `Custom { identity, validate }` nested inside a `Ref` target
+        // (e.g. WAFv2 `Statement -> AndStatement` carrying a custom
+        // ARN type) gets its validator registered. The recursion in
+        // `collect_validators_from_type` stops at `Ref` to avoid
+        // infinite cycles; iterating `schema.defs.values()` here
+        // closes the loop in one bounded pass (carina#3340).
+        for def in schema.defs.values() {
+            collect_validators_from_type(def, &mut validators);
+        }
     }
 
     validators
@@ -1120,6 +1130,11 @@ pub fn collect_custom_type_names(registry: &SchemaRegistry) -> Vec<TypeIdentity>
     for (_provider, _resource_type, _kind, schema) in registry.iter() {
         for attr_schema in schema.attributes.values() {
             collect_type_names_from_type(&attr_schema.attr_type, &mut names);
+        }
+        // Walk cyclic-struct definitions for the same reason as
+        // `collect_custom_type_validators` above (carina#3340).
+        for def in schema.defs.values() {
+            collect_type_names_from_type(def, &mut names);
         }
     }
 
@@ -1167,7 +1182,22 @@ fn collect_validators_from_type(
                 collect_validators_from_type(t, validators);
             }
         }
-        _ => {}
+        // `AttributeType::Ref`: do NOT recurse into the resolved target
+        // here — that would loop forever on cyclic CFN schemas
+        // (`Statement -> AndStatement -> List<Statement>`). The
+        // callers (`collect_custom_type_validators` /
+        // `collect_custom_type_names`) walk every entry of
+        // `schema.defs` directly in a separate loop, which terminates
+        // because each def is visited exactly once. (carina#3340.)
+        AttributeType::Ref(_) => {}
+        // Primitives carry no nested Custom types and no Ref.
+        AttributeType::String
+        | AttributeType::Int
+        | AttributeType::Float
+        | AttributeType::Bool
+        | AttributeType::Duration
+        | AttributeType::StringEnum { .. }
+        | AttributeType::CustomEnum { .. } => {}
     }
 }
 
@@ -1203,7 +1233,17 @@ fn collect_type_names_from_type(
                 collect_type_names_from_type(t, names);
             }
         }
-        _ => {}
+        // See `collect_validators_from_type` for the rationale: the
+        // caller walks `schema.defs` separately to avoid infinite
+        // recursion on cyclic schemas (carina#3340).
+        AttributeType::Ref(_) => {}
+        AttributeType::String
+        | AttributeType::Int
+        | AttributeType::Float
+        | AttributeType::Bool
+        | AttributeType::Duration
+        | AttributeType::StringEnum { .. }
+        | AttributeType::CustomEnum { .. } => {}
     }
 }
 

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -141,6 +141,7 @@ fn walk_custom_lookup(
     value: &Value,
     attr_name: &str,
     lookup: CustomTypeLookup<'_>,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
     errors: &mut Vec<TypeError>,
 ) {
     // Skip deferred-resolution values — same convention as
@@ -196,14 +197,14 @@ fn walk_custom_lookup(
         AttributeType::List { inner, .. } => {
             if let Value::Concrete(ConcreteValue::List(items)) = value {
                 for item in items {
-                    walk_custom_lookup(inner, item, attr_name, lookup, errors);
+                    walk_custom_lookup(inner, item, attr_name, lookup, defs, errors);
                 }
             }
         }
         AttributeType::Map { value: inner, .. } => {
             if let Value::Concrete(ConcreteValue::Map(map)) = value {
                 for v in map.values() {
-                    walk_custom_lookup(inner, v, attr_name, lookup, errors);
+                    walk_custom_lookup(inner, v, attr_name, lookup, defs, errors);
                 }
             }
         }
@@ -211,7 +212,7 @@ fn walk_custom_lookup(
             if let Value::Concrete(ConcreteValue::Map(map)) = value {
                 for f in fields {
                     if let Some(v) = map.get(&f.name) {
-                        walk_custom_lookup(&f.field_type, v, attr_name, lookup, errors);
+                        walk_custom_lookup(&f.field_type, v, attr_name, lookup, defs, errors);
                     }
                 }
             }
@@ -233,7 +234,7 @@ fn walk_custom_lookup(
             let mut best: Option<Vec<TypeError>> = None;
             for member in members {
                 let mut local = Vec::new();
-                walk_custom_lookup(member, value, attr_name, lookup, &mut local);
+                walk_custom_lookup(member, value, attr_name, lookup, defs, &mut local);
                 if local.is_empty() {
                     return;
                 }
@@ -251,6 +252,16 @@ fn walk_custom_lookup(
         | AttributeType::Bool
         | AttributeType::Duration
         | AttributeType::StringEnum { .. } => {}
+        // `Ref`: resolve via the schema's def map and continue the
+        // walk. The resolved target (typically a `Struct`) may carry
+        // identity-bearing custom types whose validators must run.
+        // `resolve_refs` panics on a missing def name (schema
+        // invariant violation). The first-resolve-then-recurse shape
+        // matches `Schema::validate_attr` (carina#3340).
+        AttributeType::Ref(_) => {
+            let resolved = attr_type.resolve_refs(defs);
+            walk_custom_lookup(resolved, value, attr_name, lookup, defs, errors);
+        }
     }
 }
 
@@ -525,6 +536,167 @@ pub enum AttributeType {
     },
     /// Union of multiple types (value is valid if it matches any member)
     Union(Vec<AttributeType>),
+    /// Named reference into the enclosing [`Schema`]'s definition map.
+    ///
+    /// Used to express cyclic struct definitions
+    /// (e.g. `Statement -> AndStatement -> List<Statement>` in
+    /// `AWS::WAFv2::WebACL`) without recursing at codegen time.
+    /// Resolved lazily by [`Schema::validate`] at the point of use.
+    ///
+    /// A `Ref` outside of a `Schema` context cannot be self-validated —
+    /// [`AttributeType::validate`] returns a `TypeError::ValidationFailed`
+    /// in that case. Callers who need to validate a schema that contains
+    /// `Ref` must go through [`Schema::validate`].
+    Ref(String),
+}
+
+/// A complete schema: a root attribute type together with the named
+/// definitions it can reference via [`AttributeType::Ref`].
+///
+/// Introduced in carina#3340 to model cyclic CloudFormation definition
+/// graphs (WAFv2 `WebACL.Statement`, AppSync `GraphQLApi`,
+/// StepFunctions state machine bodies, ...). The validate / diff / LSP
+/// walk-sites that may encounter a `Ref` take `&Schema` as `&self`, so
+/// the resolve step is required by the type signature rather than by
+/// convention.
+#[derive(Debug, Clone)]
+pub struct Schema {
+    /// The root attribute type. May be a `Ref` into `defs`, or any
+    /// other shape (`Struct`, `List`, primitive, ...).
+    pub root: AttributeType,
+    /// Named definitions reachable via [`AttributeType::Ref`].
+    pub defs: std::collections::BTreeMap<String, AttributeType>,
+}
+
+impl Schema {
+    /// Look up a named definition. Returns `None` if `name` is not in
+    /// `defs`; callers should treat that as a type error.
+    pub fn resolve(&self, name: &str) -> Option<&AttributeType> {
+        self.defs.get(name)
+    }
+
+    /// Validate a `Value` against this schema's `root`, resolving
+    /// any `Ref` it encounters by looking it up in `defs`.
+    pub fn validate(&self, value: &Value) -> Result<(), TypeError> {
+        self.validate_attr(&self.root, value)
+    }
+
+    /// Validate against an arbitrary `AttributeType` in the context of
+    /// this schema. Used internally to recurse through `Ref`; exposed
+    /// publicly so callers that already hold a sub-attribute (e.g. a
+    /// resource's attribute type plus the resource's struct-definition
+    /// map) can validate without re-rooting the schema.
+    pub fn validate_attr(&self, attr: &AttributeType, value: &Value) -> Result<(), TypeError> {
+        match attr {
+            AttributeType::Ref(name) => match self.resolve(name) {
+                Some(resolved) => self.validate_attr(resolved, value),
+                None => Err(TypeError::ValidationFailed {
+                    message: format!(
+                        "schema reference `{name}` is not defined in the enclosing schema"
+                    ),
+                }),
+            },
+            AttributeType::List { inner, ordered } => {
+                if let Some(ConcreteValueRef::List(items)) = value.as_concrete() {
+                    for (i, item) in items.iter().enumerate() {
+                        if let Err(inner_err) = self.validate_attr(inner, item) {
+                            return Err(TypeError::ListItemError {
+                                index: i,
+                                inner: Box::new(inner_err),
+                            });
+                        }
+                    }
+                    Ok(())
+                } else if value.as_concrete().is_none() {
+                    // Deferred — leave for the deferred-aware checker.
+                    Ok(())
+                } else {
+                    // Fall back to the standalone validator for the
+                    // not-a-list error. `ordered` is irrelevant when
+                    // the value is not even a list.
+                    let _ = ordered;
+                    AttributeType::List {
+                        inner: inner.clone(),
+                        ordered: *ordered,
+                    }
+                    .validate(value)
+                }
+            }
+            AttributeType::Map { key, value: val_ty } => {
+                if let Some(ConcreteValueRef::Map(map)) = value.as_concrete() {
+                    for (k, v) in map.iter() {
+                        let key_val = Value::Concrete(ConcreteValue::String(k.clone()));
+                        if let Err(inner_err) = self.validate_attr(key, &key_val) {
+                            return Err(TypeError::MapKeyError {
+                                key: k.clone(),
+                                inner: Box::new(inner_err),
+                            });
+                        }
+                        if let Err(inner_err) = self.validate_attr(val_ty, v) {
+                            return Err(TypeError::MapValueError {
+                                key: k.clone(),
+                                inner: Box::new(inner_err),
+                            });
+                        }
+                    }
+                    Ok(())
+                } else {
+                    AttributeType::Map {
+                        key: key.clone(),
+                        value: val_ty.clone(),
+                    }
+                    .validate(value)
+                }
+            }
+            AttributeType::Struct { name, fields } => {
+                if let Some(ConcreteValueRef::Map(map)) = value.as_concrete() {
+                    for field in fields {
+                        match map.get(&field.name) {
+                            Some(field_val) => {
+                                if let Err(inner_err) =
+                                    self.validate_attr(&field.field_type, field_val)
+                                {
+                                    return Err(TypeError::StructFieldError {
+                                        field: field.name.clone(),
+                                        inner: Box::new(inner_err),
+                                    });
+                                }
+                            }
+                            None if field.required => {
+                                return Err(TypeError::MissingRequired {
+                                    name: field.name.clone(),
+                                });
+                            }
+                            None => {}
+                        }
+                    }
+                    let _ = name;
+                    Ok(())
+                } else {
+                    AttributeType::Struct {
+                        name: name.clone(),
+                        fields: fields.clone(),
+                    }
+                    .validate(value)
+                }
+            }
+            AttributeType::Union(members) => {
+                for member in members {
+                    if self.validate_attr(member, value).is_ok() {
+                        return Ok(());
+                    }
+                }
+                Err(TypeError::TypeMismatch {
+                    expected: "Union".to_string(),
+                    got: attr.type_name(),
+                })
+            }
+            // For non-recursive variants, delegate to the standalone
+            // validator. Any `Ref` they could reach has already been
+            // peeled off by the arms above.
+            _ => attr.validate(value),
+        }
+    }
 }
 
 impl fmt::Debug for AttributeType {
@@ -594,6 +766,7 @@ impl fmt::Debug for AttributeType {
                 .field("fields", fields)
                 .finish(),
             AttributeType::Union(types) => f.debug_tuple("Union").field(types).finish(),
+            AttributeType::Ref(name) => f.debug_tuple("Ref").field(name).finish(),
         }
     }
 }
@@ -674,7 +847,61 @@ impl fmt::Display for FieldPath {
     }
 }
 
+/// Empty definition map for walk-sites whose resource schema carries
+/// no cyclic struct definitions (the common case before carina#3340's
+/// chain reaches awscc's WAFv2 WebACL).
+///
+/// Returned by reference so a single `&BTreeMap` reference can be
+/// threaded through every walk-site without per-call allocation.
+/// Walk-sites that hold a [`ResourceSchema`] should prefer `&rs.defs`
+/// to capture cyclic definitions; this constant is for sites that
+/// genuinely have no resource schema in scope (synthetic fixtures,
+/// validation helpers operating on a bare `AttributeType`).
+pub fn empty_defs() -> &'static std::collections::BTreeMap<String, AttributeType> {
+    use std::sync::OnceLock;
+    static EMPTY: OnceLock<std::collections::BTreeMap<String, AttributeType>> = OnceLock::new();
+    EMPTY.get_or_init(std::collections::BTreeMap::new)
+}
+
 impl AttributeType {
+    /// Walk through any [`AttributeType::Ref`] chain at the top of this
+    /// type, returning the first non-`Ref` target.
+    ///
+    /// Walk-sites (differ, detail_rows, LSP) must call this *before*
+    /// matching on the type, so the wildcard arm cannot silently
+    /// accept a `Ref` and discard its schema information. The
+    /// `defs` map is normally `&ResourceSchema::defs`; pass
+    /// [`empty_defs`] when no resource is in scope.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a `Ref` points to a name not present in `defs`. This
+    /// is a schema invariant (a producer that emits `Ref` must also
+    /// populate the matching def); a violation indicates a codegen
+    /// or wire-format bug, not user input.
+    pub fn resolve_refs<'a>(
+        &'a self,
+        defs: &'a std::collections::BTreeMap<String, AttributeType>,
+    ) -> &'a AttributeType {
+        let mut cur = self;
+        // A small upper bound to catch pathological cycles
+        // (`Ref("X") -> Ref("X")`) without hanging the walker.
+        for _ in 0..256 {
+            match cur {
+                AttributeType::Ref(name) => match defs.get(name) {
+                    Some(next) => cur = next,
+                    None => panic!(
+                        "AttributeType::Ref(\"{name}\") not found in schema defs; \
+                         schema invariant violated (producer must populate \
+                         ResourceSchema.defs for every Ref it emits)"
+                    ),
+                },
+                _ => return cur,
+            }
+        }
+        panic!("AttributeType::Ref chain exceeded 256 hops; pathological self-cycle in defs")
+    }
+
     /// Create a List type with default ordering (ordered=true, matching CloudFormation default).
     pub fn list(inner: AttributeType) -> Self {
         AttributeType::List {
@@ -778,6 +1005,19 @@ impl AttributeType {
     /// independently re-projected. Lists may legitimately mix concrete
     /// and deferred elements (e.g. `[vpc.id, "literal"]`).
     pub fn validate(&self, value: &Value) -> Result<(), TypeError> {
+        // `Ref` cannot be resolved without a `Schema` context. Callers
+        // who hold a schema that contains `Ref` must go through
+        // `Schema::validate` / `Schema::validate_attr`; falling through
+        // here would silently accept any value, defeating type safety
+        // (carina#3340).
+        if let AttributeType::Ref(name) = self {
+            return Err(TypeError::ValidationFailed {
+                message: format!(
+                    "internal: AttributeType::Ref(\"{name}\") reached the standalone \
+                     validator; this attribute must be validated through Schema::validate"
+                ),
+            });
+        }
         // StringEnum attributes assigned a bare `BindingRef` are the
         // shadowing collision case described in #2978: the user wrote a
         // bare identifier that happens to be a `let` binding *and* is
@@ -826,6 +1066,15 @@ impl AttributeType {
             | AttributeType::Float
             | AttributeType::Bool
             | AttributeType::Duration => self.validate_primitive(value),
+            // Unreachable: `validate` rejects `Ref` early before
+            // descending into the concrete-value dispatch. Kept as an
+            // explicit arm so the compiler enforces handling.
+            AttributeType::Ref(name) => Err(TypeError::ValidationFailed {
+                message: format!(
+                    "internal: AttributeType::Ref(\"{name}\") in validate_concrete; \
+                     this attribute must be validated through Schema::validate"
+                ),
+            }),
         }
     }
 
@@ -1447,6 +1696,7 @@ impl AttributeType {
                 let names: Vec<String> = types.iter().map(|t| t.type_name()).collect();
                 names.join(" | ")
             }
+            AttributeType::Ref(name) => format!("Ref({name})"),
         }
     }
 
@@ -2513,6 +2763,17 @@ pub struct ResourceSchema {
     /// against this resource type. `None` falls back to
     /// [`WAIT_DEFAULT_INTERVAL`].
     pub default_wait_interval: Option<std::time::Duration>,
+    /// Named definitions reachable via [`AttributeType::Ref`] from this
+    /// resource's attribute types. Empty for resources whose attribute
+    /// graph contains no cycles (the common case).
+    ///
+    /// Introduced in carina#3340 so cyclic CloudFormation definition
+    /// graphs (WAFv2 `WebACL.Statement`, AppSync `GraphQLApi`, ...) can
+    /// be represented in the type system without flattening to
+    /// `Map(String, String)` blobs. Walk-sites that traverse
+    /// `AttributeType` (differ, detail_rows, LSP) MUST consult `defs`
+    /// to resolve `Ref` variants rather than fall through a wildcard.
+    pub defs: std::collections::BTreeMap<String, AttributeType>,
 }
 
 /// Fallback total timeout when neither the user nor the resource schema
@@ -2541,7 +2802,19 @@ impl ResourceSchema {
             exclusive_required: Vec::new(),
             default_wait_timeout: None,
             default_wait_interval: None,
+            defs: std::collections::BTreeMap::new(),
         }
+    }
+
+    /// Attach a named definition reachable via [`AttributeType::Ref`].
+    ///
+    /// Used by codegen to register cyclic CFN struct definitions
+    /// (WAFv2 `WebACL.Statement`, AppSync `GraphQLApi`, ...). Each
+    /// `Ref(name)` inside this resource's attribute types is resolved
+    /// against this map.
+    pub fn with_def(mut self, name: impl Into<String>, ty: AttributeType) -> Self {
+        self.defs.insert(name.into(), ty);
+        self
     }
 
     /// Set the schema-declared default total timeout for `wait` polling.
@@ -2789,7 +3062,14 @@ impl ResourceSchema {
                     };
                     errors.push(reshaped);
                 }
-                walk_custom_lookup(&schema.attr_type, value, name, lookup, &mut errors);
+                walk_custom_lookup(
+                    &schema.attr_type,
+                    value,
+                    name,
+                    lookup,
+                    &self.defs,
+                    &mut errors,
+                );
             } else {
                 let suggestion = suggest_similar_name(name, &known);
                 errors.push(TypeError::UnknownAttribute {
@@ -2835,6 +3115,14 @@ pub fn collect_all_block_names(registry: &SchemaRegistry) -> HashMap<String, Str
             // Also collect from nested struct fields
             collect_block_names_from_type(&attr_schema.attr_type, &mut result);
         }
+        // Walk cyclic-struct definitions separately so block names on
+        // fields inside a `Ref` target (e.g. `Statement.AndStatement`)
+        // are picked up. The `Ref` arm in `collect_block_names_from_type`
+        // stops recursion to avoid loops; the visit-defs pass closes
+        // the gap (carina#3340).
+        for def in schema.defs.values() {
+            collect_block_names_from_type(def, &mut result);
+        }
     }
     result
 }
@@ -2860,7 +3148,18 @@ fn collect_block_names_from_type(attr_type: &AttributeType, result: &mut HashMap
                 collect_block_names_from_type(t, result);
             }
         }
-        _ => {}
+        // `Ref`: do not follow — the caller visits `schema.defs`
+        // entries directly to avoid infinite recursion on cyclic
+        // schemas (carina#3340).
+        AttributeType::Ref(_) => {}
+        AttributeType::String
+        | AttributeType::Int
+        | AttributeType::Float
+        | AttributeType::Bool
+        | AttributeType::Duration
+        | AttributeType::StringEnum { .. }
+        | AttributeType::Custom { .. }
+        | AttributeType::CustomEnum { .. } => {}
     }
 }
 

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -4040,6 +4040,7 @@ fn walk_custom_lookup_skips_value_unknown() {
                 message: "should never be called".to_string(),
             })
         },
+        crate::schema::empty_defs(),
         &mut errors,
     );
     assert!(
@@ -4090,6 +4091,7 @@ fn union_walk_custom_lookup_succeeds_when_any_member_accepts() {
         &Value::Concrete(ConcreteValue::String("anything".to_string())),
         "attr",
         &lookup,
+        crate::schema::empty_defs(),
         &mut errors,
     );
     assert!(
@@ -4126,6 +4128,7 @@ fn union_walk_custom_lookup_emits_smallest_error_set_when_all_fail() {
         &Value::Concrete(ConcreteValue::String("anything".to_string())),
         "attr",
         &lookup,
+        crate::schema::empty_defs(),
         &mut errors,
     );
     assert_eq!(
@@ -4167,6 +4170,7 @@ fn union_walk_custom_lookup_cidr_accepts_ipv4_when_lookup_routes_correctly() {
         &Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
         "cidr",
         &lookup,
+        crate::schema::empty_defs(),
         &mut errors,
     );
     assert!(
@@ -5020,4 +5024,139 @@ fn select_union_member_deferred_value_is_none() {
         binding: "some_ref".to_string(),
     });
     assert!(select_union_member(&members, &v).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// carina#3340: AttributeType::Ref + Schema for cyclic struct definitions.
+//
+// The CFN schema for WAFv2 WebACL has a cyclic definition graph:
+//     Statement -> AndStatement.Statements: List<Statement> -> ...
+// Modelled as:
+//     defs["Statement"]    = Struct { fields: [and_statement: Ref("AndStatement"), ...] }
+//     defs["AndStatement"] = Struct { fields: [statements: List(Ref("Statement"))] }
+// The root attribute references into `defs` via `Ref`.
+// ---------------------------------------------------------------------------
+
+fn cyclic_statement_schema() -> Schema {
+    let mut defs = std::collections::BTreeMap::new();
+    defs.insert(
+        "Statement".to_string(),
+        AttributeType::Struct {
+            name: "Statement".to_string(),
+            fields: vec![StructField::new(
+                "and_statement",
+                AttributeType::Ref("AndStatement".to_string()),
+            )],
+        },
+    );
+    defs.insert(
+        "AndStatement".to_string(),
+        AttributeType::Struct {
+            name: "AndStatement".to_string(),
+            fields: vec![StructField::new(
+                "statements",
+                AttributeType::List {
+                    inner: Box::new(AttributeType::Ref("Statement".to_string())),
+                    ordered: true,
+                },
+            )],
+        },
+    );
+    Schema {
+        root: AttributeType::Ref("Statement".to_string()),
+        defs,
+    }
+}
+
+#[test]
+fn schema_resolve_returns_defined_type() {
+    let schema = cyclic_statement_schema();
+    let resolved = schema.resolve("Statement").expect("Statement defined");
+    assert!(matches!(resolved, AttributeType::Struct { name, .. } if name == "Statement"));
+    assert!(schema.resolve("NoSuchThing").is_none());
+}
+
+#[test]
+fn schema_validate_well_formed_nested_statement_succeeds() {
+    let schema = cyclic_statement_schema();
+
+    let inner_statement = Value::Concrete(ConcreteValue::Map({
+        let mut m = indexmap::IndexMap::new();
+        m.insert(
+            "and_statement".to_string(),
+            Value::Concrete(ConcreteValue::Map({
+                let mut m2 = indexmap::IndexMap::new();
+                m2.insert(
+                    "statements".to_string(),
+                    Value::Concrete(ConcreteValue::List(vec![])),
+                );
+                m2
+            })),
+        );
+        m
+    }));
+
+    let outer = Value::Concrete(ConcreteValue::Map({
+        let mut m = indexmap::IndexMap::new();
+        m.insert(
+            "and_statement".to_string(),
+            Value::Concrete(ConcreteValue::Map({
+                let mut m2 = indexmap::IndexMap::new();
+                m2.insert(
+                    "statements".to_string(),
+                    Value::Concrete(ConcreteValue::List(vec![inner_statement])),
+                );
+                m2
+            })),
+        );
+        m
+    }));
+
+    let result = schema.validate(&outer);
+    assert!(
+        result.is_ok(),
+        "well-formed nested statement should validate: {result:?}"
+    );
+}
+
+#[test]
+fn schema_validate_malformed_nested_statement_fails() {
+    let schema = cyclic_statement_schema();
+
+    // and_statement.statements should be a list of Statement (= Map),
+    // but we put an Int instead.
+    let bad = Value::Concrete(ConcreteValue::Map({
+        let mut m = indexmap::IndexMap::new();
+        m.insert(
+            "and_statement".to_string(),
+            Value::Concrete(ConcreteValue::Map({
+                let mut m2 = indexmap::IndexMap::new();
+                m2.insert(
+                    "statements".to_string(),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::Int(42),
+                    )])),
+                );
+                m2
+            })),
+        );
+        m
+    }));
+
+    let result = schema.validate(&bad);
+    assert!(
+        result.is_err(),
+        "Int where Statement was expected should be rejected"
+    );
+}
+
+#[test]
+fn attribute_type_validate_on_ref_returns_error_without_schema() {
+    let t = AttributeType::Ref("Statement".to_string());
+    let v = Value::Concrete(ConcreteValue::String("anything".to_string()));
+    let result = t.validate(&v);
+    assert!(
+        result.is_err(),
+        "AttributeType::Ref cannot self-validate without a Schema"
+    );
 }

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -695,6 +695,21 @@ pub fn resolve_enum_value(value: &Value, parts: &NamespacedEnumParts<'_>) -> Opt
 /// }
 /// ```
 pub fn resolve_enum_value_recursive(value: &Value, attr_type: &AttributeType) -> Option<Value> {
+    resolve_enum_value_recursive_with_defs(value, attr_type, crate::schema::empty_defs())
+}
+
+/// Same as [`resolve_enum_value_recursive`] but takes the enclosing
+/// [`ResourceSchema::defs`] map so cyclic CFN definitions
+/// (`AttributeType::Ref`) can be followed during the type walk
+/// (carina#3340). Callers that hold a resource schema should prefer
+/// this entry point so a `Ref` chain inside a value tree (e.g. WAFv2
+/// `WebACL.Statement -> AndStatement -> List<Statement>`) doesn't
+/// silently lose enum normalization on the recursed cycle.
+pub fn resolve_enum_value_recursive_with_defs(
+    value: &Value,
+    attr_type: &AttributeType,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
+) -> Option<Value> {
     // First, try the leaf case: this position is itself an enum.
     if let Some(parts) = attr_type.namespaced_enum_parts()
         && let Some(resolved) = resolve_enum_value(value, &parts)
@@ -712,7 +727,7 @@ pub fn resolve_enum_value_recursive(value: &Value, attr_type: &AttributeType) ->
             for field in fields {
                 if let Some(field_value) = map.get(&field.name)
                     && let Some(new_field) =
-                        resolve_enum_value_recursive(field_value, &field.field_type)
+                        resolve_enum_value_recursive_with_defs(field_value, &field.field_type, defs)
                 {
                     rewritten.insert(field.name.clone(), new_field);
                     changed = true;
@@ -727,7 +742,7 @@ pub fn resolve_enum_value_recursive(value: &Value, attr_type: &AttributeType) ->
             let mut rewritten = items.clone();
             let mut changed = false;
             for (i, item) in items.iter().enumerate() {
-                if let Some(new_item) = resolve_enum_value_recursive(item, inner) {
+                if let Some(new_item) = resolve_enum_value_recursive_with_defs(item, inner, defs) {
                     rewritten[i] = new_item;
                     changed = true;
                 }
@@ -741,12 +756,21 @@ pub fn resolve_enum_value_recursive(value: &Value, attr_type: &AttributeType) ->
             let mut rewritten = map.clone();
             let mut changed = false;
             for (k, v) in map {
-                if let Some(new_v) = resolve_enum_value_recursive(v, inner) {
+                if let Some(new_v) = resolve_enum_value_recursive_with_defs(v, inner, defs) {
                     rewritten.insert(k.clone(), new_v);
                     changed = true;
                 }
             }
             changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
+        }
+        // `Ref`: follow the named target in the schema's def map and
+        // continue the walk. Without this arm a cyclic schema would
+        // silently drop enum normalization at every cycle point
+        // (carina#3340). `resolve_refs` panics on a missing def name
+        // (schema invariant violation).
+        AttributeType::Ref(_) => {
+            let resolved = attr_type.resolve_refs(defs);
+            resolve_enum_value_recursive_with_defs(value, resolved, defs)
         }
         // Scalars and Union: nothing to descend into.
         _ => None,
@@ -807,7 +831,8 @@ pub fn lift_state_string_enums_to_identifiers(
 ) {
     for (name, attr) in &schema.attributes {
         if let Some(value) = attributes.get(name)
-            && let Some(lifted) = lift_string_enum_leaves(value, &attr.attr_type)
+            && let Some(lifted) =
+                lift_string_enum_leaves_with_defs(value, &attr.attr_type, &schema.defs)
         {
             attributes.insert(name.clone(), lifted);
         }
@@ -911,6 +936,19 @@ pub fn lift_current_state_string_enums_for_data_sources(
 /// [`resolve_enum_value_recursive`]'s "rewrite only on diff" contract so
 /// callers can skip cloning.
 pub fn lift_string_enum_leaves(value: &Value, attr_type: &AttributeType) -> Option<Value> {
+    lift_string_enum_leaves_with_defs(value, attr_type, crate::schema::empty_defs())
+}
+
+/// Same as [`lift_string_enum_leaves`] but takes the enclosing
+/// [`ResourceSchema::defs`] map so cyclic CFN definitions
+/// (`AttributeType::Ref`) are followed during the value walk
+/// (carina#3340). Callers that hold a resource schema should prefer
+/// this entry point.
+pub fn lift_string_enum_leaves_with_defs(
+    value: &Value,
+    attr_type: &AttributeType,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
+) -> Option<Value> {
     // Leaf case: this position is itself a StringEnum.
     if let Some((_, values, _, dsl_map)) = attr_type.string_enum_parts() {
         if let Value::Concrete(ConcreteValue::String(s)) = value {
@@ -944,7 +982,8 @@ pub fn lift_string_enum_leaves(value: &Value, attr_type: &AttributeType) -> Opti
             let mut changed = false;
             for field in fields {
                 if let Some(field_value) = map.get(&field.name)
-                    && let Some(new_field) = lift_string_enum_leaves(field_value, &field.field_type)
+                    && let Some(new_field) =
+                        lift_string_enum_leaves_with_defs(field_value, &field.field_type, defs)
                 {
                     rewritten.insert(field.name.clone(), new_field);
                     changed = true;
@@ -959,7 +998,7 @@ pub fn lift_string_enum_leaves(value: &Value, attr_type: &AttributeType) -> Opti
             let mut rewritten = items.clone();
             let mut changed = false;
             for (i, item) in items.iter().enumerate() {
-                if let Some(new_item) = lift_string_enum_leaves(item, inner) {
+                if let Some(new_item) = lift_string_enum_leaves_with_defs(item, inner, defs) {
                     rewritten[i] = new_item;
                     changed = true;
                 }
@@ -973,12 +1012,18 @@ pub fn lift_string_enum_leaves(value: &Value, attr_type: &AttributeType) -> Opti
             let mut rewritten = map.clone();
             let mut changed = false;
             for (k, v) in map {
-                if let Some(new_v) = lift_string_enum_leaves(v, inner) {
+                if let Some(new_v) = lift_string_enum_leaves_with_defs(v, inner, defs) {
                     rewritten.insert(k.clone(), new_v);
                     changed = true;
                 }
             }
             changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
+        }
+        // `Ref`: resolve via defs and continue. See sibling note in
+        // `resolve_enum_value_recursive_with_defs` (carina#3340).
+        AttributeType::Ref(_) => {
+            let resolved = attr_type.resolve_refs(defs);
+            lift_string_enum_leaves_with_defs(value, resolved, defs)
         }
         // Scalars and Union: nothing to descend into.
         _ => None,

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -233,7 +233,7 @@ fn check_ref(
         return;
     };
 
-    if path_traverses_deferred(attr_schema, path.segments()) {
+    if path_traverses_deferred(attr_schema, path.segments(), &schema.defs) {
         out.push(DeferredPopulateDiagnostic {
             message: format!(
                 "attribute `{attribute_key}` references `{}`, which is populated asynchronously by the provider after Create. \
@@ -254,7 +254,11 @@ fn check_ref(
 /// `AttributeSchema.deferred_populate=true` value is deferred-bound
 /// for *every* downstream chained access on it, even with no
 /// segments).
-fn path_traverses_deferred(top_attr: &AttributeSchema, segments: &[PathSegment]) -> bool {
+fn path_traverses_deferred(
+    top_attr: &AttributeSchema,
+    segments: &[PathSegment],
+    defs: &std::collections::BTreeMap<String, AttributeType>,
+) -> bool {
     if top_attr.deferred_populate {
         return true;
     }
@@ -266,7 +270,11 @@ fn path_traverses_deferred(top_attr: &AttributeSchema, segments: &[PathSegment])
         // the resulting `current_type` is the element type — no
         // deferred flag lives on List/Map themselves (they have no
         // such field on their builders).
-        match (current_type, segment) {
+        // Resolve `Ref` chains so the cyclic-CFN case
+        // (`Statement -> AndStatement -> List<Statement>`) does not
+        // bail out at the first cycle hop (carina#3340).
+        let resolved = current_type.resolve_refs(defs);
+        match (resolved, segment) {
             (AttributeType::List { inner, .. }, PathSegment::Subscript { .. }) => {
                 current_type = inner;
             }

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -497,16 +497,24 @@ fn infer_resource_ref_with_visiting(
     use crate::resource::{PathSegment, Subscript};
     let mut current = &attr_schema.attr_type;
     for seg in segments {
-        current = match (seg, current) {
-            (PathSegment::Field { name }, attr) => match descend_struct_field(attr, name) {
-                Some(t) => t,
-                None => {
-                    return Err(InferenceError::UnknownAttribute {
-                        binding: binding.to_string(),
-                        attribute: format!("{}.{}", attribute, name),
-                    });
+        // Resolve a `Ref` chain at each step so Subscript arms below
+        // see the underlying List / Map / Struct shape instead of the
+        // opaque `Ref` (carina#3340). `descend_struct_field` already
+        // resolves internally for the Field arm; pre-resolving here
+        // also keeps the Subscript arms shape-matched.
+        let resolved = current.resolve_refs(&schema.defs);
+        current = match (seg, resolved) {
+            (PathSegment::Field { name }, attr) => {
+                match descend_struct_field(attr, name, &schema.defs) {
+                    Some(t) => t,
+                    None => {
+                        return Err(InferenceError::UnknownAttribute {
+                            binding: binding.to_string(),
+                            attribute: format!("{}.{}", attribute, name),
+                        });
+                    }
                 }
-            },
+            }
             (
                 PathSegment::Subscript {
                     index: Subscript::Int { .. },
@@ -544,6 +552,9 @@ fn infer_resource_ref_with_visiting(
     // forward the whole struct without naming the inner union branch.
     // The user can only "pick a branch" for a union they're directly
     // accessing, not for one buried inside a transferred value.
+    // Resolve any trailing `Ref` so the Union check and the
+    // TypeExpr projection see the underlying shape (carina#3340).
+    let current = current.resolve_refs(&schema.defs);
     if matches!(current, AttributeType::Union(_)) {
         return Err(InferenceError::UnknownType {
             reason: format!(
@@ -568,8 +579,13 @@ fn lookup_schema<'a>(
 fn descend_struct_field<'a>(
     attr_type: &'a AttributeType,
     field: &str,
+    defs: &'a std::collections::BTreeMap<String, AttributeType>,
 ) -> Option<&'a AttributeType> {
-    match attr_type {
+    // Resolve any leading `Ref` chain so a reference path inside a
+    // cyclic CFN struct (`WebACL.Statement -> AndStatement -> ...`)
+    // can be followed across the cycle (carina#3340).
+    let resolved = attr_type.resolve_refs(defs);
+    match resolved {
         AttributeType::Struct { fields, .. } => fields
             .iter()
             .find(|f| f.name == field)
@@ -647,6 +663,16 @@ fn attribute_type_to_type_expr(attr_type: &AttributeType) -> TypeExpr {
         // a "type annotation required" error instead of trusting this
         // result.
         AttributeType::Union(_) => TypeExpr::String,
+        // `Ref` requires the enclosing `Schema` to resolve — this pure
+        // attribute-type-to-type-expr conversion does not have one in
+        // scope. Returning `String` as a sentinel matches the
+        // `Union(_)` arm: callers that need precision must resolve the
+        // `Ref` via `Schema::resolve` upstream and convert the result.
+        // The carina#3340 model emits `Ref` only at cycle points in
+        // generated schemas, so this fallback path is unreachable for
+        // hand-written or codegen-produced attribute types reached
+        // through normal validation flows.
+        AttributeType::Ref(_) => TypeExpr::String,
     }
 }
 

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -603,7 +603,20 @@ pub fn is_string_compatible_type(attr_type: &AttributeType) -> bool {
             true
         }
         AttributeType::Union(types) => types.iter().all(is_string_compatible_type),
-        _ => false,
+        // `AttributeType::Ref` (carina#3340): resolved target is
+        // typically a `Struct`, not a string-shaped scalar. Returning
+        // `false` is the safe, schema-consistent answer. If a future
+        // schema uses `Ref` to point at a non-Struct, this helper
+        // should thread `&defs` and recurse via `resolve_refs`.
+        AttributeType::Ref(_) => false,
+        AttributeType::Int
+        | AttributeType::Float
+        | AttributeType::Bool
+        | AttributeType::Duration
+        | AttributeType::CustomEnum { .. }
+        | AttributeType::List { .. }
+        | AttributeType::Map { .. }
+        | AttributeType::Struct { .. } => false,
     }
 }
 
@@ -616,7 +629,20 @@ fn is_plain_string_or_string_union(attr_type: &AttributeType) -> bool {
     match attr_type {
         AttributeType::String => true,
         AttributeType::Union(types) => types.iter().all(is_plain_string_or_string_union),
-        _ => false,
+        // `Ref` resolves to a Struct in every cyclic CFN schema today;
+        // returning `false` is conservative and consistent with
+        // is_string_compatible_type. (carina#3340.)
+        AttributeType::Ref(_) => false,
+        AttributeType::Int
+        | AttributeType::Float
+        | AttributeType::Bool
+        | AttributeType::Duration
+        | AttributeType::Custom { .. }
+        | AttributeType::CustomEnum { .. }
+        | AttributeType::StringEnum { .. }
+        | AttributeType::List { .. }
+        | AttributeType::Map { .. }
+        | AttributeType::Struct { .. } => false,
     }
 }
 
@@ -646,7 +672,22 @@ fn attr_type_demands_specific_custom(attr_type: &AttributeType) -> bool {
             identity: Some(_), ..
         } => true,
         AttributeType::Union(types) => types.iter().any(attr_type_demands_specific_custom),
-        _ => false,
+        // `Ref` (carina#3340): does not itself demand a custom identity.
+        // The resolved target may carry one, but `_specific_custom`
+        // operates at the receiver type's outer shape — Union is the
+        // only nesting it traverses, by design (see doc comment).
+        AttributeType::Ref(_) => false,
+        AttributeType::String
+        | AttributeType::Int
+        | AttributeType::Float
+        | AttributeType::Bool
+        | AttributeType::Duration
+        | AttributeType::Custom { identity: None, .. }
+        | AttributeType::CustomEnum { .. }
+        | AttributeType::StringEnum { .. }
+        | AttributeType::List { .. }
+        | AttributeType::Map { .. }
+        | AttributeType::Struct { .. } => false,
     }
 }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -433,6 +433,7 @@ fn make_schema(resource_type: &str, attrs: Vec<(&str, AttributeType)>) -> Resour
         exclusive_required: Vec::new(),
         default_wait_timeout: None,
         default_wait_interval: None,
+        defs: std::collections::BTreeMap::new(),
     }
 }
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1376,22 +1376,43 @@ fn peel_custom(t: &AttributeType) -> &AttributeType {
 ///
 /// See #2481, #2510.
 pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value {
+    canonicalize_with_type_and_defs(value, attr_type, crate::schema::empty_defs())
+}
+
+/// Same as [`canonicalize_with_type`] but takes the enclosing
+/// [`ResourceSchema::defs`] map so cyclic CFN definitions
+/// (`AttributeType::Ref`) are followed during the type walk
+/// (carina#3340). The `Ref` arm resolves and recurses; primitives /
+/// unions terminate as before.
+pub fn canonicalize_with_type_and_defs(
+    value: Value,
+    attr_type: &AttributeType,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
+) -> Value {
     let unwrapped = peel_custom(attr_type);
     if is_string_or_list_of_strings(unwrapped) {
         return canonicalize_to_string_list(value);
+    }
+    // `Ref`: resolve and re-dispatch. Without this arm the wildcard
+    // below silently passes the value through, so a cyclic CFN field
+    // never gets its nested `string_or_list_of_strings` collapsed
+    // (carina#3340).
+    if let AttributeType::Ref(_) = unwrapped {
+        let resolved = unwrapped.resolve_refs(defs);
+        return canonicalize_with_type_and_defs(value, resolved, defs);
     }
     match (value, unwrapped) {
         (Value::Concrete(ConcreteValue::List(items)), AttributeType::List { inner, .. }) => {
             let canonicalized = items
                 .into_iter()
-                .map(|v| canonicalize_with_type(v, inner.as_ref()))
+                .map(|v| canonicalize_with_type_and_defs(v, inner.as_ref(), defs))
                 .collect();
             Value::Concrete(ConcreteValue::List(canonicalized))
         }
         (Value::Concrete(ConcreteValue::Map(map)), AttributeType::Map { value: vt, .. }) => {
             let canonicalized = map
                 .into_iter()
-                .map(|(k, v)| (k, canonicalize_with_type(v, vt.as_ref())))
+                .map(|(k, v)| (k, canonicalize_with_type_and_defs(v, vt.as_ref(), defs)))
                 .collect();
             Value::Concrete(ConcreteValue::Map(canonicalized))
         }
@@ -1404,7 +1425,7 @@ pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value 
                         .find(|f| f.name == k || f.provider_name.as_deref() == Some(k.as_str()))
                         .map(|f| &f.field_type);
                     let canon = match field_type {
-                        Some(ft) => canonicalize_with_type(v, ft),
+                        Some(ft) => canonicalize_with_type_and_defs(v, ft, defs),
                         None => v,
                     };
                     (k, canon)
@@ -1412,9 +1433,11 @@ pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value 
                 .collect();
             Value::Concrete(ConcreteValue::Map(canonicalized))
         }
-        (Value::Deferred(DeferredValue::Secret(inner)), _) => Value::Deferred(
-            DeferredValue::Secret(Box::new(canonicalize_with_type(*inner, attr_type))),
-        ),
+        (Value::Deferred(DeferredValue::Secret(inner)), _) => {
+            Value::Deferred(DeferredValue::Secret(Box::new(
+                canonicalize_with_type_and_defs(*inner, attr_type, defs),
+            )))
+        }
         // Union: the missing nesting kind (List/Map/Struct/Secret
         // already recurse; Union was the lone gap — carina#3080).
         // `principal` is `Union[Struct{ service: Union[String,
@@ -1431,7 +1454,7 @@ pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value 
         // is identity — never guess-coerce.
         (val, AttributeType::Union(members)) => {
             match crate::schema::select_union_member(members, &val) {
-                Some(member) => canonicalize_with_type(val, member),
+                Some(member) => canonicalize_with_type_and_defs(val, member, defs),
                 None => val,
             }
         }
@@ -1486,7 +1509,9 @@ pub fn canonicalize_resources_with_schemas(
         let mut new_attrs: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
         for (key, value) in std::mem::take(&mut resource.attributes) {
             let canon = match schema.attributes.get(&key) {
-                Some(attr_schema) => canonicalize_with_type(value, &attr_schema.attr_type),
+                Some(attr_schema) => {
+                    canonicalize_with_type_and_defs(value, &attr_schema.attr_type, &schema.defs)
+                }
                 None => value,
             };
             new_attrs.insert(key, canon);
@@ -1510,7 +1535,9 @@ pub fn canonicalize_data_sources_with_schemas(
         let mut new_attrs: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
         for (key, value) in std::mem::take(&mut data_source.attributes) {
             let canon = match schema.attributes.get(&key) {
-                Some(attr_schema) => canonicalize_with_type(value, &attr_schema.attr_type),
+                Some(attr_schema) => {
+                    canonicalize_with_type_and_defs(value, &attr_schema.attr_type, &schema.defs)
+                }
                 None => value,
             };
             new_attrs.insert(key, canon);
@@ -1550,7 +1577,9 @@ pub fn canonicalize_states_with_schemas(
         let mut new_attrs = std::collections::HashMap::with_capacity(state.attributes.len());
         for (key, value) in std::mem::take(&mut state.attributes) {
             let canon = match schema.attributes.get(&key) {
-                Some(attr_schema) => canonicalize_with_type(value, &attr_schema.attr_type),
+                Some(attr_schema) => {
+                    canonicalize_with_type_and_defs(value, &attr_schema.attr_type, &schema.defs)
+                }
                 None => value,
             };
             new_attrs.insert(key, canon);

--- a/carina-core/tests/cyclic_schema_ref.rs
+++ b/carina-core/tests/cyclic_schema_ref.rs
@@ -1,0 +1,222 @@
+//! Integration test for carina#3340: cyclic CFN-style struct
+//! definitions modelled via `AttributeType::Ref` + `ResourceSchema::defs`,
+//! exercised end-to-end through the differ.
+//!
+//! The shape mirrors AWS::WAFv2::WebACL `Statement` — the smallest
+//! recursive CFN definition that triggered awscc codegen's stack
+//! overflow and the entire chain that opens with this PR.
+//!
+//! What this test pins:
+//!
+//! 1. A `ResourceSchema` whose `attributes` reference a named def via
+//!    `AttributeType::Ref` and whose `defs` map carries the cyclic
+//!    struct can be constructed without panicking.
+//! 2. `Schema::validate_attr` accepts a well-formed nested value tree
+//!    that exercises the cycle at least one hop deep.
+//! 3. The differ (`diff`) treats semantically equal cyclic values as
+//!    `NoChange`, and surfaces a real change as `Update` with the
+//!    correct `changed_attributes` — confirming `type_aware_equal`'s
+//!    `Ref` resolution at the walk-site (the load-bearing rule of
+//!    the chain).
+//! 4. Every non-cyclic `ResourceSchema` constructed via the builder
+//!    keeps `defs` empty by default — guards against accidentally
+//!    forcing every caller to populate the new field.
+
+use std::collections::{BTreeMap, HashMap};
+
+use carina_core::differ::{Diff, diff};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, Schema, StructField};
+
+/// Build a minimal WAFv2-WebACL-shaped cyclic schema.
+///
+/// Top-level attribute `rules` is `List<Struct{ statement: Ref(Statement) }>`.
+/// `Statement` is `Struct { and_statement: List<Ref(Statement)> }` —
+/// the simplest shape that exercises a true cycle through `Ref`.
+fn cyclic_webacl_like_schema() -> ResourceSchema {
+    let statement_def = AttributeType::Struct {
+        name: "Statement".to_string(),
+        fields: vec![StructField::new(
+            "and_statement",
+            AttributeType::list(AttributeType::Ref("Statement".to_string())),
+        )],
+    };
+
+    let rule_struct = AttributeType::Struct {
+        name: "Rule".to_string(),
+        fields: vec![
+            StructField::new("name", AttributeType::String),
+            StructField::new("statement", AttributeType::Ref("Statement".to_string())),
+        ],
+    };
+
+    ResourceSchema::new("wafv2.WebACL")
+        .attribute(AttributeSchema::new(
+            "rules",
+            AttributeType::list(rule_struct),
+        ))
+        .with_def("Statement", statement_def)
+}
+
+fn statement_value(child_count: usize) -> Value {
+    let children: Vec<Value> = (0..child_count)
+        .map(|_| {
+            let mut leaf = indexmap::IndexMap::new();
+            leaf.insert(
+                "and_statement".to_string(),
+                Value::Concrete(ConcreteValue::List(Vec::new())),
+            );
+            Value::Concrete(ConcreteValue::Map(leaf))
+        })
+        .collect();
+    let mut top = indexmap::IndexMap::new();
+    top.insert(
+        "and_statement".to_string(),
+        Value::Concrete(ConcreteValue::List(children)),
+    );
+    Value::Concrete(ConcreteValue::Map(top))
+}
+
+fn rule_value(name: &str, child_count: usize) -> Value {
+    let mut rule = indexmap::IndexMap::new();
+    rule.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String(name.to_string())),
+    );
+    rule.insert("statement".to_string(), statement_value(child_count));
+    Value::Concrete(ConcreteValue::Map(rule))
+}
+
+#[test]
+fn cyclic_schema_validates_a_two_level_nested_value() {
+    let schema = cyclic_webacl_like_schema();
+    let rule_attr_type = &schema.attributes["rules"].attr_type;
+
+    let rules_value = Value::Concrete(ConcreteValue::List(vec![rule_value("BlockBadIPs", 1)]));
+
+    let s = Schema {
+        root: AttributeType::String, // unused for this call
+        defs: schema.defs.clone(),
+    };
+    s.validate_attr(rule_attr_type, &rules_value)
+        .expect("well-formed cyclic value must validate against schema.defs");
+}
+
+#[test]
+fn cyclic_schema_rejects_a_string_where_a_list_is_required_under_ref() {
+    let schema = cyclic_webacl_like_schema();
+    let rule_attr_type = &schema.attributes["rules"].attr_type;
+
+    let mut bad_statement = indexmap::IndexMap::new();
+    bad_statement.insert(
+        "and_statement".to_string(),
+        Value::Concrete(ConcreteValue::String("not a list".to_string())),
+    );
+    let mut bad_rule = indexmap::IndexMap::new();
+    bad_rule.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("X".to_string())),
+    );
+    bad_rule.insert(
+        "statement".to_string(),
+        Value::Concrete(ConcreteValue::Map(bad_statement)),
+    );
+    let rules_value = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(bad_rule),
+    )]));
+
+    let s = Schema {
+        root: AttributeType::String,
+        defs: schema.defs.clone(),
+    };
+    let err = s
+        .validate_attr(rule_attr_type, &rules_value)
+        .expect_err("string-where-list under Ref must fail validation");
+    let text = err.to_string();
+    assert!(
+        text.to_ascii_lowercase().contains("list") || text.to_ascii_lowercase().contains("type"),
+        "diagnostic should mention type/list mismatch, got: {text}"
+    );
+}
+
+#[test]
+fn differ_treats_equal_cyclic_values_as_unchanged() {
+    // The load-bearing assertion for carina#3340: the differ's
+    // `type_aware_equal` resolves `Ref` at function entry and so
+    // semantically equal cyclic values do not surface a phantom diff.
+    let schema = cyclic_webacl_like_schema();
+    let id = ResourceId::new("wafv2.WebACL", "main");
+
+    let rules_value = Value::Concrete(ConcreteValue::List(vec![rule_value("BlockBadIPs", 2)]));
+    let desired = build_resource(&id, &[("rules", rules_value.clone())]);
+
+    let mut current_attrs = HashMap::new();
+    current_attrs.insert("rules".to_string(), rules_value);
+    let current = State::existing(id.clone(), current_attrs);
+
+    let d = diff(&desired, &current, None, None, Some(&schema));
+    assert!(
+        matches!(d, Diff::NoChange(_)),
+        "equal cyclic values must produce NoChange, got: {d:?}"
+    );
+}
+
+#[test]
+fn differ_surfaces_a_real_change_inside_a_cyclic_value() {
+    // Counterpart to the no-phantom case: a real difference one cycle
+    // hop deep MUST surface as a single attribute diff. This proves
+    // the `Ref` resolution didn't accidentally collapse the inner
+    // walk into a no-op.
+    let schema = cyclic_webacl_like_schema();
+    let id = ResourceId::new("wafv2.WebACL", "main");
+
+    let desired_rules = Value::Concrete(ConcreteValue::List(vec![rule_value("BlockBadIPs", 3)]));
+    let desired = build_resource(&id, &[("rules", desired_rules)]);
+
+    let mut current_attrs = HashMap::new();
+    current_attrs.insert(
+        "rules".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![rule_value("BlockBadIPs", 2)])),
+    );
+    let current = State::existing(id.clone(), current_attrs);
+
+    let d = diff(&desired, &current, None, None, Some(&schema));
+    match d {
+        Diff::Update {
+            changed_attributes, ..
+        } => {
+            assert_eq!(
+                changed_attributes,
+                vec!["rules".to_string()],
+                "the rules attribute must surface as the changed key (not silently swallowed by the wildcard Ref arm)"
+            );
+        }
+        other => panic!("expected Update, got: {other:?}"),
+    }
+}
+
+#[test]
+fn resource_schema_defs_field_default_is_empty() {
+    // Regression guard: every non-cyclic resource schema must continue
+    // to construct with an empty `defs` map. A future refactor that
+    // accidentally requires `defs` would break every existing builder
+    // call.
+    let schema = ResourceSchema::new("aws.s3.Bucket")
+        .attribute(AttributeSchema::new("bucket", AttributeType::String));
+    assert!(schema.defs.is_empty(), "defs default must be empty");
+    let _: &BTreeMap<String, AttributeType> = &schema.defs;
+}
+
+fn build_resource(id: &ResourceId, attrs: &[(&str, Value)]) -> Resource {
+    // The DSL-layer `Resource::new` constructor takes (resource_type,
+    // name) and synthesizes an `id`. Use it here so the test does not
+    // touch the private `id` field, but immediately overwrite the
+    // synthesized id with the one our test owns (same shape, plus an
+    // explicit provider).
+    let mut r = Resource::new(id.resource_type.clone(), id.name.clone().to_string());
+    r.id = id.clone();
+    for (k, v) in attrs {
+        r = r.with_attribute(k.to_string(), v.clone());
+    }
+    r
+}

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -652,16 +652,24 @@ impl CompletionProvider {
     fn extract_struct_fields<'a>(
         &self,
         attr_type: &'a AttributeType,
+        defs: &'a std::collections::BTreeMap<String, AttributeType>,
     ) -> Option<&'a Vec<StructField>> {
+        // Resolve any leading `Ref` chain so the cyclic-CFN case
+        // (`Statement -> AndStatement -> List<Statement>`) descends
+        // through the cycle for completion (carina#3340).
+        let attr_type = attr_type.resolve_refs(defs);
         match attr_type {
             AttributeType::Struct { fields, .. } => Some(fields),
-            AttributeType::List { inner, .. } => match inner.as_ref() {
-                AttributeType::Struct { fields, .. } => Some(fields),
-                _ => None,
-            },
-            AttributeType::Union(members) => {
-                members.iter().find_map(|m| self.extract_struct_fields(m))
+            AttributeType::List { inner, .. } => {
+                let inner = inner.as_ref().resolve_refs(defs);
+                match inner {
+                    AttributeType::Struct { fields, .. } => Some(fields),
+                    _ => None,
+                }
             }
+            AttributeType::Union(members) => members
+                .iter()
+                .find_map(|m| self.extract_struct_fields(m, defs)),
             _ => None,
         }
     }
@@ -701,7 +709,7 @@ impl CompletionProvider {
         let mut current_type = &attr_schema.attr_type;
 
         for name in &attr_path[1..] {
-            let fields = self.extract_struct_fields(current_type)?;
+            let fields = self.extract_struct_fields(current_type, &schema.defs)?;
             let field = fields
                 .iter()
                 .find(|f| f.name == *name || f.block_name.as_deref() == Some(name))?;
@@ -717,7 +725,7 @@ impl CompletionProvider {
         attr_path: &[String],
     ) -> Option<&'a Vec<StructField>> {
         let attr_type = self.resolve_type_for_path(schema, attr_path)?;
-        self.extract_struct_fields(attr_type)
+        self.extract_struct_fields(attr_type, &schema.defs)
     }
 
     fn struct_field_completions(

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -659,6 +659,14 @@ impl CompletionProvider {
                 }
                 completions
             }
+            // `AttributeType::Ref` (carina#3340): in CFN-derived
+            // schemas the resolved target is a `Struct`, which has no
+            // value-position snippet anyway (block / attribute
+            // completions handle struct field entry separately).
+            // Returning an empty list is shape-consistent with the
+            // `Struct` arm. Threading `&defs` through completion is
+            // unnecessary at this layer.
+            AttributeType::Ref(_) => vec![],
             _ => vec![],
         }
     }
@@ -1961,6 +1969,17 @@ fn return_type_fits(ret: builtins::BuiltinReturnType, attr_type: &AttributeType)
         AttributeType::Float => false,
         AttributeType::Duration => false,
         AttributeType::Struct { .. } => false,
+        // `AttributeType::Ref` (carina#3340) names a cyclic CFN
+        // definition target. Resolution requires the enclosing
+        // [`Schema::defs`] map, which this completion-time helper
+        // does not carry. The resolved targets in practice are
+        // `Struct` shapes (WAFv2 `Statement`, AppSync `GraphQLApi`,
+        // ...), and no built-in currently returns `Struct` — so
+        // returning `false` here is semantically equivalent to the
+        // resolved-target arm and avoids threading `defs` through
+        // a purely completion-side helper. If a future built-in
+        // returns a struct-typed value, thread `defs` and resolve.
+        AttributeType::Ref(_) => false,
     }
 }
 

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -644,6 +644,15 @@ fn proto_schema_to_core(s: &proto::ResourceSchema) -> CoreResourceSchema {
         // protocol gains explicit fields. See carina-rs/carina#2825.
         default_wait_timeout: None,
         default_wait_interval: None,
+        // Cyclic CFN struct definitions reachable via
+        // `AttributeType::Ref`. Mirrors the wire `defs` map onto the
+        // core schema so walk-sites that traverse a `Ref` can resolve
+        // it against the resource's own def table (carina#3340).
+        defs: s
+            .defs
+            .iter()
+            .map(|(k, v)| (k.clone(), proto_attr_type_to_core(v)))
+            .collect(),
     }
 }
 
@@ -781,6 +790,11 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             validate: noop_validator(), // Validation is handled via ProviderContext.validators
             to_dsl: None,
         },
+        // Cyclic CFN struct reference (carina#3340). The host's
+        // structural counterpart is `AttributeType::Ref`; the matching
+        // `ResourceSchema.defs` map is converted alongside in
+        // `proto_schema_to_core` so resolution at walk-sites succeeds.
+        proto::AttributeType::Ref { name } => CoreAttributeType::Ref(name.clone()),
     }
 }
 
@@ -1624,6 +1638,7 @@ mod tests {
             operation_config: None,
             validators: vec![proto::ValidatorType::TagsKeyValueCheck],
             exclusive_required: vec![],
+            defs: Default::default(),
         };
         let core_schema = proto_schema_to_core(&proto_schema);
         assert!(core_schema.validator.is_some());
@@ -1641,6 +1656,7 @@ mod tests {
             operation_config: None,
             validators: vec![],
             exclusive_required: vec![],
+            defs: Default::default(),
         };
         let core_schema = proto_schema_to_core(&proto_schema);
         assert!(core_schema.validator.is_none());
@@ -1663,6 +1679,7 @@ mod tests {
                 "cidr_block".to_string(),
                 "ipv4_ipam_pool_id".to_string(),
             ]],
+            defs: Default::default(),
         };
         let core_schema = proto_schema_to_core(&proto_schema);
         assert_eq!(
@@ -1698,6 +1715,7 @@ mod tests {
             operation_config: None,
             validators: vec![],
             exclusive_required: vec![vec!["a".to_string(), "b".to_string()]],
+            defs: Default::default(),
         };
         let json = serde_json::to_string(&vec![proto_schema]).unwrap();
         let schemas = json_to_schemas(&json);
@@ -1774,6 +1792,7 @@ mod tests {
             operation_config: None,
             validators: vec![proto::ValidatorType::TagsKeyValueCheck],
             exclusive_required: vec![],
+            defs: Default::default(),
         };
         let core_schema = proto_schema_to_core(&proto_schema);
         let validator = core_schema.validator.unwrap();

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -323,6 +323,15 @@ pub struct ResourceSchema {
     /// serialization across the WASM plugin boundary.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub exclusive_required: Vec<Vec<String>>,
+    /// Named definitions reachable via [`AttributeType::Ref`] from
+    /// this resource's attribute types. Empty for resources whose
+    /// attribute graph contains no cycles (the common case). Mirror
+    /// of [`carina_core::schema::ResourceSchema::defs`] — carries the
+    /// cyclic CFN struct map across the JSON wire form so the host
+    /// can resolve `Ref` targets at the walk-sites that need them
+    /// (carina#3340).
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub defs: std::collections::BTreeMap<String, AttributeType>,
 }
 
 /// Per-resource operational configuration for timeouts and retries.
@@ -457,6 +466,20 @@ pub enum AttributeType {
         base: Box<AttributeType>,
         namespace: String,
     },
+    /// Named reference into the enclosing [`ResourceSchema::defs`]
+    /// map. Used to express cyclic CFN definition graphs (WAFv2
+    /// `WebACL.Statement`, AppSync `GraphQLApi`, ...) so the codegen
+    /// emission step does not stack-overflow on recursive struct
+    /// definitions (`Statement -> AndStatement -> List<Statement>`).
+    ///
+    /// Introduced in carina#3340. The host-side
+    /// [`carina_core::schema::AttributeType::Ref`] is the structural
+    /// counterpart; conversion in `carina-plugin-host::wasm_convert`
+    /// passes the variant through unchanged.
+    #[serde(rename = "ref")]
+    Ref {
+        name: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -532,6 +555,65 @@ mod tests {
         let json = serde_json::to_string(&attr).unwrap();
         let back: AttributeType = serde_json::from_str(&json).unwrap();
         assert_eq!(json, serde_json::to_string(&back).unwrap());
+    }
+
+    #[test]
+    fn ref_attribute_type_roundtrip() {
+        // carina#3340: cyclic CFN schemas emit `Ref { name }` at the
+        // recursion point; the wire form must round-trip through
+        // serde so the host can rebuild the structural Ref variant.
+        let attr = AttributeType::Ref {
+            name: "Statement".into(),
+        };
+        let json = serde_json::to_string(&attr).unwrap();
+        assert_eq!(json, r#"{"type":"ref","name":"Statement"}"#);
+        let back: AttributeType = serde_json::from_str(&json).unwrap();
+        match back {
+            AttributeType::Ref { name } => assert_eq!(name, "Statement"),
+            other => panic!("expected Ref, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resource_schema_defs_roundtrip() {
+        // carina#3340: the `defs` map carries cyclic struct definitions
+        // (`Statement` -> `AndStatement` -> `List<Statement>` ...).
+        // Pin the wire shape so a host-side regression cannot silently
+        // lose recursion-target schema information.
+        let schema = ResourceSchema {
+            resource_type: "awscc.wafv2.WebACL".into(),
+            attributes: HashMap::new(),
+            description: None,
+            kind: SchemaKind::Managed,
+            name_attribute: None,
+            force_replace: false,
+            operation_config: None,
+            validators: vec![],
+            exclusive_required: vec![],
+            defs: std::collections::BTreeMap::from([(
+                "Statement".to_string(),
+                AttributeType::Struct {
+                    name: "Statement".into(),
+                    fields: vec![StructField {
+                        name: "and_statement".into(),
+                        field_type: AttributeType::List {
+                            inner: Box::new(AttributeType::Ref {
+                                name: "Statement".into(),
+                            }),
+                            ordered: true,
+                        },
+                        required: false,
+                        description: None,
+                        block_name: None,
+                        provider_name: None,
+                    }],
+                },
+            )]),
+        };
+        let json = serde_json::to_string(&schema).unwrap();
+        let back: ResourceSchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.defs.len(), 1, "defs map lost during round-trip");
+        assert!(back.defs.contains_key("Statement"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `AttributeType::Ref(name)` + `Schema { root, defs }` to `carina_core::schema` so cyclic CFN definition graphs (WAFv2 `WebACL.Statement`, AppSync `GraphQLApi`, StepFunctions state machine bodies, ...) are representable in the type system instead of being flattened to `Map(String, String)` blobs.
- Propagate the resource schema's `defs` map through every walk-site that traverses `AttributeType`: differ (`type_aware_equal` and friends), `detail_rows` plan-display helpers, `validation::inference` reference paths, `validation::deferred_populate`, state-side enum normalization (`resolve_enum_value_recursive_with_defs`, `lift_string_enum_leaves_with_defs`), `value::canonicalize_with_type_and_defs`, LSP completion's `extract_struct_fields`, and `schema::walk_custom_lookup`. Every site that matches on `AttributeType` either resolves a `Ref` chain via `resolve_refs(defs)` at function entry, or has an explicit `Ref(_)` arm documented as primitive-only / safe-default.
- Mirror the new variant on the `carina-provider-protocol` wire form (`AttributeType::Ref { name }` + `ResourceSchema.defs`) so the host-side schema can be reconstructed structurally from plugin-provided JSON. `carina-plugin-host::wasm_convert` carries both fields across.

Closes #3340.

## Why this shape (recorded in #3340's design section)

The naive Ref addition (variant + Schema type) compiles after filling five obvious match arms. That bar is too low — silent walk-sites everywhere else (`_ => semantically_equal(...)`, `_ => None`, `_ => vec![]`) would accept a `Ref` and discard its type information. The bug class then is: any walk-site that does not explicitly route through `Schema` becomes a downstream bug source the moment a cyclic schema flows in.

This PR rejects the ""follow-up issue for the wildcard sweep"" shape (see CLAUDE.md ""Root-cause fixes only""). The full propagation lands here.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3754 tests, 72 skipped, all passing.
- [x] `cargo test --workspace --doc` — green.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — green.
- [x] `bash scripts/check-*.sh` — all five scripts green.
- [x] `cargo build --release -p carina-cli` — green.
- [x] New integration test `carina-core/tests/cyclic_schema_ref.rs` — 5 cases pinning the load-bearing assertions (validate accepts/rejects, differ returns NoChange for equal cyclic values + Update for a real change one cycle hop deep, `ResourceSchema.defs` defaults to empty).
- [x] `carina-provider-protocol` round-trip tests for the new wire variants.

## PR chain

This is PR 1 of a 3-PR chain.

- PR 2 (carina-provider-aws): rev-bump the `carina-core` pin. No semantic change — verifies JSON wire round-trip and that codegen passes the new variant through unchanged.
- PR 3 (carina-provider-awscc): rev-bump the `carina-core` pin + add the codegen recursion guard (closes [awscc#196](https://github.com/carina-rs/carina-provider-awscc/issues/196)) + add `AWS::WAFv2::WebACL` (closes [awscc#197](https://github.com/carina-rs/carina-provider-awscc/issues/197)). The WebACL is the acceptance test for the recursion guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)