### PR TITLE
Remove AttributeType::custom shim and pin Route53 name regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ plan-no-changes-enum:
 	$(PLAN_FIXTURE) no_changes_enum
 plan-dynamic-enum-az-no-diff:
 	$(PLAN_FIXTURE) dynamic_enum_az_no_diff
+plan-route53-hosted-zone-name-strip-suffix-no-diff:
+	$(PLAN_FIXTURE) route53_hosted_zone_name_strip_suffix_no_diff
 plan-destroy-full:
 	$(PLAN_FIXTURE) destroy_full --destroy
 plan-destroy-orphans:
@@ -132,6 +134,9 @@ plan-fixtures:
 	@echo ""
 	@echo "=== no_changes_enum ==="
 	@$(MAKE) plan-no-changes-enum
+	@echo ""
+	@echo "=== route53_hosted_zone_name_strip_suffix_no_diff ==="
+	@$(MAKE) plan-route53-hosted-zone-name-strip-suffix-no-diff
 	@echo ""
 	@echo "=== destroy_full ==="
 	@$(MAKE) plan-destroy-full
@@ -266,7 +271,7 @@ plan-multi-instance-create:
 	$(PLAN_FIXTURE) multi_instance_create
 plan-multi-instance-module:
 	$(PLAN_FIXTURE) multi_instance_module
-.PHONY: plan-all-create plan-no-changes plan-empty-explicit-children-no-changes plan-no-changes-enum plan-dynamic-enum-az-no-diff plan-mixed plan-delete plan-delete-list-of-maps plan-compact plan-import-deferred-interpolation \
+.PHONY: plan-all-create plan-no-changes plan-empty-explicit-children-no-changes plan-no-changes-enum plan-dynamic-enum-az-no-diff plan-route53-hosted-zone-name-strip-suffix-no-diff plan-mixed plan-delete plan-delete-list-of-maps plan-compact plan-import-deferred-interpolation \
         plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
         plan-list-diff-modified-with-unchanged \
         plan-list-diff-modified-with-unchanged-nested \

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -15,7 +15,7 @@ use carina_core::provider::{BoxFuture, Provider, ProviderFactory, ProviderResult
 use carina_core::resolver::resolve_refs_for_plan;
 use carina_core::resource::{ResourceId, State, Value};
 use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, TypeIdentity,
+    AttributeSchema, AttributeType, DslTransform, ResourceSchema, SchemaRegistry, TypeIdentity,
 };
 use carina_state::{StateFile, check_and_migrate};
 
@@ -355,6 +355,9 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
 fn fixture_provider_factories(fixture_path: &Path) -> Vec<Box<dyn ProviderFactory>> {
     match fixture_path.file_name().and_then(|name| name.to_str()) {
         Some("dynamic_enum_az_no_diff") => vec![Box::new(DynamicEnumFixtureFactory)],
+        Some("route53_hosted_zone_name_strip_suffix_no_diff") => {
+            vec![Box::new(Route53HostedZoneFixtureFactory)]
+        }
         _ => vec![],
     }
 }
@@ -408,6 +411,58 @@ impl ProviderFactory for DynamicEnumFixtureFactory {
         vec![
             ResourceSchema::new("network.Subnet")
                 .attribute(AttributeSchema::new("availability_zone", zone_name).required()),
+        ]
+    }
+}
+
+struct Route53HostedZoneFixtureFactory;
+
+impl ProviderFactory for Route53HostedZoneFixtureFactory {
+    fn name(&self) -> &str {
+        "fixture"
+    }
+
+    fn display_name(&self) -> &str {
+        "Fixture provider"
+    }
+
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+
+    fn validate_config(
+        &self,
+        _attributes: &indexmap::IndexMap<String, Value>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn extract_region(&self, _attributes: &indexmap::IndexMap<String, Value>) -> String {
+        "test".to_string()
+    }
+
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &indexmap::IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { unreachable!("plan fixture does not instantiate providers") })
+    }
+
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        let zone_name = AttributeType::refined_string(
+            Some(TypeIdentity::new(
+                Some("fixture"),
+                vec!["route53".to_string(), "HostedZone".to_string()],
+                "Name",
+            )),
+            None,
+            Some((None, Some(1024))),
+            Some(DslTransform::StripSuffix(".".to_string())),
+        );
+        vec![
+            ResourceSchema::new("route53.HostedZone")
+                .attribute(AttributeSchema::new("name", zone_name).required()),
         ]
     }
 }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -611,6 +611,27 @@ fn dynamic_enum_az_state_api_spelling_has_no_diff_in_cli_plan_path() {
 }
 
 #[test]
+fn route53_hosted_zone_name_strip_suffix_no_diff() {
+    let (plan, schemas, _moved) =
+        build_plan_from_fixture("route53_hosted_zone_name_strip_suffix_no_diff");
+    assert!(
+        plan.effects().is_empty(),
+        "Route53 HostedZone state names with a trailing dot must compare equal to DSL names without one:\n{}",
+        strip_ansi(&format_plan(
+            &plan,
+            DetailLevel::Full,
+            &HashMap::new(),
+            Some(&schemas),
+            &HashMap::new(),
+            &[],
+            &[],
+            None,
+            None,
+        ))
+    );
+}
+
+#[test]
 fn snapshot_destroy_full() {
     use carina_core::resource::Value;
     let (plan, current_states, _schemas, _moved) =

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -839,9 +839,8 @@ impl ProviderFactory for WasmStyleProviderFactory {
 }
 
 fn wasm_style_vpc_schema() -> ResourceSchema {
-    let vpc_id_type = AttributeType::custom(
+    let vpc_id_type = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         None,
         None,
         carina_core::schema::legacy_validator(|_| Ok(())),
@@ -930,9 +929,8 @@ awsccmock.ec2.security_group {
 }
 
 fn wasm_style_subnet_schema() -> ResourceSchema {
-    let vpc_id_type = AttributeType::custom(
+    let vpc_id_type = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         None,
         None,
         carina_core::schema::legacy_validator(|_| Ok(())),
@@ -1044,9 +1042,8 @@ fn vpc_id_validate_2358(v: &Value) -> Result<(), String> {
 }
 
 fn vpc_id_custom_type_2358() -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(vpc_id_validate_2358),

--- a/carina-cli/tests/fixtures/plan_display/route53_hosted_zone_name_strip_suffix_no_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/route53_hosted_zone_name_strip_suffix_no_diff/carina.state.json
@@ -1,0 +1,31 @@
+{
+  "version": 7,
+  "serial": 1,
+  "lineage": "test-lineage-route53-hosted-zone-name-strip-suffix-no-diff",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "route53.HostedZone",
+      "name": "zone",
+      "provider": "fixture",
+      "identifier": "hosted-zone-fixture",
+      "attributes": {
+        "name": "registry-dev.carina-rs.dev."
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "zone",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "name": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/route53_hosted_zone_name_strip_suffix_no_diff/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/route53_hosted_zone_name_strip_suffix_no_diff/main.crn
@@ -1,0 +1,9 @@
+provider fixture {}
+
+let zone = fixture.route53.HostedZone {
+  name = "registry-dev.carina-rs.dev"
+}
+
+exports {
+  name = zone.name
+}

--- a/carina-cli/tests/validate_unknown_custom_type_e2e.rs
+++ b/carina-cli/tests/validate_unknown_custom_type_e2e.rs
@@ -76,18 +76,16 @@ impl ProviderFactory for AwsccTestFactory {
         Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
     }
     fn schemas(&self) -> Vec<ResourceSchema> {
-        let iam_policy_arn = AttributeType::custom(
+        let iam_policy_arn = AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(Some("aws"), ["iam", "Policy"], "Arn")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(|_| Ok(())),
             None,
         );
 
-        let generic_arn = AttributeType::custom(
+        let generic_arn = AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Arn")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(|_| Ok(())),

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -120,13 +120,10 @@ fn type_aware_union_numeric() {
 
 #[test]
 fn type_aware_custom_delegates_to_base() {
-    let custom_type = AttributeType::custom(
+    let custom_type = AttributeType::refined_float_with_validator(
         Some(TypeIdentity::bare("Port")),
-        AttributeType::float(),
-        None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
-        None,
     );
     assert!(type_aware_equal(
         &Value::Concrete(ConcreteValue::Int(8080)),
@@ -489,13 +486,10 @@ fn type_aware_struct_ignores_default_custom_type() {
             StructField::new("name", AttributeType::string()),
             StructField::new(
                 "port",
-                AttributeType::custom(
+                AttributeType::refined_int_with_validator(
                     Some(TypeIdentity::bare("Port")),
-                    AttributeType::int(),
-                    None,
                     None,
                     crate::schema::legacy_validator(|_| Ok(())),
-                    None,
                 ),
             ),
         ],

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1766,12 +1766,23 @@ impl AttributeType {
         length: Option<(Option<u64>, Option<u64>)>,
         to_dsl: Option<DslTransform>,
     ) -> Self {
+        Self::refined_string_with_validator(identity, pattern, length, noop_validator(), to_dsl)
+    }
+
+    /// Create a String type with refinement metadata and a custom validator.
+    pub fn refined_string_with_validator(
+        identity: Option<TypeIdentity>,
+        pattern: Option<String>,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: CustomValidator,
+        to_dsl: Option<DslTransform>,
+    ) -> Self {
         AttributeType {
             kind: AttrTypeKind::String {
                 identity,
                 pattern,
                 length,
-                validate: noop_validator(),
+                validate,
                 to_dsl,
             },
         }
@@ -1793,11 +1804,20 @@ impl AttributeType {
         identity: Option<TypeIdentity>,
         range: Option<(Option<i64>, Option<i64>)>,
     ) -> Self {
+        Self::refined_int_with_validator(identity, range, noop_validator())
+    }
+
+    /// Create an Int type with refinement metadata and a custom validator.
+    pub fn refined_int_with_validator(
+        identity: Option<TypeIdentity>,
+        range: Option<(Option<i64>, Option<i64>)>,
+        validate: CustomValidator,
+    ) -> Self {
         AttributeType {
             kind: AttrTypeKind::Int {
                 identity,
                 range,
-                validate: noop_validator(),
+                validate,
             },
         }
     }
@@ -1818,11 +1838,20 @@ impl AttributeType {
         identity: Option<TypeIdentity>,
         range: Option<(Option<f64>, Option<f64>)>,
     ) -> Self {
+        Self::refined_float_with_validator(identity, range, noop_validator())
+    }
+
+    /// Create a Float type with refinement metadata and a custom validator.
+    pub fn refined_float_with_validator(
+        identity: Option<TypeIdentity>,
+        range: Option<(Option<f64>, Option<f64>)>,
+        validate: CustomValidator,
+    ) -> Self {
         AttributeType {
             kind: AttrTypeKind::Float {
                 identity,
                 range,
-                validate: noop_validator(),
+                validate,
             },
         }
     }
@@ -1934,53 +1963,6 @@ impl AttributeType {
         }
     }
 
-    /// Create a structural `Custom` type.
-    pub fn custom(
-        identity: Option<TypeIdentity>,
-        base: AttributeType,
-        pattern: Option<String>,
-        length: Option<(Option<u64>, Option<u64>)>,
-        validate: CustomValidator,
-        to_dsl: Option<fn(&str) -> String>,
-    ) -> Self {
-        assert!(
-            to_dsl.is_none(),
-            "custom shim: function-pointer to_dsl cannot be represented as DslTransform"
-        );
-        AttributeType {
-            kind: match base.kind {
-                AttrTypeKind::String { to_dsl, .. } => AttrTypeKind::String {
-                    identity,
-                    pattern,
-                    length,
-                    validate,
-                    to_dsl,
-                },
-                AttrTypeKind::Int { .. } => AttrTypeKind::Int {
-                    identity,
-                    range: length.map(|(min, max)| (min.map(|v| v as i64), max.map(|v| v as i64))),
-                    validate,
-                },
-                AttrTypeKind::Float { .. } => AttrTypeKind::Float {
-                    identity,
-                    range: None,
-                    validate,
-                },
-                AttrTypeKind::List {
-                    element_type,
-                    ordered,
-                    ..
-                } => AttrTypeKind::List {
-                    element_type,
-                    ordered,
-                    length,
-                    validate,
-                },
-                other => panic!("custom shim: unexpected base {other:?}"),
-            },
-        }
-    }
-
     /// Create a `Struct` type.
     pub fn struct_(name: impl Into<String>, fields: Vec<StructField>) -> Self {
         AttributeType {
@@ -2008,26 +1990,29 @@ impl AttributeType {
 
     /// Create a List type with default ordering (ordered=true, matching CloudFormation default).
     pub fn list(inner: AttributeType) -> Self {
+        Self::refined_list(inner, true, None, noop_validator())
+    }
+
+    /// Create a List type with protocol-carried refinement metadata.
+    pub fn refined_list(
+        element_type: AttributeType,
+        ordered: bool,
+        length: Option<(Option<u64>, Option<u64>)>,
+        validate: CustomValidator,
+    ) -> Self {
         AttributeType {
             kind: AttrTypeKind::List {
-                element_type: Box::new(inner),
-                ordered: true,
-                length: None,
-                validate: noop_validator(),
+                element_type: Box::new(element_type),
+                ordered,
+                length,
+                validate,
             },
         }
     }
 
     /// Create an unordered List type (insertionOrder=false).
     pub fn unordered_list(inner: AttributeType) -> Self {
-        AttributeType {
-            kind: AttrTypeKind::List {
-                element_type: Box::new(inner),
-                ordered: false,
-                length: None,
-                validate: noop_validator(),
-            },
-        }
+        Self::refined_list(inner, false, None, noop_validator())
     }
 
     /// Create a Map type with unconstrained string keys.
@@ -4801,10 +4786,8 @@ pub mod types {
 
     /// Positive integer type
     pub fn positive_int() -> AttributeType {
-        AttributeType::custom(
+        AttributeType::refined_int_with_validator(
             Some(TypeIdentity::bare("PositiveInt")),
-            AttributeType::int(),
-            None,
             None,
             legacy_validator(|value| {
                 if let Value::Concrete(ConcreteValue::Int(n)) = value {
@@ -4817,15 +4800,13 @@ pub mod types {
                     Err("Expected integer".to_string())
                 }
             }),
-            None,
         )
     }
 
     /// IPv4 CIDR block type (e.g., "10.0.0.0/16")
     pub fn ipv4_cidr() -> AttributeType {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("Ipv4Cidr")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(|value| {
@@ -4841,9 +4822,8 @@ pub mod types {
 
     /// IPv4 address type (e.g., "10.0.1.5", "192.168.0.1")
     pub fn ipv4_address() -> AttributeType {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("Ipv4Address")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(|value| {
@@ -4859,9 +4839,8 @@ pub mod types {
 
     /// IPv6 address type (e.g., "2001:db8::1", "::1")
     pub fn ipv6_address() -> AttributeType {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("Ipv6Address")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(|value| {
@@ -4877,9 +4856,8 @@ pub mod types {
 
     /// IPv6 CIDR block type (e.g., "2001:db8::/32", "::/0")
     pub fn ipv6_cidr() -> AttributeType {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("Ipv6Cidr")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(|value| {
@@ -4904,9 +4882,8 @@ pub mod types {
     /// requires a non-empty local part, a single `@`, and a domain that
     /// contains at least one dot with non-empty labels.
     pub fn email() -> AttributeType {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("Email")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(|value| {

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -1930,9 +1930,8 @@ fn exclusive_required_multiple_groups() {
 #[test]
 fn validate_union_type() {
     // Create two Custom types that validate different prefixes
-    let type_a = AttributeType::custom(
+    let type_a = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("TypeA")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(|value| {
@@ -1948,9 +1947,8 @@ fn validate_union_type() {
         }),
         None,
     );
-    let type_b = AttributeType::custom(
+    let type_b = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("TypeB")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(|value| {
@@ -2044,17 +2042,15 @@ fn union_struct_unknown_field_shows_specific_error() {
 
 #[test]
 fn union_type_name() {
-    let type_a = AttributeType::custom(
+    let type_a = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("TypeA")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
         None,
     );
-    let type_b = AttributeType::custom(
+    let type_b = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("TypeB")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -2067,17 +2063,15 @@ fn union_type_name() {
 
 #[test]
 fn union_accepts_type_name() {
-    let type_a = AttributeType::custom(
+    let type_a = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("TypeA")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
         None,
     );
-    let type_b = AttributeType::custom(
+    let type_b = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("TypeB")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3082,20 +3076,26 @@ fn validate_skips_internal_attributes() {
 }
 
 fn make_custom(name: &str, base: AttributeType) -> AttributeType {
-    AttributeType::custom(
-        Some(TypeIdentity::bare(name)),
-        base,
-        None,
-        None,
-        crate::schema::legacy_validator(|_| Ok(())),
-        None,
-    )
+    match base.raw_shape() {
+        RawShape::String { .. } => AttributeType::refined_string_with_validator(
+            Some(TypeIdentity::bare(name)),
+            None,
+            None,
+            crate::schema::legacy_validator(|_| Ok(())),
+            None,
+        ),
+        RawShape::Int { .. } => AttributeType::refined_int_with_validator(
+            Some(TypeIdentity::bare(name)),
+            None,
+            crate::schema::legacy_validator(|_| Ok(())),
+        ),
+        other => panic!("test helper does not support refined base {other:?}"),
+    }
 }
 
 fn make_custom_anon_pattern(pattern: &str) -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         Some(pattern.to_string()),
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3104,9 +3104,8 @@ fn make_custom_anon_pattern(pattern: &str) -> AttributeType {
 }
 
 fn make_custom_anon_len(min: u64, max: u64) -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         None,
         Some((Some(min), Some(max))),
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3145,13 +3144,12 @@ fn assignable_allows_same_semantic_name() {
 #[test]
 fn assignable_rejects_same_kind_across_providers() {
     let provider_custom = |provider: &str| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(
                 Some(provider),
                 Vec::<String>::new(),
                 "Region",
             )),
-            AttributeType::string(),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3209,9 +3207,8 @@ fn assignable_accepts_same_enum_typeidentity_from_distinct_constructions() {
 #[test]
 fn assignable_specific_arn_flows_into_generic_arn() {
     let mk = |segments: &[&str], pattern: Option<&str>| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(Some("aws"), segments.to_vec(), "Arn")),
-            AttributeType::string(),
             pattern.map(str::to_string),
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3249,9 +3246,8 @@ fn assignable_specific_arn_flows_into_generic_arn() {
 #[test]
 fn assignable_specific_arn_with_pattern_flows_into_generic_arn_with_pattern() {
     let mk = |segments: &[&str], pattern: &str| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(Some("aws"), segments.to_vec(), "Arn")),
-            AttributeType::string(),
             Some(pattern.to_string()),
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3269,9 +3265,8 @@ fn assignable_specific_arn_with_pattern_flows_into_generic_arn_with_pattern() {
 #[test]
 fn assignable_specific_arn_without_pattern_flows_into_generic_arn_with_pattern() {
     let mk = |segments: &[&str], pattern: Option<&str>| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(Some("aws"), segments.to_vec(), "Arn")),
-            AttributeType::string(),
             pattern.map(str::to_string),
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3288,9 +3283,8 @@ fn assignable_specific_arn_without_pattern_flows_into_generic_arn_with_pattern()
 #[test]
 fn assignable_identified_custom_length_must_be_contained() {
     let mk = |length: Option<(Option<u64>, Option<u64>)>| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("SizedString")),
-            AttributeType::string(),
             None,
             length,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3318,9 +3312,8 @@ fn assignable_identified_custom_length_must_be_contained() {
 #[test]
 fn assignable_accepts_same_typeidentity_from_distinct_constructions_vpc_id() {
     let mk = || {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(Some("aws"), vec!["ec2", "Vpc"], "Id")),
-            AttributeType::string(),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3339,13 +3332,12 @@ fn assignable_accepts_same_typeidentity_from_distinct_constructions_vpc_id() {
 #[test]
 fn assignable_accepts_same_typeidentity_from_distinct_constructions_account_id() {
     let mk = || {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(
                 Some("aws"),
                 Vec::<String>::new(),
                 "AccountId",
             )),
-            AttributeType::string(),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3363,9 +3355,8 @@ fn assignable_accepts_same_typeidentity_from_distinct_constructions_account_id()
 #[test]
 fn assignable_accepts_same_typeidentity_from_distinct_constructions_iam_role_arn() {
     let mk = || {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(Some("aws"), vec!["iam", "Role"], "Arn")),
-            AttributeType::string(),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3387,13 +3378,12 @@ fn assignable_accepts_same_typeidentity_from_distinct_constructions_iam_role_arn
 #[test]
 fn assignable_rejects_account_id_across_genuinely_different_providers() {
     let mk = |provider: &str| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(
                 Some(provider),
                 Vec::<String>::new(),
                 "AccountId",
             )),
-            AttributeType::string(),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3412,9 +3402,8 @@ fn assignable_rejects_account_id_across_genuinely_different_providers() {
 #[test]
 fn assignable_identity_axis_directionality() {
     let mk = |provider: Option<&str>, segments: &[&str]| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::new(provider, segments.to_vec(), "Arn")),
-            AttributeType::string(),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -3440,9 +3429,8 @@ fn assignable_identity_axis_directionality() {
 fn assignable_narrow_to_anonymous_unconstrained_sink() {
     // Semantic source with no pattern assigns to fully-anonymous unconstrained sink.
     let account = make_custom("AwsAccountId", AttributeType::string());
-    let anon = AttributeType::custom(
+    let anon = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3492,9 +3480,8 @@ fn assignable_union_sink_accepts_assignable_member() {
 fn assignable_union_source_requires_all_members_assignable() {
     // All members of source must be assignable to sink.
     let vpc = make_custom("VpcId", AttributeType::string());
-    let anon_any = AttributeType::custom(
+    let anon_any = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3517,9 +3504,8 @@ fn semantic_custom_assigns_to_anonymous_unconstrained_sink() {
     // Replaces the old buggy `is_compatible_with_two_string_based_customs`
     // which asserted VpcId <-> SubnetId were symmetric-compatible.
     let vpc = make_custom("VpcId", AttributeType::string());
-    let anon = AttributeType::custom(
+    let anon = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3556,9 +3542,8 @@ fn make_custom_anon_pattern_and_len(
     pattern: Option<&str>,
     length: Option<(Option<u64>, Option<u64>)>,
 ) -> AttributeType {
-    AttributeType::custom(
+    AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         pattern.map(str::to_string),
         length,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3666,9 +3651,8 @@ fn assignable_anon_length_both_none_compatible() {
 
 #[test]
 fn custom_carries_semantic_name_pattern_length() {
-    let t = AttributeType::custom(
+    let t = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         Some("^vpc-[a-f0-9]+$".to_string()),
         Some((Some(8), Some(21))),
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3691,9 +3675,8 @@ fn custom_carries_semantic_name_pattern_length() {
 
 #[test]
 fn custom_pattern_rejects_and_accepts_string_values() {
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         Some("^[a-z]+$".to_string()),
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3720,9 +3703,8 @@ fn custom_pattern_rejects_and_accepts_string_values() {
 
 #[test]
 fn custom_pattern_and_length_passes_still_run_validator() {
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         Some("^[a-z]+$".to_string()),
         Some((Some(1), Some(10))),
         validator(|_| {
@@ -3747,9 +3729,8 @@ fn custom_pattern_and_length_passes_still_run_validator() {
 #[test]
 fn custom_pattern_rejects_wafv2_description_parentheses() {
     let pattern = r"^[a-zA-Z0-9=:#@/\-,.][a-zA-Z0-9+=:#@/\-,.\s]+[a-zA-Z0-9+=:#@/\-,.]{1,256}$";
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("EntityDescription")),
-        AttributeType::string(),
         Some(pattern.to_string()),
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3781,9 +3762,8 @@ fn custom_pattern_rejects_wafv2_description_parentheses() {
 
 #[test]
 fn custom_length_uses_character_count_not_bytes() {
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         None,
         Some((Some(1), Some(5))),
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3820,9 +3800,8 @@ fn custom_length_uses_character_count_not_bytes() {
 
 #[test]
 fn custom_length_enforces_minimum_bound() {
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         None,
         Some((Some(2), None)),
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3851,13 +3830,11 @@ fn custom_length_enforces_minimum_bound() {
 
 #[test]
 fn custom_int_base_maps_length_to_range() {
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_int_with_validator(
         None,
-        AttributeType::int(),
-        Some("^[a-z]+$".to_string()),
-        Some((Some(100), Some(200))),
+        Some((Some(100), Some(200)))
+            .map(|(min, max)| (min.map(|v| v as i64), max.map(|v| v as i64))),
         crate::schema::legacy_validator(|_| Ok(())),
-        None,
     );
 
     assert!(
@@ -3877,9 +3854,8 @@ fn custom_uncompilable_pattern_is_non_fatal() {
         regex::Regex::new(pattern).is_err(),
         "test must use a pattern unsupported by the regex crate"
     );
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         Some(pattern.to_string()),
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3896,9 +3872,8 @@ fn custom_uncompilable_pattern_is_non_fatal() {
 
 #[test]
 fn schema_validate_attr_dispatches_to_custom_pattern_validation() {
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("Slug")),
-        AttributeType::string(),
         Some("^[a-z]+$".to_string()),
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3925,9 +3900,8 @@ fn schema_validate_attr_dispatches_to_custom_pattern_validation() {
 
 #[test]
 fn custom_type_name_anonymous_pattern_only() {
-    let t = AttributeType::custom(
+    let t = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         Some("^foo$".to_string()),
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3938,9 +3912,8 @@ fn custom_type_name_anonymous_pattern_only() {
 
 #[test]
 fn custom_type_name_anonymous_length_only() {
-    let t = AttributeType::custom(
+    let t = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         None,
         Some((Some(1), Some(64))),
         crate::schema::legacy_validator(|_| Ok(())),
@@ -3951,9 +3924,8 @@ fn custom_type_name_anonymous_length_only() {
 
 #[test]
 fn custom_type_name_anonymous_pattern_and_length() {
-    let t = AttributeType::custom(
+    let t = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         Some("^.*$".to_string()),
         Some((Some(1), Some(64))),
         crate::schema::legacy_validator(|_| Ok(())),
@@ -4531,9 +4503,8 @@ fn union_string_vs_custom_picks_custom_error_for_string_input() {
     }
     let union_type = AttributeType::union(vec![
         AttributeType::int(),
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("Arn")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(must_be_arn),
@@ -4598,13 +4569,10 @@ fn union_custom_with_int_base_picks_custom_error_for_int_input() {
     // through a Custom on top so the actual reachable failure path
     // is the `Custom` one.
     let union_type = AttributeType::union(vec![
-        AttributeType::custom(
+        AttributeType::refined_int_with_validator(
             Some(TypeIdentity::bare("PositiveInt")),
-            AttributeType::int(),
-            None,
             None,
             legacy_validator(must_be_positive),
-            None,
         ),
         AttributeType::bool(),
     ]);
@@ -4664,9 +4632,8 @@ fn custom_validator_can_capture_external_state() {
     // closure-capable validator can. This is the core acceptance for
     // #2217 (closure-capable Custom validator).
     let allowed_region = "ap-northeast-1".to_string();
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("Region")),
-        AttributeType::string(),
         None,
         None,
         validator(move |v| match v {
@@ -4706,9 +4673,8 @@ fn custom_validator_returns_structured_type_error_directly() {
     // bypassing the legacy `String -> ValidationFailed` round-trip.
     // This is what unlocks LSP code-action quick-fixes for Custom-typed
     // attributes (see #2220 / #2309 for the structured-error path).
-    let attr = AttributeType::custom(
+    let attr = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("Mode")),
-        AttributeType::string(),
         None,
         None,
         validator(|v| match v {
@@ -4853,9 +4819,8 @@ fn walk_custom_lookup_skips_value_unknown() {
                 .to_string(),
         })
     });
-    let custom_type = AttributeType::custom(
+    let custom_type = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("vpc_id")),
-        AttributeType::string(),
         None,
         None,
         always_fail,
@@ -4898,9 +4863,8 @@ fn union_walk_custom_lookup_succeeds_when_any_member_accepts() {
     // because the approving arm matches; the sibling's failure is
     // discarded.
     let custom = |name: &str| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare(name)),
-            AttributeType::string(),
             None,
             None,
             validator(|_v: &Value| Ok(())),
@@ -4941,9 +4905,8 @@ fn union_walk_custom_lookup_emits_smallest_error_set_when_all_fail() {
     // sum. Both arms emit a single error here, so the Union's error
     // count must be 1, not 2.
     let custom = |name: &str| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare(name)),
-            AttributeType::string(),
             None,
             None,
             validator(|_v: &Value| Ok(())),

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -2127,16 +2127,8 @@ mod tests {
         );
         let exports =
             mk_typed_exports(&[("orgs", &[("key_arn", TypeExpr::Simple("arn".to_string()))])]);
-        let kms_arn = AttributeType::custom(
+        let kms_arn = AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("KmsKeyArn")),
-            AttributeType::custom(
-                Some(TypeIdentity::bare("Arn")),
-                AttributeType::string(),
-                None,
-                None,
-                crate::schema::legacy_validator(|_| Ok(())),
-                None,
-            ),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -2182,9 +2174,8 @@ mod tests {
         // Receiver is `String`. Without narrowing, `map(AwsAccountId)`
         // compares against `String` and fails. With narrowing,
         // `AwsAccountId` (Custom over String) is accepted.
-        let aws_account_id = AttributeType::custom(
+        let aws_account_id = AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("AwsAccountId")),
-            AttributeType::string(),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -805,9 +805,8 @@ mod tests {
     }
 
     fn vpc_id_custom() -> AttributeType {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("VpcId")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(noop),

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1394,9 +1394,8 @@ fn is_type_expr_compatible_unknown_rejects_custom_receiver() {
     fn noop(_v: &crate::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let custom = AttributeType::custom(
+    let custom = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(noop),
@@ -1415,9 +1414,8 @@ fn is_type_expr_compatible_string_rejects_custom_with_semantic_name() {
     fn noop(_v: &crate::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let schema = AttributeType::custom(
+    let schema = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(noop),
@@ -1443,9 +1441,8 @@ fn is_type_expr_compatible_string_accepts_custom_without_semantic_name() {
     fn noop(_v: &crate::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let schema = AttributeType::custom(
+    let schema = AttributeType::refined_string_with_validator(
         None,
-        AttributeType::string(),
         Some("^.+$".to_string()),
         None,
         legacy_validator(noop),
@@ -1473,9 +1470,8 @@ fn is_type_expr_compatible_string_rejects_union_containing_specific_custom() {
     }
     let schema = AttributeType::union(vec![
         AttributeType::string(),
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("VpcId")),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(noop),
@@ -1502,9 +1498,8 @@ fn is_type_expr_compatible_string_rejects_union_of_only_specific_customs() {
         Ok(())
     }
     let mk = |name: &str| {
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare(name)),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(noop),
@@ -1556,9 +1551,8 @@ fn is_type_expr_compatible_simple_vpcid_accepts_custom_vpcid() {
     fn noop(_v: &crate::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let schema = AttributeType::custom(
+    let schema = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(noop),
@@ -1633,9 +1627,8 @@ fn attribute_param_ref_type_mismatch_detected() {
     role_schema = role_schema.attribute(AttributeSchema::new("role_name", AttributeType::string()));
     role_schema = role_schema.attribute(AttributeSchema::new(
         "arn",
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(TypeIdentity::bare("IamRoleArn")),
-            AttributeType::string(),
             None,
             None,
             crate::schema::legacy_validator(|_| Ok(())),
@@ -1784,9 +1777,8 @@ fn validate_export_params_rejects_type_mismatch() {
 #[test]
 fn type_compat_subtype_accepted() {
     // arn accepts a provider-scoped KMS key ARN (narrower segments, same kind).
-    let kms_key_arn = AttributeType::custom(
+    let kms_key_arn = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::new(Some("aws"), ["kms", "Key"], "Arn")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -1802,9 +1794,8 @@ fn type_compat_subtype_accepted() {
 #[test]
 fn type_compat_sibling_rejected() {
     // kms_key_arn rejects an IAM role ARN sibling.
-    let iam_role_arn = AttributeType::custom(
+    let iam_role_arn = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::new(Some("aws"), ["iam", "Role"], "Arn")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -1820,9 +1811,8 @@ fn type_compat_sibling_rejected() {
 #[test]
 fn type_compat_resource_id_subtype() {
     // resource_id accepts VPC resource IDs (narrower segments, same kind).
-    let vpc_id = AttributeType::custom(
+    let vpc_id = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::new(Some("aws"), ["ec2", "Vpc"], "ResourceId")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -1838,16 +1828,8 @@ fn type_compat_resource_id_subtype() {
 #[test]
 fn type_compat_resource_id_siblings_rejected() {
     // vpc_id rejects SubnetId (sibling)
-    let subnet_id = AttributeType::custom(
+    let subnet_id = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("SubnetId")),
-        AttributeType::custom(
-            Some(TypeIdentity::bare("AwsResourceId")),
-            AttributeType::string(),
-            None,
-            None,
-            crate::schema::legacy_validator(|_| Ok(())),
-            None,
-        ),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -1862,9 +1844,8 @@ fn type_compat_resource_id_siblings_rejected() {
 
 #[test]
 fn type_compat_exact_match() {
-    let arn = AttributeType::custom(
+    let arn = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("Arn")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),
@@ -1998,9 +1979,8 @@ fn type_compat_simple_rejected_when_union_has_no_plain_string() {
 // allow-list, this test will fail and force a re-think.
 #[test]
 fn type_compat_simple_rejected_when_union_has_string_shaped_peer() {
-    let arn = AttributeType::custom(
+    let arn = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::bare("Arn")),
-        AttributeType::string(),
         None,
         None,
         crate::schema::legacy_validator(|_| Ok(())),

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2756,9 +2756,8 @@ fn exports_map_value_offers_matching_resource_refs() {
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let account_id = AttributeType::custom(
+    let account_id = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(validate_noop),
@@ -2840,9 +2839,8 @@ fn exports_map_value_multiple_entries_returns_refs() {
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let account_id = AttributeType::custom(
+    let account_id = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(validate_noop),
@@ -2897,9 +2895,8 @@ fn exports_map_value_includes_bindings_from_sibling_files() {
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let account_id = AttributeType::custom(
+    let account_id = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(validate_noop),
@@ -2954,9 +2951,8 @@ fn custom_type_value_ref_includes_sibling_file_bindings() {
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let account_id = AttributeType::custom(
+    let account_id = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(validate_noop),
@@ -3054,9 +3050,8 @@ fn binding_dot_completion_resolves_sibling_file_binding() {
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let account_id = AttributeType::custom(
+    let account_id = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(validate_noop),
@@ -3289,9 +3284,8 @@ fn upstream_state_string_export_not_offered_to_specific_custom_receiver() {
     fn noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let vpc_id_type = AttributeType::custom(
+    let vpc_id_type = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(noop),

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -219,9 +219,8 @@ pub(super) fn test_provider_with_vpc_and_security_group() -> CompletionProvider 
     fn noop_validate(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let vpc_id_custom = AttributeType::custom(
+    let vpc_id_custom = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("VpcId")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(noop_validate),
@@ -247,9 +246,8 @@ pub(super) fn test_provider_with_custom_semantic_attr() -> CompletionProvider {
     fn noop_validate(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
-    let account_id = AttributeType::custom(
+    let account_id = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("aws_account_id")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(noop_validate),

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -983,7 +983,7 @@ fn literal_completions_from_type_expr(type_expr: &parser::TypeExpr) -> Vec<Compl
 /// reused without forking a parallel implementation.
 ///
 /// `Simple(name)` (snake_case) is reified as
-/// `AttributeType::custom(None, String, None, None, None, None)` — same shape `parse_exports_type_text` produces for `exports`
+/// refined String with a bare identity — same shape `parse_exports_type_text` produces for `exports`
 /// annotations. The other arms cover the structural cases the
 /// dispatcher recurses through. Returns `None` for shapes that have no
 /// useful default (e.g. resource refs, `<unknown>`).
@@ -1000,11 +1000,10 @@ fn type_expr_to_attribute_type(
         parser::TypeExpr::Int => Some(AttributeType::int()),
         parser::TypeExpr::Float => Some(AttributeType::float()),
         parser::TypeExpr::Duration => Some(AttributeType::duration()),
-        parser::TypeExpr::Simple(name) => Some(AttributeType::custom(
+        parser::TypeExpr::Simple(name) => Some(AttributeType::refined_string_with_validator(
             Some(carina_core::schema::TypeIdentity::bare(
                 parser::snake_to_pascal(name),
             )),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(noop),

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -2115,9 +2115,8 @@ fn parse_exports_type_text(text: &str) -> Option<AttributeType> {
         name if name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
             && name.chars().all(|c| c.is_ascii_alphanumeric()) =>
         {
-            Some(AttributeType::custom(
+            Some(AttributeType::refined_string_with_validator(
                 Some(carina_core::schema::TypeIdentity::bare(name)),
-                AttributeType::string(),
                 None,
                 None,
                 legacy_validator(noop_validate),

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1774,13 +1774,12 @@ fn distinct_semantic_customs_are_rejected() {
         .as_data_source()
         .attribute(AttributeSchema::new(
             "account_id",
-            AttributeType::custom(
+            AttributeType::refined_string_with_validator(
                 Some(carina_core::schema::TypeIdentity::new(
                     Some("aws"),
                     Vec::<String>::new(),
                     "AwsAccountId",
                 )),
-                AttributeType::string(),
                 None,
                 None,
                 legacy_validator(validate_account_id),
@@ -1791,13 +1790,12 @@ fn distinct_semantic_customs_are_rejected() {
     // Target resource: has a TargetId attribute (also String-based Custom)
     let target_schema = ResourceSchema::new("sso.Assignment").attribute(AttributeSchema::new(
         "target_id",
-        AttributeType::custom(
+        AttributeType::refined_string_with_validator(
             Some(carina_core::schema::TypeIdentity::new(
                 Some("awscc"),
                 Vec::<String>::new(),
                 "TargetId",
             )),
-            AttributeType::string(),
             None,
             None,
             legacy_validator(validate_target_id),
@@ -1837,9 +1835,8 @@ fn exports_cross_file_ref_no_false_positive() {
     use carina_core::resource::{ConcreteValue, Value};
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let aws_account_id_type = AttributeType::custom(
+    let aws_account_id_type = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("AwsAccountId")),
-        AttributeType::string(),
         None,
         None,
         carina_core::schema::legacy_validator(|v| match v {
@@ -3095,9 +3092,8 @@ fn lsp_quoted_literal_on_namespaced_custom_says_got_a_string_literal() {
 fn lsp_custom_string_pattern_mismatch_reports_required_pattern() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
-    let bucket_name = AttributeType::custom(
+    let bucket_name = AttributeType::refined_string_with_validator(
         Some(carina_core::schema::TypeIdentity::bare("BucketName")),
-        AttributeType::string(),
         Some("^prod-[a-z0-9]+$".to_string()),
         None,
         legacy_validator(|_| Ok(())),

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -76,9 +76,8 @@ pub(super) fn test_engine_with_iam_policy_arn_custom_type() -> DiagnosticEngine 
         AttributeSchema, AttributeType, ResourceSchema, TypeIdentity, legacy_validator,
     };
 
-    let iam_policy_arn = AttributeType::custom(
+    let iam_policy_arn = AttributeType::refined_string_with_validator(
         Some(TypeIdentity::new(Some("aws"), ["iam", "Policy"], "Arn")),
-        AttributeType::string(),
         None,
         None,
         legacy_validator(|_| Ok(())),

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -797,21 +797,12 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             ordered,
             length,
             ..
-        } => {
-            let base = if *ordered {
-                CoreAttributeType::list(proto_attr_type_to_core(element_type))
-            } else {
-                CoreAttributeType::unordered_list(proto_attr_type_to_core(element_type))
-            };
-            CoreAttributeType::custom(
-                None,
-                base,
-                None,
-                *length,
-                legacy_validator(|_| Ok(())),
-                None,
-            )
-        }
+        } => CoreAttributeType::refined_list(
+            proto_attr_type_to_core(element_type),
+            *ordered,
+            *length,
+            legacy_validator(|_| Ok(())),
+        ),
         proto::AttributeType::Map { inner, key } => CoreAttributeType::map_with_key(
             proto_attr_type_to_core(key),
             proto_attr_type_to_core(inner),
@@ -830,22 +821,44 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             length,
             to_dsl,
             ..
-        } => CoreAttributeType::custom(
-            if name.is_empty() {
+        } => {
+            let identity = if name.is_empty() {
                 None
             } else {
                 Some(carina_core::schema::TypeIdentity::from_dotted(name))
-            },
-            custom_base_to_core(base, to_dsl.clone()),
-            pattern.clone(),
-            *length,
-            legacy_validator(|_| Ok(())), // Validation is handled via ProviderContext.validators
-            // `to_dsl` is a `fn` pointer that does not survive the
-            // WASM-component boundary; host-side normalization for
-            // plugin-provided types is registered separately, so this
-            // arm always sees `None` after the proto→core lift.
-            None,
-        ),
+            };
+            let validate = legacy_validator(|_| Ok(())); // Validation is handled via ProviderContext.validators
+            match base.as_ref() {
+                proto::AttributeType::String { .. } => {
+                    CoreAttributeType::refined_string_with_validator(
+                        identity,
+                        pattern.clone(),
+                        *length,
+                        validate,
+                        to_dsl.clone(),
+                    )
+                }
+                proto::AttributeType::Int { .. } => CoreAttributeType::refined_int_with_validator(
+                    identity,
+                    length.map(|(min, max)| (min.map(|v| v as i64), max.map(|v| v as i64))),
+                    validate,
+                ),
+                proto::AttributeType::Float { .. } => {
+                    CoreAttributeType::refined_float_with_validator(identity, None, validate)
+                }
+                proto::AttributeType::List {
+                    element_type,
+                    ordered,
+                    ..
+                } => CoreAttributeType::refined_list(
+                    proto_attr_type_to_core(element_type),
+                    *ordered,
+                    *length,
+                    validate,
+                ),
+                other => panic!("legacy Custom wire type has unsupported base {other:?}"),
+            }
+        }
         proto::AttributeType::CustomEnum {
             name,
             base,
@@ -870,20 +883,6 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
         // `ResourceSchema.defs` map is converted alongside in
         // `proto_schema_to_core` so resolution at walk-sites succeeds.
         proto::AttributeType::Ref { name } => CoreAttributeType::ref_(name.clone()),
-    }
-}
-
-fn custom_base_to_core(
-    base: &proto::AttributeType,
-    to_dsl: Option<proto::DslTransform>,
-) -> CoreAttributeType {
-    match base {
-        proto::AttributeType::String { .. } => {
-            CoreAttributeType::refined_string(None, None, None, to_dsl)
-        }
-        proto::AttributeType::Int { .. } => CoreAttributeType::int(),
-        proto::AttributeType::Float { .. } => CoreAttributeType::float(),
-        _ => proto_attr_type_to_core(base),
     }
 }
 


### PR DESCRIPTION
## Summary

Final implementation PR in the chain from carina#3429. Retires the `AttributeType::custom(...)` compatibility shim now that both provider repos emit refined primitive / list shapes (provider-aws#422 and provider-awscc#341), and pins a regression test for Route53 HostedZone `Name` normalization so the chain's #3427 resolution cannot silently regress.

- Delete the `AttributeType::custom(...)` shim from `carina-core::schema`.
- Replace remaining shim callers with the refined primitive / list constructors (`refined_string` / `refined_int` / `refined_float` / `refined_list`).
- Keep legacy `ProtoAttributeType::Custom` deserialize compatibility in `carina-plugin-host`, but lift it directly into refined core variants instead of routing through the shim. Old provider payloads still load; new awscc/aws emit goes through the refined wire shapes added in #3432.
- Add a plan fixture (`route53_hosted_zone_name_strip_suffix_no_diff`) under `carina-cli/tests/fixtures/plan_display/` that mirrors `dynamic_enum_az_no_diff`: state stores `"registry-dev.carina-rs.dev."`, DSL desires `"registry-dev.carina-rs.dev"`, and the plan must contain no effects.

## Verification

- `RUSTC_WRAPPER= cargo check --workspace --all-targets`
- `RUSTC_WRAPPER= cargo nextest run` — 3950 passed, 72 skipped
- `RUSTC_WRAPPER= cargo test --doc`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `scripts/check-*.sh`

Refs: carina#3429
Refs: carina#3427
