### PR TITLE
Convert core consumers to CanonicalEnumValue (carina#3438 PR3)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -479,6 +479,8 @@ pub fn validate_and_resolve_errors_with_factories(
         }
     }
 
+    carina_core::value::canonicalize_resources_with_schemas(&mut parsed.resources, ctx.schemas());
+
     // Compute anonymous identifiers — downstream plan code assumes
     // every resource has a stable id, so a collision error must stop
     // the pipeline here.

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -331,8 +331,7 @@ pub(crate) fn dsl_value_to_json(
             Ok(Some(serde_json::Value::String(s.to_string())))
         }
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
-            // TODO(carina#3438): PR3 — state-facing serialization must use the typed enum object per design doc §Serialization; this flat string is a dormant placeholder.
-            Ok(Some(serde_json::Value::String(c.api_value().to_string())))
+            Ok(Some(carina_core::value::canonical_enum_to_json(c)))
         }
         Value::Concrete(ConcreteValue::Bool(b)) => Ok(Some(serde_json::Value::Bool(*b))),
         Value::Concrete(ConcreteValue::Int(i)) => Ok(Some(serde_json::Value::Number((*i).into()))),
@@ -858,6 +857,35 @@ mod stage4_unknown_err_tests {
             ConcreteValue::String("password".into()),
         ))));
         assert!(matches!(dsl_value_to_json(&v), Ok(None)));
+    }
+
+    #[test]
+    fn canonical_enum_serializes_as_typed_object() {
+        let attr_type = carina_core::schema::AttributeType::enum_(
+            carina_core::schema::TypeIdentity::new(Some("aws"), ["ec2", "Eip"], "Domain"),
+            Some(vec!["vpc".to_string()]),
+            Vec::new(),
+            None,
+            None,
+        );
+        let canonical = carina_core::resource::EnumValueResolver::new(&attr_type)
+            .resolve_state_text("vpc")
+            .unwrap();
+        let v = Value::Concrete(ConcreteValue::CanonicalEnum(canonical));
+
+        assert_eq!(
+            dsl_value_to_json(&v).unwrap(),
+            Some(serde_json::json!({
+                "Enum": {
+                    "identity": {
+                        "provider": "aws",
+                        "segments": ["ec2", "Eip"],
+                        "kind": "Domain"
+                    },
+                    "api_value": "vpc"
+                }
+            }))
+        );
     }
 
     /// Non-finite floats (NaN / +inf / -inf) cannot be represented in

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -355,10 +355,74 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
 fn fixture_provider_factories(fixture_path: &Path) -> Vec<Box<dyn ProviderFactory>> {
     match fixture_path.file_name().and_then(|name| name.to_str()) {
         Some("dynamic_enum_az_no_diff") => vec![Box::new(DynamicEnumFixtureFactory)],
+        Some("enum_display") => vec![Box::new(EnumDisplayFixtureFactory)],
         Some("route53_hosted_zone_name_strip_suffix_no_diff") => {
             vec![Box::new(Route53HostedZoneFixtureFactory)]
         }
         _ => vec![],
+    }
+}
+
+struct EnumDisplayFixtureFactory;
+
+impl ProviderFactory for EnumDisplayFixtureFactory {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+
+    fn display_name(&self) -> &str {
+        "AWS Cloud Control fixture provider"
+    }
+
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::from([(
+            "region".to_string(),
+            AttributeType::enum_(
+                TypeIdentity::new(Some("awscc"), Vec::<String>::new(), "Region"),
+                None,
+                vec![],
+                None,
+                Some(DslTransform::HyphenToUnderscore),
+            ),
+        )])
+    }
+
+    fn validate_config(
+        &self,
+        _attributes: &indexmap::IndexMap<String, Value>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn extract_region(&self, _attributes: &indexmap::IndexMap<String, Value>) -> String {
+        "ap-northeast-1".to_string()
+    }
+
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &indexmap::IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { unreachable!("plan fixture does not instantiate providers") })
+    }
+
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        let tenancy = AttributeType::enum_(
+            TypeIdentity::new(Some("awscc"), ["ec2", "Vpc"], "InstanceTenancy"),
+            Some(vec![
+                "default".to_string(),
+                "dedicated".to_string(),
+                "host".to_string(),
+            ]),
+            vec![],
+            None,
+            None,
+        );
+        vec![
+            ResourceSchema::new("ec2.Vpc")
+                .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).required())
+                .attribute(AttributeSchema::new("instance_tenancy", tenancy).required()),
+        ]
     }
 }
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_enum_display.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_enum_display.snap
@@ -6,6 +6,6 @@ Execution Plan:
 
   + awscc.ec2.Vpc 
       cidr_block: "10.0.0.0/16"
-      instance_tenancy: awscc.ec2.Vpc.InstanceTenancy.dedicated
+      instance_tenancy: dedicated
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -22,7 +22,8 @@ use crate::commands::apply::{
 };
 use crate::commands::plan::{CurrentStateEntry, PlanFile};
 use crate::commands::shared::state_writeback::{
-    ApplyStateSave, FinalizeApplyInput, build_state_after_apply, queue_state_refresh,
+    ApplyStateSave, FinalizeApplyInput, PostApplyStates, build_state_after_apply,
+    queue_state_refresh,
 };
 use crate::commands::state::run_state_refresh_locked;
 use crate::wiring::{
@@ -2638,6 +2639,81 @@ fn build_state_after_apply_persists_write_only_attributes() {
     assert_eq!(
         saved_resource.attributes.get("cidr_block"),
         Some(&json!("10.0.0.0/16"))
+    );
+}
+
+#[test]
+fn write_only_canonical_enum_state_roundtrip_converges_without_diff() {
+    use carina_core::differ::create_plan;
+    use carina_core::resource::EnumValueResolver;
+    use carina_core::schema::{AttributeSchema, AttributeType, TypeIdentity};
+
+    let domain_type = AttributeType::enum_(
+        TypeIdentity::new(Some("aws"), ["ec2", "Eip"], "Domain"),
+        Some(vec!["vpc".to_string(), "standard".to_string()]),
+        Vec::new(),
+        None,
+        None,
+    );
+    let domain = EnumValueResolver::new(&domain_type)
+        .resolve_state_text("vpc")
+        .unwrap();
+    let mut resource = Resource::with_provider("aws", "ec2.Eip", "main", None);
+    resource.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::CanonicalEnum(domain)),
+    );
+    let id = resource.id.clone();
+    let applied_states = HashMap::from([(
+        id.clone(),
+        State::existing(
+            id,
+            HashMap::from([(
+                "allocation_id".to_string(),
+                Value::Concrete(ConcreteValue::String("eipalloc-123".to_string())),
+            )]),
+        ),
+    )]);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "aws",
+        ResourceSchema::new("ec2.Eip")
+            .attribute(AttributeSchema::new(
+                "allocation_id",
+                AttributeType::string(),
+            ))
+            .attribute(AttributeSchema::new("domain", domain_type).write_only()),
+    );
+
+    let saved = build_state_after_apply(ApplyStateSave {
+        state_file: None,
+        sorted_resources: &[resource.clone()],
+        current_states: &HashMap::new(),
+        applied_states: &applied_states,
+        permanent_name_overrides: &HashMap::new(),
+        plan: &Plan::new(),
+        successfully_deleted: &HashSet::new(),
+        failed_refreshes: &HashSet::new(),
+        schemas: &schemas,
+    })
+    .unwrap();
+    let reloaded = PostApplyStates::from_current_and_state(&HashMap::new(), &saved);
+
+    let plan = create_plan(
+        &[resource],
+        &[],
+        reloaded.as_map(),
+        &HashMap::new(),
+        &schemas,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[],
+    );
+    assert!(
+        plan.effects().is_empty(),
+        "typed enum state JSON must reload as CanonicalEnum, got effects: {:?}",
+        plan.effects()
     );
 }
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -461,10 +461,22 @@ pub fn apply_anonymous_to_named_renames(
                     let create_only_values = create_only_attrs
                         .iter()
                         .filter_map(|attr| {
-                            sr.attributes
-                                .get(*attr)
-                                .and_then(|v| v.as_str())
-                                .map(|s| (attr.to_string(), s.to_string()))
+                            let attribute_type = ctx
+                                .schemas()
+                                .get(
+                                    provider,
+                                    resource_type,
+                                    carina_core::schema::SchemaKind::Resource,
+                                )
+                                .and_then(|schema| schema.attributes.get(*attr))
+                                .map(|schema_attr| &schema_attr.attr_type);
+                            sr.attributes.get(*attr).and_then(|v| {
+                                identifier::canonical_create_only_state_json_string(
+                                    v,
+                                    attribute_type,
+                                )
+                                .map(|s| (attr.to_string(), s))
+                            })
                         })
                         .collect();
                     AnonymousIdStateInfo {
@@ -520,10 +532,22 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
                     let create_only_values = create_only_attrs
                         .iter()
                         .filter_map(|attr| {
-                            sr.attributes
-                                .get(*attr)
-                                .and_then(|v| v.as_str())
-                                .map(|s| (attr.to_string(), s.to_string()))
+                            let attribute_type = ctx
+                                .schemas()
+                                .get(
+                                    provider,
+                                    resource_type,
+                                    carina_core::schema::SchemaKind::Resource,
+                                )
+                                .and_then(|schema| schema.attributes.get(*attr))
+                                .map(|schema_attr| &schema_attr.attr_type);
+                            sr.attributes.get(*attr).and_then(|v| {
+                                identifier::canonical_create_only_state_json_string(
+                                    v,
+                                    attribute_type,
+                                )
+                                .map(|s| (attr.to_string(), s))
+                            })
                         })
                         .collect();
                     AnonymousIdStateInfo {

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -212,6 +212,13 @@ pub(crate) fn type_aware_equal(
                 )
             ) =>
             {
+                if let (
+                    Value::Concrete(ConcreteValue::CanonicalEnum(left)),
+                    Value::Concrete(ConcreteValue::CanonicalEnum(right)),
+                ) = (a, b)
+                {
+                    return left == right;
+                }
                 let text = |v: &Value| -> Option<String> {
                     match v {
                         Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
@@ -228,6 +235,10 @@ pub(crate) fn type_aware_equal(
                 if sa == sb {
                     return true;
                 }
+                // Temporary compatibility while some provider-read/state
+                // paths can still surface unresolved strings. Once every
+                // enum-typed state leaf is resolver-lifted, comparison above
+                // should be CanonicalEnum × CanonicalEnum.
                 let dsl_map = crate::schema::DslMap::new(dsl_aliases, to_dsl);
                 let canonical = |s: &str| -> String {
                     let valid_values: Vec<&str> =

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -216,9 +216,17 @@ pub(crate) fn type_aware_equal(
                     Value::Concrete(ConcreteValue::CanonicalEnum(left)),
                     Value::Concrete(ConcreteValue::CanonicalEnum(right)),
                 ) = (a, b)
+                    && left == right
                 {
-                    return left == right;
+                    return true;
                 }
+                // `CanonicalEnumValue` equality remains identity-strict:
+                // `aws.Region.ap-northeast-1` and
+                // `awscc.Region.ap-northeast-1` are different typed values.
+                // Diffing answers a narrower question: would applying change
+                // provider API text? If strict equality fails, fall through to
+                // the canonical text comparison below so cross-provider export
+                // flows do not produce phantom updates.
                 let text = |v: &Value| -> Option<String> {
                     match v {
                         Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
@@ -615,7 +623,7 @@ pub(super) fn find_changed_attributes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::DslTransform;
+    use crate::schema::{DslTransform, TypeIdentity};
 
     #[test]
     fn refined_string_to_dsl_transform_is_applied_before_comparison() {
@@ -631,6 +639,68 @@ mod tests {
         assert!(type_aware_equal(
             &state,
             &desired,
+            Some(&attr_type),
+            empty_defs_for_schema_walks(),
+            None,
+        ));
+    }
+
+    #[test]
+    fn canonical_enum_cross_identity_same_api_value_is_no_change() {
+        let attr_type = AttributeType::enum_(
+            TypeIdentity::new(Some("awscc"), Vec::<String>::new(), "Region"),
+            Some(vec!["ap-northeast-1".to_string()]),
+            Vec::new(),
+            None,
+            Some(DslTransform::HyphenToUnderscore),
+        );
+        let producer = Value::Concrete(ConcreteValue::CanonicalEnum(
+            crate::resource::CanonicalEnumValue::new_for_test(
+                TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region"),
+                "ap-northeast-1",
+            ),
+        ));
+        let consumer = Value::Concrete(ConcreteValue::CanonicalEnum(
+            crate::resource::CanonicalEnumValue::new_for_test(
+                TypeIdentity::new(Some("awscc"), Vec::<String>::new(), "Region"),
+                "ap-northeast-1",
+            ),
+        ));
+
+        assert!(type_aware_equal(
+            &producer,
+            &consumer,
+            Some(&attr_type),
+            empty_defs_for_schema_walks(),
+            None,
+        ));
+    }
+
+    #[test]
+    fn canonical_enum_cross_identity_different_api_value_is_change() {
+        let attr_type = AttributeType::enum_(
+            TypeIdentity::new(Some("awscc"), Vec::<String>::new(), "Region"),
+            Some(vec!["ap-northeast-1".to_string(), "us-east-1".to_string()]),
+            Vec::new(),
+            None,
+            Some(DslTransform::HyphenToUnderscore),
+        );
+        let producer = Value::Concrete(ConcreteValue::CanonicalEnum(
+            crate::resource::CanonicalEnumValue::new_for_test(
+                TypeIdentity::new(Some("aws"), Vec::<String>::new(), "Region"),
+                "ap-northeast-1",
+            ),
+        ));
+        let consumer = Value::Concrete(ConcreteValue::CanonicalEnum(
+            crate::resource::CanonicalEnumValue::new_for_test(
+                TypeIdentity::new(Some("awscc"), Vec::<String>::new(), "Region"),
+                "us-east-1",
+            ),
+        ));
+
+        assert!(!type_aware_equal(
+            &producer,
+            &consumer,
             Some(&attr_type),
             empty_defs_for_schema_walks(),
             None,

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -167,7 +167,7 @@ fn deterministic_value_string(value: &Value) -> String {
             format!("EnumIdentifier({:?})", s.as_str())
         }
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
-            format!("CanonicalEnum({:?}, {:?})", c.identity(), c.api_value())
+            format!("EnumApiValue({:?})", c.api_value())
         }
         Value::Concrete(ConcreteValue::Int(i)) => format!("Int({})", i),
         Value::Concrete(ConcreteValue::Float(f)) => format!("Float({})", f),
@@ -290,6 +290,9 @@ pub(crate) fn canonical_enum_feature_string(
     value: &Value,
     attribute_type: Option<&AttributeType>,
 ) -> String {
+    if let Value::Concrete(ConcreteValue::CanonicalEnum(c)) = value {
+        return format!("EnumApiValue({:?})", c.api_value());
+    }
     let Some(attribute_type) = attribute_type else {
         return deterministic_value_string(value);
     };
@@ -326,6 +329,9 @@ fn canonical_create_only_value_string(
         }
         Value::Concrete(ConcreteValue::EnumIdentifier(_)) => {
             Some(canonical_enum_feature_string(value, attribute_type))
+        }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+            Some(format!("EnumApiValue({:?})", c.api_value()))
         }
         _ => None,
     }

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -333,8 +333,50 @@ fn canonical_create_only_value_string(
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
             Some(format!("EnumApiValue({:?})", c.api_value()))
         }
+        Value::Concrete(ConcreteValue::List(items)) => {
+            let inner_type = attribute_type
+                .and_then(|attr| attr.shape_ref_free().ok())
+                .and_then(|shape| match shape {
+                    crate::schema::Shape::List { element_type, .. } => Some(element_type),
+                    _ => None,
+                });
+            let parts: Vec<String> = items
+                .iter()
+                .map(|item| canonical_create_only_feature_string(item, inner_type))
+                .collect();
+            Some(format!("List([{}])", parts.join(", ")))
+        }
+        Value::Concrete(ConcreteValue::Map(map)) => {
+            let value_type = attribute_type
+                .and_then(|attr| attr.shape_ref_free().ok())
+                .and_then(|shape| match shape {
+                    crate::schema::Shape::Map { value, .. } => Some(value),
+                    _ => None,
+                });
+            let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+            entries.sort_by_key(|(key, _)| *key);
+            let parts: Vec<String> = entries
+                .iter()
+                .map(|(key, item)| {
+                    format!(
+                        "{:?}: {}",
+                        key,
+                        canonical_create_only_feature_string(item, value_type)
+                    )
+                })
+                .collect();
+            Some(format!("Map({{{}}})", parts.join(", ")))
+        }
         _ => None,
     }
+}
+
+fn canonical_create_only_feature_string(
+    value: &Value,
+    attribute_type: Option<&AttributeType>,
+) -> String {
+    canonical_create_only_value_string(value, attribute_type)
+        .unwrap_or_else(|| canonical_enum_feature_string(value, attribute_type))
 }
 
 fn canonical_create_only_text_string(
@@ -352,6 +394,21 @@ fn canonical_create_only_text_string(
     } else {
         canonical
     }
+}
+
+/// Convert a persisted state JSON create-only attribute into the same canonical
+/// feature string used for desired-side anonymous identifier reconciliation.
+///
+/// The JSON reader preserves typed enum objects as `CanonicalEnum` and ordinary
+/// legacy enum strings remain strings; `canonical_create_only_value_string`
+/// then applies schema-known List/Map/Enum normalization symmetrically.
+pub fn canonical_create_only_state_json_string(
+    value: &serde_json::Value,
+    attribute_type: Option<&AttributeType>,
+) -> Option<String> {
+    crate::value::json_to_dsl_value(value)
+        .as_ref()
+        .and_then(|value| canonical_create_only_value_string(value, attribute_type))
 }
 
 /// Maximum Hamming distance (out of 64 bits) for SimHash-based reconciliation.

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -879,9 +879,12 @@ pub fn reconcile_anonymous_identifiers(
             continue;
         }
 
-        // Collect all partial matches (at least one create-only property matches
-        // and at least one differs). If there are multiple partial matches, skip
-        // reconciliation to avoid rebinding to the wrong state entry.
+        // Full matches handle no-edit upgrades where the hash input changed
+        // across Carina versions but every create-only value is unchanged.
+        // Prefer a unique full match over partial matches; if full matches are
+        // ambiguous, skip rather than guessing. Partial matches keep the
+        // existing "some create-only values changed" reconciliation behavior.
+        let mut full_matches: Vec<&str> = Vec::new();
         let mut partial_matches: Vec<&str> = Vec::new();
         for entry in &state_entries {
             if entry.name == resource.id.name_str() {
@@ -905,15 +908,21 @@ pub fn reconcile_anonymous_identifiers(
                 }
             }
 
-            // Partial match = same resource with changes to some create-only properties
-            if matched > 0 && mismatched > 0 {
+            if matched > 0 && mismatched == 0 {
+                full_matches.push(&entry.name);
+            } else if matched > 0 && mismatched > 0 {
                 partial_matches.push(&entry.name);
             }
         }
 
-        // Only reconcile if there is exactly one partial match (unique best match).
-        // Multiple partial matches are ambiguous - skip to avoid rebinding wrong.
-        if partial_matches.len() == 1 {
+        if full_matches.len() == 1 {
+            resource.id = ResourceId::with_provider(
+                &resource.id.provider,
+                &resource.id.resource_type,
+                full_matches[0],
+                resource.id.provider_instance.clone(),
+            );
+        } else if full_matches.is_empty() && partial_matches.len() == 1 {
             resource.id = ResourceId::with_provider(
                 &resource.id.provider,
                 &resource.id.resource_type,

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -805,6 +805,20 @@ pub fn reconcile_anonymous_identifiers(
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
 ) -> Vec<(String, String)> {
     let mut renames: Vec<(String, String)> = Vec::new();
+    let mut used_names: HashMap<(String, String), HashSet<String>> = HashMap::new();
+    for resource in resources.iter() {
+        let key = (
+            resource.id.provider.clone(),
+            resource.id.resource_type.clone(),
+        );
+        used_names
+            .entry(key)
+            .or_default()
+            .insert(resource.id.name_str().to_string());
+    }
+
+    let mut claimed_names: HashMap<(String, String), HashSet<String>> = HashMap::new();
+
     for resource in resources.iter_mut() {
         if resource.id.name.is_pending() {
             continue;
@@ -823,6 +837,10 @@ pub fn reconcile_anonymous_identifiers(
 
         let create_only_attrs = schema.create_only_attributes();
         let state_entries = find_state_by_type(&resource.id.provider, &resource.id.resource_type);
+        let key = (
+            resource.id.provider.clone(),
+            resource.id.resource_type.clone(),
+        );
 
         // If the resource's name already exists in state, no reconciliation is needed.
         if state_entries
@@ -884,11 +902,23 @@ pub fn reconcile_anonymous_identifiers(
         // Prefer a unique full match over partial matches; if full matches are
         // ambiguous, skip rather than guessing. Partial matches keep the
         // existing "some create-only values changed" reconciliation behavior.
+        // Entries already used by another current resource are live and must
+        // not be stolen; entries claimed earlier in this pass are also excluded
+        // so two resources cannot collapse onto the same state row.
         let mut full_matches: Vec<&str> = Vec::new();
         let mut partial_matches: Vec<&str> = Vec::new();
         for entry in &state_entries {
             if entry.name == resource.id.name_str() {
                 // Same identifier, no reconciliation needed
+                continue;
+            }
+            if used_names
+                .get(&key)
+                .is_some_and(|names| names.contains(&entry.name))
+                || claimed_names
+                    .get(&key)
+                    .is_some_and(|names| names.contains(&entry.name))
+            {
                 continue;
             }
 
@@ -915,20 +945,25 @@ pub fn reconcile_anonymous_identifiers(
             }
         }
 
-        if full_matches.len() == 1 {
-            resource.id = ResourceId::with_provider(
-                &resource.id.provider,
-                &resource.id.resource_type,
-                full_matches[0],
-                resource.id.provider_instance.clone(),
-            );
+        let matched_name = if full_matches.len() == 1 {
+            Some(full_matches[0])
         } else if full_matches.is_empty() && partial_matches.len() == 1 {
+            Some(partial_matches[0])
+        } else {
+            None
+        };
+
+        if let Some(matched_name) = matched_name {
             resource.id = ResourceId::with_provider(
                 &resource.id.provider,
                 &resource.id.resource_type,
-                partial_matches[0],
+                matched_name,
                 resource.id.provider_instance.clone(),
             );
+            claimed_names
+                .entry(key)
+                .or_default()
+                .insert(matched_name.to_string());
         }
     }
     renames

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -876,6 +876,15 @@ pub fn reconcile_anonymous_identifiers(
                 if entry.name == resource.id.name_str() {
                     continue;
                 }
+                if used_names
+                    .get(&key)
+                    .is_some_and(|names| names.contains(&entry.name))
+                    || claimed_names
+                        .get(&key)
+                        .is_some_and(|names| names.contains(&entry.name))
+                {
+                    continue;
+                }
                 let Some(state_hash) = extract_hash_from_identifier(&entry.name) else {
                     continue;
                 };
@@ -893,6 +902,10 @@ pub fn reconcile_anonymous_identifiers(
                 // name on the resource and record a rename so the wiring
                 // layer can re-key the state entry.
                 renames.push((state_name.to_string(), resource.id.name_str().to_string()));
+                claimed_names
+                    .entry(key)
+                    .or_default()
+                    .insert(state_name.to_string());
             }
             continue;
         }

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -94,6 +94,30 @@ fn route53_state_entry(name: &str) -> AnonymousIdStateInfo {
     }
 }
 
+fn simhash_eip_schema() -> ResourceSchema {
+    ResourceSchema::new("ec2.eip")
+        .attribute(AttributeSchema::new("domain", AttributeType::string()))
+        .attribute(AttributeSchema::new("tag_name", AttributeType::string()))
+        .attribute(AttributeSchema::new("tag_env", AttributeType::string()))
+}
+
+fn simhash_eip_resource(tag_env: &str) -> Resource {
+    let mut resource = Resource::with_provider("awscc", "ec2.eip", "", None);
+    resource.set_attr(
+        "domain".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc".to_string())),
+    );
+    resource.set_attr(
+        "tag_name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-eip".to_string())),
+    );
+    resource.set_attr(
+        "tag_env".to_string(),
+        Value::Concrete(ConcreteValue::String(tag_env.to_string())),
+    );
+    resource
+}
+
 #[test]
 fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
     let schema = ResourceSchema::new("ec2.Route")
@@ -1363,6 +1387,94 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     // only mechanism for legacy state name reuse.
     assert_eq!(resources2[0].id.name_str(), new_id);
     assert_eq!(renames, vec![(old_id.clone(), new_id.clone())]);
+}
+
+#[test]
+fn test_reconcile_anonymous_id_simhash_does_not_steal_live_entry() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", simhash_eip_schema());
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let mut resources = vec![
+        simhash_eip_resource("production"),
+        simhash_eip_resource("staging"),
+    ];
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    let live_name = resources[0].id.name_str().to_string();
+    let new_name = resources[1].id.name_str().to_string();
+
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: live_name.clone(),
+        create_only_values: HashMap::new(),
+    }];
+    let renames = reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
+
+    assert_eq!(resources[0].id.name_str(), live_name);
+    assert_eq!(resources[1].id.name_str(), new_name);
+    assert!(
+        renames.is_empty(),
+        "SimHash reconcile must not rename a live state row already used by another resource"
+    );
+}
+
+#[test]
+fn test_reconcile_anonymous_id_simhash_claims_state_entry_once() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", simhash_eip_schema());
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let mut old_resources = vec![simhash_eip_resource("production")];
+    compute_anonymous_identifiers(&mut old_resources, &providers, &schemas, &identity_fn).unwrap();
+    let old_name = old_resources[0].id.name_str().to_string();
+    let old_hash = extract_hash_from_identifier(&old_name).unwrap();
+
+    let mut nearby_resources: Vec<Resource> = Vec::new();
+    for tag_env in [
+        "staging",
+        "prod",
+        "development",
+        "qa",
+        "test",
+        "preview",
+        "canary",
+    ] {
+        let mut candidate = vec![simhash_eip_resource(tag_env)];
+        compute_anonymous_identifiers(&mut candidate, &providers, &schemas, &identity_fn).unwrap();
+        let candidate_hash = extract_hash_from_identifier(candidate[0].id.name_str()).unwrap();
+        if candidate[0].id.name_str() != old_name
+            && (old_hash ^ candidate_hash).count_ones() < SIMHASH_HAMMING_THRESHOLD
+        {
+            nearby_resources.push(candidate.remove(0));
+        }
+        if nearby_resources.len() == 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        nearby_resources.len(),
+        2,
+        "test setup should find two distinct resources near the same old SimHash"
+    );
+
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: old_name.clone(),
+        create_only_values: HashMap::new(),
+    }];
+    let renames =
+        reconcile_anonymous_identifiers(&mut nearby_resources, &schemas, &|_provider, _rt| {
+            state_entries.clone()
+        });
+
+    assert_eq!(
+        renames.len(),
+        1,
+        "only one resource may claim a SimHash-matched state row"
+    );
+    assert_eq!(renames[0].0, old_name);
 }
 
 #[test]

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -159,6 +159,55 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_attribute() {
 }
 
 #[test]
+fn test_anonymous_id_stable_for_nested_canonical_enum_create_only_values() {
+    let domain = eip_domain_type("awscc");
+    let schema = ResourceSchema::new("ec2.Eip")
+        .attribute(
+            AttributeSchema::new("domains", AttributeType::list(domain.clone())).create_only(),
+        )
+        .attribute(
+            AttributeSchema::new("domain_by_name", AttributeType::map(domain)).create_only(),
+        );
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let canonical = |provider: &str, raw: &str| {
+        let attr_type = eip_domain_type(provider);
+        crate::resource::EnumValueResolver::new(&attr_type)
+            .resolve_raw(&crate::resource::RawEnumIdentifier::parse(raw))
+            .unwrap()
+    };
+    let make_resource = |provider: &str, raw: &str| {
+        let enum_value = Value::Concrete(ConcreteValue::CanonicalEnum(canonical(provider, raw)));
+        let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
+        resource.set_attr(
+            "domains".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![enum_value.clone()])),
+        );
+        resource.set_attr(
+            "domain_by_name".to_string(),
+            Value::Concrete(ConcreteValue::Map(indexmap::indexmap! {
+                "primary".to_string() => enum_value,
+            })),
+        );
+        resource
+    };
+
+    let mut resources_awscc = vec![make_resource("awscc", "awscc.ec2.Eip.Domain.vpc")];
+    let mut resources_aws = vec![make_resource("aws", "aws.ec2.Eip.Domain.vpc")];
+    compute_anonymous_identifiers(&mut resources_awscc, &providers, &schemas, &identity_fn)
+        .unwrap();
+    compute_anonymous_identifiers(&mut resources_aws, &providers, &schemas, &identity_fn).unwrap();
+
+    assert_eq!(
+        resources_awscc[0].id.name_str(),
+        resources_aws[0].id.name_str()
+    );
+}
+
+#[test]
 fn test_reconcile_anonymous_id_after_provider_namespace_change() {
     let schema = ResourceSchema::new("ec2.Eip")
         .attribute(AttributeSchema::new("domain", eip_domain_type("awscc")).create_only())

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -256,6 +256,80 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
 }
 
 #[test]
+fn test_reconcile_anonymous_id_after_nested_enum_create_only_hash_migration() {
+    let domain = eip_domain_type("awscc");
+    let schema = ResourceSchema::new("ec2.Eip")
+        .attribute(AttributeSchema::new("domains", AttributeType::list(domain)).create_only())
+        .attribute(AttributeSchema::new("public_ipv4_pool", AttributeType::string()).create_only());
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let make_old_resource = |pool: &str| {
+        let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
+        resource.set_attr(
+            "domains".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::enum_identifier("awscc.ec2.Eip.Domain.vpc".to_string()),
+            )])),
+        );
+        resource.set_attr(
+            "public_ipv4_pool".to_string(),
+            Value::Concrete(ConcreteValue::String(pool.to_string())),
+        );
+        resource
+    };
+    let make_new_resource = |pool: &str| {
+        let attr_type = eip_domain_type("aws");
+        let canonical = crate::resource::EnumValueResolver::new(&attr_type)
+            .resolve_raw(&crate::resource::RawEnumIdentifier::parse(
+                "aws.ec2.Eip.Domain.vpc",
+            ))
+            .unwrap();
+        let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
+        resource.set_attr(
+            "domains".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::CanonicalEnum(canonical),
+            )])),
+        );
+        resource.set_attr(
+            "public_ipv4_pool".to_string(),
+            Value::Concrete(ConcreteValue::String(pool.to_string())),
+        );
+        resource
+    };
+
+    let mut old_resources = vec![make_old_resource("pool-a")];
+    compute_anonymous_identifiers(&mut old_resources, &providers, &schemas, &identity_fn).unwrap();
+    let state_name = old_resources[0].id.name_str().to_string();
+
+    let mut desired_resources = vec![make_new_resource("pool-b")];
+    compute_anonymous_identifiers(&mut desired_resources, &providers, &schemas, &identity_fn)
+        .unwrap();
+    assert_ne!(state_name, desired_resources[0].id.name_str());
+
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: state_name.clone(),
+        create_only_values: vec![
+            (
+                "domains".to_string(),
+                r#"List([EnumApiValue("vpc")])"#.to_string(),
+            ),
+            ("public_ipv4_pool".to_string(), "pool-a".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    }];
+    reconcile_anonymous_identifiers(&mut desired_resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
+
+    assert_eq!(desired_resources[0].id.name_str(), state_name);
+}
+
+#[test]
 fn test_reconcile_anonymous_id_mixed_string_and_enum_identifier_for_enum_attribute() {
     let schema = ResourceSchema::new("ec2.Subnet")
         .attribute(AttributeSchema::new("region", region_type("awscc")).create_only())

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -330,6 +330,135 @@ fn test_reconcile_anonymous_id_after_nested_enum_create_only_hash_migration() {
 }
 
 #[test]
+fn test_reconcile_anonymous_id_after_nested_enum_no_edit_upgrade_full_match() {
+    let domain = eip_domain_type("awscc");
+    let schema = ResourceSchema::new("ec2.Eip")
+        .attribute(AttributeSchema::new("domains", AttributeType::list(domain)).create_only())
+        .attribute(AttributeSchema::new("public_ipv4_pool", AttributeType::string()).create_only());
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let make_old_resource = || {
+        let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
+        resource.set_attr(
+            "domains".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::enum_identifier("awscc.ec2.Eip.Domain.vpc".to_string()),
+            )])),
+        );
+        resource.set_attr(
+            "public_ipv4_pool".to_string(),
+            Value::Concrete(ConcreteValue::String("pool-a".to_string())),
+        );
+        resource
+    };
+    let make_new_resource = || {
+        let attr_type = eip_domain_type("aws");
+        let canonical = crate::resource::EnumValueResolver::new(&attr_type)
+            .resolve_raw(&crate::resource::RawEnumIdentifier::parse(
+                "aws.ec2.Eip.Domain.vpc",
+            ))
+            .unwrap();
+        let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
+        resource.set_attr(
+            "domains".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::CanonicalEnum(canonical),
+            )])),
+        );
+        resource.set_attr(
+            "public_ipv4_pool".to_string(),
+            Value::Concrete(ConcreteValue::String("pool-a".to_string())),
+        );
+        resource
+    };
+
+    let mut old_resources = vec![make_old_resource()];
+    compute_anonymous_identifiers(&mut old_resources, &providers, &schemas, &identity_fn).unwrap();
+    let state_name = old_resources[0].id.name_str().to_string();
+
+    let mut desired_resources = vec![make_new_resource()];
+    compute_anonymous_identifiers(&mut desired_resources, &providers, &schemas, &identity_fn)
+        .unwrap();
+    assert_ne!(state_name, desired_resources[0].id.name_str());
+
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: state_name.clone(),
+        create_only_values: vec![
+            (
+                "domains".to_string(),
+                r#"List([EnumApiValue("vpc")])"#.to_string(),
+            ),
+            ("public_ipv4_pool".to_string(), "pool-a".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    }];
+    reconcile_anonymous_identifiers(&mut desired_resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
+
+    assert_eq!(desired_resources[0].id.name_str(), state_name);
+}
+
+#[test]
+fn test_reconcile_anonymous_id_nested_enum_full_match_ambiguous_skips() {
+    let domain = eip_domain_type("awscc");
+    let schema = ResourceSchema::new("ec2.Eip")
+        .attribute(AttributeSchema::new("domains", AttributeType::list(domain)).create_only())
+        .attribute(AttributeSchema::new("public_ipv4_pool", AttributeType::string()).create_only());
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+
+    let attr_type = eip_domain_type("aws");
+    let canonical = crate::resource::EnumValueResolver::new(&attr_type)
+        .resolve_raw(&crate::resource::RawEnumIdentifier::parse(
+            "aws.ec2.Eip.Domain.vpc",
+        ))
+        .unwrap();
+    let mut resource = Resource::with_provider("awscc", "ec2.Eip", "awscc_ec2_eip_b3b9f005", None);
+    resource.set_attr(
+        "domains".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::CanonicalEnum(canonical),
+        )])),
+    );
+    resource.set_attr(
+        "public_ipv4_pool".to_string(),
+        Value::Concrete(ConcreteValue::String("pool-a".to_string())),
+    );
+    let original_id = resource.id.name_str().to_string();
+    let mut resources = vec![resource];
+
+    let create_only_values: HashMap<String, String> = vec![
+        (
+            "domains".to_string(),
+            r#"List([EnumApiValue("vpc")])"#.to_string(),
+        ),
+        ("public_ipv4_pool".to_string(), "pool-a".to_string()),
+    ]
+    .into_iter()
+    .collect();
+    let state_entries = vec![
+        AnonymousIdStateInfo {
+            name: "awscc_ec2_eip_4823b455".to_string(),
+            create_only_values: create_only_values.clone(),
+        },
+        AnonymousIdStateInfo {
+            name: "awscc_ec2_eip_deadbeef".to_string(),
+            create_only_values,
+        },
+    ];
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
+
+    assert_eq!(resources[0].id.name_str(), original_id);
+}
+
+#[test]
 fn test_reconcile_anonymous_id_mixed_string_and_enum_identifier_for_enum_attribute() {
     let schema = ResourceSchema::new("ec2.Subnet")
         .attribute(AttributeSchema::new("region", region_type("awscc")).create_only())
@@ -660,9 +789,9 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
 }
 
 #[test]
-fn test_reconcile_anonymous_id_no_match_when_all_same() {
-    // When ALL create-only properties match, the hash should also match,
-    // so no reconciliation is needed (same identifier)
+fn test_reconcile_anonymous_id_unique_full_match_rebinds() {
+    // A unique full match covers no-edit upgrades where the anonymous hash input
+    // changed across Carina versions but all create-only values are unchanged.
     let schema = ResourceSchema::new("iam.role")
         .attribute(AttributeSchema::new("role_name", AttributeType::string()).create_only())
         .attribute(AttributeSchema::new("path", AttributeType::string()).create_only());
@@ -679,11 +808,9 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
         Value::Concrete(ConcreteValue::String("/".to_string())),
     );
 
-    let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
-    // State has same values but different ID (shouldn't happen in practice,
-    // but reconciliation should NOT trigger since no mismatch)
+    // State has the same values but a different ID from a previous hash scheme.
     let state_entries = vec![AnonymousIdStateInfo {
         name: "iam_role_11223344".to_string(),
         create_only_values: vec![
@@ -697,8 +824,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
         state_entries.clone()
     });
 
-    // Identifier should remain unchanged (all values match = no partial match)
-    assert_eq!(resources[0].id.name_str(), original_id);
+    assert_eq!(resources[0].id.name_str(), "iam_role_11223344");
 }
 
 #[test]

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -53,6 +53,47 @@ fn eip_domain_type(provider: &str) -> AttributeType {
     )
 }
 
+fn route53_record_set_schema() -> ResourceSchema {
+    ResourceSchema::new("route53.record_set")
+        .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
+        .attribute(AttributeSchema::new("hosted_zone_id", AttributeType::string()).create_only())
+        .attribute(AttributeSchema::new("type", AttributeType::string()).identity())
+        .attribute(AttributeSchema::new("ttl", AttributeType::string()))
+        .attribute(AttributeSchema::new(
+            "resource_records",
+            AttributeType::list(AttributeType::string()),
+        ))
+}
+
+fn route53_record_set_resource(record_type: &str) -> Resource {
+    let mut resource = Resource::with_provider("awscc", "route53.record_set", "", None);
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs.dev".to_string())),
+    );
+    resource.set_attr(
+        "hosted_zone_id".to_string(),
+        Value::Concrete(ConcreteValue::String("Z123".to_string())),
+    );
+    resource.set_attr(
+        "type".to_string(),
+        Value::Concrete(ConcreteValue::String(record_type.to_string())),
+    );
+    resource
+}
+
+fn route53_state_entry(name: &str) -> AnonymousIdStateInfo {
+    AnonymousIdStateInfo {
+        name: name.to_string(),
+        create_only_values: vec![
+            ("name".to_string(), "carina-rs.dev".to_string()),
+            ("hosted_zone_id".to_string(), "Z123".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    }
+}
+
 #[test]
 fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
     let schema = ResourceSchema::new("ec2.Route")
@@ -1110,6 +1151,71 @@ fn test_identity_attribute_prevents_collision() {
         resources[0].id.name_str(),
         resources[1].id.name_str(),
         "different identity attr values should produce different identifiers"
+    );
+}
+
+#[test]
+fn test_reconcile_anonymous_id_full_match_claims_state_entry_once() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", route53_record_set_schema());
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let mut resources = vec![
+        route53_record_set_resource("A"),
+        route53_record_set_resource("AAAA"),
+    ];
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn)
+        .expect("identity attrs should produce distinct Route53 record identifiers");
+
+    let old_state_name = "route53_record_set_11223344";
+    assert_ne!(resources[0].id.name_str(), old_state_name);
+    assert_ne!(resources[1].id.name_str(), old_state_name);
+
+    let state_entries = vec![route53_state_entry(old_state_name)];
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
+
+    let names: HashSet<&str> = resources.iter().map(|r| r.id.name_str()).collect();
+    assert_eq!(names.len(), 2, "reconcile must not duplicate ResourceIds");
+    assert_eq!(
+        resources
+            .iter()
+            .filter(|r| r.id.name_str() == old_state_name)
+            .count(),
+        1,
+        "only one resource may claim the migrated state entry"
+    );
+}
+
+#[test]
+fn test_reconcile_anonymous_id_full_match_does_not_steal_live_entry() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", route53_record_set_schema());
+    let providers = vec![provider_config("awscc", vec![])];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let mut resources = vec![
+        route53_record_set_resource("A"),
+        route53_record_set_resource("AAAA"),
+    ];
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn)
+        .expect("identity attrs should produce distinct Route53 record identifiers");
+
+    let live_a_name = resources[0].id.name_str().to_string();
+    let new_aaaa_name = resources[1].id.name_str().to_string();
+    let state_entries = vec![route53_state_entry(&live_a_name)];
+
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
+
+    assert_eq!(resources[0].id.name_str(), live_a_name);
+    assert_eq!(
+        resources[1].id.name_str(),
+        new_aaaa_name,
+        "new AAAA record must not steal the live A record state entry"
     );
 }
 

--- a/carina-core/src/resource/enum_value.rs
+++ b/carina-core/src/resource/enum_value.rs
@@ -298,9 +298,9 @@ impl<'a> EnumValueResolver<'a> {
         });
         let valid_value = matched_value.is_some();
         let api_value = matched_value.map_or(api_value, Clone::clone);
-        // NOTE(carina#3438 PR3): validate receives the bare api_value here; the legacy
-        // validate_enum path passes the expanded namespaced text. Verify provider
-        // validators accept both before swapping consumers.
+        // Provider validators at this boundary receive the canonical API
+        // spelling; source-facing namespace checks have already run for
+        // RawDsl input above.
         let validation_result = validate.map(|validate| {
             validate(&crate::resource::Value::Concrete(
                 crate::resource::ConcreteValue::String(api_value.clone()),

--- a/carina-core/src/resource/enum_value.rs
+++ b/carina-core/src/resource/enum_value.rs
@@ -165,6 +165,20 @@ impl CanonicalEnumValue {
         &self.api_value
     }
 
+    /// Rebuild a canonical enum from Carina's trusted state JSON.
+    ///
+    /// This is intentionally not a general construction path: normal DSL and
+    /// provider-read inputs must go through [`EnumValueResolver`] so schema
+    /// membership and spelling rules stay centralized. State JSON already
+    /// persisted the resolved identity and API value, so round-trip decoding is
+    /// the sole resolver-gating exception.
+    pub(crate) fn from_trusted_state(identity: TypeIdentity, api_value: impl Into<String>) -> Self {
+        Self {
+            identity,
+            api_value: api_value.into(),
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn new_for_test(identity: TypeIdentity, api_value: impl Into<String>) -> Self {
         Self {

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 
-use crate::resource::{ConcreteValue, ConcreteValueRef, DeferredValue, Resource, Value};
+use crate::resource::{
+    ConcreteValue, ConcreteValueRef, DeferredValue, EnumValueResolver, RawEnumIdentifier, Resource,
+    Value,
+};
 use crate::utils::{extract_enum_value_with_values, validate_enum_namespace};
 use crate::value::format_value_with_key;
 
@@ -1462,7 +1465,10 @@ impl fmt::Display for FieldPath {
 /// drift again (carina#3347).
 pub(crate) fn lift_map_key(key_type: &AttributeType, key: &str) -> Value {
     if matches!(&key_type.kind, AttrTypeKind::Enum { .. }) {
-        Value::Concrete(ConcreteValue::enum_identifier(key.to_string()))
+        EnumValueResolver::new(key_type)
+            .resolve_state_text(key)
+            .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
+            .unwrap_or_else(|_| Value::Concrete(ConcreteValue::enum_identifier(key.to_string())))
     } else {
         Value::Concrete(ConcreteValue::String(key.to_string()))
     }
@@ -2166,6 +2172,7 @@ impl AttributeType {
                 dsl_aliases,
                 DslMap::new(dsl_aliases, to_dsl.as_ref()),
                 validate.as_ref(),
+                to_dsl.as_ref(),
                 value,
             ),
             AttrTypeKind::List { .. } => self.validate_list(value),
@@ -2265,6 +2272,7 @@ impl AttributeType {
         dsl_aliases: &[(String, String)],
         dsl_map: DslMap<'_>,
         validate: Option<&CustomValidator>,
+        to_dsl: Option<&DslTransform>,
         value: ConcreteValueRef<'_>,
     ) -> Result<(), TypeError> {
         let prefix = identity.dotted_prefix();
@@ -2274,6 +2282,30 @@ impl AttributeType {
             .map(|values| enum_expected_variants(prefix_ref, name, values, dsl_aliases))
             .unwrap_or_default();
         let enumerated = values.map(|_| true).unwrap_or(false);
+        if let ConcreteValueRef::CanonicalEnum(c) = value {
+            if c.identity().same_type(identity) {
+                return Ok(());
+            }
+            return Err(TypeError::TypeMismatch {
+                expected: name.to_string(),
+                got: c.identity().to_string(),
+            });
+        }
+        if let ConcreteValueRef::EnumIdentifier(raw) = value {
+            let enum_attr = AttributeType::enum_(
+                identity.clone(),
+                values.map(<[_]>::to_vec),
+                dsl_aliases.to_vec(),
+                validate.cloned(),
+                to_dsl.cloned(),
+            );
+            if EnumValueResolver::new(&enum_attr)
+                .resolve_raw(&RawEnumIdentifier::parse(raw.as_str()))
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
         let resolved_value = Self::resolve_enum_input(identity, value);
         let validation_result = validate.map(|validate| validate(&resolved_value));
         let validation_ok = validation_result

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -5494,7 +5494,7 @@ fn validate_map_with_enum_key_rejects_unknown_variant() {
 // schema-aware state-migration lift in
 // `crate::utils::lift_state_enum_leaves` walks loaded
 // attributes against their schema and lifts recognized API-canonical /
-// alias strings to `EnumIdentifier` so old state validates again.
+// alias strings to `CanonicalEnum` so old state validates again.
 #[test]
 fn lift_state_enum_leaves_fixes_awscc251() {
     use crate::utils::lift_state_enum_leaves;
@@ -5585,30 +5585,28 @@ fn lift_state_enum_leaves_fixes_awscc251() {
         .validate(&attrs)
         .expect("lifted state must pass strict Enum validation");
 
-    // The lifted values are EnumIdentifier in the DSL spelling: the
-    // strict carina#2986 validator requires the alias form when a
-    // `dsl_aliases` entry rewrites the API value (carina#2980).
+    // The lifted values are CanonicalEnum in the provider API spelling.
     let Value::Concrete(ConcreteValue::Map(policy)) = &attrs["policy"] else {
         panic!("policy should be a Map");
     };
-    assert_eq!(
-        policy["version"],
-        Value::Concrete(ConcreteValue::enum_identifier(
-            "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
-        ))
-    );
+    assert!(matches!(
+        &policy["version"],
+        Value::Concrete(ConcreteValue::CanonicalEnum(c))
+            if c.identity().to_string() == "aws.iam.PolicyDocument.Version"
+                && c.api_value() == "2012-10-17"
+    ));
     let Value::Concrete(ConcreteValue::List(stmts)) = &policy["statement"] else {
         panic!("statement should be a List");
     };
     let Value::Concrete(ConcreteValue::Map(stmt)) = &stmts[0] else {
         panic!("statement[0] should be a Map");
     };
-    assert_eq!(
-        stmt["effect"],
-        Value::Concrete(ConcreteValue::enum_identifier(
-            "aws.iam.PolicyDocument.Effect.allow".to_string()
-        ))
-    );
+    assert!(matches!(
+        &stmt["effect"],
+        Value::Concrete(ConcreteValue::CanonicalEnum(c))
+            if c.identity().to_string() == "aws.iam.PolicyDocument.Effect"
+                && c.api_value() == "Allow"
+    ));
 }
 
 #[test]
@@ -5630,7 +5628,7 @@ fn lift_state_enums_is_idempotent_and_preserves_invalid() {
     let schema = ResourceSchema::new("aws.iam.role_policy")
         .attribute(AttributeSchema::new("policy", policy_struct));
 
-    // Case 1: already an EnumIdentifier (post-fix re-plan) is normalized.
+    // Case 1: already an EnumIdentifier (post-fix re-plan) is canonicalized.
     let mut already = IndexMap::new();
     already.insert(
         "version".to_string(),
@@ -5645,12 +5643,14 @@ fn lift_state_enums_is_idempotent_and_preserves_invalid() {
     let Value::Concrete(ConcreteValue::Map(p)) = &attrs["policy"] else {
         panic!("map");
     };
-    assert_eq!(
-        p["version"],
-        Value::Concrete(ConcreteValue::enum_identifier(
-            "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
-        )),
-        "already-lifted EnumIdentifier must normalize to fully-qualified DSL spelling"
+    assert!(
+        matches!(
+            &p["version"],
+            Value::Concrete(ConcreteValue::CanonicalEnum(c))
+                if c.identity().to_string() == "aws.iam.PolicyDocument.Version"
+                    && c.api_value() == "2012-10-17"
+        ),
+        "already-lifted EnumIdentifier must canonicalize to API value"
     );
 
     // Case 2: unrecognized string — left as String so the strict
@@ -5717,11 +5717,13 @@ fn dynamic_enum_lift_raw_string_requires_transform_and_structural_dsl_member() {
         Value::Concrete(ConcreteValue::String("Active".to_string())),
         "uppercase raw strings must stay String"
     );
-    assert_eq!(
-        lifted_value("ap-northeast-1z"),
-        Value::Concrete(ConcreteValue::enum_identifier(
-            "aws.AvailabilityZone.ZoneName.ap_northeast_1z".to_string()
-        )),
+    assert!(
+        matches!(
+            lifted_value("ap-northeast-1z"),
+            Value::Concrete(ConcreteValue::CanonicalEnum(c))
+                if c.identity().to_string() == "aws.AvailabilityZone.ZoneName"
+                    && c.api_value() == "ap-northeast-1z"
+        ),
         "structural API-form dynamic enum strings must lift"
     );
     assert_eq!(

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -1,7 +1,7 @@
 //! Shared utility functions for value normalization and conversion
 
 use crate::resource::{ConcreteValue, Value};
-use crate::schema::{AttributeType, EnumParts, TypeIdentity};
+use crate::schema::{AttributeType, EnumParts};
 
 /// A namespaced DSL enum identifier, parsed once and reused.
 ///
@@ -1001,20 +1001,16 @@ fn lift_enum_leaves_projected(
             _ => None,
         };
         if let Some((s, source)) = raw
-            && enum_member_accepts(identity, values, validate, dsl_map, s, source)
+            && enum_member_is_recognized_for_state_lift(
+                identity, values, validate, dsl_map, s, source,
+            )
+            && let Ok(canonical) = match defs {
+                Some(defs) => crate::resource::EnumValueResolver::with_defs(attr_type, defs)
+                    .resolve_state_text(s),
+                None => crate::resource::EnumValueResolver::new(attr_type).resolve_state_text(s),
+            }
         {
-            // Normalize to the DSL spelling: the strict validator
-            // requires the alias form when one rewrites the API
-            // value. `dsl_for` is identity for non-aliased members
-            // and idempotent when the stored value is already the
-            // DSL spelling.
-            let trailing = enum_trailing_segment(s, values);
-            let dsl = dsl_map.dsl_for(trailing);
-            let full = identity
-                .dotted_prefix()
-                .map(|prefix| format!("{}.{}.{}", prefix, identity.kind, dsl))
-                .unwrap_or_else(|| format!("{}.{}", identity.kind, dsl));
-            return Some(Value::Concrete(ConcreteValue::enum_identifier(full)));
+            return Some(Value::Concrete(ConcreteValue::CanonicalEnum(canonical)));
         }
         // Recognized-or-not, an Enum leaf has no children.
         return None;
@@ -1085,38 +1081,28 @@ fn lift_enum_leaves_projected(
     }
 }
 
-fn enum_trailing_segment<'a>(value: &'a str, values: Option<&[String]>) -> &'a str {
-    let valid: Vec<&str> = values.into_iter().flatten().map(String::as_str).collect();
-    extract_enum_value_with_values(value, &valid)
-}
-
-fn enum_member_accepts(
-    identity: &TypeIdentity,
+fn enum_member_is_recognized_for_state_lift(
+    identity: &crate::schema::TypeIdentity,
     values: Option<&[String]>,
     validate: Option<&crate::schema::CustomValidator>,
     dsl_map: crate::schema::DslMap<'_>,
     value: &str,
     source: EnumLeafSource,
 ) -> bool {
-    let trailing = enum_trailing_segment(value, values);
-    let dsl = dsl_map.dsl_for(trailing);
+    let valid: Vec<&str> = values.into_iter().flatten().map(String::as_str).collect();
+    let trailing = extract_enum_value_with_values(value, &valid);
     let api = dsl_map.api_for(trailing);
-    let enumerated = values.map(|_| true).unwrap_or(false);
-    let data_match = values.into_iter().flatten().any(|candidate| {
+    let dsl = dsl_map.dsl_for(trailing);
+    if values.into_iter().flatten().any(|candidate| {
         candidate == value || candidate == trailing || candidate == &api || dsl == *candidate
-    });
-    if data_match {
+    }) {
         return true;
     }
-    if enumerated {
+    if values.is_some() {
         return false;
     }
-    let resolved = expand_enum_shorthand(
-        &Value::Concrete(ConcreteValue::enum_identifier(dsl.to_string())),
-        identity,
-    );
     if let Some(validate) = validate {
-        return validate(&resolved).is_ok();
+        return validate(&Value::Concrete(ConcreteValue::String(api))).is_ok();
     }
     dynamic_enum_member_is_structural(identity, &dsl, value, source)
 }
@@ -1128,7 +1114,7 @@ enum EnumLeafSource {
 }
 
 fn dynamic_enum_member_is_structural(
-    identity: &TypeIdentity,
+    identity: &crate::schema::TypeIdentity,
     dsl: &str,
     original: &str,
     source: EnumLeafSource,
@@ -1136,26 +1122,17 @@ fn dynamic_enum_member_is_structural(
     if NamespacedId::parse(original).is_some_and(|id| id.matches_identity(identity)) {
         return true;
     }
-    let full = enum_full_dsl_identifier(identity, dsl);
+    let full = identity
+        .dotted_prefix()
+        .map(|prefix| format!("{}.{}.{}", prefix, identity.kind, dsl))
+        .unwrap_or_else(|| format!("{}.{}", identity.kind, dsl));
     if !is_dsl_enum_format(&full) || !is_dynamic_dsl_member_segment(dsl) {
         return false;
     }
     match source {
         EnumLeafSource::EnumIdentifier => true,
-        // A plain state string with no data-form values and no host-side
-        // validator is only lifted when the provider-supplied spelling
-        // transform actually changed it. Already-DSL bare strings stay
-        // as strings so provider-side validators can make the final
-        // membership decision.
         EnumLeafSource::String => dsl != original && dsl.chars().any(|c| c.is_ascii_digit()),
     }
-}
-
-fn enum_full_dsl_identifier(identity: &TypeIdentity, dsl: &str) -> String {
-    identity
-        .dotted_prefix()
-        .map(|prefix| format!("{}.{}.{}", prefix, identity.kind, dsl))
-        .unwrap_or_else(|| format!("{}.{}", identity.kind, dsl))
 }
 
 fn is_dynamic_dsl_member_segment(s: &str) -> bool {
@@ -2662,11 +2639,13 @@ mod tests {
         let Value::Concrete(ConcreteValue::Map(pd)) = &saved[&known.id]["policy_document"] else {
             panic!("policy_document map");
         };
-        assert_eq!(
-            pd["version"],
-            Value::Concrete(ConcreteValue::enum_identifier(
-                "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
-            )),
+        assert!(
+            matches!(
+                &pd["version"],
+                Value::Concrete(ConcreteValue::CanonicalEnum(c))
+                    if c.identity().to_string() == "aws.iam.PolicyDocument.Version"
+                        && c.api_value() == "2012-10-17"
+            ),
             "resource present in registry must have its state lifted"
         );
         // Schema-less resource: untouched, no panic.
@@ -2732,12 +2711,14 @@ mod tests {
         else {
             panic!("assume_role_policy_document map");
         };
-        assert_eq!(
-            pd["version"],
-            Value::Concrete(ConcreteValue::enum_identifier(
-                "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
-            )),
-            "provider-read state String must be lifted to EnumIdentifier"
+        assert!(
+            matches!(
+                &pd["version"],
+                Value::Concrete(ConcreteValue::CanonicalEnum(c))
+                    if c.identity().to_string() == "aws.iam.PolicyDocument.Version"
+                        && c.api_value() == "2012-10-17"
+            ),
+            "provider-read state String must be lifted to CanonicalEnum"
         );
     }
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::resource::{
     CanonicalEnumValue, ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
 };
-use crate::schema::{AttrTypeKind, AttributeType};
+use crate::schema::{AttrTypeKind, AttributeType, TypeIdentity};
 use crate::utils::{convert_enum_value, extract_enum_value_with_values, is_dsl_enum_format};
 
 /// Where in the pipeline a `Value` is being serialized. Used so the
@@ -350,6 +350,9 @@ pub fn json_to_dsl_value(json: &serde_json::Value) -> Option<Value> {
             items.iter().filter_map(json_to_dsl_value).collect(),
         ))),
         serde_json::Value::Object(map) => {
+            if let Some(canonical) = json_to_canonical_enum(map) {
+                return Some(Value::Concrete(ConcreteValue::CanonicalEnum(canonical)));
+            }
             let m: IndexMap<_, _> = map
                 .iter()
                 .filter_map(|(k, v)| json_to_dsl_value(v).map(|val| (k.clone(), val)))
@@ -358,6 +361,43 @@ pub fn json_to_dsl_value(json: &serde_json::Value) -> Option<Value> {
         }
         serde_json::Value::Null => None,
     }
+}
+
+fn json_to_canonical_enum(
+    map: &serde_json::Map<String, serde_json::Value>,
+) -> Option<CanonicalEnumValue> {
+    let serde_json::Value::Object(payload) = map.get("Enum")? else {
+        return None;
+    };
+    if map.len() != 1 {
+        return None;
+    }
+
+    let serde_json::Value::Object(identity) = payload.get("identity")? else {
+        return None;
+    };
+    let provider = match identity.get("provider")? {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Null => None,
+        _ => return None,
+    };
+    let serde_json::Value::Array(segments) = identity.get("segments")? else {
+        return None;
+    };
+    let segments: Vec<String> = segments
+        .iter()
+        .map(|segment| match segment {
+            serde_json::Value::String(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect::<Option<_>>()?;
+    let kind = identity.get("kind")?.as_str()?.to_string();
+    let api_value = payload.get("api_value")?.as_str()?.to_string();
+
+    Some(CanonicalEnumValue::from_trusted_state(
+        TypeIdentity::new(provider, segments, kind),
+        api_value,
+    ))
 }
 
 /// Format a `Value` for display
@@ -2555,6 +2595,19 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn json_to_dsl_value_round_trips_canonical_enum_typed_object() {
+        let v = Value::Concrete(ConcreteValue::CanonicalEnum(
+            crate::resource::CanonicalEnumValue::new_for_test(
+                crate::schema::TypeIdentity::new(Some("aws"), ["ec2", "Eip"], "Domain"),
+                "vpc",
+            ),
+        ));
+        let json = value_to_json(&v).unwrap();
+
+        assert_eq!(json_to_dsl_value(&json), Some(v));
     }
 
     #[test]

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -6,7 +6,9 @@ use argon2::Argon2;
 use indexmap::IndexMap;
 use thiserror::Error;
 
-use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value};
+use crate::resource::{
+    CanonicalEnumValue, ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
+};
 use crate::schema::{AttrTypeKind, AttributeType};
 use crate::utils::{convert_enum_value, extract_enum_value_with_values, is_dsl_enum_format};
 
@@ -231,10 +233,7 @@ pub fn value_to_json_with_context(
         Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
             Ok(serde_json::Value::String(s.to_string()))
         }
-        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
-            // TODO(carina#3438): PR3 — state-facing serialization must use the typed enum object per design doc §Serialization; this flat string is a dormant placeholder.
-            Ok(serde_json::Value::String(c.api_value().to_string()))
-        }
+        Value::Concrete(ConcreteValue::CanonicalEnum(c)) => Ok(canonical_enum_to_json(c)),
         Value::Concrete(ConcreteValue::Int(n)) => Ok(serde_json::Value::Number((*n).into())),
         Value::Concrete(ConcreteValue::Duration(d)) => {
             Ok(serde_json::Value::Number((d.as_secs() as i64).into()))
@@ -313,6 +312,20 @@ pub fn value_to_json_with_context(
             })
         }
     }
+}
+
+pub fn canonical_enum_to_json(c: &CanonicalEnumValue) -> serde_json::Value {
+    let identity = c.identity();
+    serde_json::json!({
+        "Enum": {
+            "identity": {
+                "provider": identity.provider.clone(),
+                "segments": identity.segments.clone(),
+                "kind": identity.kind.clone(),
+            },
+            "api_value": c.api_value(),
+        }
+    })
 }
 
 /// Convert `serde_json::Value` to DSL `Value`.
@@ -1449,10 +1462,19 @@ pub(crate) fn canonicalize_with_type(
         // the ranker/canonicalizer path looked correct for other
         // branches while this leaf silently skipped normalization.
         (val, crate::schema::Shape::Enum { .. }) => {
-            // Thread `defs` here too to preserve the invariant for every
-            // `canonicalize_with_type` arm, even though the resolved Enum
-            // leaf itself does not contain a Ref.
-            crate::utils::lift_enum_leaves_with_defs(&val, unwrapped, defs).unwrap_or(val)
+            let resolver = crate::resource::EnumValueResolver::with_defs(unwrapped, defs);
+            match val {
+                Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => resolver
+                    .resolve_raw(&raw)
+                    .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
+                    .unwrap_or_else(|_| Value::Concrete(ConcreteValue::EnumIdentifier(raw))),
+                Value::Concrete(ConcreteValue::String(s)) => resolver
+                    .resolve_state_text(&s)
+                    .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
+                    .unwrap_or_else(|_| Value::Concrete(ConcreteValue::String(s))),
+                Value::Concrete(ConcreteValue::CanonicalEnum(_)) => val,
+                other => other,
+            }
         }
         // Union: the missing nesting kind (List/Map/Struct/Secret
         // already recurse; Union was the lone gap — carina#3080).
@@ -2509,6 +2531,104 @@ mod tests {
             ),
         ));
         assert_eq!(format_value(&v), "ap-northeast-1");
+    }
+
+    #[test]
+    fn value_to_json_serializes_canonical_enum_as_typed_object() {
+        let v = Value::Concrete(ConcreteValue::CanonicalEnum(
+            crate::resource::CanonicalEnumValue::new_for_test(
+                crate::schema::TypeIdentity::new(Some("aws"), ["ec2", "Eip"], "Domain"),
+                "vpc",
+            ),
+        ));
+
+        assert_eq!(
+            value_to_json(&v).unwrap(),
+            serde_json::json!({
+                "Enum": {
+                    "identity": {
+                        "provider": "aws",
+                        "segments": ["ec2", "Eip"],
+                        "kind": "Domain"
+                    },
+                    "api_value": "vpc"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn canonicalize_resources_with_schemas_replaces_enum_leaves_recursively() {
+        use crate::schema::{
+            AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, TypeIdentity,
+        };
+
+        let domain = AttributeType::enum_(
+            TypeIdentity::new(Some("aws"), ["ec2", "Eip"], "Domain"),
+            Some(vec!["vpc".to_string(), "standard".to_string()]),
+            Vec::new(),
+            None,
+            None,
+        );
+        let mut registry = SchemaRegistry::new();
+        registry.insert(
+            "aws",
+            ResourceSchema::new("ec2.Eip")
+                .attribute(AttributeSchema::new("domain", domain.clone()))
+                .attribute(AttributeSchema::new(
+                    "domains",
+                    AttributeType::list(domain.clone()),
+                ))
+                .attribute(AttributeSchema::new(
+                    "domain_by_name",
+                    AttributeType::map(domain),
+                )),
+        );
+        let mut resource = crate::resource::Resource::with_provider("aws", "ec2.Eip", "eip", None);
+        resource.set_attr(
+            "domain",
+            Value::Concrete(ConcreteValue::enum_identifier("aws.ec2.Eip.Domain.vpc")),
+        );
+        resource.set_attr(
+            "domains",
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::enum_identifier("aws.ec2.Eip.Domain.standard"),
+            )])),
+        );
+        resource.set_attr(
+            "domain_by_name",
+            Value::Concrete(ConcreteValue::Map(indexmap::indexmap! {
+                "primary".to_string() => Value::Concrete(ConcreteValue::enum_identifier("aws.ec2.Eip.Domain.vpc")),
+            })),
+        );
+        let mut resources = vec![resource];
+
+        canonicalize_resources_with_schemas(&mut resources, &registry);
+
+        let domain = resources[0].attributes.get("domain").unwrap();
+        match domain {
+            Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+                assert_eq!(c.api_value(), "vpc");
+                assert_eq!(c.identity().to_string(), "aws.ec2.Eip.Domain");
+            }
+            other => panic!("expected CanonicalEnum, got {other:?}"),
+        }
+        let domains = resources[0].attributes.get("domains").unwrap();
+        let Value::Concrete(ConcreteValue::List(items)) = domains else {
+            panic!("expected list, got {domains:?}");
+        };
+        assert!(matches!(
+            &items[0],
+            Value::Concrete(ConcreteValue::CanonicalEnum(c)) if c.api_value() == "standard"
+        ));
+        let map = resources[0].attributes.get("domain_by_name").unwrap();
+        let Value::Concrete(ConcreteValue::Map(map)) = map else {
+            panic!("expected map, got {map:?}");
+        };
+        assert!(matches!(
+            map.get("primary").unwrap(),
+            Value::Concrete(ConcreteValue::CanonicalEnum(c)) if c.api_value() == "vpc"
+        ));
     }
 
     #[test]
@@ -3695,7 +3815,7 @@ mod tests {
     }
 
     #[test]
-    fn canonicalize_enum_lifts_state_string_to_dsl_identifier() {
+    fn canonicalize_enum_lifts_state_string_to_canonical_enum() {
         let t = AttributeType::enum_(
             crate::schema::enum_identity("Effect", Some("aws.iam.PolicyDocument")),
             Some(vec!["Allow".to_string(), "Deny".to_string()]),
@@ -3708,12 +3828,13 @@ mod tests {
         );
         let v = Value::Concrete(ConcreteValue::String("Allow".to_string()));
         let canon = canonicalize_with_type(v, &t, crate::schema::empty_defs_for_schema_walks());
-        assert_eq!(
-            canon,
-            Value::Concrete(ConcreteValue::enum_identifier(
-                "aws.iam.PolicyDocument.Effect.allow".to_string()
-            ))
-        );
+        match canon {
+            Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
+                assert_eq!(c.identity().to_string(), "aws.iam.PolicyDocument.Effect");
+                assert_eq!(c.api_value(), "Allow");
+            }
+            other => panic!("expected CanonicalEnum, got {other:?}"),
+        }
     }
 
     #[test]

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -1972,7 +1972,7 @@ mod tests {
     }
 
     #[test]
-    fn proto_custom_enum_transform_lifts_state_string_to_dsl_identifier() {
+    fn proto_custom_enum_transform_lifts_state_string_to_canonical_enum() {
         let proto_attr = proto::AttributeType::CustomEnum {
             name: "ZoneName".to_string(),
             base: Box::new(proto_string()),
@@ -1987,14 +1987,15 @@ mod tests {
         let lifted = carina_core::utils::lift_enum_leaves(&state, &core_attr)
             .expect("WASM-bridged dynamic enum should lift provider state");
 
-        assert_eq!(
-            lifted,
+        match lifted {
             carina_core::resource::Value::Concrete(
-                carina_core::resource::ConcreteValue::enum_identifier(
-                    "aws.AvailabilityZone.ZoneName.ap_northeast_1a".to_string()
-                )
-            )
-        );
+                carina_core::resource::ConcreteValue::CanonicalEnum(c),
+            ) => {
+                assert_eq!(c.identity().to_string(), "aws.AvailabilityZone.ZoneName");
+                assert_eq!(c.api_value(), "ap-northeast-1a");
+            }
+            other => panic!("expected CanonicalEnum, got {other:?}"),
+        }
         match core_attr.shape_ref_free().expect("test schema is Ref-free") {
             carina_core::schema::Shape::Enum { base, .. } => {
                 assert!(matches!(
@@ -2037,15 +2038,17 @@ mod tests {
         let already_dsl = carina_core::resource::Value::Concrete(
             carina_core::resource::ConcreteValue::enum_identifier("ap_northeast_1a".to_string()),
         );
-        assert_eq!(
-            carina_core::utils::lift_enum_leaves(&already_dsl, &core_attr),
+        match carina_core::utils::lift_enum_leaves(&already_dsl, &core_attr) {
             Some(carina_core::resource::Value::Concrete(
-                carina_core::resource::ConcreteValue::enum_identifier(
-                    "aws.AvailabilityZone.ZoneName.ap_northeast_1a".to_string()
-                )
-            )),
-            "parser-produced DSL enum identifiers must still canonicalize"
-        );
+                carina_core::resource::ConcreteValue::CanonicalEnum(c),
+            )) => {
+                assert_eq!(c.identity().to_string(), "aws.AvailabilityZone.ZoneName");
+                assert_eq!(c.api_value(), "ap-northeast-1a");
+            }
+            other => panic!(
+                "parser-produced DSL enum identifiers must still canonicalize, got {other:?}"
+            ),
+        }
 
         for raw in ["   ", "", "AP-NORTHEAST-1A"] {
             let value = carina_core::resource::Value::Concrete(
@@ -2061,15 +2064,19 @@ mod tests {
         let valid = carina_core::resource::Value::Concrete(
             carina_core::resource::ConcreteValue::String("ap-northeast-1a".to_string()),
         );
-        assert_eq!(
-            carina_core::utils::lift_enum_leaves(&valid, &core_attr),
+        match carina_core::utils::lift_enum_leaves(&valid, &core_attr) {
             Some(carina_core::resource::Value::Concrete(
-                carina_core::resource::ConcreteValue::enum_identifier(
-                    "aws.AvailabilityZone.ZoneName.ap_northeast_1a".to_string()
+                carina_core::resource::ConcreteValue::CanonicalEnum(c),
+            )) => {
+                assert_eq!(c.identity().to_string(), "aws.AvailabilityZone.ZoneName");
+                assert_eq!(c.api_value(), "ap-northeast-1a");
+            }
+            other => {
+                panic!(
+                    "valid AZ strings must lift through the WASM-bridged transform, got {other:?}"
                 )
-            )),
-            "valid AZ strings must still lift through the WASM-bridged transform"
-        );
+            }
+        }
     }
 
     #[test]

--- a/notes/specs/2026-06-10-structured-enum-identifier-design.md
+++ b/notes/specs/2026-06-10-structured-enum-identifier-design.md
@@ -249,7 +249,7 @@ comparison is needed for assignability, it should be a named method rather than
 
 `Display` for `RawEnumIdentifier` should return source text. Display for
 `CanonicalEnumValue` can render `identity.api_value`, but display consumers
-should usually choose raw source where available.
+should choose deliberately per surface.
 
 ### Value projection
 
@@ -311,12 +311,15 @@ They should not perform schema resolution.
 
 ### Display, format, and LSP
 
-Formatter, LSP diagnostics, code actions, `detail_rows`, and plan display should
+Formatter, LSP diagnostics, code actions, and source-facing diagnostics should
 generally keep raw enum spelling when the source spelling is what the user needs
 to see.
 
-They should not use canonical API values as a blanket replacement for source
-text. API spelling is often not the DSL spelling users are expected to write.
+Plan display uses bare canonical `api_value` for resolved enum leaves, rendered
+unquoted. The alternative of mapping `api_value` back through `DslMap` was not
+chosen for plan output because it would make display depend on carrying schema
+context through more rendering surfaces. Source-facing paths can still preserve
+raw spelling where that is the clearer user contract.
 
 ### Validation
 
@@ -399,15 +402,19 @@ Recommended JSON shape:
 }
 ```
 
-The exact serde tag can follow the surrounding `ConcreteValue` convention, but
-the payload must include both:
+State attribute JSON uses the hand-written `{"Enum": ...}` tag shown above so
+schema-free state loading can recover a `CanonicalEnumValue` directly from the
+trusted persisted payload.
+
+Saved plans use the serde representation of the `ConcreteValue::CanonicalEnum`
+variant. That means the state JSON object and saved-plan serde object are not
+byte-identical tags, but both are typed objects and both carry the same semantic
+payload:
 
 - the enum type identity; and
 - the provider API value.
 
-The saved plan should use the same representation for value trees that carry
-resolved enum semantics. Plan display can still render DSL spelling by mapping
-`api_value` through the enum's `DslMap` when schema is available.
+Plan display renders canonical enum leaves as bare unquoted `api_value`.
 
 Provider wire JSON remains a plain string. The typed enum object is a Carina
 state/plan representation, not a provider protocol change.
@@ -433,19 +440,26 @@ Their output type changes from `EnumIdentifier(String)` to `CanonicalEnumValue`.
 
 ## Differ and reconciliation
 
-The differ currently has schema-aware enum comparison that accepts both
-`String` and `EnumIdentifier`, extracts a trailing enum value with known values,
-and folds aliases through `DslMap`.
-
-That logic should collapse to canonical comparison:
+The differ has schema-aware enum comparison that accepts `String`,
+`EnumIdentifier`, and `CanonicalEnum` during the migration. For canonical values
+it first tries strict typed equality:
 
 ```rust
 CanonicalEnumValue { identity, api_value } == CanonicalEnumValue { identity, api_value }
 ```
 
-If provider-read strings enter before resolution, that is a pipeline bug. The
-differ should not keep a fallback that re-parses raw dotted strings once the
-resolver is wired.
+If strict equality fails, differ comparison falls through to canonical API-text
+comparison before deciding an update is required. This is intentionally looser
+than `CanonicalEnumValue`'s `PartialEq`: cross-identity export flows can carry a
+producer identity such as `aws.Region` into a consumer schema such as
+`awscc.Region`, and those providers share a unified API value space for the enum
+member. The question for the differ is whether applying would change provider
+API text, not whether the two typed values have identical identity axes.
+
+String and raw enum fallback remains a migration compatibility path while some
+provider-read or state leaves can still arrive before schema resolution. The
+desired steady state is still that schema-known enum leaves are canonical before
+they reach durable identity or differ logic.
 
 Anonymous reconciliation should likewise compare canonical enum values. The
 string helpers added by #3437 become temporary shims until all identity inputs
@@ -485,7 +499,10 @@ Recommended chain:
    bump revisions in Carina.
 5. Shim removal PR. Remove string-out hash helpers, raw-string enum extraction
    APIs from durable identity paths, and any temporary constructors that let
-   production code mint canonical enum values without schema.
+   production code mint canonical enum values without schema. This must happen
+   after provider config attributes such as `region` are canonicalized; otherwise
+   removing raw fallback and `api_for_hash_feature` would regress provider
+   config hash stability.
 
 This mirrors the #3371-style split: design first, core types second, consumers
 third, external repo follow-up fourth, cleanup last.


### PR DESCRIPTION
Refs #3438
Closes #3440

## Summary

Chain PR 3 of 5 for the structured enum identifier design (`notes/specs/2026-06-10-structured-enum-identifier-design.md`): convert the core consumers to `CanonicalEnumValue`.

- Validation now resolves enum leaves through `EnumValueResolver` and replaces them in the value tree with `ConcreteValue::CanonicalEnum` — recursively, including `list<enum>` / `map<_, enum>` elements. The replacement seam is `canonicalize_with_type`, and the CLI canonicalizes resources before anonymous-ID computation on every command path (plan / apply / destroy / state / validate).
- State read-back and lifting produce `CanonicalEnum` (via `resolve_state_text`); unresolvable state text stays a plain string with the existing error behavior.
- State JSON serializes canonical enum leaves as a typed `{"Enum": {identity, api_value}}` object and reads the same shape back (`from_trusted_state` is the state-deserialization-only constructor). Saved plans use the serde `CanonicalEnum` variant tag; both carry identity + api_value, and the doc records the dual representation.
- The differ compares canonical values strictly first and falls through to api-text comparison on identity mismatch, so producer/consumer dirs with different provider identities (aws/awscc) over the same API value stay converged.
- Anonymous hash and reconciliation consume canonicalized leaves. Reconciliation gained: unique full-match rebinds (so a no-edit binary upgrade re-keys old-hash state entries instead of destroy+create), and occupancy guards (used/claimed name sets) across the full-match, partial-match, and SimHash branches so a rebind can never steal a live resource's state entry or double-claim one entry for two resources.
- Plan display of canonicalized enums shows the bare API value unquoted (`instance_tenancy: dedicated`); the `enum_display` fixture now runs with a real enum schema and the snapshot pins the new rendering.

Closes #3440 because list/map enum elements are canonicalized before hashing; `test_anonymous_id_stable_for_nested_canonical_enum_create_only_values` pins aws/awscc hash stability for nested enums.

The typestate enforcement ("identity consumers cannot compile against raw text") lands in PR 5 when the shims and raw fallbacks are removed; this PR establishes the runtime conversion order and keeps compatibility arms, as staged in the design doc.

## Review rounds

Five fresh review rounds; every finding fixed with a failing test first:

1. State `{"Enum": ...}` was write-only (no reader → permanent phantom diff for write-only enum attrs); nested create-only enums lost deterministic reconciliation; the enum display change was unwitnessed (the old snapshot ran schema-less).
2. Identity-strict `CanonicalEnum == CanonicalEnum` early-return broke cross-identity export consumption; now falls through to api-text comparison.
3. No-edit upgrades didn't rebind (full create-only matches were ignored); unique full-match rebind added. Doc updated for differ semantics, dual serialization tags, display decision, and PR5 ordering.
4. The new full-match rebind could steal a live resource's state entry or double-claim one entry (reproduced with Route53 A/AAAA); occupancy guards added to full and partial branches.
5. The SimHash branch had the same occupancy hole (pre-existing, same function, same invariant); guards and claim recording applied there too.

## Verification

- `RUSTC_WRAPPER= cargo nextest run --workspace --all-features` — 3985 passed, 72 skipped
- `RUSTC_WRAPPER= cargo test --workspace --doc`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `bash scripts/check-*.sh` — all pass
- #3437 anonymous-address regression tests: 18/18 pass, untouched
