### PR TITLE
Canonicalize enum hash inputs for anonymous resource addresses (carina#3428)

### DIFF
--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -414,6 +414,15 @@ fn identity_attributes_for_provider(ctx: &WiringContext, name: &str) -> Vec<Stri
         .unwrap_or_default()
 }
 
+fn provider_config_attribute_type_for(
+    ctx: &WiringContext,
+    provider_name: &str,
+    attr_name: &str,
+) -> Option<carina_core::schema::AttributeType> {
+    provider_mod::find_factory(ctx.factories(), provider_name)
+        .and_then(|factory| factory.provider_config_attribute_types().remove(attr_name))
+}
+
 /// Detect and apply anonymous → let-bound resource renames.
 ///
 /// Mirrors `materialize_moved_states` but for synthetic rename pairs produced
@@ -557,9 +566,15 @@ pub fn compute_anonymous_identifiers_with_ctx(
     resources: &mut [Resource],
     providers: &[ProviderConfig],
 ) -> Vec<AppError> {
-    match identifier::compute_anonymous_identifiers(resources, providers, ctx.schemas(), &|name| {
-        identity_attributes_for_provider(ctx, name)
-    }) {
+    match identifier::compute_anonymous_identifiers_with_provider_config_types(
+        resources,
+        providers,
+        ctx.schemas(),
+        &|name| identity_attributes_for_provider(ctx, name),
+        &|provider_name, attr_name| {
+            provider_config_attribute_type_for(ctx, provider_name, attr_name)
+        },
+    ) {
         Ok(()) => Vec::new(),
         Err(msg) => vec![AppError::Config(msg)],
     }

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -316,7 +316,9 @@ fn canonical_create_only_value_string(
     attribute_type: Option<&AttributeType>,
 ) -> Option<String> {
     match value {
-        Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
+        Value::Concrete(ConcreteValue::String(s)) => {
+            Some(canonical_create_only_text_string(s, attribute_type))
+        }
         Value::Concrete(ConcreteValue::EnumIdentifier(_)) => {
             Some(canonical_enum_feature_string(value, attribute_type))
         }
@@ -324,10 +326,14 @@ fn canonical_create_only_value_string(
     }
 }
 
-fn canonical_state_create_only_value_string(
+fn canonical_create_only_text_string(
     value: &str,
     attribute_type: Option<&AttributeType>,
 ) -> String {
+    if attribute_type.and_then(AttributeType::enum_parts).is_none() {
+        return value.to_string();
+    }
+
     let enum_value = Value::Concrete(ConcreteValue::EnumIdentifier(value.to_string()));
     let canonical = canonical_enum_feature_string(&enum_value, attribute_type);
     if canonical == deterministic_value_string(&enum_value) {
@@ -335,6 +341,13 @@ fn canonical_state_create_only_value_string(
     } else {
         canonical
     }
+}
+
+fn canonical_state_create_only_value_string(
+    value: &str,
+    attribute_type: Option<&AttributeType>,
+) -> String {
+    canonical_create_only_text_string(value, attribute_type)
 }
 
 /// Maximum Hamming distance (out of 64 bits) for SimHash-based reconciliation.

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -7,7 +7,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::parser::ProviderConfig;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, Value};
-use crate::schema::SchemaRegistry;
+use crate::schema::{AttributeType, ResourceSchema, SchemaRegistry};
+use crate::utils::{extract_enum_value_with_values, validate_enum_namespace};
 use crate::validation::is_string_compatible_type;
 
 /// Generate a random 8-character lowercase hex suffix using UUID v4.
@@ -231,6 +232,111 @@ fn deterministic_value_string(value: &Value) -> String {
     }
 }
 
+fn enum_identifier_segments_match(
+    raw: &str,
+    attribute_type: &AttributeType,
+    allow_dotted_value: bool,
+) -> bool {
+    let Some((identity, _, _, _, _)) = attribute_type.enum_parts() else {
+        return false;
+    };
+    if !raw.contains('.') {
+        return true;
+    }
+
+    let parts: Vec<&str> = raw.split('.').collect();
+    let Some(kind_idx) = parts.iter().position(|part| *part == identity.kind) else {
+        return false;
+    };
+    if kind_idx + 1 >= parts.len() {
+        return false;
+    }
+    if !allow_dotted_value && parts.len() != kind_idx + 2 {
+        return false;
+    }
+
+    if !identity.segments.is_empty() {
+        let prefix = &parts[..kind_idx];
+        if prefix.len() < identity.segments.len() {
+            return false;
+        }
+        let segment_start = prefix.len() - identity.segments.len();
+        if !prefix[segment_start..]
+            .iter()
+            .copied()
+            .eq(identity.segments.iter().map(String::as_str))
+        {
+            return false;
+        }
+    }
+
+    validate_enum_namespace(raw, identity).is_ok()
+        || parts
+            .get(kind_idx)
+            .is_some_and(|kind| *kind == identity.kind)
+}
+
+/// Return the anonymous-hash feature string for a schema-known enum value.
+///
+/// Only parser-surface `EnumIdentifier` values are canonicalized. All other
+/// values deliberately keep the legacy deterministic representation so deferred
+/// bindings and non-enum hash inputs do not change.
+pub(crate) fn canonical_enum_feature_string(
+    value: &Value,
+    attribute_type: Option<&AttributeType>,
+) -> String {
+    let Some(attribute_type) = attribute_type else {
+        return deterministic_value_string(value);
+    };
+    let Value::Concrete(ConcreteValue::EnumIdentifier(raw)) = value else {
+        return deterministic_value_string(value);
+    };
+    let Some((_identity, values, _aliases, _validate, dsl_map)) = attribute_type.enum_parts()
+    else {
+        return deterministic_value_string(value);
+    };
+    if !enum_identifier_segments_match(raw, attribute_type, values.is_some()) {
+        return deterministic_value_string(value);
+    }
+
+    let valid_values: Vec<&str> = values.into_iter().flatten().map(String::as_str).collect();
+    let variant = extract_enum_value_with_values(raw, &valid_values);
+    let api_value = dsl_map.api_for_hash_feature(variant);
+    if let Some(values) = values
+        && !values.iter().any(|v| v == &api_value)
+    {
+        return deterministic_value_string(value);
+    }
+
+    format!("EnumApiValue({:?})", api_value)
+}
+
+fn canonical_create_only_value_string(
+    value: &Value,
+    attribute_type: Option<&AttributeType>,
+) -> Option<String> {
+    match value {
+        Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
+        Value::Concrete(ConcreteValue::EnumIdentifier(_)) => {
+            Some(canonical_enum_feature_string(value, attribute_type))
+        }
+        _ => None,
+    }
+}
+
+fn canonical_state_create_only_value_string(
+    value: &str,
+    attribute_type: Option<&AttributeType>,
+) -> String {
+    let enum_value = Value::Concrete(ConcreteValue::EnumIdentifier(value.to_string()));
+    let canonical = canonical_enum_feature_string(&enum_value, attribute_type);
+    if canonical == deterministic_value_string(&enum_value) {
+        value.to_string()
+    } else {
+        canonical
+    }
+}
+
 /// Maximum Hamming distance (out of 64 bits) for SimHash-based reconciliation.
 /// Two identifiers with distance below this threshold are considered the "same resource"
 /// with modified attributes.
@@ -278,22 +384,26 @@ pub(crate) fn flatten_value_for_simhash(
     prefix: &str,
     value: &Value,
     out: &mut std::collections::BTreeMap<String, String>,
+    attribute_type: Option<&AttributeType>,
 ) {
     match value {
         Value::Concrete(ConcreteValue::Map(map)) => {
             for (k, v) in map {
                 let key = format!("{}.{}", prefix, k);
-                flatten_value_for_simhash(&key, v, out);
+                flatten_value_for_simhash(&key, v, out, None);
             }
         }
         Value::Concrete(ConcreteValue::List(items)) => {
             for (i, item) in items.iter().enumerate() {
                 let key = format!("{}[{}]", prefix, i);
-                flatten_value_for_simhash(&key, item, out);
+                flatten_value_for_simhash(&key, item, out, None);
             }
         }
         _ => {
-            out.insert(prefix.to_string(), deterministic_value_string(value));
+            out.insert(
+                prefix.to_string(),
+                canonical_enum_feature_string(value, attribute_type),
+            );
         }
     }
 }
@@ -353,13 +463,17 @@ pub(crate) fn extract_hash_from_identifier(identifier: &str) -> Option<u64> {
 fn simhash_from_identity_and_resource(
     identity_values: &BTreeMap<String, String>,
     resource: &Resource,
+    schema: Option<&ResourceSchema>,
 ) -> u64 {
     let mut simhash_values = identity_values.clone();
     for (key, value) in &resource.attributes {
         if key.starts_with('_') {
             continue;
         }
-        flatten_value_for_simhash(key, value, &mut simhash_values);
+        let attribute_type = schema
+            .and_then(|schema| schema.attributes.get(key))
+            .map(|attr| &attr.attr_type);
+        flatten_value_for_simhash(key, value, &mut simhash_values, attribute_type);
     }
     compute_simhash(&simhash_values)
 }
@@ -370,6 +484,7 @@ fn simhash_from_identity_and_resource(
 fn compute_resource_simhash(
     resource: &Resource,
     providers: &[ProviderConfig],
+    registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> u64 {
     let mut identity_values: BTreeMap<String, String> = BTreeMap::new();
@@ -384,8 +499,10 @@ fn compute_resource_simhash(
         }
     }
 
-    simhash_from_identity_and_resource(&identity_values, resource)
+    simhash_from_identity_and_resource(&identity_values, resource, registry.get_for(resource))
 }
+
+type ProviderConfigAttributeTypeFn<'a> = dyn Fn(&str, &str) -> Option<AttributeType> + 'a;
 
 /// Compute stable identifiers for anonymous resources (those with empty ResourceId.name).
 /// Uses create-only properties and provider identity attributes to generate a deterministic hash.
@@ -397,6 +514,22 @@ pub fn compute_anonymous_identifiers(
     providers: &[ProviderConfig],
     registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+) -> Result<(), String> {
+    compute_anonymous_identifiers_with_provider_config_types(
+        resources,
+        providers,
+        registry,
+        identity_attributes_fn,
+        &|_, _| None,
+    )
+}
+
+pub fn compute_anonymous_identifiers_with_provider_config_types(
+    resources: &mut [Resource],
+    providers: &[ProviderConfig],
+    registry: &SchemaRegistry,
+    identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+    provider_config_attribute_type_fn: &ProviderConfigAttributeTypeFn<'_>,
 ) -> Result<(), String> {
     use std::collections::BTreeMap;
     use std::hash::{Hash, Hasher};
@@ -428,7 +561,12 @@ pub fn compute_anonymous_identifiers(
         if let Some(pc) = providers.iter().find(|p| p.name == *provider_name) {
             for attr_name in &identity_attrs {
                 if let Some(value) = pc.attributes.get(attr_name.as_str()) {
-                    identity_values.insert(attr_name.clone(), deterministic_value_string(value));
+                    let attribute_type =
+                        provider_config_attribute_type_fn(provider_name, attr_name);
+                    identity_values.insert(
+                        attr_name.clone(),
+                        canonical_enum_feature_string(value, attribute_type.as_ref()),
+                    );
                 }
             }
         }
@@ -446,7 +584,14 @@ pub fn compute_anonymous_identifiers(
                 // Use the prefix for hashing to produce a stable identifier
                 hash_values.insert(attr_name, format!("Prefix({:?})", prefix));
             } else if let Some(value) = resource.get_attr(attr_name) {
-                hash_values.insert(attr_name, deterministic_value_string(value));
+                let attribute_type = schema
+                    .attributes
+                    .get(*attr_name)
+                    .map(|attr| &attr.attr_type);
+                hash_values.insert(
+                    attr_name,
+                    canonical_enum_feature_string(value, attribute_type),
+                );
             }
         }
         // Also include schema-level identity attributes in the hash.
@@ -456,7 +601,14 @@ pub fn compute_anonymous_identifiers(
             if !hash_values.contains_key(attr_name)
                 && let Some(value) = resource.get_attr(attr_name)
             {
-                hash_values.insert(attr_name, deterministic_value_string(value));
+                let attribute_type = schema
+                    .attributes
+                    .get(*attr_name)
+                    .map(|attr| &attr.attr_type);
+                hash_values.insert(
+                    attr_name,
+                    canonical_enum_feature_string(value, attribute_type),
+                );
             }
         }
 
@@ -465,7 +617,8 @@ pub fn compute_anonymous_identifiers(
         let hash_str = if use_simhash {
             // Use SimHash for locality-sensitive hashing: similar inputs produce
             // similar hashes, enabling Hamming distance reconciliation.
-            let simhash = simhash_from_identity_and_resource(&identity_values, resource);
+            let simhash =
+                simhash_from_identity_and_resource(&identity_values, resource, Some(schema));
             format!("{:016x}", simhash)
         } else {
             // Use standard hash for create-only properties
@@ -608,8 +761,14 @@ pub fn reconcile_anonymous_identifiers(
         // Collect this resource's create-only values
         let mut resource_co_values: HashMap<&str, String> = HashMap::new();
         for attr_name in &create_only_attrs {
-            if let Some(Value::Concrete(ConcreteValue::String(v))) = resource.get_attr(attr_name) {
-                resource_co_values.insert(attr_name, v.clone());
+            if let Some(value) = resource.get_attr(attr_name) {
+                let attribute_type = schema
+                    .attributes
+                    .get(*attr_name)
+                    .map(|attr| &attr.attr_type);
+                if let Some(value) = canonical_create_only_value_string(value, attribute_type) {
+                    resource_co_values.insert(attr_name, value);
+                }
             }
         }
 
@@ -661,7 +820,10 @@ pub fn reconcile_anonymous_identifiers(
             let mut mismatched = 0;
             for (attr, value) in &resource_co_values {
                 if let Some(state_value) = entry.create_only_values.get(*attr) {
-                    if state_value == value {
+                    let attribute_type = schema.attributes.get(*attr).map(|attr| &attr.attr_type);
+                    let state_value =
+                        canonical_state_create_only_value_string(state_value, attribute_type);
+                    if &state_value == value {
                         matched += 1;
                     } else {
                         mismatched += 1;
@@ -806,7 +968,7 @@ pub fn detect_anonymous_to_named_renames(
             // SimHash fallback (rule 4 in the function doc). Pick the orphan
             // entry closest to the computed SimHash; tie → ambiguous, skip.
             let resource_hash =
-                compute_resource_simhash(resource, providers, identity_attributes_fn);
+                compute_resource_simhash(resource, providers, registry, identity_attributes_fn);
             let candidates = state_entries
                 .iter()
                 .filter(|e| !used_in_dsl.contains(&e.name))

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::resource::Resource;
-use crate::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
+use crate::schema::{
+    AttributeSchema, AttributeType, DslTransform, ResourceSchema, SchemaRegistry, enum_identity,
+};
 use indexmap::IndexMap;
 
 fn make_s3_bucket_schema() -> ResourceSchema {
@@ -12,6 +14,196 @@ fn registry_with_s3_bucket() -> SchemaRegistry {
     let mut r = SchemaRegistry::new();
     r.insert("awscc", make_s3_bucket_schema());
     r
+}
+
+fn provider_config(name: &str, attrs: Vec<(&str, Value)>) -> ProviderConfig {
+    ProviderConfig {
+        name: name.to_string(),
+        attributes: attrs
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect(),
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+        unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
+    }
+}
+
+fn region_type(provider: &str) -> AttributeType {
+    AttributeType::enum_(
+        enum_identity("Region", Some(provider)),
+        None,
+        Vec::new(),
+        None,
+        Some(DslTransform::HyphenToUnderscore),
+    )
+}
+
+fn eip_domain_type(provider: &str) -> AttributeType {
+    AttributeType::enum_(
+        enum_identity("Domain", Some(&format!("{provider}.ec2.Eip"))),
+        Some(vec!["vpc".to_string(), "standard".to_string()]),
+        Vec::new(),
+        None,
+        None,
+    )
+}
+
+#[test]
+fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
+    let schema = ResourceSchema::new("ec2.Route")
+        .attribute(AttributeSchema::new(
+            "route_table_id",
+            AttributeType::string(),
+        ))
+        .attribute(AttributeSchema::new(
+            "destination_cidr_block",
+            AttributeType::string(),
+        ));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
+    let provider_attr_type = |provider: &str, attr: &str| {
+        (provider == "awscc" && attr == "region").then(|| region_type("awscc"))
+    };
+
+    let make_resource = || {
+        let mut resource = Resource::with_provider("awscc", "ec2.Route", "", None);
+        resource.set_attr(
+            "route_table_id".to_string(),
+            Value::Concrete(ConcreteValue::String("rtb-123".to_string())),
+        );
+        resource.set_attr(
+            "destination_cidr_block".to_string(),
+            Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
+        );
+        resource
+    };
+
+    let providers_awscc = vec![provider_config(
+        "awscc",
+        vec![(
+            "region",
+            Value::Concrete(ConcreteValue::EnumIdentifier(
+                "awscc.Region.ap_northeast_1".to_string(),
+            )),
+        )],
+    )];
+    let providers_aws = vec![provider_config(
+        "awscc",
+        vec![(
+            "region",
+            Value::Concrete(ConcreteValue::EnumIdentifier(
+                "aws.Region.ap_northeast_1".to_string(),
+            )),
+        )],
+    )];
+
+    let mut resources_awscc = vec![make_resource()];
+    let mut resources_aws = vec![make_resource()];
+    compute_anonymous_identifiers_with_provider_config_types(
+        &mut resources_awscc,
+        &providers_awscc,
+        &schemas,
+        &identity_fn,
+        &provider_attr_type,
+    )
+    .unwrap();
+    compute_anonymous_identifiers_with_provider_config_types(
+        &mut resources_aws,
+        &providers_aws,
+        &schemas,
+        &identity_fn,
+        &provider_attr_type,
+    )
+    .unwrap();
+
+    assert_eq!(
+        resources_awscc[0].id.name_str(),
+        resources_aws[0].id.name_str()
+    );
+}
+
+#[test]
+fn test_anonymous_id_stable_across_provider_namespace_change_in_attribute() {
+    let schema = ResourceSchema::new("ec2.Eip")
+        .attribute(AttributeSchema::new("domain", eip_domain_type("awscc")).create_only());
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let make_resource = |domain: &str| {
+        let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
+        resource.set_attr(
+            "domain".to_string(),
+            Value::Concrete(ConcreteValue::EnumIdentifier(domain.to_string())),
+        );
+        resource
+    };
+
+    let mut resources_awscc = vec![make_resource("awscc.ec2.Eip.Domain.vpc")];
+    let mut resources_aws = vec![make_resource("aws.ec2.Eip.Domain.vpc")];
+    compute_anonymous_identifiers(&mut resources_awscc, &providers, &schemas, &identity_fn)
+        .unwrap();
+    compute_anonymous_identifiers(&mut resources_aws, &providers, &schemas, &identity_fn).unwrap();
+
+    assert_eq!(
+        resources_awscc[0].id.name_str(),
+        resources_aws[0].id.name_str()
+    );
+}
+
+#[test]
+fn test_reconcile_anonymous_id_after_provider_namespace_change() {
+    let schema = ResourceSchema::new("ec2.Eip")
+        .attribute(AttributeSchema::new("domain", eip_domain_type("awscc")).create_only())
+        .attribute(AttributeSchema::new("public_ipv4_pool", AttributeType::string()).create_only());
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let make_resource = |domain: &str, pool: &str| {
+        let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
+        resource.set_attr(
+            "domain".to_string(),
+            Value::Concrete(ConcreteValue::EnumIdentifier(domain.to_string())),
+        );
+        resource.set_attr(
+            "public_ipv4_pool".to_string(),
+            Value::Concrete(ConcreteValue::String(pool.to_string())),
+        );
+        resource
+    };
+
+    let mut old_resources = vec![make_resource("awscc.ec2.Eip.Domain.vpc", "pool-a")];
+    compute_anonymous_identifiers(&mut old_resources, &providers, &schemas, &identity_fn).unwrap();
+    let state_name = old_resources[0].id.name_str().to_string();
+
+    let mut desired_resources = vec![make_resource("aws.ec2.Eip.Domain.vpc", "pool-b")];
+    compute_anonymous_identifiers(&mut desired_resources, &providers, &schemas, &identity_fn)
+        .unwrap();
+    assert_ne!(state_name, desired_resources[0].id.name_str());
+
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: state_name.clone(),
+        create_only_values: vec![
+            ("domain".to_string(), "awscc.ec2.Eip.Domain.vpc".to_string()),
+            ("public_ipv4_pool".to_string(), "pool-a".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    }];
+    reconcile_anonymous_identifiers(&mut desired_resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
+
+    assert_eq!(desired_resources[0].id.name_str(), state_name);
 }
 
 #[test]

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -207,6 +207,43 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
 }
 
 #[test]
+fn test_reconcile_anonymous_id_mixed_string_and_enum_identifier_for_enum_attribute() {
+    let schema = ResourceSchema::new("ec2.Subnet")
+        .attribute(AttributeSchema::new("region", region_type("awscc")).create_only())
+        .attribute(AttributeSchema::new("name", AttributeType::string()).create_only());
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+
+    let state_name = "awscc_ec2_subnet_oldhash".to_string();
+    let mut resource =
+        Resource::with_provider("awscc", "ec2.Subnet", "awscc_ec2_subnet_newhash", None);
+    resource.set_attr(
+        "region".to_string(),
+        Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
+    );
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("new-subnet".to_string())),
+    );
+
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: state_name.clone(),
+        create_only_values: vec![
+            ("region".to_string(), "ap-northeast-1".to_string()),
+            ("name".to_string(), "old-subnet".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    }];
+    let mut resources = vec![resource];
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
+
+    assert_eq!(resources[0].id.name_str(), state_name);
+}
+
+#[test]
 fn test_generate_random_suffix_format() {
     let suffix = generate_random_suffix();
     assert_eq!(suffix.len(), 8);

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -979,7 +979,7 @@ pub fn instance_prefix_for_call(call: &ModuleCall) -> String {
     let mut features: BTreeMap<String, String> = BTreeMap::new();
     features.insert("_module".to_string(), call.module_name.clone());
     for (k, v) in &call.arguments {
-        crate::identifier::flatten_value_for_simhash(k, v, &mut features);
+        crate::identifier::flatten_value_for_simhash(k, v, &mut features, None);
     }
     let simhash = crate::identifier::compute_simhash(&features);
     format!("{}_{:016x}", call.module_name, simhash)

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -346,6 +346,28 @@ impl<'a> DslMap<'a> {
             .unwrap_or_else(|| dsl.to_string())
     }
 
+    /// Translate a DSL spelling back to its API-canonical spelling, using
+    /// inverse transforms for dynamic enum spaces where that inverse is
+    /// lossless enough for identity/hash consumers.
+    pub(crate) fn api_for_hash_feature(&self, dsl: &str) -> String {
+        self.aliases
+            .iter()
+            .find_map(|(a, d)| (d == dsl).then(|| a.clone()))
+            .unwrap_or_else(|| match self.to_dsl {
+                Some(DslTransform::HyphenToUnderscore) => dsl.replace('_', "-"),
+                Some(DslTransform::ReplaceTable(table)) => table
+                    .iter()
+                    .find_map(|(api, mapped_dsl)| (mapped_dsl == dsl).then(|| api.clone()))
+                    .unwrap_or_else(|| dsl.to_string()),
+                Some(
+                    DslTransform::Identity
+                    | DslTransform::StripSuffix(_)
+                    | DslTransform::Unknown(_),
+                )
+                | None => dsl.to_string(),
+            })
+    }
+
     /// True only when the mapping carries no DSL-side rewrite
     /// machinery: no alias-table entries and no transform callback.
     ///

--- a/notes/specs/2026-06-10-anonymous-address-stability.md
+++ b/notes/specs/2026-06-10-anonymous-address-stability.md
@@ -321,3 +321,30 @@ test proves the same requirement for resource attributes such as EIP `domain`.
 The third test covers the end-to-end compute-then-reconcile flow with old state
 and a new desired resource whose only semantic difference is the provider
 namespace prefix embedded in the enum identifier.
+
+## Implementation notes
+
+The implementation keeps `Value::Deferred` hash inputs unchanged. User-authored
+`let` binding names are neutral local names, so provider lock bumps do not
+change their meaning, and existing deferred strings such as
+`ResourceRef(main_rtb.id)` remain the intended deterministic representation.
+
+Only `Value::Concrete(ConcreteValue::EnumIdentifier(_))` values are normalized.
+That covers provider config identity attributes such as `region` and
+schema-known resource enum attributes such as EIP `domain`. Primitive values,
+maps, lists, and deferred values continue to use the existing deterministic
+value string path unless a schema-known enum leaf is being hashed directly.
+
+When the enum schema cannot be resolved, the enum identity does not match the
+expected attribute type, or the value cannot be converted to an API-canonical
+enum value, the implementation falls back to the old deterministic string. This
+avoids surprising hash movement for cases outside the known enum path while
+stabilizing the cases that can be normalized confidently.
+
+The primary target is DSL spelling changes inside a provider-compatible enum
+space, for example `awscc.Region.ap_northeast_1` and
+`aws.Region.ap_northeast_1` both hashing as `ap-northeast-1`. Switching the
+resource provider itself, such as `awscc.ec2.Route` to `aws.ec2.Route`, still
+changes the anonymous identifier prefix from `awscc_*` to `aws_*`; that broader
+provider-switch behavior is out of scope for this implementation and should be
+tracked separately.


### PR DESCRIPTION
Closes #3428

## Summary

This PR implements the enum hash-input canonicalization designed in #3435
(`notes/specs/2026-06-10-anonymous-address-stability.md`).

Anonymous resource hash inputs now canonicalize schema-known
`Value::Concrete(ConcreteValue::EnumIdentifier(_))` values to API spelling
before hashing, for both provider identity attributes and resource attributes.
Non-enum values and all `Value::Deferred` inputs keep the existing
deterministic string path. If schema/type lookup or enum canonicalization fails,
the code falls back to the old deterministic string to avoid unexpected hash
movement.

Reconcile-side create-only comparisons go through the same canonicalization on
both the desired-resource side and the state side, so a value stored as raw
`String("ap-northeast-1")` in state matches a desired `String("ap-northeast-1")`
or `EnumIdentifier("aws.Region.ap_northeast_1")` for the same enum-typed
attribute. The symmetric promote-if-enum-then-canonical helper is shared
between the two sites.

Follow-up issues:

- Provider-switch prefix follow-up: #3439
- Type-safety follow-up: #3438
- List/map element canonicalization follow-up: #3440

## Reproducing Tests

- `test_anonymous_id_stable_across_provider_namespace_change_in_identity`
  - Proves provider config identity values such as `region` hash by API value,
    not by `awscc.*` versus `aws.*` DSL namespace.
- `test_anonymous_id_stable_across_provider_namespace_change_in_attribute`
  - Proves schema-known enum resource attributes such as EIP `domain` hash by
    API value.
- `test_reconcile_anonymous_id_after_provider_namespace_change`
  - Covers create-only reconciliation when old state and new desired resources
    use different provider namespace prefixes inside enum identifiers.
- `test_reconcile_anonymous_id_mixed_string_and_enum_identifier_for_enum_attribute`
  - Added during round-1 self-review. Covers the mixed case where the desired
    resource has `Concrete(String("ap-northeast-1"))` and the state still
    stores the raw `"ap-northeast-1"` for an enum-typed attribute. Without
    symmetric canonicalization the two sides compared as unequal, which broke
    reconciliation for the very enum attributes this PR is meant to stabilize.

## Provider-side prerequisite

The canonicalization only fires when the provider exposes the relevant
attribute as an enum (via `Provider::provider_config_attribute_types`
for identity attributes and via the resource schema for resource
attributes). The AWS and AWSCC providers already model `region` and
`Eip.Domain` as enums in their schemas, so the issue #3428 scenario is
covered. If a provider exposes a string-typed attribute instead, the
fallback path still produces stable hashes within a single namespace
spelling but does not absorb cross-namespace drift for that attribute.

## Verification

- `RUSTC_WRAPPER= cargo check -p carina-core`
- `RUSTC_WRAPPER= cargo nextest run -p carina-core`
- `RUSTC_WRAPPER= cargo nextest run -p carina-cli`
- `RUSTC_WRAPPER= cargo test -p carina-core --doc`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `RUSTC_WRAPPER= bash scripts/check-docs-use-new-spellings.sh`
- `RUSTC_WRAPPER= bash scripts/check-example-warnings.sh`
- `RUSTC_WRAPPER= bash scripts/check-no-direct-resources-access.sh`
- `RUSTC_WRAPPER= bash scripts/check-plan-fixtures.sh`
- `RUSTC_WRAPPER= bash scripts/check-provider-boundaries.sh`
