### PR TITLE
feat(schema): schema-bound type-ref projection + shape_ref_free (carina#3371 PR1)

### DIFF
--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -12,7 +12,7 @@ use crate::diff_helpers::{compute_map_diff, compute_unchanged_count, schema_awar
 use crate::effect::Effect;
 use crate::non_empty::NonEmptyVec;
 use crate::resource::{ConcreteValue, DeferredValue, ResourceId, Value};
-use crate::schema::{AttributeType, ResourceSchema, SchemaRegistry, empty_defs};
+use crate::schema::{AttributeType, ResourceSchema, SchemaRegistry, empty_defs_for_schema_walks};
 use crate::value::{format_value, format_value_with_key, is_list_of_maps, map_similarity};
 
 /// Controls how much detail is shown in plan output.
@@ -345,7 +345,7 @@ fn map_entry_subtype<'a>(
         // silently drop a `Ref` because `Shape` has no `Ref`
         // variant. `shape(defs)` panics on a dangling `Ref` —
         // schema-construction bug, surfaced loudly.
-        match t.shape(defs) {
+        match t.shape_with_defs(defs) {
             crate::schema::Shape::List { inner, .. } => t = inner,
             crate::schema::Shape::Map { value, .. } => return Some(value),
             crate::schema::Shape::Struct { fields, .. } => {
@@ -601,7 +601,9 @@ fn build_update_rows(
     explicit: Option<&crate::explicit::ExplicitFields>,
 ) -> Vec<DetailRow> {
     let mut rows = Vec::new();
-    let defs = schema.map(|s| &s.defs).unwrap_or(empty_defs());
+    let defs = schema
+        .map(|s| &s.defs)
+        .unwrap_or(empty_defs_for_schema_walks());
 
     // Project `from.attributes` through the user-authoring tree so
     // server-side default fields the user never wrote don't inflate
@@ -764,7 +766,9 @@ fn build_replace_rows(
     explicit: Option<&crate::explicit::ExplicitFields>,
 ) -> Vec<DetailRow> {
     let mut rows = Vec::new();
-    let defs = schema.map(|s| &s.defs).unwrap_or(empty_defs());
+    let defs = schema
+        .map(|s| &s.defs)
+        .unwrap_or(empty_defs_for_schema_walks());
 
     // Show changed create-only attributes
     let mut keys: Vec<_> = changed_create_only
@@ -1210,7 +1214,7 @@ fn compute_list_of_maps_diff_parts(
     // Peel any leading `Ref` so a `Ref("…")` attribute whose def is
     // `List<Struct>` still drops into the List arm — same bug class
     // as carina#3349. `resolve_refs` is a no-op on non-Ref inputs.
-    let attr_type_peeled = attr_type.map(|t| t.resolve_refs(defs).as_attr());
+    let attr_type_peeled = attr_type.map(|t| t.resolve_refs_with_defs(defs).as_attr());
     let item_type = match attr_type_peeled.map(|t| (&t.kind, t)) {
         Some((crate::schema::AttrTypeKind::List { inner, .. }, _)) => Some(inner.as_ref()),
         // The attribute itself may already be the element type when
@@ -2803,7 +2807,7 @@ mod tests {
             Some(&old_value),
             &new_value,
             None,
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             DetailLevel::Full,
         );
 
@@ -2867,7 +2871,7 @@ mod tests {
             Some(&old_value),
             &new_value,
             None,
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             DetailLevel::Full,
         );
 
@@ -3037,7 +3041,7 @@ mod tests {
             Some(&old_value),
             &new_value,
             None,
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             DetailLevel::Full,
         );
 
@@ -3081,7 +3085,7 @@ mod tests {
             Some(&old_value),
             &new_value,
             None,
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             DetailLevel::Full,
         );
         assert!(
@@ -3143,7 +3147,7 @@ mod tests {
             Some(&old_value),
             &new_value,
             None,
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             DetailLevel::Full,
         );
 

--- a/carina-core/src/diff_helpers.rs
+++ b/carina-core/src/diff_helpers.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, HashMap};
 use indexmap::IndexMap;
 
 use crate::resource::Value;
-use crate::schema::{AttributeType, ResourceSchema, empty_defs};
+use crate::schema::{AttributeType, ResourceSchema, empty_defs_for_schema_walks};
 
 /// Schema-aware value equality shared by the plan renderer
 /// (`detail_rows`) and the unchanged-count helper below (carina#3073).
@@ -57,7 +57,9 @@ pub fn compute_unchanged_count(
     exclude: Option<&std::collections::HashSet<&str>>,
     schema: Option<&ResourceSchema>,
 ) -> usize {
-    let defs: &BTreeMap<String, AttributeType> = schema.map(|s| &s.defs).unwrap_or(empty_defs());
+    let defs: &BTreeMap<String, AttributeType> = schema
+        .map(|s| &s.defs)
+        .unwrap_or(empty_defs_for_schema_walks());
     from_attrs
         .iter()
         .filter(|(k, v)| {

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 
 use crate::explicit::{self, ExplicitFields};
 use crate::resource::{ConcreteValue, DeferredValue, ResourceId, Value, merge_with_saved};
-use crate::schema::{AttributeType, ResourceSchema, empty_defs};
+use crate::schema::{AttributeType, ResourceSchema, empty_defs_for_schema_walks};
 use crate::value::{SECRET_PREFIX, SecretHashContext, argon2id_hash, value_to_json_with_context};
 
 /// Type-aware semantic comparison of two Values.
@@ -71,7 +71,7 @@ pub(crate) fn type_aware_equal(
     // so the carina#3340 / carina#3349 invariant is moved from a
     // hand-written `resolve_refs` + `Ref(_) => unreachable!()` guard
     // into the type system.
-    let shape = attr_type.map(|t| t.shape(defs));
+    let shape = attr_type.map(|t| t.shape_with_defs(defs));
 
     match shape {
         None => {
@@ -440,7 +440,7 @@ fn is_type_default(
     // `Shape` enum has no `Ref` variant by construction, so the type
     // system rather than convention enforces that every default-value
     // classification has seen its target shape.
-    let shape = attr_type.map(|t| t.shape(defs));
+    let shape = attr_type.map(|t| t.shape_with_defs(defs));
     match (value, shape) {
         (Value::Concrete(ConcreteValue::Bool(false)), Some(crate::schema::Shape::Bool) | None) => {
             true
@@ -553,7 +553,9 @@ pub(super) fn find_changed_attributes(
     // Pull the cyclic-struct definition map (`Ref` targets) from the
     // resource schema if available, otherwise an empty map. Walk-sites
     // resolve `Ref` against this map (carina#3340).
-    let defs: &BTreeMap<String, AttributeType> = schema.map(|s| &s.defs).unwrap_or(empty_defs());
+    let defs: &BTreeMap<String, AttributeType> = schema
+        .map(|s| &s.defs)
+        .unwrap_or(empty_defs_for_schema_walks());
 
     // Project `current` through `prev_explicit` so server-side defaults
     // the user never authored disappear before any comparison runs.

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -10,14 +10,14 @@ fn type_aware_int_float_coercion() {
         &Value::Concrete(ConcreteValue::Int(42)),
         &Value::Concrete(ConcreteValue::Float(42.0)),
         Some(&AttributeType::float()),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
     assert!(type_aware_equal(
         &Value::Concrete(ConcreteValue::Float(42.0)),
         &Value::Concrete(ConcreteValue::Int(42)),
         Some(&AttributeType::float()),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
     // Non-exact conversion should not be equal
@@ -25,7 +25,7 @@ fn type_aware_int_float_coercion() {
         &Value::Concrete(ConcreteValue::Int(42)),
         &Value::Concrete(ConcreteValue::Float(42.5)),
         Some(&AttributeType::float()),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
     // Without type info, Int and Float are not equal
@@ -33,7 +33,7 @@ fn type_aware_int_float_coercion() {
         &Value::Concrete(ConcreteValue::Int(42)),
         &Value::Concrete(ConcreteValue::Float(42.0)),
         None,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
 }
@@ -45,7 +45,7 @@ fn type_aware_int_float_coercion_for_int_type() {
         &Value::Concrete(ConcreteValue::Int(10)),
         &Value::Concrete(ConcreteValue::Float(10.0)),
         Some(&AttributeType::int()),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
 }
@@ -64,7 +64,7 @@ fn type_aware_list_with_inner_type() {
             Value::Concrete(ConcreteValue::Float(1.0))
         ])),
         Some(&list_type),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
 }
@@ -101,7 +101,7 @@ fn type_aware_struct_per_field() {
         &a,
         &b,
         Some(&struct_type),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None
     ));
 }
@@ -113,7 +113,7 @@ fn type_aware_union_numeric() {
         &Value::Concrete(ConcreteValue::Int(7)),
         &Value::Concrete(ConcreteValue::Float(7.0)),
         Some(&union_type),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
 }
@@ -132,7 +132,7 @@ fn type_aware_custom_delegates_to_base() {
         &Value::Concrete(ConcreteValue::Int(8080)),
         &Value::Concrete(ConcreteValue::Float(8080.0)),
         Some(&custom_type),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
 }
@@ -210,7 +210,7 @@ fn type_aware_struct_ignores_default_bool_false() {
             &desired,
             &current,
             Some(&struct_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None
         ),
         "Struct with extra default Bool(false) should be considered equal"
@@ -252,7 +252,7 @@ fn type_aware_struct_does_not_ignore_non_default_bool() {
             &desired,
             &current,
             Some(&struct_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None
         ),
         "Struct with non-default Bool(true) should NOT be considered equal"
@@ -284,7 +284,7 @@ fn type_aware_string_enum_namespaced_vs_raw() {
             )),
             &Value::Concrete(ConcreteValue::String("AES256".to_string())),
             Some(&enum_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "Namespaced enum and raw value should be considered equal"
@@ -300,7 +300,7 @@ fn type_aware_string_enum_namespaced_vs_raw() {
                 "awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256".to_string()
             )),
             Some(&enum_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "Both namespaced should be equal"
@@ -314,7 +314,7 @@ fn type_aware_string_enum_namespaced_vs_raw() {
             )),
             &Value::Concrete(ConcreteValue::String("aws:kms".to_string())),
             Some(&enum_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "Different enum values should not be equal"
@@ -349,7 +349,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
                 "aws.AvailabilityZone.ap_northeast_1a".to_string()
             )),
             Some(&az_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "AWS-canonical hyphenated form must equal the fully-qualified DSL identifier"
@@ -361,7 +361,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
             )),
             &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
             Some(&az_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "Equality must be symmetric"
@@ -377,7 +377,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
                 "aws.AvailabilityZone.ap_northeast_1a".to_string()
             )),
             Some(&az_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "Identical fully-qualified forms must be equal"
@@ -389,7 +389,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
             &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
             &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
             Some(&az_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "Identical AWS-canonical forms must be equal"
@@ -405,7 +405,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
                 "aws.AvailabilityZone.ap_northeast_1a".to_string()
             )),
             Some(&az_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "AWS-canonical String must equal the matching EnumIdentifier shape"
@@ -419,7 +419,7 @@ fn type_aware_custom_enum_canonical_vs_namespaced_identifier() {
                 "aws.AvailabilityZone.ap_northeast_1c".to_string()
             )),
             Some(&az_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None,
         ),
         "Different enum values must not be folded as equal"
@@ -469,7 +469,7 @@ fn type_aware_struct_ignores_default_string_enum_empty() {
             &desired,
             &current,
             Some(&struct_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None
         ),
         "Struct with extra default StringEnum empty string should be considered equal"
@@ -518,7 +518,7 @@ fn type_aware_struct_ignores_default_custom_type() {
             &desired,
             &current,
             Some(&struct_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None
         ),
         "Struct with extra default Custom(Int) zero should be considered equal"
@@ -566,7 +566,7 @@ fn type_aware_struct_ignores_default_nested_struct_empty() {
             &desired,
             &current,
             Some(&struct_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None
         ),
         "Struct with extra default nested Struct empty map should be considered equal"
@@ -593,7 +593,7 @@ fn type_aware_ordered_list_detects_reorder() {
             &a,
             &b,
             Some(&ordered_list_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None
         ),
         "Ordered list should detect reorder as NOT equal"
@@ -609,7 +609,7 @@ fn type_aware_ordered_list_detects_reorder() {
             &a,
             &c,
             Some(&ordered_list_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None
         ),
         "Ordered list with same order should be equal"
@@ -635,7 +635,7 @@ fn type_aware_unordered_list_ignores_reorder() {
             &a,
             &b,
             Some(&unordered_list_type),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
             None
         ),
         "Unordered list should treat reorder as equal"
@@ -795,7 +795,7 @@ fn secret_unchanged_same_hash() {
         &secret_value,
         &Value::Concrete(ConcreteValue::String(hash_str.clone())),
         None,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
     // Reversed order should also work
@@ -803,7 +803,7 @@ fn secret_unchanged_same_hash() {
         &Value::Concrete(ConcreteValue::String(hash_str)),
         &secret_value,
         None,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
 }
@@ -827,7 +827,7 @@ fn secret_changed_different_hash() {
         &new_secret,
         &Value::Concrete(ConcreteValue::String(old_hash_str)),
         None,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None,
     ));
 }
@@ -1049,11 +1049,23 @@ fn secret_matches_plain_text_state_value() {
     ))));
     let plain = Value::Concrete(ConcreteValue::String("my-password".to_string()));
     assert!(
-        type_aware_equal(&secret, &plain, None, crate::schema::empty_defs(), None),
+        type_aware_equal(
+            &secret,
+            &plain,
+            None,
+            crate::schema::empty_defs_for_schema_walks(),
+            None
+        ),
         "Secret should match plain-text state when inner values are equal"
     );
     assert!(
-        type_aware_equal(&plain, &secret, None, crate::schema::empty_defs(), None),
+        type_aware_equal(
+            &plain,
+            &secret,
+            None,
+            crate::schema::empty_defs_for_schema_walks(),
+            None
+        ),
         "Plain-text state should match secret when inner values are equal"
     );
 }
@@ -1066,7 +1078,13 @@ fn secret_does_not_match_different_plain_text() {
     ))));
     let plain = Value::Concrete(ConcreteValue::String("other-password".to_string()));
     assert!(
-        !type_aware_equal(&secret, &plain, None, crate::schema::empty_defs(), None),
+        !type_aware_equal(
+            &secret,
+            &plain,
+            None,
+            crate::schema::empty_defs_for_schema_walks(),
+            None
+        ),
         "Secret should not match different plain-text state"
     );
 }
@@ -1156,7 +1174,7 @@ fn union_string_or_list_canonical_string_list_equal_to_self() {
         &a,
         &b,
         Some(&union),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None
     ));
 }
@@ -1170,7 +1188,7 @@ fn union_string_or_list_canonical_string_list_diff_on_different_content() {
         &a,
         &b,
         Some(&union),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None
     ));
 }
@@ -1190,7 +1208,7 @@ fn union_string_or_list_non_canonical_mixed_shapes_fail_to_equal() {
         &scalar,
         &canonical,
         Some(&union),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None
     ));
 
@@ -1201,7 +1219,7 @@ fn union_string_or_list_non_canonical_mixed_shapes_fail_to_equal() {
         &legacy_list,
         &canonical,
         Some(&union),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None
     ));
 }
@@ -1225,7 +1243,7 @@ fn union_string_or_list_through_custom_wrapper() {
         &a,
         &b,
         Some(&custom),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         None
     ));
 }

--- a/carina-core/src/lint.rs
+++ b/carina-core/src/lint.rs
@@ -56,9 +56,9 @@ pub fn list_struct_attr_names(schema: &ResourceSchema) -> HashSet<String> {
             // the type level (carina#3349). `Shape` has no `Ref`
             // variant, so a `Ref`-typed attribute cannot be missed.
             matches!(
-                attr_schema.attr_type.shape(&schema.defs),
+                attr_schema.attr_type.shape_with_defs(&schema.defs),
                 Shape::List { inner, .. } if matches!(
-                    inner.shape(&schema.defs),
+                    inner.shape_with_defs(&schema.defs),
                     Shape::Struct { .. }
                 )
             )

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -19,6 +19,23 @@ mod type_identity;
 pub use resolved_attr_type::ResolvedAttrType;
 pub use type_identity::TypeIdentity;
 
+/// Error returned when a bare projection reaches a schema-bound
+/// [`AttrTypeKind::Ref`] without a defs map.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefEncountered {
+    pub name: String,
+}
+
+impl fmt::Display for RefEncountered {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "unresolved AttributeType::Ref(\"{}\") has no defs in scope",
+            self.name
+        )
+    }
+}
+
 /// Type alias for resource validator functions
 pub type ResourceValidator = fn(&HashMap<String, Value>) -> Result<(), Vec<TypeError>>;
 
@@ -919,6 +936,16 @@ impl Schema {
         self.defs.get(name)
     }
 
+    /// Resolve `ty` against this schema's definition map.
+    pub fn resolve_of<'a>(&'a self, ty: &'a AttributeType) -> ResolvedAttrType<'a> {
+        ty.resolve_refs_with_defs(&self.defs)
+    }
+
+    /// Project `ty` onto a [`Shape`] using this schema's definition map.
+    pub fn shape_of<'a>(&'a self, ty: &'a AttributeType) -> Shape<'a> {
+        ty.shape_with_defs(&self.defs)
+    }
+
     /// Validate a `Value` against this schema's `root`, resolving
     /// any `Ref` it encounters by looking it up in `defs`.
     pub fn validate(&self, value: &Value) -> Result<(), TypeError> {
@@ -1422,10 +1449,18 @@ pub(crate) fn lift_map_key(key_type: &AttributeType, key: &str) -> Value {
 /// to capture cyclic definitions; this constant is for sites that
 /// genuinely have no resource schema in scope (synthetic fixtures,
 /// validation helpers operating on a bare `AttributeType`).
-pub fn empty_defs() -> &'static std::collections::BTreeMap<String, AttributeType> {
+pub(crate) fn empty_defs_for_schema_walks()
+-> &'static std::collections::BTreeMap<String, AttributeType> {
     use std::sync::OnceLock;
     static EMPTY: OnceLock<std::collections::BTreeMap<String, AttributeType>> = OnceLock::new();
     EMPTY.get_or_init(std::collections::BTreeMap::new)
+}
+
+#[deprecated(
+    note = "use Schema::shape_of / ResourceSchema::shape_of, or AttributeType::shape_ref_free"
+)]
+pub fn empty_defs() -> &'static std::collections::BTreeMap<String, AttributeType> {
+    empty_defs_for_schema_walks()
 }
 
 impl AttributeType {
@@ -1439,7 +1474,7 @@ impl AttributeType {
     /// matching on the type, so the wildcard arm cannot silently
     /// accept a `Ref` and discard its schema information. The
     /// `defs` map is normally `&ResourceSchema::defs`; pass
-    /// [`empty_defs`] when no resource is in scope.
+    /// [`empty_defs_for_schema_walks`] when no resource is in scope.
     ///
     /// # Panics
     ///
@@ -1447,7 +1482,7 @@ impl AttributeType {
     /// is a schema invariant (a producer that emits `Ref` must also
     /// populate the matching def); a violation indicates a codegen
     /// or wire-format bug, not user input.
-    pub fn resolve_refs<'a>(
+    pub(crate) fn resolve_refs_with_defs<'a>(
         &'a self,
         defs: &'a std::collections::BTreeMap<String, AttributeType>,
     ) -> ResolvedAttrType<'a> {
@@ -1470,28 +1505,61 @@ impl AttributeType {
         panic!("AttributeType::Ref chain exceeded 256 hops; pathological self-cycle in defs")
     }
 
+    #[deprecated(
+        note = "use Schema::resolve_of / ResourceSchema::resolve_of, or AttributeType::shape_ref_free"
+    )]
+    pub fn resolve_refs<'a>(
+        &'a self,
+        defs: &'a std::collections::BTreeMap<String, AttributeType>,
+    ) -> ResolvedAttrType<'a> {
+        self.resolve_refs_with_defs(defs)
+    }
+
     /// Project this type onto a [`Shape`] view with every top-level
     /// `Ref` already peeled against `defs`.
     ///
     /// Callers that need to branch on the type's shape should `match`
     /// the returned [`Shape`] instead of `&AttributeType`. The
     /// `Shape` enum has no `Ref` variant, so a wildcard arm in
-    /// `match attr.shape(defs) { ... }` cannot silently swallow a
+    /// `match attr.shape_with_defs(defs) { ... }` cannot silently swallow a
     /// `Ref` — the carina#3349 bug class is unreachable at the type
     /// level.
     ///
     /// `defs` is normally `&ResourceSchema::defs` or `&Schema::defs`;
-    /// pass [`empty_defs`] when no resource is in scope.
+    /// pass [`empty_defs_for_schema_walks`] when no resource is in scope.
     ///
     /// # Panics
     ///
     /// Panics if a `Ref` points to a name not present in `defs` (same
     /// schema invariant as [`Self::resolve_refs`]).
+    pub(crate) fn shape_with_defs<'a>(
+        &'a self,
+        defs: &'a std::collections::BTreeMap<String, AttributeType>,
+    ) -> Shape<'a> {
+        let resolved = self.resolve_refs_with_defs(defs).as_attr();
+        Self::shape_from_resolved(resolved)
+    }
+
+    #[deprecated(
+        note = "use Schema::shape_of / ResourceSchema::shape_of, or AttributeType::shape_ref_free"
+    )]
     pub fn shape<'a>(
         &'a self,
         defs: &'a std::collections::BTreeMap<String, AttributeType>,
     ) -> Shape<'a> {
-        let resolved = self.resolve_refs(defs).as_attr();
+        self.shape_with_defs(defs)
+    }
+
+    /// Project this type without a defs map. Returns an error instead
+    /// of panicking if the top-level type is a schema-bound `Ref`.
+    pub fn shape_ref_free(&self) -> Result<Shape<'_>, RefEncountered> {
+        if let AttrTypeKind::Ref(name) = &self.kind {
+            return Err(RefEncountered { name: name.clone() });
+        }
+        Ok(Self::shape_from_resolved(self))
+    }
+
+    fn shape_from_resolved(resolved: &AttributeType) -> Shape<'_> {
         match &resolved.kind {
             AttrTypeKind::String => Shape::String,
             AttrTypeKind::Int => Shape::Int,
@@ -3655,6 +3723,17 @@ impl ResourceSchema {
         self
     }
 
+    /// Resolve `ty` against this resource schema's definition map.
+    pub fn resolve_of<'a>(&'a self, ty: &'a AttributeType) -> ResolvedAttrType<'a> {
+        ty.resolve_refs_with_defs(&self.defs)
+    }
+
+    /// Project `ty` onto a [`Shape`] using this resource schema's
+    /// definition map.
+    pub fn shape_of<'a>(&'a self, ty: &'a AttributeType) -> Shape<'a> {
+        ty.shape_with_defs(&self.defs)
+    }
+
     pub fn with_description(mut self, desc: impl Into<String>) -> Self {
         self.description = Some(desc.into());
         self
@@ -4100,7 +4179,7 @@ fn recurse_block_names_into_value(
     // (carina#3349). The `Shape` enum has no `Ref` variant, so the
     // wildcard arm below cannot silently swallow a `Ref` — the bug
     // class is structurally impossible.
-    match field_type.shape(defs) {
+    match field_type.shape_with_defs(defs) {
         Shape::Struct { fields: inner, .. } => {
             if let Value::Concrete(ConcreteValue::Map(inner_map)) = value {
                 resolve_block_names_in_map(inner_map, inner, defs, resource_id, errors);
@@ -4109,7 +4188,7 @@ fn recurse_block_names_into_value(
         Shape::List { inner, .. } => {
             // `List<Ref>`: peel the element type too via `shape(defs)`
             // so the walk reaches the underlying struct fields.
-            if let Shape::Struct { fields: inner, .. } = inner.shape(defs)
+            if let Shape::Struct { fields: inner, .. } = inner.shape_with_defs(defs)
                 && let Value::Concrete(ConcreteValue::List(items)) = value
             {
                 for item in items.iter_mut() {

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2756,7 +2756,7 @@ fn resolved_attr_type_never_returns_ref_after_peel() {
     defs.insert("Hop3".to_string(), AttributeType::string());
 
     let ref_type = AttributeType::ref_("Hop1".to_string());
-    let resolved = ref_type.resolve_refs(&defs);
+    let resolved = ref_type.resolve_refs_with_defs(&defs);
     assert!(
         !matches!(resolved.as_attr().kind(), AttrTypeKind::Ref(_)),
         "resolve_refs must never return a Ref after peeling"
@@ -2765,7 +2765,7 @@ fn resolved_attr_type_never_returns_ref_after_peel() {
 
     // Non-Ref input is returned as-is (identity behavior).
     let plain = AttributeType::int();
-    let resolved = plain.resolve_refs(&defs);
+    let resolved = plain.resolve_refs_with_defs(&defs);
     assert!(matches!(resolved.as_attr().kind(), AttrTypeKind::Int));
 }
 
@@ -2779,7 +2779,72 @@ fn resolved_attr_type_panics_on_dangling_ref() {
     // unchanged" (which would re-open the carina#3349 hazard).
     let defs = std::collections::BTreeMap::new();
     let ref_type = AttributeType::ref_("Missing".to_string());
-    let _ = ref_type.resolve_refs(&defs);
+    let _ = ref_type.resolve_refs_with_defs(&defs);
+}
+
+#[test]
+fn shape_ref_free_returns_err_for_ref_without_panicking() {
+    let ref_type = AttributeType::ref_("CaptchaConfig".to_string());
+    let err = ref_type
+        .shape_ref_free()
+        .expect_err("bare Ref projection should return a typed error");
+
+    assert_eq!(err.name, "CaptchaConfig");
+    assert_eq!(
+        err.to_string(),
+        "unresolved AttributeType::Ref(\"CaptchaConfig\") has no defs in scope"
+    );
+}
+
+#[test]
+fn shape_ref_free_projects_non_ref_shape() {
+    let attr_type = AttributeType::list(AttributeType::string());
+
+    match attr_type
+        .shape_ref_free()
+        .expect("non-Ref shape is projectable")
+    {
+        Shape::List { inner, ordered } => {
+            assert!(ordered);
+            assert!(matches!(inner.kind(), AttrTypeKind::String));
+        }
+        other => panic!("expected list shape, got {other:?}"),
+    }
+}
+
+#[test]
+fn schema_shape_of_resolves_ref_against_defs() {
+    let mut defs = std::collections::BTreeMap::new();
+    defs.insert("Alias".to_string(), AttributeType::bool());
+    let schema = Schema {
+        root: AttributeType::ref_("Alias".to_string()),
+        defs,
+    };
+
+    assert!(matches!(schema.shape_of(&schema.root), Shape::Bool));
+    assert!(matches!(
+        schema.resolve_of(&schema.root).as_attr().kind(),
+        AttrTypeKind::Bool
+    ));
+}
+
+#[cfg(test)]
+mod deprecated_projection_guard {
+    #![deny(deprecated)]
+
+    use super::*;
+
+    #[test]
+    fn new_projection_apis_are_usable_with_deprecations_denied() {
+        let attr_type = AttributeType::string();
+        assert!(matches!(
+            attr_type.shape_ref_free().expect("string is Ref-free"),
+            Shape::String
+        ));
+
+        let schema = Schema::flat(AttributeType::int());
+        assert!(matches!(schema.shape_of(&schema.root), Shape::Int));
+    }
 }
 
 #[test]
@@ -4495,7 +4560,7 @@ fn walk_custom_lookup_skips_value_unknown() {
                 message: "should never be called".to_string(),
             })
         },
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         &mut errors,
     );
     assert!(
@@ -4548,7 +4613,7 @@ fn union_walk_custom_lookup_succeeds_when_any_member_accepts() {
         &Value::Concrete(ConcreteValue::String("anything".to_string())),
         "attr",
         &lookup,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         &mut errors,
     );
     assert!(
@@ -4587,7 +4652,7 @@ fn union_walk_custom_lookup_emits_smallest_error_set_when_all_fail() {
         &Value::Concrete(ConcreteValue::String("anything".to_string())),
         "attr",
         &lookup,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         &mut errors,
     );
     assert_eq!(
@@ -4629,7 +4694,7 @@ fn union_walk_custom_lookup_cidr_accepts_ipv4_when_lookup_routes_correctly() {
         &Value::Concrete(ConcreteValue::String("10.0.0.0/8".to_string())),
         "cidr",
         &lookup,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
         &mut errors,
     );
     assert!(

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -610,7 +610,7 @@ fn walk_value_against_type(
     // would fall through the wildcard arms below and the
     // leaf-ref check would compare against the raw `Ref` instead
     // of its resolved target.
-    let expected_shape = expected.shape(defs);
+    let expected_shape = expected.shape_with_defs(defs);
     match value {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {
             check_resource_ref_at_position(path, expected, defs, exports, location, errors);

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -695,7 +695,7 @@ pub fn resolve_enum_value(value: &Value, parts: &NamespacedEnumParts<'_>) -> Opt
 /// }
 /// ```
 pub fn resolve_enum_value_recursive(value: &Value, attr_type: &AttributeType) -> Option<Value> {
-    resolve_enum_value_recursive_with_defs(value, attr_type, crate::schema::empty_defs())
+    resolve_enum_value_recursive_projected(value, attr_type, None)
 }
 
 /// Same as [`resolve_enum_value_recursive`] but takes the enclosing
@@ -710,6 +710,14 @@ pub fn resolve_enum_value_recursive_with_defs(
     attr_type: &AttributeType,
     defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> Option<Value> {
+    resolve_enum_value_recursive_projected(value, attr_type, Some(defs))
+}
+
+fn resolve_enum_value_recursive_projected(
+    value: &Value,
+    attr_type: &AttributeType,
+    defs: Option<&std::collections::BTreeMap<String, AttributeType>>,
+) -> Option<Value> {
     // First, try the leaf case: this position is itself an enum.
     if let Some(parts) = attr_type.namespaced_enum_parts()
         && let Some(resolved) = resolve_enum_value(value, &parts)
@@ -717,10 +725,10 @@ pub fn resolve_enum_value_recursive_with_defs(
         return Some(resolved);
     }
 
-    // Project onto Shape so `Ref` is peeled at the type level
-    // (carina#3349). The wildcard arm cannot silently swallow a
-    // `Ref` because `Shape` has no `Ref` variant.
-    match attr_type.shape(defs) {
+    // Project onto Shape so `Ref` is either peeled through schema defs
+    // or rejected by the bare ref-free path. The wildcard arm cannot
+    // silently swallow a `Ref` because `Shape` has no `Ref` variant.
+    match shape_for_projection(attr_type, defs)? {
         crate::schema::Shape::Struct { fields, .. } => {
             let Value::Concrete(ConcreteValue::Map(map)) = value else {
                 return None;
@@ -730,7 +738,7 @@ pub fn resolve_enum_value_recursive_with_defs(
             for field in fields {
                 if let Some(field_value) = map.get(&field.name)
                     && let Some(new_field) =
-                        resolve_enum_value_recursive_with_defs(field_value, &field.field_type, defs)
+                        resolve_enum_value_recursive_projected(field_value, &field.field_type, defs)
                 {
                     rewritten.insert(field.name.clone(), new_field);
                     changed = true;
@@ -745,7 +753,7 @@ pub fn resolve_enum_value_recursive_with_defs(
             let mut rewritten = items.clone();
             let mut changed = false;
             for (i, item) in items.iter().enumerate() {
-                if let Some(new_item) = resolve_enum_value_recursive_with_defs(item, inner, defs) {
+                if let Some(new_item) = resolve_enum_value_recursive_projected(item, inner, defs) {
                     rewritten[i] = new_item;
                     changed = true;
                 }
@@ -759,7 +767,7 @@ pub fn resolve_enum_value_recursive_with_defs(
             let mut rewritten = map.clone();
             let mut changed = false;
             for (k, v) in map {
-                if let Some(new_v) = resolve_enum_value_recursive_with_defs(v, inner, defs) {
+                if let Some(new_v) = resolve_enum_value_recursive_projected(v, inner, defs) {
                     rewritten.insert(k.clone(), new_v);
                     changed = true;
                 }
@@ -769,6 +777,16 @@ pub fn resolve_enum_value_recursive_with_defs(
         // Scalars and Union: nothing to descend into. `Ref` is
         // already peeled by `shape(defs)` above.
         _ => None,
+    }
+}
+
+fn shape_for_projection<'a>(
+    attr_type: &'a AttributeType,
+    defs: Option<&'a std::collections::BTreeMap<String, AttributeType>>,
+) -> Option<crate::schema::Shape<'a>> {
+    match defs {
+        Some(defs) => Some(attr_type.shape_with_defs(defs)),
+        None => attr_type.shape_ref_free().ok(),
     }
 }
 
@@ -931,7 +949,7 @@ pub fn lift_current_state_string_enums_for_data_sources(
 /// [`resolve_enum_value_recursive`]'s "rewrite only on diff" contract so
 /// callers can skip cloning.
 pub fn lift_string_enum_leaves(value: &Value, attr_type: &AttributeType) -> Option<Value> {
-    lift_string_enum_leaves_with_defs(value, attr_type, crate::schema::empty_defs())
+    lift_string_enum_leaves_projected(value, attr_type, None)
 }
 
 /// Same as [`lift_string_enum_leaves`] but takes the enclosing
@@ -943,6 +961,14 @@ pub fn lift_string_enum_leaves_with_defs(
     value: &Value,
     attr_type: &AttributeType,
     defs: &std::collections::BTreeMap<String, AttributeType>,
+) -> Option<Value> {
+    lift_string_enum_leaves_projected(value, attr_type, Some(defs))
+}
+
+fn lift_string_enum_leaves_projected(
+    value: &Value,
+    attr_type: &AttributeType,
+    defs: Option<&std::collections::BTreeMap<String, AttributeType>>,
 ) -> Option<Value> {
     // Leaf case: this position is itself a StringEnum.
     if let Some((_, values, _, dsl_map)) = attr_type.string_enum_parts() {
@@ -968,10 +994,10 @@ pub fn lift_string_enum_leaves_with_defs(
         return None;
     }
 
-    // Project onto Shape so `Ref` is peeled at the type level
-    // (carina#3349). The wildcard arm cannot silently swallow a
-    // `Ref` because `Shape` has no `Ref` variant.
-    match attr_type.shape(defs) {
+    // Project onto Shape so `Ref` is either peeled through schema defs
+    // or rejected by the bare ref-free path. The wildcard arm cannot
+    // silently swallow a `Ref` because `Shape` has no `Ref` variant.
+    match shape_for_projection(attr_type, defs)? {
         crate::schema::Shape::Struct { fields, .. } => {
             let Value::Concrete(ConcreteValue::Map(map)) = value else {
                 return None;
@@ -981,7 +1007,7 @@ pub fn lift_string_enum_leaves_with_defs(
             for field in fields {
                 if let Some(field_value) = map.get(&field.name)
                     && let Some(new_field) =
-                        lift_string_enum_leaves_with_defs(field_value, &field.field_type, defs)
+                        lift_string_enum_leaves_projected(field_value, &field.field_type, defs)
                 {
                     rewritten.insert(field.name.clone(), new_field);
                     changed = true;
@@ -996,7 +1022,7 @@ pub fn lift_string_enum_leaves_with_defs(
             let mut rewritten = items.clone();
             let mut changed = false;
             for (i, item) in items.iter().enumerate() {
-                if let Some(new_item) = lift_string_enum_leaves_with_defs(item, inner, defs) {
+                if let Some(new_item) = lift_string_enum_leaves_projected(item, inner, defs) {
                     rewritten[i] = new_item;
                     changed = true;
                 }
@@ -1010,7 +1036,7 @@ pub fn lift_string_enum_leaves_with_defs(
             let mut rewritten = map.clone();
             let mut changed = false;
             for (k, v) in map {
-                if let Some(new_v) = lift_string_enum_leaves_with_defs(v, inner, defs) {
+                if let Some(new_v) = lift_string_enum_leaves_projected(v, inner, defs) {
                     rewritten.insert(k.clone(), new_v);
                     changed = true;
                 }

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -273,7 +273,7 @@ fn path_traverses_deferred(
         // Resolve `Ref` chains so the cyclic-CFN case
         // (`Statement -> AndStatement -> List<Statement>`) does not
         // bail out at the first cycle hop (carina#3340).
-        let resolved = current_type.resolve_refs(defs).as_attr();
+        let resolved = current_type.resolve_refs_with_defs(defs).as_attr();
         match (resolved.kind(), segment) {
             (AttrTypeKind::List { inner, .. }, PathSegment::Subscript { .. }) => {
                 current_type = inner;

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -502,7 +502,7 @@ fn infer_resource_ref_with_visiting(
         // opaque `Ref` (carina#3340). `descend_struct_field` already
         // resolves internally for the Field arm; pre-resolving here
         // also keeps the Subscript arms shape-matched.
-        let resolved = current.resolve_refs(&schema.defs).as_attr();
+        let resolved = current.resolve_refs_with_defs(&schema.defs).as_attr();
         current = match (seg, &resolved.kind) {
             (PathSegment::Field { name }, _) => {
                 match descend_struct_field(resolved, name, &schema.defs) {
@@ -554,7 +554,7 @@ fn infer_resource_ref_with_visiting(
     // accessing, not for one buried inside a transferred value.
     // Resolve any trailing `Ref` so the Union check and the
     // TypeExpr projection see the underlying shape (carina#3340).
-    let current = current.resolve_refs(&schema.defs).as_attr();
+    let current = current.resolve_refs_with_defs(&schema.defs).as_attr();
     if matches!(&current.kind, AttrTypeKind::Union(_)) {
         return Err(InferenceError::UnknownType {
             reason: format!(
@@ -584,7 +584,7 @@ fn descend_struct_field<'a>(
     // Resolve any leading `Ref` chain so a reference path inside a
     // cyclic CFN struct (`WebACL.Statement -> AndStatement -> ...`)
     // can be followed across the cycle (carina#3340).
-    match attr_type.shape(defs) {
+    match attr_type.shape_with_defs(defs) {
         crate::schema::Shape::Struct { fields, .. } => fields
             .iter()
             .find(|f| f.name == field)

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -458,7 +458,7 @@ fn collect_ref_type_errors(
 ///
 /// `defs` carries the schema's named definitions, used to peel any
 /// `AttributeType::ref_(name)` receiver via [`AttributeType::shape`]
-/// before shape-based dispatch. Pass [`crate::schema::empty_defs()`]
+/// before shape-based dispatch. Pass [`crate::schema::empty_defs_for_schema_walks()`]
 /// when no resource schema is in scope.
 pub fn is_type_expr_compatible_with_schema(
     type_expr: &crate::parser::TypeExpr,
@@ -487,10 +487,10 @@ pub fn is_type_expr_compatible_with_schema(
             }
             is_string_compatible_type(attr_type, defs)
         }
-        TypeExpr::Bool => matches!(attr_type.shape(defs), Shape::Bool),
-        TypeExpr::Int => matches!(attr_type.shape(defs), Shape::Int),
-        TypeExpr::Float => matches!(attr_type.shape(defs), Shape::Float),
-        TypeExpr::Duration => matches!(attr_type.shape(defs), Shape::Duration),
+        TypeExpr::Bool => matches!(attr_type.shape_with_defs(defs), Shape::Bool),
+        TypeExpr::Int => matches!(attr_type.shape_with_defs(defs), Shape::Int),
+        TypeExpr::Float => matches!(attr_type.shape_with_defs(defs), Shape::Float),
+        TypeExpr::Duration => matches!(attr_type.shape_with_defs(defs), Shape::Duration),
         TypeExpr::Simple(name) => {
             // Two compatibility directions both succeed:
             //
@@ -514,7 +514,7 @@ pub fn is_type_expr_compatible_with_schema(
             // pointing at a `Custom` chain is followed correctly.
             let mut current: &AttributeType = attr_type;
             loop {
-                let resolved = current.resolve_refs(defs);
+                let resolved = current.resolve_refs_with_defs(defs);
                 let resolved_attr = resolved.as_attr();
                 let type_snake = crate::parser::pascal_to_snake(&resolved_attr.type_name());
                 if type_snake == *name {
@@ -539,13 +539,13 @@ pub fn is_type_expr_compatible_with_schema(
             // the existing `Simple → Union<String, Int>` rejection
             // (`type_compat_simple_rejected_by_mixed_string_int_union_receiver`)
             // is preserved.
-            if let Shape::Union(members) = attr_type.shape(defs) {
+            if let Shape::Union(members) = attr_type.shape_with_defs(defs) {
                 let has_plain_string = members
                     .iter()
-                    .any(|m| matches!(m.shape(defs), Shape::String));
+                    .any(|m| matches!(m.shape_with_defs(defs), Shape::String));
                 let others_shape_disjoint = members.iter().all(|m| {
                     matches!(
-                        m.shape(defs),
+                        m.shape_with_defs(defs),
                         Shape::String
                             | Shape::List { .. }
                             | Shape::Map { .. }
@@ -558,14 +558,14 @@ pub fn is_type_expr_compatible_with_schema(
             }
             false
         }
-        TypeExpr::List(inner) => match attr_type.shape(defs) {
+        TypeExpr::List(inner) => match attr_type.shape_with_defs(defs) {
             Shape::List {
                 inner: schema_inner,
                 ..
             } => is_type_expr_compatible_with_schema(inner, schema_inner, defs),
             _ => false,
         },
-        TypeExpr::Map(inner) => match attr_type.shape(defs) {
+        TypeExpr::Map(inner) => match attr_type.shape_with_defs(defs) {
             Shape::Map {
                 value: schema_inner,
                 ..
@@ -574,7 +574,7 @@ pub fn is_type_expr_compatible_with_schema(
         },
         TypeExpr::Struct {
             fields: expr_fields,
-        } => match attr_type.shape(defs) {
+        } => match attr_type.shape_with_defs(defs) {
             Shape::Struct {
                 fields: schema_fields,
                 ..
@@ -624,7 +624,7 @@ pub fn is_string_compatible_type(
     attr_type: &AttributeType,
     defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> bool {
-    match attr_type.shape(defs) {
+    match attr_type.shape_with_defs(defs) {
         Shape::String | Shape::Custom { .. } | Shape::StringEnum { .. } => true,
         Shape::Union(types) => types.iter().all(|t| is_string_compatible_type(t, defs)),
         Shape::Int
@@ -647,7 +647,7 @@ fn is_plain_string_or_string_union(
     attr_type: &AttributeType,
     defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> bool {
-    match attr_type.shape(defs) {
+    match attr_type.shape_with_defs(defs) {
         Shape::String => true,
         Shape::Union(types) => types
             .iter()
@@ -689,7 +689,7 @@ fn attr_type_demands_specific_custom(
     attr_type: &AttributeType,
     defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> bool {
-    match attr_type.shape(defs) {
+    match attr_type.shape_with_defs(defs) {
         Shape::Custom {
             identity: Some(_), ..
         } => true,
@@ -1392,7 +1392,7 @@ pub(crate) fn narrow_attribute_type<'a>(
         // attribute would fall into the wildcard arm below and
         // every nested narrowing step would mis-report a shape
         // mismatch.
-        let shape = current.shape(defs);
+        let shape = current.shape_with_defs(defs);
         current = match (seg, shape) {
             (PathSegment::Field { name }, Shape::Struct { fields, name: sn }) => {
                 let Some(field) = fields.iter().find(|f| f.name == *name) else {

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1303,7 +1303,7 @@ fn is_type_expr_compatible_struct_rejects_missing_schema_field_when_expr_has_ext
     assert!(!is_type_expr_compatible_with_schema(
         &expr,
         &schema,
-        crate::schema::empty_defs()
+        crate::schema::empty_defs_for_schema_walks()
     ));
 }
 
@@ -1326,7 +1326,7 @@ fn is_type_expr_compatible_struct_matches_same_shape_schema() {
     assert!(is_type_expr_compatible_with_schema(
         &expr,
         &schema,
-        crate::schema::empty_defs()
+        crate::schema::empty_defs_for_schema_walks()
     ));
 }
 
@@ -1344,7 +1344,7 @@ fn is_type_expr_compatible_struct_flows_into_map_when_fields_share_type() {
     assert!(is_type_expr_compatible_with_schema(
         &expr,
         &schema,
-        crate::schema::empty_defs()
+        crate::schema::empty_defs_for_schema_walks()
     ));
 }
 
@@ -1357,7 +1357,7 @@ fn is_type_expr_compatible_struct_rejects_map_with_wrong_element_type() {
     assert!(!is_type_expr_compatible_with_schema(
         &expr,
         &schema,
-        crate::schema::empty_defs()
+        crate::schema::empty_defs_for_schema_walks()
     ));
 }
 
@@ -1374,17 +1374,17 @@ fn is_type_expr_compatible_unknown_rejects_all_concrete_receivers() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Unknown,
         &AttributeType::string(),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Unknown,
         &AttributeType::int(),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Unknown,
         &AttributeType::bool(),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1405,7 +1405,7 @@ fn is_type_expr_compatible_unknown_rejects_custom_receiver() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Unknown,
         &custom,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1427,7 +1427,7 @@ fn is_type_expr_compatible_string_rejects_custom_with_semantic_name() {
         !is_type_expr_compatible_with_schema(
             &TypeExpr::String,
             &schema,
-            crate::schema::empty_defs()
+            crate::schema::empty_defs_for_schema_walks()
         ),
         "TypeExpr::String must not satisfy Custom{{semantic_name:VpcId}}"
     );
@@ -1455,7 +1455,7 @@ fn is_type_expr_compatible_string_accepts_custom_without_semantic_name() {
         is_type_expr_compatible_with_schema(
             &TypeExpr::String,
             &schema,
-            crate::schema::empty_defs()
+            crate::schema::empty_defs_for_schema_walks()
         ),
         "TypeExpr::String must satisfy Custom with no semantic_name"
     );
@@ -1486,7 +1486,7 @@ fn is_type_expr_compatible_string_rejects_union_containing_specific_custom() {
         !is_type_expr_compatible_with_schema(
             &TypeExpr::String,
             &schema,
-            crate::schema::empty_defs()
+            crate::schema::empty_defs_for_schema_walks()
         ),
         "TypeExpr::String must not satisfy a Union containing Custom{{semantic}}"
     );
@@ -1516,7 +1516,7 @@ fn is_type_expr_compatible_string_rejects_union_of_only_specific_customs() {
         !is_type_expr_compatible_with_schema(
             &TypeExpr::String,
             &schema,
-            crate::schema::empty_defs()
+            crate::schema::empty_defs_for_schema_walks()
         ),
         "TypeExpr::String must not satisfy a Union of only specific-Custom alternatives"
     );
@@ -1540,7 +1540,7 @@ fn is_type_expr_compatible_string_accepts_union_of_only_strings() {
         is_type_expr_compatible_with_schema(
             &TypeExpr::String,
             &schema,
-            crate::schema::empty_defs()
+            crate::schema::empty_defs_for_schema_walks()
         ),
         "TypeExpr::String must satisfy a Union of only string-shaped non-specific types"
     );
@@ -1568,7 +1568,7 @@ fn is_type_expr_compatible_simple_vpcid_accepts_custom_vpcid() {
     assert!(is_type_expr_compatible_with_schema(
         &expr,
         &schema,
-        crate::schema::empty_defs()
+        crate::schema::empty_defs_for_schema_walks()
     ));
 }
 
@@ -1801,7 +1801,7 @@ fn type_compat_subtype_accepted() {
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("arn".to_string()),
         &kms_key_arn,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1826,7 +1826,7 @@ fn type_compat_sibling_rejected() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("kms_key_arn".to_string()),
         &iam_role_arn,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1851,7 +1851,7 @@ fn type_compat_resource_id_subtype() {
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("aws_resource_id".to_string()),
         &vpc_id,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1876,7 +1876,7 @@ fn type_compat_resource_id_siblings_rejected() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("vpc_id".to_string()),
         &subnet_id,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1893,7 +1893,7 @@ fn type_compat_exact_match() {
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("arn".to_string()),
         &arn,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1907,7 +1907,7 @@ fn type_compat_simple_rejected_by_mixed_string_int_union_receiver() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("aws_account_id".to_string()),
         &mixed,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1922,7 +1922,7 @@ fn type_compat_simple_subtypes_into_plain_string() {
     assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("aws_account_id".to_string()),
         &AttributeType::string(),
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -1958,7 +1958,7 @@ fn type_compat_simple_into_union_struct_or_string() {
             is_type_expr_compatible_with_schema(
                 &TypeExpr::Simple(name.to_string()),
                 &principal_union,
-                crate::schema::empty_defs(),
+                crate::schema::empty_defs_for_schema_walks(),
             ),
             "Simple({name}) should be assignable to Union<Struct, String>"
         );
@@ -1985,7 +1985,7 @@ fn type_compat_simple_rejected_when_union_has_other_scalar() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
         &mixed,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -2004,7 +2004,7 @@ fn type_compat_simple_rejected_when_union_has_no_plain_string() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
         &no_string,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 
@@ -2030,7 +2030,7 @@ fn type_compat_simple_rejected_when_union_has_string_shaped_peer() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
         &with_custom,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
     let with_enum = AttributeType::union(vec![
         AttributeType::string(),
@@ -2044,7 +2044,7 @@ fn type_compat_simple_rejected_when_union_has_string_shaped_peer() {
     assert!(!is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
         &with_enum,
-        crate::schema::empty_defs(),
+        crate::schema::empty_defs_for_schema_walks(),
     ));
 }
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1373,7 +1373,7 @@ fn peel_custom(t: &AttributeType) -> &AttributeType {
 /// map so cyclic CFN definitions (`AttributeType::Ref`) are followed
 /// during the walk (carina#3340). The `Ref` arm resolves and recurses;
 /// primitives / unions terminate as before. Pass
-/// [`crate::schema::empty_defs()`] when the caller is confident no
+/// [`crate::schema::empty_defs_for_schema_walks()`] when the caller is confident no
 /// `Ref` is reachable.
 ///
 /// See #2481, #2510.
@@ -1392,7 +1392,7 @@ pub(crate) fn canonicalize_with_type(
     // Without this, the historical wildcard `(v, _) => v` silently
     // passed Ref-typed values through without canonicalization —
     // exactly the carina#3340 / carina#3349 bug class.
-    match (value, unwrapped.shape(defs)) {
+    match (value, unwrapped.shape_with_defs(defs)) {
         (Value::Concrete(ConcreteValue::List(items)), crate::schema::Shape::List { inner, .. }) => {
             let canonicalized = items
                 .into_iter()
@@ -3229,7 +3229,7 @@ mod tests {
     fn canonicalize_scalar_to_string_list() {
         let t = string_or_list_of_strings();
         let v = Value::Concrete(ConcreteValue::String("repo:foo:*".to_string()));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(
             canon,
             Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]))
@@ -3242,7 +3242,7 @@ mod tests {
         let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
             ConcreteValue::String("repo:foo:*".to_string()),
         )]));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(
             canon,
             Value::Concrete(ConcreteValue::StringList(vec!["repo:foo:*".to_string()]))
@@ -3257,7 +3257,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("b".to_string())),
             Value::Concrete(ConcreteValue::String("c".to_string())),
         ]));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(
             canon,
             Value::Concrete(ConcreteValue::StringList(vec![
@@ -3272,7 +3272,8 @@ mod tests {
     fn canonicalize_idempotent_on_string_list() {
         let t = string_or_list_of_strings();
         let v = Value::Concrete(ConcreteValue::StringList(vec!["a".to_string()]));
-        let canon = canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs());
+        let canon =
+            canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(canon, v);
     }
 
@@ -3282,7 +3283,7 @@ mod tests {
         let canon = canonicalize_with_type(
             v.clone(),
             &AttributeType::string(),
-            crate::schema::empty_defs(),
+            crate::schema::empty_defs_for_schema_walks(),
         );
         assert_eq!(canon, v);
     }
@@ -3295,7 +3296,8 @@ mod tests {
         let v = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
             ConcreteValue::Int(1),
         )]));
-        let canon = canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs());
+        let canon =
+            canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(canon, v);
     }
 
@@ -3314,7 +3316,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3343,7 +3345,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3387,7 +3389,7 @@ mod tests {
             )),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3412,7 +3414,7 @@ mod tests {
             )])),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3432,7 +3434,8 @@ mod tests {
     fn canonicalize_union_string_member_passthrough() {
         let t = principal_union();
         let v = Value::Concrete(ConcreteValue::String("*".to_string()));
-        let canon = canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs());
+        let canon =
+            canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(canon, v);
     }
 
@@ -3442,7 +3445,8 @@ mod tests {
     fn canonicalize_union_no_matching_member_is_identity() {
         let t = AttributeType::union(vec![AttributeType::int(), AttributeType::bool()]);
         let v = Value::Concrete(ConcreteValue::String("not-an-int".to_string()));
-        let canon = canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs());
+        let canon =
+            canonicalize_with_type(v.clone(), &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(canon, v);
     }
 
@@ -3455,7 +3459,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("repo:foo:*".to_string())),
         );
         let v = Value::Concrete(ConcreteValue::Map(map));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         match canon {
             Value::Concrete(ConcreteValue::Map(m)) => {
                 assert_eq!(
@@ -3482,7 +3486,7 @@ mod tests {
             None,
         );
         let v = Value::Concrete(ConcreteValue::String("x".to_string()));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(
             canon,
             Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]))
@@ -3495,7 +3499,7 @@ mod tests {
         let v = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
             ConcreteValue::String("s".to_string()),
         ))));
-        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs());
+        let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         match canon {
             Value::Deferred(DeferredValue::Secret(inner)) => {
                 assert_eq!(

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -651,23 +651,23 @@ impl CompletionProvider {
 
     fn extract_struct_fields<'a>(
         &self,
+        schema: &'a ResourceSchema,
         attr_type: &'a AttributeType,
-        defs: &'a std::collections::BTreeMap<String, AttributeType>,
     ) -> Option<&'a [StructField]> {
         use carina_core::schema::Shape;
         // Project onto `Shape` so any `Ref` chain is peeled at the
         // type level (carina#3349). The cyclic-CFN case
         // (`Statement -> AndStatement -> List<Statement>`) descends
-        // because `shape(defs)` walks `Ref` against `defs`.
-        match attr_type.shape(defs) {
+        // because `shape_of` walks `Ref` against the schema's defs.
+        match schema.shape_of(attr_type) {
             Shape::Struct { fields, .. } => Some(fields),
-            Shape::List { inner, .. } => match inner.shape(defs) {
+            Shape::List { inner, .. } => match schema.shape_of(inner) {
                 Shape::Struct { fields, .. } => Some(fields),
                 _ => None,
             },
             Shape::Union(members) => members
                 .iter()
-                .find_map(|m| self.extract_struct_fields(m, defs)),
+                .find_map(|m| self.extract_struct_fields(schema, m)),
             _ => None,
         }
     }
@@ -707,7 +707,7 @@ impl CompletionProvider {
         let mut current_type = &attr_schema.attr_type;
 
         for name in &attr_path[1..] {
-            let fields = self.extract_struct_fields(current_type, &schema.defs)?;
+            let fields = self.extract_struct_fields(schema, current_type)?;
             let field = fields
                 .iter()
                 .find(|f| f.name == *name || f.block_name.as_deref() == Some(name))?;
@@ -723,7 +723,7 @@ impl CompletionProvider {
         attr_path: &[String],
     ) -> Option<&'a [StructField]> {
         let attr_type = self.resolve_type_for_path(schema, attr_path)?;
-        self.extract_struct_fields(attr_type, &schema.defs)
+        self.extract_struct_fields(schema, attr_type)
     }
 
     fn struct_field_completions(
@@ -784,8 +784,7 @@ impl CompletionProvider {
         attr_path: &[String],
     ) -> Option<&'a AttributeType> {
         let attr_type = self.resolve_type_for_path(schema, attr_path)?;
-        let defs = carina_core::schema::empty_defs();
-        if let Shape::Map { key, .. } = attr_type.shape(defs) {
+        if let Shape::Map { key, .. } = schema.shape_of(attr_type) {
             Some(key)
         } else {
             None
@@ -798,9 +797,8 @@ impl CompletionProvider {
         key_type: &AttributeType,
         trigger_suggest: &Command,
     ) -> Vec<CompletionItem> {
-        let defs = carina_core::schema::empty_defs();
-        match key_type.shape(defs) {
-            Shape::StringEnum { values, .. } => values
+        match key_type.shape_ref_free() {
+            Ok(Shape::StringEnum { values, .. }) => values
                 .iter()
                 .map(|v| CompletionItem {
                     label: v.clone(),
@@ -810,7 +808,7 @@ impl CompletionProvider {
                     ..Default::default()
                 })
                 .collect(),
-            _ => vec![],
+            Ok(_) | Err(_) => vec![],
         }
     }
 

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -446,11 +446,11 @@ impl CompletionProvider {
         // binding refs, and structural type candidates).
         if let Some(attr_type) = type_expr_to_attribute_type(&arg.type_expr) {
             // Synthetic `attr_type` is built directly from a `TypeExpr`,
-            // which never lowers to `AttributeType::Ref`; empty defs is
-            // sufficient for the Ref-peel inside compatibility checks.
+            // which never lowers to `AttributeType::Ref`; an empty map is
+            // sufficient for compatibility checks that still accept defs.
             return self.value_completions_for_attribute_type(
                 &attr_type,
-                carina_core::schema::empty_defs(),
+                &std::collections::BTreeMap::new(),
                 text,
                 base_path,
             );

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -93,9 +93,9 @@ impl CompletionProvider {
                 // class as carina#3349.
                 if let Some(bn) = &attr.block_name
                     && matches!(
-                        attr.attr_type.shape(&schema.defs),
+                        schema.shape_of(&attr.attr_type),
                         Shape::List { inner, .. } if matches!(
-                            inner.shape(&schema.defs),
+                            schema.shape_of(inner),
                             Shape::Struct { .. }
                         )
                     )
@@ -286,11 +286,7 @@ impl CompletionProvider {
         let target_attr_type = target_schema
             .and_then(|s| s.attributes.get(attr_name))
             .map(|a| &a.attr_type);
-        let target_defs: &std::collections::BTreeMap<String, carina_core::schema::AttributeType> =
-            match target_schema {
-                Some(s) => &s.defs,
-                None => carina_core::schema::empty_defs(),
-            };
+        let target_defs = target_schema.map(|s| &s.defs);
 
         // In-scope bare identifiers: `let` bindings + `arguments {}`
         // parameters (#2624 / #2642). When the target attribute's
@@ -309,6 +305,8 @@ impl CompletionProvider {
         match target_attr_type {
             None => completions.extend(in_scope),
             Some(attr_type) => {
+                let target_defs =
+                    target_defs.expect("target_attr_type is only set when target_schema exists");
                 // Argument count is small (usually < 10), so a Vec
                 // walked linearly is cheaper than a HashMap.
                 let typed_arguments: Vec<(String, carina_core::parser::TypeExpr)> = self
@@ -346,6 +344,7 @@ impl CompletionProvider {
         let for_bindings = super::top_level::extract_for_bindings_in_scope(text, position);
         for binding in &for_bindings {
             if let Some(attr_type) = attr_type_for_for_filter
+                && let Some(target_defs) = target_defs
                 && let Some(element_type) = infer_for_binding_type(
                     binding,
                     &upstream_sources,
@@ -379,7 +378,7 @@ impl CompletionProvider {
             // (cyclic-CFN case) also gets the snippet (same bug class as
             // carina#3349).
             if matches!(
-                attr_schema.attr_type.shape(&schema.defs),
+                schema.shape_of(&attr_schema.attr_type),
                 Shape::Struct { .. }
             ) {
                 completions.push(CompletionItem {
@@ -548,12 +547,11 @@ impl CompletionProvider {
     /// Extract the Custom type's kind name from an AttributeType, if it
     /// is a Custom type with a structured identity.
     fn extract_custom_type_name(attr_type: &AttributeType) -> Option<&str> {
-        let defs = carina_core::schema::empty_defs();
-        match attr_type.shape(defs) {
-            Shape::Custom {
+        match attr_type.shape_ref_free() {
+            Ok(Shape::Custom {
                 identity: Some(id), ..
-            } => Some(&id.kind),
-            _ => None,
+            }) => Some(&id.kind),
+            Ok(_) | Err(_) => None,
         }
     }
 
@@ -562,8 +560,10 @@ impl CompletionProvider {
         attr_type: &AttributeType,
         resource_type: Option<&str>,
     ) -> Vec<CompletionItem> {
-        let defs = carina_core::schema::empty_defs();
-        match attr_type.shape(defs) {
+        let Ok(shape) = attr_type.shape_ref_free() else {
+            return Vec::new();
+        };
+        match shape {
             Shape::Bool => {
                 vec![
                     CompletionItem {
@@ -1267,12 +1267,11 @@ impl CompletionProvider {
             return Vec::new();
         };
         let effective = if in_nested {
-            let defs = carina_core::schema::empty_defs();
-            match annotation.shape(defs) {
-                Shape::List { inner, .. } | Shape::Map { value: inner, .. } => inner.clone(),
+            match annotation.shape_ref_free() {
+                Ok(Shape::List { inner, .. } | Shape::Map { value: inner, .. }) => inner.clone(),
                 // Inside `{ ... }` of a non-collection annotation we
                 // don't know what the user means — fall silent.
-                _ => return Vec::new(),
+                Ok(_) | Err(_) => return Vec::new(),
             }
         } else {
             annotation
@@ -1980,12 +1979,13 @@ fn return_type_fits(ret: builtins::BuiltinReturnType, attr_type: &AttributeType)
     // Shape's deliberate omission of a `Ref` variant lifts the
     // carina#3349 invariant (Ref must be peeled before a wildcard
     // arm sees it) into the type system: this match cannot leak Ref
-    // into the trailing wildcard. Pass `empty_defs` because this
-    // completion-time helper does not carry the schema's defs map —
-    // unresolved Ref attrs simply fall through to `false`, which is
-    // shape-consistent with the historical `Struct => false` arm.
-    let defs = carina_core::schema::empty_defs();
-    match attr_type.shape(defs) {
+    // into the trailing wildcard. Bare completion-time helpers use
+    // `shape_ref_free`; an unexpected Ref falls through to `false`,
+    // matching the existing silent fallback contract.
+    let Ok(shape) = attr_type.shape_ref_free() else {
+        return false;
+    };
+    match shape {
         Shape::Union(members) => members.iter().any(|m| return_type_fits(ret, m)),
         Shape::String => matches!(ret, R::String | R::Any),
         Shape::Int => matches!(ret, R::Int | R::Any),

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -535,7 +535,7 @@ impl DiagnosticEngine {
                             // bare-struct attribute is still caught (same
                             // bug class as carina#3349).
                             if matches!(
-                                attr_schema.attr_type.shape(&schema.defs),
+                                schema.shape_of(&attr_schema.attr_type),
                                 carina_core::schema::Shape::Struct { .. }
                             ) && matches!(attr_value, Value::Concrete(ConcreteValue::List(_)))
                             {
@@ -566,7 +566,7 @@ impl DiagnosticEngine {
                             // else (and when the StringEnum branch can't locate a
                             // value range).
                             if let carina_core::schema::Shape::StringEnum { .. } =
-                                attr_schema.attr_type.shape(&schema.defs)
+                                schema.shape_of(&attr_schema.attr_type)
                                 && let Some(diag) = build_string_enum_diagnostic(
                                     &attr_schema.attr_type,
                                     attr_value,
@@ -586,7 +586,7 @@ impl DiagnosticEngine {
                             // wildcard arm cannot silently drop a Ref-typed
                             // attribute (carina#3349 invariant lifted into
                             // the type system).
-                            let attr_shape = attr_schema.attr_type.shape(&schema.defs);
+                            let attr_shape = schema.shape_of(&attr_schema.attr_type);
                             let type_error = match (attr_shape, attr_value) {
                                 // Bool type should not receive String
                                 (
@@ -765,7 +765,7 @@ impl DiagnosticEngine {
                                     carina_core::schema::Shape::List { inner, .. },
                                     Value::Concrete(ConcreteValue::List(_)),
                                 ) if !matches!(
-                                    inner.shape(&schema.defs),
+                                    schema.shape_of(inner),
                                     carina_core::schema::Shape::Struct { .. }
                                 ) =>
                                 {
@@ -836,10 +836,10 @@ impl DiagnosticEngine {
                             // struct-field validation. Same bug class as
                             // carina#3349 — a raw match arm would silently
                             // drop `Ref` and skip the entire pass.
-                            let is_struct_shape = match attr_schema.attr_type.shape(&schema.defs) {
+                            let is_struct_shape = match schema.shape_of(&attr_schema.attr_type) {
                                 carina_core::schema::Shape::Struct { .. } => true,
                                 carina_core::schema::Shape::List { inner, .. } => matches!(
-                                    inner.shape(&schema.defs),
+                                    schema.shape_of(inner),
                                     carina_core::schema::Shape::Struct { .. }
                                 ),
                                 _ => false,

--- a/carina-lsp/src/diagnostics/validation.rs
+++ b/carina-lsp/src/diagnostics/validation.rs
@@ -192,9 +192,9 @@ impl DiagnosticEngine {
             // `Ref("LifecycleConfiguration")` whose def carries a
             // `List<Ref<Rule>>` field (same bug class as carina#3349).
             let is_list_struct = matches!(
-                attr_schema.attr_type.shape(&schema.defs),
+                schema.shape_of(&attr_schema.attr_type),
                 Shape::List { inner, .. } if matches!(
-                    inner.shape(&schema.defs),
+                    schema.shape_of(inner),
                     Shape::Struct { .. }
                 )
             );

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -1556,16 +1556,21 @@ mod tests {
             .get("description")
             .expect("description attribute");
         assert_eq!(desc_attr.name, "description");
-        let defs = carina_core::schema::empty_defs();
         assert!(matches!(
-            desc_attr.attr_type.shape(defs),
+            desc_attr
+                .attr_type
+                .shape_ref_free()
+                .expect("test schema is Ref-free"),
             carina_core::schema::Shape::String
         ));
         assert!(desc_attr.required);
 
         let enabled_attr = schema.attributes.get("enabled").expect("enabled attribute");
         assert!(matches!(
-            enabled_attr.attr_type.shape(defs),
+            enabled_attr
+                .attr_type
+                .shape_ref_free()
+                .expect("test schema is Ref-free"),
             carina_core::schema::Shape::Bool
         ));
 
@@ -1574,7 +1579,10 @@ mod tests {
             .get("priority")
             .expect("priority attribute");
         assert!(matches!(
-            priority_attr.attr_type.shape(defs),
+            priority_attr
+                .attr_type
+                .shape_ref_free()
+                .expect("test schema is Ref-free"),
             carina_core::schema::Shape::Int
         ));
 
@@ -1585,17 +1593,24 @@ mod tests {
         assert_eq!(ingress_attr.removable, Some(false));
 
         // List with ordered: false
-        match ingress_attr.attr_type.shape(defs) {
+        match ingress_attr
+            .attr_type
+            .shape_ref_free()
+            .expect("test schema is Ref-free")
+        {
             carina_core::schema::Shape::List { inner, ordered } => {
                 assert!(!ordered, "list should be unordered");
 
                 // Union inside list
-                match inner.shape(defs) {
+                match inner.shape_ref_free().expect("test schema is Ref-free") {
                     carina_core::schema::Shape::Union(members) => {
                         assert_eq!(members.len(), 2);
 
                         // First member: struct with block_name and provider_name on fields
-                        match members[0].shape(defs) {
+                        match members[0]
+                            .shape_ref_free()
+                            .expect("test schema is Ref-free")
+                        {
                             carina_core::schema::Shape::Struct { name, fields } => {
                                 assert_eq!(name, "IngressRule");
                                 assert_eq!(fields.len(), 2);
@@ -1603,7 +1618,10 @@ mod tests {
                                 let from_port = &fields[0];
                                 assert_eq!(from_port.name, "from_port");
                                 assert!(matches!(
-                                    from_port.field_type.shape(defs),
+                                    from_port
+                                        .field_type
+                                        .shape_ref_free()
+                                        .expect("test schema is Ref-free"),
                                     carina_core::schema::Shape::Int
                                 ));
                                 assert!(from_port.required);
@@ -1620,7 +1638,10 @@ mod tests {
                                 let protocol = &fields[1];
                                 assert_eq!(protocol.name, "protocol");
                                 assert!(matches!(
-                                    protocol.field_type.shape(defs),
+                                    protocol
+                                        .field_type
+                                        .shape_ref_free()
+                                        .expect("test schema is Ref-free"),
                                     carina_core::schema::Shape::String
                                 ));
                                 assert!(protocol.block_name.is_none());
@@ -1631,7 +1652,9 @@ mod tests {
 
                         // Second member: String
                         assert!(matches!(
-                            members[1].shape(defs),
+                            members[1]
+                                .shape_ref_free()
+                                .expect("test schema is Ref-free"),
                             carina_core::schema::Shape::String
                         ));
                     }
@@ -1652,9 +1675,10 @@ mod tests {
         // accepts `duration = 30min` against that declaration.
         let json = r#"{"timeout":{"type":"Duration"}}"#;
         let types = json_to_attribute_types(json);
-        let defs = carina_core::schema::empty_defs();
         assert!(matches!(
-            types.get("timeout").map(|t| t.shape(defs)),
+            types
+                .get("timeout")
+                .map(|t| t.shape_ref_free().expect("test schema is Ref-free")),
             Some(carina_core::schema::Shape::Duration)
         ));
     }
@@ -1838,8 +1862,7 @@ mod tests {
             ],
         };
         let core_attr = proto_attr_type_to_core(&proto_attr);
-        let defs = carina_core::schema::empty_defs();
-        match core_attr.shape(defs) {
+        match core_attr.shape_ref_free().expect("test schema is Ref-free") {
             carina_core::schema::Shape::StringEnum { dsl_aliases, .. } => {
                 assert_eq!(dsl_aliases.len(), 2);
                 assert!(
@@ -1862,8 +1885,7 @@ mod tests {
         let json = r#"{"type":"string_enum","values":["A","B"],"name":"X"}"#;
         let proto_attr: proto::AttributeType = serde_json::from_str(json).unwrap();
         let core_attr = proto_attr_type_to_core(&proto_attr);
-        let defs = carina_core::schema::empty_defs();
-        match core_attr.shape(defs) {
+        match core_attr.shape_ref_free().expect("test schema is Ref-free") {
             carina_core::schema::Shape::StringEnum { dsl_aliases, .. } => {
                 assert!(dsl_aliases.is_empty());
             }
@@ -1880,8 +1902,7 @@ mod tests {
             length: Some((Some(1), Some(9))),
         };
         let core_attr = proto_attr_type_to_core(&proto_attr);
-        let defs = carina_core::schema::empty_defs();
-        match core_attr.shape(defs) {
+        match core_attr.shape_ref_free().expect("test schema is Ref-free") {
             carina_core::schema::Shape::Custom {
                 identity,
                 pattern,


### PR DESCRIPTION
## Summary

PR1 of the carina#3371 chain (the type-level half of awscc#290 hazard-1). Makes `ref_type.shape(empty_defs())` for a Ref-bearing schema-derived type **unwritable through the public API** — the runtime panic becomes a compile-gated deprecation (schema-coupled path) or a typed `Result` (bare path).

Design: `notes/specs/2026-05-31-schema-bound-typeref-design.md` (Design (b), Result variant).

## What changed

**New public API:**
- `Schema::shape_of(&ty)` / `ResourceSchema::shape_of(&ty)` (+ `resolve_of`) — borrow `self.defs` internally, so a `Ref` is projectable only through an object that owns the defs that resolve it.
- `AttributeType::shape_ref_free(&self) -> Result<Shape, RefEncountered>` — no defs, returns `Err(RefEncountered)` on a `Ref` instead of panicking. The sanctioned bare / no-schema path.
- `RefEncountered` error type.

**Deprecated (panic-intact shims, kept so git-pinned providers still compile):**
- `AttributeType::shape(defs)`, `AttributeType::resolve_refs(defs)`, `empty_defs()` are now `#[deprecated]` thin wrappers over `pub(crate)` carriers (`shape_with_defs` / `resolve_refs_with_defs` / `empty_defs_for_schema_walks`). In-crate code uses the carriers, so it never trips the deprecation lint — which means `cargo clippy --workspace --all-targets -- -D warnings` enforces "no in-repo caller uses the old foot-gun".

**In-repo migration:** all carina-core / carina-lsp / carina-plugin-host callers moved off the deprecated API. Bucket-A sites (schema in scope) use the `pub(crate)` defs carriers or `shape_of`; bucket-B1 sites (Ref-free, no schema) use `shape_ref_free()` with the Err arm matching their existing "fall silent / return None" contract. Behavior is preserved exactly — the `schema.map(...).unwrap_or(empty_defs())` fallbacks keep the same empty-defs semantics, and the only semantic change is that the bare enum-lift wrappers now return `None` (not panic) if a `Ref` ever reaches them.

## TDD

- `shape_ref_free_returns_err_for_ref_without_panicking` — `Err(RefEncountered{name})`, no panic.
- `shape_ref_free_projects_non_ref_shape` — correct `Shape` for non-Ref.
- `schema_shape_of_resolves_ref_against_defs` — `Ref` resolved through a real schema.
- A `#![deny(deprecated)]` test module pins that the new projection APIs are usable with deprecations denied (encodes that the old foot-gun is deprecation-gated).

## Verify

- `cargo check -p carina-core` — clean
- `cargo nextest run -p carina-core` — 2273 passed, 1 skipped
- `cargo nextest run --workspace` — 3806 passed, 72 skipped
- `cargo test --workspace --doc` — 22 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `scripts/check-*.sh` — OK

## Scope

PR1 lands independently (additive; pinned providers unaffected until they bump). The chain continues with aws PR2 / awscc PR3 (rev-bump + migrate; PR3 forces the still-latent awscc#286 sites to thread `config.schema.defs`) and carina-core PR4 (delete the deprecated shims). `Refs #3371` — the chain is not complete until PR4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
