### PR TITLE
feat(schema): add RawShape view for Ref-preserving transport sites

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -716,6 +716,149 @@ impl fmt::Debug for Shape<'_> {
     }
 }
 
+/// A `Ref`-preserving projection of [`AttributeType`] for callers that
+/// must round-trip the type *across a boundary* without resolving
+/// `Ref` against `defs` (typically: WIT/JSON serializers in WASM
+/// plugin guests that emit a [`crate::schema`] schema to the host
+/// alongside a `defs` map of its own).
+///
+/// [`Shape`] is the right view for **walk-sites** (differ, detail_rows,
+/// LSP, validation): it resolves `Ref` against the enclosing
+/// [`Schema`]'s `defs` map and is structurally guaranteed not to carry
+/// `Ref`. [`RawShape`] is the right view for **transport-sites**: the
+/// caller is not consuming the schema's meaning, only relaying its
+/// structural form, and resolving `Ref` would either (a) infinite-loop
+/// on cyclic schemas like WAFv2 `WebACL.Statement`, or (b) flatten the
+/// `defs` map into the root and lose the cyclic structure the receiver
+/// needs to re-build.
+///
+/// Mirrors [`Shape`] variant-for-variant **plus** a [`RawShape::Ref`]
+/// variant. New `AttributeType` variants must be added to both
+/// projections; the `AttrTypeKind::raw_shape` match is non-exhaustive
+/// against the source enum and the compiler will surface the omission.
+#[derive(Clone, Copy)]
+pub enum RawShape<'a> {
+    /// String — see [`AttrTypeKind::String`].
+    String,
+    /// Integer — see [`AttrTypeKind::Int`].
+    Int,
+    /// Floating-point — see [`AttrTypeKind::Float`].
+    Float,
+    /// Boolean — see [`AttrTypeKind::Bool`].
+    Bool,
+    /// Time duration — see [`AttrTypeKind::Duration`].
+    Duration,
+    /// Namespaced string enum — see [`AttrTypeKind::StringEnum`].
+    StringEnum {
+        name: &'a str,
+        values: &'a [String],
+        identity: Option<&'a TypeIdentity>,
+        dsl_aliases: &'a [(String, String)],
+    },
+    /// Structural custom type — see [`AttrTypeKind::Custom`].
+    Custom {
+        identity: Option<&'a TypeIdentity>,
+        base: &'a AttributeType,
+        pattern: Option<&'a str>,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: &'a CustomValidator,
+        to_dsl: Option<fn(&str) -> String>,
+    },
+    /// Enum-shorthand custom type — see [`AttrTypeKind::CustomEnum`].
+    CustomEnum {
+        identity: &'a TypeIdentity,
+        base: &'a AttributeType,
+        validate: &'a CustomValidator,
+        to_dsl: Option<fn(&str) -> String>,
+    },
+    /// List with element type and ordering — see [`AttrTypeKind::List`].
+    List {
+        inner: &'a AttributeType,
+        ordered: bool,
+    },
+    /// Map with typed key/value — see [`AttrTypeKind::Map`].
+    Map {
+        key: &'a AttributeType,
+        value: &'a AttributeType,
+    },
+    /// Named struct — see [`AttrTypeKind::Struct`].
+    Struct {
+        name: &'a str,
+        fields: &'a [StructField],
+    },
+    /// Union of types — see [`AttrTypeKind::Union`].
+    Union(&'a [AttributeType]),
+    /// Named reference into the enclosing [`Schema`]'s `defs` map.
+    /// Carries the name; the receiver re-emits an `AttributeType::ref_(name)`
+    /// and looks up the definition in its own copy of `defs`.
+    Ref(&'a str),
+}
+
+impl fmt::Debug for RawShape<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RawShape::String => f.write_str("RawShape::String"),
+            RawShape::Int => f.write_str("RawShape::Int"),
+            RawShape::Float => f.write_str("RawShape::Float"),
+            RawShape::Bool => f.write_str("RawShape::Bool"),
+            RawShape::Duration => f.write_str("RawShape::Duration"),
+            RawShape::StringEnum {
+                name,
+                values,
+                identity,
+                dsl_aliases,
+            } => f
+                .debug_struct("RawShape::StringEnum")
+                .field("name", name)
+                .field("values", values)
+                .field("identity", identity)
+                .field("dsl_aliases", dsl_aliases)
+                .finish(),
+            RawShape::Custom {
+                identity,
+                base,
+                pattern,
+                length,
+                validate: _,
+                to_dsl: _,
+            } => f
+                .debug_struct("RawShape::Custom")
+                .field("identity", identity)
+                .field("base", base)
+                .field("pattern", pattern)
+                .field("length", length)
+                .finish_non_exhaustive(),
+            RawShape::CustomEnum {
+                identity,
+                base,
+                validate: _,
+                to_dsl: _,
+            } => f
+                .debug_struct("RawShape::CustomEnum")
+                .field("identity", identity)
+                .field("base", base)
+                .finish_non_exhaustive(),
+            RawShape::List { inner, ordered } => f
+                .debug_struct("RawShape::List")
+                .field("inner", inner)
+                .field("ordered", ordered)
+                .finish(),
+            RawShape::Map { key, value } => f
+                .debug_struct("RawShape::Map")
+                .field("key", key)
+                .field("value", value)
+                .finish(),
+            RawShape::Struct { name, fields } => f
+                .debug_struct("RawShape::Struct")
+                .field("name", name)
+                .field("fields", fields)
+                .finish(),
+            RawShape::Union(members) => f.debug_tuple("RawShape::Union").field(members).finish(),
+            RawShape::Ref(name) => f.debug_tuple("RawShape::Ref").field(name).finish(),
+        }
+    }
+}
+
 /// A complete schema: a root attribute type together with the named
 /// definitions it can reference via [`AttrTypeKind::Ref`].
 ///
@@ -1409,6 +1552,83 @@ impl AttributeType {
                 "resolve_refs guarantees the returned attr is not Ref; \
                  reaching this arm violates ResolvedAttrType's invariant"
             ),
+        }
+    }
+
+    /// Project this type onto a [`RawShape`] view that **preserves
+    /// `Ref`** instead of resolving it against any `defs` map.
+    ///
+    /// Intended for callers that round-trip the type across a
+    /// transport boundary (the WASM plugin↔host WIT/JSON serializers
+    /// in `carina-provider-{aws,awscc}/src/convert.rs`,
+    /// `carina-plugin-host/src/wasm_convert.rs`). At a transport
+    /// site, resolving `Ref` is wrong on two counts: cyclic schemas
+    /// like WAFv2 `WebACL.Statement` recurse forever, and even on
+    /// acyclic schemas, flattening `Ref` discards the `defs` shape
+    /// the receiver needs to reconstruct.
+    ///
+    /// Walk-sites (differ, detail_rows, LSP, validation, ...) must
+    /// keep using [`Self::shape`] — `RawShape::Ref` is reachable here
+    /// by design and a wildcard arm would silently re-introduce the
+    /// carina#3349 bug class at the walk-site.
+    pub fn raw_shape<'a>(&'a self) -> RawShape<'a> {
+        match &self.kind {
+            AttrTypeKind::String => RawShape::String,
+            AttrTypeKind::Int => RawShape::Int,
+            AttrTypeKind::Float => RawShape::Float,
+            AttrTypeKind::Bool => RawShape::Bool,
+            AttrTypeKind::Duration => RawShape::Duration,
+            AttrTypeKind::StringEnum {
+                name,
+                values,
+                identity,
+                dsl_aliases,
+            } => RawShape::StringEnum {
+                name: name.as_str(),
+                values: values.as_slice(),
+                identity: identity.as_ref(),
+                dsl_aliases: dsl_aliases.as_slice(),
+            },
+            AttrTypeKind::Custom {
+                identity,
+                base,
+                pattern,
+                length,
+                validate,
+                to_dsl,
+            } => RawShape::Custom {
+                identity: identity.as_ref(),
+                base: base.as_ref(),
+                pattern: pattern.as_deref(),
+                length: *length,
+                validate,
+                to_dsl: *to_dsl,
+            },
+            AttrTypeKind::CustomEnum {
+                identity,
+                base,
+                validate,
+                to_dsl,
+            } => RawShape::CustomEnum {
+                identity,
+                base: base.as_ref(),
+                validate,
+                to_dsl: *to_dsl,
+            },
+            AttrTypeKind::List { inner, ordered } => RawShape::List {
+                inner: inner.as_ref(),
+                ordered: *ordered,
+            },
+            AttrTypeKind::Map { key, value } => RawShape::Map {
+                key: key.as_ref(),
+                value: value.as_ref(),
+            },
+            AttrTypeKind::Struct { name, fields } => RawShape::Struct {
+                name: name.as_str(),
+                fields: fields.as_slice(),
+            },
+            AttrTypeKind::Union(members) => RawShape::Union(members.as_slice()),
+            AttrTypeKind::Ref(name) => RawShape::Ref(name.as_str()),
         }
     }
 

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -5349,3 +5349,37 @@ fn attribute_type_validate_on_ref_returns_error_without_schema() {
         "AttributeType::Ref cannot self-validate without a Schema"
     );
 }
+
+#[test]
+fn raw_shape_preserves_ref_at_top() {
+    // RawShape::Ref is the carina#3349 follow-up: transport-site
+    // callers (WASM plugin↔host serializers) must round-trip Ref
+    // without resolving it, because resolving against the local
+    // `defs` would either infinite-loop on cyclic schemas
+    // (WAFv2 WebACL.Statement) or flatten the structure the
+    // receiver needs to rebuild from `defs`.
+    let t = AttributeType::ref_("Statement");
+    match t.raw_shape() {
+        RawShape::Ref(name) => assert_eq!(name, "Statement"),
+        other => panic!("expected RawShape::Ref(\"Statement\"), got {other:?}"),
+    }
+}
+
+#[test]
+fn raw_shape_passes_through_non_ref_variants() {
+    // Sanity check that non-Ref variants still project correctly.
+    assert!(matches!(
+        AttributeType::string().raw_shape(),
+        RawShape::String
+    ));
+    assert!(matches!(AttributeType::int().raw_shape(), RawShape::Int));
+    assert!(matches!(AttributeType::bool().raw_shape(), RawShape::Bool));
+    match AttributeType::list(AttributeType::string()).raw_shape() {
+        RawShape::List { ordered, .. } => assert!(ordered),
+        other => panic!("expected RawShape::List, got {other:?}"),
+    }
+    match AttributeType::unordered_list(AttributeType::string()).raw_shape() {
+        RawShape::List { ordered, .. } => assert!(!ordered),
+        other => panic!("expected RawShape::List(unordered), got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Why

carina#3349 made `AttributeType` opaque with `Shape<'a>` as the only external matching view. `Shape` deliberately omits `Ref` — walk-sites (differ, detail_rows, LSP, validation) must resolve refs against `defs` before dispatching, and the type-system guarantee that a `match shape { ... }` wildcard cannot silently swallow a `Ref` is the load-bearing part of the bug-class fix.

That guarantee was the right call for walk-sites but left a gap for **transport sites** — the WIT/JSON serializers in `carina-provider-{aws,awscc}/src/convert.rs` that round-trip an `AttributeType` across the WASM plugin↔host boundary alongside its own `defs` map. At a transport site, resolving `Ref` is wrong on two counts:

1. Cyclic schemas like WAFv2 `WebACL.Statement` recurse forever (and `Shape::shape(defs)` would either infinite-loop or panic).
2. Even on acyclic schemas, resolving flattens `Ref` into the root and discards the `defs` shape the receiver needs to rebuild from its own copy of the def map.

Surfaced while bumping `carina-provider-awscc` to this commit (`2c1bd052`) for the carina#3349 absorption — `core_to_proto_attribute_type` has nowhere to dispatch a `CoreAttributeType::Ref` because external matching was removed entirely. The aws sub-agent will hit the same wall in `carina-provider-aws/src/convert.rs::core_to_proto_attribute_type`.

## What

- New `pub enum RawShape<'a>` in `carina_core::schema`, mirroring `Shape` variant-for-variant **plus** a `RawShape::Ref(&str)` variant.
- New `pub fn AttributeType::raw_shape(&self) -> RawShape<'_>` — does **not** resolve `Ref`, returns the top kind verbatim.
- Doc-comments on both items spell out the walk-site / transport-site split so future contributors don't reach for `raw_shape()` when `shape(defs)` is the right tool.
- The `AttrTypeKind::raw_shape` match is non-exhaustive against the source enum — new `AttributeType` variants produce a compile error at this site (same hygiene `shape` already gets).

## Tests

- `raw_shape_preserves_ref_at_top` — the load-bearing case (`AttributeType::ref_("Statement").raw_shape()` → `RawShape::Ref("Statement")`).
- `raw_shape_passes_through_non_ref_variants` — sanity for `String` / `Int` / `Bool` and `List` ordered/unordered passthrough.

Full workspace nextest + clippy + doctests + `scripts/check-*.sh` clean.

## Walk-site vs transport-site (decision matrix)

| Caller intent | API | Ref behavior |
| --- | --- | --- |
| Validate / diff / render / complete | `attr.shape(&defs)` | Resolved against `defs` (panics if missing). `Shape` has no `Ref` variant — wildcard arm is safe. |
| Transport across a boundary, receiver reconstructs from its own `defs` | `attr.raw_shape()` | Preserved verbatim as `RawShape::Ref(name)`. Caller must also transport `defs` alongside. |