### PR TITLE
carina-core: add cross-provider TypeIdentity regression tests (carina#3413)

### DIFF
--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -3171,6 +3171,26 @@ fn assignable_rejects_same_enum_kind_across_namespaces() {
     assert!(!bar_enum.is_assignable_to(&aws_enum));
 }
 
+/// carina#3413: same `TypeIdentity` for an Enum constructed independently
+/// must remain mutually assignable. Mirrors the Custom-variant tests above
+/// in the Enum codepath (carina#3412's identity-aware arm).
+#[test]
+fn assignable_accepts_same_enum_typeidentity_from_distinct_constructions() {
+    let mk = || {
+        AttributeType::enum_(
+            crate::schema::enum_identity("Status", Some("aws.s3.Bucket.Versioning")),
+            Some(vec!["enabled".to_string(), "suspended".to_string()]),
+            vec![],
+            None,
+            None,
+        )
+    };
+    let a = mk();
+    let b = mk();
+    assert!(a.is_assignable_to(&b));
+    assert!(b.is_assignable_to(&a));
+}
+
 /// The generic provider-scoped `aws.Arn` (no service/resource segments)
 /// stays assignable against a more specific `aws.iam.Role.Arn`: an
 /// `segments` is **directional**: an empty `segments` source carries
@@ -3202,6 +3222,105 @@ fn assignable_specific_arn_flows_into_generic_arn() {
     let cert_arn = mk(&["acm", "Certificate"]);
     assert!(!role_arn.is_assignable_to(&cert_arn));
     assert!(!cert_arn.is_assignable_to(&role_arn));
+}
+
+/// carina#3413: two callers that independently construct the SAME
+/// `TypeIdentity` (e.g. both call `provider_type("ec2", "Vpc", "Id")`,
+/// producing `aws.ec2.Vpc.Id`) must produce AttributeType values that
+/// are mutually assignable. This is the type-safety property that
+/// lets a value flow from one provider's resource attribute into
+/// another provider's resource attribute without a runtime alias
+/// check, after the awscc-local carina-aws-types crate was dismantled
+/// in carina-provider-awscc#338.
+#[test]
+fn assignable_accepts_same_typeidentity_from_distinct_constructions_vpc_id() {
+    let mk = || {
+        AttributeType::custom(
+            Some(TypeIdentity::new(Some("aws"), vec!["ec2", "Vpc"], "Id")),
+            AttributeType::string(),
+            None,
+            None,
+            crate::schema::legacy_validator(|_| Ok(())),
+            None,
+        )
+    };
+    let a = mk();
+    let b = mk();
+    assert!(a.is_assignable_to(&b));
+    assert!(b.is_assignable_to(&a));
+}
+
+/// carina#3413: same as above but for the `aws.AccountId` form which
+/// has empty `segments`. Guards against accidental loosening that
+/// would only cover populated-segments identities.
+#[test]
+fn assignable_accepts_same_typeidentity_from_distinct_constructions_account_id() {
+    let mk = || {
+        AttributeType::custom(
+            Some(TypeIdentity::new(
+                Some("aws"),
+                Vec::<String>::new(),
+                "AccountId",
+            )),
+            AttributeType::string(),
+            None,
+            None,
+            crate::schema::legacy_validator(|_| Ok(())),
+            None,
+        )
+    };
+    let a = mk();
+    let b = mk();
+    assert!(a.is_assignable_to(&b));
+    assert!(b.is_assignable_to(&a));
+}
+
+/// carina#3413: deeper segments path (`aws.iam.Role.Arn`). One of the
+/// concrete identities motivating the original issue body.
+#[test]
+fn assignable_accepts_same_typeidentity_from_distinct_constructions_iam_role_arn() {
+    let mk = || {
+        AttributeType::custom(
+            Some(TypeIdentity::new(Some("aws"), vec!["iam", "Role"], "Arn")),
+            AttributeType::string(),
+            None,
+            None,
+            crate::schema::legacy_validator(|_| Ok(())),
+            None,
+        )
+    };
+    let a = mk();
+    let b = mk();
+    assert!(a.is_assignable_to(&b));
+    assert!(b.is_assignable_to(&a));
+}
+
+/// carina#3413 guard: canonicalizing AWS identities to `aws.*` must
+/// NOT loosen `is_assignable_to` between genuinely different
+/// providers. A hypothetical `gcp.AccountId` must still be rejected
+/// against `aws.AccountId`. Complements
+/// `assignable_rejects_same_kind_across_providers` in the AccountId
+/// context that motivated carina#3413.
+#[test]
+fn assignable_rejects_account_id_across_genuinely_different_providers() {
+    let mk = |provider: &str| {
+        AttributeType::custom(
+            Some(TypeIdentity::new(
+                Some(provider),
+                Vec::<String>::new(),
+                "AccountId",
+            )),
+            AttributeType::string(),
+            None,
+            None,
+            crate::schema::legacy_validator(|_| Ok(())),
+            None,
+        )
+    };
+    let aws_account = mk("aws");
+    let gcp_account = mk("gcp");
+    assert!(!aws_account.is_assignable_to(&gcp_account));
+    assert!(!gcp_account.is_assignable_to(&aws_account));
 }
 
 /// Directional per-axis subsumption: source missing a populated sink


### PR DESCRIPTION
## Summary

PR 4 of the carina#3413 implementation chain. The design (carina#3421) and its provider-side implementation PRs are merged:

- carina-rs/carina#3421 — design doc
- carina-rs/carina-provider-aws#417 — ``carina-aws-types`` becomes the single source of truth
- carina-rs/carina-provider-awscc#338 — local ``carina-aws-types`` dismantled; awscc consumes upstream

Both providers now physically reference the same Rust constructors, and every ``TypeIdentity`` they emit has ``provider = Some("aws")``. The cross-namespace assignment problem from carina#3413 is type-safe by construction — ``is_assignable_to`` doesn't need to learn about aws/awscc compatibility because there is no ``awscc.*`` ``TypeIdentity`` to be compatible with.

This PR adds regression tests that pin that contract structurally. They live in ``carina-core/src/schema/tests.rs`` next to the existing cross-namespace assignment tests.

## Tests added

Positive side — same TypeIdentity from distinct AttributeType constructions must be mutually assignable:

- ``assignable_accepts_same_enum_typeidentity_from_distinct_constructions`` (Enum variant, e.g. ``aws.s3.Bucket.Versioning.Status``)
- ``assignable_accepts_same_typeidentity_from_distinct_constructions_vpc_id`` (Custom, region-scope: ``aws.ec2.Vpc.Id``)
- ``assignable_accepts_same_typeidentity_from_distinct_constructions_account_id`` (Custom, account-wide with empty segments: ``aws.AccountId``)
- ``assignable_accepts_same_typeidentity_from_distinct_constructions_iam_role_arn`` (Custom, deep segments: ``aws.iam.Role.Arn``)

Negative side — provider-axis differentiation still enforced:

- ``assignable_rejects_account_id_across_genuinely_different_providers`` (e.g. hypothetical ``gcp.AccountId`` rejected against ``aws.AccountId``)

If a future change to ``is_assignable_to``, ``TypeIdentity::assignable_to``, or the Custom/Enum arms regresses the contract, these tests fail immediately.

## Verify

- ``cargo nextest run -p carina-core schema::tests::assignable``: 32 passed (added 5 new tests)
- ``cargo nextest run -p carina-core``: 2321 passed, 1 skipped
- ``cargo test --workspace --doc``: pass
- ``cargo clippy --workspace --all-targets -- -D warnings``: clean

Closes #3413

🤖 Generated with [Claude Code](https://claude.com/claude-code)