### PR TITLE
Move backend migration-pending warning AFTER plan summary on plan

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -726,10 +726,6 @@ pub async fn run_plan(
         // from the plan's terminal section so they don't read as a run-on
         // (#3148).
         print!("{}", refresh_plan_separator(refresh));
-        if let Some(note) = drift_note.as_ref() {
-            println!("{}", note.yellow());
-            println!();
-        }
         print_plan(
             &ctx.plan,
             detail,
@@ -741,6 +737,10 @@ pub async fn run_plan(
             Some(&ctx.prev_explicit),
             Some(&ctx.expansion_trace),
         );
+        if let Some(note) = drift_note.as_ref() {
+            println!();
+            println!("{}", note.yellow());
+        }
     }
 
     // Save plan to file if --out was specified

--- a/carina-cli/tests/backend_drift_gate.rs
+++ b/carina-cli/tests/backend_drift_gate.rs
@@ -224,6 +224,32 @@ mod backend_drift_gate {
     }
 
     #[test]
+    fn plan_drift_warning_prints_after_plan_summary() {
+        let tmp = write_drift_fixture(true);
+        let project = tmp.path();
+
+        let output = carina(project, &["plan", "--refresh=false", "."]);
+
+        assert!(
+            output.status.success(),
+            "plan should warn and exit 0 on drift.\nstdout: {}\nstderr: {}",
+            stdout(&output),
+            stderr(&output),
+        );
+        let stdout = stdout(&output);
+        let no_changes_idx = stdout
+            .find("No changes. Infrastructure is up-to-date.")
+            .expect("plan summary must be present in stdout");
+        let warning_idx = stdout
+            .find("Backend migration pending: plan read state from the OLD backend")
+            .expect("backend migration warning must be present in stdout");
+        assert!(
+            warning_idx > no_changes_idx,
+            "warning must appear after the plan summary, got stdout:\n{stdout}",
+        );
+    }
+
+    #[test]
     fn plan_out_with_drift_records_locked_backend() {
         let tmp = write_drift_fixture(true);
         let project = tmp.path();


### PR DESCRIPTION
## Summary

`carina plan` emitted the `Backend migration pending: plan read state from the OLD backend ...` warning between `Refreshing state...` and `Execution Plan:`, where it was easy to scroll past on multi-resource plans and was stripped by CI tooling that slices output on `^Execution Plan:` ... `^Plan: `.

Move the warning to after `print_plan` in the TTY branch so it follows the `Plan: N to add, M to change, K to destroy` summary (or `No changes` when the diff is empty). The JSON and TUI branches are unchanged.

## Before

```
Refreshing state...

Backend migration pending: plan read state from the OLD backend ...

No changes. Infrastructure is up-to-date.
```

## After

```
Refreshing state...

No changes. Infrastructure is up-to-date.

Backend migration pending: plan read state from the OLD backend ...
```

## Test plan

- [x] New regression test `plan_drift_warning_prints_after_plan_summary` in `carina-cli/tests/backend_drift_gate.rs` asserts the warning's byte offset is greater than the `No changes` line's offset
- [x] Existing `plan_warns_and_uses_locked_backend` still passes (warning still appears in stdout with the same text)
- [x] `cargo nextest run -p carina-cli` — 592 passed
- [x] `cargo clippy -p carina-cli --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `bash scripts/check-*.sh` — clean

Closes #3407
