### PR TITLE
Implement protocol compatibility for refined attribute types

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1759,6 +1759,24 @@ impl AttributeType {
         }
     }
 
+    /// Create a String type with protocol-carried refinement metadata.
+    pub fn refined_string(
+        identity: Option<TypeIdentity>,
+        pattern: Option<String>,
+        length: Option<(Option<u64>, Option<u64>)>,
+        to_dsl: Option<DslTransform>,
+    ) -> Self {
+        AttributeType {
+            kind: AttrTypeKind::String {
+                identity,
+                pattern,
+                length,
+                validate: noop_validator(),
+                to_dsl,
+            },
+        }
+    }
+
     /// Create the primitive `Int` type.
     pub fn int() -> Self {
         AttributeType {
@@ -1770,12 +1788,40 @@ impl AttributeType {
         }
     }
 
+    /// Create an Int type with protocol-carried refinement metadata.
+    pub fn refined_int(
+        identity: Option<TypeIdentity>,
+        range: Option<(Option<i64>, Option<i64>)>,
+    ) -> Self {
+        AttributeType {
+            kind: AttrTypeKind::Int {
+                identity,
+                range,
+                validate: noop_validator(),
+            },
+        }
+    }
+
     /// Create the primitive `Float` type.
     pub fn float() -> Self {
         AttributeType {
             kind: AttrTypeKind::Float {
                 identity: None,
                 range: None,
+                validate: noop_validator(),
+            },
+        }
+    }
+
+    /// Create a Float type with protocol-carried refinement metadata.
+    pub fn refined_float(
+        identity: Option<TypeIdentity>,
+        range: Option<(Option<f64>, Option<f64>)>,
+    ) -> Self {
+        AttributeType {
+            kind: AttrTypeKind::Float {
+                identity,
+                range,
                 validate: noop_validator(),
             },
         }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -739,9 +739,35 @@ fn proto_attr_schema_to_core(a: &proto::AttributeSchema) -> CoreAttributeSchema 
 
 fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
     match t {
-        proto::AttributeType::String => CoreAttributeType::string(),
-        proto::AttributeType::Int => CoreAttributeType::int(),
-        proto::AttributeType::Float => CoreAttributeType::float(),
+        proto::AttributeType::String {
+            pattern,
+            length,
+            to_dsl,
+            identity,
+            ..
+        } => CoreAttributeType::refined_string(
+            identity
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(carina_core::schema::TypeIdentity::from_dotted),
+            pattern.clone(),
+            *length,
+            to_dsl.clone(),
+        ),
+        proto::AttributeType::Int { range, identity } => CoreAttributeType::refined_int(
+            identity
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(carina_core::schema::TypeIdentity::from_dotted),
+            *range,
+        ),
+        proto::AttributeType::Float { range, identity } => CoreAttributeType::refined_float(
+            identity
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(carina_core::schema::TypeIdentity::from_dotted),
+            *range,
+        ),
         proto::AttributeType::Bool => CoreAttributeType::bool(),
         proto::AttributeType::Duration => CoreAttributeType::duration(),
         proto::AttributeType::StringEnum {
@@ -766,12 +792,25 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             None,
             None,
         ),
-        proto::AttributeType::List { inner, ordered } => {
-            if *ordered {
-                CoreAttributeType::list(proto_attr_type_to_core(inner))
+        proto::AttributeType::List {
+            element_type,
+            ordered,
+            length,
+            ..
+        } => {
+            let base = if *ordered {
+                CoreAttributeType::list(proto_attr_type_to_core(element_type))
             } else {
-                CoreAttributeType::unordered_list(proto_attr_type_to_core(inner))
-            }
+                CoreAttributeType::unordered_list(proto_attr_type_to_core(element_type))
+            };
+            CoreAttributeType::custom(
+                None,
+                base,
+                None,
+                *length,
+                legacy_validator(|_| Ok(())),
+                None,
+            )
         }
         proto::AttributeType::Map { inner, key } => CoreAttributeType::map_with_key(
             proto_attr_type_to_core(key),
@@ -789,13 +828,15 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             base,
             pattern,
             length,
+            to_dsl,
+            ..
         } => CoreAttributeType::custom(
             if name.is_empty() {
                 None
             } else {
                 Some(carina_core::schema::TypeIdentity::from_dotted(name))
             },
-            proto_attr_type_to_core(base),
+            custom_base_to_core(base, to_dsl.clone()),
             pattern.clone(),
             *length,
             legacy_validator(|_| Ok(())), // Validation is handled via ProviderContext.validators
@@ -832,6 +873,20 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
     }
 }
 
+fn custom_base_to_core(
+    base: &proto::AttributeType,
+    to_dsl: Option<proto::DslTransform>,
+) -> CoreAttributeType {
+    match base {
+        proto::AttributeType::String { .. } => {
+            CoreAttributeType::refined_string(None, None, None, to_dsl)
+        }
+        proto::AttributeType::Int { .. } => CoreAttributeType::int(),
+        proto::AttributeType::Float { .. } => CoreAttributeType::float(),
+        _ => proto_attr_type_to_core(base),
+    }
+}
+
 fn proto_struct_field_to_core(f: &proto::StructField) -> CoreStructField {
     CoreStructField {
         name: f.name.clone(),
@@ -853,6 +908,16 @@ fn proto_struct_field_to_core(f: &proto::StructField) -> CoreStructField {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn proto_string() -> proto::AttributeType {
+        proto::AttributeType::String {
+            pattern: None,
+            length: None,
+            validate: None,
+            to_dsl: None,
+            identity: None,
+        }
+    }
 
     /// RFC #2371 stage 4 contract pin: `Value::Deferred(DeferredValue::Unknown)` reaching either
     /// WASM-boundary converter is a stage-2 invariant violation
@@ -1903,7 +1968,7 @@ mod tests {
     fn proto_custom_enum_transform_lifts_state_string_to_dsl_identifier() {
         let proto_attr = proto::AttributeType::CustomEnum {
             name: "ZoneName".to_string(),
-            base: Box::new(proto::AttributeType::String),
+            base: Box::new(proto_string()),
             namespace: "aws.AvailabilityZone".to_string(),
             dsl_transform: Some(proto::DslTransform::HyphenToUnderscore),
         };
@@ -1938,7 +2003,7 @@ mod tests {
     fn proto_custom_enum_transform_does_not_lift_garbage_state_string() {
         let proto_attr = proto::AttributeType::CustomEnum {
             name: "ZoneName".to_string(),
-            base: Box::new(proto::AttributeType::String),
+            base: Box::new(proto_string()),
             namespace: "aws.AvailabilityZone".to_string(),
             dsl_transform: Some(proto::DslTransform::HyphenToUnderscore),
         };
@@ -2004,7 +2069,7 @@ mod tests {
     fn proto_custom_enum_strip_suffix_transform_resolves_on_host() {
         let proto_attr = proto::AttributeType::CustomEnum {
             name: "ZoneName".to_string(),
-            base: Box::new(proto::AttributeType::String),
+            base: Box::new(proto_string()),
             namespace: "test.Dynamic".to_string(),
             dsl_transform: Some(proto::DslTransform::StripSuffix(".".to_string())),
         };
@@ -2062,7 +2127,7 @@ mod tests {
     fn proto_custom_enum_none_transform_uses_no_transform() {
         let proto_attr = proto::AttributeType::CustomEnum {
             name: "ZoneName".to_string(),
-            base: Box::new(proto::AttributeType::String),
+            base: Box::new(proto_string()),
             namespace: "aws.AvailabilityZone".to_string(),
             dsl_transform: None,
         };
@@ -2079,9 +2144,11 @@ mod tests {
     fn proto_custom_pattern_and_length_propagate_to_core() {
         let proto_attr = proto::AttributeType::Custom {
             name: "awscc.wafv2.WebACL.EntityDescription".to_string(),
-            base: Box::new(proto::AttributeType::String),
+            base: Box::new(proto_string()),
             pattern: Some("^x$".to_string()),
             length: Some((Some(1), Some(9))),
+            validate: None,
+            to_dsl: None,
         };
         let core_attr = proto_attr_type_to_core(&proto_attr);
         match core_attr.shape_ref_free().expect("test schema is Ref-free") {
@@ -2099,6 +2166,173 @@ mod tests {
                 assert_eq!(length, Some((Some(1), Some(9))));
             }
             other => panic!("expected Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_custom_string_payload_lifts_to_refined_core_string() {
+        let json = r#"{
+            "type":"custom",
+            "name":"aws.route53.HostedZone.Name",
+            "base":{"type":"String"},
+            "pattern":"^[a-z.]+$",
+            "length":[1,1024],
+            "to_dsl":{"type":"StripSuffix","value":"."}
+        }"#;
+        let proto_attr: proto::AttributeType = serde_json::from_str(json).unwrap();
+        let core_attr = proto_attr_type_to_core(&proto_attr);
+
+        match core_attr.shape_ref_free().expect("test schema is Ref-free") {
+            carina_core::schema::Shape::String {
+                identity,
+                pattern,
+                length,
+                to_dsl,
+                ..
+            } => {
+                assert_eq!(identity.map(|id| id.kind.as_str()), Some("Name"));
+                assert_eq!(pattern, Some("^[a-z.]+$"));
+                assert_eq!(length, Some((Some(1), Some(1024))));
+                assert_eq!(to_dsl.unwrap().apply("example.com."), "example.com");
+            }
+            other => panic!("expected refined String, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_custom_int_payload_lifts_length_to_refined_core_range() {
+        let json = r#"{
+            "type":"custom",
+            "name":"aws.ec2.Port",
+            "base":{"type":"Int"},
+            "length":[0,65535]
+        }"#;
+        let proto_attr: proto::AttributeType = serde_json::from_str(json).unwrap();
+        let core_attr = proto_attr_type_to_core(&proto_attr);
+
+        match core_attr.shape_ref_free().expect("test schema is Ref-free") {
+            carina_core::schema::Shape::Int {
+                identity, range, ..
+            } => {
+                assert_eq!(identity.map(|id| id.kind.as_str()), Some("Port"));
+                assert_eq!(range, Some((Some(0), Some(65535))));
+            }
+            other => panic!("expected refined Int, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_custom_float_payload_lifts_to_refined_core_float_identity() {
+        let json = r#"{
+            "type":"custom",
+            "name":"awscc.wafv2.Size",
+            "base":{"type":"Float"}
+        }"#;
+        let proto_attr: proto::AttributeType = serde_json::from_str(json).unwrap();
+        let core_attr = proto_attr_type_to_core(&proto_attr);
+
+        match core_attr.shape_ref_free().expect("test schema is Ref-free") {
+            carina_core::schema::Shape::Float {
+                identity, range, ..
+            } => {
+                assert_eq!(identity.map(|id| id.kind.as_str()), Some("Size"));
+                assert!(range.is_none());
+            }
+            other => panic!("expected refined Float, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_custom_list_payload_lifts_to_refined_core_list() {
+        let json = r#"{
+            "type":"custom",
+            "name":"awscc.wafv2.StatementList",
+            "base":{
+                "type":"list",
+                "inner":{"type":"String"},
+                "ordered":false
+            },
+            "length":[1,5],
+            "validate":true
+        }"#;
+        let proto_attr: proto::AttributeType = serde_json::from_str(json).unwrap();
+        let core_attr = proto_attr_type_to_core(&proto_attr);
+
+        match core_attr.shape_ref_free().expect("test schema is Ref-free") {
+            carina_core::schema::Shape::List {
+                element_type,
+                ordered,
+                length,
+                ..
+            } => {
+                assert!(!ordered);
+                assert_eq!(length, Some((Some(1), Some(5))));
+                assert!(matches!(
+                    element_type.shape_ref_free().expect("element is Ref-free"),
+                    carina_core::schema::Shape::String { .. }
+                ));
+            }
+            other => panic!("expected refined List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn new_primitive_payloads_lift_to_refined_core_shapes() {
+        let cases = [
+            r#"{
+                "type":"String",
+                "identity":"aws.route53.HostedZone.Name",
+                "pattern":"^[a-z.]+$",
+                "length":[1,1024],
+                "to_dsl":{"type":"StripSuffix","value":"."}
+            }"#,
+            r#"{"type":"Int","identity":"aws.ec2.Port","range":[-1,65535]}"#,
+            r#"{"type":"Float","identity":"awscc.wafv2.Size","range":[0.0,1.0]}"#,
+            r#"{
+                "type":"list",
+                "element_type":{"type":"String"},
+                "ordered":true,
+                "length":[1,3],
+                "validate":true
+            }"#,
+        ];
+
+        for json in cases {
+            let proto_attr: proto::AttributeType = serde_json::from_str(json).unwrap();
+            let core_attr = proto_attr_type_to_core(&proto_attr);
+            match core_attr.shape_ref_free().expect("test schema is Ref-free") {
+                carina_core::schema::Shape::String {
+                    identity,
+                    pattern,
+                    length,
+                    to_dsl,
+                    ..
+                } => {
+                    assert_eq!(identity.map(|id| id.kind.as_str()), Some("Name"));
+                    assert_eq!(pattern, Some("^[a-z.]+$"));
+                    assert_eq!(length, Some((Some(1), Some(1024))));
+                    assert_eq!(to_dsl.unwrap().apply("example.com."), "example.com");
+                }
+                carina_core::schema::Shape::Int {
+                    identity, range, ..
+                } => {
+                    assert_eq!(identity.map(|id| id.kind.as_str()), Some("Port"));
+                    assert_eq!(range, Some((Some(-1), Some(65535))));
+                }
+                carina_core::schema::Shape::Float {
+                    identity, range, ..
+                } => {
+                    assert_eq!(identity.map(|id| id.kind.as_str()), Some("Size"));
+                    assert_eq!(range, Some((Some(0.0), Some(1.0))));
+                }
+                carina_core::schema::Shape::List {
+                    ordered, length, ..
+                } => {
+                    assert!(ordered);
+                    assert_eq!(length, Some((Some(1), Some(3))));
+                }
+                other => panic!("unexpected lifted shape: {other:?}"),
+            }
         }
     }
 

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -393,9 +393,30 @@ pub struct AttributeSchema {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum AttributeType {
-    String,
-    Int,
-    Float,
+    String {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pattern: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        length: Option<(Option<u64>, Option<u64>)>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        validate: Option<serde_json::Value>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        to_dsl: Option<DslTransform>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        identity: Option<String>,
+    },
+    Int {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        range: Option<(Option<i64>, Option<i64>)>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        identity: Option<String>,
+    },
+    Float {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        range: Option<(Option<f64>, Option<f64>)>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        identity: Option<String>,
+    },
     Bool,
     /// Time duration. Authored in the DSL as a literal like `30min`,
     /// `1h`, or `15s` (`duration_literal` in the grammar); reaches the
@@ -432,11 +453,16 @@ pub enum AttributeType {
     },
     #[serde(rename = "list")]
     List {
-        inner: Box<AttributeType>,
+        #[serde(rename = "element_type", alias = "inner")]
+        element_type: Box<AttributeType>,
         /// Whether list elements are ordered (positional comparison).
         /// When false, elements are compared as multisets (order-insensitive).
         #[serde(default = "default_true")]
         ordered: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        length: Option<(Option<u64>, Option<u64>)>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        validate: Option<serde_json::Value>,
     },
     #[serde(rename = "map")]
     Map {
@@ -471,6 +497,10 @@ pub enum AttributeType {
         pattern: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         length: Option<(Option<u64>, Option<u64>)>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        validate: Option<serde_json::Value>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        to_dsl: Option<DslTransform>,
     },
     /// Enum-shaped custom type: values are written as namespaced
     /// shorthand and expanded host-side via `expand_enum_shorthand`
@@ -600,6 +630,16 @@ pub struct StructField {
 mod tests {
     use super::*;
 
+    fn string_attr() -> AttributeType {
+        AttributeType::String {
+            pattern: None,
+            length: None,
+            validate: None,
+            to_dsl: None,
+            identity: None,
+        }
+    }
+
     #[test]
     fn test_value_roundtrip() {
         let values = vec![
@@ -678,9 +718,11 @@ mod tests {
     fn custom_pattern_and_length_round_trip() {
         let attr = AttributeType::Custom {
             name: "awscc.wafv2.WebACL.EntityDescription".to_string(),
-            base: Box::new(AttributeType::String),
+            base: Box::new(string_attr()),
             pattern: Some("^[a-z]+$".to_string()),
             length: Some((Some(1), Some(9))),
+            validate: None,
+            to_dsl: None,
         };
 
         let json = serde_json::to_string(&attr).unwrap();
@@ -696,6 +738,104 @@ mod tests {
             }
             other => panic!("expected Custom, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn refined_primitive_attribute_types_round_trip() {
+        let attrs = [
+            AttributeType::String {
+                pattern: Some("^[a-z]+$".to_string()),
+                length: Some((Some(1), Some(63))),
+                validate: Some(serde_json::json!(true)),
+                to_dsl: Some(DslTransform::StripSuffix(".".to_string())),
+                identity: Some("aws.route53.HostedZone.Name".to_string()),
+            },
+            AttributeType::Int {
+                range: Some((Some(-1), Some(65535))),
+                identity: Some("aws.ec2.Port".to_string()),
+            },
+            AttributeType::Float {
+                range: Some((Some(0.0), Some(1.0))),
+                identity: Some("awscc.wafv2.Rate".to_string()),
+            },
+            AttributeType::List {
+                element_type: Box::new(string_attr()),
+                ordered: false,
+                length: Some((Some(1), Some(5))),
+                validate: Some(serde_json::json!(true)),
+            },
+        ];
+
+        for attr in attrs {
+            let json = serde_json::to_string(&attr).unwrap();
+            let back: AttributeType = serde_json::from_str(&json).unwrap();
+            assert_eq!(json, serde_json::to_string(&back).unwrap());
+        }
+    }
+
+    #[test]
+    fn primitive_attribute_types_default_missing_refinements() {
+        for json in [
+            r#"{"type":"String"}"#,
+            r#"{"type":"Int"}"#,
+            r#"{"type":"Float"}"#,
+        ] {
+            let attr: AttributeType = serde_json::from_str(json).unwrap();
+            match attr {
+                AttributeType::String {
+                    pattern,
+                    length,
+                    validate,
+                    to_dsl,
+                    identity,
+                } => {
+                    assert!(pattern.is_none());
+                    assert!(length.is_none());
+                    assert!(validate.is_none());
+                    assert!(to_dsl.is_none());
+                    assert!(identity.is_none());
+                }
+                AttributeType::Int { range, identity } => {
+                    assert!(range.is_none());
+                    assert!(identity.is_none());
+                }
+                AttributeType::Float { range, identity } => {
+                    assert!(range.is_none());
+                    assert!(identity.is_none());
+                }
+                other => panic!("unexpected primitive default shape: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn list_inner_alias_deserializes_and_emits_element_type() {
+        let json = r#"{
+            "type":"list",
+            "inner":{"type":"String"},
+            "ordered":false,
+            "length":[1,3],
+            "validate":true
+        }"#;
+        let attr: AttributeType = serde_json::from_str(json).unwrap();
+        match &attr {
+            AttributeType::List {
+                element_type,
+                ordered,
+                length,
+                validate,
+            } => {
+                assert!(matches!(**element_type, AttributeType::String { .. }));
+                assert!(!ordered);
+                assert_eq!(*length, Some((Some(1), Some(3))));
+                assert_eq!(*validate, Some(serde_json::json!(true)));
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
+
+        let emitted = serde_json::to_string(&attr).unwrap();
+        assert!(emitted.contains("element_type"), "emitted: {emitted}");
+        assert!(!emitted.contains("inner"), "emitted: {emitted}");
     }
 
     #[test]
@@ -721,10 +861,12 @@ mod tests {
                     fields: vec![StructField {
                         name: "and_statement".into(),
                         field_type: AttributeType::List {
-                            inner: Box::new(AttributeType::Ref {
+                            element_type: Box::new(AttributeType::Ref {
                                 name: "Statement".into(),
                             }),
                             ordered: true,
+                            length: None,
+                            validate: None,
                         },
                         required: false,
                         description: None,
@@ -819,14 +961,14 @@ mod tests {
                     name: "IamPolicyPrincipal".into(),
                     fields: vec![StructField {
                         name: "service".into(),
-                        field_type: AttributeType::String,
+                        field_type: string_attr(),
                         required: false,
                         description: None,
                         block_name: None,
                         provider_name: None,
                     }],
                 },
-                AttributeType::String,
+                string_attr(),
             ],
         };
 
@@ -963,7 +1105,7 @@ mod tests {
         for transform in transforms {
             let attr = AttributeType::CustomEnum {
                 name: "ZoneName".to_string(),
-                base: Box::new(AttributeType::String),
+                base: Box::new(string_attr()),
                 namespace: "aws.AvailabilityZone".to_string(),
                 dsl_transform: Some(transform.clone()),
             };


### PR DESCRIPTION
## Summary

Second implementation PR in the chain from carina#3429. Adds protocol wire support for the refined primitive types introduced by PR #3431.

- `ProtoAttributeType::String` / `Int` / `Float` carry optional refinement fields (`identity`, `length`/`range`, `to_dsl`) with `serde(default)`. Old payloads without these fields still deserialize as unconstrained primitives.
- `ProtoAttributeType::List` emits `element_type` and accepts legacy `inner` via `serde(alias)`.
- `ProtoAttributeType::Custom` is retained for deserialize compatibility from legacy providers, with optional `to_dsl` / `validate` fields added to widen what we can lift.
- The host-side wasm conversion lifts legacy `Custom { base=String/Int/Float/List, ... }` payloads into the refined core variants using the rules from the design doc.
- `DslTransform::Unknown(...)` continues to act as a no-op on `apply`, preserving forward compatibility with future provider transform variants.

The provider repos (aws/awscc) and their generated schemas are intentionally untouched — that work is PR3/PR4 in the chain.

## Verification

- `RUSTC_WRAPPER= cargo check --workspace --all-targets`
- `RUSTC_WRAPPER= cargo nextest run --workspace --all-targets` — 3948 passed, 72 skipped
- `RUSTC_WRAPPER= cargo test --doc --workspace`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `scripts/check-provider-boundaries.sh`
- `scripts/check-plan-fixtures.sh`
- `RUSTC_WRAPPER= scripts/check-example-warnings.sh`
- `scripts/check-docs-use-new-spellings.sh`
- `scripts/check-no-direct-resources-access.sh`

## Notes

`Cargo.toml` / `build.rs` were not touched, so the `cargo build --release` gate is skipped per the verify-protocol guidance.

Refs: carina#3429
