### PR TITLE
fix(plan): resolve enum-form `until` predicate alias so already-satisfied waits are elided (carina#3358)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1203,6 +1203,19 @@ async fn run_apply_locked(
         .map(|sf| sf.build_directives())
         .unwrap_or_default();
     let schemas = ctx.schemas();
+    // carina#3358: canonicalize the `until` predicate RHS enum aliases
+    // before the differ lowers the wait into `Effect::Wait`, mirroring
+    // the plan path (`create_plan_from_parsed_with_upstream`). The apply
+    // path is a separate pipeline that calls `create_plan` directly, so
+    // it needs the same resolution or an enum-form `until` predicate
+    // would poll to timeout against the canonical state value.
+    let mut wait_bindings = parsed.wait_bindings.clone();
+    crate::wiring::resolve_enum_aliases_in_wait_bindings(
+        ctx,
+        &mut wait_bindings,
+        &resources_for_plan,
+        &data_sources_for_plan,
+    );
     let mut plan = create_plan(
         &resources_for_plan,
         &data_sources_for_plan,
@@ -1212,7 +1225,7 @@ async fn run_apply_locked(
         &saved_attrs,
         &prev_explicit,
         &orphan_dependencies,
-        &parsed.wait_bindings,
+        &wait_bindings,
     );
 
     // Populate cascading updates for create_before_destroy Replace effects.

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1189,12 +1189,18 @@ async fn run_apply_locked(
     carina_core::value::canonicalize_states_with_schemas(&mut current_states, ctx.schemas());
 
     // Run the normalization pipeline (same as plan path in wiring.rs).
+    // `prepare` also canonicalizes the wait `until` predicate enum
+    // aliases (carina#3358); the apply path is a separate pipeline that
+    // calls `create_plan` directly, so it relies on the same shared seam.
+    let mut wait_bindings = parsed.wait_bindings.clone();
     let preprocessor = crate::wiring::PlanPreprocessor::new(&provider, ctx);
     preprocessor
         .prepare(
             &mut resources_for_plan,
             &mut current_states,
             &parsed.providers,
+            &data_sources_for_plan,
+            &mut wait_bindings,
         )
         .await;
 
@@ -1203,19 +1209,6 @@ async fn run_apply_locked(
         .map(|sf| sf.build_directives())
         .unwrap_or_default();
     let schemas = ctx.schemas();
-    // carina#3358: canonicalize the `until` predicate RHS enum aliases
-    // before the differ lowers the wait into `Effect::Wait`, mirroring
-    // the plan path (`create_plan_from_parsed_with_upstream`). The apply
-    // path is a separate pipeline that calls `create_plan` directly, so
-    // it needs the same resolution or an enum-form `until` predicate
-    // would poll to timeout against the canonical state value.
-    let mut wait_bindings = parsed.wait_bindings.clone();
-    crate::wiring::resolve_enum_aliases_in_wait_bindings(
-        ctx,
-        &mut wait_bindings,
-        &resources_for_plan,
-        &data_sources_for_plan,
-    );
     let mut plan = create_plan(
         &resources_for_plan,
         &data_sources_for_plan,

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -256,6 +256,18 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &state_file,
     );
 
+    // carina#3358: resolve `until` predicate enum aliases before the
+    // differ lowers the wait, the same step the plan/apply pipelines run.
+    // The fixture harness uses an empty factory set so this is a no-op
+    // here, but keeping the sibling call consistent means a fixture that
+    // ever gains real factories cannot silently regress.
+    let mut wait_bindings = parsed.wait_bindings.clone();
+    crate::wiring::resolve_enum_aliases_in_wait_bindings(
+        &wiring,
+        &mut wait_bindings,
+        &resources,
+        &data_sources_for_plan,
+    );
     let mut plan = create_plan(
         &resources,
         &data_sources_for_plan,
@@ -265,7 +277,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &saved_attrs,
         &prev_explicit,
         &orphan_dependencies,
-        &parsed.wait_bindings,
+        &wait_bindings,
     );
 
     cascade_dependent_updates(

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -584,14 +584,24 @@ impl<'a> PlanPreprocessor<'a> {
         Self { normalizer, ctx }
     }
 
-    /// Run the full normalization pipeline on desired resources and current states.
+    /// Run the full normalization pipeline on desired resources, current
+    /// states, and `wait` predicates.
     ///
-    /// Call after `resolve_refs_with_state_and_remote()` and before `create_plan()`.
+    /// Call after `resolve_refs_with_state_and_remote()` and before
+    /// `create_plan()`. This is the single seam both the plan and apply
+    /// pipelines traverse, so the three enum-alias passes
+    /// (resources, states, and — carina#3358 — wait `until` predicates)
+    /// live here together: a `create_plan` caller that runs `prepare`
+    /// cannot canonicalize resources/states while silently skipping
+    /// waits. `wait_bindings` is mutated in place; pass the same slice
+    /// on to `create_plan`.
     pub async fn prepare(
         &self,
         resources: &mut [Resource],
         current_states: &mut HashMap<ResourceId, State>,
         provider_configs: &[ProviderConfig],
+        data_sources: &[carina_core::resource::DataSource],
+        wait_bindings: &mut [carina_core::parser::WaitBinding],
     ) {
         // RFC #2371 stage 2 + #2387: strip every attribute the WASM
         // provider boundary refuses to serialize — `Value::Deferred(DeferredValue::Unknown)`
@@ -624,6 +634,12 @@ impl<'a> PlanPreprocessor<'a> {
         }
         resolve_enum_aliases_with_ctx(self.ctx, resources);
         resolve_enum_aliases_in_states(self.ctx, current_states);
+        // carina#3358: the `until` predicate RHS is the third enum-alias
+        // axis. Resolve it here, beside the resource/state passes, so the
+        // shared seam keeps all three in lockstep. `resources` carry
+        // their real `id`/`binding` (stripping only touched attributes),
+        // so target lookup is valid at this point.
+        resolve_enum_aliases_in_wait_bindings(self.ctx, wait_bindings, resources, data_sources);
         restore_stripped_attributes(resources, stripped);
     }
 }
@@ -2068,10 +2084,18 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     carina_core::value::canonicalize_states_with_schemas(&mut current_states, ctx.schemas());
 
     // Run the normalization pipeline: normalize_desired → normalize_state →
-    // merge_default_tags → resolve_enum_aliases (order matters).
+    // merge_default_tags → resolve_enum_aliases (resources, states, and
+    // wait `until` predicates — carina#3358). Order matters.
+    let mut wait_bindings = parsed.wait_bindings.clone();
     let preprocessor = PlanPreprocessor::new(&provider, &ctx);
     preprocessor
-        .prepare(&mut resources, &mut current_states, &parsed.providers)
+        .prepare(
+            &mut resources,
+            &mut current_states,
+            &parsed.providers,
+            &data_sources_for_plan,
+            &mut wait_bindings,
+        )
         .await;
 
     // Build directives map from state file for orphaned resource deletion
@@ -2079,18 +2103,6 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         .as_ref()
         .map(|sf| sf.build_directives())
         .unwrap_or_default();
-    // carina#3358: canonicalize the `until` predicate RHS enum aliases
-    // before the differ lowers the wait into `Effect::Wait`, using the
-    // same resolver the resource/state passes use. Without this an
-    // enum-form predicate's raw DSL identifier never matches the
-    // AWS-canonical state value.
-    let mut wait_bindings = parsed.wait_bindings.clone();
-    resolve_enum_aliases_in_wait_bindings(
-        &ctx,
-        &mut wait_bindings,
-        &resources,
-        &data_sources_for_plan,
-    );
     let mut plan = create_plan(
         &resources,
         &data_sources_for_plan,

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -829,6 +829,73 @@ pub fn resolve_enum_aliases_in_states(
     }
 }
 
+/// Resolve enum-alias values in each `wait` binding's `until` predicate
+/// RHS to their canonical AWS form, mirroring [`resolve_enum_aliases_in_states`]
+/// for resources/states.
+///
+/// carina#3358: the parser lowers an enum-form predicate
+/// (`until = cert.status == aws.acm.Certificate.Status.Issued`) into a
+/// raw dotted-identifier string (`"aws.acm.Certificate.Status.Issued"`)
+/// — see `lower_until_rhs` in
+/// `carina-core/src/parser/expressions/wait_expr.rs`, whose comment
+/// promises "the differ resolves these to canonical AWS string values at
+/// plan time". Nothing did: the plan-path enum-alias pass canonicalized
+/// `resources` and `current_states` but never `wait_bindings`. So
+/// `WaitPredicate::evaluate` compared the raw DSL identifier against the
+/// AWS-canonical state value (`"ISSUED"`) and never matched — both in the
+/// plan-time elision gate (carina#3359) and in the executor's apply-time
+/// poll (`carina-core/src/executor/wait.rs`), which would poll to
+/// timeout. This closes that gap at the single seam by reusing the exact
+/// per-value resolver (`resolve_value_alias`) the resource/state passes
+/// use, so the `Effect::Wait.until.value` `create_plan` persists is
+/// canonical.
+///
+/// The predicate attribute is `lhs_segments[1]` (segment 0 is the target
+/// binding root). The target resource's `(provider, resource_type)` is
+/// recovered by matching `wb.target` against the already-resolved managed
+/// resources and data sources. Bindings whose target/attr/factory cannot
+/// be resolved are left unchanged (target validation lives in
+/// `carina_core::validation::wait`).
+pub(crate) fn resolve_enum_aliases_in_wait_bindings(
+    ctx: &WiringContext,
+    wait_bindings: &mut [carina_core::parser::WaitBinding],
+    resources: &[Resource],
+    data_sources: &[carina_core::resource::DataSource],
+) {
+    for wb in wait_bindings.iter_mut() {
+        let Some(attr_name) = wb.until_predicate.lhs_segments.get(1).cloned() else {
+            continue;
+        };
+        let target = wb.target.as_str();
+        // Recover the target's identity from the resolved sets that
+        // `create_plan` itself consumes, so provider/resource_type match
+        // what the differ sees.
+        let target_id = resources
+            .iter()
+            .find(|r| r.binding.as_deref() == Some(target))
+            .map(|r| &r.id)
+            .or_else(|| {
+                data_sources
+                    .iter()
+                    .find(|d| d.binding.as_deref() == Some(target))
+                    .map(|d| &d.id)
+            });
+        let Some(id) = target_id else { continue };
+        if id.provider.is_empty() {
+            continue;
+        }
+        let Some(factory) = provider_mod::find_factory(ctx.factories(), &id.provider) else {
+            continue;
+        };
+        carina_core::value::resolve_value_alias(
+            &mut wb.until_predicate.rhs,
+            &id.resource_type,
+            &attr_name,
+            factory,
+        );
+    }
+}
+
 pub fn check_unused_bindings<E: carina_core::parser::ExportParamLike>(
     parsed: &carina_core::parser::File<E>,
 ) -> Vec<String> {
@@ -2012,6 +2079,18 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         .as_ref()
         .map(|sf| sf.build_directives())
         .unwrap_or_default();
+    // carina#3358: canonicalize the `until` predicate RHS enum aliases
+    // before the differ lowers the wait into `Effect::Wait`, using the
+    // same resolver the resource/state passes use. Without this an
+    // enum-form predicate's raw DSL identifier never matches the
+    // AWS-canonical state value.
+    let mut wait_bindings = parsed.wait_bindings.clone();
+    resolve_enum_aliases_in_wait_bindings(
+        &ctx,
+        &mut wait_bindings,
+        &resources,
+        &data_sources_for_plan,
+    );
     let mut plan = create_plan(
         &resources,
         &data_sources_for_plan,
@@ -2021,7 +2100,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         &saved_attrs,
         &prev_explicit,
         &orphan_dependencies,
-        &parsed.wait_bindings,
+        &wait_bindings,
     );
 
     // Populate cascading updates for Replace effects with create_before_destroy.

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -2513,3 +2513,257 @@ mod kind_default_source_tests {
         assert_eq!(kind_default_source(&configs, "awscc"), None);
     }
 }
+
+/// carina#3358 (reopened after PR #3359): an enum-form `until` predicate
+/// must be resolved to the canonical AWS value before the differ lowers
+/// the wait into `Effect::Wait`, so an already-satisfied wait is elided.
+///
+/// PR #3359's gate calls `until.evaluate(&state.attributes)`. The parser
+/// lowers `until = cert.status == aws.acm.Certificate.Status.Issued` into
+/// the RAW dotted string `"aws.acm.Certificate.Status.Issued"`; the
+/// canonical state value is `"ISSUED"`. Unless the alias is resolved the
+/// two never compare equal, so the gate's `target_needs_wait` stays
+/// `true` and the no-op wait is emitted — the exact registry-dev repro.
+mod wait_until_enum_alias {
+    use super::super::*;
+    use carina_core::parser::{UntilPredicateAst, WaitBinding};
+    use carina_core::provider::{
+        BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
+    };
+    use carina_core::schema::{AttributeType, ResourceSchema};
+
+    /// Minimal aws-like factory that knows the ACM `status` enum alias
+    /// `Issued` -> `ISSUED` (`convert_enum_value("aws.acm.Certificate.Status.Issued")`
+    /// yields `"Issued"`, so that is the alias-map key). Everything else
+    /// is stubbed to the bare minimum the helper needs (it only consults
+    /// `get_enum_alias_reverse`).
+    struct AcmAliasFactory;
+
+    impl ProviderFactory for AcmAliasFactory {
+        fn name(&self) -> &str {
+            "aws"
+        }
+        fn display_name(&self) -> &str {
+            "AWS (carina#3358 enum-alias stub)"
+        }
+        fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+            HashMap::new()
+        }
+        fn validate_config(&self, _a: &IndexMap<String, Value>) -> Result<(), String> {
+            Ok(())
+        }
+        fn extract_region(&self, _a: &IndexMap<String, Value>) -> String {
+            "us-east-1".to_string()
+        }
+        fn create_provider(
+            &self,
+            _b: Option<&str>,
+            _a: &IndexMap<String, Value>,
+        ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+            Box::pin(async { Ok(Box::new(StubProvider) as Box<dyn Provider>) })
+        }
+        fn create_normalizer(
+            &self,
+            _b: Option<&str>,
+            _a: &IndexMap<String, Value>,
+        ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+            Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+        }
+        fn schemas(&self) -> Vec<ResourceSchema> {
+            vec![ResourceSchema::new("acm.Certificate")]
+        }
+        fn get_enum_alias_reverse(
+            &self,
+            resource_type: &str,
+            attr_name: &str,
+            value: &str,
+        ) -> Option<String> {
+            match (resource_type, attr_name, value) {
+                ("acm.Certificate", "status", "Issued") => Some("ISSUED".to_string()),
+                _ => None,
+            }
+        }
+    }
+
+    // The helper only consults `factory.get_enum_alias_reverse`; the
+    // provider is never instantiated. These methods exist only to
+    // satisfy the trait and are unreachable in these tests.
+    struct StubProvider;
+    impl Provider for StubProvider {
+        fn name(&self) -> &str {
+            "aws"
+        }
+        fn read(
+            &self,
+            id: &ResourceId,
+            _i: Option<&str>,
+            _r: carina_core::provider::ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::not_found(id)) })
+        }
+        fn read_data_source(
+            &self,
+            r: &carina_core::resource::DataSource,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = r.id.clone();
+            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        }
+        fn create(
+            &self,
+            id: &ResourceId,
+            _r: carina_core::provider::CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        }
+        fn update(
+            &self,
+            id: &ResourceId,
+            _i: &str,
+            _r: carina_core::provider::UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        }
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _i: &str,
+            _r: carina_core::provider::DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async move { Ok(()) })
+        }
+    }
+
+    fn enum_wait_binding() -> WaitBinding {
+        WaitBinding {
+            binding: "cert_issued".into(),
+            target: "cert".into(),
+            until_raw: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
+            until_predicate: UntilPredicateAst {
+                lhs_segments: vec!["cert".to_string(), "status".to_string()],
+                // Exactly what `lower_until_rhs` produces for the enum form:
+                // the raw dotted identifier, NOT the canonical value.
+                rhs: Value::Concrete(ConcreteValue::String(
+                    "aws.acm.Certificate.Status.Issued".to_string(),
+                )),
+            },
+            timeout_secs: Some(60),
+            depends_on: vec![],
+            line: 1,
+        }
+    }
+
+    fn cert_resource() -> Resource {
+        // Unchanged cert: desired matches state (status already ISSUED).
+        let mut r = Resource::with_provider("aws", "acm.Certificate", "cert", None);
+        r.binding = Some("cert".to_string());
+        r.set_attr(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        );
+        r
+    }
+
+    fn changed_consumer() -> Resource {
+        // New (absent from state) → Create → mutating; references the
+        // wait binding so `gates_a_pending_change` is satisfied.
+        let mut r = Resource::with_provider("aws", "cloudfront.Distribution", "dist", None);
+        r.binding = Some("dist".to_string());
+        r.dependency_bindings.insert("cert_issued".to_string());
+        r
+    }
+
+    fn cert_state() -> HashMap<ResourceId, State> {
+        let id = ResourceId::with_provider("aws", "acm.Certificate", "cert", None);
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        );
+        let mut states = HashMap::new();
+        states.insert(
+            id.clone(),
+            State::existing(id, attrs).with_identifier("arn:aws:acm:::certificate/abc"),
+        );
+        states
+    }
+
+    /// The fix's core: `resolve_enum_aliases_in_wait_bindings` rewrites
+    /// the raw enum RHS to the canonical AWS value using the target
+    /// resource's `(provider, resource_type)` and the factory alias map.
+    #[test]
+    fn helper_resolves_until_rhs_enum_alias_to_canonical() {
+        let ctx = WiringContext::new(vec![Box::new(AcmAliasFactory) as Box<dyn ProviderFactory>]);
+        let mut waits = vec![enum_wait_binding()];
+        let resources = vec![cert_resource()];
+
+        resolve_enum_aliases_in_wait_bindings(&ctx, &mut waits, &resources, &[]);
+
+        assert_eq!(
+            waits[0].until_predicate.rhs,
+            Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+            "until RHS enum identifier must resolve to the canonical AWS value"
+        );
+    }
+
+    /// End-to-end logic at the plan seam: with the RAW enum RHS the
+    /// differ emits a no-op wait (the bug); after the wiring's
+    /// enum-alias resolution it is elided. Drives the real
+    /// `resolve_enum_aliases_in_wait_bindings` -> `create_plan` pair the
+    /// plan path uses.
+    #[test]
+    fn create_plan_elides_already_satisfied_wait_after_enum_alias_resolution() {
+        let ctx = WiringContext::new(vec![Box::new(AcmAliasFactory) as Box<dyn ProviderFactory>]);
+        let resources = vec![cert_resource(), changed_consumer()];
+        let states = cert_state();
+
+        // Bug repro: unresolved RAW enum RHS → wait wrongly emitted.
+        let raw_waits = vec![enum_wait_binding()];
+        let plan_raw = create_plan(
+            &resources,
+            &[],
+            &states,
+            &HashMap::new(),
+            ctx.schemas(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &raw_waits,
+        );
+        assert!(
+            plan_raw
+                .effects()
+                .iter()
+                .any(|e| matches!(e, Effect::Wait { .. })),
+            "precondition: with the raw enum RHS the differ emits the no-op \
+             wait (the carina#3358 bug); effects were {:?}",
+            plan_raw.effects()
+        );
+
+        // Fixed: resolve the alias first → predicate satisfied → elided.
+        let mut waits = vec![enum_wait_binding()];
+        resolve_enum_aliases_in_wait_bindings(&ctx, &mut waits, &resources, &[]);
+        let plan_fixed = create_plan(
+            &resources,
+            &[],
+            &states,
+            &HashMap::new(),
+            ctx.schemas(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &waits,
+        );
+        assert!(
+            !plan_fixed
+                .effects()
+                .iter()
+                .any(|e| matches!(e, Effect::Wait { .. })),
+            "carina#3358: after enum-alias resolution the already-satisfied \
+             wait must be elided; effects were {:?}",
+            plan_fixed.effects()
+        );
+    }
+}

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -2532,10 +2532,17 @@ mod wait_until_enum_alias {
     };
     use carina_core::schema::{AttributeType, ResourceSchema};
 
-    /// Minimal aws-like factory that knows the ACM `status` enum alias
-    /// `Issued` -> `ISSUED` (`convert_enum_value("aws.acm.Certificate.Status.Issued")`
-    /// yields `"Issued"`, so that is the alias-map key). Everything else
-    /// is stubbed to the bare minimum the helper needs (it only consults
+    /// Minimal aws-like factory that mirrors the REAL
+    /// `carina-provider-aws` ACM `status` enum reverse alias:
+    /// `("status", "issued") => "ISSUED"` (snake_case DSL spelling →
+    /// canonical AWS value; verified against
+    /// `carina-provider-aws/.../acm/certificate.rs`). The DSL value
+    /// `aws.acm.Certificate.Status.issued` — the exact form in the
+    /// reopened issue #3358 — passes through `convert_enum_value` to the
+    /// trailing segment `"issued"`, which is the alias-map key. Keying on
+    /// PascalCase `"Issued"` would NOT match the real provider, so the
+    /// test would prove a path production never exercises. Everything
+    /// else is stubbed to the minimum the helper needs (it only consults
     /// `get_enum_alias_reverse`).
     struct AcmAliasFactory;
 
@@ -2579,7 +2586,7 @@ mod wait_until_enum_alias {
             value: &str,
         ) -> Option<String> {
             match (resource_type, attr_name, value) {
-                ("acm.Certificate", "status", "Issued") => Some("ISSUED".to_string()),
+                ("acm.Certificate", "status", "issued") => Some("ISSUED".to_string()),
                 _ => None,
             }
         }
@@ -2640,13 +2647,15 @@ mod wait_until_enum_alias {
         WaitBinding {
             binding: "cert_issued".into(),
             target: "cert".into(),
-            until_raw: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
+            // The exact DSL form from the reopened issue #3358
+            // (snake_case `issued`, matching the real provider alias).
+            until_raw: "cert.status == aws.acm.Certificate.Status.issued".to_string(),
             until_predicate: UntilPredicateAst {
                 lhs_segments: vec!["cert".to_string(), "status".to_string()],
                 // Exactly what `lower_until_rhs` produces for the enum form:
                 // the raw dotted identifier, NOT the canonical value.
                 rhs: Value::Concrete(ConcreteValue::String(
-                    "aws.acm.Certificate.Status.Issued".to_string(),
+                    "aws.acm.Certificate.Status.issued".to_string(),
                 )),
             },
             timeout_secs: Some(60),

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -400,12 +400,15 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
     carina_core::value::canonicalize_states_with_schemas(&mut current_states, ctx.schemas());
 
     let provider = NoopProvider { cert_publishes_arn };
+    let mut wait_bindings = parsed.wait_bindings.clone();
     let preprocessor = PlanPreprocessor::new(&NoopNormalizer, &ctx);
     preprocessor
         .prepare(
             &mut resources_for_plan,
             &mut current_states,
             &parsed.providers,
+            &parsed.data_sources,
+            &mut wait_bindings,
         )
         .await;
 
@@ -418,7 +421,7 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
-        &parsed.wait_bindings,
+        &wait_bindings,
     );
 
     let has_wait = plan.effects().iter().any(|e| {

--- a/carina-core/src/parser/expressions/wait_expr.rs
+++ b/carina-core/src/parser/expressions/wait_expr.rs
@@ -395,6 +395,11 @@ mod tests {
             "cert.status == aws.acm.Certificate.Status.Issued"
         );
         assert_eq!(we.until_predicate.lhs_segments, vec!["cert", "status"]);
+        // The RHS is kept as the RAW dotted identifier here; enum-alias
+        // resolution to the canonical AWS value happens downstream in the
+        // plan/apply pipeline (`resolve_enum_aliases_in_wait_bindings`,
+        // carina#3358). If this ever pre-resolves at parse time, that
+        // wiring step — and its tests — must be revisited.
         assert_eq!(
             we.until_predicate.rhs,
             Value::Concrete(ConcreteValue::String(


### PR DESCRIPTION
Closes #3358

Follow-up to #3359, which was reopened: the already-satisfied-wait elision gate it added never fired for the real registry-dev stack.

## Root cause

The parser lowers an enum-form predicate

```
until = cert.status == aws.acm.Certificate.Status.issued
```

into the **raw dotted identifier** `Value::Concrete(ConcreteValue::String("aws.acm.Certificate.Status.issued"))` (`lower_until_rhs`), whose comment promises "the differ resolves these to canonical AWS string values at plan time" — but nothing did. The plan-path enum-alias pass canonicalized `resources` and `current_states`, never `parsed.wait_bindings`. So `WaitPredicate::evaluate` compared the raw DSL identifier against the AWS-canonical state value (`"ISSUED"`) and never matched, in **both**:

- the #3359 plan-time elision gate (`target_needs_wait` stayed true → the no-op wait was emitted), and
- the executor's apply-time poll (`executor/wait.rs`), which would poll to timeout.

The string-literal form `until = cert.status == "ISSUED"` already worked, which is why #3359's hand-built tests (and the apply-module fixture) passed while the enum form regressed in production.

## Fix

Add `resolve_enum_aliases_in_wait_bindings`, reusing the exact per-value resolver (`carina_core::value::resolve_value_alias`) the resource/state passes already use. It looks up the wait target's `(provider, resource_type)` from the resolved resource/data-source sets and resolves the predicate RHS (`lhs_segments[1]` attribute) to the canonical AWS value.

It runs inside **`PlanPreprocessor::prepare`** — the single seam both the plan pipeline (`create_plan_from_parsed_with_upstream`) and the separate apply pipeline (`commands/apply`) traverse, beside the existing resource/state enum-alias passes. A `create_plan` caller that runs `prepare` therefore cannot canonicalize resources/states while silently skipping waits (avoids the "every consumer must remember" trap). `prepare` gains `data_sources` + `&mut wait_bindings` params; the standalone per-pipeline calls are removed. The fixture harness keeps a direct call (it bypasses `prepare`; no-op without factories).

Because carina-core's `create_plan` has no access to provider factories (which own the alias map), the resolution must be carina-cli-side — symmetric with the established `resolve_enum_aliases_with_ctx` for resources/states.

## Verified against the real provider

`carina-provider-aws` defines `acm.Certificate.status` as a `StringEnum` with reverse alias `("status", "issued") => "ISSUED"` (snake_case key) and the issue's DSL is `Status.issued`. `convert_enum_value("aws.acm.Certificate.Status.issued")` → `"issued"` → `"ISSUED"`. The regression test mirrors that exact casing (an earlier draft used PascalCase `Issued`, which the real provider's map does not contain — corrected so the test exercises the production path).

## Tests (`carina-cli/src/wiring/tests.rs`)

A hermetic factory mirroring the real provider's reverse alias proves the helper resolves the raw enum RHS to `"ISSUED"`; an end-to-end differ test asserts the no-op wait **is** emitted with the raw RHS (the bug) and **is** elided after resolution. The parser-output contract the fix depends on is pinned by the existing `parses_target_and_until` test (RHS kept raw).

## Verify

- `cargo nextest run --workspace` — 3786 passed
- `cargo test --workspace --doc` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --release` — clean
- `bash scripts/check-*.sh` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
