### PR TITLE
fix(cli): restore tree gutter on List<Struct> continuation rows (carina#3356)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ plan-fixtures:
 	@echo ""
 	@echo "=== destroy_orphans ==="
 	@$(MAKE) plan-destroy-orphans
+	@echo "---"
+	@$(MAKE) plan-destroy-list-struct-child-gutter
 	@echo ""
 	@echo "=== read_only_attrs ==="
 	@$(MAKE) plan-read-only-attrs
@@ -186,6 +188,10 @@ plan-fixtures:
 	@echo "---"
 	@$(MAKE) plan-policy-pretty-dynamic-key-list
 	@echo "---"
+	@$(MAKE) plan-list-struct-child-gutter
+	@echo "---"
+	@$(MAKE) plan-list-diff-added-struct-child-gutter
+	@echo "---"
 	@$(MAKE) plan-pretty-long-string-list
 	@echo "---"
 	@$(MAKE) plan-pretty-short-string-list
@@ -226,6 +232,12 @@ plan-policy-pretty-nested:
 	$(PLAN_FIXTURE) policy_pretty_nested
 plan-policy-pretty-dynamic-key-list:
 	$(PLAN_FIXTURE) policy_pretty_dynamic_key_list
+plan-list-struct-child-gutter:
+	$(PLAN_FIXTURE) list_struct_child_gutter
+plan-list-diff-added-struct-child-gutter:
+	$(PLAN_FIXTURE) list_diff_added_struct_child_gutter
+plan-destroy-list-struct-child-gutter:
+	$(PLAN_FIXTURE) destroy_list_struct_child_gutter --destroy
 plan-pretty-long-string-list:
 	$(PLAN_FIXTURE) pretty_long_string_list
 plan-pretty-short-string-list:
@@ -251,6 +263,8 @@ plan-multi-instance-module:
         plan-upstream-state-map-subscript plan-upstream-state-map-dot-notation \
         plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
         plan-policy-pretty-nested plan-policy-pretty-dynamic-key-list \
+        plan-list-struct-child-gutter plan-list-diff-added-struct-child-gutter \
+        plan-destroy-list-struct-child-gutter \
         plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
         plan-module-anonymous-resource plan-server-default-struct-leaf \
         plan-multi-instance-create plan-multi-instance-module \

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1241,6 +1241,64 @@ fn strike_lines(rendered: &str) -> String {
     out
 }
 
+/// Re-apply the tree gutter to every continuation line of a rendered,
+/// multi-line attribute-value block.
+///
+/// `format_value_pretty` lays out a vertical value (list-of-struct,
+/// list-of-scalars, expanded map) with its continuation lines indented by
+/// **plain spaces** sized to the parent attribute's column width. The
+/// caller emits `<attr_prefix><key>: <block>` and the `attr_prefix` —
+/// which carries the `│` tree glyph for a nested resource — lands only on
+/// the first physical row. Every continuation row then floats at the same
+/// column but without the `│`, detaching the value from the tree until the
+/// next sibling row snaps the gutter back (#3356). This is the CLI
+/// analogue of the continuation-row gutter loss #2523 fixed for the TUI
+/// (`carina-tui`); the same value-block class reaches the CLI renderer via
+/// the list-expansion path, so #2523's TUI-side fix does not cover it.
+///
+/// The fix is to swap the first `attr_prefix` columns of leading
+/// whitespace on each continuation line for `attr_prefix` itself, so the
+/// gutter glyph is restored at its column while the value-relative indent
+/// past it is preserved. Lines shorter than the gutter (the blank
+/// inter-element separators injected for #2555) collapse to the bare
+/// gutter with no trailing padding, matching how the tree draws its own
+/// `│`-only continuation lines.
+///
+/// Only continuation lines are touched; line 0 is returned verbatim
+/// because the caller emits `attr_prefix` (or the diff `+ {` opener) ahead
+/// of it directly. Leading whitespace is plain (the per-line colorizers
+/// keep the indent unstyled), so splitting on the first column boundary
+/// never lands inside an ANSI escape.
+fn reindent_with_gutter(block: &str, attr_prefix: &str) -> String {
+    if !block.contains('\n') {
+        return block.to_string();
+    }
+    let gutter_cols = attr_prefix.chars().count();
+    let mut out = String::with_capacity(block.len() + attr_prefix.len());
+    for (i, line) in block.split('\n').enumerate() {
+        if i == 0 {
+            out.push_str(line);
+            continue;
+        }
+        out.push('\n');
+        // Drop the first `gutter_cols` leading spaces (always plain ASCII
+        // spaces from `format_value_pretty`'s indenters), then keep
+        // whatever indentation/content follows that column. ASCII spaces
+        // are 1 byte each, so the column count is the byte count.
+        let leading_spaces = line.bytes().take_while(|&b| b == b' ').count();
+        let drop = leading_spaces.min(gutter_cols);
+        let rest = &line[drop..];
+        if rest.is_empty() {
+            // Blank separator line: emit the bare gutter, no trailing pad.
+            out.push_str(attr_prefix.trim_end());
+        } else {
+            out.push_str(attr_prefix);
+            out.push_str(rest);
+        }
+    }
+    out
+}
+
 /// Apply type-based coloring to a value, with dimmed modifier for default values.
 fn colored_value_dimmed(rendered: &str) -> String {
     // List: color each element individually
@@ -1327,6 +1385,7 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
                 Effect::Delete { .. } => strike_lines(&pretty),
                 _ => colored_value(&pretty, false),
             };
+            let cv = reindent_with_gutter(&cv, attr_prefix);
             writeln!(out, "{}{}: {}", attr_prefix, key, cv).unwrap();
         }
         DetailRow::MapExpanded { key, entries } => {
@@ -1338,9 +1397,10 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
                 // before the next sibling key so the list boundary stays
                 // visible — the `*` marker disambiguates element starts
                 // but not element ends (#2555). The blank only fires
-                // when a sibling actually follows.
+                // when a sibling actually follows. It carries the bare
+                // gutter so the tree bar stays continuous (#3356).
                 if prev_needs_separator {
-                    writeln!(out).unwrap();
+                    writeln!(out, "{}", attr_prefix.trim_end()).unwrap();
                 }
                 prev_needs_separator = carina_core::value::needs_trailing_separator(&entry.value);
                 let layout = carina_core::value::PrettyLayout {
@@ -1352,6 +1412,7 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
                     Effect::Delete { .. } => strike_lines(&pretty),
                     _ => colored_value(&pretty, false),
                 };
+                let cv = reindent_with_gutter(&cv, attr_prefix);
                 if let Some(ann) = &entry.annotation {
                     writeln!(
                         out,
@@ -1793,16 +1854,19 @@ fn render_added_removed_block(
     // Fields render at `attr_prefix.cols + 6`: 2 leading spaces, "+ {" is 3
     // chars, then 1 more for the inner `  ` padding before the key — same
     // column the modified-with-nested branch above uses for its
-    // `Unchanged` arm at `{attr_prefix}      `.
+    // `Unchanged` arm at `{attr_prefix}      `. The indent carries
+    // `attr_prefix` (not bare spaces) so a nested resource's `│` gutter is
+    // drawn on every field row, not dropped (#3356).
     let field_indent_cols = attr_prefix.chars().count() + 6;
-    let field_indent = " ".repeat(field_indent_cols);
+    let field_indent = format!("{}      ", attr_prefix);
     let mut prev_needs_separator = false;
     for (key, value) in &item.fields {
         // Mirror `format_map_vertical` / `MapExpanded`: a multi-element
         // list-of-maps child needs a blank line before the next sibling
-        // key so the boundary stays visible (#2555).
+        // key so the boundary stays visible (#2555). The blank still
+        // carries the bare gutter so the tree bar stays continuous.
         if prev_needs_separator {
-            writeln!(out).unwrap();
+            writeln!(out, "{}", attr_prefix.trim_end()).unwrap();
         }
         prev_needs_separator = carina_core::value::needs_trailing_separator(value);
         let layout = carina_core::value::PrettyLayout {
@@ -1814,6 +1878,7 @@ fn render_added_removed_block(
             ListOfMapsDiffItemKind::Added => colored_value(&pretty, false),
             ListOfMapsDiffItemKind::Removed => strike_lines(&pretty),
         };
+        let cv = reindent_with_gutter(&cv, attr_prefix);
         writeln!(out, "{}{}: {}", field_indent, key, cv).unwrap();
     }
     writeln!(out, "{}    }}", attr_prefix).unwrap();

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1701,3 +1701,54 @@ fn test_composition_header_drops_parens_for_none_source_path() {
     let header = strip_ansi(&format_composition_header("r", None));
     assert_eq!(header, r#"+ module "r""#);
 }
+
+/// carina#3356: `reindent_with_gutter` restores the tree gutter on every
+/// continuation line of a multi-line value block. The caller emits
+/// `attr_prefix` ahead of line 0, so line 0 is returned verbatim; each
+/// later line's leading `attr_prefix`-width spaces are swapped for the
+/// gutter string, preserving the value-relative indent past the gutter.
+#[test]
+fn test_reindent_with_gutter_restores_gutter_on_continuation_lines() {
+    // attr_prefix is 8 columns wide: 5 spaces, `│`, 2 spaces.
+    let attr_prefix = "     │  ";
+    // `format_value_pretty`-style block: line 0 bare (caller prepends the
+    // prefix), continuation lines indented with plain spaces sized to the
+    // gutter width + value indent. The `*`-marked element key sits 2 cols
+    // past the gutter; the sibling continuation key aligns 2 further in.
+    let block = "\n          * action: \"x\"\n            effect: \"y\"";
+    let out = reindent_with_gutter(block, attr_prefix);
+    assert_eq!(
+        out,
+        "\n     │    * action: \"x\"\n     │      effect: \"y\"",
+    );
+}
+
+/// A blank inter-element separator (empty line) collapses to the bare
+/// gutter with no trailing padding, matching the tree's own `│`-only
+/// continuation lines (and avoiding trailing-whitespace noise).
+#[test]
+fn test_reindent_with_gutter_blank_line_becomes_bare_gutter() {
+    let attr_prefix = "     │  ";
+    let block = "\n          * a: \"x\"\n\n          * b: \"y\"";
+    let out = reindent_with_gutter(block, attr_prefix);
+    assert_eq!(out, "\n     │    * a: \"x\"\n     │\n     │    * b: \"y\"",);
+}
+
+/// A single-line value has no continuation rows, so it is returned
+/// unchanged — the caller's `attr_prefix` on line 0 already suffices.
+#[test]
+fn test_reindent_with_gutter_single_line_unchanged() {
+    assert_eq!(reindent_with_gutter("\"scalar\"", "     │  "), "\"scalar\"");
+}
+
+/// For a root resource the gutter is pure spaces, so reindenting is a
+/// no-op (leading spaces swapped for an equal-width run of spaces) and a
+/// blank separator trims back to empty — existing root-level snapshots
+/// must stay byte-identical.
+#[test]
+fn test_reindent_with_gutter_no_gutter_is_noop() {
+    let attr_prefix = "      "; // 6 spaces, no `│`
+    let block = "\n        * a: \"x\"\n\n        * b: \"y\"";
+    let out = reindent_with_gutter(block, attr_prefix);
+    assert_eq!(out, block);
+}

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -261,6 +261,32 @@ fn snapshot_policy_pretty_nested() {
     insta::assert_snapshot!(output);
 }
 
+/// carina#3356: a `List<Struct>` attribute on a resource that is a
+/// *dependent child* in the plan tree. Its attribute rows carry the `│`
+/// tree gutter, and every physical row of the multi-line list value
+/// (each `* ...` element and its nested lines) must inherit that gutter
+/// and indent — not just the first row. Pre-fix the list body floated
+/// outside the tree at a shallower indent with no `│` until rendering
+/// snapped back to the gutter on the next scalar attribute. This is the
+/// CLI analogue of #2523 (which was TUI-only) for the list-expansion
+/// path.
+#[test]
+fn snapshot_list_struct_child_gutter() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("list_struct_child_gutter");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        None,
+    ));
+    insta::assert_snapshot!(output);
+}
+
 #[test]
 fn snapshot_policy_pretty_dynamic_key_list() {
     // #2528 acceptance: an IAM trust-policy `condition.<op>.<context-key>:
@@ -569,6 +595,30 @@ fn snapshot_destroy_full() {
     use carina_core::resource::Value;
     let (plan, current_states, _schemas, _moved) =
         build_plan_and_states_from_fixture("destroy_full");
+    let delete_attributes: HashMap<ResourceId, HashMap<String, Value>> = current_states
+        .into_iter()
+        .filter(|(_, state)| state.exists)
+        .map(|(id, state)| (id, state.attributes))
+        .collect();
+    let output = strip_ansi(&format_destroy_plan(
+        &plan,
+        DetailLevel::Full,
+        &delete_attributes,
+    ));
+    insta::assert_snapshot!(output);
+}
+
+/// carina#3356 (destroy-path counterpart of `snapshot_list_struct_child_gutter`):
+/// a destroy plan whose non-last child carries a struck-through
+/// `List<Struct>` value. Every physical row of the struck value must keep
+/// the `│` tree gutter (the `strike_lines` + `reindent_with_gutter`
+/// branch), and the strikethrough must not bleed across the gutter
+/// (cf. #3115).
+#[test]
+fn snapshot_destroy_list_struct_child_gutter() {
+    use carina_core::resource::Value;
+    let (plan, current_states, _schemas, _moved) =
+        build_plan_and_states_from_fixture("destroy_list_struct_child_gutter");
     let delete_attributes: HashMap<ResourceId, HashMap<String, Value>> = current_states
         .into_iter()
         .filter(|(_, state)| state.exists)
@@ -1299,6 +1349,30 @@ fn snapshot_list_diff_added_struct() {
         "added struct element should not render as a single very wide line; got: {}",
         output
     );
+    insta::assert_snapshot!(output);
+}
+
+/// carina#3356 (diff-path counterpart of `snapshot_list_struct_child_gutter`):
+/// a `~` update that adds a struct element to a `List<Struct>` on a
+/// resource nested as a non-last child in the tree. The added-element
+/// `+ { ... }` block and every field row inside it must carry the `│`
+/// tree gutter, not bare-space indentation. Pre-fix
+/// `render_added_removed_block` laid the field rows out with plain
+/// spaces, so the diff block floated outside the tree under a gutter.
+#[test]
+fn snapshot_list_diff_added_struct_child_gutter() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("list_diff_added_struct_child_gutter");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        None,
+    ));
     insta::assert_snapshot!(output);
 }
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_destroy_list_struct_child_gutter.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_destroy_list_struct_child_gutter.snap
@@ -1,0 +1,26 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Destroy Plan:
+
+  - awscc.iam.Role role
+      assume_role_policy_document: "{}"
+      role_name: "test-role"
+        │
+        ├─ - awscc.iam.RolePolicy policy
+        │     policy_name: "test-inline"
+        │     role_name: "test-role"
+        │     statement: 
+        │       * action: "s3:GetObject"
+        │         effect: "Allow"
+        │         resource: "arn:aws:s3:::example/*"
+        │         sid: "AllowS3Read"
+        │
+        │       * action: "s3:PutObject"
+        │         effect: "Deny"
+        │         resource: "arn:aws:s3:::example/*"
+        │         sid: "DenyS3Write"
+        │
+        └─ - awscc.s3.Bucket zzz_bucket
+              bucket_name: "zzz-trailing-sibling"

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_added_struct_child_gutter.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_added_struct_child_gutter.snap
@@ -1,0 +1,30 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.iam.Role role
+      assume_role_policy_document: "{}"
+      role_name: "test-role"
+        │
+        ├─ ~ awscc.iam.RolePolicy policy
+        │     statement:
+        │         {action: "s3:GetObject", effect: "Allow", resource: "arn:aws:s3:::example/*", sid: "AllowS3Read"}
+        │       + {
+        │           action: [
+        │             "cloudformation:CancelResourceRequest",
+        │             "cloudformation:CreateResource",
+        │             "cloudformation:DeleteResource",
+        │             "cloudformation:GetResource",
+        │           ]
+        │           effect: "Allow"
+        │           resource: ["*"]
+        │           sid: "CloudControl"
+        │         }
+        │     # (2 unchanged attributes hidden)
+        │
+        └─ + awscc.s3.Bucket 
+              bucket_name: "zzz-trailing-sibling"
+
+Plan: 2 to add, 1 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_struct_child_gutter.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_struct_child_gutter.snap
@@ -1,0 +1,28 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.iam.Role role
+      assume_role_policy_document: "{}"
+      role_name: "test-role"
+        │
+        ├─ + awscc.iam.RolePolicy 
+        │     policy_name: "test-inline"
+        │     role_name: "test-role"
+        │     statement: 
+        │       * action: "s3:GetObject"
+        │         effect: "Allow"
+        │         resource: "arn:aws:s3:::example/*"
+        │         sid: "AllowS3Read"
+        │
+        │       * action: "s3:PutObject"
+        │         effect: "Deny"
+        │         resource: "arn:aws:s3:::example/*"
+        │         sid: "DenyS3Write"
+        │
+        └─ + awscc.s3.Bucket 
+              bucket_name: "zzz-trailing-sibling"
+
+Plan: 3 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/destroy_list_struct_child_gutter/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/destroy_list_struct_child_gutter/carina.state.json
@@ -1,0 +1,106 @@
+{
+  "version": 7,
+  "serial": 1,
+  "lineage": "test-lineage-destroy-list-struct-child-gutter",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.Role",
+      "name": "role",
+      "provider": "awscc",
+      "identifier": "test-role",
+      "attributes": {
+        "role_name": "test-role",
+        "assume_role_policy_document": "{}"
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "role",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "role_name": {
+            "kind": "leaf"
+          },
+          "assume_role_policy_document": {
+            "kind": "leaf"
+          }
+        }
+      }
+    },
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowS3Read",
+            "effect": "Allow",
+            "action": "s3:GetObject",
+            "resource": "arn:aws:s3:::example/*"
+          },
+          {
+            "sid": "DenyS3Write",
+            "effect": "Deny",
+            "action": "s3:PutObject",
+            "resource": "arn:aws:s3:::example/*"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "policy",
+      "dependency_bindings": [
+        "role"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
+    },
+    {
+      "resource_type": "s3.Bucket",
+      "name": "zzz_bucket",
+      "provider": "awscc",
+      "identifier": "zzz-trailing-sibling",
+      "attributes": {
+        "bucket_name": "zzz-trailing-sibling"
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "zzz_bucket",
+      "dependency_bindings": [
+        "role"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "bucket_name": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/destroy_list_struct_child_gutter/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/destroy_list_struct_child_gutter/main.crn
@@ -1,0 +1,12 @@
+# Destroy-path counterpart to `list_struct_child_gutter` for carina#3356.
+# Empty config (provider only) against a state holding a parent Role with
+# two dependent children. The RolePolicy carries a `List<Struct>`
+# `statement` attribute and sorts before the trailing Bucket, so on the
+# destroy plan it renders as a non-last child drawing the `│` gutter. Its
+# struck-through multi-line value must keep the gutter on every physical
+# row — the `strike_lines` + `reindent_with_gutter` Delete branch, which
+# must not bleed the strikethrough across the gutter (cf. #3115).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_added_struct_child_gutter/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_added_struct_child_gutter/carina.state.json
@@ -1,0 +1,46 @@
+{
+  "version": 7,
+  "serial": 1,
+  "lineage": "test-lineage-list-diff-added-struct-child-gutter",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowS3Read",
+            "effect": "Allow",
+            "action": "s3:GetObject",
+            "resource": "arn:aws:s3:::example/*"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "policy",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_added_struct_child_gutter/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_added_struct_child_gutter/main.crn
@@ -1,0 +1,55 @@
+# Diff-path counterpart to `list_struct_child_gutter` for carina#3356.
+# A `~` update that *adds* a struct element to a `List<Struct>` attribute,
+# on a resource that is a non-last dependent child in the plan tree. The
+# added-element block (`+ { ... }`) and its fields must carry the `│` tree
+# gutter on every physical row — the same continuation-row gutter that the
+# create path (`PrettyAttribute`) needed. Before the fix the field rows
+# used bare-space indentation (`render_added_removed_block`) and floated
+# outside the tree.
+#
+# `role` is the parent; the RolePolicy (the diff target) and a trailing
+# Bucket both order after it, so the RolePolicy is a non-last child and
+# draws the gutter. State carries one statement; the DSL adds a second.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let role = awscc.iam.Role {
+  role_name                   = 'test-role'
+  assume_role_policy_document = '{}'
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid      = 'AllowS3Read'
+      effect   = 'Allow'
+      action   = 's3:GetObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+    {
+      sid    = 'CloudControl'
+      effect = 'Allow'
+      action = [
+        'cloudformation:CancelResourceRequest',
+        'cloudformation:CreateResource',
+        'cloudformation:DeleteResource',
+        'cloudformation:GetResource',
+      ]
+      resource = ['*']
+    },
+  ]
+  directives { depends_on = [role] }
+}
+
+awscc.s3.Bucket {
+  bucket_name = 'zzz-trailing-sibling'
+  directives { depends_on = [role] }
+}
+
+exports {
+  policy_name = policy.policy_name
+}

--- a/carina-cli/tests/fixtures/plan_display/list_struct_child_gutter/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_struct_child_gutter/main.crn
@@ -1,0 +1,46 @@
+# Plan-display fixture for carina#3356: a `List<Struct>` attribute on a
+# resource that is a *non-last dependent child* in the plan tree, so its
+# attribute rows carry the `│` tree gutter (a trailing sibling keeps the
+# vertical bar drawn). Every physical row of the multi-line list value
+# (each `* ...` element and its nested lines) must inherit the same `│`
+# gutter + indent as the first row. Before the fix the list body floated
+# outside the tree at a shallower indent with no `│` until rendering
+# snapped back on the next scalar attribute / sibling.
+#
+# `role` is the parent; both the RolePolicy and a trailing Bucket declare
+# an explicit ordering edge to it. The RolePolicy renders first (sorted
+# before the Bucket), so it is a non-last child and draws the `│` gutter.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let role = awscc.iam.Role {
+  role_name                   = 'test-role'
+  assume_role_policy_document = '{}'
+}
+
+awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid      = 'AllowS3Read'
+      effect   = 'Allow'
+      action   = 's3:GetObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+    {
+      sid      = 'DenyS3Write'
+      effect   = 'Deny'
+      action   = 's3:PutObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+  ]
+  directives { depends_on = [role] }
+}
+
+awscc.s3.Bucket {
+  bucket_name = 'zzz-trailing-sibling'
+  directives { depends_on = [role] }
+}


### PR DESCRIPTION
## Summary

Fixes carina#3356: in the CLI `carina plan` Execution Plan, a multi-line
`List<Struct>` attribute value (also expanded maps and list-of-scalars)
lost its `│` tree gutter and indent on every continuation row when the
resource was a **nested tree child**. The list body floated outside the
tree at a shallower indent with no `│`, snapping back only on the next
scalar attribute.

### Before (nested child, `│` lost on the list body)

```
        ├─ + awscc.iam.RolePolicy
        │     statement:
                * action: "s3:GetObject"     ← no │, shallower indent
                  effect: "Allow"            ← no │
        │     scope: ...                      ← snaps back
```

### After

```
        ├─ + awscc.iam.RolePolicy
        │     statement:
        │       * action: "s3:GetObject"
        │         effect: "Allow"
```

## Root cause

`carina_core::value::format_value_pretty` indents the continuation lines
of a multi-line value block with **plain spaces**. The CLI renderer
prepended `attr_prefix` (the gutter string, which carries the `│` glyph
for a nested resource) to only the **first** physical row, so every
continuation row dropped the gutter.

## Fix

A single helper `reindent_with_gutter(block, attr_prefix)` swaps the
leading gutter-width spaces of each continuation line for `attr_prefix`
itself — restoring the `│` at its column while preserving the
value-relative indent. Blank inter-element separators (#2555) collapse to
the bare gutter.

It is applied at the three — and only three — sites that defer
pretty-rendering of a raw `Value` under a gutter prefix:
`DetailRow::PrettyAttribute`, `DetailRow::MapExpanded`, and
`render_added_removed_block` (the list-of-maps diff `+`/`-` path). Every
other diff renderer already pre-stringifies to single-line in
`carina-core` or recurses with an explicit per-line prefix, so this is the
single upstream seam for the whole class — not a per-symptom carve-out.

This is the CLI analogue of the continuation-row gutter loss #2523 fixed
for the TUI; the same value-block class reaches the CLI renderer via the
list-expansion path, so #2523's TUI-side fix does not cover it.

## Tests

Three non-last-child fixtures + snapshots cover all three rendering paths,
plus unit tests for the helper:

- `list_struct_child_gutter` — create path (`PrettyAttribute`)
- `list_diff_added_struct_child_gutter` — diff path (`render_added_removed_block`)
- `destroy_list_struct_child_gutter` — destroy/strikethrough path

Each fixture has a trailing sibling so the target renders as a non-last
child (`├─`), guaranteeing a real `│` gutter is drawn (the bug is invisible
for last children / root resources where `attr_prefix` is all spaces).

Verify: `cargo nextest run -p carina-cli` (558 pass), `cargo clippy -p
carina-cli --all-targets -- -D warnings`, `cargo test -p carina-cli
--doc`, and all `scripts/check-*.sh` green.

Closes #3356

🤖 Generated with [Claude Code](https://claude.com/claude-code)