### PR TITLE
docs(scripts): use git worktree in pre-commit branch hint

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -9,7 +9,7 @@
 current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
 if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
     echo "ERROR: Direct commits to '$current_branch' are not allowed."
-    echo "Create a feature branch first: git wt <branch-name> main"
+    echo "Create a feature branch first: git worktree add .worktrees/<branch-name> -b <branch-name> main"
     exit 1
 fi
 


### PR DESCRIPTION
## What

The pre-commit hook (`scripts/pre-commit`) that blocks direct commits
to `main` printed a hint suggesting `git wt <branch-name> main`. `git wt`
is a local-only wrapper tool that has been dropped in favor of the
standard `git worktree` commands (see #3361). Update the hint to use
`git worktree add`.

## Why

`git wt` is not installed for every contributor; the standard
`git worktree add` is portable and equivalent. Follow-up to #3361
which removed `git wt` from `CLAUDE.md`.

## Verification

- One-line message change in a shell script; no Rust touched.
- pre-commit hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)