### PR TITLE
fix(validate): enforce schema string pattern and length on Custom attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "indexmap",
  "pest",
  "pest_derive",
+ "regex",
  "semver",
  "serde",
  "serde_json",

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 futures = "0.3"
 pest = "2"
 pest_derive = "2"
+regex = "1" # Full regex is required: awscc CFN patterns use \p{...} Unicode classes that regex-lite cannot compile (awscc#295).
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -2139,8 +2139,14 @@ impl AttributeType {
         }
     }
 
-    /// Validate against a `Custom` variant by delegating to its
-    /// `validate` closure on the raw value.
+    /// Validate against a `Custom` variant.
+    ///
+    /// For String-shaped concrete values, this first enforces the schema
+    /// `pattern` constraint, then the `length` constraint using character
+    /// count. Patterns that Rust's regex engine cannot compile are skipped so
+    /// provider schema compatibility issues do not become user validation
+    /// errors (awscc#295). After those structural checks, validation delegates
+    /// to the Custom `validate` closure.
     ///
     /// Pre-carina#3222 this function also handled enum-shaped Customs
     /// (gated on `namespace.is_some()`); those are now
@@ -2152,9 +2158,54 @@ impl AttributeType {
     /// guard for `Value::Deferred(DeferredValue::ResourceRef)`/`Value::Deferred(DeferredValue::Interpolation)` is gone —
     /// the dispatcher filters them out in [`Self::validate`].
     fn validate_custom(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
-        let AttrTypeKind::Custom { validate, .. } = &self.kind else {
+        let AttrTypeKind::Custom {
+            identity,
+            base: _,
+            pattern,
+            length,
+            validate,
+            to_dsl: _,
+        } = &self.kind
+        else {
             unreachable!("validate_custom called on non-Custom");
         };
+        let type_name = identity.as_ref().map(|id| id.kind.clone());
+        // Pattern and length only apply to String-shaped concrete values.
+        // EnumIdentifier/StringList-shaped Custom values are not checked here;
+        // structural string Customs for awscc#295 arrive as String.
+        if let ConcreteValueRef::String(s) = value {
+            if let Some(pattern) = pattern
+                // awscc#295: CloudFormation patterns may contain constructs
+                // Rust's regex crate rejects; skip those provider constraints
+                // instead of reporting a schema-compatibility issue as a user error.
+                && let Ok(re) = regex::Regex::new(pattern)
+                // awscc#295: JSON Schema / CloudControl `pattern` is an
+                // unanchored substring match unless the pattern supplies ^/$.
+                && !re.is_match(s)
+            {
+                return Err(TypeError::PatternMismatch {
+                    value: s.to_string(),
+                    pattern: pattern.clone(),
+                    attribute: None,
+                    type_name,
+                });
+            }
+            if let Some((min, max)) = length {
+                let count = s.chars().count();
+                let count_u64 = count as u64;
+                if min.is_some_and(|min| count_u64 < min) || max.is_some_and(|max| count_u64 > max)
+                {
+                    return Err(TypeError::LengthOutOfRange {
+                        value: s.to_string(),
+                        length: count,
+                        min: *min,
+                        max: *max,
+                        attribute: None,
+                        type_name,
+                    });
+                }
+            }
+        }
         validate(&value.to_owned_value())
     }
 
@@ -2868,6 +2919,51 @@ fn format_invalid_enum(
     }
 }
 
+fn format_invalid_value_intro(
+    value: &str,
+    attribute: Option<&str>,
+    type_name: Option<&str>,
+) -> String {
+    match (attribute, type_name) {
+        (Some(a), Some(t)) => format!("Invalid value '{}' for '{}' ({})", value, a, t),
+        (Some(a), None) => format!("Invalid value '{}' for '{}'", value, a),
+        (None, Some(t)) => format!("Invalid {} value '{}'", t, value),
+        (None, None) => format!("Invalid value '{}'", value),
+    }
+}
+
+fn format_pattern_mismatch(
+    value: &str,
+    pattern: &str,
+    attribute: Option<&str>,
+    type_name: Option<&str>,
+) -> String {
+    format!(
+        "{}: does not match required pattern /{}/",
+        format_invalid_value_intro(value, attribute, type_name),
+        pattern
+    )
+}
+
+fn format_length_out_of_range(
+    value: &str,
+    length: usize,
+    min: Option<u64>,
+    max: Option<u64>,
+    attribute: Option<&str>,
+    type_name: Option<&str>,
+) -> String {
+    let min = min.map(|v| v.to_string()).unwrap_or_default();
+    let max = max.map(|v| v.to_string()).unwrap_or_default();
+    format!(
+        "{}: length {} is outside allowed range [{}, {}]",
+        format_invalid_value_intro(value, attribute, type_name),
+        length,
+        min,
+        max
+    )
+}
+
 /// One candidate variant carried by `TypeError::InvalidEnumVariant` and
 /// `TypeError::StringLiteralExpectedEnum`. Splits a fully-qualified enum
 /// identifier into structured pieces so IDE / LSP code actions can
@@ -2943,7 +3039,7 @@ impl fmt::Display for ExpectedEnumVariant {
 }
 
 /// Type error
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum TypeError {
     #[error("Type mismatch: expected {expected}, got {got}")]
     TypeMismatch { expected: String, got: String },
@@ -2969,6 +3065,30 @@ pub enum TypeError {
         /// programmatic consumers (LSP code actions, `carina explain-error`)
         /// can read the structured fields directly. See #2220.
         expected: Vec<ExpectedEnumVariant>,
+    },
+
+    #[error(
+        "{}",
+        format_pattern_mismatch(value, pattern, attribute.as_deref(), type_name.as_deref())
+    )]
+    PatternMismatch {
+        value: String,
+        pattern: String,
+        attribute: Option<String>,
+        type_name: Option<String>,
+    },
+
+    #[error(
+        "{}",
+        format_length_out_of_range(value, *length, *min, *max, attribute.as_deref(), type_name.as_deref())
+    )]
+    LengthOutOfRange {
+        value: String,
+        length: usize,
+        min: Option<u64>,
+        max: Option<u64>,
+        attribute: Option<String>,
+        type_name: Option<String>,
     },
 
     /// The value was written in the source as a quoted string literal
@@ -3052,8 +3172,8 @@ pub enum TypeError {
 }
 
 impl TypeError {
-    /// Attach an attribute name to the error. Currently only affects
-    /// `InvalidEnumVariant`; other variants return `self` unchanged.
+    /// Attach an attribute name to errors whose diagnostics include an
+    /// attribute context; other variants return `self` unchanged.
     ///
     /// Callers that know which attribute produced the error (e.g. the
     /// attribute loop in `ResourceSchema::validate`) wrap the primitive
@@ -3061,13 +3181,20 @@ impl TypeError {
     /// `AttrTypeKind::validate` unaware of attribute names while still
     /// letting the final message say `for 'target_id'`.
     ///
-    /// See #2098. `InvalidEnumVariant` is the only variant enriched for
-    /// now; adding the same slot to `ValidationFailed` / `TypeMismatch`
-    /// is tracked as future work.
+    /// See #2098. Adding the same slot to `ValidationFailed` /
+    /// `TypeMismatch` is tracked as future work.
     #[must_use]
     pub fn with_attribute(mut self, attribute: impl Into<String>) -> Self {
         match &mut self {
             TypeError::InvalidEnumVariant {
+                attribute: attr_slot,
+                ..
+            }
+            | TypeError::PatternMismatch {
+                attribute: attr_slot,
+                ..
+            }
+            | TypeError::LengthOutOfRange {
                 attribute: attr_slot,
                 ..
             }

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -389,6 +389,37 @@ fn with_attribute_is_noop_for_variants_that_dont_carry_attribute() {
 }
 
 #[test]
+fn custom_constraint_errors_format_type_and_attribute_context() {
+    let pattern = TypeError::PatternMismatch {
+        value: "ABC".to_string(),
+        pattern: "^[a-z]+$".to_string(),
+        attribute: None,
+        type_name: Some("EntityDescription".to_string()),
+    };
+    assert_eq!(
+        pattern.to_string(),
+        "Invalid EntityDescription value 'ABC': does not match required pattern /^[a-z]+$/"
+    );
+    assert_eq!(
+        pattern.with_attribute("description").to_string(),
+        "Invalid value 'ABC' for 'description' (EntityDescription): does not match required pattern /^[a-z]+$/"
+    );
+
+    let length = TypeError::LengthOutOfRange {
+        value: "".to_string(),
+        length: 0,
+        min: Some(1),
+        max: None,
+        attribute: None,
+        type_name: Some("EntityDescription".to_string()),
+    };
+    assert_eq!(
+        length.with_attribute("description").to_string(),
+        "Invalid value '' for 'description' (EntityDescription): length 0 is outside allowed range [1, ]"
+    );
+}
+
+#[test]
 fn schema_validate_wraps_enum_error_with_attribute_name() {
     // End-to-end at the ResourceSchema boundary: the attribute loop in
     // `ResourceSchema::validate` must wrap type errors with the attribute
@@ -3275,6 +3306,236 @@ fn custom_carries_semantic_name_pattern_length() {
         }
         _ => panic!("expected Custom"),
     }
+}
+
+#[test]
+fn custom_pattern_rejects_and_accepts_string_values() {
+    let attr = AttributeType::custom(
+        None,
+        AttributeType::string(),
+        Some("^[a-z]+$".to_string()),
+        None,
+        noop_validator(),
+        None,
+    );
+
+    let err = attr
+        .validate(&Value::Concrete(ConcreteValue::String("ABC".to_string())))
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TypeError::PatternMismatch {
+            value: "ABC".to_string(),
+            pattern: "^[a-z]+$".to_string(),
+            attribute: None,
+            type_name: None,
+        }
+    );
+    assert!(
+        attr.validate(&Value::Concrete(ConcreteValue::String("abc".to_string())))
+            .is_ok()
+    );
+}
+
+#[test]
+fn custom_pattern_and_length_passes_still_run_validator() {
+    let attr = AttributeType::custom(
+        None,
+        AttributeType::string(),
+        Some("^[a-z]+$".to_string()),
+        Some((Some(1), Some(10))),
+        validator(|_| {
+            Err(TypeError::ValidationFailed {
+                message: "closure rejected".to_string(),
+            })
+        }),
+        None,
+    );
+
+    let err = attr
+        .validate(&Value::Concrete(ConcreteValue::String("abc".to_string())))
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TypeError::ValidationFailed {
+            message: "closure rejected".to_string(),
+        }
+    );
+}
+
+#[test]
+fn custom_pattern_rejects_wafv2_description_parentheses() {
+    let pattern = r"^[a-zA-Z0-9=:#@/\-,.][a-zA-Z0-9+=:#@/\-,.\s]+[a-zA-Z0-9+=:#@/\-,.]{1,256}$";
+    let attr = AttributeType::custom(
+        Some(TypeIdentity::bare("EntityDescription")),
+        AttributeType::string(),
+        Some(pattern.to_string()),
+        None,
+        noop_validator(),
+        None,
+    );
+
+    let err = attr
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "Protects the Carina Provider Registry (dev) CloudFront distribution".to_string(),
+        )))
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TypeError::PatternMismatch {
+            value: "Protects the Carina Provider Registry (dev) CloudFront distribution"
+                .to_string(),
+            pattern: pattern.to_string(),
+            attribute: None,
+            type_name: Some("EntityDescription".to_string()),
+        }
+    );
+    assert!(
+        attr.validate(&Value::Concrete(ConcreteValue::String(
+            "Protects the registry dev distribution".to_string()
+        )))
+        .is_ok()
+    );
+}
+
+#[test]
+fn custom_length_uses_character_count_not_bytes() {
+    let attr = AttributeType::custom(
+        None,
+        AttributeType::string(),
+        None,
+        Some((Some(1), Some(5))),
+        noop_validator(),
+        None,
+    );
+
+    let err = attr
+        .validate(&Value::Concrete(ConcreteValue::String(
+            "abcdef".to_string(),
+        )))
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TypeError::LengthOutOfRange {
+            value: "abcdef".to_string(),
+            length: 6,
+            min: Some(1),
+            max: Some(5),
+            attribute: None,
+            type_name: None,
+        }
+    );
+    assert!(
+        attr.validate(&Value::Concrete(ConcreteValue::String("abcde".to_string())))
+            .is_ok()
+    );
+    assert!(
+        attr.validate(&Value::Concrete(ConcreteValue::String(
+            "ねこに".to_string()
+        )))
+        .is_ok()
+    );
+}
+
+#[test]
+fn custom_length_enforces_minimum_bound() {
+    let attr = AttributeType::custom(
+        None,
+        AttributeType::string(),
+        None,
+        Some((Some(2), None)),
+        noop_validator(),
+        None,
+    );
+
+    let err = attr
+        .validate(&Value::Concrete(ConcreteValue::String("a".to_string())))
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TypeError::LengthOutOfRange {
+            value: "a".to_string(),
+            length: 1,
+            min: Some(2),
+            max: None,
+            attribute: None,
+            type_name: None,
+        }
+    );
+    assert!(
+        attr.validate(&Value::Concrete(ConcreteValue::String("ab".to_string())))
+            .is_ok()
+    );
+}
+
+#[test]
+fn custom_non_string_base_skips_pattern_and_length() {
+    let attr = AttributeType::custom(
+        None,
+        AttributeType::int(),
+        Some("^[a-z]+$".to_string()),
+        Some((Some(100), Some(200))),
+        noop_validator(),
+        None,
+    );
+
+    assert!(
+        attr.validate(&Value::Concrete(ConcreteValue::Int(5)))
+            .is_ok()
+    );
+}
+
+#[test]
+fn custom_uncompilable_pattern_is_non_fatal() {
+    let pattern = r"(?=x)";
+    assert!(
+        regex::Regex::new(pattern).is_err(),
+        "test must use a pattern unsupported by the regex crate"
+    );
+    let attr = AttributeType::custom(
+        None,
+        AttributeType::string(),
+        Some(pattern.to_string()),
+        None,
+        noop_validator(),
+        None,
+    );
+
+    assert!(
+        attr.validate(&Value::Concrete(ConcreteValue::String(
+            "anything".to_string()
+        )))
+        .is_ok()
+    );
+}
+
+#[test]
+fn schema_validate_attr_dispatches_to_custom_pattern_validation() {
+    let attr = AttributeType::custom(
+        Some(TypeIdentity::bare("Slug")),
+        AttributeType::string(),
+        Some("^[a-z]+$".to_string()),
+        None,
+        noop_validator(),
+        None,
+    );
+    let schema = Schema::flat(AttributeType::string());
+
+    let err = schema
+        .validate_attr(
+            &attr,
+            &Value::Concrete(ConcreteValue::String("ABC".to_string())),
+        )
+        .unwrap_err();
+    assert_eq!(
+        err,
+        TypeError::PatternMismatch {
+            value: "ABC".to_string(),
+            pattern: "^[a-z]+$".to_string(),
+            attribute: None,
+            type_name: Some("Slug".to_string()),
+        }
+    );
 }
 
 #[test]

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -3083,6 +3083,48 @@ fn lsp_quoted_literal_on_namespaced_custom_says_got_a_string_literal() {
     );
 }
 
+#[test]
+fn lsp_custom_string_pattern_mismatch_reports_required_pattern() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
+
+    let bucket_name = AttributeType::custom(
+        Some(carina_core::schema::TypeIdentity::bare("BucketName")),
+        AttributeType::string(),
+        Some("^prod-[a-z0-9]+$".to_string()),
+        None,
+        legacy_validator(|_| Ok(())),
+        None,
+    );
+    let schema = ResourceSchema::new("s3.bucket")
+        .attribute(AttributeSchema::new("bucket_name", bucket_name));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("aws", schema);
+    let engine = custom_engine(schemas);
+
+    let doc = create_document(
+        r#"aws.s3.bucket {
+  bucket_name = "dev_bucket"
+}
+"#,
+    );
+    let diagnostics = engine.analyze(&doc, None);
+    let pattern_mismatch = diagnostics
+        .iter()
+        .find(|d| d.message.contains("does not match required pattern"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected pattern mismatch diagnostic, got: {:?}",
+                diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+            )
+        });
+
+    assert!(
+        pattern_mismatch.message.contains("^prod-[a-z0-9]+$"),
+        "diagnostic must include the schema pattern, got: {}",
+        pattern_mismatch.message
+    );
+}
+
 // #2131 / #2132: a ResourceRef whose root is declared in a sibling `.crn`
 // must NOT be flagged `Undefined resource`. The LSP text-scan used to
 // feed on the current file's bindings plus a hand-rolled sibling scan

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -761,15 +761,20 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
         proto::AttributeType::Union { members } => {
             CoreAttributeType::union(members.iter().map(proto_attr_type_to_core).collect())
         }
-        proto::AttributeType::Custom { name, base } => CoreAttributeType::custom(
+        proto::AttributeType::Custom {
+            name,
+            base,
+            pattern,
+            length,
+        } => CoreAttributeType::custom(
             if name.is_empty() {
                 None
             } else {
                 Some(carina_core::schema::TypeIdentity::from_dotted(name))
             },
             proto_attr_type_to_core(base),
-            None,
-            None,
+            pattern.clone(),
+            *length,
             noop_validator(), // Validation is handled via ProviderContext.validators
             // `to_dsl` is a `fn` pointer that does not survive the
             // WASM-component boundary; host-side normalization for
@@ -1802,6 +1807,34 @@ mod tests {
                 assert!(dsl_aliases.is_empty());
             }
             other => panic!("expected StringEnum, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn proto_custom_pattern_and_length_propagate_to_core() {
+        let proto_attr = proto::AttributeType::Custom {
+            name: "awscc.wafv2.WebACL.EntityDescription".to_string(),
+            base: Box::new(proto::AttributeType::String),
+            pattern: Some("^x$".to_string()),
+            length: Some((Some(1), Some(9))),
+        };
+        let core_attr = proto_attr_type_to_core(&proto_attr);
+        let defs = carina_core::schema::empty_defs();
+        match core_attr.shape(defs) {
+            carina_core::schema::Shape::Custom {
+                identity,
+                pattern,
+                length,
+                ..
+            } => {
+                assert_eq!(
+                    identity.map(|id| id.kind.as_str()),
+                    Some("EntityDescription")
+                );
+                assert_eq!(pattern, Some("^x$"));
+                assert_eq!(length, Some((Some(1), Some(9))));
+            }
+            other => panic!("expected Custom, got {other:?}"),
         }
     }
 

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -453,6 +453,10 @@ pub enum AttributeType {
     Custom {
         name: String,
         base: Box<AttributeType>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pattern: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        length: Option<(Option<u64>, Option<u64>)>,
     },
     /// Enum-shaped custom type: values are written as namespaced
     /// shorthand and expanded host-side via `expand_enum_shorthand`
@@ -571,6 +575,30 @@ mod tests {
         match back {
             AttributeType::Ref { name } => assert_eq!(name, "Statement"),
             other => panic!("expected Ref, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn custom_pattern_and_length_round_trip() {
+        let attr = AttributeType::Custom {
+            name: "awscc.wafv2.WebACL.EntityDescription".to_string(),
+            base: Box::new(AttributeType::String),
+            pattern: Some("^[a-z]+$".to_string()),
+            length: Some((Some(1), Some(9))),
+        };
+
+        let json = serde_json::to_string(&attr).unwrap();
+        assert!(json.contains("pattern"));
+        assert!(json.contains("length"));
+        let back: AttributeType = serde_json::from_str(&json).unwrap();
+        match back {
+            AttributeType::Custom {
+                pattern, length, ..
+            } => {
+                assert_eq!(pattern.as_deref(), Some("^[a-z]+$"));
+                assert_eq!(length, Some((Some(1), Some(9))));
+            }
+            other => panic!("expected Custom, got {:?}", other),
         }
     }
 


### PR DESCRIPTION
## Summary

`carina validate` / `plan` did not enforce string **`pattern`** (regex) or **length** constraints declared in the resource schema, so a value violating a field's regex passed validate and plan and failed only at `apply` when AWS rejected it.

Concrete case (the reported one): `awscc.wafv2.WebAcl`'s `description` carries the CFN `EntityDescription` pattern `^[a-zA-Z0-9=:#@/\-,.]...{1,256}$` (no parentheses), so a description like `"... (dev) ..."` passed validate/plan and only failed at apply.

## Root cause

`AttrTypeKind::Custom` **already carried** `pattern: Option<String>` and `length: Option<(Option<u64>, Option<u64>)>`, and the awscc provider already emits them in its generated schemas. But `validate_custom` destructured `let AttrTypeKind::Custom { validate, .. }` — the `..` silently dropped both fields, so they were never checked. The fix removes that drop and enforces the constraints at the single upstream seam.

## Changes

- **`validate_custom`** now binds `pattern`/`length` and, for String-shaped values, checks the regex (`is_match` — unanchored, matching JSON Schema / CloudControl `pattern` semantics) then the length by **character count**. A pattern the `regex` engine can't compile is **skipped, not failed** — a provider schema-compatibility gap must not become a user error.
- New structured `TypeError::PatternMismatch` / `LengthOutOfRange` variants (carry value/pattern/length + attribute/type_name; `with_attribute`-aware; LSP-ready, mirroring `InvalidEnumVariant`).
- `pattern`/`length` threaded across the provider protocol boundary (`carina-provider-protocol` `Custom` variant + `wasm_convert` proto→core) so WASM plugin providers' constraints are enforced too — same bug, sibling site.
- `regex = "1"` added to `carina-core`. **Full `regex` (not `regex-lite`)** because awscc CFN patterns use `\p{...}` Unicode classes that `regex-lite` cannot compile.
- CHANGELOG entry.

## Behavior change

Configs that previously passed `validate`/`plan` but violate a provider-declared `pattern`/length are now rejected at validate time — which is the point: caught before `apply` instead of failing in CI after merge.

## Tests

`carina-core/src/schema/tests.rs`, `wasm_convert.rs`, `types.rs`: pattern reject/accept, the real WebACL `EntityDescription` pattern with the parenthesised value (the issue's repro), char-vs-byte length (`"ねこに"` = 3 chars), min-bound, non-string base skips constraints, closure still runs after pattern/length pass, uncompilable-pattern non-fatal, `Schema::validate_attr` dispatch, and proto round-trip.

Verify: `cargo nextest run` (2383 passed) + `cargo test --workspace --doc` + `cargo clippy --workspace --all-targets -D warnings` + `scripts/check-*.sh` all green.

Closes carina-rs/carina-provider-awscc#295

🤖 Generated with [Claude Code](https://claude.com/claude-code)