### PR TITLE
Expose a provider-agnostic send_request over wasi:http

### DIFF
--- a/carina-plugin-sdk/src/wasi_http.rs
+++ b/carina-plugin-sdk/src/wasi_http.rs
@@ -1,9 +1,23 @@
-//! WASM HTTP client that bridges the AWS SDK's HTTP interface to wasi:http.
+//! WASM HTTP transport over `wasi:http/outgoing-handler`.
 //!
-//! This module provides `WasiHttpClient`, which implements the AWS SDK's
-//! `HttpClient` trait by delegating HTTP requests to the `wasi:http/outgoing-handler`
-//! interface. This allows AWS SDK operations to work inside a WASM component
-//! running on a host that provides wasi:http support.
+//! The wasi:http transport core ([`execute`]) is provider-agnostic: it
+//! takes a neutral [`WasiRequest`] (`http`-crate-shaped: method, uri,
+//! headers, body) and returns a [`WasiResponse`]. Two adapters sit on
+//! top:
+//!
+//! - [`send_request`] — the **generic** entry point any provider can
+//!   use to issue a plain HTTP request with only the `http` crate's
+//!   types (no AWS SDK dependency). This is how non-AWS providers (e.g.
+//!   the GitHub provider) talk to their REST APIs.
+//! - [`WasiHttpClient`] — implements the AWS SDK's `HttpClient` trait by
+//!   translating its `HttpRequest`/`SdkBody` into the same neutral core,
+//!   so AWS SDK operations work inside a WASM component too.
+//!
+//! Keeping the wasi:http body-framing fixes (carina#3254 Content-Length,
+//! carina#3320 handle-before-write ordering, carina#3318 blocking-write
+//! chunking) in the single [`execute`] core means every caller — AWS SDK
+//! or generic — gets them; a new provider cannot reintroduce the bugs by
+//! re-implementing the transport.
 //!
 //! This module is only compiled for `target_arch = "wasm32"`.
 
@@ -137,76 +151,94 @@ fn build_request_options(
     Some(opts)
 }
 
-/// Convert an AWS SDK HttpRequest to a wasi:http outgoing request, execute it,
-/// and convert the response back.
-fn make_request(
-    request: HttpRequest,
-    options: Option<RequestOptions>,
-) -> Result<Response<SdkBody>, ConnectorError> {
+/// A provider-agnostic HTTP request for the wasi:http transport core.
+///
+/// Internal to this module — callers go through [`send_request`] (generic)
+/// or [`WasiHttpClient`] (AWS SDK), never construct this directly, so they
+/// cannot bypass the body-framing fixes in [`execute`].
+struct WasiRequest {
+    /// HTTP method, uppercase (`GET`, `PUT`, ...).
+    method: String,
+    /// Absolute request URI (scheme + authority + path + query).
+    uri: String,
+    /// Header name/value pairs. Values are bytes to allow non-UTF-8.
+    headers: Vec<(String, Vec<u8>)>,
+    /// Request body (empty `Vec` for body-less requests).
+    body: Vec<u8>,
+}
+
+/// The response from the wasi:http transport core. Internal to this module.
+struct WasiResponse {
+    /// HTTP status code.
+    status: u16,
+    /// Response header name/value pairs (values lossy-UTF-8 decoded).
+    headers: Vec<(String, String)>,
+    /// Response body bytes.
+    body: Vec<u8>,
+}
+
+/// The single wasi:http transport core. Both the generic
+/// [`send_request`] and the AWS SDK [`WasiHttpClient`] funnel through
+/// here, so the body-framing fixes (carina#3254 / #3320 / #3318) apply
+/// to every caller.
+fn execute(request: WasiRequest, options: Option<RequestOptions>) -> Result<WasiResponse, String> {
     let trace = trace_enabled();
     let req_start = if trace { Some(Instant::now()) } else { None };
     let trace_method = if trace {
-        request.method().to_string()
+        request.method.clone()
     } else {
         String::new()
     };
     let trace_uri = if trace {
-        request.uri().to_string()
+        request.uri.clone()
     } else {
         String::new()
     };
 
     if trace {
-        // Dump request headers as we received them from the AWS SDK, before
-        // any wasi:http translation. Used to confirm whether DELETE requests
-        // carry `content-length: 0` / `transfer-encoding: chunked` /
-        // `expect: 100-continue` (the body-framing hypotheses being narrowed
-        // for the ~20 s S3 latency).
-        let body_in = request.body().bytes().map(|b| b.len()).unwrap_or(0);
+        // Dump request headers before any wasi:http translation. Used to
+        // confirm whether body-less requests carry `content-length: 0` /
+        // `transfer-encoding: chunked` / `expect: 100-continue` (the
+        // body-framing hypotheses narrowed for the ~20 s S3 latency).
         let header_pairs: Vec<String> = request
-            .headers()
+            .headers
             .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
+            .map(|(k, v)| format!("{}={}", k, String::from_utf8_lossy(v)))
             .collect();
         eprintln!(
             "carina-wasi-http-trace-headers method={} uri={} body_in={} headers=[{}]",
             trace_method,
             trace_uri,
-            body_in,
+            request.body.len(),
             header_pairs.join("; "),
         );
     }
 
     // Parse the URI
-    let uri = request.uri().to_string();
-    let parsed = uri
+    let parsed = request
+        .uri
         .parse::<http::Uri>()
-        .map_err(|e| ConnectorError::other(e.into(), None))?;
+        .map_err(|e| format!("Invalid URI: {e}"))?;
 
-    // Classify the SDK body into Empty / Sized so the wire framing is
-    // explicit. Without this, AWS SDK-emitted body-less DELETEs lose
-    // their length signal at the wasi:http boundary, the host falls
-    // back to `Transfer-Encoding: chunked`, and S3 sits for ~20s
-    // (carina-rs/carina#3254) waiting for chunked-body bytes that
-    // hyper never produces.
-    let body = RequestBody::from_sdk_body(request.body().bytes().unwrap_or(&[]));
+    // Classify the body into Empty / Sized so the wire framing is
+    // explicit. Without this, body-less requests lose their length
+    // signal at the wasi:http boundary, the host falls back to
+    // `Transfer-Encoding: chunked`, and S3 sits for ~20s
+    // (carina-rs/carina#3254) waiting for chunked-body bytes that hyper
+    // never produces.
+    let body = RequestBody::from_sdk_body(&request.body);
 
-    // Build headers, injecting `content-length` if the SDK omitted it.
-    let mut headers_list: Vec<(String, Vec<u8>)> = request
-        .headers()
-        .iter()
-        .map(|(k, v)| (k.to_string(), v.as_bytes().to_vec()))
-        .collect();
+    // Build headers, injecting `content-length` if the caller omitted it.
+    let mut headers_list = request.headers;
     inject_content_length_header(&mut headers_list, &body);
-    let fields = Fields::from_list(&headers_list).map_err(|e| {
-        ConnectorError::other(format!("Failed to create headers: {e:?}").into(), None)
-    })?;
+    let fields =
+        Fields::from_list(&headers_list).map_err(|e| format!("Failed to create headers: {e:?}"))?;
 
     // Create outgoing request
     let outgoing_req = OutgoingRequest::new(fields);
 
     // Set method
-    let method = match request.method() {
+    let method = match request.method.as_str() {
         "GET" => Method::Get,
         "POST" => Method::Post,
         "PUT" => Method::Put,
@@ -220,7 +252,7 @@ fn make_request(
     };
     outgoing_req
         .set_method(&method)
-        .map_err(|()| ConnectorError::other("Failed to set method".into(), None))?;
+        .map_err(|()| "Failed to set method".to_string())?;
 
     // Set scheme
     let scheme = match parsed.scheme_str() {
@@ -231,13 +263,13 @@ fn make_request(
     };
     outgoing_req
         .set_scheme(scheme.as_ref())
-        .map_err(|()| ConnectorError::other("Failed to set scheme".into(), None))?;
+        .map_err(|()| "Failed to set scheme".to_string())?;
 
     // Set authority (host[:port])
     let authority = parsed.authority().map(|a| a.to_string());
     outgoing_req
         .set_authority(authority.as_deref())
-        .map_err(|()| ConnectorError::other("Failed to set authority".into(), None))?;
+        .map_err(|()| "Failed to set authority".to_string())?;
 
     // Set path with query
     let path_and_query = parsed
@@ -246,7 +278,7 @@ fn make_request(
         .unwrap_or_else(|| "/".to_string());
     outgoing_req
         .set_path_with_query(Some(&path_and_query))
-        .map_err(|()| ConnectorError::other("Failed to set path".into(), None))?;
+        .map_err(|()| "Failed to set path".to_string())?;
 
     let t_setup_done = req_start.map(|s| s.elapsed());
 
@@ -260,7 +292,7 @@ fn make_request(
     let body_len = body.content_length();
     let outgoing_body = outgoing_req
         .body()
-        .map_err(|()| ConnectorError::other("Failed to get outgoing body".into(), None))?;
+        .map_err(|()| "Failed to get outgoing body".to_string())?;
 
     // Hand the request off to the host *first* so the hyper task that
     // consumes the body channel is spawned before we start writing.
@@ -270,9 +302,8 @@ fn make_request(
     // inside `wasmtime-wasi-io`'s `blocking_write_and_flush` default
     // impl would block forever — the carina-rs/carina#3320 20-minute
     // host I/O hang.
-    let future_response = outgoing_handler::handle(outgoing_req, options).map_err(|e| {
-        ConnectorError::other(format!("outgoing-handler error: {e:?}").into(), None)
-    })?;
+    let future_response = outgoing_handler::handle(outgoing_req, options)
+        .map_err(|e| format!("outgoing-handler error: {e:?}"))?;
     let t_handle_done = req_start.map(|s| s.elapsed());
 
     // Now ship the body. The hyper consumer is live, so each
@@ -281,7 +312,7 @@ fn make_request(
     write_body(&outgoing_body, body.as_bytes())?;
     let t_write_body_done = req_start.map(|s| s.elapsed());
     OutgoingBody::finish(outgoing_body, None)
-        .map_err(|e| ConnectorError::other(format!("Failed to finish body: {e:?}").into(), None))?;
+        .map_err(|e| format!("Failed to finish body: {e:?}"))?;
     let t_body_finish_done = req_start.map(|s| s.elapsed());
 
     // Wait for the response by polling
@@ -291,9 +322,9 @@ fn make_request(
 
     let response = future_response
         .get()
-        .ok_or_else(|| ConnectorError::other("Response not ready after block".into(), None))?
-        .map_err(|()| ConnectorError::other("Response already taken".into(), None))?
-        .map_err(|e| ConnectorError::other(format!("HTTP error: {e:?}").into(), None))?;
+        .ok_or_else(|| "Response not ready after block".to_string())?
+        .map_err(|()| "Response already taken".to_string())?
+        .map_err(|e| format!("HTTP error: {e:?}"))?;
     let t_get_response_done = req_start.map(|s| s.elapsed());
 
     // Read response status
@@ -311,31 +342,25 @@ fn make_request(
     // Read response body
     let incoming_body = response
         .consume()
-        .map_err(|()| ConnectorError::other("Failed to consume response body".into(), None))?;
+        .map_err(|()| "Failed to consume response body".to_string())?;
     let response_bytes = read_body(&incoming_body)?;
     let _trailers = IncomingBody::finish(incoming_body);
     let t_read_body_done = req_start.map(|s| s.elapsed());
 
     if trace {
         // Emit a single-line breakdown so it can be greped from log files.
-        // Cumulative milliseconds since make_request entry, one column per phase.
-        // Phases that should be ~instant on the WASM side (everything except
-        // pollable.block) are the ones that flag a host-side stall when they
-        // grow.
+        // Cumulative milliseconds since execute() entry, one column per
+        // phase. Phases that should be ~instant on the WASM side
+        // (everything except pollable.block) flag a host-side stall when
+        // they grow.
         let ms = |d: Option<Duration>| d.map(|x| x.as_millis()).unwrap_or(0);
-        // Columns are emitted in execution order so a reader can scan
-        // left-to-right and see where the wall-clock went. The order
-        // is: setup → handle (hand request off so the hyper consumer
-        // is live before we write — see carina-rs/carina#3320) →
-        // write_body → body_finish → pollable_block → get_response →
-        // read_body.
         eprintln!(
             "carina-wasi-http-trace method={} uri={} status={} body_in={} body_out={} \
              setup_ms={} handle_ms={} write_body_ms={} body_finish_ms={} \
              pollable_block_ms={} get_response_ms={} read_body_ms={}",
             trace_method,
             trace_uri,
-            u16::from(status),
+            status,
             body_len,
             response_bytes.len(),
             ms(t_setup_done),
@@ -348,15 +373,79 @@ fn make_request(
         );
     }
 
+    Ok(WasiResponse {
+        status,
+        headers: header_entries,
+        body: response_bytes,
+    })
+}
+
+/// Issue a plain HTTP request over wasi:http, using only `http`-crate
+/// types — no AWS SDK dependency.
+///
+/// This is the generic transport for providers that talk to a REST API
+/// directly (e.g. the GitHub provider). The request body is taken by
+/// value; the response body is fully buffered into the returned
+/// `http::Response<Vec<u8>>`.
+///
+/// Errors are returned as `String` (the provider maps them to its own
+/// error type). The body-framing fixes in [`execute`] (carina#3254 /
+/// #3320 / #3318) apply here exactly as they do for the AWS SDK path.
+pub fn send_request(request: http::Request<Vec<u8>>) -> Result<http::Response<Vec<u8>>, String> {
+    let (parts, body) = request.into_parts();
+    let headers = parts
+        .headers
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.as_bytes().to_vec()))
+        .collect();
+    let wasi_req = WasiRequest {
+        method: parts.method.as_str().to_string(),
+        uri: parts.uri.to_string(),
+        headers,
+        body,
+    };
+
+    let wasi_resp = execute(wasi_req, None)?;
+
+    let mut builder = http::Response::builder().status(wasi_resp.status);
+    for (key, value) in wasi_resp.headers {
+        builder = builder.header(key, value);
+    }
+    builder
+        .body(wasi_resp.body)
+        .map_err(|e| format!("Failed to build response: {e}"))
+}
+
+/// Convert an AWS SDK HttpRequest to a [`WasiRequest`], run it through the
+/// wasi:http transport core, and convert the response back to the SDK's
+/// `Response<SdkBody>`.
+fn make_request(
+    request: HttpRequest,
+    options: Option<RequestOptions>,
+) -> Result<Response<SdkBody>, ConnectorError> {
+    let headers = request
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.as_bytes().to_vec()))
+        .collect();
+    let wasi_req = WasiRequest {
+        method: request.method().to_string(),
+        uri: request.uri().to_string(),
+        headers,
+        body: request.body().bytes().unwrap_or(&[]).to_vec(),
+    };
+
+    let wasi_resp =
+        execute(wasi_req, options).map_err(|e| ConnectorError::other(e.into(), None))?;
+
     // Build the AWS SDK Response
     let mut sdk_response = Response::new(
-        aws_smithy_runtime_api::http::StatusCode::try_from(status)
+        aws_smithy_runtime_api::http::StatusCode::try_from(wasi_resp.status)
             .map_err(|e| ConnectorError::other(e.into(), None))?,
-        SdkBody::from(response_bytes),
+        SdkBody::from(wasi_resp.body),
     );
 
-    // Copy headers
-    for (key, value) in header_entries {
+    for (key, value) in wasi_resp.headers {
         sdk_response
             .headers_mut()
             .try_append(key, value)
@@ -377,35 +466,32 @@ fn make_request(
 /// entry fails with `cannot enter component instance`. Splitting via
 /// [`chunks_for_blocking_write`] keeps every call inside the
 /// contract, regardless of how large the SDK-buffered body is.
-fn write_body(body: &OutgoingBody, data: &[u8]) -> Result<(), ConnectorError> {
+fn write_body(body: &OutgoingBody, data: &[u8]) -> Result<(), String> {
     let stream = body
         .write()
-        .map_err(|()| ConnectorError::other("Failed to get output stream".into(), None))?;
+        .map_err(|()| "Failed to get output stream".to_string())?;
     for chunk in chunks_for_blocking_write(data) {
         debug_assert!(chunk.len() <= BLOCKING_WRITE_AND_FLUSH_MAX_BYTES);
         stream
             .blocking_write_and_flush(chunk)
-            .map_err(|e| ConnectorError::other(format!("Write error: {e:?}").into(), None))?;
+            .map_err(|e| format!("Write error: {e:?}"))?;
     }
     drop(stream);
     Ok(())
 }
 
 /// Read all bytes from an incoming body.
-fn read_body(body: &IncomingBody) -> Result<Vec<u8>, ConnectorError> {
+fn read_body(body: &IncomingBody) -> Result<Vec<u8>, String> {
     let stream = body
         .stream()
-        .map_err(|()| ConnectorError::other("Failed to get input stream".into(), None))?;
+        .map_err(|()| "Failed to get input stream".to_string())?;
     let mut buf = Vec::new();
     loop {
         match stream.blocking_read(64 * 1024) {
             Ok(chunk) => buf.extend_from_slice(&chunk),
             Err(StreamError::Closed) => break,
             Err(e) => {
-                return Err(ConnectorError::other(
-                    format!("Read error: {e:?}").into(),
-                    None,
-                ));
+                return Err(format!("Read error: {e:?}"));
             }
         }
     }


### PR DESCRIPTION
## Summary

Makes the carina-plugin-sdk wasi:http transport usable by **non-AWS** providers. Until now the transport was reachable only through `WasiHttpClient`, an AWS-SDK `HttpClient` trait impl — a provider that talks to a plain REST API (the GitHub provider, carina#3342) had no way to issue an HTTP request without pulling in `aws-smithy` types.

## What changed (single file: `carina-plugin-sdk/src/wasi_http.rs`)

Factor the transport so the wasi:http core is provider-agnostic:

- **`execute(WasiRequest, options) -> Result<WasiResponse, String>`** — the wasi:http send/receive core, holding the three hard-won body-framing fixes (carina#3254 Content-Length classification, carina#3320 handle-before-write ordering, carina#3318 chunked blocking-write). `WasiRequest`/`WasiResponse` are `http`-crate-shaped (method/uri/headers/body) and **module-private**.
- **`make_request`** becomes a thin AWS-SDK adapter: smithy `HttpRequest` → `WasiRequest` → `execute` → `Response<SdkBody>`. Behavior-identical (verified — pure factoring).
- **`pub fn send_request(http::Request<Vec<u8>>) -> Result<http::Response<Vec<u8>>, String>`** (new) — lets any provider issue a plain HTTP request with only the `http` crate, no AWS SDK dependency.

## Why this shape (root-cause, long-term)

`execute` is private and **both** adapters funnel through it. A new provider cannot reintroduce the body-framing bugs by re-implementing the transport — the type system routes every caller through the one fixed core. The "send an HTTP request" capability is no longer tied to the AWS SDK context; AWS becomes one consumer of a generic transport rather than its sole gateway.

This is the enabling change for the GitHub provider's REST calls (`PUT /orgs/{org}/actions/secrets/{name}`, etc.), chosen over having the GitHub provider hand-build `aws-smithy` `HttpRequest`/`SdkBody` (which would couple a non-AWS provider to smithy types and let each future non-AWS provider re-discover the wasi:http framing pitfalls).

## Test plan

- [x] `cargo check/clippy -p carina-plugin-sdk --target wasm32-wasip2` — green
- [x] `cargo check/clippy -p carina-plugin-sdk -p carina-plugin-host` (host) — green
- [x] `cargo nextest run -p carina-plugin-sdk -p carina-plugin-host` — 110 passed
- [x] `cargo test -p carina-plugin-sdk --doc` — green
- [x] 1 adversarial review confirming the three wasi:http fixes are intact and the AWS SDK path is behavior-identical
- [ ] CI green on this PR

The AWS SDK path is exercised by existing tests / real AWS runs; `send_request`'s first real consumer is the GitHub provider (carina#3342), landing next.

Refs carina-rs/carina#3342.
