### PR TITLE
Introduce refined primitive attribute types in carina-core

### DIFF
--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -346,7 +346,10 @@ fn map_entry_subtype<'a>(
         // variant. `shape(defs)` panics on a dangling `Ref` —
         // schema-construction bug, surfaced loudly.
         match t.shape_with_defs(defs) {
-            crate::schema::Shape::List { inner, .. } => t = inner,
+            crate::schema::Shape::List {
+                element_type: inner,
+                ..
+            } => t = inner,
             crate::schema::Shape::Map { value, .. } => return Some(value),
             crate::schema::Shape::Struct { .. } => {
                 let fields = crate::schema::struct_fields_with_defs(t, defs)
@@ -1220,7 +1223,13 @@ fn compute_list_of_maps_diff_parts(
     // as carina#3349. `resolve_refs` is a no-op on non-Ref inputs.
     let attr_type_peeled = attr_type.map(|t| t.resolve_refs_with_defs(defs).as_attr());
     let item_type = match attr_type_peeled.map(|t| (&t.kind, t)) {
-        Some((crate::schema::AttrTypeKind::List { inner, .. }, _)) => Some(inner.as_ref()),
+        Some((
+            crate::schema::AttrTypeKind::List {
+                element_type: inner,
+                ..
+            },
+            _,
+        )) => Some(inner.as_ref()),
         // The attribute itself may already be the element type when
         // this is reached recursively from a Map value.
         _ => attr_type_peeled,
@@ -1537,7 +1546,10 @@ fn compute_string_list_change(
 fn string_list_inner_type(attr_type: &AttributeType) -> Option<&AttributeType> {
     use crate::schema::AttrTypeKind;
     match &attr_type.kind {
-        AttrTypeKind::List { inner, .. } => Some(inner),
+        AttrTypeKind::List {
+            element_type: inner,
+            ..
+        } => Some(inner),
         AttrTypeKind::Union(members) => members.iter().find_map(string_list_inner_type),
         // `AttributeType::Ref` (carina#3340): in CFN-derived schemas
         // the resolved target is a `Struct`, never a `List<String>`.
@@ -1546,13 +1558,12 @@ fn string_list_inner_type(attr_type: &AttributeType) -> Option<&AttributeType> {
         // `Ref` for list shapes would need to thread `&defs` and
         // resolve here.
         AttrTypeKind::Ref(_) => None,
-        AttrTypeKind::String
-        | AttrTypeKind::Int
-        | AttrTypeKind::Float
+        AttrTypeKind::String { .. }
+        | AttrTypeKind::Int { .. }
+        | AttrTypeKind::Float { .. }
         | AttrTypeKind::Bool
         | AttrTypeKind::Duration
         | AttrTypeKind::Enum { .. }
-        | AttrTypeKind::Custom { .. }
         | AttrTypeKind::Map { .. }
         | AttrTypeKind::Struct { .. } => None,
     }

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -95,19 +95,23 @@ pub(crate) fn type_aware_equal(
             (
                 Value::Concrete(ConcreteValue::Int(i)),
                 Value::Concrete(ConcreteValue::Float(f)),
-                crate::schema::Shape::Float | crate::schema::Shape::Int,
+                crate::schema::Shape::Float { .. } | crate::schema::Shape::Int { .. },
             ) => (*i as f64) == *f && (*i as f64) as i64 == *i,
             (
                 Value::Concrete(ConcreteValue::Float(f)),
                 Value::Concrete(ConcreteValue::Int(i)),
-                crate::schema::Shape::Float | crate::schema::Shape::Int,
+                crate::schema::Shape::Float { .. } | crate::schema::Shape::Int { .. },
             ) => *f == (*i as f64) && (*i as f64) as i64 == *i,
 
             // Lists: ordered or multiset comparison with inner type awareness
             (
                 Value::Concrete(ConcreteValue::List(la)),
                 Value::Concrete(ConcreteValue::List(lb)),
-                crate::schema::Shape::List { inner, ordered },
+                crate::schema::Shape::List {
+                    element_type: inner,
+                    ordered,
+                    ..
+                },
             ) => type_aware_lists_equal(la, lb, Some(inner), defs, ordered, secret_ctx),
 
             // Maps: recursive comparison with inner value type
@@ -146,7 +150,8 @@ pub(crate) fn type_aware_equal(
                     ) if types.iter().any(|t| {
                         matches!(
                             &t.kind,
-                            crate::schema::AttrTypeKind::Float | crate::schema::AttrTypeKind::Int
+                            crate::schema::AttrTypeKind::Float { .. }
+                                | crate::schema::AttrTypeKind::Int { .. }
                         )
                     }) =>
                     {
@@ -204,11 +209,6 @@ pub(crate) fn type_aware_equal(
                     dsl_map.api_for(&dsl_map.dsl_for(trailing))
                 };
                 canonical(&sa).eq_ignore_ascii_case(&canonical(&sb))
-            }
-
-            // Custom types with base type: delegate to base
-            (_, _, crate::schema::Shape::Custom { base, .. }) => {
-                type_aware_equal(a, b, Some(base), defs, secret_ctx)
             }
 
             // `Shape` has no `Ref` variant by construction (see
@@ -364,8 +364,8 @@ fn is_type_default(
         (Value::Concrete(ConcreteValue::Bool(false)), Some(crate::schema::Shape::Bool) | None) => {
             true
         }
-        (Value::Concrete(ConcreteValue::Int(0)), Some(crate::schema::Shape::Int)) => true,
-        (Value::Concrete(ConcreteValue::Float(f)), Some(crate::schema::Shape::Float))
+        (Value::Concrete(ConcreteValue::Int(0)), Some(crate::schema::Shape::Int { .. })) => true,
+        (Value::Concrete(ConcreteValue::Float(f)), Some(crate::schema::Shape::Float { .. }))
             if *f == 0.0 =>
         {
             true
@@ -375,7 +375,7 @@ fn is_type_default(
         {
             true
         }
-        (Value::Concrete(ConcreteValue::String(s)), Some(crate::schema::Shape::String))
+        (Value::Concrete(ConcreteValue::String(s)), Some(crate::schema::Shape::String { .. }))
             if s.is_empty() =>
         {
             true
@@ -393,10 +393,6 @@ fn is_type_default(
             Value::Concrete(ConcreteValue::Map(m)),
             Some(crate::schema::Shape::Map { .. } | crate::schema::Shape::Struct { .. }),
         ) if m.is_empty() => true,
-        // Custom types: delegate to the base type
-        (_, Some(crate::schema::Shape::Custom { base, .. })) => {
-            is_type_default(value, Some(base), defs)
-        }
         _ => false,
     }
 }

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -1228,24 +1228,14 @@ fn union_string_or_list_non_canonical_mixed_shapes_fail_to_equal() {
 }
 
 #[test]
-fn union_string_or_list_through_custom_wrapper() {
-    // `Custom` wrappers around the union must remain transparent —
-    // the comparator delegates `Custom { base, .. }` to its `base`.
-    let inner = string_or_list_of_strings_type();
-    let custom = AttributeType::custom(
-        Some(TypeIdentity::bare("PolicyConditionValue")),
-        inner,
-        None,
-        None,
-        std::sync::Arc::new(|_| Ok(())),
-        None,
-    );
+fn union_string_or_list_compares_string_list() {
+    let union = string_or_list_of_strings_type();
     let a = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
     let b = Value::Concrete(ConcreteValue::StringList(vec!["x".to_string()]));
     assert!(type_aware_equal(
         &a,
         &b,
-        Some(&custom),
+        Some(&union),
         crate::schema::empty_defs_for_schema_walks(),
         None
     ));

--- a/carina-core/src/lint.rs
+++ b/carina-core/src/lint.rs
@@ -57,7 +57,7 @@ pub fn list_struct_attr_names(schema: &ResourceSchema) -> HashSet<String> {
             // variant, so a `Ref`-typed attribute cannot be missed.
             matches!(
                 attr_schema.attr_type.shape_with_defs(&schema.defs),
-                Shape::List { inner, .. } if matches!(
+                Shape::List { element_type: inner, .. } if matches!(
                     inner.shape_with_defs(&schema.defs),
                     Shape::Struct { .. }
                 )

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -1149,7 +1149,17 @@ fn collect_validators_from_type(
     use crate::schema::AttrTypeKind;
 
     match &attr_type.kind {
-        AttrTypeKind::Custom {
+        AttrTypeKind::String {
+            identity: Some(id),
+            validate,
+            ..
+        }
+        | AttrTypeKind::Int {
+            identity: Some(id),
+            validate,
+            ..
+        }
+        | AttrTypeKind::Float {
             identity: Some(id),
             validate,
             ..
@@ -1164,8 +1174,13 @@ fn collect_validators_from_type(
                 })
             });
         }
-        AttrTypeKind::Custom { identity: None, .. } => {}
-        AttrTypeKind::List { inner, .. } => {
+        AttrTypeKind::String { identity: None, .. }
+        | AttrTypeKind::Int { identity: None, .. }
+        | AttrTypeKind::Float { identity: None, .. } => {}
+        AttrTypeKind::List {
+            element_type: inner,
+            ..
+        } => {
             collect_validators_from_type(inner, validators);
         }
         AttrTypeKind::Map { key, value: inner } => {
@@ -1191,12 +1206,7 @@ fn collect_validators_from_type(
         // because each def is visited exactly once. (carina#3340.)
         AttrTypeKind::Ref(_) => {}
         // Primitives carry no nested Custom types and no Ref.
-        AttrTypeKind::String
-        | AttrTypeKind::Int
-        | AttrTypeKind::Float
-        | AttrTypeKind::Bool
-        | AttrTypeKind::Duration
-        | AttrTypeKind::Enum { .. } => {}
+        AttrTypeKind::Bool | AttrTypeKind::Duration | AttrTypeKind::Enum { .. } => {}
     }
 }
 
@@ -1209,13 +1219,24 @@ fn collect_type_names_from_type(
     use crate::schema::AttrTypeKind;
 
     match &attr_type.kind {
-        AttrTypeKind::Custom {
+        AttrTypeKind::String {
+            identity: Some(id), ..
+        }
+        | AttrTypeKind::Int {
+            identity: Some(id), ..
+        }
+        | AttrTypeKind::Float {
             identity: Some(id), ..
         } => {
             names.insert(id.clone());
         }
-        AttrTypeKind::Custom { identity: None, .. } => {}
-        AttrTypeKind::List { inner, .. } => {
+        AttrTypeKind::String { identity: None, .. }
+        | AttrTypeKind::Int { identity: None, .. }
+        | AttrTypeKind::Float { identity: None, .. } => {}
+        AttrTypeKind::List {
+            element_type: inner,
+            ..
+        } => {
             collect_type_names_from_type(inner, names);
         }
         AttrTypeKind::Map { key, value: inner } => {
@@ -1236,12 +1257,7 @@ fn collect_type_names_from_type(
         // caller walks `schema.defs` separately to avoid infinite
         // recursion on cyclic schemas (carina#3340).
         AttrTypeKind::Ref(_) => {}
-        AttrTypeKind::String
-        | AttrTypeKind::Int
-        | AttrTypeKind::Float
-        | AttrTypeKind::Bool
-        | AttrTypeKind::Duration
-        | AttrTypeKind::Enum { .. } => {}
+        AttrTypeKind::Bool | AttrTypeKind::Duration | AttrTypeKind::Enum { .. } => {}
     }
 }
 

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -41,7 +41,7 @@ impl fmt::Display for RefEncountered {
 /// Type alias for resource validator functions
 pub type ResourceValidator = fn(&HashMap<String, Value>) -> Result<(), Vec<TypeError>>;
 
-/// Validator stored on `AttrTypeKind::Custom`. Boxed as `Arc<dyn Fn>` so it
+/// Validator stored on refined primitive/list shapes. Boxed as `Arc<dyn Fn>` so it
 /// can capture provider-side state (region, account ID, schema handles) and
 /// return a structured `TypeError` directly — both of which a bare `fn`
 /// pointer cannot do. See #2217.
@@ -58,6 +58,10 @@ where
     Arc::new(f)
 }
 
+fn noop_validator() -> CustomValidator {
+    validator(|_| Ok(()))
+}
+
 /// Build a [`CustomValidator`] from a closure that still uses the legacy
 /// `Result<(), String>` shape. The returned message is wrapped in
 /// `TypeError::ValidationFailed`. Use this for builtins that haven't yet
@@ -69,7 +73,7 @@ where
     Arc::new(move |v| f(v).map_err(|message| TypeError::ValidationFailed { message }))
 }
 
-/// External validator looked up by `AttrTypeKind::Custom.identity`
+/// External validator looked up by refined primitive identity.
 /// at validation time. Used to bridge to provider-supplied validators
 /// (the `ProviderContext.validators` map and WASM factory's
 /// `validate_custom_type`) that the schema itself cannot carry across
@@ -143,7 +147,7 @@ fn enum_binding_collision_message(
     )
 }
 
-/// Walk an [`AttributeType`] and apply `lookup` to every `Custom` node
+/// Walk an [`AttributeType`] and apply `lookup` to every identified refined node
 /// reached. Pushes any returned error into `errors`, tagged with
 /// `attr_name` so it points back at the user-visible attribute. Used
 /// by `ResourceSchema::validate_inner` to bridge provider-supplied
@@ -172,24 +176,10 @@ fn walk_custom_lookup(
         return;
     }
     match &attr_type.kind {
-        AttrTypeKind::Custom { identity, .. } => {
-            if let Some(id) = identity
-                && let Err(e) = lookup(id, value)
-            {
-                // Re-wrap as `ResourceValidationFailed` so the attribute
-                // slot survives. `with_attribute` only enriches the two
-                // enum-variant errors; bare `ValidationFailed` would
-                // arrive at the LSP without a position hint and get
-                // filtered out by the resource-level dedup.
-                let message = match e {
-                    TypeError::ValidationFailed { message } => message,
-                    other => other.to_string(),
-                };
-                errors.push(TypeError::ResourceValidationFailed {
-                    message,
-                    attribute: Some(attr_name.to_string()),
-                });
-            }
+        AttrTypeKind::String { identity, .. }
+        | AttrTypeKind::Int { identity, .. }
+        | AttrTypeKind::Float { identity, .. } => {
+            run_identified_lookup(identity.as_ref(), value, attr_name, lookup, errors)
         }
         AttrTypeKind::Enum { identity, .. } => {
             if let Err(e) = lookup(identity, value) {
@@ -203,7 +193,10 @@ fn walk_custom_lookup(
                 });
             }
         }
-        AttrTypeKind::List { inner, .. } => {
+        AttrTypeKind::List {
+            element_type: inner,
+            ..
+        } => {
             if let Value::Concrete(ConcreteValue::List(items)) = value {
                 for item in items {
                     walk_custom_lookup(inner, item, attr_name, lookup, defs, errors);
@@ -255,11 +248,7 @@ fn walk_custom_lookup(
                 errors.extend(b);
             }
         }
-        AttrTypeKind::String
-        | AttrTypeKind::Int
-        | AttrTypeKind::Float
-        | AttrTypeKind::Bool
-        | AttrTypeKind::Duration => {}
+        AttrTypeKind::Bool | AttrTypeKind::Duration => {}
         // `Ref`: resolve via the schema's def map and continue the
         // walk. The resolved target (typically a `Struct`) may carry
         // identity-bearing custom types whose validators must run.
@@ -276,6 +265,27 @@ fn walk_custom_lookup(
                 // the dangling-Ref diagnostic for this attribute.
             }
         },
+    }
+}
+
+fn run_identified_lookup(
+    identity: Option<&TypeIdentity>,
+    value: &Value,
+    attr_name: &str,
+    lookup: CustomTypeLookup<'_>,
+    errors: &mut Vec<TypeError>,
+) {
+    if let Some(id) = identity
+        && let Err(e) = lookup(id, value)
+    {
+        let message = match e {
+            TypeError::ValidationFailed { message } => message,
+            other => other.to_string(),
+        };
+        errors.push(TypeError::ResourceValidationFailed {
+            message,
+            attribute: Some(attr_name.to_string()),
+        });
     }
 }
 
@@ -437,11 +447,25 @@ pub struct AttributeType {
 #[derive(Clone)]
 pub(crate) enum AttrTypeKind {
     /// String
-    String,
+    String {
+        identity: Option<TypeIdentity>,
+        pattern: Option<String>,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: CustomValidator,
+        to_dsl: Option<DslTransform>,
+    },
     /// Integer
-    Int,
+    Int {
+        identity: Option<TypeIdentity>,
+        range: Option<(Option<i64>, Option<i64>)>,
+        validate: CustomValidator,
+    },
     /// Floating-point number
-    Float,
+    Float {
+        identity: Option<TypeIdentity>,
+        range: Option<(Option<f64>, Option<f64>)>,
+        validate: CustomValidator,
+    },
     /// Boolean
     Bool,
     /// Time duration. Values use the `<integer><unit>` literal
@@ -468,53 +492,15 @@ pub(crate) enum AttrTypeKind {
         /// Optional API → DSL transform for dynamic enum spaces.
         to_dsl: Option<DslTransform>,
     },
-    /// Structurally-validated custom type — values carry their own
-    /// format (e.g. `arn:aws:s3:::bucket-name`, `vpc-12345678`) and
-    /// reach the validator verbatim. Distinct from [`AttrTypeKind::Enum`],
-    /// which gates enum shorthand through `expand_enum_shorthand`.
-    ///
-    /// The split was introduced in carina#3222 (S2.5c-followup) so the
-    /// enum-shorthand vs structural divide is a compile-time fact
-    /// rather than a runtime `namespace.is_some()` check — the
-    /// carina#3216 class of mis-expansion (`aws.Arn.arn:aws:s3:...`)
-    /// is structurally impossible under this shape.
-    Custom {
-        /// `Some(identity)` when this type carries a structured type
-        /// identity (e.g. `aws.iam.Role.Arn`, `aws.VpcId`). `None` when
-        /// this is a generic string/int pattern type synthesized by
-        /// codegen for a property without a named semantic.
-        ///
-        /// Replaces the former flat `semantic_name: Option<String>`:
-        /// keying identity on discrete `provider + segments + kind`
-        /// axes keeps two providers' same-named types distinct. See
-        /// [`TypeIdentity`].
-        identity: Option<TypeIdentity>,
-        base: Box<AttributeType>,
-        /// Optional regex pattern constraint (for structural comparison).
-        pattern: Option<String>,
-        /// Optional length bounds (min, max).
-        length: Option<(Option<u64>, Option<u64>)>,
-        validate: CustomValidator,
-        /// Optional value-level normalization callback applied when
-        /// the provider reads a state value back from the SDK. For
-        /// example, `route53.hosted_zone.name` arrives with a trailing
-        /// `.` that the DSL form does not carry — the closure strips
-        /// it so the differ does not report a phantom diff.
-        ///
-        /// Distinct from [`AttrTypeKind::Enum`]'s `to_dsl`, which
-        /// expands the *DSL spelling* of enum variants. Here the
-        /// closure is a generic state→DSL normalizer.
-        /// `Option<fn>` because closures cannot cross the WASM
-        /// boundary; structural normalization is host-side only.
-        to_dsl: Option<fn(&str) -> String>,
-    },
     /// List
     /// `ordered`: if true, element order matters (sequential comparison);
     /// if false, order is ignored (multiset comparison).
     /// Defaults to true (matching CloudFormation's insertionOrder default).
     List {
-        inner: Box<AttributeType>,
+        element_type: Box<AttributeType>,
         ordered: bool,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: CustomValidator,
     },
     /// Map with typed keys and values.
     /// `key`: type constraint for map keys (e.g., `String` for unconstrained,
@@ -565,12 +551,26 @@ pub(crate) enum AttrTypeKind {
 /// enum and the compiler will surface the omission.
 #[derive(Clone, Copy)]
 pub enum Shape<'a> {
-    /// String — see [`AttrTypeKind::String`].
-    String,
-    /// Integer — see [`AttrTypeKind::Int`].
-    Int,
-    /// Floating-point — see [`AttrTypeKind::Float`].
-    Float,
+    /// String — see [`AttrTypeKind::String { .. }`].
+    String {
+        identity: Option<&'a TypeIdentity>,
+        pattern: Option<&'a str>,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: &'a CustomValidator,
+        to_dsl: Option<&'a DslTransform>,
+    },
+    /// Integer — see [`AttrTypeKind::Int { .. }`].
+    Int {
+        identity: Option<&'a TypeIdentity>,
+        range: Option<(Option<i64>, Option<i64>)>,
+        validate: &'a CustomValidator,
+    },
+    /// Floating-point — see [`AttrTypeKind::Float { .. }`].
+    Float {
+        identity: Option<&'a TypeIdentity>,
+        range: Option<(Option<f64>, Option<f64>)>,
+        validate: &'a CustomValidator,
+    },
     /// Boolean — see [`AttrTypeKind::Bool`].
     Bool,
     /// Time duration — see [`AttrTypeKind::Duration`].
@@ -584,19 +584,12 @@ pub enum Shape<'a> {
         validate: Option<&'a CustomValidator>,
         to_dsl: Option<&'a DslTransform>,
     },
-    /// Structural custom type — see [`AttrTypeKind::Custom`].
-    Custom {
-        identity: Option<&'a TypeIdentity>,
-        base: &'a AttributeType,
-        pattern: Option<&'a str>,
-        length: Option<(Option<u64>, Option<u64>)>,
-        validate: &'a CustomValidator,
-        to_dsl: Option<fn(&str) -> String>,
-    },
     /// List with element type and ordering — see [`AttrTypeKind::List`].
     List {
-        inner: &'a AttributeType,
+        element_type: &'a AttributeType,
         ordered: bool,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: &'a CustomValidator,
     },
     /// Map with typed key/value — see [`AttrTypeKind::Map`].
     Map {
@@ -642,9 +635,36 @@ impl ShapeWalkBudget {
 impl fmt::Debug for Shape<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Shape::String => f.write_str("Shape::String"),
-            Shape::Int => f.write_str("Shape::Int"),
-            Shape::Float => f.write_str("Shape::Float"),
+            Shape::String {
+                identity,
+                pattern,
+                length,
+                validate: _,
+                to_dsl: _,
+            } => f
+                .debug_struct("Shape::String { .. }")
+                .field("identity", identity)
+                .field("pattern", pattern)
+                .field("length", length)
+                .finish_non_exhaustive(),
+            Shape::Int {
+                identity,
+                range,
+                validate: _,
+            } => f
+                .debug_struct("Shape::Int { .. }")
+                .field("identity", identity)
+                .field("range", range)
+                .finish_non_exhaustive(),
+            Shape::Float {
+                identity,
+                range,
+                validate: _,
+            } => f
+                .debug_struct("Shape::Float { .. }")
+                .field("identity", identity)
+                .field("range", range)
+                .finish_non_exhaustive(),
             Shape::Bool => f.write_str("Shape::Bool"),
             Shape::Duration => f.write_str("Shape::Duration"),
             Shape::Enum {
@@ -661,25 +681,17 @@ impl fmt::Debug for Shape<'_> {
                 .field("values", values)
                 .field("dsl_aliases", dsl_aliases)
                 .finish_non_exhaustive(),
-            Shape::Custom {
-                identity,
-                base,
-                pattern,
+            Shape::List {
+                element_type,
+                ordered,
                 length,
                 validate: _,
-                to_dsl: _,
             } => f
-                .debug_struct("Shape::Custom")
-                .field("identity", identity)
-                .field("base", base)
-                .field("pattern", pattern)
+                .debug_struct("Shape::List")
+                .field("element_type", element_type)
+                .field("ordered", ordered)
                 .field("length", length)
                 .finish_non_exhaustive(),
-            Shape::List { inner, ordered } => f
-                .debug_struct("Shape::List")
-                .field("inner", inner)
-                .field("ordered", ordered)
-                .finish(),
             Shape::Map { key, value } => f
                 .debug_struct("Shape::Map")
                 .field("key", key)
@@ -713,12 +725,26 @@ impl fmt::Debug for Shape<'_> {
 /// against the source enum and the compiler will surface the omission.
 #[derive(Clone, Copy)]
 pub enum RawShape<'a> {
-    /// String — see [`AttrTypeKind::String`].
-    String,
-    /// Integer — see [`AttrTypeKind::Int`].
-    Int,
-    /// Floating-point — see [`AttrTypeKind::Float`].
-    Float,
+    /// String — see [`AttrTypeKind::String { .. }`].
+    String {
+        identity: Option<&'a TypeIdentity>,
+        pattern: Option<&'a str>,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: &'a CustomValidator,
+        to_dsl: Option<&'a DslTransform>,
+    },
+    /// Integer — see [`AttrTypeKind::Int { .. }`].
+    Int {
+        identity: Option<&'a TypeIdentity>,
+        range: Option<(Option<i64>, Option<i64>)>,
+        validate: &'a CustomValidator,
+    },
+    /// Floating-point — see [`AttrTypeKind::Float { .. }`].
+    Float {
+        identity: Option<&'a TypeIdentity>,
+        range: Option<(Option<f64>, Option<f64>)>,
+        validate: &'a CustomValidator,
+    },
     /// Boolean — see [`AttrTypeKind::Bool`].
     Bool,
     /// Time duration — see [`AttrTypeKind::Duration`].
@@ -732,19 +758,12 @@ pub enum RawShape<'a> {
         validate: Option<&'a CustomValidator>,
         to_dsl: Option<&'a DslTransform>,
     },
-    /// Structural custom type — see [`AttrTypeKind::Custom`].
-    Custom {
-        identity: Option<&'a TypeIdentity>,
-        base: &'a AttributeType,
-        pattern: Option<&'a str>,
-        length: Option<(Option<u64>, Option<u64>)>,
-        validate: &'a CustomValidator,
-        to_dsl: Option<fn(&str) -> String>,
-    },
     /// List with element type and ordering — see [`AttrTypeKind::List`].
     List {
-        inner: &'a AttributeType,
+        element_type: &'a AttributeType,
         ordered: bool,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: &'a CustomValidator,
     },
     /// Map with typed key/value — see [`AttrTypeKind::Map`].
     Map {
@@ -767,9 +786,36 @@ pub enum RawShape<'a> {
 impl fmt::Debug for RawShape<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RawShape::String => f.write_str("RawShape::String"),
-            RawShape::Int => f.write_str("RawShape::Int"),
-            RawShape::Float => f.write_str("RawShape::Float"),
+            RawShape::String {
+                identity,
+                pattern,
+                length,
+                validate: _,
+                to_dsl: _,
+            } => f
+                .debug_struct("RawShape::String { .. }")
+                .field("identity", identity)
+                .field("pattern", pattern)
+                .field("length", length)
+                .finish_non_exhaustive(),
+            RawShape::Int {
+                identity,
+                range,
+                validate: _,
+            } => f
+                .debug_struct("RawShape::Int { .. }")
+                .field("identity", identity)
+                .field("range", range)
+                .finish_non_exhaustive(),
+            RawShape::Float {
+                identity,
+                range,
+                validate: _,
+            } => f
+                .debug_struct("RawShape::Float { .. }")
+                .field("identity", identity)
+                .field("range", range)
+                .finish_non_exhaustive(),
             RawShape::Bool => f.write_str("RawShape::Bool"),
             RawShape::Duration => f.write_str("RawShape::Duration"),
             RawShape::Enum {
@@ -786,25 +832,17 @@ impl fmt::Debug for RawShape<'_> {
                 .field("values", values)
                 .field("dsl_aliases", dsl_aliases)
                 .finish_non_exhaustive(),
-            RawShape::Custom {
-                identity,
-                base,
-                pattern,
+            RawShape::List {
+                element_type,
+                ordered,
                 length,
                 validate: _,
-                to_dsl: _,
             } => f
-                .debug_struct("RawShape::Custom")
-                .field("identity", identity)
-                .field("base", base)
-                .field("pattern", pattern)
+                .debug_struct("RawShape::List")
+                .field("element_type", element_type)
+                .field("ordered", ordered)
                 .field("length", length)
                 .finish_non_exhaustive(),
-            RawShape::List { inner, ordered } => f
-                .debug_struct("RawShape::List")
-                .field("inner", inner)
-                .field("ordered", ordered)
-                .finish(),
             RawShape::Map { key, value } => f
                 .debug_struct("RawShape::Map")
                 .field("key", key)
@@ -864,7 +902,7 @@ impl Schema {
     /// **Do not** call [`Self::validate`] or [`Self::validate_collect`]
     /// on a Schema produced by `with_defs`; those entry points walk
     /// `self.root`, which here is a non-load-bearing
-    /// `AttrTypeKind::String` and will silently validate every
+    /// `AttrTypeKind::String { .. }` and will silently validate every
     /// value as a String.
     pub fn with_defs(defs: std::collections::BTreeMap<String, AttributeType>) -> Self {
         Self {
@@ -1024,7 +1062,10 @@ impl Schema {
                     }
                 }
             }
-            AttrTypeKind::List { inner, .. } => {
+            AttrTypeKind::List {
+                element_type: inner,
+                ..
+            } => {
                 let Some(items) = (match concrete {
                     ConcreteValueRef::List(items) => Some(items),
                     _ => None,
@@ -1081,7 +1122,12 @@ impl Schema {
                     ),
                 }),
             },
-            AttrTypeKind::List { inner, ordered } => {
+            AttrTypeKind::List {
+                element_type: inner,
+                ordered,
+                length,
+                validate,
+            } => {
                 if let Some(ConcreteValueRef::List(items)) = value.as_concrete() {
                     for (i, item) in items.iter().enumerate() {
                         if let Err(inner_err) = self.validate_attr(inner, item) {
@@ -1102,8 +1148,10 @@ impl Schema {
                     let _ = ordered;
                     AttributeType {
                         kind: AttrTypeKind::List {
-                            inner: inner.clone(),
+                            element_type: inner.clone(),
                             ordered: *ordered,
+                            length: *length,
+                            validate: validate.clone(),
                         },
                     }
                     .validate(value)
@@ -1227,9 +1275,40 @@ impl fmt::Debug for AttributeType {
     // variant matches what `#[derive(Debug)]` would produce.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
-            AttrTypeKind::String => f.write_str("String"),
-            AttrTypeKind::Int => f.write_str("Int"),
-            AttrTypeKind::Float => f.write_str("Float"),
+            AttrTypeKind::String {
+                identity,
+                pattern,
+                length,
+                to_dsl,
+                validate: _,
+            } => f
+                .debug_struct("String")
+                .field("identity", identity)
+                .field("pattern", pattern)
+                .field("length", length)
+                .field("to_dsl", to_dsl)
+                .field("validate", &"<closure>")
+                .finish(),
+            AttrTypeKind::Int {
+                identity,
+                range,
+                validate: _,
+            } => f
+                .debug_struct("Int")
+                .field("identity", identity)
+                .field("range", range)
+                .field("validate", &"<closure>")
+                .finish(),
+            AttrTypeKind::Float {
+                identity,
+                range,
+                validate: _,
+            } => f
+                .debug_struct("Float")
+                .field("identity", identity)
+                .field("range", range)
+                .field("validate", &"<closure>")
+                .finish(),
             AttrTypeKind::Bool => f.write_str("Bool"),
             AttrTypeKind::Duration => f.write_str("Duration"),
             AttrTypeKind::Enum {
@@ -1248,26 +1327,17 @@ impl fmt::Debug for AttributeType {
                 .field("to_dsl", to_dsl)
                 .field("validate", &"<closure>")
                 .finish(),
-            AttrTypeKind::Custom {
-                identity,
-                base,
-                pattern,
+            AttrTypeKind::List {
+                element_type,
+                ordered,
                 length,
-                to_dsl,
                 validate: _,
             } => f
-                .debug_struct("Custom")
-                .field("identity", identity)
-                .field("base", base)
-                .field("pattern", pattern)
-                .field("length", length)
-                .field("to_dsl", to_dsl)
-                .field("validate", &"<closure>")
-                .finish(),
-            AttrTypeKind::List { inner, ordered } => f
                 .debug_struct("List")
-                .field("inner", inner)
+                .field("element_type", element_type)
                 .field("ordered", ordered)
+                .field("length", length)
+                .field("validate", &"<closure>")
                 .finish(),
             AttrTypeKind::Map { key, value } => f
                 .debug_struct("Map")
@@ -1503,9 +1573,37 @@ impl AttributeType {
 
     fn shape_from_resolved(resolved: &AttributeType) -> Shape<'_> {
         match &resolved.kind {
-            AttrTypeKind::String => Shape::String,
-            AttrTypeKind::Int => Shape::Int,
-            AttrTypeKind::Float => Shape::Float,
+            AttrTypeKind::String {
+                identity,
+                pattern,
+                length,
+                validate,
+                to_dsl,
+            } => Shape::String {
+                identity: identity.as_ref(),
+                pattern: pattern.as_deref(),
+                length: *length,
+                validate,
+                to_dsl: to_dsl.as_ref(),
+            },
+            AttrTypeKind::Int {
+                identity,
+                range,
+                validate,
+            } => Shape::Int {
+                identity: identity.as_ref(),
+                range: *range,
+                validate,
+            },
+            AttrTypeKind::Float {
+                identity,
+                range,
+                validate,
+            } => Shape::Float {
+                identity: identity.as_ref(),
+                range: *range,
+                validate,
+            },
             AttrTypeKind::Bool => Shape::Bool,
             AttrTypeKind::Duration => Shape::Duration,
             AttrTypeKind::Enum {
@@ -1523,24 +1621,16 @@ impl AttributeType {
                 validate: validate.as_ref(),
                 to_dsl: to_dsl.as_ref(),
             },
-            AttrTypeKind::Custom {
-                identity,
-                base,
-                pattern,
+            AttrTypeKind::List {
+                element_type,
+                ordered,
                 length,
                 validate,
-                to_dsl,
-            } => Shape::Custom {
-                identity: identity.as_ref(),
-                base: base.as_ref(),
-                pattern: pattern.as_deref(),
+            } => Shape::List {
+                element_type: element_type.as_ref(),
+                ordered: *ordered,
                 length: *length,
                 validate,
-                to_dsl: *to_dsl,
-            },
-            AttrTypeKind::List { inner, ordered } => Shape::List {
-                inner: inner.as_ref(),
-                ordered: *ordered,
             },
             AttrTypeKind::Map { key, value } => Shape::Map {
                 key: key.as_ref(),
@@ -1575,9 +1665,37 @@ impl AttributeType {
     /// carina#3349 bug class at the walk-site.
     pub fn raw_shape<'a>(&'a self) -> RawShape<'a> {
         match &self.kind {
-            AttrTypeKind::String => RawShape::String,
-            AttrTypeKind::Int => RawShape::Int,
-            AttrTypeKind::Float => RawShape::Float,
+            AttrTypeKind::String {
+                identity,
+                pattern,
+                length,
+                validate,
+                to_dsl,
+            } => RawShape::String {
+                identity: identity.as_ref(),
+                pattern: pattern.as_deref(),
+                length: *length,
+                validate,
+                to_dsl: to_dsl.as_ref(),
+            },
+            AttrTypeKind::Int {
+                identity,
+                range,
+                validate,
+            } => RawShape::Int {
+                identity: identity.as_ref(),
+                range: *range,
+                validate,
+            },
+            AttrTypeKind::Float {
+                identity,
+                range,
+                validate,
+            } => RawShape::Float {
+                identity: identity.as_ref(),
+                range: *range,
+                validate,
+            },
             AttrTypeKind::Bool => RawShape::Bool,
             AttrTypeKind::Duration => RawShape::Duration,
             AttrTypeKind::Enum {
@@ -1595,24 +1713,16 @@ impl AttributeType {
                 validate: validate.as_ref(),
                 to_dsl: to_dsl.as_ref(),
             },
-            AttrTypeKind::Custom {
-                identity,
-                base,
-                pattern,
+            AttrTypeKind::List {
+                element_type,
+                ordered,
                 length,
                 validate,
-                to_dsl,
-            } => RawShape::Custom {
-                identity: identity.as_ref(),
-                base: base.as_ref(),
-                pattern: pattern.as_deref(),
+            } => RawShape::List {
+                element_type: element_type.as_ref(),
+                ordered: *ordered,
                 length: *length,
                 validate,
-                to_dsl: *to_dsl,
-            },
-            AttrTypeKind::List { inner, ordered } => RawShape::List {
-                inner: inner.as_ref(),
-                ordered: *ordered,
             },
             AttrTypeKind::Map { key, value } => RawShape::Map {
                 key: key.as_ref(),
@@ -1639,21 +1749,35 @@ impl AttributeType {
     /// Create the primitive `String` type.
     pub fn string() -> Self {
         AttributeType {
-            kind: AttrTypeKind::String,
+            kind: AttrTypeKind::String {
+                identity: None,
+                pattern: None,
+                length: None,
+                validate: noop_validator(),
+                to_dsl: None,
+            },
         }
     }
 
     /// Create the primitive `Int` type.
     pub fn int() -> Self {
         AttributeType {
-            kind: AttrTypeKind::Int,
+            kind: AttrTypeKind::Int {
+                identity: None,
+                range: None,
+                validate: noop_validator(),
+            },
         }
     }
 
     /// Create the primitive `Float` type.
     pub fn float() -> Self {
         AttributeType {
-            kind: AttrTypeKind::Float,
+            kind: AttrTypeKind::Float {
+                identity: None,
+                range: None,
+                validate: noop_validator(),
+            },
         }
     }
 
@@ -1773,14 +1897,40 @@ impl AttributeType {
         validate: CustomValidator,
         to_dsl: Option<fn(&str) -> String>,
     ) -> Self {
+        assert!(
+            to_dsl.is_none(),
+            "custom shim: function-pointer to_dsl cannot be represented as DslTransform"
+        );
         AttributeType {
-            kind: AttrTypeKind::Custom {
-                identity,
-                base: Box::new(base),
-                pattern,
-                length,
-                validate,
-                to_dsl,
+            kind: match base.kind {
+                AttrTypeKind::String { to_dsl, .. } => AttrTypeKind::String {
+                    identity,
+                    pattern,
+                    length,
+                    validate,
+                    to_dsl,
+                },
+                AttrTypeKind::Int { .. } => AttrTypeKind::Int {
+                    identity,
+                    range: length.map(|(min, max)| (min.map(|v| v as i64), max.map(|v| v as i64))),
+                    validate,
+                },
+                AttrTypeKind::Float { .. } => AttrTypeKind::Float {
+                    identity,
+                    range: None,
+                    validate,
+                },
+                AttrTypeKind::List {
+                    element_type,
+                    ordered,
+                    ..
+                } => AttrTypeKind::List {
+                    element_type,
+                    ordered,
+                    length,
+                    validate,
+                },
+                other => panic!("custom shim: unexpected base {other:?}"),
             },
         }
     }
@@ -1814,8 +1964,10 @@ impl AttributeType {
     pub fn list(inner: AttributeType) -> Self {
         AttributeType {
             kind: AttrTypeKind::List {
-                inner: Box::new(inner),
+                element_type: Box::new(inner),
                 ordered: true,
+                length: None,
+                validate: noop_validator(),
             },
         }
     }
@@ -1824,8 +1976,10 @@ impl AttributeType {
     pub fn unordered_list(inner: AttributeType) -> Self {
         AttributeType {
             kind: AttrTypeKind::List {
-                inner: Box::new(inner),
+                element_type: Box::new(inner),
                 ordered: false,
+                length: None,
+                validate: noop_validator(),
             },
         }
     }
@@ -1961,14 +2115,13 @@ impl AttributeType {
                 validate.as_ref(),
                 value,
             ),
-            AttrTypeKind::Custom { .. } => self.validate_custom(value),
             AttrTypeKind::List { .. } => self.validate_list(value),
             AttrTypeKind::Map { .. } => self.validate_map(value),
             AttrTypeKind::Struct { .. } => self.validate_struct(value),
             AttrTypeKind::Union(_) => self.validate_union(value),
-            AttrTypeKind::String
-            | AttrTypeKind::Int
-            | AttrTypeKind::Float
+            AttrTypeKind::String { .. }
+            | AttrTypeKind::Int { .. }
+            | AttrTypeKind::Float { .. }
             | AttrTypeKind::Bool
             | AttrTypeKind::Duration => self.validate_primitive(value),
             // Unreachable: `validate` rejects `Ref` early before
@@ -1994,13 +2147,51 @@ impl AttributeType {
     /// Value::Deferred(DeferredValue::Interpolation(_))` arm is now structurally unrepresentable.
     fn validate_primitive(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
         match (&self.kind, value) {
-            (AttrTypeKind::String, ConcreteValueRef::String(_)) => Ok(()),
-            (AttrTypeKind::Int, ConcreteValueRef::Int(_)) => Ok(()),
-            (AttrTypeKind::Float, ConcreteValueRef::Float(f)) if f.is_finite() => Ok(()),
-            (AttrTypeKind::Float, ConcreteValueRef::Float(f)) => Err(TypeError::ValidationFailed {
-                message: format!("non-finite float value: {f}"),
-            }),
-            (AttrTypeKind::Float, ConcreteValueRef::Int(_)) => Ok(()),
+            (
+                AttrTypeKind::String {
+                    identity,
+                    pattern,
+                    length,
+                    validate,
+                    ..
+                },
+                ConcreteValueRef::String(s),
+            ) => {
+                validate_string_refinement(identity.as_ref(), pattern.as_deref(), *length, s)?;
+                validate(&value.to_owned_value())
+            }
+            (
+                AttrTypeKind::Int {
+                    range, validate, ..
+                },
+                ConcreteValueRef::Int(i),
+            ) => {
+                validate_int_range(*range, i)?;
+                validate(&value.to_owned_value())
+            }
+            (
+                AttrTypeKind::Float {
+                    range, validate, ..
+                },
+                ConcreteValueRef::Float(f),
+            ) if f.is_finite() => {
+                validate_float_range(*range, f)?;
+                validate(&value.to_owned_value())
+            }
+            (AttrTypeKind::Float { .. }, ConcreteValueRef::Float(f)) => {
+                Err(TypeError::ValidationFailed {
+                    message: format!("non-finite float value: {f}"),
+                })
+            }
+            (
+                AttrTypeKind::Float {
+                    range, validate, ..
+                },
+                ConcreteValueRef::Int(i),
+            ) => {
+                validate_float_range(*range, i as f64)?;
+                validate(&value.to_owned_value())
+            }
             (AttrTypeKind::Bool, ConcreteValueRef::Bool(_)) => Ok(()),
             (AttrTypeKind::Duration, ConcreteValueRef::Duration(_)) => Ok(()),
             _ => Err(TypeError::TypeMismatch {
@@ -2140,75 +2331,6 @@ impl AttributeType {
         }
     }
 
-    /// Validate against a `Custom` variant.
-    ///
-    /// For String-shaped concrete values, this first enforces the schema
-    /// `pattern` constraint, then the `length` constraint using character
-    /// count. Patterns that Rust's regex engine cannot compile are skipped so
-    /// provider schema compatibility issues do not become user validation
-    /// errors (awscc#295). After those structural checks, validation delegates
-    /// to the Custom `validate` closure.
-    ///
-    /// Pre-carina#3222 this function also handled enum-shaped Customs
-    /// (gated on `namespace.is_some()`). Those are now
-    /// [`AttrTypeKind::Enum`], so the structurally-validated arm is the
-    /// only thing left here.
-    ///
-    /// Phase 2 of RFC #2972: takes [`ConcreteValueRef`]. The deferred-skip
-    /// guard for `Value::Deferred(DeferredValue::ResourceRef)`/`Value::Deferred(DeferredValue::Interpolation)` is gone —
-    /// the dispatcher filters them out in [`Self::validate`].
-    fn validate_custom(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
-        let AttrTypeKind::Custom {
-            identity,
-            base: _,
-            pattern,
-            length,
-            validate,
-            to_dsl: _,
-        } = &self.kind
-        else {
-            unreachable!("validate_custom called on non-Custom");
-        };
-        let type_name = identity.as_ref().map(|id| id.kind.clone());
-        // Pattern and length only apply to String-shaped concrete values.
-        // EnumIdentifier/StringList-shaped Custom values are not checked here;
-        // structural string Customs for awscc#295 arrive as String.
-        if let ConcreteValueRef::String(s) = value {
-            if let Some(pattern) = pattern
-                // awscc#295: CloudFormation patterns may contain constructs
-                // Rust's regex crate rejects; skip those provider constraints
-                // instead of reporting a schema-compatibility issue as a user error.
-                && let Ok(re) = regex::Regex::new(pattern)
-                // awscc#295: JSON Schema / CloudControl `pattern` is an
-                // unanchored substring match unless the pattern supplies ^/$.
-                && !re.is_match(s)
-            {
-                return Err(TypeError::PatternMismatch {
-                    value: s.to_string(),
-                    pattern: pattern.clone(),
-                    attribute: None,
-                    type_name,
-                });
-            }
-            if let Some((min, max)) = length {
-                let count = s.chars().count();
-                let count_u64 = count as u64;
-                if min.is_some_and(|min| count_u64 < min) || max.is_some_and(|max| count_u64 > max)
-                {
-                    return Err(TypeError::LengthOutOfRange {
-                        value: s.to_string(),
-                        length: count,
-                        min: *min,
-                        max: *max,
-                        attribute: None,
-                        type_name,
-                    });
-                }
-            }
-        }
-        validate(&value.to_owned_value())
-    }
-
     /// Validate a `List` variant by validating each item with the inner type.
     ///
     /// Phase 2 of RFC #2972 (closes #2954): takes [`ConcreteValueRef`].
@@ -2220,7 +2342,13 @@ impl AttributeType {
     /// `Ok(())` immediately. Type fitness for upstream list refs is
     /// the deferred-aware checker's job.
     fn validate_list(&self, value: ConcreteValueRef<'_>) -> Result<(), TypeError> {
-        let AttrTypeKind::List { inner, .. } = &self.kind else {
+        let AttrTypeKind::List {
+            element_type: inner,
+            length,
+            validate,
+            ..
+        } = &self.kind
+        else {
             unreachable!("validate_list called on non-List");
         };
         // `ConcreteValueRef::StringList` is the canonicalized form for
@@ -2228,6 +2356,7 @@ impl AttributeType {
         // Structurally equivalent to a `List` of strings — accept the
         // same way.
         if let ConcreteValueRef::StringList(items) = value {
+            validate_list_length(*length, items.len())?;
             for (i, s) in items.iter().enumerate() {
                 inner
                     .validate(&Value::Concrete(ConcreteValue::String(s.clone())))
@@ -2236,7 +2365,7 @@ impl AttributeType {
                         inner: Box::new(e),
                     })?;
             }
-            return Ok(());
+            return validate(&value.to_owned_value());
         }
         let ConcreteValueRef::List(items) = value else {
             return Err(TypeError::TypeMismatch {
@@ -2244,13 +2373,14 @@ impl AttributeType {
                 got: value.type_name().to_string(),
             });
         };
+        validate_list_length(*length, items.len())?;
         for (i, item) in items.iter().enumerate() {
             inner.validate(item).map_err(|e| TypeError::ListItemError {
                 index: i,
                 inner: Box::new(e),
             })?;
         }
-        Ok(())
+        validate(&value.to_owned_value())
     }
 
     /// Validate a `Map` variant: keys against `key`, values against `value`.
@@ -2395,19 +2525,27 @@ impl AttributeType {
 
     pub fn type_name(&self) -> String {
         match &self.kind {
-            AttrTypeKind::String => "String".to_string(),
-            AttrTypeKind::Int => "Int".to_string(),
-            AttrTypeKind::Float => "Float".to_string(),
             AttrTypeKind::Bool => "Bool".to_string(),
             AttrTypeKind::Duration => "Duration".to_string(),
             AttrTypeKind::Enum { identity, .. } => identity.to_string(),
-            AttrTypeKind::Custom {
+            AttrTypeKind::String {
                 identity,
                 pattern,
                 length,
                 ..
             } => custom_display_name(identity.as_ref(), pattern.as_deref(), length.as_ref()),
-            AttrTypeKind::List { inner, .. } => format!("List<{}>", inner.type_name()),
+            AttrTypeKind::Int { identity, .. } => identity
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "Int".to_string()),
+            AttrTypeKind::Float { identity, .. } => identity
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "Float".to_string()),
+            AttrTypeKind::List {
+                element_type: inner,
+                ..
+            } => format!("List<{}>", inner.type_name()),
             AttrTypeKind::Map { value: inner, .. } => format!("Map<{}>", inner.type_name()),
             AttrTypeKind::Struct { name, .. } => format!("Struct({})", name),
             AttrTypeKind::Union(types) => {
@@ -2432,7 +2570,19 @@ impl AttributeType {
     /// Used for cross-schema type compatibility: all String-based Custom types
     /// are considered compatible with each other.
     pub fn is_string_based_custom(&self) -> bool {
-        matches!(&self.kind, AttrTypeKind::Custom { base, .. } if matches!(base.kind, AttrTypeKind::String))
+        matches!(
+            &self.kind,
+            AttrTypeKind::String {
+                identity: Some(_),
+                ..
+            } | AttrTypeKind::String {
+                pattern: Some(_),
+                ..
+            } | AttrTypeKind::String {
+                length: Some(_),
+                ..
+            }
+        )
     }
 
     /// Check if a value of `self`'s type can be assigned to a sink of
@@ -2494,23 +2644,19 @@ impl AttributeType {
         }
         match (&self.kind, &sink.kind) {
             (
-                Custom {
+                String {
                     identity: Some(s_id),
                     length: s_len,
-                    base: s_base,
+                    pattern: _,
                     ..
                 },
-                Custom {
+                String {
                     identity: Some(k_id),
                     length: k_len,
-                    base: k_base,
+                    pattern: _,
                     ..
                 },
-            ) => {
-                s_id.assignable_to(k_id)
-                    && length_contains(s_len.as_ref(), k_len.as_ref())
-                    && s_base.is_assignable_to(k_base)
-            }
+            ) => s_id.assignable_to(k_id) && length_contains(s_len.as_ref(), k_len.as_ref()),
             (Enum { identity: s_id, .. }, Enum { identity: k_id, .. })
                 if !s_id.assignable_to(k_id) =>
             {
@@ -2530,39 +2676,74 @@ impl AttributeType {
             ) => s_id.assignable_to(k_id) && s_base.is_assignable_to(k_base),
             // Anonymous source → identified sink has no proof of identity.
             (
-                Custom { identity: None, .. },
-                Custom {
+                String { identity: None, .. }
+                | Int { identity: None, .. }
+                | Float { identity: None, .. },
+                String {
+                    identity: Some(_), ..
+                }
+                | Int {
+                    identity: Some(_), ..
+                }
+                | Float {
                     identity: Some(_), ..
                 },
             ) => false,
             (
-                Custom {
+                String {
                     pattern: s_pat,
                     length: s_len,
-                    base: s_base,
                     ..
                 },
-                Custom {
+                String {
                     pattern: k_pat,
                     length: k_len,
-                    base: k_base,
                     ..
                 },
             ) => {
-                if let (Some(sp), Some(kp)) = (s_pat, k_pat) {
-                    if sp != kp {
-                        return false;
-                    }
-                } else if k_pat.is_some() && s_pat.is_none() {
+                if !pattern_compatible(s_pat.as_deref(), k_pat.as_deref()) {
                     return false;
                 }
                 if !length_contains(s_len.as_ref(), k_len.as_ref()) {
                     return false;
                 }
-                s_base.is_assignable_to(k_base)
+                true
             }
-            (Custom { base, .. }, _non_custom_kind) => base.is_assignable_to(sink),
-            (_non_custom, Custom { .. }) => false,
+            (
+                Int {
+                    identity: Some(s_id),
+                    range: s_range,
+                    ..
+                },
+                Int {
+                    identity: Some(k_id),
+                    range: k_range,
+                    ..
+                },
+            ) => s_id.assignable_to(k_id) && i64_range_contains(s_range.as_ref(), k_range.as_ref()),
+            (Int { range: s_range, .. }, Int { range: k_range, .. }) => {
+                i64_range_contains(s_range.as_ref(), k_range.as_ref())
+            }
+            (
+                Float {
+                    identity: Some(s_id),
+                    range: s_range,
+                    ..
+                },
+                Float {
+                    identity: Some(k_id),
+                    range: k_range,
+                    ..
+                },
+            ) => s_id.assignable_to(k_id) && f64_range_contains(s_range.as_ref(), k_range.as_ref()),
+            (Float { range: s_range, .. }, Float { range: k_range, .. }) => {
+                f64_range_contains(s_range.as_ref(), k_range.as_ref())
+            }
+            (String { .. }, _) | (Int { .. }, _) | (Float { .. }, _)
+                if self.type_name() != sink.type_name() =>
+            {
+                false
+            }
             (_a, _b) => self.type_name() == sink.type_name(),
         }
     }
@@ -2607,6 +2788,89 @@ fn validation_error_message(err: TypeError) -> String {
     }
 }
 
+fn validate_string_refinement(
+    identity: Option<&TypeIdentity>,
+    pattern: Option<&str>,
+    length: Option<(Option<u64>, Option<u64>)>,
+    s: &str,
+) -> Result<(), TypeError> {
+    let type_name = identity.map(|id| id.kind.clone());
+    if let Some(pattern) = pattern
+        && let Ok(re) = regex::Regex::new(pattern)
+        && !re.is_match(s)
+    {
+        return Err(TypeError::PatternMismatch {
+            value: s.to_string(),
+            pattern: pattern.to_string(),
+            attribute: None,
+            type_name,
+        });
+    }
+    if let Some((min, max)) = length {
+        let count = s.chars().count();
+        let count_u64 = count as u64;
+        if min.is_some_and(|min| count_u64 < min) || max.is_some_and(|max| count_u64 > max) {
+            return Err(TypeError::LengthOutOfRange {
+                value: s.to_string(),
+                length: count,
+                min,
+                max,
+                attribute: None,
+                type_name,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_list_length(
+    length: Option<(Option<u64>, Option<u64>)>,
+    count: usize,
+) -> Result<(), TypeError> {
+    if let Some((min, max)) = length {
+        let count_u64 = count as u64;
+        if min.is_some_and(|min| count_u64 < min) || max.is_some_and(|max| count_u64 > max) {
+            return Err(TypeError::LengthOutOfRange {
+                value: format!("{count} items"),
+                length: count,
+                min,
+                max,
+                attribute: None,
+                type_name: Some("List".to_string()),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_int_range(
+    range: Option<(Option<i64>, Option<i64>)>,
+    value: i64,
+) -> Result<(), TypeError> {
+    if let Some((min, max)) = range
+        && (min.is_some_and(|min| value < min) || max.is_some_and(|max| value > max))
+    {
+        return Err(TypeError::ValidationFailed {
+            message: format!("value {value} is outside allowed range {min:?}..={max:?}"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_float_range(
+    range: Option<(Option<f64>, Option<f64>)>,
+    value: f64,
+) -> Result<(), TypeError> {
+    if let Some((min, max)) = range
+        && (min.is_some_and(|min| value < min) || max.is_some_and(|max| value > max))
+    {
+        return Err(TypeError::ValidationFailed {
+            message: format!("value {value} is outside allowed range {min:?}..={max:?}"),
+        });
+    }
+    Ok(())
+}
+
 /// Rank a Union member against a runtime value by structural distance:
 /// how close the member's outer constructor is to the input's. Higher
 /// is closer; 0 means no shared structure. Used by `validate_union`
@@ -2638,9 +2902,9 @@ pub(crate) fn union_member_score(member: &AttributeType, value: ConcreteValueRef
         // still routes through this member so that error reaches the
         // caller instead of a generic `TypeMismatch`.
         (AT::Map { .. }, ConcreteValueRef::Map(_))
-        | (AT::String, ConcreteValueRef::String(_))
-        | (AT::Int, ConcreteValueRef::Int(_))
-        | (AT::Float, ConcreteValueRef::Float(_))
+        | (AT::String { .. }, ConcreteValueRef::String(_))
+        | (AT::Int { .. }, ConcreteValueRef::Int(_))
+        | (AT::Float { .. }, ConcreteValueRef::Float(_))
         | (AT::Bool, ConcreteValueRef::Bool(_))
         | (AT::Enum { .. }, ConcreteValueRef::String(_))
         | (AT::Enum { .. }, ConcreteValueRef::EnumIdentifier(_)) => 80,
@@ -2653,7 +2917,13 @@ pub(crate) fn union_member_score(member: &AttributeType, value: ConcreteValueRef
         // re-projecting the first element through `as_concrete()` —
         // a deferred element contributes no bonus (the projection
         // returns `None`).
-        (AT::List { inner, .. }, ConcreteValueRef::List(items)) => {
+        (
+            AT::List {
+                element_type: inner,
+                ..
+            },
+            ConcreteValueRef::List(items),
+        ) => {
             let inner_bonus = items
                 .first()
                 .and_then(|first| first.as_concrete())
@@ -2661,11 +2931,6 @@ pub(crate) fn union_member_score(member: &AttributeType, value: ConcreteValueRef
                 .unwrap_or(0);
             80 + inner_bonus
         }
-        // Custom defers to its `base`. A Custom with a Struct/Int/
-        // String base ranks the same as that base would — its
-        // validator's `ValidationFailed` message is then the one
-        // `validate_union` surfaces on failure.
-        (AT::Custom { base, .. }, v) => union_member_score(base, v),
         // Nested Union: recurse and take the best inner match.
         (AT::Union(inner), v) => inner
             .iter()
@@ -2759,6 +3024,48 @@ fn length_contains(
     let s_max = s_max.unwrap_or(u64::MAX);
     let k_min = k_min.unwrap_or(0);
     let k_max = k_max.unwrap_or(u64::MAX);
+    k_min <= s_min && s_max <= k_max
+}
+
+fn pattern_compatible(source: Option<&str>, sink: Option<&str>) -> bool {
+    match (source, sink) {
+        (_, None) => true,
+        (Some(source), Some(sink)) => source == sink,
+        (None, Some(_)) => false,
+    }
+}
+
+fn i64_range_contains(
+    source: Option<&(Option<i64>, Option<i64>)>,
+    sink: Option<&(Option<i64>, Option<i64>)>,
+) -> bool {
+    let Some((s_min, s_max)) = source else {
+        return sink.is_none();
+    };
+    let Some((k_min, k_max)) = sink else {
+        return true;
+    };
+    let s_min = s_min.unwrap_or(i64::MIN);
+    let s_max = s_max.unwrap_or(i64::MAX);
+    let k_min = k_min.unwrap_or(i64::MIN);
+    let k_max = k_max.unwrap_or(i64::MAX);
+    k_min <= s_min && s_max <= k_max
+}
+
+fn f64_range_contains(
+    source: Option<&(Option<f64>, Option<f64>)>,
+    sink: Option<&(Option<f64>, Option<f64>)>,
+) -> bool {
+    let Some((s_min, s_max)) = source else {
+        return sink.is_none();
+    };
+    let Some((k_min, k_max)) = sink else {
+        return true;
+    };
+    let s_min = s_min.unwrap_or(f64::NEG_INFINITY);
+    let s_max = s_max.unwrap_or(f64::INFINITY);
+    let k_min = k_min.unwrap_or(f64::NEG_INFINITY);
+    let k_max = k_max.unwrap_or(f64::INFINITY);
     k_min <= s_min && s_max <= k_max
 }
 
@@ -3830,10 +4137,10 @@ impl ResourceSchema {
                     }
                 }
             }
-            Shape::Custom { base, .. } => {
-                self.append_enum_values_from_top_level_attr_type(base, input, out);
-            }
-            Shape::List { inner, .. } => {
+            Shape::List {
+                element_type: inner,
+                ..
+            } => {
                 self.append_enum_values_from_top_level_attr_type(inner, input, out);
             }
             Shape::Map { value, .. } => {
@@ -3846,9 +4153,9 @@ impl ResourceSchema {
                     }
                 }
             }
-            Shape::String
-            | Shape::Int
-            | Shape::Float
+            Shape::String { .. }
+            | Shape::Int { .. }
+            | Shape::Float { .. }
             | Shape::Bool
             | Shape::Duration
             | Shape::Struct { .. } => {}
@@ -4045,7 +4352,7 @@ impl ResourceSchema {
     }
 
     /// As [`validate_with_origins`], but also runs `lookup` on every
-    /// `AttrTypeKind::Custom` value reached during traversal so
+    /// refined primitive identity reached during traversal so
     /// provider-supplied validators that the schema itself cannot
     /// carry (WASM plugin path) still get to reject bad values.
     pub fn validate_with_origins_and_lookup(
@@ -4192,7 +4499,10 @@ fn collect_block_names_from_type(attr_type: &AttributeType, result: &mut HashMap
                 collect_block_names_from_type(&field.field_type, result);
             }
         }
-        AttrTypeKind::List { inner, .. } => {
+        AttrTypeKind::List {
+            element_type: inner,
+            ..
+        } => {
             collect_block_names_from_type(inner, result);
         }
         AttrTypeKind::Map { value: inner, .. } => {
@@ -4207,13 +4517,12 @@ fn collect_block_names_from_type(attr_type: &AttributeType, result: &mut HashMap
         // entries directly to avoid infinite recursion on cyclic
         // schemas (carina#3340).
         AttrTypeKind::Ref(_) => {}
-        AttrTypeKind::String
-        | AttrTypeKind::Int
-        | AttrTypeKind::Float
+        AttrTypeKind::String { .. }
+        | AttrTypeKind::Int { .. }
+        | AttrTypeKind::Float { .. }
         | AttrTypeKind::Bool
         | AttrTypeKind::Duration
-        | AttrTypeKind::Enum { .. }
-        | AttrTypeKind::Custom { .. } => {}
+        | AttrTypeKind::Enum { .. } => {}
     }
 }
 
@@ -4314,7 +4623,10 @@ fn recurse_block_names_into_value(
                 resolve_block_names_in_map(inner_map, inner, defs, resource_id, errors);
             }
         }
-        Shape::List { inner, .. } => {
+        Shape::List {
+            element_type: inner,
+            ..
+        } => {
             // `List<Ref>`: peel the element type too via `shape(defs)`
             // so the walk reaches the underlying struct fields.
             if let Shape::Struct { .. } = inner.shape_with_defs(defs)

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2860,12 +2860,18 @@ fn resolved_attr_type_never_returns_ref_after_peel() {
         !matches!(resolved.as_attr().kind(), AttrTypeKind::Ref(_)),
         "resolve_refs must never return a Ref after peeling"
     );
-    assert!(matches!(resolved.as_attr().kind(), AttrTypeKind::String));
+    assert!(matches!(
+        resolved.as_attr().kind(),
+        AttrTypeKind::String { .. }
+    ));
 
     // Non-Ref input is returned as-is (identity behavior).
     let plain = AttributeType::int();
     let resolved = plain.resolve_refs_with_defs(&defs);
-    assert!(matches!(resolved.as_attr().kind(), AttrTypeKind::Int));
+    assert!(matches!(
+        resolved.as_attr().kind(),
+        AttrTypeKind::Int { .. }
+    ));
 }
 
 #[test]
@@ -2903,9 +2909,13 @@ fn shape_ref_free_projects_non_ref_shape() {
         .shape_ref_free()
         .expect("non-Ref shape is projectable")
     {
-        Shape::List { inner, ordered } => {
+        Shape::List {
+            element_type: inner,
+            ordered,
+            ..
+        } => {
             assert!(ordered);
-            assert!(matches!(inner.kind(), AttrTypeKind::String));
+            assert!(matches!(inner.kind(), AttrTypeKind::String { .. }));
         }
         other => panic!("expected list shape, got {other:?}"),
     }
@@ -2936,11 +2946,11 @@ mod projection_api_guard {
         let attr_type = AttributeType::string();
         assert!(matches!(
             attr_type.shape_ref_free().expect("string is Ref-free"),
-            Shape::String
+            Shape::String { .. }
         ));
 
         let schema = Schema::flat(AttributeType::int());
-        assert!(matches!(schema.shape_of(&schema.root), Shape::Int));
+        assert!(matches!(schema.shape_of(&schema.root), Shape::Int { .. }));
     }
 }
 
@@ -3665,7 +3675,7 @@ fn custom_carries_semantic_name_pattern_length() {
         None,
     );
     match t.kind() {
-        AttrTypeKind::Custom {
+        AttrTypeKind::String {
             identity,
             pattern,
             length,
@@ -3675,7 +3685,7 @@ fn custom_carries_semantic_name_pattern_length() {
             assert_eq!(pattern.as_deref(), Some("^vpc-[a-f0-9]+$"));
             assert_eq!(*length, Some((Some(8), Some(21))));
         }
-        _ => panic!("expected Custom"),
+        _ => panic!("expected refined String"),
     }
 }
 
@@ -3840,7 +3850,7 @@ fn custom_length_enforces_minimum_bound() {
 }
 
 #[test]
-fn custom_non_string_base_skips_pattern_and_length() {
+fn custom_int_base_maps_length_to_range() {
     let attr = AttributeType::custom(
         None,
         AttributeType::int(),
@@ -3851,8 +3861,12 @@ fn custom_non_string_base_skips_pattern_and_length() {
     );
 
     assert!(
-        attr.validate(&Value::Concrete(ConcreteValue::Int(5)))
+        attr.validate(&Value::Concrete(ConcreteValue::Int(150)))
             .is_ok()
+    );
+    assert!(
+        attr.validate(&Value::Concrete(ConcreteValue::Int(5)))
+            .is_err()
     );
 }
 
@@ -3980,13 +3994,12 @@ fn validate_email_function_directly() {
 fn validate_email_type() {
     let t = types::email();
 
-    // Type identity: Custom with kind "Email" and String base
+    // Type identity: refined String with kind "Email"
     match t.kind() {
-        AttrTypeKind::Custom { identity, base, .. } => {
+        AttrTypeKind::String { identity, .. } => {
             assert_eq!(identity.as_ref().map(|id| id.kind.as_str()), Some("Email"));
-            assert!(matches!(base.kind(), AttrTypeKind::String));
         }
-        other => panic!("Expected AttributeType::Custom, got: {:?}", other),
+        other => panic!("Expected refined String, got: {:?}", other),
     }
 
     // Valid emails
@@ -6050,9 +6063,12 @@ fn raw_shape_passes_through_non_ref_variants() {
     // Sanity check that non-Ref variants still project correctly.
     assert!(matches!(
         AttributeType::string().raw_shape(),
-        RawShape::String
+        RawShape::String { .. }
     ));
-    assert!(matches!(AttributeType::int().raw_shape(), RawShape::Int));
+    assert!(matches!(
+        AttributeType::int().raw_shape(),
+        RawShape::Int { .. }
+    ));
     assert!(matches!(AttributeType::bool().raw_shape(), RawShape::Bool));
     match AttributeType::list(AttributeType::string()).raw_shape() {
         RawShape::List { ordered, .. } => assert!(ordered),

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -622,7 +622,10 @@ fn walk_value_against_type(
             // element against the same expected type — the leaf-ref
             // comparison will fire if the element doesn't fit.
             let inner = match expected_shape {
-                crate::schema::Shape::List { inner, .. } => inner,
+                crate::schema::Shape::List {
+                    element_type: inner,
+                    ..
+                } => inner,
                 _ => expected,
             };
             for item in items {
@@ -1939,7 +1942,7 @@ mod tests {
         assert!(matches!(errs[0].export_type, TypeExpr::Int));
         assert!(matches!(
             errs[0].expected_type.kind(),
-            crate::schema::AttrTypeKind::String
+            crate::schema::AttrTypeKind::String { .. }
         ));
         assert!(errs[0].diagnostic_message().contains("String"));
     }

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -765,7 +765,10 @@ fn resolve_enum_value_recursive_projected(
             }
             changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
         }
-        crate::schema::Shape::List { inner, .. } => {
+        crate::schema::Shape::List {
+            element_type: inner,
+            ..
+        } => {
             let Value::Concrete(ConcreteValue::List(items)) = value else {
                 return None;
             };
@@ -1045,7 +1048,10 @@ fn lift_enum_leaves_projected(
             }
             changed.then_some(Value::Concrete(ConcreteValue::Map(rewritten)))
         }
-        crate::schema::Shape::List { inner, .. } => {
+        crate::schema::Shape::List {
+            element_type: inner,
+            ..
+        } => {
             let Value::Concrete(ConcreteValue::List(items)) = value else {
                 return None;
             };

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -275,7 +275,13 @@ fn path_traverses_deferred(
         // bail out at the first cycle hop (carina#3340).
         let resolved = current_type.resolve_refs_with_defs(defs).as_attr();
         match (resolved.kind(), segment) {
-            (AttrTypeKind::List { inner, .. }, PathSegment::Subscript { .. }) => {
+            (
+                AttrTypeKind::List {
+                    element_type: inner,
+                    ..
+                },
+                PathSegment::Subscript { .. },
+            ) => {
                 current_type = inner;
             }
             (AttrTypeKind::Map { value, .. }, PathSegment::Subscript { .. }) => {

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -519,7 +519,10 @@ fn infer_resource_ref_with_visiting(
                 PathSegment::Subscript {
                     index: Subscript::Int { .. },
                 },
-                AttrTypeKind::List { inner, .. },
+                AttrTypeKind::List {
+                    element_type: inner,
+                    ..
+                },
             ) => inner,
             (
                 PathSegment::Subscript {
@@ -617,12 +620,13 @@ fn descend_struct_field<'a>(
 ///   unification.
 fn attribute_type_to_type_expr(attr_type: &AttributeType) -> TypeExpr {
     match attr_type.kind() {
-        AttrTypeKind::String => TypeExpr::String,
-        AttrTypeKind::Int => TypeExpr::Int,
-        AttrTypeKind::Float => TypeExpr::Float,
-        AttrTypeKind::Bool => TypeExpr::Bool,
-        AttrTypeKind::Duration => TypeExpr::Duration,
-        AttrTypeKind::Custom {
+        AttrTypeKind::String {
+            identity: Some(id), ..
+        }
+        | AttrTypeKind::Int {
+            identity: Some(id), ..
+        }
+        | AttrTypeKind::Float {
             identity: Some(id), ..
         } => match &id.provider {
             Some(provider) => TypeExpr::SchemaType {
@@ -632,7 +636,11 @@ fn attribute_type_to_type_expr(attr_type: &AttributeType) -> TypeExpr {
             },
             None => TypeExpr::Simple(crate::parser::pascal_to_snake(&id.kind)),
         },
-        AttrTypeKind::Custom { base, .. } => attribute_type_to_type_expr(base),
+        AttrTypeKind::String { .. } => TypeExpr::String,
+        AttrTypeKind::Int { .. } => TypeExpr::Int,
+        AttrTypeKind::Float { .. } => TypeExpr::Float,
+        AttrTypeKind::Bool => TypeExpr::Bool,
+        AttrTypeKind::Duration => TypeExpr::Duration,
         AttrTypeKind::Enum {
             identity,
             values,
@@ -650,9 +658,10 @@ fn attribute_type_to_type_expr(attr_type: &AttributeType) -> TypeExpr {
             }
         }
         AttrTypeKind::Enum { .. } => TypeExpr::String,
-        AttrTypeKind::List { inner, .. } => {
-            TypeExpr::List(Box::new(attribute_type_to_type_expr(inner)))
-        }
+        AttrTypeKind::List {
+            element_type: inner,
+            ..
+        } => TypeExpr::List(Box::new(attribute_type_to_type_expr(inner))),
         AttrTypeKind::Map { value, .. } => {
             TypeExpr::Map(Box::new(attribute_type_to_type_expr(value)))
         }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -14,9 +14,7 @@ use crate::parser::{
 };
 use crate::provider::ProviderFactory;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
-use crate::schema::{
-    AttrTypeKind, AttributeType, SchemaRegistry, Shape, TypeIdentity, suggest_similar_name,
-};
+use crate::schema::{AttributeType, SchemaRegistry, Shape, TypeIdentity, suggest_similar_name};
 
 /// Render the trailing `" Did you mean 'X'?"` segment for an unknown
 /// name in a diagnostic, or an empty string when nothing close enough
@@ -492,8 +490,8 @@ pub fn is_type_expr_compatible_with_schema(
             is_string_compatible_type(attr_type, defs)
         }
         TypeExpr::Bool => matches!(attr_type.shape_with_defs(defs), Shape::Bool),
-        TypeExpr::Int => matches!(attr_type.shape_with_defs(defs), Shape::Int),
-        TypeExpr::Float => matches!(attr_type.shape_with_defs(defs), Shape::Float),
+        TypeExpr::Int => matches!(attr_type.shape_with_defs(defs), Shape::Int { .. }),
+        TypeExpr::Float => matches!(attr_type.shape_with_defs(defs), Shape::Float { .. }),
         TypeExpr::Duration => matches!(attr_type.shape_with_defs(defs), Shape::Duration),
         TypeExpr::Simple(name) => {
             // Two compatibility directions both succeed:
@@ -516,18 +514,25 @@ pub fn is_type_expr_compatible_with_schema(
             //
             // The walk traverses post-Ref-peel shapes so a `Ref`
             // pointing at a `Custom` chain is followed correctly.
-            let mut current: &AttributeType = attr_type;
-            loop {
-                let resolved = current.resolve_refs_with_defs(defs);
-                let resolved_attr = resolved.as_attr();
-                let type_snake = crate::parser::pascal_to_snake(&resolved_attr.type_name());
-                if type_snake == *name {
+            let resolved = attr_type.resolve_refs_with_defs(defs);
+            let resolved_attr = resolved.as_attr();
+            let type_snake = crate::parser::pascal_to_snake(&resolved_attr.type_name());
+            if type_snake == *name {
+                return true;
+            }
+            match resolved_attr.shape_with_defs(defs) {
+                Shape::String {
+                    identity: Some(id), ..
+                }
+                | Shape::Int {
+                    identity: Some(id), ..
+                }
+                | Shape::Float {
+                    identity: Some(id), ..
+                } if crate::parser::pascal_to_snake(&id.kind) == *name => {
                     return true;
                 }
-                match resolved_attr.kind() {
-                    AttrTypeKind::Custom { base, .. } => current = base.as_ref(),
-                    _ => break,
-                }
+                _ => {}
             }
             if is_plain_string_or_string_union(attr_type, defs) {
                 return true;
@@ -548,15 +553,13 @@ pub fn is_type_expr_compatible_with_schema(
                     .expect("Shape::Union must expose union members internally");
                 let has_plain_string = members
                     .iter()
-                    .any(|m| matches!(m.shape_with_defs(defs), Shape::String));
+                    .any(|m| is_plain_string_or_string_union(m, defs));
                 let others_shape_disjoint = members.iter().all(|m| {
-                    matches!(
-                        m.shape_with_defs(defs),
-                        Shape::String
-                            | Shape::List { .. }
-                            | Shape::Map { .. }
-                            | Shape::Struct { .. }
-                    )
+                    is_plain_string_or_string_union(m, defs)
+                        || matches!(
+                            m.shape_with_defs(defs),
+                            Shape::List { .. } | Shape::Map { .. } | Shape::Struct { .. }
+                        )
                 });
                 if has_plain_string && others_shape_disjoint {
                     return true;
@@ -566,7 +569,7 @@ pub fn is_type_expr_compatible_with_schema(
         }
         TypeExpr::List(inner) => match attr_type.shape_with_defs(defs) {
             Shape::List {
-                inner: schema_inner,
+                element_type: schema_inner,
                 ..
             } => is_type_expr_compatible_with_schema(inner, schema_inner, defs),
             _ => false,
@@ -636,13 +639,13 @@ pub fn is_string_compatible_type(
     defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> bool {
     match attr_type.shape_with_defs(defs) {
-        Shape::String | Shape::Custom { .. } | Shape::Enum { .. } => true,
+        Shape::String { .. } | Shape::Enum { .. } => true,
         Shape::Union => crate::schema::union_members_with_defs(attr_type, defs)
             .expect("Shape::Union must expose union members internally")
             .iter()
             .all(|t| is_string_compatible_type(t, defs)),
-        Shape::Int
-        | Shape::Float
+        Shape::Int { .. }
+        | Shape::Float { .. }
         | Shape::Bool
         | Shape::Duration
         | Shape::List { .. }
@@ -661,16 +664,21 @@ fn is_plain_string_or_string_union(
     defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> bool {
     match attr_type.shape_with_defs(defs) {
-        Shape::String => true,
+        Shape::String {
+            identity: None,
+            pattern: None,
+            length: None,
+            ..
+        } => true,
+        Shape::String { .. } => false,
         Shape::Union => crate::schema::union_members_with_defs(attr_type, defs)
             .expect("Shape::Union must expose union members internally")
             .iter()
             .all(|t| is_plain_string_or_string_union(t, defs)),
-        Shape::Int
-        | Shape::Float
+        Shape::Int { .. }
+        | Shape::Float { .. }
         | Shape::Bool
         | Shape::Duration
-        | Shape::Custom { .. }
         | Shape::Enum { .. }
         | Shape::List { .. }
         | Shape::Map { .. }
@@ -703,17 +711,16 @@ fn attr_type_demands_specific_custom(
     defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> bool {
     match attr_type.shape_with_defs(defs) {
-        Shape::Custom {
+        Shape::String {
             identity: Some(_), ..
         } => true,
-        Shape::Custom { identity: None, .. } => false,
+        Shape::String { identity: None, .. } => false,
         Shape::Union => crate::schema::union_members_with_defs(attr_type, defs)
             .expect("Shape::Union must expose union members internally")
             .iter()
             .any(|t| attr_type_demands_specific_custom(t, defs)),
-        Shape::String
-        | Shape::Int
-        | Shape::Float
+        Shape::Int { .. }
+        | Shape::Float { .. }
         | Shape::Bool
         | Shape::Duration
         | Shape::Enum { .. }
@@ -1539,7 +1546,10 @@ pub(crate) fn narrow_attribute_type<'a>(
                 PathSegment::Subscript {
                     index: Subscript::Int { .. },
                 },
-                Shape::List { inner, .. },
+                Shape::List {
+                    element_type: inner,
+                    ..
+                },
             ) => inner,
             (
                 PathSegment::Subscript {

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1783,17 +1783,10 @@ fn validate_export_params_rejects_type_mismatch() {
 
 #[test]
 fn type_compat_subtype_accepted() {
-    // arn accepts KmsKeyArn (subtype via base chain: KmsKeyArn → Arn)
+    // arn accepts a provider-scoped KMS key ARN (narrower segments, same kind).
     let kms_key_arn = AttributeType::custom(
-        Some(TypeIdentity::bare("KmsKeyArn")),
-        AttributeType::custom(
-            Some(TypeIdentity::bare("Arn")),
-            AttributeType::string(),
-            None,
-            None,
-            crate::schema::legacy_validator(|_| Ok(())),
-            None,
-        ),
+        Some(TypeIdentity::new(Some("aws"), ["kms", "Key"], "Arn")),
+        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -1808,17 +1801,10 @@ fn type_compat_subtype_accepted() {
 
 #[test]
 fn type_compat_sibling_rejected() {
-    // kms_key_arn rejects IamRoleArn (sibling: IamRoleArn → Arn, not KmsKeyArn)
+    // kms_key_arn rejects an IAM role ARN sibling.
     let iam_role_arn = AttributeType::custom(
-        Some(TypeIdentity::bare("IamRoleArn")),
-        AttributeType::custom(
-            Some(TypeIdentity::bare("Arn")),
-            AttributeType::string(),
-            None,
-            None,
-            crate::schema::legacy_validator(|_| Ok(())),
-            None,
-        ),
+        Some(TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn")),
+        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -1833,24 +1819,17 @@ fn type_compat_sibling_rejected() {
 
 #[test]
 fn type_compat_resource_id_subtype() {
-    // aws_resource_id accepts VpcId (subtype)
+    // resource_id accepts VPC resource IDs (narrower segments, same kind).
     let vpc_id = AttributeType::custom(
-        Some(TypeIdentity::bare("VpcId")),
-        AttributeType::custom(
-            Some(TypeIdentity::bare("AwsResourceId")),
-            AttributeType::string(),
-            None,
-            None,
-            crate::schema::legacy_validator(|_| Ok(())),
-            None,
-        ),
+        Some(TypeIdentity::new(Some("aws"), ["ec2", "Vpc"], "ResourceId")),
+        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
         None,
     );
     assert!(is_type_expr_compatible_with_schema(
-        &TypeExpr::Simple("aws_resource_id".to_string()),
+        &TypeExpr::Simple("resource_id".to_string()),
         &vpc_id,
         crate::schema::empty_defs_for_schema_walks(),
     ));

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1333,9 +1333,14 @@ fn is_string_or_list_of_strings(attr_type: &AttributeType) -> bool {
     let mut has_list_of_string = false;
     for m in members {
         match &peel_custom(m).kind {
-            AttrTypeKind::String => has_string = true,
-            AttrTypeKind::List { inner, .. }
-                if matches!(&peel_custom(inner.as_ref()).kind, AttrTypeKind::String) =>
+            AttrTypeKind::String { .. } => has_string = true,
+            AttrTypeKind::List {
+                element_type: inner,
+                ..
+            } if matches!(
+                &peel_custom(inner.as_ref()).kind,
+                AttrTypeKind::String { .. }
+            ) =>
             {
                 has_list_of_string = true;
             }
@@ -1346,11 +1351,7 @@ fn is_string_or_list_of_strings(attr_type: &AttributeType) -> bool {
 }
 
 fn peel_custom(t: &AttributeType) -> &AttributeType {
-    let mut cur = t;
-    while let AttrTypeKind::Custom { base, .. } = &cur.kind {
-        cur = base.as_ref();
-    }
-    cur
+    t
 }
 
 /// Convert `value` to the canonical `Value::Concrete(ConcreteValue::StringList)` form when
@@ -1393,7 +1394,13 @@ pub(crate) fn canonicalize_with_type(
     // passed Ref-typed values through without canonicalization —
     // exactly the carina#3340 / carina#3349 bug class.
     match (value, unwrapped.shape_with_defs(defs)) {
-        (Value::Concrete(ConcreteValue::List(items)), crate::schema::Shape::List { inner, .. }) => {
+        (
+            Value::Concrete(ConcreteValue::List(items)),
+            crate::schema::Shape::List {
+                element_type: inner,
+                ..
+            },
+        ) => {
             let canonicalized = items
                 .into_iter()
                 .map(|v| canonicalize_with_type(v, inner, defs))
@@ -3876,16 +3883,8 @@ mod tests {
     }
 
     #[test]
-    fn canonicalize_through_custom_wrapper() {
-        // Custom wrappers must be transparent for type matching.
-        let t = AttributeType::custom(
-            Some(crate::schema::TypeIdentity::bare("PolicyConditionValue")),
-            string_or_list_of_strings(),
-            None,
-            None,
-            std::sync::Arc::new(|_| Ok(())),
-            None,
-        );
+    fn canonicalize_string_or_list_union() {
+        let t = string_or_list_of_strings();
         let v = Value::Concrete(ConcreteValue::String("x".to_string()));
         let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -671,7 +671,10 @@ impl CompletionProvider {
         // because `shape_of` walks `Ref` against the schema's defs.
         match schema.shape_of(attr_type) {
             Shape::Struct { .. } => schema.struct_fields_with_budget(attr_type, budget),
-            Shape::List { inner, .. } => match schema.shape_of(inner) {
+            Shape::List {
+                element_type: inner,
+                ..
+            } => match schema.shape_of(inner) {
                 Shape::Struct { .. } => schema.struct_fields_with_budget(inner, budget),
                 _ => None,
             },

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -94,7 +94,7 @@ impl CompletionProvider {
                 if let Some(bn) = &attr.block_name
                     && matches!(
                         schema.shape_of(&attr.attr_type),
-                        Shape::List { inner, .. } if matches!(
+                        Shape::List { element_type: inner, .. } if matches!(
                             schema.shape_of(inner),
                             Shape::Struct { .. }
                         )
@@ -544,11 +544,17 @@ impl CompletionProvider {
         }
     }
 
-    /// Extract the Custom type's kind name from an AttributeType, if it
-    /// is a Custom type with a structured identity.
+    /// Extract a refined type's kind name from an AttributeType, if it
+    /// has a structured identity.
     fn extract_custom_type_name(attr_type: &AttributeType) -> Option<&str> {
         match attr_type.shape_ref_free() {
-            Ok(Shape::Custom {
+            Ok(Shape::String {
+                identity: Some(id), ..
+            })
+            | Ok(Shape::Int {
+                identity: Some(id), ..
+            })
+            | Ok(Shape::Float {
                 identity: Some(id), ..
             }) => Some(&id.kind),
             Ok(_) | Err(_) => None,
@@ -624,10 +630,10 @@ impl CompletionProvider {
                         .unwrap_or_default(),
                 }
             }
-            Shape::Int => {
+            Shape::Int { .. } => {
                 vec![] // No specific completions for integers
             }
-            Shape::Float => {
+            Shape::Float { .. } => {
                 vec![] // No specific completions for floats
             }
             // Curated unit-snippet completions for Duration attributes,
@@ -662,10 +668,10 @@ impl CompletionProvider {
                     ..Default::default()
                 },
             ],
-            Shape::Custom {
+            Shape::String {
                 identity: Some(id), ..
             } if id.kind == "Cidr" || id.kind == "Ipv4Cidr" => self.cidr_completions(),
-            Shape::Custom {
+            Shape::String {
                 identity: Some(id), ..
             } if id.kind == "Ipv6Cidr" => self.ipv6_cidr_completions(),
             // Generic ARN snippet only for the bare `Arn` type. Specific
@@ -677,7 +683,7 @@ impl CompletionProvider {
             // family snippets can be added as additional arms later if
             // the per-type formats are useful enough to justify the
             // surface. See #2621.
-            Shape::Custom {
+            Shape::String {
                 identity: Some(id), ..
             } if id.kind == "Arn" => self.arn_completions(),
             // AvailabilityZone is split into two distinct types post-S2.5:
@@ -686,7 +692,7 @@ impl CompletionProvider {
             // lives in `segments`. We surface AZ-letter completions only for
             // zone-name typed sinks — zone-id values look like `usw2-az1` and
             // are not derivable from region code + letter.
-            Shape::Custom {
+            Shape::String {
                 identity: Some(id), ..
             } if id.kind == "ZoneName"
                 && id.segments.first().map(String::as_str) == Some("AvailabilityZone") =>
@@ -694,9 +700,10 @@ impl CompletionProvider {
                 self.availability_zone_completions(id)
             }
             // List(non-Struct): delegate to inner type completions
-            Shape::List { inner, .. } => {
-                self.completions_for_type_with_budget(inner, resource_type, budget)
-            }
+            Shape::List {
+                element_type: inner,
+                ..
+            } => self.completions_for_type_with_budget(inner, resource_type, budget),
             // Map: delegate to inner value type completions
             Shape::Map { value: inner, .. } => {
                 self.completions_for_type_with_budget(inner, resource_type, budget)
@@ -1301,7 +1308,13 @@ impl CompletionProvider {
         };
         let effective = if in_nested {
             match annotation.shape_ref_free() {
-                Ok(Shape::List { inner, .. } | Shape::Map { value: inner, .. }) => inner.clone(),
+                Ok(
+                    Shape::List {
+                        element_type: inner,
+                        ..
+                    }
+                    | Shape::Map { value: inner, .. },
+                ) => inner.clone(),
                 // Inside `{ ... }` of a non-collection annotation we
                 // don't know what the user means — fall silent.
                 Ok(_) | Err(_) => return Vec::new(),
@@ -2031,8 +2044,15 @@ fn return_type_fits(
             .ok()
             .flatten()
             .is_some_and(|members| members.iter().any(|m| return_type_fits(ret, m, budget))),
-        Shape::String => matches!(ret, R::String | R::Any),
-        Shape::Int => matches!(ret, R::Int | R::Any),
+        Shape::String {
+            identity: None,
+            pattern: None,
+            length: None,
+            to_dsl: None,
+            ..
+        } => matches!(ret, R::String | R::Any),
+        Shape::String { .. } => false,
+        Shape::Int { .. } => matches!(ret, R::Int | R::Any),
         // No built-in currently returns a Bool; leave as unfit.
         Shape::Bool => false,
         Shape::List { .. } => matches!(ret, R::List | R::Any),
@@ -2041,13 +2061,8 @@ fn return_type_fits(
         // currently produces such values, and `Any` alone doesn't give us
         // enough confidence to suggest one.
         Shape::Enum { .. } => false,
-        // Custom types carry a semantic meaning (Cidr, AwsAccountId, Arn,
-        // …) that built-ins don't declare. Not even `Any` fits — we need
-        // a semantic return annotation before a built-in can be suggested
-        // here.
-        Shape::Custom { .. } => false,
         // Float, Duration, and Struct attributes — no matching built-in today.
-        Shape::Float => false,
+        Shape::Float { .. } => false,
         Shape::Duration => false,
         Shape::Struct { .. } => false,
     }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -613,7 +613,7 @@ impl DiagnosticEngine {
                                 )),
                                 // Int type should not receive String
                                 (
-                                    carina_core::schema::Shape::Int,
+                                    carina_core::schema::Shape::Int { .. },
                                     Value::Concrete(ConcreteValue::String(s)),
                                 ) => Some(format!(
                                     "Type mismatch: expected Int, got String \"{}\".",
@@ -621,7 +621,7 @@ impl DiagnosticEngine {
                                 )),
                                 // Float type should not receive String
                                 (
-                                    carina_core::schema::Shape::Float,
+                                    carina_core::schema::Shape::Float { .. },
                                     Value::Concrete(ConcreteValue::String(s)),
                                 ) => Some(format!(
                                     "Type mismatch: expected Float, got String \"{}\".",
@@ -631,7 +631,15 @@ impl DiagnosticEngine {
                                 (
                                     carina_core::schema::Shape::Union
                                     | carina_core::schema::Shape::Enum { .. }
-                                    | carina_core::schema::Shape::Custom { .. },
+                                    | carina_core::schema::Shape::String {
+                                        identity: Some(_), ..
+                                    }
+                                    | carina_core::schema::Shape::Int {
+                                        identity: Some(_), ..
+                                    }
+                                    | carina_core::schema::Shape::Float {
+                                        identity: Some(_), ..
+                                    },
                                     Value::Deferred(DeferredValue::ResourceRef { path }),
                                 ) => check_resource_ref_type_mismatch(
                                     &binding_schema_map,
@@ -664,8 +672,26 @@ impl DiagnosticEngine {
                                     })
                                 }
                                 (
-                                    carina_core::schema::Shape::Custom {
-                                        identity, validate, ..
+                                    carina_core::schema::Shape::String {
+                                        identity: Some(identity),
+                                        validate,
+                                        ..
+                                    },
+                                    value,
+                                )
+                                | (
+                                    carina_core::schema::Shape::Int {
+                                        identity: Some(identity),
+                                        validate,
+                                        ..
+                                    },
+                                    value,
+                                )
+                                | (
+                                    carina_core::schema::Shape::Float {
+                                        identity: Some(identity),
+                                        validate,
+                                        ..
                                     },
                                     value,
                                 ) => {
@@ -688,15 +714,13 @@ impl DiagnosticEngine {
                                         );
                                         validate(value)
                                             .err()
-                                            .or_else(|| {
-                                                identity.and_then(|id| lookup(id, value).err())
-                                            })
+                                            .or_else(|| lookup(identity, value).err())
                                             .map(|inner_err| inner_err.to_string())
                                     }
                                 }
                                 // String type - check for bare resource binding
                                 (
-                                    carina_core::schema::Shape::String,
+                                    carina_core::schema::Shape::String { .. },
                                     Value::Concrete(ConcreteValue::String(s)),
                                 ) => {
                                     if let Some(binding) =
@@ -721,7 +745,10 @@ impl DiagnosticEngine {
                                 // `List<Ref<Struct>>` correctly defers to
                                 // the struct-validation pass (carina#3349).
                                 (
-                                    carina_core::schema::Shape::List { inner, .. },
+                                    carina_core::schema::Shape::List {
+                                        element_type: inner,
+                                        ..
+                                    },
                                     Value::Concrete(ConcreteValue::List(_)),
                                 ) if !matches!(
                                     schema.shape_of(inner),
@@ -797,7 +824,10 @@ impl DiagnosticEngine {
                             // drop `Ref` and skip the entire pass.
                             let is_struct_shape = match schema.shape_of(&attr_schema.attr_type) {
                                 carina_core::schema::Shape::Struct { .. } => true,
-                                carina_core::schema::Shape::List { inner, .. } => matches!(
+                                carina_core::schema::Shape::List {
+                                    element_type: inner,
+                                    ..
+                                } => matches!(
                                     schema.shape_of(inner),
                                     carina_core::schema::Shape::Struct { .. }
                                 ),

--- a/carina-lsp/src/diagnostics/validation.rs
+++ b/carina-lsp/src/diagnostics/validation.rs
@@ -193,7 +193,7 @@ impl DiagnosticEngine {
             // `List<Ref<Rule>>` field (same bug class as carina#3349).
             let is_list_struct = matches!(
                 schema.shape_of(&attr_schema.attr_type),
-                Shape::List { inner, .. } if matches!(
+                Shape::List { element_type: inner, .. } if matches!(
                     schema.shape_of(inner),
                     Shape::Struct { .. }
                 )

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -1566,7 +1566,7 @@ mod tests {
                 .attr_type
                 .shape_ref_free()
                 .expect("test schema is Ref-free"),
-            carina_core::schema::Shape::String
+            carina_core::schema::Shape::String { .. }
         ));
         assert!(desc_attr.required);
 
@@ -1588,7 +1588,7 @@ mod tests {
                 .attr_type
                 .shape_ref_free()
                 .expect("test schema is Ref-free"),
-            carina_core::schema::Shape::Int
+            carina_core::schema::Shape::Int { .. }
         ));
 
         // Ingress attribute: list with ordered=false, provider_name, block_name, removable
@@ -1603,7 +1603,11 @@ mod tests {
             .shape_ref_free()
             .expect("test schema is Ref-free")
         {
-            carina_core::schema::Shape::List { inner, ordered } => {
+            carina_core::schema::Shape::List {
+                element_type: inner,
+                ordered,
+                ..
+            } => {
                 assert!(!ordered, "list should be unordered");
 
                 // Union inside list
@@ -1624,7 +1628,7 @@ mod tests {
                                         .field_type
                                         .shape_ref_free()
                                         .expect("test schema is Ref-free"),
-                                    carina_core::schema::Shape::Int
+                                    carina_core::schema::Shape::Int { .. }
                                 ));
                                 assert!(from_port.required);
                                 assert_eq!(
@@ -1644,7 +1648,7 @@ mod tests {
                                         .field_type
                                         .shape_ref_free()
                                         .expect("test schema is Ref-free"),
-                                    carina_core::schema::Shape::String
+                                    carina_core::schema::Shape::String { .. }
                                 ));
                                 assert!(protocol.block_name.is_none());
                                 assert!(protocol.provider_name.is_none());
@@ -1657,7 +1661,7 @@ mod tests {
                             members[1]
                                 .shape_ref_free()
                                 .expect("test schema is Ref-free"),
-                            carina_core::schema::Shape::String
+                            carina_core::schema::Shape::String { .. }
                         ));
                     }
                     other => panic!("expected Union inside list, got {:?}", other),
@@ -1923,7 +1927,7 @@ mod tests {
             carina_core::schema::Shape::Enum { base, .. } => {
                 assert!(matches!(
                     base.shape_ref_free().expect("base is Ref-free"),
-                    carina_core::schema::Shape::String
+                    carina_core::schema::Shape::String { .. }
                 ));
             }
             other => panic!("expected Enum, got {other:?}"),
@@ -2081,7 +2085,7 @@ mod tests {
         };
         let core_attr = proto_attr_type_to_core(&proto_attr);
         match core_attr.shape_ref_free().expect("test schema is Ref-free") {
-            carina_core::schema::Shape::Custom {
+            carina_core::schema::Shape::String {
                 identity,
                 pattern,
                 length,


### PR DESCRIPTION
## Summary

First implementation PR in the chain from carina#3429. Removes `AttrTypeKind::Custom` from the core schema model and lifts refinement metadata (`pattern`, `length`, `validate`, `identity`, `to_dsl`) onto the variants that own each concern.

- `AttrTypeKind::Custom` / `Shape::Custom` / `RawShape::Custom` are deleted.
- `String` / `Int` / `Float` / `List` carry their own refinement fields.
- `List.inner` is renamed to `List.element_type` in `AttrTypeKind`, `Shape`, and `RawShape`.
- `AttributeType::custom(...)` remains as a compatibility shim that dispatches on `base` to build the refined variant. All non-test call sites in the workspace pass `to_dsl: None`; the shim asserts on `Some(fn)` to make the unimplementable case explicit.
- `DslTransform` is imported from `carina-provider-protocol` and held directly on the refined `String` variant.
- Validation, assignability, type-name handling, the differ, provider schema walking, LSP completion / diagnostics, and host-side wasm conversion are migrated to the refined shape model.

The provider protocol wire types (`ProtoAttributeType::Custom`) are intentionally left unchanged. Lifting that into `String { to_dsl: Option<DslTransform> }` over the wire is PR2 in the chain.

## Verification

All ran in the worktree:

- `RUSTC_WRAPPER= cargo fmt --all --check`
- `RUSTC_WRAPPER= cargo check --workspace --all-targets`
- `RUSTC_WRAPPER= cargo nextest run --workspace --all-targets` — 3940 passed, 72 skipped
- `RUSTC_WRAPPER= cargo test --doc --workspace`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `scripts/check-provider-boundaries.sh`
- `scripts/check-plan-fixtures.sh`
- `RUSTC_WRAPPER= scripts/check-example-warnings.sh`
- `scripts/check-docs-use-new-spellings.sh`
- `scripts/check-no-direct-resources-access.sh`

## Notes

- `Cargo.toml` / `build.rs` were not touched, so the `cargo build --release` gate is skipped per the verify-protocol guidance.
- The shim's `Some(fn) → panic` arm is reachable only if a future caller passes a non-`None` function pointer; all current call sites (core, LSP, plugin-host wasm conversion) pass `None`. The host-side wasm conversion path explicitly forces `None` because `fn` pointers cannot cross the WASM boundary.

Refs: carina#3429
