### PR TITLE
fix(schema): lift StringEnum Map keys in Schema::validate_attr (carina#3347)

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -835,7 +835,7 @@ impl Schema {
             AttributeType::Map { key, value: val_ty } => {
                 if let Some(ConcreteValueRef::Map(map)) = value.as_concrete() {
                     for (k, v) in map.iter() {
-                        let key_val = Value::Concrete(ConcreteValue::String(k.clone()));
+                        let key_val = lift_map_key(key, k);
                         if let Err(inner_err) = self.validate_attr(key, &key_val) {
                             return Err(TypeError::MapKeyError {
                                 key: k.clone(),
@@ -1073,6 +1073,21 @@ impl fmt::Display for FieldPath {
             first = false;
         }
         Ok(())
+    }
+}
+
+/// Lift a `Map` key string into the `Value` shape its `key_type`
+/// expects. `StringEnum` map keys are lifted to `EnumIdentifier` so
+/// the strict carina#2986 validator accepts the bare-identifier form
+/// users write in source; every other key type lowers to `String`
+/// (carina#2996). Shared between `Schema::validate_attr`'s Map arm
+/// and the standalone `validate_map` so the two walkers cannot
+/// drift again (carina#3347).
+pub(crate) fn lift_map_key(key_type: &AttributeType, key: &str) -> Value {
+    if matches!(key_type, AttributeType::StringEnum { .. }) {
+        Value::Concrete(ConcreteValue::EnumIdentifier(key.to_string()))
+    } else {
+        Value::Concrete(ConcreteValue::String(key.to_string()))
     }
 }
 
@@ -1614,19 +1629,8 @@ impl AttributeType {
                 got: value.type_name().to_string(),
             });
         };
-        // carina#2996: map-literal grammar is `(identifier | string) "="
-        // expression`, and both shapes lower to the same `String` key by
-        // the time we see them. For `StringEnum` keys, lift the key into
-        // `EnumIdentifier` form so the strict carina#2986 validator
-        // accepts it — there is no other syntax for writing an enum-
-        // shaped map key.
-        let key_is_enum = matches!(key_type.as_ref(), AttributeType::StringEnum { .. });
         for k in map.keys() {
-            let key_value = if key_is_enum {
-                Value::Concrete(ConcreteValue::EnumIdentifier(k.clone()))
-            } else {
-                Value::Concrete(ConcreteValue::String(k.clone()))
-            };
+            let key_value = lift_map_key(key_type, k);
             key_type
                 .validate(&key_value)
                 .map_err(|e| TypeError::MapKeyError {

--- a/carina-core/tests/cyclic_schema_ref.rs
+++ b/carina-core/tests/cyclic_schema_ref.rs
@@ -357,6 +357,60 @@ fn cyclic_ref_terminates_on_finite_value() {
         .expect("finite cyclic value must validate (carina#3345)");
 }
 
+/// Regression for carina#3347: `Schema::validate_attr`'s `Map` arm
+/// must lift a `Map<StringEnum, ...>` key into `EnumIdentifier` shape
+/// before validating it, mirroring `validate_map`'s pre-existing
+/// `key_is_enum` special case (carina#2996). Without this lift, a
+/// Map key written as a bare identifier in source surfaces as
+/// `StringLiteralExpectedEnum` because the lift wraps the key as a
+/// plain `String`.
+///
+/// The carina#3346 migration routed every production validate call
+/// through `Schema::validate_attr`, exposing this latent divergence
+/// as a `validate_iam_policy_document` regression in awscc#282 when
+/// pulling the new rev.
+#[test]
+fn schema_validate_attr_map_arm_lifts_string_enum_key() {
+    use carina_core::resource::ConcreteValue;
+    use carina_core::schema::{AttributeType, Schema};
+
+    let key_type = AttributeType::StringEnum {
+        name: "Op".to_string(),
+        values: vec!["eq".to_string(), "neq".to_string()],
+        identity: None,
+        dsl_aliases: vec![],
+    };
+    let attr_type = AttributeType::Map {
+        key: Box::new(key_type),
+        value: Box::new(AttributeType::String),
+    };
+
+    let mut payload = indexmap::IndexMap::new();
+    payload.insert(
+        "eq".to_string(),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
+    );
+    let value = Value::Concrete(ConcreteValue::Map(payload));
+
+    let schema = Schema::flat(attr_type);
+    schema
+        .validate(&value)
+        .expect("a bare-identifier Map key for a StringEnum key type must validate");
+
+    // Negative case: an unknown enum variant must still fail
+    // (guard against a "lift everything to EnumIdentifier and accept"
+    // regression).
+    let mut bad_payload = indexmap::IndexMap::new();
+    bad_payload.insert(
+        "unknown".to_string(),
+        Value::Concrete(ConcreteValue::String("x".to_string())),
+    );
+    let bad_value = Value::Concrete(ConcreteValue::Map(bad_payload));
+    schema
+        .validate(&bad_value)
+        .expect_err("an unknown StringEnum Map key must fail validation");
+}
+
 fn build_resource(id: &ResourceId, attrs: &[(&str, Value)]) -> Resource {
     // The DSL-layer `Resource::new` constructor takes (resource_type,
     // name) and synthesizes an `id`. Use it here so the test does not


### PR DESCRIPTION
## Summary

Closes #3347. After carina#3346 routed every production validate call through `Schema::validate_attr`, the schema-aware Map arm at `carina-core/src/schema/mod.rs:835` exposed a latent divergence: it lifted Map keys as `ConcreteValue::String(k)` unconditionally, while the standalone `validate_map` at line 1604 has a `key_is_enum` branch that lifts to `EnumIdentifier` for `StringEnum` keys (carina#2996). awscc#282 surfaced this as `validate_iam_policy_document_accepts_for_all_values_string_equals` failing on the carina-core rev bump.

## Why this shape

Per `CLAUDE.md` "Root-cause fixes only": the two walkers (`Schema::validate_attr` and standalone `validate_map`) both lower Map keys, both need the `key_is_enum` lift, and they had drifted because the lift block was copy-pasted into one and never the other. Leaving the fix as duplicate-by-convention 4-line blocks at both sites guarantees the next contributor adding e.g. a `Custom`-keyed shape or a third validator entry point repeats the omission.

The fix extracts a shared `lift_map_key(key_type, k)` helper that both walkers call, so the two sites cannot drift again.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 3759 tests, 72 skipped, all passing.
- [x] `cargo test --workspace --doc` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all five green.
- [x] New regression test `schema_validate_attr_map_arm_lifts_string_enum_key` in `carina-core/tests/cyclic_schema_ref.rs` covers both:
  - Success path: bare-identifier key for a known enum variant
  - Negative case: unknown variant must still fail (guards against a "lift to `EnumIdentifier` and accept everything" regression)

## Follow-up

This unblocks the awscc-side migration tracked at carina-rs/carina-provider-awscc#282 (post-carina#3345 `canonicalize_with_type` → `Schema::canonicalize_attr`). That PR will re-bump the carina-core rev to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)