### PR TITLE
Move backend-drift safety gate from `init` to `apply`/`destroy`/`refresh`

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -15,13 +15,15 @@ use carina_core::executor::{ExecutionInput, ExecutionResult};
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer, ReadRequest};
 use carina_core::resolver::resolve_refs_with_state_and_remote;
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+#[cfg(test)]
+use carina_core::resource::ConcreteValue;
+use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::value::format_value;
-use carina_state::{LockInfo, StateBackend, StateFile, resolve_backend};
+use carina_state::{BackendLock, LockInfo, StateBackend, StateFile};
 
 use carina_core::parser::ProviderContext;
 
-use super::validate_and_resolve_with_config;
+use super::{DriftCommand, validate_and_resolve_with_config, verify_for_mutation};
 use crate::DetailLevel;
 use crate::commands::plan::PlanFile;
 use crate::commands::shared::effect_execution::{
@@ -538,7 +540,6 @@ pub async fn run_apply(
     path: &Path,
     auto_approve: bool,
     lock: bool,
-    reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
     let loaded = load_configuration_with_config(
@@ -554,12 +555,12 @@ pub async fn run_apply(
     let ctx = WiringContext::new(factories);
     validate_and_resolve_with_config(&mut parsed, base_dir, false)?;
 
-    // Detect backend reconfiguration before touching any state
-    crate::commands::check_backend_lock(base_dir, parsed.backend.as_ref(), reconfigure)?;
+    let verified_backend =
+        verify_for_mutation(base_dir, parsed.backend.as_ref(), DriftCommand::Apply)?;
 
     // Check for backend configuration - use local backend by default
-    let backend_config = parsed.backend.as_ref();
-    let backend: Box<dyn StateBackend> = resolve_backend(backend_config)
+    let backend: Box<dyn StateBackend> = verified_backend
+        .resolve()
         .await
         .map_err(AppError::Backend)?;
 
@@ -567,7 +568,7 @@ pub async fn run_apply(
     #[allow(unused_assignments)]
     let mut lock_info: Option<LockInfo> = None;
 
-    if let Some(config) = backend_config {
+    if verified_backend.is_configured() {
         // Check if bucket exists (bootstrap detection)
         let bucket_exists = backend.bucket_exists().await.map_err(AppError::Backend)?;
 
@@ -580,13 +581,9 @@ pub async fn run_apply(
             );
 
             // Get bucket name from config
-            let bucket_name = config
-                .attributes
-                .get("bucket")
-                .and_then(|v| match v {
-                    Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
-                    _ => None,
-                })
+            let bucket_name = verified_backend
+                .string_attribute("bucket")
+                .map(str::to_owned)
                 .ok_or("Missing bucket name in backend configuration")?;
 
             // Check if there's a bucket resource defined with matching name
@@ -641,13 +638,8 @@ pub async fn run_apply(
                 }
             } else {
                 // Auto-create the bucket if auto_create is enabled
-                let auto_create = config
-                    .attributes
-                    .get("auto_create")
-                    .and_then(|v| match v {
-                        Value::Concrete(ConcreteValue::Bool(b)) => Some(*b),
-                        _ => None,
-                    })
+                let auto_create = verified_backend
+                    .bool_attribute("auto_create")
                     .unwrap_or(true);
 
                 if auto_create {
@@ -1470,10 +1462,32 @@ async fn run_apply_locked(
     }
 }
 
+fn ensure_saved_plan_backend_matches_current(
+    plan_backend_config: Option<&carina_core::parser::BackendConfig>,
+    current_backend_config: Option<&carina_core::parser::BackendConfig>,
+) -> Result<(), AppError> {
+    let planned = BackendLock::for_config(plan_backend_config)
+        .map_err(|e| AppError::Config(format!("Failed to inspect saved plan backend: {e}")))?;
+    let current = BackendLock::for_config(current_backend_config)
+        .map_err(|e| AppError::Config(format!("Failed to inspect current backend: {e}")))?;
+
+    if planned == current {
+        Ok(())
+    } else {
+        Err(AppError::Config(format!(
+            "Saved plan backend does not match the current `backend.crn`.\n\
+             The plan file recorded one backend, but the project now declares another.\n\
+             Re-run `carina plan` to produce a fresh saved plan before applying.\n{}",
+            planned.describe_diff(&current)
+        )))
+    }
+}
+
 pub async fn run_apply_from_plan(
     plan_path: &PathBuf,
     auto_approve: bool,
     lock: bool,
+    provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
     // Read and deserialize the plan file
     let content =
@@ -1525,8 +1539,26 @@ pub async fn run_apply_from_plan(
         .cyan()
     );
 
+    let source_path = std::path::PathBuf::from(&plan_file.source_path);
+    let base_dir = get_base_dir(&source_path);
+    let current_config = load_configuration_with_config(
+        &source_path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?;
+    let verified_backend = verify_for_mutation(
+        base_dir,
+        current_config.parsed.backend.as_ref(),
+        DriftCommand::Apply,
+    )?;
+    ensure_saved_plan_backend_matches_current(
+        plan_file.backend_config.as_ref(),
+        current_config.parsed.backend.as_ref(),
+    )?;
+
     // Set up backend
-    let backend: Box<dyn StateBackend> = resolve_backend(plan_file.backend_config.as_ref())
+    let backend: Box<dyn StateBackend> = verified_backend
+        .resolve()
         .await
         .map_err(AppError::Backend)?;
 
@@ -1549,8 +1581,6 @@ pub async fn run_apply_from_plan(
         None
     };
 
-    let source_path = std::path::PathBuf::from(&plan_file.source_path);
-    let base_dir = get_base_dir(&source_path);
     let op_result = crate::signal::run_with_ctrl_c(run_apply_from_plan_locked(
         plan_file,
         auto_approve,

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -2,6 +2,44 @@ use super::*;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
 use std::time::Duration;
 
+fn s3_backend_config_with_encrypt(encrypt: bool) -> carina_core::parser::BackendConfig {
+    let mut attributes = HashMap::new();
+    attributes.insert(
+        "bucket".to_string(),
+        Value::Concrete(ConcreteValue::String("state-bucket".to_string())),
+    );
+    attributes.insert(
+        "key".to_string(),
+        Value::Concrete(ConcreteValue::String("project/state.json".to_string())),
+    );
+    attributes.insert(
+        "region".to_string(),
+        Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+    );
+    attributes.insert(
+        "encrypt".to_string(),
+        Value::Concrete(ConcreteValue::Bool(encrypt)),
+    );
+    carina_core::parser::BackendConfig {
+        backend_type: "s3".to_string(),
+        attributes,
+    }
+}
+
+#[test]
+fn saved_plan_backend_cross_check_rejects_non_addressing_attribute_change() {
+    let planned = s3_backend_config_with_encrypt(false);
+    let current = s3_backend_config_with_encrypt(true);
+
+    let err = ensure_saved_plan_backend_matches_current(Some(&planned), Some(&current))
+        .expect_err("any backend attribute change should invalidate a saved plan");
+    let msg = err.to_string();
+
+    assert!(msg.contains("Saved plan backend does not match the current `backend.crn`"));
+    assert!(msg.contains("The plan file recorded one backend"));
+    assert!(msg.contains("Re-run `carina plan`"));
+}
+
 #[test]
 fn build_state_after_apply_finds_write_only_with_provider_prefix() {
     // The schema map is keyed by provider-prefixed names (e.g., "awscc.ec2.Vpc"),
@@ -2015,7 +2053,13 @@ mod saved_plan_version_tests {
         });
         std::fs::write(&plan_path, serde_json::to_string(&v3).unwrap()).expect("write plan");
 
-        let result = crate::commands::apply::run_apply_from_plan(&plan_path, true, false).await;
+        let result = crate::commands::apply::run_apply_from_plan(
+            &plan_path,
+            true,
+            false,
+            &carina_core::parser::ProviderContext::default(),
+        )
+        .await;
 
         let err = result.expect_err("v3 saved plan must be rejected");
         let msg = err.to_string();

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -17,11 +17,11 @@ use carina_core::effect::Effect;
 use carina_core::plan::Plan;
 use carina_core::provider::Provider;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
-use carina_state::{LockInfo, StateBackend, resolve_backend};
+use carina_state::{LockInfo, StateBackend};
 
 use carina_core::parser::ProviderContext;
 
-use super::validate_and_resolve_with_config;
+use super::{DriftCommand, validate_and_resolve_with_config, verify_for_mutation};
 use crate::DetailLevel;
 use crate::commands::shared::progress::{
     RefreshProgress, format_duration, refresh_multi_progress, spinner_style,
@@ -46,7 +46,6 @@ pub async fn run_destroy(
     lock: bool,
     refresh: bool,
     force: bool,
-    reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
     let mut parsed = load_configuration_with_config(
@@ -59,27 +58,22 @@ pub async fn run_destroy(
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, true)?;
 
-    // Detect backend reconfiguration before touching any state
-    crate::commands::check_backend_lock(base_dir, parsed.backend.as_ref(), reconfigure)?;
+    let verified_backend =
+        verify_for_mutation(base_dir, parsed.backend.as_ref(), DriftCommand::Destroy)?;
 
     // Don't exit early when resources are empty -- orphaned resources in the
     // state file may still need to be destroyed.
 
     // Check for backend configuration - use local backend by default
-    let backend_config = parsed.backend.as_ref();
-    let backend: Box<dyn StateBackend> = resolve_backend(backend_config)
+    let backend: Box<dyn StateBackend> = verified_backend
+        .resolve()
         .await
         .map_err(AppError::Backend)?;
 
-    let mut protected_bucket: Option<String> = None;
-
     // Get the state bucket name for protection check (S3 backend only)
-    if let Some(config) = backend_config {
-        protected_bucket = config.attributes.get("bucket").and_then(|v| match v {
-            Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
-            _ => None,
-        });
-    }
+    let protected_bucket = verified_backend
+        .string_attribute("bucket")
+        .map(str::to_owned);
 
     // Acquire lock (unless --lock=false)
     let lock_info: Option<LockInfo> = if lock {

--- a/carina-cli/src/commands/export.rs
+++ b/carina-cli/src/commands/export.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 
 use carina_core::config_loader::load_configuration_with_config;
 use carina_core::parser::ProviderContext;
-use carina_state::{StateBackend, resolve_backend};
+use carina_state::{StateBackend, resolve_backend_for_read};
 
 use crate::error::AppError;
 
@@ -33,7 +33,7 @@ pub async fn run_export(
     )?
     .parsed;
 
-    let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
+    let backend: Box<dyn StateBackend> = resolve_backend_for_read(parsed.backend.as_ref())
         .await
         .map_err(AppError::Backend)?;
 

--- a/carina-cli/src/commands/init.rs
+++ b/carina-cli/src/commands/init.rs
@@ -4,11 +4,13 @@ use colored::Colorize;
 
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::parser::ProviderContext;
-use carina_state::BackendLock;
 
 use carina_provider_resolver::{self, LockMode};
 
 use crate::commands::migrate_state::{MigrationOutcome, SourceDisposition, run_init_migrate_state};
+use crate::commands::{
+    BackendDriftStatus, drift_warning, ensure_backend_lock, inspect_backend_drift,
+};
 
 pub async fn run_init(
     path: &Path,
@@ -86,65 +88,75 @@ pub async fn run_init(
     }
 
     let backend_config = loaded.parsed.backend.as_ref();
+    let mut migration_pending = false;
 
-    // Backend lock lifecycle:
-    //
-    // - No lock yet            → first init, create it (nothing to migrate).
-    // - Lock matches config    → nothing to do.
-    // - Lock differs + no flag → refuse, point at --migrate-state.
-    // - Lock differs + flag    → migrate state, then re-lock.
-    let existing_lock =
-        BackendLock::load(base_dir).map_err(|e| format!("Failed to read backend lock: {e}"))?;
-    let configured = BackendLock::for_config(backend_config)
-        .map_err(|e| format!("Invalid backend configuration: {e}"))?;
-
-    match existing_lock {
-        None => {
-            crate::commands::ensure_backend_lock(base_dir, backend_config)
+    match inspect_backend_drift(base_dir, backend_config).map_err(|e| e.to_string())? {
+        BackendDriftStatus::Fresh => {
+            ensure_backend_lock(base_dir, backend_config)
                 .map_err(|e| format!("Failed to create backend lock: {e}"))?;
-        }
-        Some(existing) if existing == configured => {
-            // Already initialized against this backend; nothing to do.
-        }
-        Some(existing) => {
-            if !migrate_state {
-                return Err(format!(
-                    "Backend configuration changed since the last init:\n\n{}\n\n\
-                     Re-run with `--migrate-state` to move the state file from the \
-                     old backend to the configured one, or revert the backend \
-                     configuration to match the lock.",
-                    existing.describe_diff(&configured)
-                ));
+            if migrate_state {
+                println!(
+                    "{}",
+                    "No state migration needed; backend lock initialized.".green()
+                );
             }
-            match run_init_migrate_state(base_dir, backend_config, force)
-                .await
-                .map_err(|e| e.to_string())?
-            {
-                MigrationOutcome::NotNeeded => {
-                    // Races with another init that already migrated; the
-                    // lock now matches, so this is a benign no-op.
-                }
-                MigrationOutcome::Migrated { resources, source } => {
-                    println!(
-                        "{}",
-                        format!("State migrated ({resources} resource(s)).").green()
-                    );
-                    // `DeleteFailed` already produced a precise stderr
-                    // warning inside the migration; only the deliberate
-                    // remote-backup case needs this extra hint here.
-                    if source == SourceDisposition::KeptAsBackup {
+        }
+        BackendDriftStatus::Unchanged => {
+            // Already initialized against this backend; nothing to do.
+            if migrate_state {
+                println!(
+                    "{}",
+                    "No state migration needed; backend lock already matches the configuration."
+                        .green()
+                );
+            }
+        }
+        BackendDriftStatus::Drifted {
+            existing,
+            configured,
+        } => {
+            if !migrate_state {
+                eprintln!("{}", drift_warning(&existing, &configured).yellow());
+                migration_pending = true;
+            } else {
+                match run_init_migrate_state(base_dir, backend_config, force)
+                    .await
+                    .map_err(|e| e.to_string())?
+                {
+                    MigrationOutcome::NotNeeded => {
+                        // Races with another init that already migrated; the
+                        // lock now matches, so this is a benign no-op.
+                    }
+                    MigrationOutcome::Migrated { resources, source } => {
                         println!(
-                            "The old state at the previous backend was kept as a \
-                             backup; remove it manually once you have confirmed \
-                             the new backend."
+                            "{}",
+                            format!("State migrated ({resources} resource(s)).").green()
                         );
+                        // `DeleteFailed` already produced a precise stderr
+                        // warning inside the migration; only the deliberate
+                        // remote-backup case needs this extra hint here.
+                        if source == SourceDisposition::KeptAsBackup {
+                            println!(
+                                "The old state at the previous backend was kept as a \
+                                 backup; remove it manually once you have confirmed \
+                                 the new backend."
+                            );
+                        }
                     }
                 }
             }
         }
     }
 
-    println!("{}", "Initialized successfully.".green());
+    if migration_pending {
+        println!(
+            "{}",
+            "Backend migration pending. Provider plugins resolved; run `carina init --migrate-state .` to complete initialization."
+                .yellow()
+        );
+    } else {
+        println!("{}", "Initialized successfully.".green());
+    }
 
     Ok(())
 }

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -14,13 +14,17 @@ pub mod state;
 pub mod validate;
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use carina_core::module_resolver;
 use carina_core::parser::{BackendConfig, ProviderContext};
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::upstream_exports::UpstreamRefDiagnostic;
-use carina_state::BackendLock;
+use carina_state::{
+    BackendConfig as StateBackendConfig, BackendError, BackendLock, StateBackend,
+    resolve_backend_anchored,
+};
 
 use crate::error::AppError;
 use crate::wiring::{
@@ -32,48 +36,145 @@ use crate::wiring::{
     validate_resources_with_ctx, validate_wait_bindings_with_ctx,
 };
 
-/// Detect whether the `backend` block in the current configuration has
-/// changed since the last run, by comparing against `carina-backend.lock`
-/// under `base_dir`.
-///
-/// - If no lock exists, returns an error asking user to run `carina init`.
-/// - If the lock matches, nothing happens.
-/// - If the lock differs and `reconfigure` is `false`, returns an error
-///   explaining the change and asking the user to re-run with `--reconfigure`.
-/// - If `reconfigure` is `true`, overwrites the lock with the new config.
-pub fn check_backend_lock(
+#[must_use = "Drifted must be handled before mutating state — apply/destroy must refuse, init/plan must warn"]
+#[derive(Debug, PartialEq)]
+pub enum BackendDriftStatus {
+    Fresh,
+    Unchanged,
+    Drifted {
+        existing: BackendLock,
+        configured: BackendLock,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriftCommand {
+    Apply,
+    Destroy,
+    RefreshState,
+}
+
+impl DriftCommand {
+    fn verb_phrase(self) -> &'static str {
+        match self {
+            Self::Apply => "Cannot apply",
+            Self::Destroy => "Cannot destroy",
+            Self::RefreshState => "Cannot refresh state",
+        }
+    }
+}
+
+pub fn inspect_backend_drift(
     base_dir: &Path,
     backend_config: Option<&BackendConfig>,
-    reconfigure: bool,
-) -> Result<(), AppError> {
-    let current = BackendLock::for_config(backend_config)?;
+) -> Result<BackendDriftStatus, AppError> {
+    let configured = BackendLock::for_config(backend_config)?;
     let existing = BackendLock::load(base_dir).map_err(AppError::Backend)?;
 
-    match existing {
-        Some(existing) if existing != current => {
-            if reconfigure {
-                current.save(base_dir).map_err(AppError::Backend)?;
-                Ok(())
-            } else {
-                Err(AppError::Config(format!(
-                    "Backend configuration has changed since the last run:\n\n{}\n\n\
-                     Changing backend settings can silently redirect Carina at a \
-                     different state file, which may cause state loss or drift.\n\n\
-                     To preserve existing state, run `carina init --migrate-state` \
-                     — it will copy state from the old backend to the new one and \
-                     update the backend lock.\n\n\
-                     To discard the old state and start fresh with the new backend, \
-                     re-run with --reconfigure.",
-                    existing.describe_diff(&current)
-                )))
-            }
-        }
-        Some(_) => Ok(()),
-        // No lock file — user must run `carina init` first
-        None => Err(AppError::Config(
+    Ok(match existing {
+        None => BackendDriftStatus::Fresh,
+        Some(existing) if existing == configured => BackendDriftStatus::Unchanged,
+        Some(existing) => BackendDriftStatus::Drifted {
+            existing,
+            configured,
+        },
+    })
+}
+
+#[must_use = "VerifiedBackend proves Fresh and Drifted were rejected before mutating state"]
+#[derive(Debug, Clone)]
+pub struct VerifiedBackend {
+    parser_config: Option<BackendConfig>,
+    state_config: Option<StateBackendConfig>,
+    base_dir: PathBuf,
+}
+
+impl VerifiedBackend {
+    pub async fn resolve(&self) -> Result<Box<dyn StateBackend>, BackendError> {
+        resolve_backend_anchored(self.state_config.as_ref(), &self.base_dir).await
+    }
+
+    pub fn is_configured(&self) -> bool {
+        self.parser_config.is_some()
+    }
+
+    pub fn string_attribute(&self, key: &str) -> Option<&str> {
+        self.parser_config.as_ref().and_then(|config| {
+            config.attributes.get(key).and_then(|value| match value {
+                Value::Concrete(ConcreteValue::String(value)) => Some(value.as_str()),
+                _ => None,
+            })
+        })
+    }
+
+    pub fn bool_attribute(&self, key: &str) -> Option<bool> {
+        self.parser_config.as_ref().and_then(|config| {
+            config.attributes.get(key).and_then(|value| match value {
+                Value::Concrete(ConcreteValue::Bool(value)) => Some(*value),
+                _ => None,
+            })
+        })
+    }
+}
+
+pub fn verify_for_mutation(
+    base_dir: &Path,
+    backend_config: Option<&BackendConfig>,
+    command: DriftCommand,
+) -> Result<VerifiedBackend, AppError> {
+    let verified_base_dir = base_dir
+        .canonicalize()
+        .unwrap_or_else(|_| base_dir.to_path_buf());
+
+    match inspect_backend_drift(&verified_base_dir, backend_config)? {
+        BackendDriftStatus::Fresh => Err(AppError::Config(
             "Backend lock file not found. Run 'carina init' to initialize the project.".to_string(),
         )),
+        BackendDriftStatus::Unchanged => Ok(VerifiedBackend {
+            parser_config: backend_config.cloned(),
+            state_config: backend_config.map(StateBackendConfig::from),
+            base_dir: verified_base_dir,
+        }),
+        BackendDriftStatus::Drifted {
+            existing,
+            configured,
+        } => Err(AppError::Config(drift_error_message(
+            command,
+            &existing,
+            &configured,
+        ))),
     }
+}
+
+fn backend_drift_header(existing: &BackendLock, configured: &BackendLock) -> String {
+    format!(
+        "Backend configuration changed since the last state migration:\n{}",
+        existing.describe_diff(configured)
+    )
+}
+
+pub fn drift_warning(existing: &BackendLock, configured: &BackendLock) -> String {
+    format!(
+        "{}\n\n    plan reads state from the OLD backend recorded in carina-backend.lock.\n    \
+         Before running apply or destroy, run `carina init --migrate-state .`\n    \
+         to migrate state from the OLD backend to the new one.\n\n    \
+         To revert instead, restore the backend block to match the lock.",
+        backend_drift_header(existing, configured)
+    )
+}
+
+pub fn drift_error_message(
+    command: DriftCommand,
+    existing: &BackendLock,
+    configured: &BackendLock,
+) -> String {
+    format!(
+        "{}\n\n{} without first migrating the state. State migration is an\n\
+         explicit, named operation:\n\n    carina init --migrate-state .\n\n\
+         Or revert the `backend` block to match the lock if the change was unintended.",
+        backend_drift_header(existing, configured),
+        command.verb_phrase()
+    )
 }
 
 /// Error message for a provider block that declares no `source` attribute.
@@ -509,13 +610,127 @@ mod tests {
         }
     }
 
-    #[test]
-    fn check_backend_lock_errors_when_lock_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let config = s3_backend_config("my-bucket", "us-east-1");
-        let err = check_backend_lock(tmp.path(), Some(&config), false).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("carina init"));
+    fn local_backend_config(path: &str) -> BackendConfig {
+        let mut attributes = HashMap::new();
+        attributes.insert(
+            "path".to_string(),
+            Value::Concrete(ConcreteValue::String(path.to_string())),
+        );
+        BackendConfig {
+            backend_type: "local".to_string(),
+            attributes,
+        }
+    }
+
+    mod inspect_backend_drift {
+        use super::*;
+
+        #[test]
+        fn inspect_returns_fresh_when_no_lock() {
+            let tmp = tempfile::tempdir().unwrap();
+            let config = s3_backend_config("my-bucket", "us-east-1");
+
+            let status = crate::commands::inspect_backend_drift(tmp.path(), Some(&config)).unwrap();
+
+            assert_eq!(status, BackendDriftStatus::Fresh);
+        }
+
+        #[test]
+        fn inspect_returns_unchanged_when_config_matches_lock() {
+            let tmp = tempfile::tempdir().unwrap();
+            let config = s3_backend_config("my-bucket", "us-east-1");
+            ensure_backend_lock(tmp.path(), Some(&config)).unwrap();
+
+            let status = crate::commands::inspect_backend_drift(tmp.path(), Some(&config)).unwrap();
+
+            assert_eq!(status, BackendDriftStatus::Unchanged);
+        }
+
+        #[test]
+        fn inspect_returns_drifted_when_config_differs() {
+            let tmp = tempfile::tempdir().unwrap();
+            let old = s3_backend_config("old-bucket", "us-east-1");
+            let new = s3_backend_config("new-bucket", "us-east-1");
+            ensure_backend_lock(tmp.path(), Some(&old)).unwrap();
+
+            let status = crate::commands::inspect_backend_drift(tmp.path(), Some(&new)).unwrap();
+            let existing = BackendLock::for_config(Some(&old)).unwrap();
+            let configured = BackendLock::for_config(Some(&new)).unwrap();
+
+            assert_eq!(
+                status,
+                BackendDriftStatus::Drifted {
+                    existing,
+                    configured,
+                }
+            );
+        }
+
+        #[test]
+        fn inspect_returns_fresh_with_no_backend_and_no_lock() {
+            let tmp = tempfile::tempdir().unwrap();
+
+            let status = crate::commands::inspect_backend_drift(tmp.path(), None).unwrap();
+
+            assert_eq!(status, BackendDriftStatus::Fresh);
+        }
+
+        #[test]
+        fn inspect_returns_drifted_when_lock_is_remote_and_config_is_local() {
+            let tmp = tempfile::tempdir().unwrap();
+            let remote = s3_backend_config("my-bucket", "us-east-1");
+            ensure_backend_lock(tmp.path(), Some(&remote)).unwrap();
+
+            let status = crate::commands::inspect_backend_drift(tmp.path(), None).unwrap();
+            let existing = BackendLock::for_config(Some(&remote)).unwrap();
+            let configured = BackendLock::for_config(None).unwrap();
+
+            assert_eq!(
+                status,
+                BackendDriftStatus::Drifted {
+                    existing,
+                    configured,
+                }
+            );
+        }
+
+        #[test]
+        fn drift_warning_names_old_and_new() {
+            let old =
+                BackendLock::for_config(Some(&local_backend_config("legacy/state.json"))).unwrap();
+            let new = BackendLock::for_config(Some(&local_backend_config("state.json"))).unwrap();
+
+            let warning = drift_warning(&old, &new);
+
+            assert!(warning.contains("legacy/state.json"));
+            assert!(warning.contains("state.json"));
+            assert!(warning.contains("carina init --migrate-state"));
+        }
+
+        #[test]
+        fn drift_error_names_apply_blocker() {
+            let old =
+                BackendLock::for_config(Some(&local_backend_config("legacy/state.json"))).unwrap();
+            let new = BackendLock::for_config(Some(&local_backend_config("state.json"))).unwrap();
+
+            let error = drift_error_message(DriftCommand::Apply, &old, &new);
+
+            assert!(error.contains("carina init --migrate-state"));
+            assert!(error.contains("Cannot apply without first migrating the state"));
+        }
+
+        #[test]
+        fn drift_error_names_refresh_blocker() {
+            let old =
+                BackendLock::for_config(Some(&local_backend_config("legacy/state.json"))).unwrap();
+            let new = BackendLock::for_config(Some(&local_backend_config("state.json"))).unwrap();
+
+            let error = drift_error_message(DriftCommand::RefreshState, &old, &new);
+
+            assert!(error.contains("carina init --migrate-state"));
+            assert!(error.contains("Cannot refresh state without first migrating the state"));
+            assert!(!error.contains("Cannot apply without first migrating the state"));
+        }
     }
 
     #[test]
@@ -524,78 +739,6 @@ mod tests {
         let config = s3_backend_config("my-bucket", "us-east-1");
         ensure_backend_lock(tmp.path(), Some(&config)).unwrap();
         assert!(tmp.path().join("carina-backend.lock").exists());
-    }
-
-    #[test]
-    fn check_backend_lock_passes_when_config_unchanged() {
-        let tmp = tempfile::tempdir().unwrap();
-        let config = s3_backend_config("my-bucket", "us-east-1");
-        ensure_backend_lock(tmp.path(), Some(&config)).unwrap();
-        let result = check_backend_lock(tmp.path(), Some(&config), false);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn check_backend_lock_blocks_on_bucket_change() {
-        let tmp = tempfile::tempdir().unwrap();
-        let old = s3_backend_config("old-bucket", "us-east-1");
-        let new = s3_backend_config("new-bucket", "us-east-1");
-        ensure_backend_lock(tmp.path(), Some(&old)).unwrap();
-        let err = check_backend_lock(tmp.path(), Some(&new), false).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("Backend configuration has changed"));
-        assert!(msg.contains("bucket"));
-        assert!(msg.contains("old-bucket"));
-        assert!(msg.contains("new-bucket"));
-        assert!(msg.contains("carina init --migrate-state"));
-        assert!(msg.contains("--reconfigure"));
-    }
-
-    #[test]
-    fn check_backend_lock_accepts_change_with_reconfigure() {
-        let tmp = tempfile::tempdir().unwrap();
-        let old = s3_backend_config("old-bucket", "us-east-1");
-        let new = s3_backend_config("new-bucket", "us-east-1");
-        ensure_backend_lock(tmp.path(), Some(&old)).unwrap();
-        let result = check_backend_lock(tmp.path(), Some(&new), true);
-        assert!(result.is_ok());
-        let result2 = check_backend_lock(tmp.path(), Some(&new), false);
-        assert!(result2.is_ok());
-    }
-
-    #[test]
-    fn check_backend_lock_errors_when_lock_missing_no_backend() {
-        let tmp = tempfile::tempdir().unwrap();
-        let err = check_backend_lock(tmp.path(), None, false).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("carina init"));
-    }
-
-    #[test]
-    fn check_backend_lock_blocks_local_to_remote_transition() {
-        let tmp = tempfile::tempdir().unwrap();
-        // Simulate first apply with no backend (local default)
-        ensure_backend_lock(tmp.path(), None).unwrap();
-        // Second run: user adds an S3 backend
-        let new = s3_backend_config("my-bucket", "us-east-1");
-        let err = check_backend_lock(tmp.path(), Some(&new), false).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("Backend configuration has changed"));
-        assert!(msg.contains("local"));
-        assert!(msg.contains("s3"));
-        assert!(msg.contains("--reconfigure"));
-    }
-
-    #[test]
-    fn check_backend_lock_allows_local_to_remote_with_reconfigure() {
-        let tmp = tempfile::tempdir().unwrap();
-        ensure_backend_lock(tmp.path(), None).unwrap();
-        let new = s3_backend_config("my-bucket", "us-east-1");
-        let result = check_backend_lock(tmp.path(), Some(&new), true);
-        assert!(result.is_ok());
-        // Subsequent run with the new backend should now pass
-        let result2 = check_backend_lock(tmp.path(), Some(&new), false);
-        assert!(result2.is_ok());
     }
 
     fn empty_parsed_file() -> carina_core::parser::InferredFile {

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -18,7 +18,9 @@ use carina_state::{
     create_local_backend, resolve_backend_anchored,
 };
 
-use super::validate_and_resolve_with_config;
+use super::{
+    BackendDriftStatus, drift_warning, inspect_backend_drift, validate_and_resolve_with_config,
+};
 use crate::DetailLevel;
 use crate::commands::shared::state_writeback::apply_name_overrides;
 use crate::display::{print_plan, refresh_plan_separator};
@@ -155,9 +157,16 @@ pub struct CurrentStateEntry {
 fn build_plan_file<E>(
     path: &Path,
     parsed: &carina_core::parser::File<E>,
+    backend_config: Option<BackendConfig>,
     state_file: &Option<StateFile>,
     ctx: &crate::wiring::PlanContext,
 ) -> Result<PlanFile, carina_core::value::SerializationError> {
+    let source_path = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string();
+
     Ok(PlanFile {
         // carina#3329: bumped 4→5 — `Effect::Import.identifier` is now
         // a tagged `Value`, not a plain string, so a pre-#3329 v4 plan
@@ -173,11 +182,11 @@ fn build_plan_file<E>(
         version: 5,
         carina_version: env!("CARGO_PKG_VERSION").to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
-        source_path: path.display().to_string(),
+        source_path,
         state_lineage: state_file.as_ref().map(|s| s.lineage.clone()),
         state_serial: state_file.as_ref().map(|s| s.serial),
         provider_configs: parsed.providers.clone(),
-        backend_config: parsed.backend.clone(),
+        backend_config,
         plan: redact_secrets_in_plan(&ctx.plan)?,
         sorted_resources: ctx
             .sorted_resources
@@ -222,6 +231,21 @@ fn build_plan_file<E>(
             })
             .collect(),
     })
+}
+
+/// Convert a state-layer backend config back into the parser-layer shape saved in `PlanFile`.
+///
+/// This is used only for drifted `plan --out`, where the saved plan must record
+/// the locked backend that supplied state. The input usually comes from
+/// `BackendLock::to_state_config`, whose lock-value round trip has lossy
+/// fallbacks: unsigned numbers may downcast to `i64`, null becomes `Bool(false)`,
+/// and structured values become debug strings. Current backend configs use only
+/// scalar attributes, so this is inert until a future backend adds richer attrs.
+fn parser_backend_config_from_state(config: &StateBackendConfig) -> BackendConfig {
+    BackendConfig {
+        backend_type: config.backend_type.clone(),
+        attributes: config.attributes.clone(),
+    }
 }
 
 /// Format a `SerializationError` from `build_plan_file` into the
@@ -371,7 +395,6 @@ pub async fn run_plan(
     tui: bool,
     refresh: bool,
     json: bool,
-    reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<bool, AppError> {
     let mut parsed = load_configuration_with_config(
@@ -384,8 +407,34 @@ pub async fn run_plan(
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, false)?;
 
-    // Detect backend reconfiguration before touching any state
-    crate::commands::check_backend_lock(base_dir, parsed.backend.as_ref(), reconfigure)?;
+    let mut plan_backend_config = parsed.backend.as_ref().map(StateBackendConfig::from);
+    let mut plan_file_backend_config = parsed.backend.clone();
+    let mut use_locked_backend = false;
+    let drift_note = match inspect_backend_drift(base_dir, parsed.backend.as_ref())? {
+        BackendDriftStatus::Fresh => {
+            return Err(AppError::Config(
+                "Backend lock file not found. Run 'carina init' to initialize the project."
+                    .to_string(),
+            ));
+        }
+        BackendDriftStatus::Unchanged => None,
+        BackendDriftStatus::Drifted {
+            existing,
+            configured,
+        } => {
+            let warning = drift_warning(&existing, &configured);
+            eprintln!("{}", warning.yellow());
+            let locked_config = existing.to_state_config();
+            plan_file_backend_config = Some(parser_backend_config_from_state(&locked_config));
+            plan_backend_config = Some(locked_config);
+            use_locked_backend = true;
+            Some(
+                "Backend migration pending: plan read state from the OLD backend recorded in \
+                 carina-backend.lock. Run `carina init --migrate-state .` before apply."
+                    .to_string(),
+            )
+        }
+    };
 
     // Check for backend configuration and load state
     // Use local backend by default if no backend is configured
@@ -393,11 +442,14 @@ pub async fn run_plan(
     let mut state_bucket_name = String::new();
     let mut state_file: Option<StateFile> = None;
 
-    let plan_backend: Box<dyn StateBackend> = if let Some(config) = parsed.backend.as_ref() {
-        let state_config = StateBackendConfig::from(config);
-        let backend = create_backend(&state_config)
-            .await
-            .map_err(AppError::Backend)?;
+    let plan_backend: Box<dyn StateBackend> = if let Some(config) = plan_backend_config.as_ref() {
+        let backend = if use_locked_backend {
+            resolve_backend_anchored(Some(config), base_dir)
+                .await
+                .map_err(AppError::Backend)?
+        } else {
+            create_backend(config).await.map_err(AppError::Backend)?
+        };
 
         let bucket_exists = backend.bucket_exists().await.map_err(AppError::Backend)?;
 
@@ -412,6 +464,13 @@ pub async fn run_plan(
                 .await
                 .map_err(AppError::Backend)?
                 .map(|loaded| loaded.into_state());
+        } else if use_locked_backend {
+            return Err(AppError::Config(
+                "Locked backend recorded in carina-backend.lock no longer exists. \
+                 Restore the old state backend or revert backend.crn to match the lock before \
+                 planning this migration."
+                    .to_string(),
+            ));
         } else {
             // Check if there's a matching s3_bucket resource defined
             let bucket_name = config
@@ -623,11 +682,20 @@ pub async fn run_plan(
         .collect();
 
     if json {
+        if let Some(note) = drift_note.as_ref() {
+            eprintln!("{}", note.yellow());
+        }
         // `build_plan_file` propagates `SerializationError` so the user
         // sees an actionable diagnostic (which upstream / for-binding
         // is unresolved) instead of a panic backtrace.
-        let plan_file = build_plan_file(path, &parsed, &state_file, &ctx)
-            .map_err(|e| format_plan_save_error(&e, "--json"))?;
+        let plan_file = build_plan_file(
+            path,
+            &parsed,
+            plan_file_backend_config.clone(),
+            &state_file,
+            &ctx,
+        )
+        .map_err(|e| format_plan_save_error(&e, "--json"))?;
         let json_str = serde_json::to_string_pretty(&plan_file)
             .map_err(|e| format!("Failed to serialize plan: {}", e))?;
         println!("{}", json_str);
@@ -658,6 +726,10 @@ pub async fn run_plan(
         // from the plan's terminal section so they don't read as a run-on
         // (#3148).
         print!("{}", refresh_plan_separator(refresh));
+        if let Some(note) = drift_note.as_ref() {
+            println!("{}", note.yellow());
+            println!();
+        }
         print_plan(
             &ctx.plan,
             detail,
@@ -673,8 +745,14 @@ pub async fn run_plan(
 
     // Save plan to file if --out was specified
     if let Some(out_path) = out {
-        let plan_file = build_plan_file(path, &parsed, &state_file, &ctx)
-            .map_err(|e| format_plan_save_error(&e, "--out"))?;
+        let plan_file = build_plan_file(
+            path,
+            &parsed,
+            plan_file_backend_config.clone(),
+            &state_file,
+            &ctx,
+        )
+        .map_err(|e| format_plan_save_error(&e, "--out"))?;
         let json_out = carina_core::utils::pretty_with_newline(&plan_file)
             .map_err(|e| format!("Failed to serialize plan: {}", e))?;
         fs::write(out_path, json_out).map_err(|e| format!("Failed to write plan file: {}", e))?;
@@ -1463,7 +1541,6 @@ exports { region: String = "ap-northeast-1" }"#,
             false,
             false,
             true,
-            false,
             &ProviderContext::default(),
         )
         .await
@@ -1524,7 +1601,6 @@ mod run_plan_out_tests {
             false,
             false,
             true,
-            false,
             &ProviderContext::default(),
         )
         .await

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -15,10 +15,14 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, LockInfo, ResourceState, StateBackend,
-    StateFile, StateUrl, create_backend, load_state_from_url, resolve_backend,
+    StateFile, StateUrl, create_backend, load_state_from_url, resolve_backend_anchored,
+    resolve_backend_for_read,
 };
 
-use super::validate_and_resolve_with_config;
+use super::{
+    BackendDriftStatus, DriftCommand, inspect_backend_drift, validate_and_resolve_with_config,
+    verify_for_mutation,
+};
 use crate::commands::shared::state_writeback::apply_name_overrides;
 use crate::error::AppError;
 use crate::wiring::{
@@ -281,10 +285,20 @@ pub async fn run_force_unlock(
         &carina_core::schema::SchemaRegistry::new(),
     )?
     .parsed;
+    let base_dir = get_base_dir(path);
 
-    let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
-        .await
-        .map_err(AppError::Backend)?;
+    let backend_config = match inspect_backend_drift(base_dir, parsed.backend.as_ref())? {
+        BackendDriftStatus::Drifted { existing, .. } => Some(existing.to_state_config()),
+        BackendDriftStatus::Fresh | BackendDriftStatus::Unchanged => {
+            parsed.backend.as_ref().map(StateBackendConfig::from)
+        }
+    };
+
+    // Bypasses verify_for_mutation by design. On drift, targets the OLD locked backend so users can unlock a stale migration.
+    let backend: Box<dyn StateBackend> =
+        resolve_backend_anchored(backend_config.as_ref(), base_dir)
+            .await
+            .map_err(AppError::Backend)?;
 
     println!("{}", "Force unlocking state...".yellow().bold());
     println!("Lock ID: {}", lock_id);
@@ -333,7 +347,7 @@ async fn load_state_file(
     )?;
     let parsed = loaded.parsed;
 
-    let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
+    let backend: Box<dyn StateBackend> = resolve_backend_for_read(parsed.backend.as_ref())
         .await
         .map_err(AppError::Backend)?;
 
@@ -735,6 +749,7 @@ async fn run_state_bucket_delete(
         }
     }
 
+    // Bypasses verify_for_mutation by design. The configured-bucket-name guard pins this to the NEW backend; for an orphaned OLD bucket, delete manually via the cloud console.
     // Create backend to get provider metadata
     let state_config = StateBackendConfig::from(backend_config);
     let backend = create_backend(&state_config)
@@ -815,8 +830,15 @@ pub async fn run_state_refresh(
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, true)?;
 
+    let verified_backend = verify_for_mutation(
+        base_dir,
+        parsed.backend.as_ref(),
+        DriftCommand::RefreshState,
+    )?;
+
     // Create backend
-    let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
+    let backend: Box<dyn StateBackend> = verified_backend
+        .resolve()
         .await
         .map_err(AppError::Backend)?;
 

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -74,10 +74,6 @@ enum Commands {
         /// Output plan as JSON
         #[arg(long)]
         json: bool,
-
-        /// Accept a changed backend configuration and overwrite the local backend lock
-        #[arg(long)]
-        reconfigure: bool,
     },
     /// Apply changes to reach the desired state
     Apply {
@@ -92,10 +88,6 @@ enum Commands {
         /// Enable/disable state locking (default: true)
         #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
         lock: bool,
-
-        /// Accept a changed backend configuration and overwrite the local backend lock
-        #[arg(long)]
-        reconfigure: bool,
     },
     /// Destroy all resources defined in the configuration file
     Destroy {
@@ -118,10 +110,6 @@ enum Commands {
         /// Force destroy even if resources have prevent_destroy set
         #[arg(long)]
         force: bool,
-
-        /// Accept a changed backend configuration and overwrite the local backend lock
-        #[arg(long)]
-        reconfigure: bool,
     },
     /// Show export values from the state
     Export {
@@ -321,7 +309,6 @@ async fn main() {
         tui,
         refresh,
         json,
-        reconfigure,
     } = cli.command
     {
         match run_plan(
@@ -331,7 +318,6 @@ async fn main() {
             tui,
             refresh,
             json,
-            reconfigure,
             &provider_context,
         )
         .await
@@ -358,12 +344,11 @@ async fn main() {
             path,
             auto_approve,
             lock,
-            reconfigure,
         } => {
             if path.extension().is_some_and(|ext| ext == "json") {
-                run_apply_from_plan(&path, auto_approve, lock).await
+                run_apply_from_plan(&path, auto_approve, lock, &provider_context).await
             } else {
-                run_apply(&path, auto_approve, lock, reconfigure, &provider_context).await
+                run_apply(&path, auto_approve, lock, &provider_context).await
             }
         }
         Commands::Destroy {
@@ -372,19 +357,7 @@ async fn main() {
             lock,
             refresh,
             force,
-            reconfigure,
-        } => {
-            run_destroy(
-                &path,
-                auto_approve,
-                lock,
-                refresh,
-                force,
-                reconfigure,
-                &provider_context,
-            )
-            .await
-        }
+        } => run_destroy(&path, auto_approve, lock, refresh, force, &provider_context).await,
         Commands::Export { name, json, raw } => {
             let format = if raw {
                 commands::export::OutputFormat::Raw

--- a/carina-cli/tests/backend_drift_gate.rs
+++ b/carina-cli/tests/backend_drift_gate.rs
@@ -1,0 +1,543 @@
+//! End-to-end coverage for moving the backend-drift gate downstream
+//! from `init` to mutating commands (carina#3405).
+
+use std::fs;
+use std::process::{Command, Output};
+
+use carina_core::resource::{ConcreteValue, Value};
+use carina_state::{BackendLock, LockInfo, ResourceState, StateFile};
+use tempfile::TempDir;
+
+fn carina(project: &std::path::Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_carina"));
+    cmd.current_dir(project)
+        .env("NO_COLOR", "1")
+        .env_remove("CLICOLOR_FORCE")
+        .args(args)
+        .output()
+        .expect("failed to execute carina")
+}
+
+fn local_backend_lock(path: &str) -> BackendLock {
+    let mut attributes = std::collections::HashMap::new();
+    attributes.insert(
+        "path".to_string(),
+        Value::Concrete(ConcreteValue::String(path.to_string())),
+    );
+    let config = carina_core::parser::BackendConfig {
+        backend_type: "local".to_string(),
+        attributes,
+    };
+    BackendLock::for_config(Some(&config)).unwrap()
+}
+
+fn s3_backend_lock(bucket: &str, key: &str) -> BackendLock {
+    let mut attributes = std::collections::HashMap::new();
+    attributes.insert(
+        "bucket".to_string(),
+        Value::Concrete(ConcreteValue::String(bucket.to_string())),
+    );
+    attributes.insert(
+        "key".to_string(),
+        Value::Concrete(ConcreteValue::String(key.to_string())),
+    );
+    attributes.insert(
+        "region".to_string(),
+        Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
+    );
+    let config = carina_core::parser::BackendConfig {
+        backend_type: "s3".to_string(),
+        attributes,
+    };
+    BackendLock::for_config(Some(&config)).unwrap()
+}
+
+fn state_json(lineage: &str) -> String {
+    let mut state = StateFile::new();
+    state.serial = 3;
+    state.lineage = lineage.to_string();
+    state.upsert_resource(
+        ResourceState::new("test.resource", "r1", "mock")
+            .with_identifier("mock-id")
+            .with_attribute("name", serde_json::json!("r1")),
+    );
+    serde_json::to_string_pretty(&state).expect("serialize state fixture")
+}
+
+fn empty_state_json() -> String {
+    serde_json::to_string_pretty(&StateFile::new()).expect("serialize empty state fixture")
+}
+
+fn write_project(project: &std::path::Path, backend_path: &str, include_resource: bool) {
+    fs::write(
+        project.join("backend.crn"),
+        format!("backend local {{ path = \"{backend_path}\" }}\n"),
+    )
+    .unwrap();
+    let main = if include_resource {
+        "let r1 = mock.test.resource { name = \"r1\" }\n"
+    } else {
+        "exports {\n}\n"
+    };
+    fs::write(project.join("main.crn"), main).unwrap();
+}
+
+fn write_drift_fixture(include_resource: bool) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    write_project(project, "state.json", include_resource);
+
+    fs::create_dir_all(project.join("legacy")).unwrap();
+    fs::write(
+        project.join("legacy/state.json"),
+        state_json("legacy-lineage"),
+    )
+    .unwrap();
+    local_backend_lock("legacy/state.json")
+        .save(project)
+        .unwrap();
+
+    tmp
+}
+
+fn write_clean_fixture(include_resource: bool) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    write_project(project, "state.json", include_resource);
+    local_backend_lock("state.json").save(project).unwrap();
+    tmp
+}
+
+fn lock_json(project: &std::path::Path) -> String {
+    fs::read_to_string(project.join("carina-backend.lock")).unwrap()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+mod backend_drift_gate {
+    use super::*;
+
+    #[test]
+    fn init_warns_but_exits_zero_on_drift() {
+        let tmp = write_drift_fixture(false);
+        let project = tmp.path();
+        let before_lock = lock_json(project);
+
+        let output = carina(project, &["init", "."]);
+
+        assert!(
+            output.status.success(),
+            "init should warn and exit 0 on drift.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+        let stderr = stderr(&output);
+        assert!(
+            stderr.contains("Backend configuration changed")
+                && stderr.contains("carina init --migrate-state"),
+            "init drift warning must name the pending migration, got:\n{stderr}",
+        );
+        assert_eq!(
+            lock_json(project),
+            before_lock,
+            "init without --migrate-state must not rewrite the backend lock",
+        );
+    }
+
+    #[test]
+    fn init_migrate_state_still_migrates() {
+        let tmp = write_drift_fixture(false);
+        let project = tmp.path();
+
+        let output = carina(project, &["init", "--migrate-state", "."]);
+
+        assert!(
+            output.status.success(),
+            "init --migrate-state should succeed.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+        assert!(
+            project.join("state.json").exists(),
+            "state must be migrated to the configured backend path",
+        );
+        let lock = BackendLock::load(project).unwrap().unwrap();
+        assert_eq!(lock, local_backend_lock("state.json"));
+    }
+
+    #[test]
+    fn init_migrate_state_noop_when_backend_unchanged() {
+        let tmp = write_clean_fixture(false);
+        let project = tmp.path();
+
+        let output = carina(project, &["init", "--migrate-state", "."]);
+
+        assert!(
+            output.status.success(),
+            "init --migrate-state should succeed when no migration is needed.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+        assert!(
+            stdout(&output).contains(
+                "No state migration needed; backend lock already matches the configuration."
+            ),
+            "init --migrate-state should use the unchanged-backend no-op message.\nstdout:\n{}",
+            stdout(&output),
+        );
+    }
+
+    #[test]
+    fn plan_warns_and_uses_locked_backend() {
+        let tmp = write_drift_fixture(true);
+        let project = tmp.path();
+
+        let output = carina(project, &["plan", "--refresh=false", "."]);
+
+        assert!(
+            output.status.success(),
+            "plan should warn and exit 0 on drift.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+        let stderr = stderr(&output);
+        assert!(
+            stderr.contains("Backend configuration changed")
+                && stderr.contains("carina init --migrate-state"),
+            "plan drift warning must name the pending migration, got:\n{stderr}",
+        );
+        let stdout = stdout(&output);
+        assert!(
+            stdout.contains("No changes. Infrastructure is up-to-date."),
+            "plan must read the locked legacy state and see the existing resource.\nstdout:\n{stdout}",
+        );
+        assert!(
+            !stdout.contains("Create mock.test.resource"),
+            "plan read from the configured empty backend instead of the locked legacy backend.\nstdout:\n{stdout}",
+        );
+    }
+
+    #[test]
+    fn plan_out_with_drift_records_locked_backend() {
+        let tmp = write_drift_fixture(true);
+        let project = tmp.path();
+        let plan_path = project.join("plan.json");
+
+        let output = carina(
+            project,
+            &["plan", "--refresh=false", "--out", "plan.json", "."],
+        );
+
+        assert!(
+            output.status.success(),
+            "plan --out should succeed while warning on drift.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+        let plan_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(plan_path).unwrap()).unwrap();
+        assert_eq!(
+            plan_json
+                .pointer("/backend_config/attributes/path/String")
+                .and_then(serde_json::Value::as_str),
+            Some("legacy/state.json"),
+            "saved plan must record the locked backend that supplied state:\n{plan_json:#}",
+        );
+    }
+
+    #[test]
+    fn apply_refuses_on_drift() {
+        let tmp = write_drift_fixture(true);
+        let project = tmp.path();
+        let before_state = fs::read_to_string(project.join("legacy/state.json")).unwrap();
+
+        let output = carina(project, &["apply", "--auto-approve", "."]);
+
+        assert!(
+            !output.status.success(),
+            "apply must refuse on backend drift",
+        );
+        let stderr = stderr(&output);
+        assert!(stderr.contains("carina init --migrate-state"));
+        assert!(stderr.contains("Cannot apply without first migrating the state"));
+        assert!(!stderr.contains("Cannot refresh state without first migrating the state"));
+        assert_eq!(
+            fs::read_to_string(project.join("legacy/state.json")).unwrap(),
+            before_state,
+            "refused apply must not modify the locked legacy state",
+        );
+        assert!(
+            !project.join("state.json").exists(),
+            "refused apply must not create state at the configured backend path",
+        );
+    }
+
+    #[test]
+    fn apply_plan_file_refuses_on_drift() {
+        let tmp = write_clean_fixture(true);
+        let project = tmp.path();
+        fs::write(project.join("state.json"), state_json("saved-plan-lineage")).unwrap();
+
+        let plan_output = carina(
+            project,
+            &["plan", "--refresh=false", "--out", "plan.json", "."],
+        );
+        assert!(
+            plan_output.status.success(),
+            "initial plan --out should succeed.\nstdout: {}\nstderr: {}",
+            stdout(&plan_output),
+            stderr(&plan_output),
+        );
+
+        write_project(project, "new/state.json", true);
+        let output = carina(project, &["apply", "--auto-approve", "plan.json"]);
+
+        assert!(
+            !output.status.success(),
+            "saved-plan apply must refuse when current backend config drifted",
+        );
+        let stderr = stderr(&output);
+        assert!(stderr.contains("carina init --migrate-state"));
+        assert!(stderr.contains("Cannot apply without first migrating the state"));
+    }
+
+    #[test]
+    fn apply_plan_file_refuses_when_backend_changed_since_plan() {
+        let tmp = write_clean_fixture(false);
+        let project = tmp.path();
+        fs::write(project.join("state.json"), empty_state_json()).unwrap();
+
+        let plan_output = carina(
+            project,
+            &["plan", "--refresh=false", "--out", "plan.json", "."],
+        );
+        assert!(
+            plan_output.status.success(),
+            "initial plan --out should succeed.\nstdout: {}\nstderr: {}",
+            stdout(&plan_output),
+            stderr(&plan_output),
+        );
+
+        write_project(project, "new/state.json", false);
+        fs::create_dir_all(project.join("new")).unwrap();
+        let migrate_output = carina(project, &["init", "--migrate-state", "."]);
+        assert!(
+            migrate_output.status.success(),
+            "migration to the new backend should succeed.\nstdout: {}\nstderr: {}",
+            stdout(&migrate_output),
+            stderr(&migrate_output),
+        );
+
+        let output = carina(project, &["apply", "--auto-approve", "plan.json"]);
+
+        assert!(
+            !output.status.success(),
+            "saved-plan apply must refuse when the clean backend changed since plan time",
+        );
+        assert!(
+            stderr(&output).contains("Saved plan backend does not match the current `backend.crn`"),
+            "error should explain that the saved plan backend is stale.\nstderr:\n{}",
+            stderr(&output),
+        );
+    }
+
+    #[test]
+    fn apply_moved_plan_file_uses_canonical_source_path() {
+        let tmp = write_clean_fixture(false);
+        let project = tmp.path();
+
+        let plan_output = carina(
+            project,
+            &["plan", "--refresh=false", "--out", "plan.json", "."],
+        );
+        assert!(
+            plan_output.status.success(),
+            "plan --out should succeed.\nstdout: {}\nstderr: {}",
+            stdout(&plan_output),
+            stderr(&plan_output),
+        );
+
+        let plan_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(project.join("plan.json")).unwrap()).unwrap();
+        let source_path = plan_json
+            .get("source_path")
+            .and_then(serde_json::Value::as_str)
+            .expect("saved plan should include source_path");
+        assert!(
+            std::path::Path::new(source_path).is_absolute(),
+            "saved plan source_path must be absolute so moved plan files still reload the project"
+        );
+
+        let moved_dir = project.join("moved");
+        fs::create_dir_all(&moved_dir).unwrap();
+        fs::rename(project.join("plan.json"), moved_dir.join("plan.json")).unwrap();
+
+        let output = carina(&moved_dir, &["apply", "--auto-approve", "plan.json"]);
+
+        assert!(
+            output.status.success(),
+            "saved-plan apply should reload the canonical project source even when the plan file moved.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+    }
+
+    #[test]
+    fn state_refresh_refuses_on_drift() {
+        let tmp = write_drift_fixture(true);
+        let project = tmp.path();
+        let before_state = fs::read_to_string(project.join("legacy/state.json")).unwrap();
+
+        let output = carina(project, &["state", "refresh", "."]);
+
+        assert!(
+            !output.status.success(),
+            "state refresh must refuse on backend drift",
+        );
+        let stderr = stderr(&output);
+        assert!(stderr.contains("carina init --migrate-state"));
+        assert!(stderr.contains("Cannot refresh state without first migrating the state"));
+        assert!(!stderr.contains("Cannot apply without first migrating the state"));
+        assert_eq!(
+            fs::read_to_string(project.join("legacy/state.json")).unwrap(),
+            before_state,
+            "refused state refresh must not modify the locked legacy state",
+        );
+        assert!(
+            !project.join("state.json").exists(),
+            "refused state refresh must not create state at the configured backend path",
+        );
+    }
+
+    #[test]
+    fn force_unlock_targets_locked_backend_on_drift() {
+        let tmp = write_drift_fixture(false);
+        let project = tmp.path();
+        let lock = LockInfo::new("migrate-state");
+        let lock_id = lock.id.clone();
+        let old_lock_path = project.join("legacy/state.lock");
+        let new_lock_path = project.join("state.lock");
+        fs::write(&old_lock_path, serde_json::to_string_pretty(&lock).unwrap()).unwrap();
+
+        let output = carina(project, &["force-unlock", &lock_id, "."]);
+
+        assert!(
+            output.status.success(),
+            "force-unlock should target the locked legacy backend on drift.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+        assert!(
+            !old_lock_path.exists(),
+            "force-unlock should remove the stale lock from the locked legacy backend",
+        );
+        assert!(
+            !new_lock_path.exists(),
+            "force-unlock must not touch/create a lock at the new configured backend path",
+        );
+    }
+
+    #[test]
+    fn bucket_delete_pinned_to_configured_bucket_name() {
+        let tmp = TempDir::new().unwrap();
+        let project = tmp.path();
+        fs::write(
+            project.join("backend.crn"),
+            "backend s3 { bucket = \"new-bucket\" key = \"state.json\" region = \"us-east-1\" }\n",
+        )
+        .unwrap();
+        fs::write(project.join("main.crn"), "exports {\n}\n").unwrap();
+        s3_backend_lock("old-bucket", "state.json")
+            .save(project)
+            .unwrap();
+
+        let output = carina(
+            project,
+            &["state", "bucket-delete", "old-bucket", "--force", "."],
+        );
+
+        assert!(
+            !output.status.success(),
+            "bucket-delete should reject the locked old bucket name when configured bucket differs",
+        );
+        assert!(
+            stderr(&output).contains(
+                "Bucket name 'old-bucket' does not match backend configuration bucket 'new-bucket'"
+            ),
+            "bucket-delete should be pinned to the configured bucket guard.\nstderr:\n{}",
+            stderr(&output),
+        );
+    }
+
+    #[test]
+    fn destroy_refuses_on_drift() {
+        let tmp = write_drift_fixture(true);
+        let project = tmp.path();
+        let before_state = fs::read_to_string(project.join("legacy/state.json")).unwrap();
+
+        let output = carina(project, &["destroy", "--auto-approve", "."]);
+
+        assert!(
+            !output.status.success(),
+            "destroy must refuse on backend drift",
+        );
+        let stderr = stderr(&output);
+        assert!(stderr.contains("carina init --migrate-state"));
+        assert!(stderr.contains("Cannot destroy without first migrating the state"));
+        assert!(!stderr.contains("Cannot apply without first migrating the state"));
+        assert_eq!(
+            fs::read_to_string(project.join("legacy/state.json")).unwrap(),
+            before_state,
+            "refused destroy must not modify the locked legacy state",
+        );
+        assert!(
+            !project.join("state.json").exists(),
+            "refused destroy must not create state at the configured backend path",
+        );
+    }
+
+    #[test]
+    fn plan_clean_when_no_drift_works_normally() {
+        let tmp = write_clean_fixture(true);
+        let project = tmp.path();
+        fs::write(project.join("state.json"), state_json("clean-lineage")).unwrap();
+
+        let output = carina(project, &["plan", "--refresh=false", "."]);
+
+        assert!(
+            output.status.success(),
+            "clean plan should succeed.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+        assert!(
+            !stderr(&output).contains("Backend configuration changed"),
+            "clean plan must not warn about backend drift",
+        );
+    }
+
+    #[test]
+    fn apply_clean_when_no_drift_works_normally() {
+        let tmp = write_clean_fixture(false);
+        let project = tmp.path();
+
+        let output = carina(project, &["apply", "--auto-approve", "."]);
+
+        assert!(
+            !stderr(&output).contains("Cannot apply without first migrating the state")
+                && !stderr(&output).contains("Cannot destroy without first migrating the state")
+                && !stderr(&output)
+                    .contains("Cannot refresh state without first migrating the state")
+                && !stderr(&output).contains("carina init --migrate-state"),
+            "clean apply must not be refused by the backend drift gate.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+    }
+}

--- a/carina-cli/tests/init_migrate_state_e2e.rs
+++ b/carina-cli/tests/init_migrate_state_e2e.rs
@@ -82,24 +82,32 @@ fn init_then_backend_change_blocks_without_flag_and_migrates_with_it() {
     // 2. Refactor: the backend address changes (the issue's core case).
     write_project(project, "new.state.json");
 
-    // Bare `carina init` must REFUSE and point at --migrate-state.
+    // Bare `carina init` warns but does not migrate or rewrite the lock.
+    let lock_before = fs::read_to_string(project.join("carina-backend.lock")).unwrap();
     let out = carina(&["init", project_str]);
     assert!(
-        !out.status.success(),
-        "init must fail on backend drift without --migrate-state",
+        out.status.success(),
+        "init must warn and exit 0 on backend drift without --migrate-state.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         stderr.contains("Backend configuration changed") && stderr.contains("--migrate-state"),
-        "drift error must name --migrate-state, got:\n{stderr}",
+        "drift warning must name --migrate-state, got:\n{stderr}",
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("carina-backend.lock")).unwrap(),
+        lock_before,
+        "init without --migrate-state must not rewrite the backend lock",
     );
     assert!(
         !project.join("new.state.json").exists(),
-        "a refused init must not create the new state file",
+        "init without --migrate-state must not create the new state file",
     );
     assert!(
         project.join("old.state.json").exists(),
-        "a refused init must not touch the old state file",
+        "init without --migrate-state must not touch the old state file",
     );
 
     // 3. `--migrate-state` moves the state and re-locks.

--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -1,11 +1,10 @@
 //! Local backend-configuration lock file for change detection.
 //!
-//! Carina stores a hash of the current `backend` block in a local file
-//! (`carina-backend.lock`) at the project root. Before
-//! each plan/apply, the stored hash is compared against the current
-//! configuration — a mismatch indicates that the backend has been
-//! reconfigured (for example, the bucket or key was changed), and Carina
-//! refuses to proceed without an explicit `--reconfigure` override.
+//! Carina stores a snapshot of the current `backend` block in a local
+//! file (`carina-backend.lock`) at the project root. Commands compare
+//! the stored snapshot against the current configuration: `init` and
+//! `plan` warn on mismatch, while mutating commands refuse until
+//! `carina init --migrate-state` explicitly moves state.
 //!
 //! This prevents silently pointing state operations at a different state
 //! file, which could lead to resources being treated as unmanaged or
@@ -61,8 +60,8 @@ impl BackendLock {
     }
 
     /// Build a lock snapshot representing the implicit local backend that
-    /// is used when no `backend` block is configured. Allows
-    /// `check_backend_lock` to detect local → remote transitions.
+    /// is used when no `backend` block is configured. Allows drift
+    /// inspection to detect local → remote transitions.
     pub fn local_default() -> Self {
         Self {
             backend_type: crate::backend::LOCAL_BACKEND_TYPE.to_string(),
@@ -74,9 +73,9 @@ impl BackendLock {
     /// backend when present, the implicit local default when absent.
     ///
     /// This is the single source of truth for "what backend does this
-    /// configuration name"; `check_backend_lock`, `ensure_backend_lock`,
-    /// `init`'s drift check, and the migration path all go through it so
-    /// they cannot disagree.
+    /// configuration name"; lock creation, drift inspection, `init`'s
+    /// warning path, and the migration path all go through it so they
+    /// cannot disagree.
     pub fn for_config(
         backend_config: Option<&carina_core::parser::BackendConfig>,
     ) -> Result<Self, carina_core::value::SerializationError> {

--- a/carina-state/src/backends/mod.rs
+++ b/carina-state/src/backends/mod.rs
@@ -38,11 +38,11 @@ pub fn create_local_backend() -> Box<dyn StateBackend> {
     Box::new(LocalBackend::new())
 }
 
-/// Resolve a backend from an optional parser BackendConfig.
+/// Resolve a backend from an optional parser BackendConfig for read-only use.
 ///
 /// If a config is provided, converts it to a StateBackendConfig and creates the
 /// appropriate backend. If no config is provided, falls back to a local backend.
-pub async fn resolve_backend(
+pub async fn resolve_backend_for_read(
     backend_config: Option<&carina_core::parser::BackendConfig>,
 ) -> BackendResult<Box<dyn StateBackend>> {
     if let Some(config) = backend_config {
@@ -56,7 +56,7 @@ pub async fn resolve_backend(
 /// Resolve a backend, anchoring a local backend's relative state `path`
 /// (or the unset default) at `base_dir` instead of the process CWD.
 ///
-/// `resolve_backend` / `create_backend` treat a local `path` as
+/// `resolve_backend_for_read` / `create_backend` treat a local `path` as
 /// CWD-relative, which is correct only when the command is run from the
 /// project directory. Commands that accept an explicit directory
 /// argument (`carina init <dir>`, upstream `remote_state` resolution)
@@ -119,8 +119,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_backend_none_returns_local() {
-        let backend = resolve_backend(None).await;
+    async fn test_resolve_backend_for_read_none_returns_local() {
+        let backend = resolve_backend_for_read(None).await;
         assert!(backend.is_ok(), "None config should return a local backend");
         // Local backend read_state returns Ok(None) when no state file exists
         let state = backend.unwrap().read_state().await;
@@ -128,7 +128,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_backend_invalid_config_returns_error() {
+    async fn test_resolve_backend_for_read_invalid_config_returns_error() {
         use carina_core::parser::BackendConfig as ParserBackendConfig;
 
         let config = ParserBackendConfig {
@@ -136,7 +136,7 @@ mod tests {
             attributes: HashMap::new(),
         };
 
-        let result = resolve_backend(Some(&config)).await;
+        let result = resolve_backend_for_read(Some(&config)).await;
         assert!(result.is_err());
 
         if let Err(BackendError::UnsupportedBackend(name)) = result {

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -54,7 +54,7 @@ pub use backend::{BackendConfig, BackendError, BackendResult, LOCAL_BACKEND_TYPE
 pub use backend_lock::BackendLock;
 pub use backends::{
     LocalBackend, StateUrl, anchored_local_path, create_backend, create_local_backend,
-    load_state_from_url, resolve_backend, resolve_backend_anchored,
+    load_state_from_url, resolve_backend_anchored, resolve_backend_for_read,
 };
 pub use lock::LockInfo;
 pub use state::{

--- a/notes/specs/2026-04-14-backend-lock-init.md
+++ b/notes/specs/2026-04-14-backend-lock-init.md
@@ -55,7 +55,7 @@ project/
 ### Task 1: Move backend lock to project root
 
 - `carina-state/src/backend_lock.rs` — change `LOCK_DIR` / `LOCK_FILE` to write `carina-backend.lock` at project root
-- Migration: `check_backend_lock()` checks both old (`.carina/backend-lock.json`) and new location; reads from old if new doesn't exist
+- Migration: backend lock loading checks both old (`.carina/backend-lock.json`) and new location; reads from old if new doesn't exist
 - Update tests
 
 ### Task 2: Create backend lock in init, remove from apply/destroy
@@ -63,7 +63,7 @@ project/
 - `carina-cli/src/commands/init.rs` — add `ensure_backend_lock()` call after plugin resolution
 - `carina-cli/src/commands/apply.rs` — remove `ensure_backend_lock()` (2 call sites)
 - `carina-cli/src/commands/destroy.rs` — remove `ensure_backend_lock()` (1 call site)
-- `carina-cli/src/commands/mod.rs` — `check_backend_lock()` returns error when lock missing + backend configured
+- `carina-cli/src/commands/mod.rs` — backend drift inspection reports missing locks so commands can decide whether to initialize or refuse
 - Update tests
 
 ### Task 3: Copy `file://` plugins into `.carina/providers/`

--- a/site/src/content/reference/cli/apply.md
+++ b/site/src/content/reference/cli/apply.md
@@ -43,6 +43,17 @@ carina apply plan.json
 
 When applying a saved plan, Carina checks the state lineage and serial number against the current state to detect drift since the plan was created.
 
+Before applying either a live configuration or a saved plan, Carina also
+checks the current project backend against `carina-backend.lock`. If the
+backend changed, apply refuses and points at
+`carina init --migrate-state .`; this prevents silently writing state to
+the new backend before migration is explicit. Saved-plan apply re-loads
+the project's current `.crn` files from the plan's recorded source path
+before running the same gate.
+Carina also rejects a saved plan whose backend configuration differs
+from the project's current `backend.crn`; re-run `carina plan` to
+produce a fresh saved plan.
+
 ## Confirmation Flow
 
 When `--auto-approve` is not set, Carina follows this flow:

--- a/site/src/content/reference/cli/destroy.md
+++ b/site/src/content/reference/cli/destroy.md
@@ -30,9 +30,13 @@ Refresh state from the cloud provider before computing the destroy plan. Default
 
 Destroy even resources that have `prevent_destroy = true` in their `directives` block.
 
-### `--reconfigure`
+## Backend Drift
 
-Accept a changed backend configuration and overwrite the local backend lock. Use when the backend block in your configuration has changed since the last apply.
+Before destroying resources, Carina checks the current project backend
+against `carina-backend.lock`. If the backend changed, destroy refuses
+and points at `carina init --migrate-state .`; this prevents silently
+reading or writing state from the new backend before migration is
+explicit.
 
 ## Examples
 

--- a/site/src/content/reference/cli/init.md
+++ b/site/src/content/reference/cli/init.md
@@ -33,11 +33,12 @@ recorded in `carina-backend.lock`. This covers backend changes such as
 moving from local state to a remote backend, or changing the
 `backend s3 { key = ... }` value during a directory refactor.
 
-Without this flag, a backend change is a **hard error** — `carina init`
-refuses to proceed and points you at `--migrate-state`. This protects
-against accidentally editing `backend.crn` or checking out a branch with
-a different backend: adopting the new backend (and abandoning the old
-state) is never silent.
+Without this flag, a backend change is a warning, not a hard error:
+`carina init` still resolves provider plugins and exits successfully, but
+it leaves `carina-backend.lock` unchanged and points you at
+`--migrate-state`. This keeps PR-time `plan` visible across backend-key
+changes while preserving the safety rule: mutating commands refuse until
+state migration is explicit.
 
 With the flag, `init` reads the state from the locked (old) backend,
 writes it to the configured backend, and verifies the copy. It then

--- a/site/src/content/reference/cli/plan.md
+++ b/site/src/content/reference/cli/plan.md
@@ -37,6 +37,12 @@ carina plan --out plan.json
 carina apply plan.json
 ```
 
+If the configured backend differs from `carina-backend.lock`, `plan`
+prints a backend-drift warning, reads state from the locked old backend,
+and includes a migration-pending note before the plan summary. A saved
+plan produced in this state records the locked backend that supplied the
+state; run `carina init --migrate-state .` before applying.
+
 ### `--detailed-exitcode`
 
 Change the exit code behavior:


### PR DESCRIPTION
Closes #3405

## Summary

- `init` and `plan` now warn (and exit 0) when `backend.crn` differs from `carina-backend.lock`; mutating commands refuse and point at `carina init --migrate-state`. This lets PR-time CI surface a `plan` diff across backend-key changes — the original motivation in #3405 — without weakening the "no silent state adoption" invariant. The gate just moved one step downstream.
- A typed API (`BackendDriftStatus` + `VerifiedBackend` newtype) makes the gate impossible for future mutating commands to forget: there is no way to obtain a mutating backend handle except through `verify_for_mutation(...).resolve()`.
- The `--reconfigure` flag is removed from `plan`/`apply`/`destroy` (project policy: no backward compat). State migration is now exclusively `carina init --migrate-state`.

## What changes per command

| Command | Drift behavior |
| ------- | -------------- |
| `carina init` | Warns, exits 0. Lock is NOT modified. |
| `carina init --migrate-state` | Unchanged (still migrates and rewrites the lock). |
| `carina plan` | Warns, reads state from the LOCKED (old) backend, emits a migration-pending note at the end of plan output. |
| `carina plan --out plan.json` | As above, AND records the LOCKED backend into the saved plan. |
| `carina apply <dir>` | Refuses with `Cannot apply without first migrating the state. ... carina init --migrate-state .` |
| `carina apply plan.json` | Re-loads project's current `backend.crn`, runs the gate against it, AND refuses if the saved plan's backend differs from the current `backend.crn` (catches "clean plan → migrate-state → stale apply"). |
| `carina destroy` | Same refusal as apply. |
| `carina state refresh` | Same refusal, with verb-specific wording `Cannot refresh state...`. |
| `carina force-unlock` | Intentional bypass. On drift, targets the OLD locked backend so the user can recover a stuck migration. |
| `carina state bucket-delete` | Intentional bypass; pinned to the configured NEW bucket by its own name guard. |

## Type-safety shape

The PR's load-bearing API lives in `carina-cli/src/commands/mod.rs`:

- `BackendDriftStatus { Fresh, Unchanged, Drifted { existing, configured } }` — `#[must_use]`, returned by `inspect_backend_drift(base_dir, backend_config)`.
- `VerifiedBackend` — `#[must_use]`, no `as_config()`. The only constructor is `verify_for_mutation(base_dir, backend_config, DriftCommand) -> Result<VerifiedBackend, AppError>`, which folds Fresh and Drifted into per-verb errors. The only way to get a mutating `Box<dyn StateBackend>` is `verified.resolve().await`.
- `carina_state::resolve_backend` → renamed `resolve_backend_for_read`, kept for genuinely read-only or recovery paths (plan reading the locked old backend, `state list/show/lookup`, `export`, `force_unlock`).

A future contributor adding a mutating command who forgets `verify_for_mutation` gets a compile error, not a runtime silent-write. This caught one bug during review: `state refresh` was originally writing state without the gate; adding the typestate surfaced it as a compile error and forced the fix.

## Tests

14 e2e tests in `carina-cli/tests/backend_drift_gate.rs` cover:

- `init`/`plan` warn + exit 0 on drift; lock NOT rewritten
- `plan` reads from the LOCKED backend, sees existing resources (`No changes` against legacy state)
- `plan --out` records the LOCKED backend in the plan file
- `apply`, `destroy`, `state refresh` refuse with the verb-specific error
- `apply plan.json` runs the gate against current `backend.crn`
- `apply plan.json` refuses when the project's backend changed since plan
- `force-unlock` targets the OLD locked backend on drift
- `state bucket-delete` stays pinned to the configured bucket name
- Clean (no drift) paths for `init`, `plan`, `apply`, `init --migrate-state` no-op

Plus unit tests for `inspect_backend_drift` (Fresh/Unchanged/Drifted including remote→local and no-config-no-lock), `drift_warning`, `drift_error_message` (verb dispatch), and the saved-plan cross-check policy (asserts even non-addressing attribute changes invalidate a saved plan).

`carina-cli`: 591 tests pass. Workspace: 3909 tests pass. Clippy clean. All `scripts/check-*.sh` pass.

## Test plan

- [ ] `cargo nextest run --workspace`
- [ ] `cargo nextest run -p carina-cli backend_drift_gate`
- [ ] Real-infra smoke: edit `backend.crn` in `carina-rs/infra`, run `carina plan` from the PR branch, confirm warning + plan diff appears together (the original PR-comment use case)
- [ ] `carina init --migrate-state .` on that fixture; confirm subsequent `apply` works without refusal

## Follow-ups (will file separately after merge)

- Read-path drift inspection is still convention-only (`plan` calls `inspect_backend_drift` by hand); make it typestate-required.
- `init --migrate-state` writes target state without acquiring a target lock (pre-existing race vs concurrent apply on the new backend).
- `init --check-backend` / `--strict` so CI can fail when backend migration is pending without parsing `plan` stderr.
- Rewrite the backend lock at the canonical path when it was loaded from the legacy `.carina/backend-lock.json` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)