### PR TITLE
Remove dagayn entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ site/.astro/
 
 # Superpowers brainstorm sessions
 .superpowers/
-# Added by dagayn
-.dagayn/
-.mcp.json


### PR DESCRIPTION
## Summary

- Remove `.dagayn/` and `.mcp.json` entries that were added by dagayn MCP integration
- dagayn MCP, skills, and hooks have been removed from this project