### PR TITLE
fix(plan): elide an already-satisfied wait whose target is unchanged (carina#3358)

### DIFF
--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -512,6 +512,40 @@ pub fn create_plan(
             .or(schema_timeout)
             .unwrap_or(WAIT_DEFAULT_TIMEOUT);
         let interval = schema_interval.unwrap_or(WAIT_DEFAULT_INTERVAL);
+        // A gated wait is still elided when it has no work to do.
+        // carina#3101 covers "no consumer is changing ⇒ the wait gates
+        // nothing ⇒ elide". carina#3358 extends that: even when a
+        // consumer *is* changing (so `gates_a_pending_change` is true),
+        // an unchanged target whose cached state already satisfies the
+        // `until` predicate gives the wait nothing to do — on `apply` it
+        // would poll-and-return immediately. Dragging such a wait into
+        // the plan is pure noise (a `> <binding> (until …)` node with no
+        // pending work), so suppress it. The wait *does* have work when:
+        //   1. the target has no resolved identifier at plan time
+        //      (`ResolvedAtApply`; typically created this run) — its
+        //      post-apply attributes are unknown, must poll;
+        //   2. the target has a mutating effect in this plan — cached
+        //      attributes are stale, must re-poll; or
+        //   3. the target is unchanged but its cached state does not yet
+        //      satisfy the predicate (missing state ⇒ treat as work).
+        let wait_has_work = match &target {
+            WaitTarget::ResolvedAtApply => true,
+            WaitTarget::Known(_) => {
+                let target_is_mutating = plan
+                    .effects()
+                    .iter()
+                    .any(|e| e.resource_id() == &target_id && e.is_mutating());
+                let target_needs_wait = current_states
+                    .get(&target_id)
+                    .map(|s| !until.evaluate(&s.attributes))
+                    .unwrap_or(true);
+
+                target_is_mutating || target_needs_wait
+            }
+        };
+        if !wait_has_work {
+            continue;
+        }
         plan.add(Effect::Wait {
             // Lower BindingName -> String at the AST→Effect seam: the
             // executor IR (Effect) is string-keyed and is the separate

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1478,3 +1478,220 @@ fn wait_emitted_when_a_consumer_has_a_pending_change() {
         plan.effects()
     );
 }
+
+/// carina#3358: an already-satisfied wait whose target is unchanged must
+/// be elided even when a consumer has a pending change that merely
+/// *references* the wait. The wait has no work to do — on `apply` its
+/// `until` predicate is already true, so it would poll-and-return
+/// immediately, contributing nothing. Mirrors the registry-dev stack:
+/// cert (unchanged, already ISSUED) + a changed distribution that wires
+/// in `web_acl_id` while still referencing `cert_issued`.
+#[test]
+fn wait_omitted_when_already_satisfied_and_target_unchanged() {
+    use crate::effect::Effect;
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+
+    // cert: exists with status == ISSUED and is unchanged (desired
+    // matches state) → NoChange, no mutating effect on the target.
+    let cert = Resource::new("acm.Certificate", "cert")
+        .with_binding("cert")
+        .with_attribute(
+            "status",
+            Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        );
+    // dist is new (absent from current_states) → Create → mutating.
+    // It references the wait binding, so the wait "gates a pending change".
+    let mut dist = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    dist.dependency_bindings.insert("cert_issued".to_string());
+    let resources = vec![cert, dist];
+
+    let mut cert_state_attrs = HashMap::new();
+    cert_state_attrs.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+    );
+    let mut current_states = HashMap::new();
+    current_states.insert(
+        ResourceId::new("acm.Certificate", "cert"),
+        State::existing(ResourceId::new("acm.Certificate", "cert"), cert_state_attrs)
+            .with_identifier("arn:aws:acm:::certificate/abc"),
+    );
+
+    let wait = WaitBinding {
+        binding: "cert_issued".into(),
+        target: "cert".into(),
+        until_raw: "cert.status == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        },
+        timeout_secs: Some(60),
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &[],
+        &current_states,
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+
+    assert!(
+        !plan
+            .effects()
+            .iter()
+            .any(|e| matches!(e, Effect::Wait { .. })),
+        "carina#3358: an already-satisfied wait whose target is unchanged \
+         must be elided even when a consumer has a pending change that \
+         merely references it; effects were {:?}",
+        plan.effects()
+    );
+}
+
+/// carina#3358 counterpart: when the wait's target *is* changing in the
+/// same plan, the cached state is stale — its post-apply attributes are
+/// unknown, so the wait must still be emitted to re-poll on `apply`.
+/// Here the target is new (`WaitTarget::ResolvedAtApply`).
+#[test]
+fn wait_emitted_when_target_is_changing_even_if_cached_state_satisfies() {
+    use crate::effect::Effect;
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+
+    // cert is new (absent from current_states) → Create → mutating
+    // target. Even though no cached state exists, the wait must poll
+    // post-apply.
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
+    let mut dist = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    dist.dependency_bindings.insert("cert_issued".to_string());
+    let resources = vec![cert, dist];
+
+    let wait = WaitBinding {
+        binding: "cert_issued".into(),
+        target: "cert".into(),
+        until_raw: "cert.status == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        },
+        timeout_secs: Some(60),
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &[],
+        &HashMap::new(),
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+
+    assert!(
+        plan.effects()
+            .iter()
+            .any(|e| matches!(e, Effect::Wait { binding, .. } if binding == "cert_issued")),
+        "carina#3358: the wait must still be emitted when its target is \
+         changing in this plan (cached state is stale); effects were {:?}",
+        plan.effects()
+    );
+}
+
+/// carina#3358: pins the `WaitTarget::Known` + `target_is_mutating`
+/// branch of `wait_has_work`. An *existing* target (resolved identifier
+/// in state → `Known`) whose cached state already satisfies the
+/// predicate, but which has a pending `Update` in this plan, must still
+/// emit the wait: the cached `ISSUED` is stale relative to the
+/// about-to-apply change, so the executor must re-poll. Without this
+/// test the `target_is_mutating ||` half of the gate is dead under the
+/// suite and could be silently dropped, re-introducing the bug for
+/// changing-but-Known targets.
+#[test]
+fn wait_emitted_when_known_target_has_pending_update_even_if_cached_state_satisfies() {
+    use crate::effect::Effect;
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+
+    // cert EXISTS in state with an identifier (→ WaitTarget::Known) and
+    // its cached `status` already satisfies the predicate, BUT it has a
+    // pending Update (desired `domain_name` differs from state).
+    let cert = Resource::new("acm.Certificate", "cert")
+        .with_binding("cert")
+        .with_attribute(
+            "domain_name",
+            Value::Concrete(ConcreteValue::String("new.example.com".to_string())),
+        );
+    let mut dist = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    dist.dependency_bindings.insert("cert_issued".to_string());
+    let resources = vec![cert, dist];
+
+    let mut cert_state_attrs = HashMap::new();
+    cert_state_attrs.insert(
+        "status".to_string(),
+        Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+    );
+    cert_state_attrs.insert(
+        "domain_name".to_string(),
+        Value::Concrete(ConcreteValue::String("old.example.com".to_string())),
+    );
+    let mut current_states = HashMap::new();
+    current_states.insert(
+        ResourceId::new("acm.Certificate", "cert"),
+        State::existing(ResourceId::new("acm.Certificate", "cert"), cert_state_attrs)
+            .with_identifier("arn:aws:acm:::certificate/abc"),
+    );
+
+    let wait = WaitBinding {
+        binding: "cert_issued".into(),
+        target: "cert".into(),
+        until_raw: "cert.status == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        },
+        timeout_secs: Some(60),
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &[],
+        &current_states,
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+
+    // Precondition: cert really has a pending Update (Known + mutating),
+    // so this hits the `target_is_mutating` arm — not `ResolvedAtApply`
+    // and not the `target_needs_wait` arm.
+    assert!(
+        plan.effects()
+            .iter()
+            .any(|e| matches!(e, Effect::Update { id, .. }
+            if id == &ResourceId::new("acm.Certificate", "cert"))),
+        "test precondition: cert must have a pending Update; effects were {:?}",
+        plan.effects()
+    );
+    assert!(
+        plan.effects()
+            .iter()
+            .any(|e| matches!(e, Effect::Wait { binding, .. } if binding == "cert_issued")),
+        "carina#3358: the wait must still be emitted when an existing \
+         (Known) target has a pending Update, even though its cached \
+         state satisfies the predicate; effects were {:?}",
+        plan.effects()
+    );
+}


### PR DESCRIPTION
Closes #3358

## Problem

`carina plan` rendered an `Effect::Wait` node in the plan tree even when the wait had **no work to do** — its `until` condition was already satisfied and its target was untouched — merely because a *consumer* of the wait had a pending change:

```
  + awscc.wafv2.WebAcl r.web_acl
        └─ ~ awscc.cloudfront.Distribution r.distribution
              distribution_config:
                ~ web_acl_id: "" → r.web_acl.arn
              └─ > r.cert_issued (until cert.status == aws.acm.Certificate.Status.issued)

Plan: 1 to add, 1 to change, 0 to destroy.
```

`r.cert_issued` waits on an ACM certificate that has been ISSUED for a long time. This plan touches neither the cert, the validation records, nor the wait — the wait is dragged in only because the changed Distribution references it. On `apply` it would poll-and-return immediately. It is pure noise the operator has to mentally discard.

## Fix

carina#3101 already elides a wait when no consumer is changing. This extends the **single** `Effect::Wait` emission seam in `create_plan` (`carina-core/src/differ/plan.rs`) with a second gate, `wait_has_work`, that runs after the existing `gates_a_pending_change` gate. Even when a consumer is changing, the wait is suppressed when its target is unchanged **and** the target's cached state already satisfies the `until` predicate.

The wait is still emitted when:

1. the target has no resolved identifier at plan time (`WaitTarget::ResolvedAtApply`; typically created this run) — post-apply attrs unknown, must poll;
2. the target has a mutating effect in this plan — cached attrs are stale, must re-poll; or
3. the target is unchanged but its cached state does not yet satisfy the predicate (missing state ⇒ treated as work).

## Why this is root-cause, not a per-site filter

The wait enters the plan at exactly one place. Gating it there means every downstream consumer — plan tree builder, `display`, TUI, executor — inherits the elision with no per-site filter to remember. Consumer value resolution (`cert_issued.arn`) is independent of `Effect::Wait` presence (it resolves through the wait-alias passthrough), so eliding the node does not affect apply correctness. `apply` re-runs `create_plan` under the lock against refreshed state, so a target that regressed out of ISSUED between plan and apply re-emits the wait.

## Tests (`carina-core/src/differ/plan_tests.rs`)

- `wait_omitted_when_already_satisfied_and_target_unchanged` — the #3358 repro (cert unchanged + ISSUED, distribution changed & referencing the wait ⇒ no `Effect::Wait`). Fails on `main`.
- `wait_emitted_when_target_is_changing_even_if_cached_state_satisfies` — target new (`ResolvedAtApply`) ⇒ wait still emitted.
- `wait_emitted_when_known_target_has_pending_update_even_if_cached_state_satisfies` — pins the `Known + target_is_mutating` branch (existing target with a pending `Update` whose cached state satisfies the predicate ⇒ wait still emitted).

Existing carina#3101 / #3085 invariants (`wait_omitted_when_all_consumers_unchanged`, `wait_emitted_when_a_consumer_has_a_pending_change`) remain green.

## Verify

- `cargo nextest run --workspace` — 3784 passed
- `cargo test --workspace --doc` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `bash scripts/check-*.sh` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)