### PR TITLE
Accept specific-to-generic Arn assignment with patterns (#3423)

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -2442,18 +2442,22 @@ impl AttributeType {
     /// Rules (first match wins):
     /// 1. Union sink: OK if source is assignable to any member.
     /// 2. Union source: OK iff source is assignable to sink for every member.
-    /// 3. Custom→Custom with both `identity: Some` where the source's
-    ///    identity is not [`TypeIdentity::assignable_to`] the sink's:
-    ///    NG. Directional per-axis subsumption — an empty axis on the
-    ///    **sink** widens (any source matches), but an empty axis on
-    ///    the **source** against a populated sink is rejected (no
-    ///    evidence). So `aws.iam.Role.Arn` flows into `aws.Arn` (sink
-    ///    is wider) but `aws.Arn` does not flow into `aws.iam.Role.Arn`
-    ///    (source has no Role-specific evidence). `aws.Region` and
-    ///    `gcp.Region` are rejected both ways (populated providers
-    ///    differ). Closes carina#3218.
-    /// 4. Custom→Custom: check pattern (pat-1 literal equality) and length
-    ///    containment (source ⊆ sink), then recurse on base.
+    /// 3. Custom→Custom with both `identity: Some`: the source's identity
+    ///    must be [`TypeIdentity::assignable_to`] the sink's, any length
+    ///    range must be contained by the sink's range, and the base types
+    ///    must also be assignable. This is the final verdict for identified
+    ///    custom types: pattern checks are subsumed by identity subsumption
+    ///    and are not consulted in this arm, while length containment remains
+    ///    a structural safety check. Directional per-axis subsumption — an
+    ///    empty axis on the **sink** widens (any source matches), but an empty
+    ///    axis on the **source** against a populated sink is rejected (no
+    ///    evidence). So `aws.iam.Role.Arn` flows into `aws.Arn` (sink is
+    ///    wider) but `aws.Arn` does not flow into `aws.iam.Role.Arn` (source
+    ///    has no Role-specific evidence). `aws.Region` and `gcp.Region` are
+    ///    rejected both ways (populated providers differ). Closes carina#3218.
+    /// 4. Custom→Custom where at least one side has `identity: None`: check
+    ///    pattern (literal equality) and length containment (source ⊆ sink),
+    ///    then recurse on base. For both-identified pairs, see rule 3.
     /// 5. Custom source → non-Custom sink: recurse on `source.base`.
     /// 6. non-Custom source → Custom sink: NG (source has no proof of
     ///    satisfying the sink's identity/pattern/length).
@@ -2492,13 +2496,21 @@ impl AttributeType {
             (
                 Custom {
                     identity: Some(s_id),
+                    length: s_len,
+                    base: s_base,
                     ..
                 },
                 Custom {
                     identity: Some(k_id),
+                    length: k_len,
+                    base: k_base,
                     ..
                 },
-            ) if !s_id.assignable_to(k_id) => false,
+            ) => {
+                s_id.assignable_to(k_id)
+                    && length_contains(s_len.as_ref(), k_len.as_ref())
+                    && s_base.is_assignable_to(k_base)
+            }
             (Enum { identity: s_id, .. }, Enum { identity: k_id, .. })
                 if !s_id.assignable_to(k_id) =>
             {

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -3198,18 +3198,18 @@ fn assignable_accepts_same_enum_typeidentity_from_distinct_constructions() {
 /// carina#3218.
 #[test]
 fn assignable_specific_arn_flows_into_generic_arn() {
-    let mk = |segments: &[&str]| {
+    let mk = |segments: &[&str], pattern: Option<&str>| {
         AttributeType::custom(
             Some(TypeIdentity::new(Some("aws"), segments.to_vec(), "Arn")),
             AttributeType::string(),
-            None,
+            pattern.map(str::to_string),
             None,
             crate::schema::legacy_validator(|_| Ok(())),
             None,
         )
     };
-    let generic = mk(&[]);
-    let role_arn = mk(&["iam", "Role"]);
+    let generic = mk(&[], None);
+    let role_arn = mk(&["iam", "Role"], None);
 
     // Specific → generic: narrower source satisfies wider sink.
     assert!(role_arn.is_assignable_to(&generic));
@@ -3219,9 +3219,82 @@ fn assignable_specific_arn_flows_into_generic_arn() {
     assert!(!generic.is_assignable_to(&role_arn));
 
     // …and two specific ARNs with different service/resource differ.
-    let cert_arn = mk(&["acm", "Certificate"]);
+    let cert_arn = mk(&["acm", "Certificate"], None);
     assert!(!role_arn.is_assignable_to(&cert_arn));
     assert!(!cert_arn.is_assignable_to(&role_arn));
+
+    // Matching patterns do not make different same-depth identities compatible.
+    let s3_bucket_arn = mk(
+        &["s3", "Bucket"],
+        Some("^arn:(aws|aws-cn|aws-us-gov):s3:::.+$"),
+    );
+    let s3_object_arn = mk(
+        &["s3", "Object"],
+        Some("^arn:(aws|aws-cn|aws-us-gov):s3:::.+$"),
+    );
+    assert!(!s3_bucket_arn.is_assignable_to(&s3_object_arn));
+    assert!(!s3_object_arn.is_assignable_to(&s3_bucket_arn));
+}
+
+#[test]
+fn assignable_specific_arn_with_pattern_flows_into_generic_arn_with_pattern() {
+    let mk = |segments: &[&str], pattern: &str| {
+        AttributeType::custom(
+            Some(TypeIdentity::new(Some("aws"), segments.to_vec(), "Arn")),
+            AttributeType::string(),
+            Some(pattern.to_string()),
+            None,
+            crate::schema::legacy_validator(|_| Ok(())),
+            None,
+        )
+    };
+
+    let generic = mk(&[], "^arn:(aws|aws-cn|aws-us-gov):[^:]+:.+$");
+    let bucket_arn = mk(&["s3", "Bucket"], "^arn:(aws|aws-cn|aws-us-gov):s3:::.+$");
+
+    assert!(bucket_arn.is_assignable_to(&generic));
+    assert!(!generic.is_assignable_to(&bucket_arn));
+}
+
+#[test]
+fn assignable_specific_arn_without_pattern_flows_into_generic_arn_with_pattern() {
+    let mk = |segments: &[&str], pattern: Option<&str>| {
+        AttributeType::custom(
+            Some(TypeIdentity::new(Some("aws"), segments.to_vec(), "Arn")),
+            AttributeType::string(),
+            pattern.map(str::to_string),
+            None,
+            crate::schema::legacy_validator(|_| Ok(())),
+            None,
+        )
+    };
+
+    let generic = mk(&[], Some("^arn:(aws|aws-cn|aws-us-gov):[^:]+:.+$"));
+    let role_arn = mk(&["iam", "Role"], None);
+
+    assert!(role_arn.is_assignable_to(&generic));
+}
+
+#[test]
+fn assignable_identified_custom_length_must_be_contained() {
+    let mk = |length: Option<(Option<u64>, Option<u64>)>| {
+        AttributeType::custom(
+            Some(TypeIdentity::bare("SizedString")),
+            AttributeType::string(),
+            None,
+            length,
+            crate::schema::legacy_validator(|_| Ok(())),
+            None,
+        )
+    };
+
+    let narrow = mk(Some((Some(1), Some(32))));
+    let wide = mk(Some((Some(1), Some(64))));
+    assert!(narrow.is_assignable_to(&wide));
+    assert!(!wide.is_assignable_to(&narrow));
+
+    let unproven = mk(None);
+    assert!(!unproven.is_assignable_to(&wide));
 }
 
 /// carina#3413: two callers that independently construct the SAME


### PR DESCRIPTION
## Summary

Fixes carina#3423. The Custom×Custom `is_assignable_to` arm checked `TypeIdentity` subsumption first (specific → generic OK) then fell through to a pattern-equality arm that required `source.pattern == sink.pattern`. Provider-emitted Custom types like `aws.s3.Bucket.Arn` and `aws.Arn` carry different patterns even when the identity relation is "specific narrower than generic", so the live `validate` path rejected what the unit test at `carina-core/src/schema/tests.rs:3180` already said must be accepted.

Repro: `awscc.ec2.FlowLog.log_destination` (typed as generic `aws.Arn`) cannot receive `bucket.arn` (typed as `aws.s3.Bucket.Arn`).

```
cannot assign aws.s3.Bucket.Arn to 'log_destination':
expected aws.Arn, got aws.s3.Bucket.Arn (from bucket.arn)
```

## Fix

The both-identified Custom×Custom arm becomes terminal:

```rust
(Custom { identity: Some(s_id), length: s_len, base: s_base, .. },
 Custom { identity: Some(k_id), length: k_len, base: k_base, .. })
    => s_id.assignable_to(k_id)
       && length_contains(s_len.as_ref(), k_len.as_ref())
       && s_base.is_assignable_to(k_base),
```

- `identity.assignable_to` is the authority for whether source matches sink. Pattern equality is no longer consulted in this arm — the provider's identity declaration subsumes it.
- `length_contains` is kept: a narrower length on the source must still fit within the sink. Same hazard the pattern check used to guard, but length narrowing is a real subset relation, not "different strings happen to be equal".
- `base.is_assignable_to(base)` is kept: a `Custom<base=int>` must not flow into `Custom<base=string>` even when identities match.

The residual pattern arm (literal pattern equality + length containment + base recursion) is unchanged but now only runs when at least one side has `identity: None`. In practice every provider-emitted Custom carries an identity, so the pattern arm becomes a safety net for anonymous Custom types in tests / future code.

## Why this is root-cause

The Round-1 review confirmed no sibling code path in `is_assignable_to` consults pattern after a positive identity match. The Enum arm already terminates with `s_id.assignable_to(k_id) && s_base.is_assignable_to(k_base)`. The Custom→non-Custom path recurses on `source.base`. The non-Custom→Custom path returns false unconditionally. The fix is at the upstream seam.

## Tests added

In `carina-core/src/schema/tests.rs`:

- `assignable_specific_arn_with_pattern_flows_into_generic_arn_with_pattern` — both sides have patterns, identities are `aws.s3.Bucket.Arn` and `aws.Arn`. Source → sink must be accepted. This is the headline failure reproduced.
- `assignable_specific_arn_without_pattern_flows_into_generic_arn_with_pattern` — source has no pattern, sink has one. Both identified. Locks in the design choice that identity subsumption overrides pattern presence.
- `assignable_identified_custom_length_must_be_contained` — identified pair with incompatible length ranges. Verifies length is still enforced.

## Doc updates

Rule 3 of the `is_assignable_to` doc comment now explicitly states that pattern is not consulted in the both-identified arm. Rule 4 is updated to "Custom→Custom where at least one side has `identity: None`" so the reader can predict which arm fires.

## Verify

- `cargo nextest run -p carina-core`: 2324 passed, 1 skipped
- `cargo test --workspace --doc`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- All `scripts/check-*.sh`: pass

## Review

5-round adversarial review found one MED (silent length-check drop in the initial draft) and two LOW findings. All addressed: length check restored, doc comment updated, missing test cases added.

Closes #3423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
