### PR TITLE
Introduce RawEnumIdentifier and CanonicalEnumValue core types (carina#3438 PR2)

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -331,6 +331,7 @@ pub(crate) fn dsl_value_to_json(
             Ok(Some(serde_json::Value::String(s.to_string())))
         }
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            // TODO(carina#3438): PR3 — state-facing serialization must use the typed enum object per design doc §Serialization; this flat string is a dormant placeholder.
             Ok(Some(serde_json::Value::String(c.api_value().to_string())))
         }
         Value::Concrete(ConcreteValue::Bool(b)) => Ok(Some(serde_json::Value::Bool(*b))),

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -326,9 +326,12 @@ pub(crate) fn dsl_value_to_json(
     use carina_core::value::{SerializationContext, SerializationError};
     let ctx = SerializationContext::StateWriteback;
     match value {
-        Value::Concrete(ConcreteValue::String(s))
-        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
-            Ok(Some(serde_json::Value::String(s.clone())))
+        Value::Concrete(ConcreteValue::String(s)) => Ok(Some(serde_json::Value::String(s.clone()))),
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            Ok(Some(serde_json::Value::String(s.to_string())))
+        }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            Ok(Some(serde_json::Value::String(c.api_value().to_string())))
         }
         Value::Concrete(ConcreteValue::Bool(b)) => Ok(Some(serde_json::Value::Bool(*b))),
         Value::Concrete(ConcreteValue::Int(i)) => Ok(Some(serde_json::Value::Number((*i).into()))),

--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -61,7 +61,7 @@ fn invalid_enum_variant_namespaced_display() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "versioning".to_string(),
-        Value::Concrete(ConcreteValue::EnumIdentifier(
+        Value::Concrete(ConcreteValue::enum_identifier(
             "aws.s3.Bucket.VersioningStatus.NotReal".to_string(),
         )),
     );
@@ -81,7 +81,7 @@ fn invalid_enum_variant_bare_display() {
         None,
     );
     let err = carina_core::schema::Schema::flat(t.clone())
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "zzz".to_string(),
         )))
         .unwrap_err();
@@ -102,7 +102,7 @@ fn invalid_enum_variant_with_dsl_aliases_display() {
         None,
     );
     let err = carina_core::schema::Schema::flat(t.clone())
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "zzz".to_string(),
         )))
         .unwrap_err();

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -414,6 +414,7 @@ fn value_type_name(value: &Value) -> &'static str {
     match value {
         Value::Concrete(ConcreteValue::String(_)) => "String",
         Value::Concrete(ConcreteValue::EnumIdentifier(_)) => "EnumIdentifier",
+        Value::Concrete(ConcreteValue::CanonicalEnum(_)) => "CanonicalEnum",
         Value::Concrete(ConcreteValue::Int(_)) => "Int",
         Value::Concrete(ConcreteValue::Float(_)) => "Float",
         Value::Concrete(ConcreteValue::Bool(_)) => "Bool",

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -108,6 +108,7 @@ pub(crate) fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
             Value::Deferred(DeferredValue::Secret(inner)) => walk(inner, deps),
             Value::Concrete(ConcreteValue::String(_))
             | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
             | Value::Concrete(ConcreteValue::Int(_))
             | Value::Concrete(ConcreteValue::Float(_))
             | Value::Concrete(ConcreteValue::Bool(_))

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -2318,8 +2318,8 @@ mod tests {
             [(
                 "policy".to_string(),
                 iam_policy_value(
-                    ConcreteValue::EnumIdentifier("allow".to_string()),
-                    ConcreteValue::EnumIdentifier("2012_10_17".to_string()),
+                    ConcreteValue::enum_identifier("allow".to_string()),
+                    ConcreteValue::enum_identifier("2012_10_17".to_string()),
                 ),
             )]
             .into_iter()
@@ -2357,8 +2357,8 @@ mod tests {
                 (
                     "policy".to_string(),
                     iam_policy_value(
-                        ConcreteValue::EnumIdentifier("allow".to_string()),
-                        ConcreteValue::EnumIdentifier("2012_10_17".to_string()),
+                        ConcreteValue::enum_identifier("allow".to_string()),
+                        ConcreteValue::enum_identifier("2012_10_17".to_string()),
                     ),
                 ),
                 (
@@ -2411,8 +2411,8 @@ mod tests {
             [(
                 "policy".to_string(),
                 iam_policy_value(
-                    ConcreteValue::EnumIdentifier("allow".to_string()),
-                    ConcreteValue::EnumIdentifier("2012_10_17".to_string()),
+                    ConcreteValue::enum_identifier("allow".to_string()),
+                    ConcreteValue::enum_identifier("2012_10_17".to_string()),
                 ),
             )]
             .into_iter()
@@ -2451,8 +2451,8 @@ mod tests {
             [(
                 "policy".to_string(),
                 iam_policy_value(
-                    ConcreteValue::EnumIdentifier("allow".to_string()),
-                    ConcreteValue::EnumIdentifier("2012_10_17".to_string()),
+                    ConcreteValue::enum_identifier("allow".to_string()),
+                    ConcreteValue::enum_identifier("2012_10_17".to_string()),
                 ),
             )]
             .into_iter()
@@ -2520,7 +2520,7 @@ mod tests {
             ResourceId::new("x.Thing", "t"),
             [(
                 "modes".to_string(),
-                mk(ConcreteValue::EnumIdentifier("on".to_string())),
+                mk(ConcreteValue::enum_identifier("on".to_string())),
             )]
             .into_iter()
             .collect(),
@@ -2551,8 +2551,8 @@ mod tests {
             [(
                 "policy".to_string(),
                 iam_policy_value(
-                    ConcreteValue::EnumIdentifier("allow".to_string()),
-                    ConcreteValue::EnumIdentifier("2012_10_17".to_string()),
+                    ConcreteValue::enum_identifier("allow".to_string()),
+                    ConcreteValue::enum_identifier("2012_10_17".to_string()),
                 ),
             )]
             .into_iter()
@@ -2596,8 +2596,8 @@ mod tests {
                 (
                     "policy".to_string(),
                     iam_policy_value(
-                        ConcreteValue::EnumIdentifier("allow".to_string()),
-                        ConcreteValue::EnumIdentifier("2012_10_17".to_string()),
+                        ConcreteValue::enum_identifier("allow".to_string()),
+                        ConcreteValue::enum_identifier("2012_10_17".to_string()),
                     ),
                 ),
                 (
@@ -2693,7 +2693,7 @@ mod tests {
         Value::Concrete(ConcreteValue::List(
             items
                 .iter()
-                .map(|s| Value::Concrete(ConcreteValue::EnumIdentifier(s.to_string())))
+                .map(|s| Value::Concrete(ConcreteValue::enum_identifier(s.to_string())))
                 .collect(),
         ))
     }

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -198,16 +198,27 @@ pub(crate) fn type_aware_equal(
                 },
             ) if matches!(
                 a,
-                Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
+                Value::Concrete(
+                    ConcreteValue::String(_)
+                        | ConcreteValue::EnumIdentifier(_)
+                        | ConcreteValue::CanonicalEnum(_)
+                )
             ) && matches!(
                 b,
-                Value::Concrete(ConcreteValue::String(_) | ConcreteValue::EnumIdentifier(_))
+                Value::Concrete(
+                    ConcreteValue::String(_)
+                        | ConcreteValue::EnumIdentifier(_)
+                        | ConcreteValue::CanonicalEnum(_)
+                )
             ) =>
             {
                 let text = |v: &Value| -> Option<String> {
                     match v {
                         Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                         Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.to_string()),
+                        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+                            Some(c.api_value().to_string())
+                        }
                         _ => None,
                     }
                 };

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -206,8 +206,8 @@ pub(crate) fn type_aware_equal(
             {
                 let text = |v: &Value| -> Option<String> {
                     match v {
-                        Value::Concrete(ConcreteValue::String(s))
-                        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.clone()),
+                        Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
+                        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.to_string()),
                         _ => None,
                     }
                 };
@@ -396,10 +396,15 @@ fn is_type_default(
         {
             true
         }
+        (Value::Concrete(ConcreteValue::String(s)), Some(crate::schema::Shape::Enum { .. }))
+            if s.is_empty() =>
+        {
+            true
+        }
         (
-            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
+            Value::Concrete(ConcreteValue::EnumIdentifier(s)),
             Some(crate::schema::Shape::Enum { .. }),
-        ) if s.is_empty() => true,
+        ) if s.as_str().is_empty() => true,
         (Value::Concrete(ConcreteValue::List(l)), Some(crate::schema::Shape::List { .. }))
             if l.is_empty() =>
         {

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -400,7 +400,7 @@ fn type_aware_enum_canonical_vs_namespaced_identifier() {
     assert!(
         type_aware_equal(
             &Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
-            &Value::Concrete(ConcreteValue::EnumIdentifier(
+            &Value::Concrete(ConcreteValue::enum_identifier(
                 "aws.AvailabilityZone.ap_northeast_1a".to_string()
             )),
             Some(&az_type),

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::resource::{ConcreteValue, DeferredValue, Value};
+use crate::resource::{CanonicalEnumValue, ConcreteValue, DeferredValue, Value};
 use crate::schema::TypeIdentity;
 use indexmap::IndexMap;
 
@@ -422,6 +422,48 @@ fn type_aware_enum_canonical_vs_namespaced_identifier() {
             None,
         ),
         "Different enum values must not be folded as equal"
+    );
+}
+
+#[test]
+fn type_aware_enum_canonical_enum_value_compares_against_string() {
+    let az_identity = TypeIdentity::new(Some("aws"), ["AvailabilityZone"], "ZoneName");
+    let az_type = AttributeType::enum_(
+        az_identity.clone(),
+        None,
+        vec![],
+        None,
+        Some(crate::schema::DslTransform::HyphenToUnderscore),
+    );
+
+    assert!(
+        type_aware_equal(
+            &Value::Concrete(ConcreteValue::CanonicalEnum(
+                CanonicalEnumValue::new_for_test(az_identity.clone(), "ap-northeast-1a"),
+            )),
+            &Value::Concrete(ConcreteValue::String(
+                "aws.AvailabilityZone.ap_northeast_1a".to_string()
+            )),
+            Some(&az_type),
+            crate::schema::empty_defs_for_schema_walks(),
+            None,
+        ),
+        "CanonicalEnum API value must compare equal to equivalent DSL String"
+    );
+
+    assert!(
+        !type_aware_equal(
+            &Value::Concrete(ConcreteValue::CanonicalEnum(
+                CanonicalEnumValue::new_for_test(az_identity, "ap-northeast-1a"),
+            )),
+            &Value::Concrete(ConcreteValue::String(
+                "aws.AvailabilityZone.ap_northeast_1c".to_string()
+            )),
+            Some(&az_type),
+            crate::schema::empty_defs_for_schema_walks(),
+            None,
+        ),
+        "Different CanonicalEnum API values must not compare equal"
     );
 }
 

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -491,8 +491,8 @@ impl Effect {
 pub fn format_import_identifier(identifier: &crate::resource::Value) -> String {
     use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, Value};
     match identifier {
-        Value::Concrete(ConcreteValue::String(s))
-        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => s.clone(),
+        Value::Concrete(ConcreteValue::String(s)) => s.clone(),
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => s.to_string(),
         Value::Deferred(DeferredValue::Interpolation(parts)) => {
             let mut out = String::new();
             for part in parts {
@@ -615,7 +615,7 @@ mod tests {
             "unexpected error message: {err}"
         );
         // Sanity: still passes for a concrete String/EnumIdentifier.
-        let s = Value::Concrete(ConcreteValue::EnumIdentifier("ENUM_X".into()));
+        let s = Value::Concrete(ConcreteValue::enum_identifier("ENUM_X"));
         assert_eq!(resolve_import_identifier(&s).unwrap(), "ENUM_X");
     }
 

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -348,13 +348,6 @@ fn canonical_create_only_text_string(
     }
 }
 
-fn canonical_state_create_only_value_string(
-    value: &str,
-    attribute_type: Option<&AttributeType>,
-) -> String {
-    canonical_create_only_text_string(value, attribute_type)
-}
-
 /// Maximum Hamming distance (out of 64 bits) for SimHash-based reconciliation.
 /// Two identifiers with distance below this threshold are considered the "same resource"
 /// with modified attributes.
@@ -840,7 +833,7 @@ pub fn reconcile_anonymous_identifiers(
                 if let Some(state_value) = entry.create_only_values.get(*attr) {
                     let attribute_type = schema.attributes.get(*attr).map(|attr| &attr.attr_type);
                     let state_value =
-                        canonical_state_create_only_value_string(state_value, attribute_type);
+                        canonical_create_only_text_string(state_value, attribute_type);
                     if &state_value == value {
                         matched += 1;
                     } else {

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -163,7 +163,12 @@ pub fn reconcile_prefixed_names(
 fn deterministic_value_string(value: &Value) -> String {
     match value {
         Value::Concrete(ConcreteValue::String(s)) => format!("String({:?})", s),
-        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => format!("EnumIdentifier({:?})", s),
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            format!("EnumIdentifier({:?})", s.as_str())
+        }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            format!("CanonicalEnum({:?}, {:?})", c.identity(), c.api_value())
+        }
         Value::Concrete(ConcreteValue::Int(i)) => format!("Int({})", i),
         Value::Concrete(ConcreteValue::Float(f)) => format!("Float({})", f),
         Value::Concrete(ConcreteValue::Bool(b)) => format!("Bool({})", b),
@@ -295,12 +300,12 @@ pub(crate) fn canonical_enum_feature_string(
     else {
         return deterministic_value_string(value);
     };
-    if !enum_identifier_segments_match(raw, attribute_type, values.is_some()) {
+    if !enum_identifier_segments_match(raw.as_str(), attribute_type, values.is_some()) {
         return deterministic_value_string(value);
     }
 
     let valid_values: Vec<&str> = values.into_iter().flatten().map(String::as_str).collect();
-    let variant = extract_enum_value_with_values(raw, &valid_values);
+    let variant = extract_enum_value_with_values(raw.as_str(), &valid_values);
     let api_value = dsl_map.api_for_hash_feature(variant);
     if let Some(values) = values
         && !values.iter().any(|v| v == &api_value)
@@ -334,7 +339,7 @@ fn canonical_create_only_text_string(
         return value.to_string();
     }
 
-    let enum_value = Value::Concrete(ConcreteValue::EnumIdentifier(value.to_string()));
+    let enum_value = Value::Concrete(ConcreteValue::enum_identifier(value.to_string()));
     let canonical = canonical_enum_feature_string(&enum_value, attribute_type);
     if canonical == deterministic_value_string(&enum_value) {
         value.to_string()

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -88,7 +88,7 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
         "awscc",
         vec![(
             "region",
-            Value::Concrete(ConcreteValue::EnumIdentifier(
+            Value::Concrete(ConcreteValue::enum_identifier(
                 "awscc.Region.ap_northeast_1".to_string(),
             )),
         )],
@@ -97,7 +97,7 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
         "awscc",
         vec![(
             "region",
-            Value::Concrete(ConcreteValue::EnumIdentifier(
+            Value::Concrete(ConcreteValue::enum_identifier(
                 "aws.Region.ap_northeast_1".to_string(),
             )),
         )],
@@ -141,7 +141,7 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_attribute() {
         let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
         resource.set_attr(
             "domain".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier(domain.to_string())),
+            Value::Concrete(ConcreteValue::enum_identifier(domain.to_string())),
         );
         resource
     };
@@ -172,7 +172,7 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
         let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
         resource.set_attr(
             "domain".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier(domain.to_string())),
+            Value::Concrete(ConcreteValue::enum_identifier(domain.to_string())),
         );
         resource.set_attr(
             "public_ipv4_pool".to_string(),

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -131,9 +131,10 @@ fn format_value(value: &Value) -> String {
             if s.len() > 50 {
                 format!("{}...", &s[..47])
             } else {
-                s.clone()
+                s.to_string()
             }
         }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => c.api_value().to_string(),
         Value::Concrete(ConcreteValue::Int(n)) => n.to_string(),
         Value::Concrete(ConcreteValue::Float(f)) => {
             let s = f.to_string();

--- a/carina-core/src/module_resolver/typecheck.rs
+++ b/carina-core/src/module_resolver/typecheck.rs
@@ -56,6 +56,7 @@ fn describe_value_shape(value: &Value) -> &'static str {
         }
         Value::Concrete(ConcreteValue::Map(_)) => "map",
         Value::Concrete(ConcreteValue::EnumIdentifier(_)) => "enum identifier",
+        Value::Concrete(ConcreteValue::CanonicalEnum(_)) => "canonical enum",
         Value::Deferred(DeferredValue::ResourceRef { .. }) => "resource reference",
         Value::Deferred(DeferredValue::BindingRef { .. }) => "binding reference",
         Value::Deferred(DeferredValue::Interpolation(_)) => "interpolation",

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -314,7 +314,7 @@ pub(in crate::parser) fn extract_directives(
 fn value_as_binding_name(value: &Value, context: &str) -> Result<String, ParseError> {
     match value {
         Value::Deferred(DeferredValue::BindingRef { binding }) => Ok(binding.clone()),
-        Value::Concrete(ConcreteValue::EnumIdentifier(name)) => Ok(name.clone()),
+        Value::Concrete(ConcreteValue::EnumIdentifier(name)) => Ok(name.to_string()),
         Value::Concrete(ConcreteValue::String(name)) => {
             let bare = name
                 .strip_prefix("${")

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -321,7 +321,7 @@ pub(crate) fn parse_for_expr(
             // proper UndefinedIdentifier with the did-you-mean machinery
             // from #2038 / #2100. See #2101 / #2138.
             let bare_ident_text: Option<String> = match &iterable {
-                Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.clone()),
+                Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.to_string()),
                 Value::Concrete(ConcreteValue::String(s)) if is_bare_identifier(s) => {
                     Some(s.clone())
                 }

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -249,7 +249,7 @@ fn parse_namespaced_id_value(
     }
 
     Ok(EvalValue::from_value(Value::Concrete(
-        ConcreteValue::EnumIdentifier(full_str.to_string()),
+        ConcreteValue::enum_identifier(full_str.to_string()),
     )))
 }
 
@@ -473,7 +473,7 @@ pub(crate) fn parse_primary_eval(
                 match ctx.get_variable(first_ident) {
                     Some(val) => Ok(val.clone()),
                     None => Ok(EvalValue::from_value(Value::Concrete(
-                        ConcreteValue::EnumIdentifier(first_ident.to_string()),
+                        ConcreteValue::enum_identifier(first_ident.to_string()),
                     ))),
                 }
             } else {

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -224,28 +224,29 @@ pub fn validate_custom_type(
 ) -> Result<(), String> {
     // Built-in DSL custom types carry no provider axis — match on `kind`.
     let builtin = identity.provider.is_none() && identity.segments.is_empty();
+    fn text(value: &Value) -> Option<&str> {
+        value
+            .as_concrete()
+            .and_then(|concrete| concrete.as_string_like())
+    }
     match (builtin.then_some(identity.kind.as_str()), value) {
-        (
-            Some("Ipv4Cidr"),
-            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
-        ) => validate_ipv4_cidr(s),
-        (
-            Some("Ipv4Address"),
-            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
-        ) => validate_ipv4_address(s),
-        (
-            Some("Ipv6Cidr"),
-            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
-        ) => validate_ipv6_cidr(s),
-        (
-            Some("Ipv6Address"),
-            Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s)),
-        ) => validate_ipv6_address(s),
+        (Some("Ipv4Cidr"), value) if text(value).is_some() => {
+            validate_ipv4_cidr(text(value).unwrap())
+        }
+        (Some("Ipv4Address"), value) if text(value).is_some() => {
+            validate_ipv4_address(text(value).unwrap())
+        }
+        (Some("Ipv6Cidr"), value) if text(value).is_some() => {
+            validate_ipv6_cidr(text(value).unwrap())
+        }
+        (Some("Ipv6Address"), value) if text(value).is_some() => {
+            validate_ipv6_address(text(value).unwrap())
+        }
         (_, Value::Deferred(DeferredValue::ResourceRef { .. })) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::FunctionCall { .. })) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::Interpolation(_))) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::Unknown(_))) => Ok(()), // resolved at upstream apply
-        (_, Value::Concrete(ConcreteValue::String(s) | ConcreteValue::EnumIdentifier(s))) => {
+        (_, value) if text(value).is_some() => {
             // Both `String` (quoted-literal source) and `EnumIdentifier`
             // (bare or namespaced identifier source) are accepted: this
             // lookup runs from `walk_custom_lookup`, which is reached
@@ -257,6 +258,7 @@ pub fn validate_custom_type(
             // Check custom validators from config (schema-extracted),
             // keyed by the full structured identity so two providers'
             // same-named types do not collide.
+            let s = text(value).unwrap();
             if let Some(validator) = config.validators.get(identity) {
                 validator(s)?;
             }

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -497,7 +497,7 @@ fn collect_reference_roots(
             // Bare-identifier fallback (`EnumIdentifier("B")`) and dotted-access
             // fallback (`EnumIdentifier("B.attr")`) both appear before the parser
             // classifies the RHS as a binding ref or resource ref.
-            push_root(name, variables, structural, roots);
+            push_root(name.as_str(), variables, structural, roots);
             if let Some((root, _)) = name.split_once('.') {
                 push_root(root, variables, structural, roots);
             }
@@ -539,6 +539,7 @@ fn collect_reference_roots(
             | ConcreteValue::Bool(_)
             | ConcreteValue::Duration(_)
             | ConcreteValue::String(_)
+            | ConcreteValue::CanonicalEnum(_)
             | ConcreteValue::StringList(_),
         )
         | Value::Deferred(DeferredValue::Unknown(_)) => {}

--- a/carina-core/src/parser/static_eval.rs
+++ b/carina-core/src/parser/static_eval.rs
@@ -14,6 +14,7 @@ pub(crate) fn is_static_value(value: &Value) -> bool {
     match value {
         Value::Concrete(ConcreteValue::String(_))
         | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+        | Value::Concrete(ConcreteValue::CanonicalEnum(_))
         | Value::Concrete(ConcreteValue::Int(_))
         | Value::Concrete(ConcreteValue::Float(_))
         | Value::Concrete(ConcreteValue::Bool(_))

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -183,7 +183,7 @@ fn parse_resource_with_namespaced_type() {
     );
     assert_eq!(
         resource.get_attr("region"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );
@@ -222,7 +222,7 @@ fn parse_variable_and_resource() {
     assert_eq!(result.resources.len(), 1);
     assert_eq!(
         result.resources[0].get_attr("region"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );
@@ -412,7 +412,7 @@ fn parse_and_resolve_resource_reference() {
     );
     assert_eq!(
         policy.get_attr("bucket_region"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );
@@ -481,7 +481,7 @@ fn parse_bare_identifier_becomes_enum_identifier() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("instance_tenancy"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "dedicated".to_string()
         )))
     );
@@ -500,7 +500,7 @@ fn resource_reference_preserves_namespaced_id() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("region"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );
@@ -519,7 +519,7 @@ fn namespaced_id_with_digit_segment() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("type"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "awscc.ec2.vpn_gateway.Type.ipsec.1".to_string()
         )))
     );
@@ -548,7 +548,7 @@ fn namespaced_id_with_numeric_tail() {
     };
     assert_eq!(
         map.get("version"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
         )))
     );
@@ -568,7 +568,7 @@ fn namespaced_id_numeric_tail_preserves_pure_digits() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(
         result.resources[0].get_attr("kind"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "Type.1".to_string()
         )))
     );
@@ -1244,7 +1244,7 @@ fn parse_backend_block() {
     );
     assert_eq!(
         backend.attributes.get("region"),
-        Some(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        Some(&Value::Concrete(ConcreteValue::enum_identifier(
             "aws.Region.ap_northeast_1".to_string()
         )))
     );

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -51,6 +51,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
     match value {
         Value::Concrete(ConcreteValue::String(_)) => "string",
         Value::Concrete(ConcreteValue::EnumIdentifier(_)) => "enum identifier",
+        Value::Concrete(ConcreteValue::CanonicalEnum(_)) => "canonical enum",
         Value::Concrete(ConcreteValue::Int(_)) => "int",
         Value::Concrete(ConcreteValue::Float(_)) => "float",
         Value::Concrete(ConcreteValue::Bool(_)) => "bool",

--- a/carina-core/src/resource/enum_value.rs
+++ b/carina-core/src/resource/enum_value.rs
@@ -239,10 +239,12 @@ impl<'a> EnumValueResolver<'a> {
         let (identity, values, dsl_aliases, validate, dsl_map) = self.parts()?;
         let valid: Vec<&str> = values.into_iter().flatten().map(String::as_str).collect();
         let direct_match = valid.iter().any(|v| enum_value_matches(text, v));
-        let variant = if direct_match {
-            text
+        let variant = if phase == EnumInputPhase::StateText && values.is_none() {
+            state_text_open_enum_value(text, identity)
+        } else if direct_match {
+            text.to_string()
         } else {
-            extract_enum_value_with_values(text, &valid)
+            extract_enum_value_with_values(text, &valid).to_string()
         };
 
         if phase == EnumInputPhase::RawDsl
@@ -254,7 +256,7 @@ impl<'a> EnumValueResolver<'a> {
             });
         }
 
-        if phase == EnumInputPhase::RawDsl && api_spelling_rejected_in_dsl(variant, dsl_aliases) {
+        if phase == EnumInputPhase::RawDsl && api_spelling_rejected_in_dsl(&variant, dsl_aliases) {
             return Err(invalid_enum_variant(
                 text,
                 identity,
@@ -265,29 +267,32 @@ impl<'a> EnumValueResolver<'a> {
         }
 
         let api_value = match phase {
-            EnumInputPhase::RawDsl => dsl_map.api_for_hash_feature(variant),
+            EnumInputPhase::RawDsl => dsl_map.api_for_hash_feature(&variant),
             EnumInputPhase::StateText => {
                 if valid.contains(&text) {
                     text.to_string()
                 } else {
-                    dsl_map.api_for_hash_feature(variant)
+                    dsl_map.api_for_hash_feature(&variant)
                 }
             }
         };
 
         let enumerated = values.is_some();
-        let valid_value = values
+        let matched_value = values
             .into_iter()
             .flatten()
-            .any(|v| enum_value_matches(&api_value, v));
+            .find(|v| enum_value_matches(&api_value, v));
+        let valid_value = matched_value.is_some();
+        let api_value = matched_value.map_or(api_value, Clone::clone);
+        // NOTE(carina#3438 PR3): validate receives the bare api_value here; the legacy
+        // validate_enum path passes the expanded namespaced text. Verify provider
+        // validators accept both before swapping consumers.
         let validation_result = validate.map(|validate| {
             validate(&crate::resource::Value::Concrete(
                 crate::resource::ConcreteValue::String(api_value.clone()),
             ))
         });
-        let validation_ok = validation_result
-            .as_ref()
-            .map_or(!enumerated, Result::is_ok);
+        let validation_ok = !enumerated && validation_result.as_ref().is_none_or(Result::is_ok);
 
         if valid_value || validation_ok {
             Ok(CanonicalEnumValue::new_resolved(
@@ -303,6 +308,19 @@ impl<'a> EnumValueResolver<'a> {
                 dsl_map,
             ))
         }
+    }
+}
+
+fn state_text_open_enum_value(text: &str, identity: &TypeIdentity) -> String {
+    match RawEnumIdentifier::parse(text).parsed() {
+        RawEnumIdentifierParts::TypeQualified { type_name, value }
+        | RawEnumIdentifierParts::ProviderQualified {
+            type_name, value, ..
+        }
+        | RawEnumIdentifierParts::FullyQualified {
+            type_name, value, ..
+        } if type_name == &identity.kind => value.clone(),
+        _ => text.to_string(),
     }
 }
 
@@ -373,7 +391,7 @@ fn expected_variants(
 mod tests {
     use super::*;
     use crate::resource::ConcreteValue;
-    use crate::schema::{DslTransform, enum_identity};
+    use crate::schema::{DslTransform, enum_identity, validator};
 
     #[test]
     fn raw_parse_classifies_identifier_shapes() {
@@ -410,6 +428,28 @@ mod tests {
         assert_eq!(
             RawEnumIdentifier::parse("some.random.string").parsed(),
             &RawEnumIdentifierParts::Unclassified
+        );
+    }
+
+    #[test]
+    fn raw_parse_preserves_pre_existing_namespaced_id_edge_semantics() {
+        // These shapes come from NamespacedId's pre-existing parser semantics.
+        assert_eq!(
+            RawEnumIdentifier::parse("").parsed(),
+            &RawEnumIdentifierParts::Bare {
+                value: String::new()
+            }
+        );
+        assert_eq!(
+            RawEnumIdentifier::parse("...").parsed(),
+            &RawEnumIdentifierParts::Unclassified
+        );
+        assert_eq!(
+            RawEnumIdentifier::parse("A.").parsed(),
+            &RawEnumIdentifierParts::TypeQualified {
+                type_name: "A".to_string(),
+                value: String::new()
+            }
         );
     }
 
@@ -455,6 +495,112 @@ mod tests {
             ))
             .unwrap();
         assert_eq!(canonical.api_value(), "Allow");
+    }
+
+    #[test]
+    fn resolve_text_normalizes_fuzzy_matches_to_values_list_entry() {
+        let effect = AttributeType::enum_(
+            enum_identity("Effect", Some("aws.iam.PolicyDocument")),
+            Some(vec!["Allow".to_string()]),
+            vec![("Allow".to_string(), "allow".to_string())],
+            None,
+            None,
+        );
+        let resolver = EnumValueResolver::new(&effect);
+        let state = resolver.resolve_state_text("ALLOW").unwrap();
+        let raw = resolver
+            .resolve_raw(&RawEnumIdentifier::parse(
+                "aws.iam.PolicyDocument.Effect.allow",
+            ))
+            .unwrap();
+        assert_eq!(state, raw);
+        assert_eq!(state.api_value(), "Allow");
+
+        let region = AttributeType::enum_(
+            enum_identity("Region", Some("aws")),
+            Some(vec!["ap-northeast-1".to_string()]),
+            vec![],
+            None,
+            None,
+        );
+        let canonical = EnumValueResolver::new(&region)
+            .resolve_state_text("ap_northeast_1")
+            .unwrap();
+        assert_eq!(canonical.api_value(), "ap-northeast-1");
+    }
+
+    #[test]
+    fn resolve_text_does_not_allow_validator_to_override_enumerated_values() {
+        let attr = AttributeType::enum_(
+            enum_identity("Example", Some("aws")),
+            Some(vec!["a".to_string()]),
+            vec![],
+            Some(validator(|_| Ok(()))),
+            None,
+        );
+
+        assert!(matches!(
+            EnumValueResolver::new(&attr).resolve_state_text("zzz"),
+            Err(TypeError::InvalidEnumVariant { .. })
+        ));
+    }
+
+    #[test]
+    fn resolve_state_text_open_enum_preserves_dotted_values() {
+        let open = AttributeType::enum_(
+            enum_identity("Type", Some("awscc.ec2.vpn_gateway")),
+            None,
+            vec![],
+            None,
+            None,
+        );
+        let resolver = EnumValueResolver::new(&open);
+
+        assert_eq!(
+            resolver.resolve_state_text("ipsec.1").unwrap().api_value(),
+            "ipsec.1"
+        );
+        assert_eq!(
+            resolver
+                .resolve_state_text("awscc.ec2.vpn_gateway.Type.ipsec.1")
+                .unwrap()
+                .api_value(),
+            "ipsec.1"
+        );
+    }
+
+    #[test]
+    fn resolve_text_open_enum_validator_parity() {
+        let open = AttributeType::enum_(
+            enum_identity("Dynamic", Some("aws")),
+            None,
+            vec![],
+            None,
+            None,
+        );
+        assert_eq!(
+            EnumValueResolver::new(&open)
+                .resolve_state_text("whatever")
+                .unwrap()
+                .api_value(),
+            "whatever"
+        );
+
+        let rejected = AttributeType::enum_(
+            enum_identity("Dynamic", Some("aws")),
+            None,
+            vec![],
+            Some(validator(|_| {
+                Err(TypeError::ValidationFailed {
+                    message: "no".to_string(),
+                })
+            })),
+            None,
+        );
+        assert!(matches!(
+            EnumValueResolver::new(&rejected).resolve_state_text("whatever"),
+            Err(TypeError::InvalidEnumVariant { .. })
+        ));
     }
 
     #[test]

--- a/carina-core/src/resource/enum_value.rs
+++ b/carina-core/src/resource/enum_value.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::schema::{
     AttributeType, DslMap, EnumParts, ExpectedEnumVariant, TypeError, TypeIdentity,
+    enum_value_matches,
 };
 use crate::utils::{NamespacedId, extract_enum_value_with_values, validate_enum_namespace};
 
@@ -106,25 +107,9 @@ impl Deref for RawEnumIdentifier {
     }
 }
 
-// TODO(carina#3438): remove in chain PR 5.
-// Temporary string-like shim for existing helper boundaries.
-impl AsRef<str> for RawEnumIdentifier {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
 impl PartialEq for RawEnumIdentifier {
     fn eq(&self, other: &Self) -> bool {
         self.text == other.text
-    }
-}
-
-// TODO(carina#3438): remove in chain PR 5.
-// Temporary equality shim preserving old String/EnumIdentifier comparisons.
-impl PartialEq<String> for RawEnumIdentifier {
-    fn eq(&self, other: &String) -> bool {
-        self.text == *other
     }
 }
 
@@ -182,7 +167,7 @@ impl CanonicalEnumValue {
         }
     }
 
-    pub(super) fn new_resolved(identity: TypeIdentity, api_value: String) -> Self {
+    fn new_resolved(identity: TypeIdentity, api_value: String) -> Self {
         Self {
             identity,
             api_value,
@@ -319,12 +304,6 @@ impl<'a> EnumValueResolver<'a> {
 enum EnumInputPhase {
     RawDsl,
     StateText,
-}
-
-fn enum_value_matches(input: &str, expected: &str) -> bool {
-    input == expected
-        || input.eq_ignore_ascii_case(expected)
-        || input.replace('_', "-").eq_ignore_ascii_case(expected)
 }
 
 fn api_spelling_rejected_in_dsl(variant: &str, dsl_aliases: &[(String, String)]) -> bool {

--- a/carina-core/src/resource/enum_value.rs
+++ b/carina-core/src/resource/enum_value.rs
@@ -238,8 +238,15 @@ impl<'a> EnumValueResolver<'a> {
     ) -> Result<CanonicalEnumValue, TypeError> {
         let (identity, values, dsl_aliases, validate, dsl_map) = self.parts()?;
         let valid: Vec<&str> = values.into_iter().flatten().map(String::as_str).collect();
+        let prefix_escaped_value = if phase == EnumInputPhase::RawDsl {
+            raw_dsl_prefix_escaped_value(text, identity, values)
+        } else {
+            None
+        };
         let direct_match = valid.iter().any(|v| enum_value_matches(text, v));
-        let variant = if phase == EnumInputPhase::StateText && values.is_none() {
+        let variant = if let Some(value) = prefix_escaped_value {
+            value.to_string()
+        } else if phase == EnumInputPhase::StateText && values.is_none() {
             state_text_open_enum_value(text, identity)
         } else if direct_match {
             text.to_string()
@@ -249,6 +256,7 @@ impl<'a> EnumValueResolver<'a> {
 
         if phase == EnumInputPhase::RawDsl
             && !direct_match
+            && prefix_escaped_value.is_none()
             && let Err(message) = validate_enum_namespace(text, identity)
         {
             return Err(TypeError::ValidationFailed {
@@ -278,10 +286,16 @@ impl<'a> EnumValueResolver<'a> {
         };
 
         let enumerated = values.is_some();
-        let matched_value = values
+        let exact_value = values
             .into_iter()
             .flatten()
-            .find(|v| enum_value_matches(&api_value, v));
+            .find(|v| v.as_str() == api_value);
+        let matched_value = exact_value.or_else(|| {
+            values
+                .into_iter()
+                .flatten()
+                .find(|v| enum_value_matches(&api_value, v))
+        });
         let valid_value = matched_value.is_some();
         let api_value = matched_value.map_or(api_value, Clone::clone);
         // NOTE(carina#3438 PR3): validate receives the bare api_value here; the legacy
@@ -309,6 +323,20 @@ impl<'a> EnumValueResolver<'a> {
             ))
         }
     }
+}
+
+fn raw_dsl_prefix_escaped_value<'a>(
+    text: &str,
+    identity: &TypeIdentity,
+    values: Option<&'a [String]>,
+) -> Option<&'a str> {
+    let namespace = identity.dotted_prefix()?;
+    let expected_prefix = format!("{}.{}.", namespace, identity.kind);
+    let tail = text.strip_prefix(&expected_prefix)?;
+    values?
+        .iter()
+        .map(String::as_str)
+        .find(|value| *value == tail)
 }
 
 fn state_text_open_enum_value(text: &str, identity: &TypeIdentity) -> String {
@@ -495,6 +523,10 @@ mod tests {
             ))
             .unwrap();
         assert_eq!(canonical.api_value(), "Allow");
+        let bare_alias = EnumValueResolver::new(&effect)
+            .resolve_raw(&RawEnumIdentifier::parse("allow"))
+            .unwrap();
+        assert_eq!(bare_alias.api_value(), "Allow");
     }
 
     #[test]
@@ -527,6 +559,22 @@ mod tests {
             .resolve_state_text("ap_northeast_1")
             .unwrap();
         assert_eq!(canonical.api_value(), "ap-northeast-1");
+    }
+
+    #[test]
+    fn resolve_text_keeps_exact_member_before_fuzzy_sibling() {
+        let attr = AttributeType::enum_(
+            enum_identity("Example", Some("aws")),
+            Some(vec!["foo-bar".to_string(), "foo_bar".to_string()]),
+            vec![],
+            None,
+            None,
+        );
+
+        let canonical = EnumValueResolver::new(&attr)
+            .resolve_state_text("foo_bar")
+            .unwrap();
+        assert_eq!(canonical.api_value(), "foo_bar");
     }
 
     #[test]
@@ -567,6 +615,31 @@ mod tests {
                 .api_value(),
             "ipsec.1"
         );
+        assert_eq!(
+            resolver
+                .resolve_state_text("aws.ec2.vpn_gateway.Type.ipsec.1")
+                .unwrap()
+                .api_value(),
+            "ipsec.1"
+        );
+    }
+
+    #[test]
+    fn resolve_raw_accepts_fully_qualified_dotted_value_member() {
+        let attr = AttributeType::enum_(
+            enum_identity("Type", Some("awscc.ec2.vpn_gateway")),
+            Some(vec!["ipsec.1".to_string()]),
+            vec![],
+            None,
+            None,
+        );
+
+        let canonical = EnumValueResolver::new(&attr)
+            .resolve_raw(&RawEnumIdentifier::parse(
+                "awscc.ec2.vpn_gateway.Type.ipsec.1",
+            ))
+            .unwrap();
+        assert_eq!(canonical.api_value(), "ipsec.1");
     }
 
     #[test]

--- a/carina-core/src/resource/enum_value.rs
+++ b/carina-core/src/resource/enum_value.rs
@@ -12,7 +12,7 @@ use crate::schema::{
 use crate::utils::{NamespacedId, extract_enum_value_with_values, validate_enum_namespace};
 
 /// Parser-surface enum identifier text plus schema-free syntax classification.
-#[derive(Debug, Clone, Eq)]
+#[derive(Clone, Eq)]
 pub struct RawEnumIdentifier {
     text: String,
     parsed: RawEnumIdentifierParts,
@@ -94,6 +94,12 @@ impl RawEnumIdentifier {
 impl fmt::Display for RawEnumIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.text)
+    }
+}
+
+impl fmt::Debug for RawEnumIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.text, f)
     }
 }
 
@@ -366,6 +372,7 @@ fn expected_variants(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resource::ConcreteValue;
     use crate::schema::{DslTransform, enum_identity};
 
     #[test]
@@ -404,6 +411,12 @@ mod tests {
             RawEnumIdentifier::parse("some.random.string").parsed(),
             &RawEnumIdentifierParts::Unclassified
         );
+    }
+
+    #[test]
+    fn debug_output_is_transparent_to_text() {
+        let v = ConcreteValue::enum_identifier("dedicated");
+        assert_eq!(format!("{:?}", v), r#"EnumIdentifier("dedicated")"#);
     }
 
     #[test]

--- a/carina-core/src/resource/enum_value.rs
+++ b/carina-core/src/resource/enum_value.rs
@@ -1,0 +1,545 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::schema::{
+    AttributeType, DslMap, EnumParts, ExpectedEnumVariant, TypeError, TypeIdentity,
+};
+use crate::utils::{NamespacedId, extract_enum_value_with_values, validate_enum_namespace};
+
+/// Parser-surface enum identifier text plus schema-free syntax classification.
+#[derive(Debug, Clone, Eq)]
+pub struct RawEnumIdentifier {
+    text: String,
+    parsed: RawEnumIdentifierParts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RawEnumIdentifierParts {
+    Bare {
+        value: String,
+    },
+    TypeQualified {
+        type_name: String,
+        value: String,
+    },
+    ProviderQualified {
+        provider: String,
+        type_name: String,
+        value: String,
+    },
+    FullyQualified {
+        provider: String,
+        segments: Vec<String>,
+        type_name: String,
+        value: String,
+    },
+    Unclassified,
+}
+
+impl RawEnumIdentifier {
+    pub fn parse(text: impl Into<String>) -> Self {
+        let text = text.into();
+        let parsed = match NamespacedId::parse(&text) {
+            Some(NamespacedId::TypeQualified { type_name, value }) => {
+                RawEnumIdentifierParts::TypeQualified {
+                    type_name: type_name.to_string(),
+                    value: value.to_string(),
+                }
+            }
+            Some(NamespacedId::ProviderQualified {
+                provider,
+                type_name,
+                value,
+            }) => RawEnumIdentifierParts::ProviderQualified {
+                provider: provider.to_string(),
+                type_name: type_name.to_string(),
+                value: value.to_string(),
+            },
+            Some(NamespacedId::FullyQualified {
+                provider,
+                segments_str,
+                type_name,
+                value,
+            }) => RawEnumIdentifierParts::FullyQualified {
+                provider: provider.to_string(),
+                segments: segments_str.split('.').map(String::from).collect(),
+                type_name: type_name.to_string(),
+                value: value.to_string(),
+            },
+            None if !text.contains('.') => RawEnumIdentifierParts::Bare {
+                value: text.clone(),
+            },
+            None => RawEnumIdentifierParts::Unclassified,
+        };
+        Self { text, parsed }
+    }
+
+    pub fn parsed(&self) -> &RawEnumIdentifierParts {
+        &self.parsed
+    }
+
+    /// TODO(carina#3438): remove in chain PR 5.
+    /// Temporary accessor for call sites that still consume enum identifiers
+    /// as parser-surface strings during the PR chain.
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+}
+
+impl fmt::Display for RawEnumIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+// TODO(carina#3438): remove in chain PR 5.
+// Temporary string-like shim for existing display/formatter call sites.
+impl Deref for RawEnumIdentifier {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+// TODO(carina#3438): remove in chain PR 5.
+// Temporary string-like shim for existing helper boundaries.
+impl AsRef<str> for RawEnumIdentifier {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl PartialEq for RawEnumIdentifier {
+    fn eq(&self, other: &Self) -> bool {
+        self.text == other.text
+    }
+}
+
+// TODO(carina#3438): remove in chain PR 5.
+// Temporary equality shim preserving old String/EnumIdentifier comparisons.
+impl PartialEq<String> for RawEnumIdentifier {
+    fn eq(&self, other: &String) -> bool {
+        self.text == *other
+    }
+}
+
+// TODO(carina#3438): remove in chain PR 5.
+// Temporary equality shim preserving old String/EnumIdentifier comparisons.
+impl PartialEq<RawEnumIdentifier> for String {
+    fn eq(&self, other: &RawEnumIdentifier) -> bool {
+        *self == other.text
+    }
+}
+
+impl Hash for RawEnumIdentifier {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.text.hash(state);
+    }
+}
+
+impl Serialize for RawEnumIdentifier {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.text)
+    }
+}
+
+impl<'de> Deserialize<'de> for RawEnumIdentifier {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        String::deserialize(deserializer).map(Self::parse)
+    }
+}
+
+/// Schema-resolved enum identity plus provider API value.
+///
+/// This type intentionally has no equality implementation with
+/// [`RawEnumIdentifier`]. Raw source spelling and canonical API semantics are
+/// different phases; compare canonical values only after resolver construction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CanonicalEnumValue {
+    identity: TypeIdentity,
+    api_value: String,
+}
+
+impl CanonicalEnumValue {
+    pub fn identity(&self) -> &TypeIdentity {
+        &self.identity
+    }
+
+    pub fn api_value(&self) -> &str {
+        &self.api_value
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(identity: TypeIdentity, api_value: impl Into<String>) -> Self {
+        Self {
+            identity,
+            api_value: api_value.into(),
+        }
+    }
+
+    pub(super) fn new_resolved(identity: TypeIdentity, api_value: String) -> Self {
+        Self {
+            identity,
+            api_value,
+        }
+    }
+}
+
+impl fmt::Display for CanonicalEnumValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.identity, self.api_value)
+    }
+}
+
+pub struct EnumValueResolver<'a> {
+    attr_type: &'a AttributeType,
+    defs: Option<&'a BTreeMap<String, AttributeType>>,
+}
+
+impl<'a> EnumValueResolver<'a> {
+    pub fn new(attr_type: &'a AttributeType) -> Self {
+        Self {
+            attr_type,
+            defs: None,
+        }
+    }
+
+    pub fn with_defs(
+        attr_type: &'a AttributeType,
+        defs: &'a BTreeMap<String, AttributeType>,
+    ) -> Self {
+        Self {
+            attr_type,
+            defs: Some(defs),
+        }
+    }
+
+    pub fn resolve_raw(&self, raw: &RawEnumIdentifier) -> Result<CanonicalEnumValue, TypeError> {
+        self.resolve_text(raw.as_str(), EnumInputPhase::RawDsl)
+    }
+
+    pub fn resolve_state_text(&self, text: &str) -> Result<CanonicalEnumValue, TypeError> {
+        self.resolve_text(text, EnumInputPhase::StateText)
+    }
+
+    fn parts(&self) -> Result<EnumParts<'_>, TypeError> {
+        let attr_type = match self.defs {
+            Some(defs) => self.attr_type.resolve_refs_with_defs(defs).as_attr(),
+            None => self.attr_type,
+        };
+        attr_type
+            .enum_parts()
+            .ok_or_else(|| TypeError::TypeMismatch {
+                expected: "Enum".to_string(),
+                got: attr_type.type_name(),
+            })
+    }
+
+    fn resolve_text(
+        &self,
+        text: &str,
+        phase: EnumInputPhase,
+    ) -> Result<CanonicalEnumValue, TypeError> {
+        let (identity, values, dsl_aliases, validate, dsl_map) = self.parts()?;
+        let valid: Vec<&str> = values.into_iter().flatten().map(String::as_str).collect();
+        let direct_match = valid.iter().any(|v| enum_value_matches(text, v));
+        let variant = if direct_match {
+            text
+        } else {
+            extract_enum_value_with_values(text, &valid)
+        };
+
+        if phase == EnumInputPhase::RawDsl
+            && !direct_match
+            && let Err(message) = validate_enum_namespace(text, identity)
+        {
+            return Err(TypeError::ValidationFailed {
+                message: format!("Invalid {} '{}': {}", identity.kind, text, message),
+            });
+        }
+
+        if phase == EnumInputPhase::RawDsl && api_spelling_rejected_in_dsl(variant, dsl_aliases) {
+            return Err(invalid_enum_variant(
+                text,
+                identity,
+                values,
+                dsl_aliases,
+                dsl_map,
+            ));
+        }
+
+        let api_value = match phase {
+            EnumInputPhase::RawDsl => dsl_map.api_for_hash_feature(variant),
+            EnumInputPhase::StateText => {
+                if valid.contains(&text) {
+                    text.to_string()
+                } else {
+                    dsl_map.api_for_hash_feature(variant)
+                }
+            }
+        };
+
+        let enumerated = values.is_some();
+        let valid_value = values
+            .into_iter()
+            .flatten()
+            .any(|v| enum_value_matches(&api_value, v));
+        let validation_result = validate.map(|validate| {
+            validate(&crate::resource::Value::Concrete(
+                crate::resource::ConcreteValue::String(api_value.clone()),
+            ))
+        });
+        let validation_ok = validation_result
+            .as_ref()
+            .map_or(!enumerated, Result::is_ok);
+
+        if valid_value || validation_ok {
+            Ok(CanonicalEnumValue::new_resolved(
+                identity.clone(),
+                api_value,
+            ))
+        } else {
+            Err(invalid_enum_variant(
+                text,
+                identity,
+                values,
+                dsl_aliases,
+                dsl_map,
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnumInputPhase {
+    RawDsl,
+    StateText,
+}
+
+fn enum_value_matches(input: &str, expected: &str) -> bool {
+    input == expected
+        || input.eq_ignore_ascii_case(expected)
+        || input.replace('_', "-").eq_ignore_ascii_case(expected)
+}
+
+fn api_spelling_rejected_in_dsl(variant: &str, dsl_aliases: &[(String, String)]) -> bool {
+    dsl_aliases
+        .iter()
+        .any(|(api, dsl)| api != dsl && variant == api)
+}
+
+fn invalid_enum_variant(
+    value: &str,
+    identity: &TypeIdentity,
+    values: Option<&[String]>,
+    dsl_aliases: &[(String, String)],
+    dsl_map: DslMap<'_>,
+) -> TypeError {
+    TypeError::InvalidEnumVariant {
+        value: value.to_string(),
+        attribute: None,
+        type_name: Some(identity.kind.clone()),
+        expected: expected_variants(identity, values.unwrap_or_default(), dsl_aliases, dsl_map),
+    }
+}
+
+fn expected_variants(
+    identity: &TypeIdentity,
+    values: &[String],
+    dsl_aliases: &[(String, String)],
+    dsl_map: DslMap<'_>,
+) -> Vec<ExpectedEnumVariant> {
+    let namespace = identity.dotted_prefix();
+    let namespace = namespace.as_deref();
+    let mut expected = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut canonical_dsl_values = std::collections::HashSet::new();
+    for value in values {
+        let dsl_value = dsl_map.dsl_for(value).into_owned();
+        canonical_dsl_values.insert(dsl_value.clone());
+        if seen.insert(dsl_value.clone()) {
+            expected.push(ExpectedEnumVariant::from_namespaced(
+                namespace,
+                &identity.kind,
+                &dsl_value,
+                false,
+            ));
+        }
+    }
+    for (_api, dsl_value) in dsl_aliases {
+        if !canonical_dsl_values.contains(dsl_value) && seen.insert(dsl_value.clone()) {
+            expected.push(ExpectedEnumVariant::from_namespaced(
+                namespace,
+                &identity.kind,
+                dsl_value,
+                true,
+            ));
+        }
+    }
+    expected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{DslTransform, enum_identity};
+
+    #[test]
+    fn raw_parse_classifies_identifier_shapes() {
+        assert_eq!(
+            RawEnumIdentifier::parse("enabled").parsed(),
+            &RawEnumIdentifierParts::Bare {
+                value: "enabled".to_string()
+            }
+        );
+        assert_eq!(
+            RawEnumIdentifier::parse("Region.ap_northeast_1").parsed(),
+            &RawEnumIdentifierParts::TypeQualified {
+                type_name: "Region".to_string(),
+                value: "ap_northeast_1".to_string()
+            }
+        );
+        assert_eq!(
+            RawEnumIdentifier::parse("aws.Region.ap_northeast_1").parsed(),
+            &RawEnumIdentifierParts::ProviderQualified {
+                provider: "aws".to_string(),
+                type_name: "Region".to_string(),
+                value: "ap_northeast_1".to_string()
+            }
+        );
+        assert_eq!(
+            RawEnumIdentifier::parse("awscc.ec2.vpn_gateway.Type.ipsec.1").parsed(),
+            &RawEnumIdentifierParts::FullyQualified {
+                provider: "awscc".to_string(),
+                segments: vec!["ec2".to_string(), "vpn_gateway".to_string()],
+                type_name: "Type".to_string(),
+                value: "ipsec.1".to_string()
+            }
+        );
+        assert_eq!(
+            RawEnumIdentifier::parse("some.random.string").parsed(),
+            &RawEnumIdentifierParts::Unclassified
+        );
+    }
+
+    #[test]
+    fn resolve_raw_maps_alias_and_transform_to_same_canonical_value() {
+        let region = AttributeType::enum_(
+            enum_identity("Region", Some("aws")),
+            Some(vec!["ap-northeast-1".to_string()]),
+            vec![],
+            None,
+            Some(DslTransform::HyphenToUnderscore),
+        );
+        let canonical_from_aws = EnumValueResolver::new(&region)
+            .resolve_raw(&RawEnumIdentifier::parse("aws.Region.ap_northeast_1"));
+        let awscc_region = AttributeType::enum_(
+            enum_identity("Region", Some("awscc")),
+            Some(vec!["ap-northeast-1".to_string()]),
+            vec![],
+            None,
+            Some(DslTransform::HyphenToUnderscore),
+        );
+        let canonical_from_awscc = EnumValueResolver::new(&awscc_region)
+            .resolve_raw(&RawEnumIdentifier::parse("awscc.Region.ap_northeast_1"));
+        assert_eq!(canonical_from_aws.unwrap().api_value(), "ap-northeast-1");
+        assert_eq!(canonical_from_awscc.unwrap().api_value(), "ap-northeast-1");
+
+        let effect = AttributeType::enum_(
+            enum_identity("Effect", Some("aws.iam.PolicyDocument")),
+            Some(vec!["Allow".to_string()]),
+            vec![("Allow".to_string(), "allow".to_string())],
+            None,
+            None,
+        );
+        let canonical = EnumValueResolver::new(&effect)
+            .resolve_raw(&RawEnumIdentifier::parse(
+                "aws.iam.PolicyDocument.Effect.allow",
+            ))
+            .unwrap();
+        assert_eq!(canonical.api_value(), "Allow");
+    }
+
+    #[test]
+    fn resolve_raw_rejects_namespace_mismatch_and_invalid_value() {
+        let attr = AttributeType::enum_(
+            enum_identity("Region", Some("aws")),
+            Some(vec!["ap-northeast-1".to_string()]),
+            vec![],
+            None,
+            Some(DslTransform::HyphenToUnderscore),
+        );
+        assert!(matches!(
+            EnumValueResolver::new(&attr)
+                .resolve_raw(&RawEnumIdentifier::parse("awscc.Region.ap_northeast_1")),
+            Err(TypeError::ValidationFailed { .. })
+        ));
+        assert!(matches!(
+            EnumValueResolver::new(&attr)
+                .resolve_raw(&RawEnumIdentifier::parse("aws.Region.eu_west_1")),
+            Err(TypeError::InvalidEnumVariant { .. })
+        ));
+    }
+
+    #[test]
+    fn resolve_state_text_accepts_api_and_dsl_alias() {
+        let attr = AttributeType::enum_(
+            enum_identity("Effect", Some("aws.iam.PolicyDocument")),
+            Some(vec!["Allow".to_string()]),
+            vec![("Allow".to_string(), "allow".to_string())],
+            None,
+            None,
+        );
+        let resolver = EnumValueResolver::new(&attr);
+        assert_eq!(
+            resolver.resolve_state_text("Allow").unwrap().api_value(),
+            "Allow"
+        );
+        assert_eq!(
+            resolver.resolve_state_text("allow").unwrap().api_value(),
+            "Allow"
+        );
+    }
+
+    #[test]
+    fn canonical_equality_uses_identity_and_api_value() {
+        let aws_region = TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region");
+        let gcp_region = TypeIdentity::new(Some("gcp"), Vec::<String>::new(), "Region");
+        assert_eq!(
+            CanonicalEnumValue::new_for_test(aws_region.clone(), "us-east-1"),
+            CanonicalEnumValue::new_for_test(aws_region, "us-east-1")
+        );
+        assert_ne!(
+            CanonicalEnumValue::new_for_test(gcp_region, "us-east-1"),
+            CanonicalEnumValue::new_for_test(
+                TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region"),
+                "us-east-1"
+            )
+        );
+    }
+
+    #[test]
+    fn serde_round_trips_raw_as_plain_string_and_canonical_as_object() {
+        let raw = RawEnumIdentifier::parse("aws.Region.ap_northeast_1");
+        let encoded = serde_json::to_string(&raw).unwrap();
+        assert_eq!(encoded, r#""aws.Region.ap_northeast_1""#);
+        let decoded: RawEnumIdentifier = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, raw);
+        assert_eq!(decoded.parsed(), raw.parsed());
+
+        let canonical = CanonicalEnumValue::new_for_test(
+            TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region"),
+            "ap-northeast-1",
+        );
+        let encoded = serde_json::to_string(&canonical).unwrap();
+        assert!(encoded.contains(r#""identity""#));
+        assert!(encoded.contains(r#""api_value":"ap-northeast-1""#));
+        let decoded: CanonicalEnumValue = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, canonical);
+    }
+}

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1,10 +1,16 @@
 //! Resource - Representing resources and their state
 
+mod enum_value;
+
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+
+pub use enum_value::{
+    CanonicalEnumValue, EnumValueResolver, RawEnumIdentifier, RawEnumIdentifierParts,
+};
 
 /// The `name` portion of a `ResourceId`.
 ///
@@ -618,7 +624,8 @@ pub enum ConcreteValue {
     /// variant so the validator can distinguish "identifier value"
     /// from "string value" without re-deriving the question from
     /// string content. See carina#2986.
-    EnumIdentifier(String),
+    EnumIdentifier(RawEnumIdentifier),
+    CanonicalEnum(CanonicalEnumValue),
     Int(i64),
     Float(f64),
     Bool(bool),
@@ -681,7 +688,8 @@ pub enum DeferredValue {
 pub enum ConcreteValueRef<'a> {
     String(&'a str),
     /// See `ConcreteValue::EnumIdentifier`.
-    EnumIdentifier(&'a str),
+    EnumIdentifier(&'a RawEnumIdentifier),
+    CanonicalEnum(&'a CanonicalEnumValue),
     Int(i64),
     Float(f64),
     Bool(bool),
@@ -699,9 +707,19 @@ impl<'a> ConcreteValueRef<'a> {
     pub fn as_string_like(&self) -> Option<&'a str> {
         match self {
             ConcreteValueRef::String(s) => Some(s),
-            ConcreteValueRef::EnumIdentifier(s) => Some(s),
+            ConcreteValueRef::EnumIdentifier(s) => Some(s.as_str()),
+            ConcreteValueRef::CanonicalEnum(_) => None,
             _ => None,
         }
+    }
+}
+
+impl ConcreteValue {
+    /// TODO(carina#3438): remove in chain PR 5.
+    /// Temporary constructor for call sites that still build parser-surface
+    /// enum identifiers from string text.
+    pub fn enum_identifier(text: impl Into<String>) -> Self {
+        Self::EnumIdentifier(RawEnumIdentifier::parse(text))
     }
 }
 
@@ -742,6 +760,7 @@ impl Value {
             Value::Concrete(c) => Some(match c {
                 ConcreteValue::String(s) => ConcreteValueRef::String(s),
                 ConcreteValue::EnumIdentifier(s) => ConcreteValueRef::EnumIdentifier(s),
+                ConcreteValue::CanonicalEnum(c) => ConcreteValueRef::CanonicalEnum(c),
                 ConcreteValue::Int(n) => ConcreteValueRef::Int(*n),
                 ConcreteValue::Float(f) => ConcreteValueRef::Float(*f),
                 ConcreteValue::Bool(b) => ConcreteValueRef::Bool(*b),
@@ -866,14 +885,18 @@ impl PartialEq for Value {
             (
                 Value::Concrete(ConcreteValue::EnumIdentifier(a)),
                 Value::Concrete(ConcreteValue::EnumIdentifier(b)),
-            )
-            | (
+            ) => a == b,
+            (
                 Value::Concrete(ConcreteValue::EnumIdentifier(a)),
                 Value::Concrete(ConcreteValue::String(b)),
-            )
-            | (
+            ) => a.as_str() == b,
+            (
                 Value::Concrete(ConcreteValue::String(a)),
                 Value::Concrete(ConcreteValue::EnumIdentifier(b)),
+            ) => a == b,
+            (
+                Value::Concrete(ConcreteValue::CanonicalEnum(a)),
+                Value::Concrete(ConcreteValue::CanonicalEnum(b)),
             ) => a == b,
             (Value::Concrete(ConcreteValue::Int(a)), Value::Concrete(ConcreteValue::Int(b))) => {
                 a == b
@@ -1111,6 +1134,7 @@ impl Value {
             Value::Deferred(DeferredValue::Secret(inner)) => inner.visit_refs(f),
             Value::Concrete(ConcreteValue::String(_))
             | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
             | Value::Concrete(ConcreteValue::Int(_))
             | Value::Concrete(ConcreteValue::Float(_))
             | Value::Concrete(ConcreteValue::Bool(_))
@@ -1185,8 +1209,9 @@ impl Value {
     fn hash_into(&self, hasher: &mut impl Hasher) {
         std::mem::discriminant(self).hash(hasher);
         match self {
-            Value::Concrete(ConcreteValue::String(s))
-            | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => s.hash(hasher),
+            Value::Concrete(ConcreteValue::String(s)) => s.hash(hasher),
+            Value::Concrete(ConcreteValue::EnumIdentifier(s)) => s.hash(hasher),
+            Value::Concrete(ConcreteValue::CanonicalEnum(c)) => c.hash(hasher),
             Value::Concrete(ConcreteValue::Int(i)) => i.hash(hasher),
             Value::Concrete(ConcreteValue::Float(f)) => {
                 // Use bits for deterministic hashing (NaN == NaN for our purposes)

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1462,7 +1462,7 @@ impl fmt::Display for FieldPath {
 /// drift again (carina#3347).
 pub(crate) fn lift_map_key(key_type: &AttributeType, key: &str) -> Value {
     if matches!(&key_type.kind, AttrTypeKind::Enum { .. }) {
-        Value::Concrete(ConcreteValue::EnumIdentifier(key.to_string()))
+        Value::Concrete(ConcreteValue::enum_identifier(key.to_string()))
     } else {
         Value::Concrete(ConcreteValue::String(key.to_string()))
     }
@@ -2303,7 +2303,7 @@ impl AttributeType {
         // must stay internal: error messages should quote what the user
         // actually typed. See #2077.
         let user_input = match value {
-            ConcreteValueRef::EnumIdentifier(s) => Some(s),
+            ConcreteValueRef::EnumIdentifier(s) => Some(s.as_str()),
             _ => None,
         };
         if let Value::Concrete(ConcreteValue::String(s)) = &resolved_value {
@@ -3668,6 +3668,7 @@ impl Value {
         match self {
             Value::Concrete(ConcreteValue::String(_)) => "String".to_string(),
             Value::Concrete(ConcreteValue::EnumIdentifier(_)) => "EnumIdentifier".to_string(),
+            Value::Concrete(ConcreteValue::CanonicalEnum(_)) => "CanonicalEnum".to_string(),
             Value::Concrete(ConcreteValue::Int(_)) => "Int".to_string(),
             Value::Concrete(ConcreteValue::Float(_)) => "Float".to_string(),
             Value::Concrete(ConcreteValue::Bool(_)) => "Bool".to_string(),
@@ -3698,6 +3699,7 @@ impl ConcreteValueRef<'_> {
         match self {
             ConcreteValueRef::String(_) => "String",
             ConcreteValueRef::EnumIdentifier(_) => "EnumIdentifier",
+            ConcreteValueRef::CanonicalEnum(_) => "CanonicalEnum",
             ConcreteValueRef::Int(_) => "Int",
             ConcreteValueRef::Float(_) => "Float",
             ConcreteValueRef::Bool(_) => "Bool",
@@ -3716,7 +3718,10 @@ impl ConcreteValueRef<'_> {
         match self {
             ConcreteValueRef::String(s) => Value::Concrete(ConcreteValue::String(s.to_string())),
             ConcreteValueRef::EnumIdentifier(s) => {
-                Value::Concrete(ConcreteValue::EnumIdentifier(s.to_string()))
+                Value::Concrete(ConcreteValue::enum_identifier(s.to_string()))
+            }
+            ConcreteValueRef::CanonicalEnum(c) => {
+                Value::Concrete(ConcreteValue::CanonicalEnum(c.clone()))
             }
             ConcreteValueRef::Int(n) => Value::Concrete(ConcreteValue::Int(n)),
             ConcreteValueRef::Float(f) => Value::Concrete(ConcreteValue::Float(f)),

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -3167,7 +3167,7 @@ fn length_display(min: Option<&u64>, max: Option<&u64>) -> String {
     }
 }
 
-fn enum_value_matches(input: &str, expected: &str) -> bool {
+pub(crate) fn enum_value_matches(input: &str, expected: &str) -> bool {
     input == expected
         || input.eq_ignore_ascii_case(expected)
         || input.replace('_', "-").eq_ignore_ascii_case(expected)

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -53,25 +53,25 @@ fn validate_enum_type() {
         None,
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "awscc.ec2.ipam_pool.AddressFamily.IPv4".to_string()
         )))
         .is_ok()
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "IPv6".to_string()
         )))
         .is_ok()
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "ipv4".to_string()
         )))
         .is_ok()
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "IPv5".to_string()
         )))
         .is_err()
@@ -132,14 +132,14 @@ fn validate_enum_accepts_dsl_alias() {
     // not accept the API form when an alias is registered. Users
     // write `all`. Updated for carina#2980 / carina#2986.
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "-1".to_string()
         )))
         .is_err()
     );
     // DSL alias "all" should be accepted
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "awscc.ec2.SecurityGroup.IpProtocol.all".to_string()
         )))
         .is_ok()
@@ -148,14 +148,14 @@ fn validate_enum_accepts_dsl_alias() {
     // which is already snake_case) keep working — the API spelling
     // *is* the DSL spelling for them.
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "tcp".to_string()
         )))
         .is_ok()
     );
     // Invalid values should still be rejected
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "invalid".to_string()
         )))
         .is_err()
@@ -197,7 +197,7 @@ fn assert_iam_policy_version_candidates(expected: &[ExpectedEnumVariant]) {
 #[test]
 fn invalid_enum_variant_candidates_use_dsl_spelling_for_enum_aliases() {
     let err = iam_policy_version_enum()
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "bad_version".to_string(),
         )))
         .unwrap_err();
@@ -264,7 +264,7 @@ fn enum_candidates_preserve_genuine_extra_aliases() {
         None,
     );
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "bad_mode".to_string(),
         )))
         .unwrap_err();
@@ -304,7 +304,7 @@ fn validate_enum_all_without_dsl_aliases_requires_explicit_variant() {
     // Without "all" in values and no dsl_aliases entry mapping to "all", it is rejected
     assert!(
         without_all
-            .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            .validate(&Value::Concrete(ConcreteValue::enum_identifier(
                 "all".to_string()
             )))
             .is_err()
@@ -327,7 +327,7 @@ fn validate_enum_all_without_dsl_aliases_requires_explicit_variant() {
     );
     assert!(
         with_all
-            .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+            .validate(&Value::Concrete(ConcreteValue::enum_identifier(
                 "all".to_string()
             )))
             .is_ok()
@@ -350,21 +350,21 @@ fn validate_enum_accepts_values_with_dots() {
     // "Quoted string" for historical reasons but values are written
     // unquoted in real DSL).
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "ipsec.1".to_string()
         )))
         .is_ok()
     );
     // Fully qualified form should also be accepted
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "awscc.ec2.vpn_gateway.Type.ipsec.1".to_string()
         )))
         .is_ok()
     );
     // Invalid value should still be rejected
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "ipsec.2".to_string()
         )))
         .is_err()
@@ -466,7 +466,7 @@ fn with_attribute_adds_attribute_name_to_enum_error() {
     // Identifier path (`InvalidEnumVariant`): the message keeps the
     // single-quoted form for the bare value.
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "aaa".to_string(),
         )))
         .unwrap_err()
@@ -694,7 +694,7 @@ fn schema_validate_with_origins_emits_string_literal_diagnostic_for_quoted_enum(
     let mut attrs = HashMap::new();
     attrs.insert(
         "target_type".to_string(),
-        Value::Concrete(ConcreteValue::EnumIdentifier("aaa".to_string())),
+        Value::Concrete(ConcreteValue::enum_identifier("aaa".to_string())),
     );
     let errs = schema
         .validate_with_origins(&attrs, &|_| false)
@@ -727,7 +727,7 @@ fn schema_validate_with_origins_leaves_valid_values_alone() {
     let mut attrs = HashMap::new();
     attrs.insert(
         "target_type".to_string(),
-        Value::Concrete(ConcreteValue::EnumIdentifier("AWS_ACCOUNT".to_string())),
+        Value::Concrete(ConcreteValue::enum_identifier("AWS_ACCOUNT".to_string())),
     );
     assert!(
         schema.validate_with_origins(&attrs, &|_| true).is_ok(),
@@ -4276,7 +4276,7 @@ fn expected_includes_to_dsl_aliases_with_alias_flag() {
     // be rejected earlier as `StringLiteralExpectedEnum` — that path is
     // covered by `validate_enum_rejects_quoted_string_literal`.
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "zzz".to_string(),
         )))
         .unwrap_err();
@@ -4441,7 +4441,7 @@ fn union_string_vs_enum_picks_enum_error_for_string_input() {
         ),
     ]);
     let err = union_type
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "zzz".to_string(),
         )))
         .unwrap_err();
@@ -5028,7 +5028,7 @@ fn dsl_aliases_validator_accepts_dsl_spellings_only() {
     // input as `EnumIdentifier` because the user wrote it as a bare
     // identifier, not a quoted string.
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "BucketOwnerEnforced".to_string(),
         )))
         .unwrap_err();
@@ -5040,21 +5040,21 @@ fn dsl_aliases_validator_accepts_dsl_spellings_only() {
 
     // Bare DSL spelling: accepted (alias).
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "bucket_owner_enforced".to_string()
         )))
         .is_ok()
     );
     // Fully-qualified API spelling: REJECTED under strict mode.
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string()
         )))
         .is_err()
     );
     // Fully-qualified DSL spelling: accepted (the awscc#199 case).
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "awscc.s3.Bucket.ObjectOwnership.bucket_owner_enforced".to_string()
         )))
         .is_ok()
@@ -5063,7 +5063,7 @@ fn dsl_aliases_validator_accepts_dsl_spellings_only() {
     // An unrelated value: rejected, listing only the DSL spellings
     // that `validate` accepts and users can type.
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "garbage".to_string(),
         )))
         .unwrap_err();
@@ -5098,7 +5098,7 @@ fn enum_without_dsl_aliases_accepts_api_spelling_as_before() {
         None,
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "ALL".to_string()
         )))
         .is_ok(),
@@ -5126,7 +5126,7 @@ fn dsl_aliases_diagnostic_tags_alias_entries_distinct_from_canonical() {
     // pin). A `String` here would take the `StringLiteralExpectedEnum`
     // path which is covered by sibling tests.
     let err = t
-        .validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        .validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "zzz".to_string(),
         )))
         .unwrap_err();
@@ -5161,13 +5161,13 @@ fn dsl_aliases_empty_keeps_api_only_validation() {
         None,
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "active".to_string()
         )))
         .is_ok()
     );
     assert!(
-        t.validate(&Value::Concrete(ConcreteValue::EnumIdentifier(
+        t.validate(&Value::Concrete(ConcreteValue::enum_identifier(
             "nope".to_string()
         )))
         .is_err()
@@ -5308,7 +5308,7 @@ mod enum_binding_collision {
         // — the validator resolves it against the `dsl_aliases` table
         // for `ResourceType` and accepts.
         let t = flow_log_resource_type();
-        let value = Value::Concrete(ConcreteValue::EnumIdentifier("vpc".to_string()));
+        let value = Value::Concrete(ConcreteValue::enum_identifier("vpc".to_string()));
         assert!(t.validate(&value).is_ok());
     }
 
@@ -5318,7 +5318,7 @@ mod enum_binding_collision {
         // validator as `ConcreteValue::EnumIdentifier` (carina#2986
         // Phase 3 parser routing).
         let t = flow_log_resource_type();
-        let value = Value::Concrete(ConcreteValue::EnumIdentifier(
+        let value = Value::Concrete(ConcreteValue::enum_identifier(
             "awscc.ec2.FlowLog.ResourceType.vpc".to_string(),
         ));
         assert!(t.validate(&value).is_ok());
@@ -5593,7 +5593,7 @@ fn lift_state_enum_leaves_fixes_awscc251() {
     };
     assert_eq!(
         policy["version"],
-        Value::Concrete(ConcreteValue::EnumIdentifier(
+        Value::Concrete(ConcreteValue::enum_identifier(
             "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
         ))
     );
@@ -5605,7 +5605,7 @@ fn lift_state_enum_leaves_fixes_awscc251() {
     };
     assert_eq!(
         stmt["effect"],
-        Value::Concrete(ConcreteValue::EnumIdentifier(
+        Value::Concrete(ConcreteValue::enum_identifier(
             "aws.iam.PolicyDocument.Effect.allow".to_string()
         ))
     );
@@ -5634,7 +5634,7 @@ fn lift_state_enums_is_idempotent_and_preserves_invalid() {
     let mut already = IndexMap::new();
     already.insert(
         "version".to_string(),
-        Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
+        Value::Concrete(ConcreteValue::enum_identifier("2012_10_17".to_string())),
     );
     let mut attrs: HashMap<String, Value> = HashMap::new();
     attrs.insert(
@@ -5647,7 +5647,7 @@ fn lift_state_enums_is_idempotent_and_preserves_invalid() {
     };
     assert_eq!(
         p["version"],
-        Value::Concrete(ConcreteValue::EnumIdentifier(
+        Value::Concrete(ConcreteValue::enum_identifier(
             "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
         )),
         "already-lifted EnumIdentifier must normalize to fully-qualified DSL spelling"
@@ -5719,7 +5719,7 @@ fn dynamic_enum_lift_raw_string_requires_transform_and_structural_dsl_member() {
     );
     assert_eq!(
         lifted_value("ap-northeast-1z"),
-        Value::Concrete(ConcreteValue::EnumIdentifier(
+        Value::Concrete(ConcreteValue::enum_identifier(
             "aws.AvailabilityZone.ZoneName.ap_northeast_1z".to_string()
         )),
         "structural API-form dynamic enum strings must lift"

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -707,6 +707,7 @@ fn walk_value_against_type(
         }
         Value::Concrete(ConcreteValue::String(_))
         | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+        | Value::Concrete(ConcreteValue::CanonicalEnum(_))
         | Value::Concrete(ConcreteValue::Int(_))
         | Value::Concrete(ConcreteValue::Float(_))
         | Value::Concrete(ConcreteValue::Bool(_))

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -1014,7 +1014,7 @@ fn lift_enum_leaves_projected(
                 .dotted_prefix()
                 .map(|prefix| format!("{}.{}.{}", prefix, identity.kind, dsl))
                 .unwrap_or_else(|| format!("{}.{}", identity.kind, dsl));
-            return Some(Value::Concrete(ConcreteValue::EnumIdentifier(full)));
+            return Some(Value::Concrete(ConcreteValue::enum_identifier(full)));
         }
         // Recognized-or-not, an Enum leaf has no children.
         return None;
@@ -1112,7 +1112,7 @@ fn enum_member_accepts(
         return false;
     }
     let resolved = expand_enum_shorthand(
-        &Value::Concrete(ConcreteValue::EnumIdentifier(dsl.to_string())),
+        &Value::Concrete(ConcreteValue::enum_identifier(dsl.to_string())),
         identity,
     );
     if let Some(validate) = validate {
@@ -1252,7 +1252,7 @@ pub fn convert_region_value(value: &str) -> String {
 /// let mut attrs = IndexMap::new();
 /// attrs.insert(
 ///     "region".to_string(),
-///     Value::Concrete(ConcreteValue::EnumIdentifier("aws.Region.us_east_1".into())),
+///     Value::Concrete(ConcreteValue::enum_identifier("aws.Region.us_east_1")),
 /// );
 /// assert_eq!(extract_region_from_attrs(&attrs, "ap-northeast-1"), "us-east-1");
 ///
@@ -2284,7 +2284,7 @@ mod tests {
         }
 
         fn ei(s: &str) -> Value {
-            Value::Concrete(ConcreteValue::EnumIdentifier(s.to_string()))
+            Value::Concrete(ConcreteValue::enum_identifier(s.to_string()))
         }
 
         /// Regression for aws#313: post-carina#2986 the parser emits
@@ -2557,7 +2557,7 @@ mod tests {
 
         #[test]
         fn enum_identifier_namespaced_form() {
-            let attrs = attrs_with_region(Value::Concrete(ConcreteValue::EnumIdentifier(
+            let attrs = attrs_with_region(Value::Concrete(ConcreteValue::enum_identifier(
                 "aws.Region.us_east_1".to_string(),
             )));
             assert_eq!(
@@ -2664,7 +2664,7 @@ mod tests {
         };
         assert_eq!(
             pd["version"],
-            Value::Concrete(ConcreteValue::EnumIdentifier(
+            Value::Concrete(ConcreteValue::enum_identifier(
                 "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
             )),
             "resource present in registry must have its state lifted"
@@ -2734,7 +2734,7 @@ mod tests {
         };
         assert_eq!(
             pd["version"],
-            Value::Concrete(ConcreteValue::EnumIdentifier(
+            Value::Concrete(ConcreteValue::enum_identifier(
                 "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
             )),
             "provider-read state String must be lifted to EnumIdentifier"

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -336,6 +336,7 @@ fn infer_type_from_value_with_visiting(
         // layer — the value-layer distinction matters only inside the
         // `Enum` validator. See carina#2986.
         Value::Concrete(ConcreteValue::EnumIdentifier(_)) => Ok(TypeExpr::String),
+        Value::Concrete(ConcreteValue::CanonicalEnum(_)) => Ok(TypeExpr::String),
         Value::Concrete(ConcreteValue::Int(_)) => Ok(TypeExpr::Int),
         Value::Concrete(ConcreteValue::Float(_)) => Ok(TypeExpr::Float),
         Value::Concrete(ConcreteValue::Bool(_)) => Ok(TypeExpr::Bool),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -489,11 +489,7 @@ pub(crate) fn format_value_into<S: FormatSink>(
             // identifier ready for direct display.
             sink.write_str(s.as_str())
         }
-        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
-            sink.write_str("\"")?;
-            sink.write_str(c.api_value())?;
-            sink.write_str("\"")
-        }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => sink.write_str(c.api_value()),
         Value::Concrete(ConcreteValue::Int(n)) => sink.write_str(&n.to_string()),
         Value::Concrete(ConcreteValue::Duration(d)) => sink.write_str(&render_duration(*d)),
         Value::Concrete(ConcreteValue::Float(f)) => {
@@ -2501,6 +2497,17 @@ mod tests {
     fn test_format_value_bare_enum_string() {
         let v = Value::Concrete(ConcreteValue::String("dedicated".to_string()));
         assert_eq!(format_value(&v), "\"dedicated\"");
+    }
+
+    #[test]
+    fn test_format_value_canonical_enum_unquoted() {
+        let v = Value::Concrete(ConcreteValue::CanonicalEnum(
+            crate::resource::CanonicalEnumValue::new_for_test(
+                crate::schema::TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region"),
+                "ap-northeast-1",
+            ),
+        ));
+        assert_eq!(format_value(&v), "ap-northeast-1");
     }
 
     #[test]

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -221,13 +221,18 @@ pub fn value_to_json_with_context(
 ) -> Result<serde_json::Value, SerializationError> {
     let ctx = SerializationContext::ValueToJson;
     match value {
-        Value::Concrete(ConcreteValue::String(s))
-        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+        Value::Concrete(ConcreteValue::String(s)) => {
             // Both serialize as a flat JSON string. The schema-aware
             // state loader re-classifies `EnumIdentifier` from the
             // attribute's declared type, so the on-disk JSON stays
             // unchanged. See carina#2986 design doc §5.
             Ok(serde_json::Value::String(s.clone()))
+        }
+        Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            Ok(serde_json::Value::String(s.to_string()))
+        }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            Ok(serde_json::Value::String(c.api_value().to_string()))
         }
         Value::Concrete(ConcreteValue::Int(n)) => Ok(serde_json::Value::Number((*n).into())),
         Value::Concrete(ConcreteValue::Duration(d)) => {
@@ -482,7 +487,12 @@ pub(crate) fn format_value_into<S: FormatSink>(
             // match how the user typed them. The resolver has already
             // canonicalized any namespaced form, so `s` is the bare
             // identifier ready for direct display.
-            sink.write_str(s)
+            sink.write_str(s.as_str())
+        }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            sink.write_str("\"")?;
+            sink.write_str(c.api_value())?;
+            sink.write_str("\"")
         }
         Value::Concrete(ConcreteValue::Int(n)) => sink.write_str(&n.to_string()),
         Value::Concrete(ConcreteValue::Duration(d)) => sink.write_str(&render_duration(*d)),
@@ -1280,8 +1290,9 @@ pub fn as_string_list(value: &Value) -> Option<Vec<String>> {
         Value::Concrete(ConcreteValue::List(items)) => items
             .iter()
             .map(|v| match v {
-                Value::Concrete(ConcreteValue::String(s))
-                | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.clone()),
+                Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
+                Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(s.to_string()),
+                Value::Concrete(ConcreteValue::CanonicalEnum(c)) => Some(c.api_value().to_string()),
                 _ => None,
             })
             .collect(),
@@ -3691,7 +3702,7 @@ mod tests {
         let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
         assert_eq!(
             canon,
-            Value::Concrete(ConcreteValue::EnumIdentifier(
+            Value::Concrete(ConcreteValue::enum_identifier(
                 "aws.iam.PolicyDocument.Effect.allow".to_string()
             ))
         );
@@ -4307,7 +4318,9 @@ mod tests {
         let mut desired = vec![
             Resource::with_provider("awscc", "ec2.Subnet", "subnet", None).with_attribute(
                 "availability_zone",
-                Value::Concrete(ConcreteValue::EnumIdentifier("ap_northeast_1a".to_string())),
+                Value::Concrete(ConcreteValue::enum_identifier(
+                    "ap_northeast_1a".to_string(),
+                )),
             ),
         ];
         canonicalize_resources_with_schemas(&mut desired, &registry);

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -232,6 +232,7 @@ pub fn value_to_json_with_context(
             Ok(serde_json::Value::String(s.to_string()))
         }
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            // TODO(carina#3438): PR3 — state-facing serialization must use the typed enum object per design doc §Serialization; this flat string is a dormant placeholder.
             Ok(serde_json::Value::String(c.api_value().to_string()))
         }
         Value::Concrete(ConcreteValue::Int(n)) => Ok(serde_json::Value::Number((*n).into())),

--- a/carina-lsp/src/code_action.rs
+++ b/carina-lsp/src/code_action.rs
@@ -306,7 +306,7 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "Version".to_string(),
-            Value::Concrete(ConcreteValue::EnumIdentifier("bad_version".to_string())),
+            Value::Concrete(ConcreteValue::enum_identifier("bad_version")),
         );
         let mut errs = schema.validate(&attrs).unwrap_err();
         let err = errs.remove(0);

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -47,12 +47,17 @@ use crate::wasm_bindings::carina::provider::types as wit;
 /// equivalent to the pre-#2387 `ResourceRef` debug-string.
 pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError> {
     match v {
-        CoreValue::Concrete(ConcreteValue::String(s))
-        | CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+        CoreValue::Concrete(ConcreteValue::String(s)) => {
             // Enum identifiers lower to the WIT boundary as plain
             // strings — the WASM plugin sees the same wire shape as
             // any other string value. See carina#2986.
             Ok(wit::Value::StrVal(s.clone()))
+        }
+        CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            Ok(wit::Value::StrVal(s.to_string()))
+        }
+        CoreValue::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            Ok(wit::Value::StrVal(c.api_value().to_string()))
         }
         CoreValue::Concrete(ConcreteValue::Int(i)) => Ok(wit::Value::IntVal(*i)),
         CoreValue::Concrete(ConcreteValue::Float(f)) => Ok(wit::Value::FloatVal(*f)),
@@ -185,9 +190,12 @@ pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
 /// pass that keeps these arms unreachable in legitimate flows.
 fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationError> {
     match v {
-        CoreValue::Concrete(ConcreteValue::String(s))
-        | CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => {
-            Ok(serde_json::Value::String(s.clone()))
+        CoreValue::Concrete(ConcreteValue::String(s)) => Ok(serde_json::Value::String(s.clone())),
+        CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+            Ok(serde_json::Value::String(s.to_string()))
+        }
+        CoreValue::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            Ok(serde_json::Value::String(c.api_value().to_string()))
         }
         CoreValue::Concrete(ConcreteValue::Int(i)) => Ok(serde_json::Value::Number((*i).into())),
         CoreValue::Concrete(ConcreteValue::Float(f)) => Ok(serde_json::Number::from_f64(*f)
@@ -1982,7 +1990,7 @@ mod tests {
         assert_eq!(
             lifted,
             carina_core::resource::Value::Concrete(
-                carina_core::resource::ConcreteValue::EnumIdentifier(
+                carina_core::resource::ConcreteValue::enum_identifier(
                     "aws.AvailabilityZone.ZoneName.ap_northeast_1a".to_string()
                 )
             )
@@ -2027,12 +2035,12 @@ mod tests {
         );
 
         let already_dsl = carina_core::resource::Value::Concrete(
-            carina_core::resource::ConcreteValue::EnumIdentifier("ap_northeast_1a".to_string()),
+            carina_core::resource::ConcreteValue::enum_identifier("ap_northeast_1a".to_string()),
         );
         assert_eq!(
             carina_core::utils::lift_enum_leaves(&already_dsl, &core_attr),
             Some(carina_core::resource::Value::Concrete(
-                carina_core::resource::ConcreteValue::EnumIdentifier(
+                carina_core::resource::ConcreteValue::enum_identifier(
                     "aws.AvailabilityZone.ZoneName.ap_northeast_1a".to_string()
                 )
             )),
@@ -2056,7 +2064,7 @@ mod tests {
         assert_eq!(
             carina_core::utils::lift_enum_leaves(&valid, &core_attr),
             Some(carina_core::resource::Value::Concrete(
-                carina_core::resource::ConcreteValue::EnumIdentifier(
+                carina_core::resource::ConcreteValue::enum_identifier(
                     "aws.AvailabilityZone.ZoneName.ap_northeast_1a".to_string()
                 )
             )),

--- a/notes/specs/2026-06-10-structured-enum-identifier-design.md
+++ b/notes/specs/2026-06-10-structured-enum-identifier-design.md
@@ -230,9 +230,13 @@ impl EnumValueResolver<'_> {
 
 `resolve_raw` is for parser-fed desired values. `resolve_state_text` is for
 provider-read and state-file text that reaches an enum-typed schema position.
-Both paths apply namespace checks, valid-value extraction, alias inversion, and
-provider custom validation. Tests can use an explicit test-only constructor, but
-production code should not mint `CanonicalEnumValue` without schema.
+The RawDsl path applies namespace checks, valid-value extraction, alias
+inversion, and provider custom validation. The StateText path applies
+valid-value extraction, alias inversion, and provider custom validation, but
+does not apply namespace checks because state may still carry pre-bump
+foreign-namespace DSL text such as `awscc.ec2.Eip.Domain.vpc` after the schema
+identity has moved to `aws.*`. Tests can use an explicit test-only constructor,
+but production code should not mint `CanonicalEnumValue` without schema.
 
 ### Equality and display
 

--- a/notes/specs/2026-06-10-structured-enum-identifier-design.md
+++ b/notes/specs/2026-06-10-structured-enum-identifier-design.md
@@ -144,7 +144,7 @@ schema-bearing shapes instead of wildcard-matching raw representation details.
 Parser output should retain source-shape information explicitly:
 
 ```rust
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RawEnumIdentifier {
     text: String,
     parsed: RawEnumIdentifierParts,
@@ -184,6 +184,11 @@ pub enum ConcreteValue {
 dotted shapes and store owned structured parts. The raw `text` field remains the
 source for `Display`, formatter, LSP, and diagnostics. `Unclassified` is allowed
 because only the schema can decide whether some text is a valid enum member.
+
+`RawEnumIdentifier` should serialize as the plain source text string and
+deserialize by re-running `parse`. The `parsed` field is derived entirely from
+`text`, so persisting it would add redundant state-file data while changing the
+legacy `EnumIdentifier` payload shape.
 
 ### Canonical enum value
 


### PR DESCRIPTION
Refs #3438

## Summary

Chain PR 2 of 5 for the structured enum identifier design (`notes/specs/2026-06-10-structured-enum-identifier-design.md`, merged in #3441): introduce the core raw/canonical typestate types and the resolver skeleton, keeping behavior unchanged through temporary shims.

- `RawEnumIdentifier` — parser-surface enum text plus schema-free syntactic classification (`Bare` / `TypeQualified` / `ProviderQualified` / `FullyQualified` / `Unclassified`, built on `NamespacedId::parse`). Display/Debug/Hash/PartialEq/serde are all text-transparent, so existing output, hashes, and state-file JSON stay byte-identical.
- `CanonicalEnumValue { identity: TypeIdentity, api_value }` — schema-resolved semantic value. Private fields; production code can only obtain one through the resolver. No `PartialEq` in either direction with the raw type.
- `EnumValueResolver` — `resolve_raw` (DSL values: namespace check, legacy prefix-escape for dotted enumerated values, strict DSL-spelling enforcement) and `resolve_state_text` (state/provider text: no namespace check, because state legitimately carries pre-bump foreign-namespace spellings — the #3428 case). Both snap fuzzy matches to the exact values-list member (exact-first) so one logical member always yields one `api_value`; the custom validator is consulted only for open enums, mirroring `validate_enum`.
- `ConcreteValue::EnumIdentifier(String)` → `EnumIdentifier(RawEnumIdentifier)`, plus a dormant `CanonicalEnum(CanonicalEnumValue)` variant. Nothing produces `CanonicalEnum` yet; consumer conversion is chain PR 3. The differ's enum-aware comparison and display already handle the variant explicitly (api_value text, unquoted) so no wildcard silently swallows it later.
- Temporary shims (`ConcreteValue::enum_identifier`, `as_str`, `Deref<Target=str>`, one-directional `PartialEq<RawEnumIdentifier> for String`) are each tagged `TODO(carina#3438): remove in chain PR 5`. Unused shim surface (AsRef, the reverse PartialEq direction) was measured (`cargo check` with the impl removed → 0 errors) and dropped.
- State-facing JSON arms for `CanonicalEnum` are flat-string placeholders tagged `TODO(carina#3438): PR3` pointing at the design doc's typed-object serialization; provider wire JSON stays a plain string per the doc.

Doc deltas in this PR: `RawEnumIdentifier` serializes as plain source text (re-parsed on load) instead of a derived struct — `parsed` is derived from `text`, so persisting it would only bloat state files; and the resolver section now states the StateText namespace-check exemption explicitly.

## Review rounds

Five fresh-eyes review rounds ran on this branch; each finding was fixed with a failing test first:

1. Spec conformance — StateText namespace exemption documented; serialization placeholders marked for PR3.
2. Behavior preservation — derived `Debug` leaked `RawEnumIdentifier { text, parsed }` into user-facing errors and LSP hover; replaced with a text-transparent manual impl.
3. Resolver semantics — fuzzy-accepted spellings now snap to the values-list member (no two `CanonicalEnumValue`s for one logical member); enumerated enums no longer let a custom validator accept out-of-list values; open-enum state text keeps dotted values (`ipsec.1`) intact.
4. Resolver regressions — legacy prefix-escape restored so fully-qualified dotted enumerated values (`awscc.ec2.vpn_gateway.Type.ipsec.1`) resolve like `validate` accepts them; snap is exact-first so an exact member is never rewritten to a fuzzy sibling.
5. Final pass — no issues; full trace of the prefix-escape path and re-run of the #3437 anonymous-address regression tests (12/12 pass).

## Verification

- `RUSTC_WRAPPER= cargo check --workspace --all-targets`
- `RUSTC_WRAPPER= cargo nextest run --workspace --all-features` — 3970 passed, 72 skipped
- `RUSTC_WRAPPER= cargo test --workspace --doc`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/check-*.sh` — all pass
