### PR TITLE
refactor(core): remove dead schema_types API (carina#3374)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -141,7 +141,6 @@ fn enrich_provider_context(
                 Ok(())
             },
         )),
-        schema_types: Default::default(),
         resource_types: ProviderContext::resource_types_from_schema_registry(schemas),
         // carina#3239: schemas are loaded at this point, so the strict
         // "unknown custom type in type position" parser check applies.

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -281,7 +281,6 @@ fn create_provider_context() -> carina_core::parser::ProviderContext {
         })),
         validators: std::collections::HashMap::new(),
         custom_type_validator: None,
-        schema_types: Default::default(),
         resource_types: Default::default(),
         // Schemas not yet loaded — early-parse runs before
         // `enrich_provider_context` populates the validator set, so the

--- a/carina-core/src/builtins/decrypt.rs
+++ b/carina-core/src/builtins/decrypt.rs
@@ -93,7 +93,6 @@ mod tests {
             decryptor: Some(decrypt_fn),
             validators: HashMap::new(),
             custom_type_validator: None,
-            schema_types: Default::default(),
             resource_types: Default::default(),
             customs_loaded: false,
         }

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -3019,7 +3019,6 @@ fn test_argument_type_custom_validator() {
         decryptor: None,
         validators,
         custom_type_validator: None,
-        schema_types: Default::default(),
         resource_types: Default::default(),
         customs_loaded: false,
     };
@@ -3096,7 +3095,6 @@ fn test_argument_type_list_of_custom_type() {
         decryptor: None,
         validators,
         custom_type_validator: None,
-        schema_types: Default::default(),
         resource_types: Default::default(),
         customs_loaded: false,
     };

--- a/carina-core/src/parser/config.rs
+++ b/carina-core/src/parser/config.rs
@@ -42,13 +42,6 @@ pub struct ProviderContext {
     /// Factory-based custom type validator that calls through to provider factories
     /// (e.g., WASM plugins) for types not covered by `validators`.
     pub custom_type_validator: Option<CustomTypeValidatorFn>,
-    /// Schema types registered by providers, keyed by
-    /// `(provider, path, type_name)` (e.g., `("awscc", "ec2", "VpcId")`).
-    ///
-    /// This set is for explicit provider-defined schema aliases only. It is
-    /// not a resource-kind registry; use [`ProviderContext::resource_types`]
-    /// and [`ProviderContext::has_resource_type`] for resource refs.
-    pub schema_types: HashSet<(String, String, String)>,
     /// Resource kinds loaded from provider schemas, keyed by `(provider,
     /// resource_type)` such as `("aws", "iam.Role")`.
     pub resource_types: HashSet<(String, String)>,
@@ -71,29 +64,6 @@ pub struct ProviderContext {
 }
 
 impl ProviderContext {
-    /// Register `(provider, path, type_name)` as a schema type so the parser
-    /// classifies matching 3+ segment paths as `TypeExpr::SchemaType` rather
-    /// than `TypeExpr::Ref`. Provider crates call this during setup.
-    pub fn register_schema_type(
-        &mut self,
-        provider: impl Into<String>,
-        path: impl Into<String>,
-        type_name: impl Into<String>,
-    ) {
-        self.schema_types
-            .insert((provider.into(), path.into(), type_name.into()));
-    }
-
-    /// Return `true` iff `(provider, path, type_name)` has been registered via
-    /// [`register_schema_type`]. Used by the parser to route 3+ segment paths.
-    pub fn is_schema_type(&self, provider: &str, path: &str, type_name: &str) -> bool {
-        self.schema_types.contains(&(
-            provider.to_string(),
-            path.to_string(),
-            type_name.to_string(),
-        ))
-    }
-
     /// Return `true` iff `(provider, resource_type)` is a loaded managed
     /// resource or data source kind.
     pub fn has_resource_type(&self, provider: &str, resource_type: &str) -> bool {
@@ -123,7 +93,6 @@ impl std::fmt::Debug for ProviderContext {
                 "custom_type_validator",
                 &self.custom_type_validator.as_ref().map(|_| "..."),
             )
-            .field("schema_types", &self.schema_types)
             .field("resource_types", &self.resource_types)
             .field("customs_loaded", &self.customs_loaded)
             .finish()

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -5099,7 +5099,7 @@ fn parse_three_segment_resource_path_is_ref() {
 }
 
 #[test]
-fn parse_four_segment_path_with_pascal_tail_is_schema_type() {
+fn parse_four_segment_path_with_pascal_tail_is_dotted_unresolved() {
     let input = r#"
         arguments {
             vpc_id: awscc.ec2.VpcId
@@ -6424,7 +6424,6 @@ fn parse_decrypt_uses_config_decryptor() {
         })),
         validators: HashMap::new(),
         custom_type_validator: None,
-        schema_types: Default::default(),
         resource_types: Default::default(),
         customs_loaded: false,
     };
@@ -6488,7 +6487,6 @@ fn parse_custom_validator_accepts_valid() {
         decryptor: None,
         validators,
         custom_type_validator: None,
-        schema_types: Default::default(),
         resource_types: Default::default(),
         customs_loaded: false,
     };
@@ -6531,7 +6529,6 @@ fn parse_custom_validator_rejects_invalid() {
         decryptor: None,
         validators,
         custom_type_validator: None,
-        schema_types: Default::default(),
         resource_types: Default::default(),
         customs_loaded: false,
     };
@@ -6591,15 +6588,13 @@ fn snake_to_pascal_conversion() {
 }
 
 #[test]
-fn parse_schema_type_in_arguments() {
+fn parse_dotted_type_in_arguments_as_unresolved() {
     let input = r#"
 arguments {
   vpc_id: awscc.ec2.VpcId
 }
 "#;
-    let mut ctx = ProviderContext::default();
-    ctx.register_schema_type("awscc", "ec2", "VpcId");
-    let parsed = parse(input, &ctx).unwrap();
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(parsed.arguments.len(), 1);
     let arg = &parsed.arguments[0];
     assert_eq!(arg.name, "vpc_id");
@@ -6614,24 +6609,38 @@ arguments {
 
 #[test]
 fn parse_schema_type_display() {
+    let ctx = ProviderContext::default();
     let t = TypeExpr::SchemaType {
         provider: "awscc".to_string(),
         path: "ec2".to_string(),
         type_name: "VpcId".to_string(),
     };
     assert_eq!(t.to_string(), "awscc.ec2.VpcId");
+
+    let input = r#"
+        let subnet = awscc.ec2.Subnet {
+            vpc_id = awscc.ec2.Vpc.VpcId
+        }
+    "#;
+    let parsed = parse(input, &ctx).unwrap();
+    let resource = &parsed.resources[0];
+    let attr = resource
+        .attributes
+        .get("vpc_id")
+        .expect("vpc_id attribute present");
+    // SchemaType-style identifier values must render as unquoted dotted identifiers.
+    let formatted = crate::value::format_value(attr);
+    assert_eq!(formatted, "awscc.ec2.Vpc.VpcId");
 }
 
 #[test]
-fn parse_schema_type_list() {
+fn parse_dotted_type_list_as_unresolved() {
     let input = r#"
 arguments {
   subnet_ids: list(awscc.ec2.SubnetId)
 }
 "#;
-    let mut ctx = ProviderContext::default();
-    ctx.register_schema_type("awscc", "ec2", "SubnetId");
-    let parsed = parse(input, &ctx).unwrap();
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(parsed.arguments.len(), 1);
     let arg = &parsed.arguments[0];
     match &arg.type_expr {

--- a/carina-core/src/parser/types.rs
+++ b/carina-core/src/parser/types.rs
@@ -81,9 +81,8 @@ const BUILTIN_BARE_CUSTOM_TYPES: &[&str] =
 /// [`ProviderContext::customs_loaded`] is `true`.
 ///
 /// `TypeExpr::Simple` only carries the bare axis, so this check is
-/// deliberately scoped to bare identities — provider-scoped types like
-/// `aws.iam.Role.Arn` arrive through the `TypeExpr::SchemaType` path
-/// instead and are validated by `schema_types`.
+/// deliberately scoped to bare identities — dotted type expressions are
+/// parsed as unresolved paths and classified during validation.
 ///
 /// Exposed at the crate root so the validation layer
 /// (`crate::validation`) can apply the same predicate to argument
@@ -263,7 +262,7 @@ fn parse_type_expr_atom(
             // Dotted type paths are deliberately left unresolved during parsing:
             // bootstrap contexts do not yet know provider schemas or custom
             // validators. Enriched validation resolves this to either Ref or
-            // SchemaType and rejects unknown dotted custom types.
+            // SchemaType and rejects unknown dotted paths.
             let mut ref_inner = inner.into_inner();
             let path_str = next_pair(&mut ref_inner, "resource type path", "type ref")?.as_str();
             let path = ResourceTypePath::parse(path_str).ok_or_else(|| {
@@ -416,9 +415,9 @@ mod tests {
 
     /// A bare custom-type identity registered in `ProviderContext.validators`
     /// makes the corresponding PascalCase name acceptable in a type
-    /// position. Provider-scoped identities (`aws.iam.Role.Arn`) live on
-    /// the `TypeExpr::SchemaType` path, not here — `TypeExpr::Simple`
-    /// only carries the *bare* axis.
+    /// position. Dotted identities (`aws.iam.Role.Arn`) are parsed as
+    /// unresolved paths, not here — `TypeExpr::Simple` only carries the
+    /// *bare* axis.
     #[test]
     fn parse_type_expr_str_accepts_registered_bare_custom_when_customs_loaded() {
         use crate::schema::TypeIdentity;

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -771,9 +771,8 @@ pub fn validate_no_arguments_in_root<E>(parsed: &crate::parser::File<E>) -> Resu
 /// silent-accept bug.
 ///
 /// The check is restricted to bare PascalCase names that parsed as
-/// `TypeExpr::Simple`. Provider-scoped customs (`aws.iam.Role.Arn`)
-/// travel through `TypeExpr::SchemaType` and have their own
-/// `schema_types`-based validation; they are out of scope here.
+/// `TypeExpr::Simple`. Dotted type expressions (`aws.iam.Role.Arn`)
+/// are resolved separately by the dotted-type validation pass.
 pub fn validate_argument_custom_types<E: crate::parser::ExportParamLike>(
     parsed: &crate::parser::File<E>,
     config: &ProviderContext,

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -46,7 +46,6 @@ fn context_with_iam_policy_arn_validator() -> ProviderContext {
         decryptor: None,
         validators,
         custom_type_validator: None,
-        schema_types: Default::default(),
         resource_types: Default::default(),
         customs_loaded: false,
     }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -105,7 +105,6 @@ impl DiagnosticEngine {
                     Ok(())
                 },
             )),
-            schema_types: Default::default(),
             resource_types:
                 carina_core::parser::ProviderContext::resource_types_from_schema_registry(&schemas),
             customs_loaded,

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -141,7 +141,6 @@ async fn main() {
             decryptor: None,
             validators: HashMap::new(),
             custom_type_validator: None,
-            schema_types: Default::default(),
             resource_types: Default::default(),
             // Schemas load asynchronously after LSP initialize; the
             // strict carina#3239 parser check is enabled inside

--- a/carina-lsp/tests/support/test_client.rs
+++ b/carina-lsp/tests/support/test_client.rs
@@ -31,7 +31,6 @@ impl TestClient {
                 decryptor: None,
                 validators: HashMap::new(),
                 custom_type_validator: None,
-                schema_types: Default::default(),
                 resource_types: Default::default(),
                 customs_loaded: false,
             };


### PR DESCRIPTION
## What

Closes #3374. Removes the dead `schema_types` API from `ProviderContext`.

#3373 (issue #3368) moved dotted-type classification out of the parser into the `validation::resolve_file_type_exprs` resolve step, which removed the parser's only call to `ProviderContext::is_schema_type`. The whole `schema_types` API was already effectively dead before that — `schema_types` was never populated in production (no provider ever called `register_schema_type`) — and #3373 orphaned its last reference.

## Removed

- `ProviderContext::schema_types` field, `register_schema_type()`, `is_schema_type()`, and the `schema_types` line in the `Debug` impl (`carina-core/src/parser/config.rs`).
- Every `schema_types: Default::default()` initializer across the CLI, LSP, core, and test helpers (9 sites).
- Migrated the parser tests that exercised the old parse-time `SchemaType` classification (`register_schema_type` setups) to assert the new `DottedUnresolved` parse output. The value-Display `SchemaType` test is kept and slightly strengthened — that path is still live.

## Not touched (live #3373 machinery)

`resource_types` / `has_resource_type` / `resource_types_from_schema_registry` and `resolve_file_type_exprs` / `resolve_type_expr` / `resolve_dotted_unresolved` are unchanged. The unknown-type diagnostic phrasing is left as-is (the issue's "optional" item, out of scope).

## Verify

Pure behavior-preserving deletion. `cargo nextest run --workspace` (3813 passed), `--doc`, `cargo clippy --workspace --all-targets -D warnings` (clean — no unused-import/dead-code left behind), all `scripts/check-*.sh`. `grep` confirms zero remaining `schema_types` / `is_schema_type` / `register_schema_type` references.

Refs #3368, #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
