### PR TITLE
fix(core): accept deep multi-segment enum identities (carina#3378 PR-A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,14 +493,15 @@ Enum values use namespaced identifiers like `aws.s3.Bucket.VersioningStatus.enab
    resource.chars().all(|c| c.is_lowercase() || c.is_ascii_digit() || c == '_')
    ```
 
-2. **Update `NamespacedId::parse` in `carina-core/src/utils.rs`** for new
-   patterns. It is the single source of truth for the 2/3/4/5-part shapes
-   and the four sibling utilities (`is_dsl_enum_format`,
-   `convert_enum_value`, `extract_enum_value_with_values`,
-   `validate_enum_namespace`) all delegate to it. **TypeName is pinned at
-   index 3 for 5+ part inputs** so PascalCase resource segments (`Vpc`)
-   parse correctly and dotted values (`ipsec.1`) flow into the trailing
-   slice — preserve this invariant when adding shapes.
+2. **Treat `TypeIdentity` as the source of truth when one is available.**
+   `NamespacedId::parse` in `carina-core/src/utils.rs` remains the
+   schema-free syntactic gate for namespaced-looking values, and its 5+
+   part branch still pins `TypeName` at index 3 so dotted values
+   (`ipsec.1`) flow into the trailing slice. Validation paths that have
+   an identity, such as `validate_enum_namespace`, must compare against
+   the identity's provider, structural segments, and kind rather than
+   re-deriving those axes from the dotted display string. Deep
+   multi-segment full paths validate by this structural identity match.
 
 3. **Plan display should not quote namespaced identifiers** - They are identifiers, not strings
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -834,12 +834,19 @@ pub fn resolve_enum_aliases_in_states(
             Some(f) => f,
             None => continue,
         };
+        let schemas = factory.schemas();
         // Reuse the core per-value alias resolver (single source of
         // truth shared with the resource path, carina#3063).
         let keys: Vec<String> = state.attributes.keys().cloned().collect();
         for key in keys {
             if let Some(value) = state.attributes.get_mut(&key) {
-                carina_core::value::resolve_value_alias(value, &id.resource_type, &key, factory);
+                carina_core::value::resolve_value_alias_with_schemas(
+                    value,
+                    &id.resource_type,
+                    &key,
+                    factory,
+                    &schemas,
+                );
             }
         }
     }
@@ -903,11 +910,15 @@ pub(crate) fn resolve_enum_aliases_in_wait_bindings(
         let Some(factory) = provider_mod::find_factory(ctx.factories(), &id.provider) else {
             continue;
         };
-        carina_core::value::resolve_value_alias(
+        // One schema snapshot per wait binding is acceptable: this path is
+        // bounded by wait-binding count, not resource attribute fanout.
+        let schemas = factory.schemas();
+        carina_core::value::resolve_value_alias_with_schemas(
             &mut wb.until_predicate.rhs,
             &id.resource_type,
             &attr_name,
             factory,
+            &schemas,
         );
     }
 }

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -569,10 +569,19 @@ pub fn validate_enum_namespace(
         ));
     }
 
-    if let Some(id) = NamespacedId::parse(s)
-        && id.matches_identity(identity)
-    {
-        return Ok(());
+    if is_two_part {
+        if let Some(id) = NamespacedId::parse(s)
+            && id.matches_identity(identity)
+        {
+            return Ok(());
+        }
+    } else if is_full_form {
+        let Some(value) = s.strip_prefix(&format!("{prefix}.")) else {
+            return Err(format!("expected format {}.value", prefix));
+        };
+        if !value.is_empty() && !value.contains('.') {
+            return Ok(());
+        }
     }
     // Mirror the original error-message shape: 2-part inputs get the
     // "or full form" hint, full-form inputs get only the full form.
@@ -1262,7 +1271,7 @@ pub fn pretty_with_newline_bytes<T: serde::Serialize>(value: &T) -> serde_json::
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::TypeIdentity;
+    use crate::schema::{TypeIdentity, string_enum_identity};
 
     /// Build a `TypeIdentity` from the legacy `(name, namespace)` pair
     /// the pre-S2.5b test corpus used. Provider is the first segment of
@@ -1537,6 +1546,20 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_namespace_deep_structural_full_path_valid() {
+        let identity =
+            string_enum_identity("Status", Some("aws.s3.BucketLifecycleConfiguration.Rules"));
+
+        assert!(
+            validate_enum_namespace(
+                "aws.s3.BucketLifecycleConfiguration.Rules.Status.enabled",
+                &identity,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
     fn test_namespaced_id_parse_numeric_tail() {
         // Digit-led tail with underscores parses through the 5-part shape
         // and flows into `value` verbatim (carina#3051).
@@ -1639,6 +1662,13 @@ mod tests {
     }
 
     #[test]
+    fn test_is_dsl_enum_format_deep_structural_plain_value() {
+        assert!(is_dsl_enum_format(
+            "aws.s3.BucketLifecycleConfiguration.Rules.Status.enabled"
+        ));
+    }
+
+    #[test]
     fn test_is_dsl_enum_format_non_matching() {
         assert!(!is_dsl_enum_format("my-bucket"));
         assert!(!is_dsl_enum_format("ap-northeast-1"));
@@ -1653,6 +1683,27 @@ mod tests {
         let values = &["ipsec.1"];
         assert_eq!(
             extract_enum_value_with_values("awscc.ec2.vpn_gateway.Type.ipsec.1", values),
+            "ipsec.1"
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_value_with_values_deep_structural_plain_value() {
+        let values = &["enabled", "disabled"];
+        assert_eq!(
+            extract_enum_value_with_values(
+                "aws.s3.BucketLifecycleConfiguration.Rules.Status.enabled",
+                values,
+            ),
+            "enabled"
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_value_with_values_deep_structural_dotted_value() {
+        let values = &["ipsec.1"];
+        assert_eq!(
+            extract_enum_value_with_values("aws.x.Y.Z.Type.ipsec.1", values),
             "ipsec.1"
         );
     }

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -1560,6 +1560,36 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_namespace_deep_structural_wrong_middle_segment_invalid() {
+        let identity =
+            string_enum_identity("Status", Some("aws.s3.BucketLifecycleConfiguration.Rules"));
+
+        assert!(
+            validate_enum_namespace("aws.s3.WrongStruct.Rules.Status.enabled", &identity).is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_namespace_deep_structural_dotted_value_invalid() {
+        let identity = string_enum_identity("Type", Some("aws.x.Y.Z"));
+
+        assert!(validate_enum_namespace("aws.x.Y.Z.Type.ipsec.1", &identity).is_err());
+    }
+
+    #[test]
+    fn test_validate_namespace_deep_structural_wrong_identity_invalid() {
+        let identity = string_enum_identity("Status", Some("aws.ec2.SecurityGroup.Rules"));
+
+        assert!(
+            validate_enum_namespace(
+                "aws.s3.BucketLifecycleConfiguration.Rules.Status.enabled",
+                &identity,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
     fn test_namespaced_id_parse_numeric_tail() {
         // Digit-led tail with underscores parses through the 5-part shape
         // and flows into `value` verbatim (carina#3051).

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value};
 use crate::schema::{AttrTypeKind, AttributeType};
-use crate::utils::{convert_enum_value, is_dsl_enum_format};
+use crate::utils::{convert_enum_value, extract_enum_value_with_values, is_dsl_enum_format};
 
 /// Where in the pipeline a `Value` is being serialized. Used so the
 /// caller of a failing serialization (e.g. `--out plan.json`) can
@@ -1588,34 +1588,210 @@ pub fn canonicalize_states_with_schemas(
 /// Public so the carina-cli state-side alias pass
 /// (`resolve_enum_aliases_in_states`) reuses this exact implementation
 /// rather than keeping a divergent copy.
+///
+/// Single-shot convenience wrapper. Callers resolving multiple values for
+/// the same factory should fetch [`crate::provider::ProviderFactory::schemas`]
+/// once and call [`resolve_value_alias_with_schemas`] to avoid cloning the
+/// provider's full schema list per attribute.
 pub fn resolve_value_alias(
     value: &mut Value,
     resource_type: &str,
     attr_name: &str,
     factory: &dyn crate::provider::ProviderFactory,
 ) {
+    let schemas = factory.schemas();
+    resolve_value_alias_with_schemas(value, resource_type, attr_name, factory, &schemas);
+}
+
+/// Resolve a single value's enum alias using a caller-provided schema snapshot.
+///
+/// This is the hot-loop variant of [`resolve_value_alias`]. `schemas` must be
+/// the result of [`crate::provider::ProviderFactory::schemas`] for `factory`.
+pub fn resolve_value_alias_with_schemas(
+    value: &mut Value,
+    resource_type: &str,
+    attr_name: &str,
+    factory: &dyn crate::provider::ProviderFactory,
+    schemas: &[crate::schema::ResourceSchema],
+) {
     match value {
         Value::Concrete(ConcreteValue::String(s)) if is_dsl_enum_format(s) => {
-            let raw = convert_enum_value(s);
+            let valid_values = enum_valid_values_for_alias(schemas, resource_type, attr_name, s);
+            let raw = if valid_values.is_empty() {
+                convert_enum_value(s)
+            } else {
+                let valid_refs: Vec<&str> = valid_values.iter().map(String::as_str).collect();
+                extract_enum_value_with_values(s, &valid_refs)
+            };
             if let Some(canonical) = factory.get_enum_alias_reverse(resource_type, attr_name, raw) {
                 *s = canonical;
             }
         }
         Value::Concrete(ConcreteValue::List(items)) => {
             for item in items.iter_mut() {
-                resolve_value_alias(item, resource_type, attr_name, factory);
+                resolve_value_alias_with_schemas(item, resource_type, attr_name, factory, schemas);
             }
         }
         Value::Concrete(ConcreteValue::Map(map)) => {
             let map_keys: Vec<String> = map.keys().cloned().collect();
             for map_key in map_keys {
                 if let Some(v) = map.get_mut(&map_key) {
-                    resolve_value_alias(v, resource_type, &map_key, factory);
+                    resolve_value_alias_with_schemas(v, resource_type, &map_key, factory, schemas);
                 }
             }
         }
         _ => {}
     }
+}
+
+fn enum_valid_values_for_alias(
+    schemas: &[crate::schema::ResourceSchema],
+    resource_type: &str,
+    attr_name: &str,
+    input: &str,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for schema in schemas
+        .iter()
+        .filter(|schema| schema.resource_type == resource_type)
+    {
+        for attr_schema in schema.attributes.values() {
+            collect_enum_valid_values_for_attr_name(
+                schema,
+                attr_name,
+                input,
+                &attr_schema.name,
+                &attr_schema.attr_type,
+                0,
+                &mut out,
+            );
+        }
+    }
+    out
+}
+
+fn collect_enum_valid_values_for_attr_name(
+    schema: &crate::schema::ResourceSchema,
+    target_attr_name: &str,
+    input: &str,
+    current_attr_name: &str,
+    attr_type: &AttributeType,
+    depth: usize,
+    out: &mut Vec<String>,
+) {
+    if depth > 64 {
+        return;
+    }
+
+    match schema.shape_of(attr_type) {
+        crate::schema::Shape::StringEnum { values, .. }
+            if current_attr_name == target_attr_name =>
+        {
+            collect_string_enum_values_if_input_matches(schema, input, attr_type, values, out);
+        }
+        crate::schema::Shape::StringEnum { .. }
+        | crate::schema::Shape::String
+        | crate::schema::Shape::Int
+        | crate::schema::Shape::Float
+        | crate::schema::Shape::Bool
+        | crate::schema::Shape::Duration => {}
+        crate::schema::Shape::Custom { base, .. }
+        | crate::schema::Shape::CustomEnum { base, .. } => {
+            collect_enum_valid_values_for_attr_name(
+                schema,
+                target_attr_name,
+                input,
+                current_attr_name,
+                base,
+                depth + 1,
+                out,
+            );
+        }
+        crate::schema::Shape::List { inner, .. } => {
+            collect_enum_valid_values_for_attr_name(
+                schema,
+                target_attr_name,
+                input,
+                current_attr_name,
+                inner,
+                depth + 1,
+                out,
+            );
+        }
+        crate::schema::Shape::Map { value, .. } => {
+            collect_enum_valid_values_for_attr_name(
+                schema,
+                target_attr_name,
+                input,
+                current_attr_name,
+                value,
+                depth + 1,
+                out,
+            );
+        }
+        crate::schema::Shape::Struct { fields, .. } => {
+            for field in fields {
+                collect_enum_valid_values_for_attr_name(
+                    schema,
+                    target_attr_name,
+                    input,
+                    &field.name,
+                    &field.field_type,
+                    depth + 1,
+                    out,
+                );
+            }
+        }
+        crate::schema::Shape::Union(members) => {
+            for member in members {
+                collect_enum_valid_values_for_attr_name(
+                    schema,
+                    target_attr_name,
+                    input,
+                    current_attr_name,
+                    member,
+                    depth + 1,
+                    out,
+                );
+            }
+        }
+    }
+}
+
+fn collect_string_enum_values_if_input_matches(
+    schema: &crate::schema::ResourceSchema,
+    input: &str,
+    attr_type: &AttributeType,
+    values: &[String],
+    out: &mut Vec<String>,
+) {
+    let crate::schema::Shape::StringEnum { name, identity, .. } = schema.shape_of(attr_type) else {
+        return;
+    };
+    if !string_enum_identity_matches_input(input, name, identity) {
+        return;
+    }
+    for value in values {
+        if !out.contains(value) {
+            out.push(value.clone());
+        }
+    }
+}
+
+fn string_enum_identity_matches_input(
+    input: &str,
+    enum_name: &str,
+    identity: Option<&crate::schema::TypeIdentity>,
+) -> bool {
+    if input.strip_prefix(&format!("{enum_name}.")).is_some() {
+        return true;
+    }
+    if let Some(identity) = identity {
+        return input
+            .strip_prefix(&format!("{identity}."))
+            .is_some_and(|value| !value.is_empty());
+    }
+    false
 }
 
 /// Re-apply enum-alias resolution to every resource, looking up the
@@ -1637,9 +1813,10 @@ pub fn resolve_enum_aliases_for_resources(
         };
         let resource_type = resource.id.resource_type.clone();
         let keys: Vec<String> = resource.attributes.keys().cloned().collect();
+        let schemas = factory.schemas();
         for key in keys {
             if let Some(value) = resource.attributes.get_mut(&key) {
-                resolve_value_alias(value, &resource_type, &key, factory);
+                resolve_value_alias_with_schemas(value, &resource_type, &key, factory, &schemas);
             }
         }
     }
@@ -1648,6 +1825,99 @@ pub fn resolve_enum_aliases_for_resources(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct DeepEnumAliasFactory;
+
+    impl crate::provider::ProviderFactory for DeepEnumAliasFactory {
+        fn name(&self) -> &str {
+            "aws"
+        }
+
+        fn display_name(&self) -> &str {
+            "AWS"
+        }
+
+        fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+            HashMap::new()
+        }
+
+        fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+            String::new()
+        }
+
+        fn create_provider(
+            &self,
+            _binding: Option<&str>,
+            _attributes: &IndexMap<String, Value>,
+        ) -> futures::future::BoxFuture<
+            '_,
+            crate::provider::ProviderResult<Box<dyn crate::provider::Provider>>,
+        > {
+            unreachable!("DeepEnumAliasFactory::create_provider is not used in these tests")
+        }
+
+        fn schemas(&self) -> Vec<crate::schema::ResourceSchema> {
+            use crate::schema::{
+                AttributeSchema, ResourceSchema, StructField, string_enum_identity,
+            };
+
+            let status = AttributeType::string_enum(
+                "Status",
+                vec!["enabled".to_string(), "disabled".to_string()],
+                Some(string_enum_identity(
+                    "Status",
+                    Some("aws.s3.BucketLifecycleConfiguration.Rules"),
+                )),
+                Vec::new(),
+            );
+            let rules = AttributeType::list(AttributeType::struct_(
+                "Rules",
+                vec![StructField::new("status", status)],
+            ));
+
+            vec![
+                ResourceSchema::new("s3.BucketLifecycleConfiguration")
+                    .attribute(AttributeSchema::new("rules", rules)),
+            ]
+        }
+
+        fn get_enum_alias_reverse(
+            &self,
+            resource_type: &str,
+            attr_name: &str,
+            value: &str,
+        ) -> Option<String> {
+            match (resource_type, attr_name, value) {
+                ("s3.BucketLifecycleConfiguration", "status", "disabled") => {
+                    Some("Disabled".to_string())
+                }
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_value_alias_extracts_deep_structural_enum_with_schema_values() {
+        let mut value = Value::Concrete(ConcreteValue::String(
+            "aws.s3.BucketLifecycleConfiguration.Rules.Status.disabled".to_string(),
+        ));
+
+        resolve_value_alias(
+            &mut value,
+            "s3.BucketLifecycleConfiguration",
+            "status",
+            &DeepEnumAliasFactory,
+        );
+
+        assert_eq!(
+            value,
+            Value::Concrete(ConcreteValue::String("Disabled".to_string()))
+        );
+    }
 
     #[test]
     fn render_duration_picks_largest_clean_unit() {

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1618,6 +1618,13 @@ pub fn resolve_value_alias_with_schemas(
         Value::Concrete(ConcreteValue::String(s)) if is_dsl_enum_format(s) => {
             let valid_values = enum_valid_values_for_alias(schemas, resource_type, attr_name, s);
             let raw = if valid_values.is_empty() {
+                // Schema-free fallback for attributes that are not known enum
+                // fields in the schema snapshot. This is fail-closed: unknown
+                // `(resource_type, attr_name)` pairs should not have reverse
+                // alias entries, so even a lossy extraction leaves `s`
+                // unchanged. Keep `convert_enum_value` here rather than
+                // last-segment extraction to preserve dotted enum values like
+                // `awscc.ec2.vpn_gateway.Type.ipsec.1`.
                 convert_enum_value(s)
             } else {
                 let valid_refs: Vec<&str> = valid_values.iter().map(String::as_str).collect();
@@ -1900,6 +1907,108 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct SchemaAliasFactory {
+        schemas: Vec<crate::schema::ResourceSchema>,
+        resource_type: &'static str,
+        attr_name: &'static str,
+        alias_value: &'static str,
+        canonical: Option<&'static str>,
+    }
+
+    impl crate::provider::ProviderFactory for SchemaAliasFactory {
+        fn name(&self) -> &str {
+            "aws"
+        }
+
+        fn display_name(&self) -> &str {
+            "AWS"
+        }
+
+        fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+            HashMap::new()
+        }
+
+        fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+            String::new()
+        }
+
+        fn create_provider(
+            &self,
+            _binding: Option<&str>,
+            _attributes: &IndexMap<String, Value>,
+        ) -> futures::future::BoxFuture<
+            '_,
+            crate::provider::ProviderResult<Box<dyn crate::provider::Provider>>,
+        > {
+            unreachable!("SchemaAliasFactory::create_provider is not used in these tests")
+        }
+
+        fn schemas(&self) -> Vec<crate::schema::ResourceSchema> {
+            self.schemas.clone()
+        }
+
+        fn get_enum_alias_reverse(
+            &self,
+            resource_type: &str,
+            attr_name: &str,
+            value: &str,
+        ) -> Option<String> {
+            match (
+                resource_type == self.resource_type,
+                attr_name == self.attr_name,
+                value == self.alias_value,
+                self.canonical,
+            ) {
+                (true, true, true, Some(canonical)) => Some(canonical.to_string()),
+                _ => None,
+            }
+        }
+    }
+
+    fn status_enum(namespace: Option<&str>) -> AttributeType {
+        use crate::schema::string_enum_identity;
+
+        AttributeType::string_enum(
+            "Status",
+            vec!["enabled".to_string(), "disabled".to_string()],
+            namespace.map(|ns| string_enum_identity("Status", Some(ns))),
+            Vec::new(),
+        )
+    }
+
+    fn schema_with_attr(
+        resource_type: &'static str,
+        attr_name: &'static str,
+        attr_type: AttributeType,
+    ) -> crate::schema::ResourceSchema {
+        use crate::schema::{AttributeSchema, ResourceSchema};
+
+        ResourceSchema::new(resource_type).attribute(AttributeSchema::new(attr_name, attr_type))
+    }
+
+    fn resolve_with_schema_alias_factory(
+        schema: crate::schema::ResourceSchema,
+        resource_type: &'static str,
+        attr_name: &'static str,
+        input: &str,
+    ) -> Value {
+        let factory = SchemaAliasFactory {
+            schemas: vec![schema],
+            resource_type,
+            attr_name,
+            alias_value: "disabled",
+            canonical: Some("Disabled"),
+        };
+        let mut value = Value::Concrete(ConcreteValue::String(input.to_string()));
+        resolve_value_alias(&mut value, resource_type, attr_name, &factory);
+        value
+    }
+
     #[test]
     fn resolve_value_alias_extracts_deep_structural_enum_with_schema_values() {
         let mut value = Value::Concrete(ConcreteValue::String(
@@ -1916,6 +2025,126 @@ mod tests {
         assert_eq!(
             value,
             Value::Concrete(ConcreteValue::String("Disabled".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_value_alias_fail_closed_when_valid_values_empty() {
+        let schema = schema_with_attr(
+            "s3.BucketLifecycleConfiguration",
+            "known_status",
+            status_enum(Some("aws.s3.BucketLifecycleConfiguration.Rules")),
+        );
+        let factory = SchemaAliasFactory {
+            schemas: vec![schema],
+            resource_type: "s3.BucketLifecycleConfiguration",
+            attr_name: "missing_status",
+            alias_value: "disabled",
+            canonical: None,
+        };
+        let original = "aws.s3.BucketLifecycleConfiguration.Rules.Status.disabled";
+        let mut value = Value::Concrete(ConcreteValue::String(original.to_string()));
+
+        resolve_value_alias(
+            &mut value,
+            "s3.BucketLifecycleConfiguration",
+            "missing_status",
+            &factory,
+        );
+
+        assert_eq!(
+            value,
+            Value::Concrete(ConcreteValue::String(original.to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_value_alias_extracts_top_level_list_string_enum() {
+        let schema = schema_with_attr(
+            "svc.Resource",
+            "statuses",
+            AttributeType::list(status_enum(Some("aws.svc.Resource.Status"))),
+        );
+
+        assert_eq!(
+            resolve_with_schema_alias_factory(
+                schema,
+                "svc.Resource",
+                "statuses",
+                "aws.svc.Resource.Status.disabled",
+            ),
+            Value::Concrete(ConcreteValue::String("Disabled".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_value_alias_extracts_map_value_string_enum() {
+        let schema = schema_with_attr(
+            "svc.Resource",
+            "status_by_name",
+            AttributeType::map(status_enum(Some("aws.svc.Resource.Status"))),
+        );
+
+        assert_eq!(
+            resolve_with_schema_alias_factory(
+                schema,
+                "svc.Resource",
+                "status_by_name",
+                "aws.svc.Resource.Status.disabled",
+            ),
+            Value::Concrete(ConcreteValue::String("Disabled".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_value_alias_extracts_union_string_enum_member() {
+        let schema = schema_with_attr(
+            "svc.Resource",
+            "status",
+            AttributeType::union(vec![
+                AttributeType::string(),
+                status_enum(Some("aws.svc.Resource.Status")),
+            ]),
+        );
+
+        assert_eq!(
+            resolve_with_schema_alias_factory(
+                schema,
+                "svc.Resource",
+                "status",
+                "aws.svc.Resource.Status.disabled",
+            ),
+            Value::Concrete(ConcreteValue::String("Disabled".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_value_alias_extracts_bare_string_enum_by_name() {
+        let schema = schema_with_attr("svc.Resource", "status", status_enum(None));
+
+        assert_eq!(
+            resolve_with_schema_alias_factory(schema, "svc.Resource", "status", "Status.disabled"),
+            Value::Concrete(ConcreteValue::String("Disabled".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_value_alias_does_not_collect_values_for_mismatched_identity() {
+        let schema = schema_with_attr(
+            "s3.BucketLifecycleConfiguration",
+            "status",
+            status_enum(Some("aws.s3.OtherStruct.Status")),
+        );
+        let original = "aws.s3.BucketLifecycleConfiguration.Rules.Status.disabled";
+
+        assert_eq!(
+            resolve_with_schema_alias_factory(
+                schema,
+                "s3.BucketLifecycleConfiguration",
+                "status",
+                original,
+            ),
+            Value::Concrete(ConcreteValue::String(original.to_string()))
         );
     }
 


### PR DESCRIPTION
## Summary

PR-A of carina#3378 — the carina-core **enabling** half. Makes carina-core
correctly accept and process enum canonical identities that carry
intermediate struct segments, e.g.
`aws.s3.BucketLifecycleConfiguration.Rules.Status.enabled` (where `Rules`
is an intermediate struct and `Status` the plain kind). carina-provider-aws
will emit these structural identities in PR-B; this PR is what lets them
validate and resolve.

Design: `notes/specs/2026-05-31-enum-identity-intermediate-segments-design.md`
(merged in #3381; value-extraction decision in #3382).

## Root cause

Two consumer-side defects, both rooted in `NamespacedId::parse`'s positional
5+-part branch, which pins TypeName at index 3:

1. `validate_enum_namespace` rejected the deep full-path form against its
   own matching identity (parse split it as type_name=`Rules`,
   value=`Status.enabled`, so `matches_identity` saw `Rules != Status`).
2. `resolve_value_alias` extracted the wrong key for deep forms via the
   positional `convert_enum_value` (`Status.enabled` instead of `enabled`),
   so reverse-alias lookups silently missed. Nested struct enums reach this
   path as the deep fully-qualified `String` once providers emit structural
   identities.

## Fix (the structured `TypeIdentity` is the source of truth)

- **`validate_enum_namespace`** now validates the full form by structural
  identity match — strip the identity's own dotted prefix and accept the
  single remaining non-dotted segment as the value — instead of routing the
  split through the positional parse. The part-count gate is preserved, so
  the deliberate strict rejection of dotted full forms is unchanged.
- **`resolve_value_alias`** now extracts via the schema-aware
  `extract_enum_value_with_values` (segment-count agnostic, dotted-value
  safe), finding the attribute's valid `StringEnum` values through
  `ResourceSchema::shape_of`. `factory.schemas()` is hoisted out of the
  per-attribute loops (it returns a full `Vec<ResourceSchema>` by value), via
  a new `resolve_value_alias_with_schemas`. No `ProviderFactory`/trait change
  — zero provider/plugin radius.
- **`NamespacedId::parse` / `convert_enum_value` unchanged**: parse stays the
  schema-free syntactic gate (`primary.rs` enum-vs-ref) and dotted-value
  extractor, so the dotted-value contract (`…Type.ipsec.1` → `ipsec.1`) is
  preserved. No single positional rule can serve both the dotted and
  deep-plain 6-part shapes — only the schema-aware path can.
- The two pure-display sites (`format_value_into`, `plan_tree`) keep
  schema-free behavior; their output is cosmetic, never fed back into
  comparison/state/alias.
- CLAUDE.md "Namespaced Enum Identifiers" updated: the identity is the source
  of truth for validation; the positional parse is a syntactic gate only.

## Tests

Deep-structural positive + negative cases for `validate_enum_namespace`
(deep valid, wrong middle segment, deep dotted value rejected by the
part-count gate, mismatched identity); `is_dsl_enum_format` /
`extract_enum_value_with_values` deep cases; and `resolve_value_alias`
coverage across List / Map / Union / bare(identity=None) / mismatched-identity
no-collect / fail-closed empty-valid-values.

## Verify

- `cargo nextest run --workspace`: 3835 passed, 0 failed
- `cargo test --workspace --doc`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `scripts/check-*.sh`: all pass

refs #3378

🤖 Generated with [Claude Code](https://claude.com/claude-code)