### PR TITLE
fix(schema): thread defs through every validate/canonicalize seam (carina#3345)

### DIFF
--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -81,7 +81,7 @@ fn invalid_enum_variant_bare_display() {
         identity: None,
         dsl_aliases: vec![],
     };
-    let err = t
+    let err = carina_core::schema::Schema::flat(t.clone())
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "zzz".to_string(),
         )))
@@ -104,7 +104,7 @@ fn invalid_enum_variant_with_dsl_aliases_display() {
             ("Suspended".to_string(), "suspended".to_string()),
         ],
     };
-    let err = t
+    let err = carina_core::schema::Schema::flat(t.clone())
         .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
             "zzz".to_string(),
         )))

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -255,13 +255,19 @@ fn walk_custom_lookup(
         // `Ref`: resolve via the schema's def map and continue the
         // walk. The resolved target (typically a `Struct`) may carry
         // identity-bearing custom types whose validators must run.
-        // `resolve_refs` panics on a missing def name (schema
-        // invariant violation). The first-resolve-then-recurse shape
-        // matches `Schema::validate_attr` (carina#3340).
-        AttributeType::Ref(_) => {
-            let resolved = attr_type.resolve_refs(defs);
-            walk_custom_lookup(resolved, value, attr_name, lookup, defs, errors);
-        }
+        // A missing def name is reported by `Schema::validate_attr`
+        // as `ValidationFailed`; here we just skip the custom-lookup
+        // walk so a user-facing dangling-Ref does not abort the
+        // process (carina#3345).
+        AttributeType::Ref(name) => match defs.get(name) {
+            Some(resolved) => {
+                walk_custom_lookup(resolved, value, attr_name, lookup, defs, errors);
+            }
+            None => {
+                // Skip — the `validate_attr` pass already emitted
+                // the dangling-Ref diagnostic for this attribute.
+            }
+        },
     }
 }
 
@@ -569,6 +575,41 @@ pub struct Schema {
 }
 
 impl Schema {
+    /// Construct a `Schema` from `root` with an empty `defs` map. A
+    /// `Ref` reached during walking surfaces as a clean
+    /// `ValidationFailed` (`schema reference '<name>' is not defined
+    /// in the enclosing schema`); callers expecting `Ref` to resolve
+    /// must populate `defs`. Typical uses: unit-test fixtures, leaf
+    /// validation, provider-config schemas that are known flat.
+    pub fn flat(root: AttributeType) -> Self {
+        Self {
+            root,
+            defs: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// Construct a `Schema` that carries only `defs`, with a
+    /// placeholder `root`. Use when the call shape is "iterate
+    /// attributes against a shared def map" and the per-call
+    /// attribute is supplied through [`Self::validate_attr`]
+    /// (which ignores `self.root`). Examples:
+    /// `ResourceSchema::validate_inner`, provider-config validation
+    /// in `carina-core::validation` and `carina-lsp::diagnostics`.
+    ///
+    /// **Do not** call [`Self::validate`] or [`Self::validate_collect`]
+    /// on a Schema produced by `with_defs`; those entry points walk
+    /// `self.root`, which here is a non-load-bearing
+    /// `AttributeType::String` and will silently validate every
+    /// value as a String.
+    pub fn with_defs(defs: std::collections::BTreeMap<String, AttributeType>) -> Self {
+        Self {
+            // `validate_attr(attr, value)` ignores `self.root`; pick
+            // the cheapest leaf as a non-load-bearing placeholder.
+            root: AttributeType::String,
+            defs,
+        }
+    }
+
     /// Look up a named definition. Returns `None` if `name` is not in
     /// `defs`; callers should treat that as a type error.
     pub fn resolve(&self, name: &str) -> Option<&AttributeType> {
@@ -579,6 +620,175 @@ impl Schema {
     /// any `Ref` it encounters by looking it up in `defs`.
     pub fn validate(&self, value: &Value) -> Result<(), TypeError> {
         self.validate_attr(&self.root, value)
+    }
+
+    /// Canonicalize a `Value` against `attr_type` using this schema's
+    /// `defs` map. The Schema-aware entry point for the
+    /// `string_or_list_of_strings` and `Ref` walks (carina#3345). This
+    /// is the only way to invoke canonicalization from outside
+    /// `carina-core`, so callers cannot accidentally drop `defs`.
+    pub fn canonicalize_attr(&self, attr: &AttributeType, value: Value) -> Value {
+        crate::value::canonicalize_with_type(value, attr, &self.defs)
+    }
+
+    /// Canonicalize a `Value` against this schema's `root`. Wrapper
+    /// over [`Self::canonicalize_attr`] for the common case where the
+    /// caller is driving from `Schema::root`.
+    pub fn canonicalize(&self, value: Value) -> Value {
+        self.canonicalize_attr(&self.root, value)
+    }
+
+    /// Schema-aware path-collecting validator. Equivalent to
+    /// [`AttributeType::validate_collect`] but resolves
+    /// `AttributeType::Ref` against `defs` at every walk-site, so the
+    /// LSP per-keystroke diagnostic pass surfaces real per-field
+    /// errors against cyclic CFN-style schemas instead of the
+    /// standalone-validator sentinel (carina#3345).
+    ///
+    /// Returns `(FieldPath, TypeError)` pairs anchored at each
+    /// offending location, mirroring the non-Schema-aware variant for
+    /// downstream consumers like the LSP range mapper.
+    pub fn validate_collect(&self, value: &Value) -> Vec<(FieldPath, TypeError)> {
+        let mut out = Vec::new();
+        self.collect_attr_into(&self.root, &FieldPath::new(), value, &mut out);
+        out
+    }
+
+    fn collect_attr_into(
+        &self,
+        attr: &AttributeType,
+        path: &FieldPath,
+        value: &Value,
+        out: &mut Vec<(FieldPath, TypeError)>,
+    ) {
+        // Peel Ref so the downstream arms never have to think about it.
+        if let AttributeType::Ref(name) = attr {
+            match self.resolve(name) {
+                Some(resolved) => {
+                    self.collect_attr_into(resolved, path, value, out);
+                }
+                None => {
+                    out.push((
+                        path.clone(),
+                        TypeError::ValidationFailed {
+                            message: format!(
+                                "schema reference `{name}` is not defined in the enclosing schema"
+                            ),
+                        },
+                    ));
+                }
+            }
+            return;
+        }
+        let Some(concrete) = value.as_concrete() else {
+            return;
+        };
+        match attr {
+            AttributeType::Struct { name, fields } => {
+                // Mirror the pre-#3345 standalone-validator collect_struct
+                // behavior, but route field walks through
+                // collect_attr_into so Ref-typed fields are resolved
+                // against self.defs.
+                if matches!(concrete, ConcreteValueRef::List(_)) {
+                    out.push((
+                        path.clone(),
+                        TypeError::BlockSyntaxNotAllowed {
+                            attribute: name.to_string(),
+                        },
+                    ));
+                    return;
+                }
+                let Some(map) = (match concrete {
+                    ConcreteValueRef::Map(m) => Some(m),
+                    _ => None,
+                }) else {
+                    out.push((
+                        path.clone(),
+                        TypeError::TypeMismatch {
+                            expected: attr.type_name(),
+                            got: concrete.type_name().to_string(),
+                        },
+                    ));
+                    return;
+                };
+
+                let accepted = build_accepted_field_map(fields);
+                let canonical_field_names: Vec<&str> =
+                    fields.iter().map(|f| f.name.as_str()).collect();
+
+                // Required-field check.
+                for f in fields {
+                    if f.required && !map.contains_key(&f.name) {
+                        let field_path = path.push_field(f.name.clone());
+                        out.push((
+                            field_path,
+                            TypeError::MissingRequired {
+                                name: f.name.clone(),
+                            },
+                        ));
+                    }
+                }
+
+                for (k, v) in map {
+                    match accepted.get(k.as_str()) {
+                        Some(field) => {
+                            let next_path = path.push_field(k.clone());
+                            self.collect_attr_into(&field.field_type, &next_path, v, out);
+                        }
+                        None => {
+                            let suggestion = suggest_similar_name(k, &canonical_field_names);
+                            out.push((
+                                path.push_field(k.clone()),
+                                TypeError::UnknownStructField {
+                                    struct_name: name.to_string(),
+                                    field: k.clone(),
+                                    suggestion,
+                                },
+                            ));
+                        }
+                    }
+                }
+            }
+            AttributeType::List { inner, .. } => {
+                let Some(items) = (match concrete {
+                    ConcreteValueRef::List(items) => Some(items),
+                    _ => None,
+                }) else {
+                    out.push((
+                        path.clone(),
+                        TypeError::TypeMismatch {
+                            expected: attr.type_name(),
+                            got: concrete.type_name().to_string(),
+                        },
+                    ));
+                    return;
+                };
+                for (i, item) in items.iter().enumerate() {
+                    let next_path = path.push_index(i);
+                    self.collect_attr_into(inner, &next_path, item, out);
+                }
+            }
+            // Union of leaves is the only Union shape in the current
+            // schema vocabulary (e.g. `string_or_list_of_strings`).
+            // Delegate to `validate_attr` which runs the best-scoring
+            // member selection and returns a single error anchored at
+            // the current path. If a Union-of-structs shape is ever
+            // introduced, this arm should recurse via collect_attr_into
+            // on the selected member to preserve per-field paths.
+            AttributeType::Union(_) => {
+                if let Err(e) = self.validate_attr(attr, value) {
+                    out.push((path.clone(), e));
+                }
+            }
+            _ => {
+                // For non-recursive shapes the existing single-shot
+                // dispatcher is correct. Forward any error under the
+                // current path.
+                if let Err(e) = self.validate_attr(attr, value) {
+                    out.push((path.clone(), e));
+                }
+            }
+        }
     }
 
     /// Validate against an arbitrary `AttributeType` in the context of
@@ -681,15 +891,34 @@ impl Schema {
                 }
             }
             AttributeType::Union(members) => {
+                // Mirror `validate_union`'s best-scoring selection so
+                // the StringEnum-rich diagnostic (variant list, alias
+                // hints) survives when the user-supplied value shape
+                // most closely matches a StringEnum member — the LSP
+                // quick-fix depends on the structured payload (#2309).
+                let Some(concrete) = value.as_concrete() else {
+                    return Ok(());
+                };
+                let mut best: Option<(u32, TypeError)> = None;
                 for member in members {
-                    if self.validate_attr(member, value).is_ok() {
-                        return Ok(());
+                    match self.validate_attr(member, value) {
+                        Ok(()) => return Ok(()),
+                        Err(e) => {
+                            let score = union_member_score(member, concrete);
+                            if score > 0
+                                && best
+                                    .as_ref()
+                                    .is_none_or(|(prev_score, _)| score > *prev_score)
+                            {
+                                best = Some((score, e));
+                            }
+                        }
                     }
                 }
-                Err(TypeError::TypeMismatch {
-                    expected: "Union".to_string(),
-                    got: attr.type_name(),
-                })
+                Err(best.map(|(_, e)| e).unwrap_or(TypeError::TypeMismatch {
+                    expected: attr.type_name(),
+                    got: concrete.type_name().to_string(),
+                }))
             }
             // For non-recursive variants, delegate to the standalone
             // validator. Any `Ref` they could reach has already been
@@ -1004,7 +1233,7 @@ impl AttributeType {
     /// `inner.validate(&Value)` again, so each nested element is
     /// independently re-projected. Lists may legitimately mix concrete
     /// and deferred elements (e.g. `[vpc.id, "literal"]`).
-    pub fn validate(&self, value: &Value) -> Result<(), TypeError> {
+    pub(crate) fn validate(&self, value: &Value) -> Result<(), TypeError> {
         // `Ref` cannot be resolved without a `Schema` context. Callers
         // who hold a schema that contains `Ref` must go through
         // `Schema::validate` / `Schema::validate_attr`; falling through
@@ -1075,159 +1304,6 @@ impl AttributeType {
                      this attribute must be validated through Schema::validate"
                 ),
             }),
-        }
-    }
-
-    /// Validate a value and collect every error along with the
-    /// [`FieldPath`] from the value's root to the offending location
-    /// (#2214).
-    ///
-    /// This is the path-tagged sibling of [`Self::validate`]: where
-    /// `validate` returns the first error wrapped in
-    /// `StructFieldError` / `ListItemError` / `MapValueError` enclosure
-    /// and stops, `validate_collect` keeps walking through every
-    /// field of every nested struct (and every item of a list-of-struct)
-    /// so a downstream tool like the LSP can surface every problem at
-    /// once with positional information.
-    ///
-    /// For non-Struct, non-List<Struct> shapes the result is exactly
-    /// one error (or none) — there is no nested context to descend
-    /// into, so this method is no slower than `validate` for primitives.
-    pub fn validate_collect(&self, value: &Value) -> Vec<(FieldPath, TypeError)> {
-        let mut out = Vec::new();
-        self.collect_into(&FieldPath::new(), value, &mut out);
-        out
-    }
-
-    fn collect_into(&self, path: &FieldPath, value: &Value, out: &mut Vec<(FieldPath, TypeError)>) {
-        // Project to the concrete axis. Deferred values contribute no
-        // type-check errors at this layer — the deferred-aware checker
-        // covers them.
-        let Some(concrete) = value.as_concrete() else {
-            return;
-        };
-
-        match self {
-            AttributeType::Struct { name, fields } => {
-                self.collect_struct(path, name, fields, concrete, out);
-            }
-            AttributeType::List { inner, .. } => {
-                self.collect_list(path, inner, concrete, out);
-            }
-            // For everything else the existing single-shot validator is
-            // already correct: it returns at most one error and there
-            // is no nested structure to recurse into. Forward the error
-            // (if any) under the current path.
-            _ => {
-                if let Err(e) = self.validate_concrete(concrete) {
-                    out.push((path.clone(), e));
-                }
-            }
-        }
-    }
-
-    fn collect_struct(
-        &self,
-        path: &FieldPath,
-        name: &str,
-        fields: &[StructField],
-        value: ConcreteValueRef<'_>,
-        out: &mut Vec<(FieldPath, TypeError)>,
-    ) {
-        // Block syntax → List([Map(...)]) for List<Struct>; bare Struct
-        // rejects List with `BlockSyntaxNotAllowed`.
-        if matches!(value, ConcreteValueRef::List(_)) {
-            out.push((
-                path.clone(),
-                TypeError::BlockSyntaxNotAllowed {
-                    attribute: name.to_string(),
-                },
-            ));
-            return;
-        }
-        let ConcreteValueRef::Map(map) = value else {
-            out.push((
-                path.clone(),
-                TypeError::TypeMismatch {
-                    expected: self.type_name(),
-                    got: value.type_name().to_string(),
-                },
-            ));
-            return;
-        };
-
-        // Map every accepted name (canonical + block_name alias) to the
-        // canonical `StructField`. Pre-#2214 the LSP did this alias
-        // resolution itself; now the core validator is the single
-        // source of truth and `validate_struct` shares the same map
-        // (#2214 reconciliation).
-        let accepted = build_accepted_field_map(fields);
-        let canonical_field_names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
-
-        // Required-field check.
-        for f in fields {
-            if f.required && !map.contains_key(&f.name) {
-                let field_path = path.push_field(f.name.clone());
-                out.push((
-                    field_path,
-                    TypeError::MissingRequired {
-                        name: f.name.clone(),
-                    },
-                ));
-            }
-        }
-
-        // Each present field — descend (for nested struct/list of
-        // struct) or run the leaf validator. `collect_into` projects
-        // the field value through `as_concrete()` again, so deferred
-        // field values silently contribute no errors here. Phase 2 of
-        // RFC #2972 makes this a single, type-aware filter point
-        // instead of the old per-site `matches!(v, Value::Deferred(DeferredValue::ResourceRef)
-        // { .. })` skip.
-        for (k, v) in map {
-            match accepted.get(k.as_str()) {
-                Some(field) => {
-                    let next_path = path.push_field(k.clone());
-                    field.field_type.collect_into(&next_path, v, out);
-                }
-                None => {
-                    let suggestion = suggest_similar_name(k, &canonical_field_names);
-                    out.push((
-                        path.push_field(k.clone()),
-                        TypeError::UnknownStructField {
-                            struct_name: name.to_string(),
-                            field: k.clone(),
-                            suggestion,
-                        },
-                    ));
-                }
-            }
-        }
-    }
-
-    fn collect_list(
-        &self,
-        path: &FieldPath,
-        inner: &AttributeType,
-        value: ConcreteValueRef<'_>,
-        out: &mut Vec<(FieldPath, TypeError)>,
-    ) {
-        let ConcreteValueRef::List(items) = value else {
-            out.push((
-                path.clone(),
-                TypeError::TypeMismatch {
-                    expected: self.type_name(),
-                    got: value.type_name().to_string(),
-                },
-            ));
-            return;
-        };
-        // For List<Struct> we want per-item descent so each item's
-        // errors carry a `[i]` step in the path. For plain List<T>
-        // this still works — each item runs the leaf validator under
-        // the indexed path.
-        for (i, item) in items.iter().enumerate() {
-            inner.collect_into(&path.push_index(i), item, out);
         }
     }
 
@@ -2969,6 +3045,23 @@ impl ResourceSchema {
             .collect()
     }
 
+    /// Construct a [`Schema`] view rooted at `root` and carrying this
+    /// resource's `defs` map.
+    ///
+    /// Use this in every place that needs to validate or canonicalize
+    /// against a single attribute of the resource: the resulting
+    /// `Schema` is the only API that resolves `AttributeType::Ref`
+    /// against this resource's def map, so a future caller that needs
+    /// per-attribute validation cannot accidentally drop `defs`
+    /// (carina#3345). The `root` argument is typically
+    /// `attr_schema.attr_type.clone()`.
+    pub fn schema_view_for(&self, root: AttributeType) -> Schema {
+        Schema {
+            root,
+            defs: self.defs.clone(),
+        }
+    }
+
     /// Validate resource attributes.
     ///
     /// This variant does not have origin information for string values, so
@@ -3036,6 +3129,16 @@ impl ResourceSchema {
             known.push(bn.as_str());
         }
 
+        // Build a `Schema` view over this resource's `defs` once so
+        // every attribute validation walks the same def map. Routing
+        // through `Schema::validate_attr` is what makes cyclic CFN
+        // attributes (`AttributeType::Ref`) resolve correctly; the
+        // `defs`-less `AttributeType::validate(value)` call this
+        // replaced trips the "reached the standalone validator"
+        // sentinel for every Ref-containing attribute (carina#3345,
+        // post-#3340 awscc `s3.Bucket/*` failures).
+        let schema_view = Schema::with_defs(self.defs.clone());
+
         // Type check each attribute and reject unknown ones
         for (name, value) in attributes {
             // Skip parser-internal attributes (leading `_`, e.g.
@@ -3050,7 +3153,7 @@ impl ResourceSchema {
             let canonical = bn_map.get(name).map(|s| s.as_str()).unwrap_or(name);
 
             if let Some(schema) = self.attributes.get(canonical) {
-                if let Err(e) = schema.attr_type.validate(value) {
+                if let Err(e) = schema_view.validate_attr(&schema.attr_type, value) {
                     // Tag the error with the attribute name the user actually
                     // wrote (which may be a block-name alias), so diagnostics
                     // point back at a token that appears in their source.

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -3240,7 +3240,7 @@ mod validate_collect_tests {
             ),
             ("mfa_delete", Value::Concrete(ConcreteValue::Bool(false))),
         ]);
-        let errors = ty.validate_collect(&v);
+        let errors = crate::schema::Schema::flat(ty.clone()).validate_collect(&v);
         assert!(
             errors.is_empty(),
             "valid struct must produce no errors, got {errors:?}"
@@ -3263,7 +3263,7 @@ mod validate_collect_tests {
             ),
             ("mfa", Value::Concrete(ConcreteValue::Bool(false))),
         ]);
-        let errors = ty.validate_collect(&v);
+        let errors = crate::schema::Schema::flat(ty.clone()).validate_collect(&v);
         assert_eq!(
             errors.len(),
             2,
@@ -3292,7 +3292,7 @@ mod validate_collect_tests {
                 Value::Concrete(ConcreteValue::String("not an int".to_string())),
             )]),
         )]);
-        let errors = outer.validate_collect(&v);
+        let errors = crate::schema::Schema::flat(outer.clone()).validate_collect(&v);
         assert_eq!(errors.len(), 1, "got {errors:?}");
         let (path, _err) = &errors[0];
         let steps: Vec<String> = path.steps().iter().map(|s| s.to_string()).collect();
@@ -3320,7 +3320,7 @@ mod validate_collect_tests {
             )]),
             map_value(vec![("name", Value::Concrete(ConcreteValue::Int(42)))]),
         ]));
-        let errors = outer_attr.validate_collect(&v);
+        let errors = crate::schema::Schema::flat(outer_attr.clone()).validate_collect(&v);
         assert_eq!(errors.len(), 1, "got {errors:?}");
         let path = &errors[0].0;
         let steps: Vec<String> = path.steps().iter().map(|s| s.to_string()).collect();
@@ -3346,7 +3346,7 @@ mod validate_collect_tests {
             "transition",
             Value::Concrete(ConcreteValue::String("ok".to_string())),
         )]);
-        let errors = ty.validate_collect(&v);
+        let errors = crate::schema::Schema::flat(ty.clone()).validate_collect(&v);
         assert!(
             errors.is_empty(),
             "block_name alias must not flag the field as unknown, got {errors:?}"
@@ -3366,7 +3366,7 @@ mod validate_collect_tests {
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
         )]);
-        let errors = ty.validate_collect(&v);
+        let errors = crate::schema::Schema::flat(ty.clone()).validate_collect(&v);
         assert!(
             errors.is_empty(),
             "ResourceRef in struct field must not produce an error, got {errors:?}"
@@ -3388,7 +3388,7 @@ mod validate_collect_tests {
             "statuus",
             Value::Concrete(ConcreteValue::String("x".to_string())),
         )]);
-        let errors = ty.validate_collect(&v);
+        let errors = crate::schema::Schema::flat(ty.clone()).validate_collect(&v);
         assert_eq!(errors.len(), 1);
         match &errors[0].1 {
             TypeError::UnknownStructField {

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -887,12 +887,18 @@ pub fn validate_provider_config<E>(
         let Some(factory) = factories.iter().find(|f| f.name() == provider.name) else {
             continue;
         };
-        // Host-side type-level validation.
+        // Host-side type-level validation. Routed through
+        // `Schema::validate_attr` with an empty `defs` because provider
+        // configs are flat (no cyclic CFN-style Refs today); if a
+        // future provider config grows a `Ref`, the empty-defs path
+        // returns a clean `ValidationFailed` instead of tripping the
+        // standalone validator sentinel (carina#3345).
         let attr_types = factory.provider_config_attribute_types();
+        let schema_view = crate::schema::Schema::with_defs(std::collections::BTreeMap::new());
         for (attr_name, value) in &provider.attributes {
             if let Some(attr_type) = attr_types.get(attr_name) {
-                attr_type
-                    .validate(value)
+                schema_view
+                    .validate_attr(attr_type, value)
                     .map_err(|e| format!("provider {}: {}: {}", provider.name, attr_name, e))?;
             }
         }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1369,22 +1369,15 @@ fn peel_custom(t: &AttributeType) -> &AttributeType {
 ///   type for the schema) or carry an unresolved expression that must
 ///   be canonicalized after resolution by a later pass.
 ///
-/// For non-`string_or_list_of_strings` types, the function still
-/// recurses into containers so that struct/list/map fields whose
-/// declared type *is* the union are canonicalized in place. Returns
-/// `value` unchanged when no nested canonicalization applies.
+/// `defs` carries the enclosing [`crate::schema::ResourceSchema::defs`]
+/// map so cyclic CFN definitions (`AttributeType::Ref`) are followed
+/// during the walk (carina#3340). The `Ref` arm resolves and recurses;
+/// primitives / unions terminate as before. Pass
+/// [`crate::schema::empty_defs()`] when the caller is confident no
+/// `Ref` is reachable.
 ///
 /// See #2481, #2510.
-pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value {
-    canonicalize_with_type_and_defs(value, attr_type, crate::schema::empty_defs())
-}
-
-/// Same as [`canonicalize_with_type`] but takes the enclosing
-/// [`ResourceSchema::defs`] map so cyclic CFN definitions
-/// (`AttributeType::Ref`) are followed during the type walk
-/// (carina#3340). The `Ref` arm resolves and recurses; primitives /
-/// unions terminate as before.
-pub fn canonicalize_with_type_and_defs(
+pub(crate) fn canonicalize_with_type(
     value: Value,
     attr_type: &AttributeType,
     defs: &std::collections::BTreeMap<String, AttributeType>,
@@ -1399,20 +1392,20 @@ pub fn canonicalize_with_type_and_defs(
     // (carina#3340).
     if let AttributeType::Ref(_) = unwrapped {
         let resolved = unwrapped.resolve_refs(defs);
-        return canonicalize_with_type_and_defs(value, resolved, defs);
+        return canonicalize_with_type(value, resolved, defs);
     }
     match (value, unwrapped) {
         (Value::Concrete(ConcreteValue::List(items)), AttributeType::List { inner, .. }) => {
             let canonicalized = items
                 .into_iter()
-                .map(|v| canonicalize_with_type_and_defs(v, inner.as_ref(), defs))
+                .map(|v| canonicalize_with_type(v, inner.as_ref(), defs))
                 .collect();
             Value::Concrete(ConcreteValue::List(canonicalized))
         }
         (Value::Concrete(ConcreteValue::Map(map)), AttributeType::Map { value: vt, .. }) => {
             let canonicalized = map
                 .into_iter()
-                .map(|(k, v)| (k, canonicalize_with_type_and_defs(v, vt.as_ref(), defs)))
+                .map(|(k, v)| (k, canonicalize_with_type(v, vt.as_ref(), defs)))
                 .collect();
             Value::Concrete(ConcreteValue::Map(canonicalized))
         }
@@ -1425,7 +1418,7 @@ pub fn canonicalize_with_type_and_defs(
                         .find(|f| f.name == k || f.provider_name.as_deref() == Some(k.as_str()))
                         .map(|f| &f.field_type);
                     let canon = match field_type {
-                        Some(ft) => canonicalize_with_type_and_defs(v, ft, defs),
+                        Some(ft) => canonicalize_with_type(v, ft, defs),
                         None => v,
                     };
                     (k, canon)
@@ -1433,11 +1426,9 @@ pub fn canonicalize_with_type_and_defs(
                 .collect();
             Value::Concrete(ConcreteValue::Map(canonicalized))
         }
-        (Value::Deferred(DeferredValue::Secret(inner)), _) => {
-            Value::Deferred(DeferredValue::Secret(Box::new(
-                canonicalize_with_type_and_defs(*inner, attr_type, defs),
-            )))
-        }
+        (Value::Deferred(DeferredValue::Secret(inner)), _) => Value::Deferred(
+            DeferredValue::Secret(Box::new(canonicalize_with_type(*inner, attr_type, defs))),
+        ),
         // Union: the missing nesting kind (List/Map/Struct/Secret
         // already recurse; Union was the lone gap — carina#3080).
         // `principal` is `Union[Struct{ service: Union[String,
@@ -1454,7 +1445,7 @@ pub fn canonicalize_with_type_and_defs(
         // is identity — never guess-coerce.
         (val, AttributeType::Union(members)) => {
             match crate::schema::select_union_member(members, &val) {
-                Some(member) => canonicalize_with_type_and_defs(val, member, defs),
+                Some(member) => canonicalize_with_type(val, member, defs),
                 None => val,
             }
         }
@@ -1510,7 +1501,7 @@ pub fn canonicalize_resources_with_schemas(
         for (key, value) in std::mem::take(&mut resource.attributes) {
             let canon = match schema.attributes.get(&key) {
                 Some(attr_schema) => {
-                    canonicalize_with_type_and_defs(value, &attr_schema.attr_type, &schema.defs)
+                    canonicalize_with_type(value, &attr_schema.attr_type, &schema.defs)
                 }
                 None => value,
             };
@@ -1536,7 +1527,7 @@ pub fn canonicalize_data_sources_with_schemas(
         for (key, value) in std::mem::take(&mut data_source.attributes) {
             let canon = match schema.attributes.get(&key) {
                 Some(attr_schema) => {
-                    canonicalize_with_type_and_defs(value, &attr_schema.attr_type, &schema.defs)
+                    canonicalize_with_type(value, &attr_schema.attr_type, &schema.defs)
                 }
                 None => value,
             };
@@ -1578,7 +1569,7 @@ pub fn canonicalize_states_with_schemas(
         for (key, value) in std::mem::take(&mut state.attributes) {
             let canon = match schema.attributes.get(&key) {
                 Some(attr_schema) => {
-                    canonicalize_with_type_and_defs(value, &attr_schema.attr_type, &schema.defs)
+                    canonicalize_with_type(value, &attr_schema.attr_type, &schema.defs)
                 }
                 None => value,
             };
@@ -3240,7 +3231,7 @@ mod tests {
     fn canonicalize_scalar_to_string_list() {
         let t = string_or_list_of_strings();
         let v = Value::Concrete(ConcreteValue::String("repo:foo:*".to_string()));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         assert_eq!(
             canon,
             Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]))
@@ -3253,7 +3244,7 @@ mod tests {
         let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
             ConcreteValue::String("repo:foo:*".to_string()),
         )]));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         assert_eq!(
             canon,
             Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]))
@@ -3268,7 +3259,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("b".to_string())),
             Value::Concrete(ConcreteValue::String("c".to_string())),
         ]));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         assert_eq!(
             canon,
             Value::Concrete(ConcreteValue::StringList(vec![
@@ -3283,14 +3274,18 @@ mod tests {
     fn canonicalize_idempotent_on_string_list() {
         let t = string_or_list_of_strings();
         let v = Value::Concrete(ConcreteValue::StringList(vec!["a".to_string()]));
-        let canon = canonicalize_with_type(v.clone(), &t);
+        let canon = canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs());
         assert_eq!(canon, v);
     }
 
     #[test]
     fn canonicalize_passes_through_non_applicable_type() {
         let v = Value::Concrete(ConcreteValue::String("foo".to_string()));
-        let canon = canonicalize_with_type(v.clone(), &AttributeType::String);
+        let canon = canonicalize_with_type(
+            v.clone(),
+            &AttributeType::String,
+            crate::schema::empty_defs(),
+        );
         assert_eq!(canon, v);
     }
 
@@ -3302,7 +3297,7 @@ mod tests {
         let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
             ConcreteValue::Int(1),
         )]));
-        let canon = canonicalize_with_type(v.clone(), &t);
+        let canon = canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs());
         assert_eq!(canon, v);
     }
 
@@ -3321,7 +3316,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3350,7 +3345,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3394,7 +3389,7 @@ mod tests {
             )),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3419,7 +3414,7 @@ mod tests {
             )])),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3439,7 +3434,7 @@ mod tests {
     fn canonicalize_union_string_member_passthrough() {
         let t = principal_union();
         let v = Value::Concrete(ConcreteValue::String("*".to_string()));
-        let canon = canonicalize_with_type(v.clone(), &t);
+        let canon = canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs());
         assert_eq!(canon, v);
     }
 
@@ -3449,7 +3444,7 @@ mod tests {
     fn canonicalize_union_no_matching_member_is_identity() {
         let t = AttributeType::Union(vec![AttributeType::Int, AttributeType::Bool]);
         let v = Value::Concrete(ConcreteValue::String("not-an-int".to_string()));
-        let canon = canonicalize_with_type(v.clone(), &t);
+        let canon = canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs());
         assert_eq!(canon, v);
     }
 
@@ -3465,7 +3460,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("repo:foo:*".to_string())),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3492,7 +3487,7 @@ mod tests {
             to_dsl: None,
         };
         let v = Value::Concrete(ConcreteValue::String("x".to_string()));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         assert_eq!(
             canon,
             Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]))
@@ -3505,7 +3500,7 @@ mod tests {
         let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
             ConcreteValue::String("s".to_string()),
         ))));
-        let canon = canonicalize_with_type(v, &t);
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
         match canon {
             Value::Deferred(DeferredValue::Secret(inner)) => {
                 assert_eq!(

--- a/carina-core/tests/cyclic_schema_ref.rs
+++ b/carina-core/tests/cyclic_schema_ref.rs
@@ -207,6 +207,156 @@ fn resource_schema_defs_field_default_is_empty() {
     let _: &BTreeMap<String, AttributeType> = &schema.defs;
 }
 
+/// Regression for carina#3345: `ResourceSchema::validate` must route a
+/// `Ref`-containing attribute through `Schema::validate_attr` so the
+/// enclosing `defs` are in scope, not through the standalone
+/// `AttributeType::validate` which can only reject `Ref` with the
+/// "reached the standalone validator" sentinel.
+///
+/// The 7 awscc `s3.Bucket/*` apply failures from the 2026-05-29
+/// acceptance run all hit this site (`schema/mod.rs:3053`).
+#[test]
+fn resource_schema_validate_routes_ref_through_defs() {
+    let schema = cyclic_webacl_like_schema();
+
+    let mut attrs = HashMap::new();
+    attrs.insert(
+        "rules".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![rule_value("BlockBadIPs", 1)])),
+    );
+
+    let result = schema.validate(&attrs);
+    assert!(
+        result.is_ok(),
+        "ResourceSchema::validate on a Ref-typed attribute with valid value \
+         must succeed, but got: {:?}",
+        result.err()
+    );
+}
+
+/// Regression for carina#3345 Symptom B: `Schema::canonicalize_attr`
+/// must drive the `Ref` arm through the schema's `defs` map and
+/// canonicalize the resolved type's inner shape. This pins the
+/// public Schema-aware canonicalization entry point used by providers
+/// when normalising upstream state — the awscc
+/// `ec2_vpc_endpoint/{gateway,interface}` plan-verify failures hit
+/// this path with `Ref("DnsOptionsSpecification")` and a defs-less
+/// caller panicked at `schema/mod.rs:893`.
+///
+/// The schema here pairs a `Ref` with a leaf type whose
+/// canonicalization is observable (`String → StringList` via the
+/// `string_or_list_of_strings` collapse #2481/#2510) so a "Ref not
+/// followed" regression would leave the raw `String` in place
+/// instead of folding it to `StringList`.
+#[test]
+fn canonicalize_through_defs_resolves_ref_arm_and_walks_resolved_type() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+
+    // `Selectors` def is a struct with a `string_or_list_of_strings`
+    // field. `selectors` attribute references it via Ref.
+    let selectors_def = AttributeType::Struct {
+        name: "Selectors".to_string(),
+        fields: vec![StructField::new(
+            "tags",
+            AttributeType::Union(vec![
+                AttributeType::String,
+                AttributeType::list(AttributeType::String),
+            ]),
+        )],
+    };
+    let schema = ResourceSchema::new("test.WithRef")
+        .attribute(AttributeSchema::new(
+            "selectors",
+            AttributeType::Ref("Selectors".to_string()),
+        ))
+        .with_def("Selectors", selectors_def);
+
+    let attr_type = &schema.attributes["selectors"].attr_type;
+
+    // Construct the value with a bare `String` under `tags`, which
+    // `canonicalize_with_type` must collapse to `StringList`
+    // *if* the Ref is followed and the resolved struct's field type
+    // is consulted.
+    let mut payload = indexmap::IndexMap::new();
+    payload.insert(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::String("env=prod".to_string())),
+    );
+    let value = Value::Concrete(ConcreteValue::Map(payload));
+
+    let canon = schema
+        .schema_view_for(attr_type.clone())
+        .canonicalize(value);
+
+    let Value::Concrete(ConcreteValue::Map(canon_map)) = canon else {
+        panic!("canonicalized value must remain a Map");
+    };
+    let tags = canon_map.get("tags").expect("tags must be present");
+    assert!(
+        matches!(tags, Value::Concrete(ConcreteValue::StringList(_))),
+        "Ref must be resolved against defs and `tags` collapsed to \
+         StringList via string_or_list_of_strings (carina#3345 \
+         Symptom B). Got: {tags:?}"
+    );
+}
+
+/// Regression for carina#3345: a `Ref("Missing")` whose name is
+/// absent from `defs` must surface a clean `ValidationFailed` with
+/// the documented error string rather than a panic or a silent
+/// pass-through. `ResourceSchema::validate` is the user-facing
+/// entry point that surfaces this.
+#[test]
+fn dangling_ref_surfaces_clean_validation_error() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let schema = ResourceSchema::new("test.WithDanglingRef").attribute(AttributeSchema::new(
+        "broken",
+        AttributeType::Ref("Nowhere".to_string()),
+    ));
+    // No `with_def` call — `defs` stays empty by design.
+
+    let mut attrs = HashMap::new();
+    attrs.insert(
+        "broken".to_string(),
+        Value::Concrete(ConcreteValue::String("anything".to_string())),
+    );
+
+    let errors = schema
+        .validate(&attrs)
+        .expect_err("dangling Ref must fail validation");
+    let combined: String = errors
+        .iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        combined.contains("schema reference `Nowhere` is not defined"),
+        "expected dangling-Ref message, got: {combined}"
+    );
+}
+
+/// Regression for carina#3345: a true cyclic def (`Statement` →
+/// `List<Ref(Statement)>`) over a finite value must terminate, not
+/// blow the stack or hang.  This pins the load-bearing termination
+/// invariant for `Schema::validate_attr`'s recursion on Ref-cycles.
+#[test]
+fn cyclic_ref_terminates_on_finite_value() {
+    let schema = cyclic_webacl_like_schema();
+    let rule_attr_type = &schema.attributes["rules"].attr_type;
+
+    // 3-level nesting: outer rule contains a statement whose
+    // `and_statement` carries two statements, each of which has
+    // its own `and_statement: []`. Exercises the cycle twice.
+    let rules_value = Value::Concrete(ConcreteValue::List(vec![rule_value("Top", 2)]));
+
+    let s = carina_core::schema::Schema {
+        root: AttributeType::String,
+        defs: schema.defs.clone(),
+    };
+    s.validate_attr(rule_attr_type, &rules_value)
+        .expect("finite cyclic value must validate (carina#3345)");
+}
+
 fn build_resource(id: &ResourceId, attrs: &[(&str, Value)]) -> Resource {
     // The DSL-layer `Resource::new` constructor takes (resource_type,
     // name) and synthesizes an `id`. Use it here so the test does not

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -279,11 +279,15 @@ impl DiagnosticEngine {
             };
 
             // Host-side type-level validation (catches malformed namespace
-            // identifiers, invalid enum values, etc.).
+            // identifiers, invalid enum values, etc.). Provider configs
+            // are flat (no cyclic CFN-style `AttributeType::Ref` today),
+            // so a single empty-`defs` `Schema` view is sufficient.
             let attr_types = factory.provider_config_attribute_types();
+            let schema_view =
+                carina_core::schema::Schema::with_defs(std::collections::BTreeMap::new());
             for (attr_name, value) in &provider.attributes {
                 if let Some(attr_type) = attr_types.get(attr_name)
-                    && let Err(e) = attr_type.validate(value)
+                    && let Err(e) = schema_view.validate_attr(attr_type, value)
                     && let Some((line, col)) =
                         self.find_provider_attr_position(doc, &provider.name, attr_name)
                 {

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -625,7 +625,9 @@ impl DiagnosticEngine {
                                 // plain message so the user still sees a
                                 // diagnostic, just without the quick-fix.
                                 (carina_core::schema::AttributeType::StringEnum { .. }, value) => {
-                                    attr_schema.attr_type.validate(value).err().map(|e| {
+                                    let schema_view =
+                                        schema.schema_view_for(attr_schema.attr_type.clone());
+                                    schema_view.validate(value).err().map(|e| {
                                         let tagged = e.with_attribute(attr_name);
                                         let reshaped =
                                             if resource_quoted_string_attrs.contains(attr_name) {
@@ -758,8 +760,9 @@ impl DiagnosticEngine {
                                     carina_core::schema::AttributeType::Struct { .. }
                                 ) =>
                                 {
-                                    attr_schema
-                                        .attr_type
+                                    let schema_view =
+                                        schema.schema_view_for(attr_schema.attr_type.clone());
+                                    schema_view
                                         .validate(attr_value)
                                         .err()
                                         .map(|e| e.with_attribute(attr_name).to_string())
@@ -768,11 +771,14 @@ impl DiagnosticEngine {
                                 (
                                     carina_core::schema::AttributeType::Map { .. },
                                     Value::Concrete(ConcreteValue::Map(_)),
-                                ) => attr_schema
-                                    .attr_type
-                                    .validate(attr_value)
-                                    .err()
-                                    .map(|e| e.with_attribute(attr_name).to_string()),
+                                ) => {
+                                    let schema_view =
+                                        schema.schema_view_for(attr_schema.attr_type.clone());
+                                    schema_view
+                                        .validate(attr_value)
+                                        .err()
+                                        .map(|e| e.with_attribute(attr_name).to_string())
+                                }
                                 // Validate Union static values (non-ResourceRef, non-BindingRef).
                                 // Ref-shaped values are unresolved at this
                                 // checkpoint and must not be type-checked
@@ -785,8 +791,9 @@ impl DiagnosticEngine {
                                             | Value::Deferred(DeferredValue::BindingRef { .. })
                                     ) =>
                                 {
-                                    attr_schema
-                                        .attr_type
+                                    let schema_view =
+                                        schema.schema_view_for(attr_schema.attr_type.clone());
+                                    schema_view
                                         .validate(value)
                                         .err()
                                         .map(|e| e.with_attribute(attr_name).to_string())
@@ -821,11 +828,13 @@ impl DiagnosticEngine {
                                 _ => false,
                             };
                             if is_struct_shape {
+                                let schema_view =
+                                    schema.schema_view_for(attr_schema.attr_type.clone());
                                 diagnostics.extend(self.validate_struct_value(
                                     doc,
                                     attr_name,
                                     attr_value,
-                                    &attr_schema.attr_type,
+                                    &schema_view,
                                 ));
                             }
                         }
@@ -1391,7 +1400,11 @@ fn build_string_enum_diagnostic(
     value_range: Option<tower_lsp::lsp_types::Range>,
 ) -> Option<Diagnostic> {
     use crate::code_action::{EnumDiagnosticData, EnumDiagnosticKind};
-    let err = attr_type.validate(attr_value).err()?;
+    // `StringEnum` carries no `AttributeType::Ref` by construction, so an
+    // empty `defs` is sound here.
+    let err = carina_core::schema::Schema::flat(attr_type.clone())
+        .validate(attr_value)
+        .err()?;
     let tagged = err.with_attribute(attr_name);
     // Reshape into the shape-mismatch diagnostic when the value came
     // from a quoted string literal — mirrors CLI behavior (#2094).

--- a/carina-lsp/src/diagnostics/validation.rs
+++ b/carina-lsp/src/diagnostics/validation.rs
@@ -1,8 +1,9 @@
 //! LSP adapter that runs core's path-tagged validator
-//! ([`AttributeType::validate_collect`]) and anchors each error at
-//! its source position. The recursive struct/list-of-struct walk
-//! lives entirely in `carina-core` after #2214; this module just
-//! translates `(FieldPath, TypeError)` to LSP diagnostics.
+//! ([`carina_core::schema::Schema::validate_collect`]) and anchors
+//! each error at its source position. The recursive
+//! struct/list-of-struct walk lives entirely in `carina-core` after
+//! #2214; this module just translates `(FieldPath, TypeError)` to LSP
+//! diagnostics.
 
 use std::collections::HashMap;
 
@@ -11,29 +12,32 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 use crate::document::Document;
 use crate::position;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeType, FieldPath, FieldPathStep, ResourceSchema};
+use carina_core::schema::{FieldPath, FieldPathStep, ResourceSchema};
 
 use super::{DiagnosticEngine, carina_diagnostic};
 
 impl DiagnosticEngine {
-    /// Run [`AttributeType::validate_collect`] against the resource
-    /// attribute's schema and translate each `(FieldPath, TypeError)`
-    /// into an LSP `Diagnostic` anchored at the offending source
-    /// position. The LSP no longer recurses into nested struct shapes
-    /// — that responsibility belongs to the core validator (#2214).
+    /// Run [`carina_core::schema::Schema::validate_collect`] against
+    /// the resource attribute's schema and translate each
+    /// `(FieldPath, TypeError)` into an LSP `Diagnostic` anchored at
+    /// the offending source position. The LSP no longer recurses into
+    /// nested struct shapes — that responsibility belongs to the core
+    /// validator (#2214).
     ///
-    /// Takes `&AttributeType` (rather than `&[StructField]`) so the
-    /// per-keystroke diagnostic pass borrows the schema instead of
-    /// deep-cloning every `StructField` (which itself contains
-    /// recursive `AttributeType` sub-trees).
+    /// `schema_view` carries `ResourceSchema::defs` so a cyclic
+    /// CFN-style `AttributeType::Ref` resolves correctly
+    /// (carina#3345). Construct it via
+    /// [`carina_core::schema::ResourceSchema::schema_view_for`] so
+    /// `defs` stays threaded through every per-keystroke diagnostic
+    /// pass.
     pub(super) fn validate_struct_value(
         &self,
         doc: &Document,
         attr_name: &str,
         value: &Value,
-        ty: &AttributeType,
+        schema_view: &carina_core::schema::Schema,
     ) -> Vec<Diagnostic> {
-        let errors = ty.validate_collect(value);
+        let errors = schema_view.validate_collect(value);
         let mut diagnostics = Vec::new();
         for (path, err) in errors {
             if let Some((line, col, end_col)) = self.range_for_path(doc, attr_name, &path) {


### PR DESCRIPTION
## Summary

Closes #3345. Acceptance run on 2026-05-29 surfaced 9 awscc failures post-carina#3340 (`AttributeType::Ref` + `ResourceSchema::defs`): 7 `s3.Bucket/*` apply hit the "reached the standalone validator" sentinel, 2 `ec2_vpc_endpoint/*` plan-verify panicked at `schema/mod.rs:893`. Five production caller sites in this repo (`schema/mod.rs:3053`, `validation/mod.rs:895`, `lsp/diagnostics/mod.rs` x4, `lsp/diagnostics/checks.rs:286`, `lsp/diagnostics/validation.rs:36`) called the defs-less wrappers `AttributeType::validate(value)`, `validate_collect(value)`, `canonicalize_with_type(value, attr)` — erasing the def map carina#3340 introduced.

## Why this shape

Per `CLAUDE.md` "Long-term view + type safety" (and the carina#3324 → #3326 lesson recorded in memory): a runtime patch at N consumer sites that still permits the bug at the type level is **a runtime patch disguised as a root-cause fix**. The fix here removes the defs-less route from the type:

- `AttributeType::validate(&Value)` / `validate_collect(&Value)`: demoted to `pub(crate)`; internal helpers removed when unused.
- `canonicalize_with_type(value, attr)` (defs-less wrapper): demoted to `pub(crate)`. The Schema-aware entry points are `Schema::canonicalize` and `Schema::canonicalize_attr`.
- `canonicalize_with_type_and_defs` renamed to `canonicalize_with_type` since the suffix-less variant no longer exists.
- New constructors: `Schema::flat(root)`, `Schema::with_defs(defs)`, `ResourceSchema::schema_view_for(root)` so the "build a Schema view" ritual lands at one place.
- New `Schema::validate_collect(&Value)` walks `Ref` against `defs` for the LSP per-keystroke diagnostic pass.
- `Schema::validate_attr`'s `Union` arm restored the best-scoring member selection so StringEnum-rich diagnostics (variant list, alias hints, code-action quick-fix payload) survive the migration.
- Latent panic fixed (round-4 review finding): `walk_custom_lookup` called `resolve_refs` unconditionally and panicked when a `Ref` def name was missing. It now skips the walk; `Schema::validate_attr` surfaces the dangling-`Ref` diagnostic instead.

## Migration breadcrumb for awscc

The awscc `canonicalize_with_type(value, &attr_schema.attr_type)` call at `carina-provider-awscc/src/provider/normalizer.rs:228` **breaks at compile time** after this PR merges. The follow-up awscc PR migrates it to:

```rust
schema.canonicalize_attr(&attr_schema.attr_type, value)
```

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3758 tests, 72 skipped, all passing.
- [x] `cargo test --workspace --doc` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all five green.
- [x] 4 new regression tests in `carina-core/tests/cyclic_schema_ref.rs`:
  - `resource_schema_validate_routes_ref_through_defs` (Symptom A)
  - `canonicalize_through_defs_resolves_ref_arm_and_walks_resolved_type` (Symptom B, observable via `string_or_list_of_strings` collapse)
  - `dangling_ref_surfaces_clean_validation_error`
  - `cyclic_ref_terminates_on_finite_value`

Review: 5 rounds, every round produced at least one issue that was addressed (test strengthening, Union-arm error fidelity, `ResourceSchema::schema_view_for` helper, type-safety completion via `Schema::canonicalize`, dangling-`Ref` panic fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)