### PR TITLE
fix(core): suggest nearest full-identity custom type, not generic kind match (carina#3377)

### DIFF
--- a/carina-cli/tests/validate_unknown_custom_type_e2e.rs
+++ b/carina-cli/tests/validate_unknown_custom_type_e2e.rs
@@ -34,7 +34,9 @@ use tempfile::TempDir;
 // check itself, not an unrelated "unknown provider" diagnostic.
 // ---------------------------------------------------------------------------
 
-struct AwsccTestFactory;
+struct AwsccTestFactory {
+    include_generic_arn: bool,
+}
 
 impl ProviderFactory for AwsccTestFactory {
     fn name(&self) -> &str {
@@ -83,12 +85,26 @@ impl ProviderFactory for AwsccTestFactory {
             None,
         );
 
+        let generic_arn = AttributeType::custom(
+            Some(TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn")),
+            AttributeType::string(),
+            None,
+            None,
+            legacy_validator(|_| Ok(())),
+            None,
+        );
+
+        let mut iam_role = ResourceSchema::new("iam.Role")
+            .attribute(AttributeSchema::new("policy_arn", iam_policy_arn));
+        if self.include_generic_arn {
+            iam_role = iam_role.attribute(AttributeSchema::new("role_arn", generic_arn));
+        }
+
         vec![
             ResourceSchema::new("ec2.Vpc")
                 .attribute(AttributeSchema::new("cidr_block", AttributeType::string()))
                 .attribute(AttributeSchema::new("vpc_id", AttributeType::string())),
-            ResourceSchema::new("iam.Role")
-                .attribute(AttributeSchema::new("policy_arn", iam_policy_arn)),
+            iam_role,
         ]
     }
 }
@@ -143,7 +159,15 @@ impl Provider for NoopProvider {
 }
 
 fn factories() -> Vec<Box<dyn ProviderFactory>> {
-    vec![Box::new(AwsccTestFactory) as Box<dyn ProviderFactory>]
+    vec![Box::new(AwsccTestFactory {
+        include_generic_arn: false,
+    }) as Box<dyn ProviderFactory>]
+}
+
+fn factories_with_generic_arn() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(AwsccTestFactory {
+        include_generic_arn: true,
+    }) as Box<dyn ProviderFactory>]
 }
 
 /// Two-directory fixture: a module that *declares* an unknown
@@ -342,6 +366,94 @@ fn validate_snake_case_suggests_dotted_registered_identity() {
         !diags.iter().any(|d| d.contains("IamPolicyArn")),
         "validate must not suggest the unregistered bare name \
          `IamPolicyArn`; got diagnostics: {:#?}",
+        diags
+    );
+}
+
+/// Reproduces carina#3377: a typo in a non-final dotted segment must
+/// prefer the nearest full registered identity over the generic
+/// same-kind identity.
+#[test]
+fn validate_suggests_full_identity_for_non_final_segment_typo() {
+    let fixture = write_fixture("list(aws.iam.Plicy.Arn)");
+    let caller = fixture.path().join("caller");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(
+        &caller,
+        factories_with_generic_arn(),
+    );
+
+    assert!(
+        diags.iter().any(|d| {
+            d.contains("unknown custom type")
+                && d.contains("aws.iam.Plicy.Arn")
+                && d.contains("suggestion: use 'aws.iam.Policy.Arn'")
+        }),
+        "validate should suggest the nearest full dotted identity \
+         `aws.iam.Policy.Arn`; got diagnostics: {:#?}",
+        diags
+    );
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.contains("suggestion: use 'aws.Arn'")),
+        "validate must not collapse non-final dotted typos to the generic \
+         same-kind identity `aws.Arn`; got diagnostics: {:#?}",
+        diags
+    );
+}
+
+/// Far dotted typos should remain unknown without falling back to a
+/// generic same-kind identity.
+#[test]
+fn validate_no_suggestion_for_far_dotted_typo() {
+    let fixture = write_fixture("list(aws.iam.TotallyFake.Arn)");
+    let caller = fixture.path().join("caller");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(
+        &caller,
+        factories_with_generic_arn(),
+    );
+
+    assert!(
+        diags.iter().any(|d| {
+            d.contains("unknown custom type") && d.contains("aws.iam.TotallyFake.Arn")
+        }),
+        "validate must reject the unregistered dotted custom type; got \
+         diagnostics: {:#?}",
+        diags
+    );
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.contains("suggestion: use 'aws.Arn'")),
+        "validate must not suggest the generic same-kind identity \
+         `aws.Arn`; got diagnostics: {:#?}",
+        diags
+    );
+}
+
+/// A distance-1 typo in the final segment should still be corrected by
+/// the full-identity edit-distance matcher.
+#[test]
+fn validate_suggests_for_distance1_final_segment_typo() {
+    let fixture = write_fixture("list(aws.iam.Policy.Arnn)");
+    let caller = fixture.path().join("caller");
+
+    let diags = carina_cli::commands::validate::validate_with_factories(
+        &caller,
+        factories_with_generic_arn(),
+    );
+
+    assert!(
+        diags.iter().any(|d| {
+            d.contains("unknown custom type")
+                && d.contains("aws.iam.Policy.Arnn")
+                && d.contains("suggestion: use 'aws.iam.Policy.Arn'")
+        }),
+        "validate should suggest the registered dotted identity \
+         `aws.iam.Policy.Arn` for a distance-1 final-segment typo; got \
+         diagnostics: {:#?}",
         diags
     );
 }

--- a/carina-core/src/parser/types.rs
+++ b/carina-core/src/parser/types.rs
@@ -136,12 +136,6 @@ pub(crate) fn suggest_registered_dotted_custom_type(
         .find(|(_, key)| key == &input_key)
         .map(|(id, _)| id.to_string())
         .or_else(|| {
-            candidates
-                .iter()
-                .find(|(id, _)| input_key.ends_with(&pascal_to_snake(&id.kind)))
-                .map(|(id, _)| id.to_string())
-        })
-        .or_else(|| {
             let max_distance = match input_key.len() {
                 0..=2 => 1,
                 3..=5 => 2,

--- a/carina-lsp/src/diagnostics/tests/basic.rs
+++ b/carina-lsp/src/diagnostics/tests/basic.rs
@@ -885,7 +885,7 @@ fn arguments_unknown_custom_type_surfaces_lsp_diagnostic() {
 }
 
 #[test]
-fn arguments_unknown_dotted_custom_type_surfaces_lsp_diagnostic_with_dotted_suggestion() {
+fn arguments_unknown_dotted_custom_type_surfaces_lsp_diagnostic_without_misleading_suggestion() {
     let engine = test_engine_with_iam_policy_arn_custom_type();
     let doc = create_document("arguments {\n  fake: aws.iam.TotallyFake.Arn\n}\n");
     let diagnostics = engine.analyze(&doc, None);
@@ -900,10 +900,34 @@ fn arguments_unknown_dotted_custom_type_surfaces_lsp_diagnostic_with_dotted_sugg
         messages
     );
     assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.contains("suggestion: use 'aws.iam.Policy.Arn'")),
+        "LSP must not collapse a far dotted typo to an unrelated registered identity; got: {:?}",
+        messages
+    );
+}
+
+#[test]
+fn arguments_dotted_custom_type_suggests_nearest_identity_for_distance1_typo() {
+    let engine = test_engine_with_iam_policy_arn_custom_type();
+    let doc = create_document("arguments {\n  policy: aws.iam.Plicy.Arn\n}\n");
+    let diagnostics = engine.analyze(&doc, None);
+    let messages = diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>();
+
+    assert!(
         diagnostics.iter().any(|d| {
-            d.message.contains("aws.iam.Policy.Arn") && !d.message.contains("IamPolicyArn")
+            d.message.contains("unknown custom type") && d.message.contains("aws.iam.Plicy.Arn")
         }),
-        "LSP must suggest the registered dotted identity, not the bare name; got: {:?}",
+        "LSP must reject the misspelled dotted custom type; got: {:?}",
+        messages
+    );
+    assert!(
+        diagnostics.iter().any(|d| {
+            d.message.contains("suggestion: use 'aws.iam.Policy.Arn'")
+                && !d.message.contains("IamPolicyArn")
+        }),
+        "LSP must suggest the nearest dotted identity, not the bare name; got: {:?}",
         messages
     );
 }


### PR DESCRIPTION
## What

Closes #3377. Follow-up to #3368. The unknown-custom-type suggestion collapsed to the generic `aws.Arn` for any typo beyond a distance-1 final segment — including a single-character typo in a non-final segment.

| Typed `<T>` | Before | After |
| --- | --- | --- |
| `aws.iam.Policy.Arnn` (dist-1 final) | `aws.iam.Policy.Arn` ✅ | `aws.iam.Policy.Arn` ✅ |
| `aws.iam.Plicy.Arn` (dist-1 non-final segment) | `aws.Arn` ❌ | `aws.iam.Policy.Arn` ✅ |
| `aws.iam.TotallyFake.Arn` (far typo) | `aws.Arn` ❌ | no suggestion ✅ |
| `aws.s3.Bucket.Arn` (unregistered) | `aws.Arn` ❌ | no suggestion ✅ |

## Root cause

`suggest_registered_dotted_custom_type` had a three-stage matcher whose **middle stage matched on the trailing kind alone** (`input_key.ends_with(snake(id.kind))`). Any `*_arn` input matched the generic `aws.Arn` (kind `Arn`), and since candidates are sorted by dotted identity, `aws.Arn` won the lookup before the full-identity edit-distance stage could find the intended type.

## Fix

Remove the kind-suffix stage. Suggestion now resolves through **exact-key match → full-identity edit distance** (length-scaled threshold, unchanged). A non-final-segment typo suggests the nearest full identity; a far/fake dotted name yields no suggestion rather than collapsing to a generic kind match.

Suggestion-selection only — acceptance/rejection behavior is unchanged (bogus dotted names are still rejected; the edit-distance threshold is untouched).

## Tests

- New e2e tests (real validate path): non-final-segment typo → suggests `aws.iam.Policy.Arn`; far typo → no `aws.Arn` collapse; distance-1-final typo → still suggests (regression guard). The test factory now also registers a generic `aws.Arn` so the bug actually reproduces (without it the old stage-2 returned the right answer by luck).
- The LSP test that asserted the old collapse (`TotallyFake.Arn` → suggests `aws.iam.Policy.Arn`) was asserting the bug; it is updated to assert no misleading suggestion, and a new positive LSP test covers the distance-1 typo → correct suggestion (preserving LSP-CLI parity).
- Verify: `cargo nextest run --workspace` (3817 passed), doctests ok, `cargo clippy --workspace --all-targets -D warnings` clean, all `scripts/check-*.sh` OK.

Refs #3368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
