### PR TITLE
DslTransform::apply returns Cow<'_, str> to avoid no-change allocations (carina#3415)

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -3,6 +3,7 @@
 //! Providers define schemas for each resource type,
 //! enabling type validation at parse time.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::Arc;
@@ -305,13 +306,13 @@ impl<'a> DslMap<'a> {
 
     /// Translate an API spelling to its DSL spelling. Returns the
     /// input unchanged when no mapping applies.
-    pub fn dsl_for(&self, api: &str) -> String {
+    pub fn dsl_for<'b>(&self, api: &'b str) -> Cow<'b, str> {
         self.aliases
             .iter()
-            .find_map(|(a, d)| (a == api).then(|| d.clone()))
+            .find_map(|(a, d)| (a == api).then(|| Cow::Owned(d.clone())))
             .unwrap_or_else(|| {
                 self.to_dsl
-                    .map_or_else(|| api.to_string(), |transform| transform.apply(api))
+                    .map_or_else(|| Cow::Borrowed(api), |transform| transform.apply(api))
             })
     }
 
@@ -2813,11 +2814,13 @@ fn enum_expected_variants(
 
     for value in values {
         let dsl_value = dsl_map.dsl_for(value);
-        canonical_dsl_values.insert(dsl_value.clone());
-        if seen_values.insert(dsl_value.clone()) {
+        let owned = dsl_value.into_owned();
+        canonical_dsl_values.insert(owned.clone());
+        if !seen_values.contains(&owned) {
             expected.push(ExpectedEnumVariant::from_namespaced(
-                namespace, type_name, &dsl_value, false,
+                namespace, type_name, &owned, false,
             ));
+            seen_values.insert(owned);
         }
     }
 

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -1106,7 +1106,7 @@ fn enum_member_accepts(
         return false;
     }
     let resolved = expand_enum_shorthand(
-        &Value::Concrete(ConcreteValue::EnumIdentifier(dsl.clone())),
+        &Value::Concrete(ConcreteValue::EnumIdentifier(dsl.to_string())),
         identity,
     );
     if let Some(validate) = validate {

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -3,6 +3,7 @@
 //! These mirror carina-core types but are JSON-serializable across the process boundary.
 
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 fn default_true() -> bool {
@@ -514,16 +515,18 @@ pub enum DslTransform {
 }
 
 impl DslTransform {
-    pub fn apply(&self, s: &str) -> String {
+    pub fn apply<'a>(&self, s: &'a str) -> Cow<'a, str> {
         match self {
-            Self::Identity | Self::Unknown(_) => s.to_string(),
-            Self::HyphenToUnderscore => s.replace('-', "_"),
-            Self::StripSuffix(suffix) => s.strip_suffix(suffix.as_str()).unwrap_or(s).to_string(),
-            Self::ReplaceTable(table) => table
-                .iter()
-                .find(|(k, _)| k == s)
-                .map(|(_, v)| v.clone())
-                .unwrap_or_else(|| s.to_string()),
+            Self::Identity | Self::Unknown(_) => Cow::Borrowed(s),
+            Self::HyphenToUnderscore => Cow::Owned(s.replace('-', "_")),
+            Self::StripSuffix(suffix) => match s.strip_suffix(suffix.as_str()) {
+                Some(stripped) => Cow::Borrowed(stripped),
+                None => Cow::Borrowed(s),
+            },
+            Self::ReplaceTable(table) => match table.iter().find(|(k, _)| k == s) {
+                Some((_, v)) => Cow::Owned(v.clone()),
+                None => Cow::Borrowed(s),
+            },
         }
     }
 }
@@ -983,6 +986,25 @@ mod tests {
         ]);
         assert_eq!(transform.apply("-1"), "all");
         assert_eq!(transform.apply("udp"), "udp");
+    }
+
+    #[test]
+    fn dsl_transform_no_change_paths_borrow_input() {
+        let identity = DslTransform::Identity;
+        let result = identity.apply("unchanged");
+        assert!(matches!(result, Cow::Borrowed("unchanged")));
+
+        let unknown = DslTransform::Unknown(serde_json::json!({"type":"FutureTransform"}));
+        let result = unknown.apply("foo.bar.");
+        assert!(matches!(result, Cow::Borrowed("foo.bar.")));
+
+        let strip_suffix = DslTransform::StripSuffix(".".to_string());
+        let result = strip_suffix.apply("foo");
+        assert!(matches!(result, Cow::Borrowed("foo")));
+
+        let replace_table = DslTransform::ReplaceTable(vec![("-1".to_string(), "all".to_string())]);
+        let result = replace_table.apply("udp");
+        assert!(matches!(result, Cow::Borrowed("udp")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Changes `DslTransform::apply` to return `Cow<'_, str>` instead of `String`, avoiding allocations on Identity / Unknown / StripSuffix-no-match / ReplaceTable-no-match paths. Closes the follow-up tracker `carina#3415` from `carina#3414` (PR carina-rs/carina#3416 merged).

## Why

At state-read scale (`lift_enum_leaves_projected` walks every attribute on every resource on every plan / apply / state command, and `canonicalize_with_type` does the same for the desired side), the per-call `String::from(s)` allocation on the no-change paths adds up to O(N) redundant allocations. Borrowing avoids it.

## Changes

```rust
pub fn apply<'a>(&self, s: &'a str) -> Cow<'a, str> {
    match self {
        Self::Identity | Self::Unknown(_) => Cow::Borrowed(s),
        Self::HyphenToUnderscore => Cow::Owned(s.replace('-', "_")),
        Self::StripSuffix(suffix) => s.strip_suffix(suffix.as_str())
            .map(Cow::Borrowed)
            .unwrap_or(Cow::Borrowed(s)),
        Self::ReplaceTable(table) => match table.iter().find(|(k, _)| k == s) {
            Some((_, v)) => Cow::Owned(v.clone()),
            None => Cow::Borrowed(s),
        },
    }
}
```

`HyphenToUnderscore` and `ReplaceTable`-match still allocate (output differs from input). `StripSuffix`-match returns a borrowed shorter slice — no allocation.

## Tests

Four structural assertions added pinning `Cow::Borrowed` for the no-allocation paths:
- Identity arm
- Unknown(value) arm
- StripSuffix on a non-matching input
- ReplaceTable on a no-match key

A future refactor that silently re-introduces `.to_string()` on any of these arms fails one of these tests immediately. The existing behavioral `assert_eq!` tests still hold because `Cow<str>: PartialEq<&str>`.

## Drive-bys

- `carina-core/src/schema/mod.rs` (the post-Cow rewrite site): no longer double-clones the canonicalised DSL value when feeding two HashSets — computes the owned form once.
- `carina-core/src/utils.rs:1108`: uses the idiomatic `dsl.to_string()` instead of `dsl.clone().into_owned()`.

## Verification

- `cargo check --workspace --all-targets` clean
- `cargo nextest run --workspace --all-features` → 3932 passed, 72 skipped
- `cargo test --workspace --doc` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `bash scripts/check-*.sh` (5 scripts) all OK

## Cross-repo

Provider crates (aws / awscc) consume `DslTransform` via the re-export from `carina_core::schema`. Their next dep-bump will compile against the new `Cow<'_, str>` signature transparently — Rust will reject any caller that bound the result as `String` without `.into_owned()`. No follow-up PR required in the provider repos for normal usage.

Closes #3415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
