### PR TITLE
Apply refined String to_dsl in type_aware_equal

### DIFF
--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -103,6 +103,22 @@ pub(crate) fn type_aware_equal(
                 crate::schema::Shape::Float { .. } | crate::schema::Shape::Int { .. },
             ) => *f == (*i as f64) && (*i as f64) as i64 == *i,
 
+            // String refinements may carry provider/API-to-DSL normalization
+            // such as Route53 trailing-dot stripping.
+            (
+                Value::Concrete(ConcreteValue::String(sa)),
+                Value::Concrete(ConcreteValue::String(sb)),
+                crate::schema::Shape::String {
+                    to_dsl: Some(transform),
+                    ..
+                },
+            ) => transform.apply(sa) == transform.apply(sb),
+            (
+                Value::Concrete(ConcreteValue::String(sa)),
+                Value::Concrete(ConcreteValue::String(sb)),
+                crate::schema::Shape::String { to_dsl: None, .. },
+            ) => sa == sb,
+
             // Lists: ordered or multiset comparison with inner type awareness
             (
                 Value::Concrete(ConcreteValue::List(la)),
@@ -567,4 +583,30 @@ pub(super) fn find_changed_attributes(
     }
 
     changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::DslTransform;
+
+    #[test]
+    fn refined_string_to_dsl_transform_is_applied_before_comparison() {
+        let attr_type = AttributeType::refined_string(
+            None,
+            None,
+            None,
+            Some(DslTransform::StripSuffix(".".to_string())),
+        );
+        let state = Value::Concrete(ConcreteValue::String("foo.example.com.".to_string()));
+        let desired = Value::Concrete(ConcreteValue::String("foo.example.com".to_string()));
+
+        assert!(type_aware_equal(
+            &state,
+            &desired,
+            Some(&attr_type),
+            empty_defs_for_schema_walks(),
+            None,
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

PR1 (#3431) introduced refined primitives but missed wiring `Shape::String`'s `to_dsl` into `type_aware_equal`. Without a `Shape::String` arm in the comparator, refined String values fall through to plain equality and `DslTransform::StripSuffix(".")` is never applied, so carina#3427's trailing-dot canonicalization stays broken even after a provider emits the refined shape.

- Add a `Shape::String` arm that applies the `to_dsl` transform to both sides before comparing when one is present.
- Keep `to_dsl: None` strings on a plain equality path so unrefined strings keep their existing behavior.
- Add a regression test for `StripSuffix(".")` against `"foo.example.com."` vs `"foo.example.com"`.

The remaining PRs in the carina#3429 chain (provider-awscc / provider-aws migrations and cleanup) now rest on a comparator that actually respects refined String metadata.

## Verification

- `RUSTC_WRAPPER= cargo nextest run -p carina-core`
- `RUSTC_WRAPPER= cargo check --workspace --all-targets`
- `RUSTC_WRAPPER= cargo test --doc --workspace`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `for script in scripts/check-*.sh; do "$script" || exit $?; done`

Refs: carina#3429, carina#3427
