### PR TITLE
parser: seed plain let literals across sibling .crn files (#3391)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,14 @@ plan-exports:
 	$(PLAN_FIXTURE) exports
 plan-exports-multifile:
 	$(PLAN_FIXTURE) exports_multifile
+plan-exports-multifile-let-literal:
+	$(PLAN_FIXTURE) exports_multifile_let_literal
+plan-exports-multifile-bare-resource-ref:
+	$(PLAN_FIXTURE) exports_multifile_bare_resource_ref
+plan-exports-multifile-use-alias-seed:
+	$(PLAN_FIXTURE) exports_multifile_use_alias_seed_does_not_leak
+plan-exports-multifile-string-let-attr-rejected:
+	$(PLAN_FIXTURE) exports_multifile_string_let_attr_access_rejected
 plan-policy-pretty:
 	$(PLAN_FIXTURE) policy_pretty
 plan-policy-pretty-nested:
@@ -261,7 +269,11 @@ plan-multi-instance-module:
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
         plan-upstream-state-map-subscript plan-upstream-state-map-dot-notation \
-        plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
+        plan-deferred-for plan-exports plan-exports-multifile \
+        plan-exports-multifile-let-literal plan-exports-multifile-bare-resource-ref \
+        plan-exports-multifile-use-alias-seed \
+        plan-exports-multifile-string-let-attr-rejected \
+        plan-policy-pretty \
         plan-policy-pretty-nested plan-policy-pretty-dynamic-key-list \
         plan-list-struct-child-gutter plan-list-diff-added-struct-child-gutter \
         plan-destroy-list-struct-child-gutter \

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -34,6 +34,7 @@ pub struct FixturePlan {
     pub moved_origins: HashMap<ResourceId, ResourceId>,
     pub deferred_for_expressions: Vec<carina_core::parser::DeferredForExpression>,
     pub export_params: Vec<carina_core::parser::InferredExportParam>,
+    pub resolved_export_params: Vec<carina_core::parser::InferredExportParam>,
     /// Per-resource user-authoring trees lifted from the fixture's
     /// `carina.state.json`. Forwarded to `format_plan` so server-side
     /// default fields the user never wrote do not surface in plan
@@ -301,6 +302,19 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         .iter()
         .map(|(from, to)| (to.clone(), from.clone()))
         .collect();
+    let export_wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
+        .wait_bindings
+        .iter()
+        .map(carina_core::binding_index::WaitAliasSpec::from)
+        .collect();
+    let resolved_export_params = crate::commands::plan::resolve_export_values_for_display(
+        &parsed.export_params,
+        &resources,
+        &parsed.compositions,
+        &data_sources_for_plan,
+        &current_states,
+        &export_wait_aliases,
+    );
 
     FixturePlan {
         plan,
@@ -309,6 +323,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         moved_origins,
         deferred_for_expressions: parsed.deferred_for_expressions,
         export_params: parsed.export_params,
+        resolved_export_params,
         prev_explicit,
         expansion_trace: parsed.expansion_trace,
     }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -1271,6 +1271,137 @@ fn plan_snapshot_exports_multifile() {
 }
 
 #[test]
+fn plan_snapshot_exports_multifile_let_literal() {
+    use crate::commands::plan::compute_export_diffs;
+
+    let fp = build_plan_from_fixture_name("exports_multifile_let_literal");
+
+    let export_changes = compute_export_diffs(&fp.resolved_export_params, &HashMap::new());
+    let output = strip_ansi(&format_plan(
+        &fp.plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&fp.schemas),
+        &fp.moved_origins,
+        &export_changes,
+        &[],
+        None,
+        None,
+    ));
+
+    assert!(
+        output.contains("bad_name = 'literal-via-let-chain'"),
+        "bad_name export should render the sibling let literal, got:\n{}",
+        output
+    );
+    assert!(
+        output.contains("good_name = 'literal-via-resource-attr'"),
+        "good_name export should render the sibling resource attribute, got:\n{}",
+        output
+    );
+    for line in output
+        .lines()
+        .filter(|line| line.contains("bad_name =") || line.contains("good_name ="))
+    {
+        assert!(
+            !line.contains("(known after apply)"),
+            "literal exports must not be deferred placeholders, got line: {}",
+            line
+        );
+    }
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn plan_snapshot_exports_multifile_bare_resource_ref_seed_stays_deferred() {
+    use crate::commands::plan::compute_export_diffs;
+
+    let fp = build_plan_from_fixture_name("exports_multifile_bare_resource_ref");
+
+    let export_changes = compute_export_diffs(&fp.resolved_export_params, &HashMap::new());
+    let output = strip_ansi(&format_plan(
+        &fp.plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&fp.schemas),
+        &fp.moved_origins,
+        &export_changes,
+        &[],
+        None,
+        None,
+    ));
+
+    assert!(
+        !output.contains("\"${resource_binding}\"")
+            && !output.contains("'${resource_binding}'")
+            && !output.contains("${resource_binding}"),
+        "bare structural let seed must not render as the parser placeholder string, got:\n{}",
+        output
+    );
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn plan_snapshot_exports_multifile_use_alias_seed_does_not_leak() {
+    use crate::commands::plan::compute_export_diffs;
+
+    let fp = build_plan_from_fixture_name("exports_multifile_use_alias_seed_does_not_leak");
+
+    let export_changes = compute_export_diffs(&fp.resolved_export_params, &HashMap::new());
+    let output = strip_ansi(&format_plan(
+        &fp.plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&fp.schemas),
+        &fp.moved_origins,
+        &export_changes,
+        &[],
+        None,
+        None,
+    ));
+
+    assert!(
+        !output.contains("${use:"),
+        "use-alias seed must not render the parser placeholder string, got:\n{}",
+        output
+    );
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn plan_snapshot_exports_multifile_string_let_attr_access_rejected() {
+    let fixture_path = PathBuf::from(format!(
+        "{}/tests/fixtures/plan_display/exports_multifile_string_let_attr_access_rejected",
+        env!("CARGO_MANIFEST_DIR")
+    ));
+    let mut parsed = load_configuration(&fixture_path).unwrap().parsed;
+    let errors = crate::commands::validate_and_resolve_errors(&mut parsed, &fixture_path, true);
+    let message = errors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        !errors.is_empty(),
+        "field access on a sibling string let must be rejected"
+    );
+    assert!(
+        message.contains("'X' is not a resource, cannot access attribute 'foo'"),
+        "expected scalar field-access diagnostic naming X.foo, got:\n{}",
+        message
+    );
+    assert!(
+        !message.contains("(known after apply)"),
+        "scalar field-access rejection must not degrade to deferred output, got:\n{}",
+        message
+    );
+}
+
+#[test]
 fn plan_snapshot_export_changes_mixed() {
     use crate::commands::plan::ExportChange;
     use carina_core::parser::TypeExpr;

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile_bare_resource_ref_seed_stays_deferred.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile_bare_resource_ref_seed_stays_deferred.snap
@@ -1,0 +1,14 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + mock.compute.Instance inst.resource_binding
+      name: "fixture-instance"
+
+Exports:
+
+  + x = (known after apply)
+
+Plan: 1 to add, 0 to change, 0 to destroy, 1 export change(s).

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile_let_literal.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile_let_literal.snap
@@ -1,0 +1,15 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + mock.compute.Instance inst.cluster
+      cluster_name: "literal-via-resource-attr"
+
+Exports:
+
+  + bad_name = 'literal-via-let-chain'
+  + good_name = 'literal-via-resource-attr'
+
+Plan: 1 to add, 0 to change, 0 to destroy, 2 export change(s).

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile_use_alias_seed_does_not_leak.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile_use_alias_seed_does_not_leak.snap
@@ -1,0 +1,12 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+
+Exports:
+
+  + z = (known after apply)
+
+Plan: 0 to add, 0 to change, 0 to destroy, 1 export change(s).

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_bare_resource_ref/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_bare_resource_ref/main.crn
@@ -1,0 +1,10 @@
+provider mock {
+  region = 'test'
+}
+
+let foo = use { source = './usecase' }
+let inst = foo { }
+
+exports {
+  x = inst.x
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_bare_resource_ref/usecase/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_bare_resource_ref/usecase/main.crn
@@ -1,0 +1,3 @@
+attributes {
+  x = resource_binding
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_bare_resource_ref/usecase/resource.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_bare_resource_ref/usecase/resource.crn
@@ -1,0 +1,3 @@
+let resource_binding = mock.compute.Instance {
+  name = 'fixture-instance'
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_let_literal/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_let_literal/main.crn
@@ -1,0 +1,13 @@
+backend local { path = "carina.state.json" }
+
+provider mock {
+  region = 'test'
+}
+
+let foo = use { source = './usecase' }
+let inst = foo { }
+
+exports {
+  bad_name = inst.bad_name
+  good_name = inst.good_name
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_let_literal/usecase/cluster.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_let_literal/usecase/cluster.crn
@@ -1,0 +1,5 @@
+let bad_name = 'literal-via-let-chain'
+
+let cluster = mock.compute.Instance {
+  cluster_name = 'literal-via-resource-attr'
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_let_literal/usecase/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_let_literal/usecase/main.crn
@@ -1,0 +1,4 @@
+attributes {
+  bad_name  = bad_name
+  good_name = cluster.cluster_name
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_string_let_attr_access_rejected/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_string_let_attr_access_rejected/main.crn
@@ -1,0 +1,8 @@
+backend local { path = "carina.state.json" }
+
+let foo = use { source = './usecase' }
+let inst = foo { }
+
+exports {
+  z = inst.z
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_string_let_attr_access_rejected/usecase/helpers.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_string_let_attr_access_rejected/usecase/helpers.crn
@@ -1,0 +1,1 @@
+let X = 'literal'

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_string_let_attr_access_rejected/usecase/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_string_let_attr_access_rejected/usecase/main.crn
@@ -1,0 +1,3 @@
+attributes {
+  z = X.foo
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_use_alias_seed_does_not_leak/loader.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_use_alias_seed_does_not_leak/loader.crn
@@ -1,0 +1,1 @@
+let foo = use { source = './usecase' }

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_use_alias_seed_does_not_leak/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_use_alias_seed_does_not_leak/main.crn
@@ -1,0 +1,7 @@
+backend local { path = "carina.state.json" }
+
+let inst = foo { }
+
+exports {
+  z = foo
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile_use_alias_seed_does_not_leak/usecase/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile_use_alias_seed_does_not_leak/usecase/main.crn
@@ -1,0 +1,3 @@
+attributes {
+  y = 'x'
+}

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -390,14 +390,17 @@ pub(crate) fn merge_parsed_file<E>(target: &mut File<E>, source: File<E>) {
 ///   legacy per-file parse — sibling-defined names are not in scope, so
 ///   ResourceRef / String fallback paths fire as before. The Pass-1
 ///   `ParsedFile`s are merged only to collect the *binding-name union*
-///   from sibling files; the merged result itself is discarded.
+///   from sibling files and the actual values for plain value-shaped
+///   `let` bindings; the merged result itself is discarded after Pass 2
+///   seeds are built.
 /// - **Pass 2** parses every input again, this time seeding the per-file
-///   `ParseContext` with the binding-name union from Pass 1. Names that
-///   originate in *sibling* files now resolve through the normal
-///   `ctx.get_variable` / `ctx.is_resource_binding` paths, so an
-///   `arguments {}` block in `main.crn` is visible from `role.crn`,
-///   a `let` declared in `helpers.crn` is visible from `main.crn`,
-///   etc.
+///   `ParseContext` with the binding-name union from Pass 1. Plain
+///   value-shaped `let` seeds use their actual Pass-1 value; structural
+///   bindings use placeholders. Names that originate in *sibling* files
+///   now resolve through the normal `ctx.get_variable` /
+///   `ctx.is_resource_binding` paths, so an `arguments {}` block in
+///   `main.crn` is visible from `role.crn`, a `let` declared in
+///   `helpers.crn` is visible from `main.crn`, etc.
 ///
 /// The returned vector preserves the input order. Any per-file parse
 /// error from Pass 2 short-circuits and is returned to the caller; Pass
@@ -420,9 +423,7 @@ pub fn parse_directory_files(
         let parsed = parser::parse(content, config)?;
         merge_parsed_file(&mut union, parsed);
     }
-    let seeds: Vec<&str> = parser::collect_known_bindings_merged(&union)
-        .into_iter()
-        .collect();
+    let seeds = parser::collect_seed_bindings_merged(&union);
 
     // Pass 2: re-parse each file with the union seeded into `ctx`.
     let mut out = Vec::with_capacity(files.len());

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -1178,6 +1178,31 @@ impl<E> File<E> {
             .chain(self.data_sources.iter().map(ResourceRef::DataSource))
     }
 
+    /// Every non-variable binding name declared in the file.
+    ///
+    /// This intentionally excludes `variables`: parser-side variables
+    /// include both plain value `let`s and placeholder entries for
+    /// structural `let`s. Callers that need the complete in-scope set
+    /// should union this with `variables`; callers that need to classify
+    /// plain value lets can use this as the exclusion set.
+    pub(crate) fn structural_binding_names(&self) -> HashSet<&str> {
+        let mut names = HashSet::new();
+        names.extend(self.iter_top_level_resources().filter_map(|r| r.binding()));
+        names.extend(self.arguments.iter().map(|a| a.name.as_str()));
+        names.extend(
+            self.module_calls
+                .iter()
+                .filter_map(|c| c.binding_name.as_deref()),
+        );
+        names.extend(self.upstream_states.iter().map(|u| u.binding.as_str()));
+        names.extend(self.wait_bindings.iter().map(|w| w.binding.as_str()));
+        names.extend(self.uses.iter().map(|u| u.alias.as_str()));
+        names.extend(self.user_functions.keys().map(String::as_str));
+        names.extend(self.providers.iter().filter_map(|p| p.binding.as_deref()));
+        names.extend(self.structural_bindings.iter().map(String::as_str));
+        names
+    }
+
     /// Consume `self` and yield the top-level nodes as owned
     /// [`GraphNode`]s.
     ///
@@ -1483,8 +1508,121 @@ pub(super) fn substitute_placeholder(
 mod substitute_placeholder_tests {
     use super::*;
     use crate::resource::{
-        AccessPath, ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
+        AccessPath, ConcreteValue, DeferredValue, InterpolationPart, ResourceId, Signature,
+        UnknownReason, Value,
     };
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn structural_binding_names_covers_every_non_variable_kind() {
+        let mut parsed = ParsedFile::default();
+
+        let mut resource = Resource::new("mock.compute.Instance", "resource_node");
+        resource.binding = Some("resource_name".to_string());
+        parsed.resources.push(resource); // allow: direct — fixture test inspection
+
+        let mut data_source = DataSource::new("mock.compute.Instance", "data_node");
+        data_source.binding = Some("data_source_name".to_string());
+        parsed.data_sources.push(data_source);
+
+        parsed.compositions.push(Composition {
+            id: ResourceId::new("_virtual", "composition_node"),
+            signature: Signature {
+                arguments: IndexMap::new(),
+                attributes: IndexMap::new(),
+            },
+            binding: Some("composition_name".to_string()),
+            dependency_bindings: BTreeSet::new(),
+            module_name: "module_name".to_string(),
+            instance: "composition_name".to_string(),
+            quoted_string_attrs: HashSet::new(),
+        });
+
+        parsed.arguments.push(ArgumentParameter {
+            name: "argument_name".to_string(),
+            type_expr: TypeExpr::String,
+            default: None,
+            description: None,
+            validations: Vec::new(),
+        });
+        parsed.module_calls.push(ModuleCall {
+            module_name: "module".to_string(),
+            binding_name: Some("module_call_name".to_string()),
+            arguments: HashMap::new(),
+        });
+        parsed.upstream_states.push(UpstreamState {
+            binding: "upstream_name".to_string(),
+            source: "upstream".into(),
+        });
+        parsed.wait_bindings.push(WaitBinding {
+            binding: BindingName::from("wait_name"),
+            target: BindingName::from("resource_name"),
+            until_raw: "resource_name.status == 'ready'".to_string(),
+            until_predicate: UntilPredicateAst {
+                lhs_segments: vec!["resource_name".to_string(), "status".to_string()],
+                rhs: Value::Concrete(ConcreteValue::String("ready".to_string())),
+            },
+            timeout_secs: None,
+            depends_on: Vec::new(),
+            line: 1,
+        });
+        parsed.uses.push(UseStatement {
+            path: "./module".to_string(),
+            alias: "use_alias".to_string(),
+        });
+        parsed.user_functions.insert(
+            "function_name".to_string(),
+            UserFunction {
+                name: "function_name".to_string(),
+                params: Vec::new(),
+                return_type: None,
+                local_lets: Vec::new(),
+                body: UserFunctionBody(Value::Concrete(ConcreteValue::Int(1))),
+            },
+        );
+        parsed.providers.push(ProviderConfig {
+            name: "mock".to_string(),
+            attributes: IndexMap::new(),
+            default_tags: IndexMap::new(),
+            source: None,
+            version: None,
+            revision: None,
+            unresolved_attributes: IndexMap::new(),
+            binding: Some("provider_name".to_string()),
+            is_default: false,
+        });
+        parsed
+            .structural_bindings
+            .insert("structural_name".to_string());
+        parsed.variables.insert(
+            "plain_value_name".to_string(),
+            Value::Concrete(ConcreteValue::String("literal".to_string())),
+        );
+
+        let names = parsed.structural_binding_names();
+        for expected in [
+            "resource_name",
+            "data_source_name",
+            "composition_name",
+            "argument_name",
+            "module_call_name",
+            "upstream_name",
+            "wait_name",
+            "use_alias",
+            "function_name",
+            "provider_name",
+            "structural_name",
+        ] {
+            assert!(
+                names.contains(expected),
+                "structural_binding_names should include {expected}; got {names:?}"
+            );
+        }
+        assert!(
+            !names.contains("plain_value_name"),
+            "plain value lets must be excluded from structural binding names"
+        );
+    }
 
     #[test]
     fn replaces_for_value_with_bound_value() {

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -31,6 +31,42 @@ use crate::resource::{DataSource, DeferredValue, Resource, Value};
 use indexmap::IndexMap;
 use pest::Parser;
 
+#[derive(Clone, Copy)]
+pub(crate) struct BindingSeed<'a> {
+    name: &'a str,
+    kind: SeedKind<'a>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SeedKind<'a> {
+    Value(&'a Value),
+    Structural,
+}
+
+impl<'a> BindingSeed<'a> {
+    pub(crate) fn value(name: &'a str, value: &'a Value) -> Self {
+        Self {
+            name,
+            kind: SeedKind::Value(value),
+        }
+    }
+
+    pub(crate) fn structural(name: &'a str) -> Self {
+        Self {
+            name,
+            kind: SeedKind::Structural,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &'a str {
+        self.name
+    }
+
+    pub(crate) fn kind(&self) -> SeedKind<'a> {
+        self.kind
+    }
+}
+
 /// Parse a .crn file with the given configuration.
 ///
 /// The config allows injecting a decryptor function for `decrypt()` calls
@@ -50,14 +86,16 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
 
 /// Parse a .crn file with `seeds` pre-registered as lexical bindings.
 ///
-/// Each name in `seeds` is registered in the per-file [`ParseContext`]
-/// the same way `register_argument_binding` does: a placeholder
-/// `Value::Deferred(DeferredValue::ResourceRef{ binding: <name>, attribute: "", … })` is
-/// installed in `ctx.variables`, and a placeholder `Resource` is
-/// installed in `ctx.resource_bindings`. This means subsequent
-/// expressions resolve the name via the normal `ctx.get_variable` /
-/// `ctx.is_resource_binding` paths instead of degrading to the literal-
-/// string fallback in `primary.rs::variable_ref` / `parse_namespaced_id_value`.
+/// Each seed carries the directory-wide binding name and, for plain
+/// value-shaped `let` bindings, the pass-1 value from the merged file.
+/// Value seeds are installed directly in `ctx.variables`; all other
+/// binding kinds use the existing [`Value::Deferred(DeferredValue::BindingRef)`]
+/// placeholder and a placeholder `Resource` in `ctx.resource_bindings`.
+/// This keeps value lets value-shaped while structural sibling names
+/// still resolve through the normal `ctx.get_variable` /
+/// `ctx.is_resource_binding` paths instead of degrading to the
+/// literal-string fallback in `primary.rs::variable_ref` /
+/// `parse_namespaced_id_value`.
 ///
 /// The seed list is the directory aggregate: every binding declared in
 /// any sibling `.crn` (resource bindings, argument names, attribute
@@ -72,7 +110,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
 pub fn parse_with_seeded_bindings(
     input: &str,
     config: &ProviderContext,
-    seeds: &[&str],
+    seeds: &[BindingSeed<'_>],
 ) -> Result<ParsedFile, ParseError> {
     let preprocess_result =
         crate::heredoc::preprocess_heredocs(input).map_err(|e| ParseError::InvalidExpression {
@@ -426,31 +464,44 @@ pub fn parse_with_seeded_bindings(
     })
 }
 
-/// Pre-register `seeds` as lexical bindings in `ctx`. Mirrors the
-/// shape of `register_argument_binding` so seeded names resolve through
-/// the same `ctx.get_variable` / `ctx.is_resource_binding` paths that
-/// locally-declared `let` / `arguments` names use after parsing.
+/// Pre-register `seeds` as lexical bindings in `ctx`.
 ///
-/// Each seed is installed as a [`Value::Deferred(DeferredValue::BindingRef)`] — a bare-binding
-/// reference with no attribute slot. This is intentional: a seed
-/// represents "a name exists in scope; we know nothing more about it".
-/// When a downstream expression accesses `name.attr`, the parser
-/// composes a fresh [`Value::Deferred(DeferredValue::ResourceRef)`] with the real attribute
-/// instead of mutating the seed. Storing the seed as `ResourceRef`
-/// with an empty `attribute` field would be a type-level lie and
-/// previously surfaced as the empty-field diagnostic in #2847.
+/// Plain value seeds mirror a local `let name = <value>`: only
+/// `ctx.variables` is populated. Structural seeds mirror the
+/// placeholder shape used for resource/module/data/upstream bindings:
+/// `ctx.variables` receives a [`Value::Deferred(DeferredValue::BindingRef)`]
+/// and `ctx.resource_bindings` receives a `_seeded` resource marker.
+/// Storing the structural seed as `ResourceRef` with an empty
+/// `attribute` field would be a type-level lie and previously surfaced
+/// as the empty-field diagnostic in #2847.
 ///
 /// Empty seed list is a no-op — single-file callers (the legacy
 /// `parse(input, config)` wrapper, parser tests) pay no cost.
-fn seed_bindings(ctx: &mut ParseContext<'_>, seeds: &[&str]) {
-    for &name in seeds {
-        let placeholder_ref = Value::Deferred(DeferredValue::BindingRef {
-            binding: name.to_string(),
-        });
-        ctx.set_variable(name.to_string(), placeholder_ref);
-        let placeholder = Resource::new("_seeded", name);
-        ctx.set_resource_binding(name.to_string(), placeholder);
-        ctx.seeded_bindings.insert(name.to_string());
+fn seed_bindings(ctx: &mut ParseContext<'_>, seeds: &[BindingSeed<'_>]) {
+    for seed in seeds {
+        match seed.kind() {
+            SeedKind::Value(value) => {
+                ctx.set_variable(seed.name().to_string(), value.clone());
+            }
+            SeedKind::Structural => {
+                // Asymmetry: a local resource `let cluster = ...` registers
+                // `Concrete(String("${cluster}"))` in `ctx.variables`; a
+                // seeded structural binding registers `Deferred(BindingRef)`.
+                // Dotted refs (`cluster.attr`) go through `is_resource_binding`
+                // first and never observe the difference; bare refs read
+                // `ctx.variables`, but every current consumer (e.g.
+                // `value_as_binding_name`, the eval pipeline) handles both
+                // shapes identically. A new consumer that pattern-matches on
+                // only one shape would surface this: converge the two then.
+                let placeholder_ref = Value::Deferred(DeferredValue::BindingRef {
+                    binding: seed.name().to_string(),
+                });
+                ctx.set_variable(seed.name().to_string(), placeholder_ref);
+                let placeholder = Resource::new("_seeded", seed.name());
+                ctx.set_resource_binding(seed.name().to_string(), placeholder);
+            }
+        }
+        ctx.seeded_bindings.insert(seed.name().to_string());
     }
 }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use entry::{parse_expression, parse_expression_eval};
 pub use error::{ParseError, ParseWarning};
 pub(crate) use functions::evaluate_user_function;
 pub use functions::{provider_context_lookup, validate_custom_type};
+pub(crate) use resolve::collect_seed_bindings_merged;
 pub use resolve::{
     check_identifier_scope, check_provider_instance_routing, collect_known_bindings_merged,
     finalize_provider_configs, resolve_provider_attributes_with_remote,

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -4,6 +4,7 @@
 
 use super::ProviderContext;
 use super::ast::{AttributeParameter, ExportParameter, ModuleCall, ParsedFile};
+use super::entry::BindingSeed;
 use super::error::{ParseError, undefined_identifier_error};
 use super::static_eval::is_static_value;
 use crate::eval_value::EvalValue;
@@ -360,28 +361,36 @@ pub fn resolve_resource_refs_with_config(
 /// borrowed view (changing that signature would force `undefined_identifier_error`
 /// to rebuild a borrowed view per call).
 pub fn collect_known_bindings_merged(parsed: &ParsedFile) -> std::collections::HashSet<&str> {
-    let mut known: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    // carina#3181: walk the typed top-level slices — managed resources,
-    // data sources, and compositions all contribute a binding name in scope.
-    known.extend(
-        parsed
-            .iter_top_level_resources()
-            .filter_map(|r| r.binding()),
-    );
-    known.extend(parsed.arguments.iter().map(|a| a.name.as_str()));
-    known.extend(
-        parsed
-            .module_calls
-            .iter()
-            .filter_map(|c| c.binding_name.as_deref()),
-    );
-    known.extend(parsed.upstream_states.iter().map(|u| u.binding.as_str()));
-    known.extend(parsed.wait_bindings.iter().map(|w| w.binding.as_str()));
-    known.extend(parsed.uses.iter().map(|i| i.alias.as_str()));
-    known.extend(parsed.user_functions.keys().map(String::as_str));
+    let mut known = parsed.structural_binding_names();
     known.extend(parsed.variables.keys().map(String::as_str));
-    known.extend(parsed.structural_bindings.iter().map(String::as_str));
     known
+}
+
+/// Directory-wide parse seeds for Pass 2.
+///
+/// Plain value-shaped `let` bindings carry their pass-1 value so bare
+/// sibling identifiers parse to that value instead of a deferred
+/// placeholder. Structural bindings may also have parser placeholder
+/// entries in `parsed.variables` (`"${binding}"`); those must not become
+/// value seeds, so structural names continue to use the placeholder
+/// installed by `seed_bindings`.
+pub(crate) fn collect_seed_bindings_merged(parsed: &ParsedFile) -> Vec<BindingSeed<'_>> {
+    let structural = parsed.structural_binding_names();
+
+    collect_known_bindings_merged(parsed)
+        .into_iter()
+        .map(|name| {
+            if structural.contains(name) {
+                BindingSeed::structural(name)
+            } else if let Some(value) = parsed.variables.get(name) {
+                BindingSeed::value(name, value)
+            } else {
+                unreachable!(
+                    "collect_known_bindings_merged names are either structural or in variables"
+                )
+            }
+        })
+        .collect()
 }
 
 /// Directory-wide identifier-scope validation for a merged [`ParsedFile`].
@@ -881,4 +890,74 @@ pub fn finalize_provider_configs<E>(parsed: &mut super::File<E>) -> Result<(), P
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod seed_precedence_tests {
+    use super::*;
+    use crate::parser::entry::SeedKind;
+
+    #[test]
+    fn structural_let_with_placeholder_in_variables_seeds_as_structural() {
+        // A `let cluster = mock.compute.Instance {}` shape: `cluster` appears
+        // in `parsed.resources` and in `parsed.variables`, where let_binding.rs
+        // stores the parser placeholder string "${cluster}".
+        let mut parsed = ParsedFile::default();
+
+        let mut resource = Resource::new("mock.compute.Instance", "instance");
+        resource.binding = Some("cluster".to_string());
+        parsed.resources.push(resource); // allow: direct — fixture test inspection
+
+        parsed.variables.insert(
+            "cluster".to_string(),
+            Value::Concrete(ConcreteValue::String("${cluster}".to_string())),
+        );
+
+        let seeds = collect_seed_bindings_merged(&parsed);
+        let cluster_seed = seeds
+            .iter()
+            .find(|seed| seed.name() == "cluster")
+            .expect("cluster seed missing");
+
+        match cluster_seed.kind() {
+            SeedKind::Structural => {}
+            SeedKind::Value(value) => panic!(
+                "structural binding `cluster` with placeholder in variables \
+                 must seed as Structural, not Value({value:?}). The structural-first \
+                 precedence in collect_seed_bindings_merged is load-bearing for \
+                 carina#3391's fix: if Value wins, the parser placeholder \
+                 \"${{cluster}}\" leaks as the seed value and sibling-file `cluster.attr` \
+                 references can resolve to the placeholder string instead of \
+                 going through the resource-binding path."
+            ),
+        }
+    }
+
+    #[test]
+    fn plain_let_literal_seeds_as_value() {
+        // A `let bad_name = 'literal'` shape: `bad_name` appears in
+        // `parsed.variables` only, not in any structural source.
+        let mut parsed = ParsedFile::default();
+        parsed.variables.insert(
+            "bad_name".to_string(),
+            Value::Concrete(ConcreteValue::String("literal".to_string())),
+        );
+
+        let seeds = collect_seed_bindings_merged(&parsed);
+        let bad_seed = seeds
+            .iter()
+            .find(|seed| seed.name() == "bad_name")
+            .expect("bad_name seed missing");
+
+        match bad_seed.kind() {
+            SeedKind::Value(value) => {
+                assert_eq!(
+                    value,
+                    &Value::Concrete(ConcreteValue::String("literal".to_string())),
+                    "Value seed must carry the actual literal"
+                );
+            }
+            SeedKind::Structural => panic!("plain value let must seed as Value, not Structural"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Fix: in a multi-file directory, a plain `let X = '<literal>'` declared in a sibling `.crn` and referenced as `attributes { X = X }` from another file now renders the literal when surfaced through an `exports` chain, instead of degrading to `(known after apply)`.
- Root cause: directory-parser Pass-2 seeded `Value::Deferred(BindingRef)` placeholders for every sibling-defined binding name. The placeholder is the right shape for structural bindings (resource / module / data source / upstream state / wait / named provider / argument / use alias / user function) — dotted refs flow through `is_resource_binding` first — but wrong for plain value lets, where `Rule::variable_ref`'s no-access arm returned the placeholder via `ctx.get_variable` and it leaked through composition attributes into export rendering.
- Fix shape: replace the `&[&str]` seed list with a typed `BindingSeed { name, kind: SeedKind::Value(&Value) | SeedKind::Structural }`. Structural names keep the BindingRef placeholder + the `_seeded` resource marker; plain value lets carry their Pass-1 value into `ctx.variables` only. `BindingSeed`'s fields are private and only constructible via `BindingSeed::value(name, &value)` / `BindingSeed::structural(name)`, so the broken state "structural name paired with a value seed" is unrepresentable at the type level.
- Single source of truth: a new `File::structural_binding_names()` on the parser AST returns every non-Variable binding name; `collect_known_bindings_merged`, `collect_seed_bindings_merged`, and `BindingNameSet::from_parsed`'s `Structural`-fallback loop all consult it (or its consumer). The three helpers previously hand-enumerated the same set and had already drifted on `providers` membership.
- Side fix surfaced during review: `seed_bindings` now only installs the `_seeded` Resource marker for `SeedKind::Structural`. Previously the unconditional installation shadowed value seeds — `let X = 'literal'` followed by `X.foo` was silently routed through `ResourceRef` and rendered `(known after apply)` instead of being rejected with the scalar field-access diagnostic that local lets receive.

## Tests

Four new directory fixtures + snapshots in `carina-cli/tests/fixtures/plan_display/`:

- `exports_multifile_let_literal` pins the issue's "bad chain" (sibling let → attributes → export must render the literal) and "good chain" (resource attr → attributes → export must render the literal) side by side, matching the issue's vocabulary.
- `exports_multifile_bare_resource_ref_seed_stays_deferred` — bare references to a sibling resource binding must NOT leak the `"${binding}"` parser placeholder.
- `exports_multifile_use_alias_seed_does_not_leak` — bare references to a sibling `use` alias must NOT leak `"${use:./path}"`.
- `exports_multifile_string_let_attr_access_rejected` — field access on a sibling string let must produce the same scalar-field-access diagnostic as a local let, not `(known after apply)`.

Two pure unit tests pin the helpers:

- `structural_binding_names_covers_every_non_variable_kind` (ast.rs) mechanically asserts every non-Variable binding source ends up in the helper's output, so a future kind cannot be silently forgotten.
- `seed_precedence_tests` (resolve.rs) pins structural-first precedence in `collect_seed_bindings_merged`, so a dual-presence name (`let cluster = mock.compute.Instance{}` is in both `parsed.resources` AND `parsed.variables` with a `"${cluster}"` parser placeholder) is classified Structural, not Value.

The regression test was written first and verified failing on `main` before the fix landed.

## Test plan

- [x] `cargo nextest run --workspace --no-fail-fast` (3875 passed, 0 failed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (each script)
- [x] `cargo insta pending-snapshots` (none pending)
- [x] Manual: `carina plan` against the issue's bad-chain repro renders the literal

## Follow-up (out of scope for this PR)

A chained sibling let — `helpers.crn: let A = 'foo'` → `bridge.crn: let B = A` → `main.crn: exports z = B` — still renders `(known after apply)`. Pass-1 of `bridge.crn` has no seed for `A`, so `B`'s Pass-1 value is a deferred placeholder that the value-seed pipeline propagates verbatim. This is a separate class of bug (Pass-1 single-file scope vs the Pass-2 seeding addressed here); I'll file a follow-up issue.

Closes #3391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
