### PR TITLE
refactor(schema): remove deprecated type-ref shims (carina#3371 PR4)

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1456,13 +1456,6 @@ pub(crate) fn empty_defs_for_schema_walks()
     EMPTY.get_or_init(std::collections::BTreeMap::new)
 }
 
-#[deprecated(
-    note = "use Schema::shape_of / ResourceSchema::shape_of, or AttributeType::shape_ref_free"
-)]
-pub fn empty_defs() -> &'static std::collections::BTreeMap<String, AttributeType> {
-    empty_defs_for_schema_walks()
-}
-
 impl AttributeType {
     /// Walk through any [`AttrTypeKind::Ref`] chain at the top of this
     /// type, returning the first non-`Ref` target wrapped in
@@ -1505,16 +1498,6 @@ impl AttributeType {
         panic!("AttributeType::Ref chain exceeded 256 hops; pathological self-cycle in defs")
     }
 
-    #[deprecated(
-        note = "use Schema::resolve_of / ResourceSchema::resolve_of, or AttributeType::shape_ref_free"
-    )]
-    pub fn resolve_refs<'a>(
-        &'a self,
-        defs: &'a std::collections::BTreeMap<String, AttributeType>,
-    ) -> ResolvedAttrType<'a> {
-        self.resolve_refs_with_defs(defs)
-    }
-
     /// Project this type onto a [`Shape`] view with every top-level
     /// `Ref` already peeled against `defs`.
     ///
@@ -1531,23 +1514,13 @@ impl AttributeType {
     /// # Panics
     ///
     /// Panics if a `Ref` points to a name not present in `defs` (same
-    /// schema invariant as [`Self::resolve_refs`]).
+    /// schema invariant as [`Self::resolve_refs_with_defs`]).
     pub(crate) fn shape_with_defs<'a>(
         &'a self,
         defs: &'a std::collections::BTreeMap<String, AttributeType>,
     ) -> Shape<'a> {
         let resolved = self.resolve_refs_with_defs(defs).as_attr();
         Self::shape_from_resolved(resolved)
-    }
-
-    #[deprecated(
-        note = "use Schema::shape_of / ResourceSchema::shape_of, or AttributeType::shape_ref_free"
-    )]
-    pub fn shape<'a>(
-        &'a self,
-        defs: &'a std::collections::BTreeMap<String, AttributeType>,
-    ) -> Shape<'a> {
-        self.shape_with_defs(defs)
     }
 
     /// Project this type without a defs map. Returns an error instead

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2829,13 +2829,11 @@ fn schema_shape_of_resolves_ref_against_defs() {
 }
 
 #[cfg(test)]
-mod deprecated_projection_guard {
-    #![deny(deprecated)]
-
+mod projection_api_guard {
     use super::*;
 
     #[test]
-    fn new_projection_apis_are_usable_with_deprecations_denied() {
+    fn new_projection_apis_are_usable() {
         let attr_type = AttributeType::string();
         assert!(matches!(
             attr_type.shape_ref_free().expect("string is Ref-free"),


### PR DESCRIPTION
## Summary

PR4 (final) of the carina#3371 chain — permanently seals the awscc#290 hazard-1 hole.

PR1 added `Schema::shape_of` / `ResourceSchema::shape_of` / `resolve_of` + `AttributeType::shape_ref_free() -> Result<Shape, RefEncountered>` and deprecated `shape(defs)` / `resolve_refs(defs)` / `empty_defs()` as panic-intact shims, kept only so the git-pinned providers compiled during migration. Now that aws (carina-rs/carina-provider-aws#399) and awscc (carina-rs/carina-provider-awscc#302) are migrated and merged, this PR deletes the shims.

## Change

- Delete the three `#[deprecated]` public shims `AttributeType::shape(defs)`, `AttributeType::resolve_refs(defs)`, and `empty_defs()` from `carina-core/src/schema/mod.rs`.
- Keep the `pub(crate)` carriers (`shape_with_defs` / `resolve_refs_with_defs` / `empty_defs_for_schema_walks`) for in-crate schema-walk recursion.
- Update the PR1 `#![deny(deprecated)]` test module: drop the now-moot deprecation framing, keep the positive assertions that `shape_ref_free()` / `shape_of()` work.

After this, the only public projection APIs are `shape_of` (a `Ref` is projectable only through a schema that owns its defs) and `shape_ref_free` (returns `Result`, cannot panic). `ref_type.shape(empty_defs())` is no longer writable at all — the type-permitted runtime panic of awscc#286/#288/#290 is structurally impossible.

## Verify

- `cargo check -p carina-core` — clean
- `cargo nextest run --workspace` — 3808 passed, 72 skipped
- `cargo test --workspace --doc` — 22 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `scripts/check-*.sh` — OK

The pinned providers are unaffected until they next bump past this commit (their current pin still has the shims).

Closes #3371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
