### PR TITLE
Remove transitional shims and finish enum typestate (carina#3438 PR5)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -479,14 +479,17 @@ pub fn validate_and_resolve_errors_with_factories(
         }
     }
 
-    carina_core::value::canonicalize_resources_with_schemas(&mut parsed.resources, ctx.schemas());
+    let canonical_resources = carina_core::value::canonicalize_resources_with_schemas(
+        &mut parsed.resources,
+        ctx.schemas(),
+    );
 
     // Compute anonymous identifiers — downstream plan code assumes
     // every resource has a stable id, so a collision error must stop
     // the pipeline here.
     errors.extend(compute_anonymous_identifiers_with_ctx(
         &ctx,
-        &mut parsed.resources,
+        canonical_resources,
         &parsed.providers,
     ));
     if !errors.is_empty() {
@@ -858,6 +861,131 @@ exports {
             result.is_ok(),
             "skip_resource_validation=true must bypass upstream field check, got: {:?}",
             result.err()
+        );
+    }
+
+    struct ResourceCreateOnlyEnumFactory {
+        enum_provider: &'static str,
+    }
+
+    impl carina_core::provider::ProviderFactory for ResourceCreateOnlyEnumFactory {
+        fn name(&self) -> &str {
+            "awscc"
+        }
+
+        fn display_name(&self) -> &str {
+            "AWSCC resource create-only enum test provider"
+        }
+
+        fn provider_config_attribute_types(
+            &self,
+        ) -> HashMap<String, carina_core::schema::AttributeType> {
+            HashMap::new()
+        }
+
+        fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+            "ap-northeast-1".to_string()
+        }
+
+        fn create_provider(
+            &self,
+            _binding: Option<&str>,
+            _attributes: &IndexMap<String, Value>,
+        ) -> carina_core::provider::BoxFuture<
+            '_,
+            carina_core::provider::ProviderResult<Box<dyn carina_core::provider::Provider>>,
+        > {
+            Box::pin(async {
+                Ok(Box::new(carina_provider_mock::MockProvider::new())
+                    as Box<dyn carina_core::provider::Provider>)
+            })
+        }
+
+        fn create_normalizer(
+            &self,
+            _binding: Option<&str>,
+            _attributes: &IndexMap<String, Value>,
+        ) -> carina_core::provider::BoxFuture<'_, Box<dyn carina_core::provider::ProviderNormalizer>>
+        {
+            Box::pin(async {
+                Box::new(carina_core::provider::NoopNormalizer)
+                    as Box<dyn carina_core::provider::ProviderNormalizer>
+            })
+        }
+
+        fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {
+            vec![
+                carina_core::schema::ResourceSchema::new("ec2.Subnet").attribute(
+                    carina_core::schema::AttributeSchema::new(
+                        "placement_region",
+                        carina_core::schema::AttributeType::enum_(
+                            carina_core::schema::TypeIdentity::new(
+                                Some(self.enum_provider),
+                                Vec::<String>::new(),
+                                "Region",
+                            ),
+                            None,
+                            Vec::new(),
+                            None,
+                            Some(carina_core::schema::DslTransform::HyphenToUnderscore),
+                        ),
+                    )
+                    .create_only(),
+                ),
+            ]
+        }
+    }
+
+    fn resource_create_only_enum_file(raw_region: &str) -> carina_core::parser::InferredFile {
+        let mut resource =
+            carina_core::resource::Resource::with_provider("awscc", "ec2.Subnet", "", None);
+        resource.set_attr(
+            "placement_region".to_string(),
+            Value::Concrete(ConcreteValue::enum_identifier(raw_region)),
+        );
+
+        carina_core::parser::InferredFile {
+            resources: vec![resource],
+            ..carina_core::parser::InferredFile::default()
+        }
+    }
+
+    #[test]
+    fn validate_and_resolve_canonicalizes_resource_create_only_enums_before_anonymous_hash() {
+        let base_dir = tempfile::tempdir().unwrap();
+        let mut awscc = resource_create_only_enum_file("awscc.Region.ap_northeast_1");
+        let mut aws = resource_create_only_enum_file("aws.Region.ap_northeast_1");
+
+        let errors = validate_and_resolve_errors_with_factories(
+            &mut awscc,
+            base_dir.path(),
+            false,
+            vec![Box::new(ResourceCreateOnlyEnumFactory {
+                enum_provider: "awscc",
+            })],
+            HashMap::new(),
+        );
+        assert!(errors.is_empty(), "awscc spelling errors: {errors:?}");
+
+        let errors = validate_and_resolve_errors_with_factories(
+            &mut aws,
+            base_dir.path(),
+            false,
+            vec![Box::new(ResourceCreateOnlyEnumFactory {
+                enum_provider: "aws",
+            })],
+            HashMap::new(),
+        );
+        assert!(errors.is_empty(), "aws spelling errors: {errors:?}");
+
+        assert_eq!(
+            awscc.resources[0].id.name_str(),
+            aws.resources[0].id.name_str(),
+            "resource create-only enum spelling must canonicalize before anonymous hash"
         );
     }
 }

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -595,7 +595,7 @@ pub fn apply_provider_prefix_renames(renames: &[(String, String)], state_file: &
 
 pub fn compute_anonymous_identifiers_with_ctx(
     ctx: &WiringContext,
-    resources: &mut [Resource],
+    mut resources: carina_core::value::CanonicalizedResources<'_>,
     providers: &[ProviderConfig],
 ) -> Vec<AppError> {
     let canonical_providers =
@@ -607,7 +607,7 @@ pub fn compute_anonymous_identifiers_with_ctx(
         );
 
     match identifier::compute_anonymous_identifiers_with_provider_configs(
-        resources,
+        resources.as_mut_slice(),
         &canonical_providers,
         ctx.schemas(),
         &|name| identity_attributes_for_provider(ctx, name),
@@ -2803,7 +2803,9 @@ pub fn compute_anonymous_identifiers(
     providers: &[ProviderConfig],
 ) -> Result<(), AppError> {
     let ctx = WiringContext::new(vec![]);
-    let errors = compute_anonymous_identifiers_with_ctx(&ctx, resources, providers);
+    let canonical_resources =
+        carina_core::value::canonicalize_resources_with_schemas(resources, ctx.schemas());
+    let errors = compute_anonymous_identifiers_with_ctx(&ctx, canonical_resources, providers);
     if errors.is_empty() {
         Ok(())
     } else {

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -442,13 +442,13 @@ pub fn apply_anonymous_to_named_renames(
         return Vec::new();
     };
 
-    let mut canonical_providers = providers.to_vec();
-    carina_core::value::canonicalize_provider_configs_with_attribute_types(
-        &mut canonical_providers,
-        &|provider_name, attr_name| {
-            provider_config_attribute_type_for(ctx, provider_name, attr_name)
-        },
-    );
+    let canonical_providers =
+        carina_core::value::canonicalize_provider_configs_with_attribute_types(
+            providers,
+            &|provider_name, attr_name| {
+                provider_config_attribute_type_for(ctx, provider_name, attr_name)
+            },
+        );
 
     let renames = identifier::detect_anonymous_to_named_renames(
         resources,
@@ -598,13 +598,13 @@ pub fn compute_anonymous_identifiers_with_ctx(
     resources: &mut [Resource],
     providers: &[ProviderConfig],
 ) -> Vec<AppError> {
-    let mut canonical_providers = providers.to_vec();
-    carina_core::value::canonicalize_provider_configs_with_attribute_types(
-        &mut canonical_providers,
-        &|provider_name, attr_name| {
-            provider_config_attribute_type_for(ctx, provider_name, attr_name)
-        },
-    );
+    let canonical_providers =
+        carina_core::value::canonicalize_provider_configs_with_attribute_types(
+            providers,
+            &|provider_name, attr_name| {
+                provider_config_attribute_type_for(ctx, provider_name, attr_name)
+            },
+        );
 
     match identifier::compute_anonymous_identifiers_with_provider_configs(
         resources,

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -469,21 +469,9 @@ pub fn apply_anonymous_to_named_renames(
                     let create_only_values = create_only_attrs
                         .iter()
                         .filter_map(|attr| {
-                            let attribute_type = ctx
-                                .schemas()
-                                .get(
-                                    provider,
-                                    resource_type,
-                                    carina_core::schema::SchemaKind::Resource,
-                                )
-                                .and_then(|schema| schema.attributes.get(*attr))
-                                .map(|schema_attr| &schema_attr.attr_type);
                             sr.attributes.get(*attr).and_then(|v| {
-                                identifier::canonical_create_only_state_json_string(
-                                    v,
-                                    attribute_type,
-                                )
-                                .map(|s| (attr.to_string(), s))
+                                identifier::canonical_create_only_state_json_string(v)
+                                    .map(|s| (attr.to_string(), s))
                             })
                         })
                         .collect();
@@ -540,21 +528,9 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
                     let create_only_values = create_only_attrs
                         .iter()
                         .filter_map(|attr| {
-                            let attribute_type = ctx
-                                .schemas()
-                                .get(
-                                    provider,
-                                    resource_type,
-                                    carina_core::schema::SchemaKind::Resource,
-                                )
-                                .and_then(|schema| schema.attributes.get(*attr))
-                                .map(|schema_attr| &schema_attr.attr_type);
                             sr.attributes.get(*attr).and_then(|v| {
-                                identifier::canonical_create_only_state_json_string(
-                                    v,
-                                    attribute_type,
-                                )
-                                .map(|s| (attr.to_string(), s))
+                                identifier::canonical_create_only_state_json_string(v)
+                                    .map(|s| (attr.to_string(), s))
                             })
                         })
                         .collect();

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -442,6 +442,14 @@ pub fn apply_anonymous_to_named_renames(
         return Vec::new();
     };
 
+    let mut canonical_providers = providers.to_vec();
+    carina_core::value::canonicalize_provider_configs_with_attribute_types(
+        &mut canonical_providers,
+        &|provider_name, attr_name| {
+            provider_config_attribute_type_for(ctx, provider_name, attr_name)
+        },
+    );
+
     let renames = identifier::detect_anonymous_to_named_renames(
         resources,
         ctx.schemas(),
@@ -486,7 +494,7 @@ pub fn apply_anonymous_to_named_renames(
                 })
                 .collect()
         },
-        providers,
+        &canonical_providers,
         &|name| identity_attributes_for_provider(ctx, name),
     );
 
@@ -590,14 +598,19 @@ pub fn compute_anonymous_identifiers_with_ctx(
     resources: &mut [Resource],
     providers: &[ProviderConfig],
 ) -> Vec<AppError> {
-    match identifier::compute_anonymous_identifiers_with_provider_config_types(
-        resources,
-        providers,
-        ctx.schemas(),
-        &|name| identity_attributes_for_provider(ctx, name),
+    let mut canonical_providers = providers.to_vec();
+    carina_core::value::canonicalize_provider_configs_with_attribute_types(
+        &mut canonical_providers,
         &|provider_name, attr_name| {
             provider_config_attribute_type_for(ctx, provider_name, attr_name)
         },
+    );
+
+    match identifier::compute_anonymous_identifiers_with_provider_configs(
+        resources,
+        &canonical_providers,
+        ctx.schemas(),
+        &|name| identity_attributes_for_provider(ctx, name),
     ) {
         Ok(()) => Vec::new(),
         Err(msg) => vec![AppError::Config(msg)],

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -823,7 +823,9 @@ fn dependency_chain_wrappers_return_vec_app_error() {
     let errors = resolve_attr_prefixes_with_ctx(&ctx, &mut resources);
     assert!(errors.is_empty(), "resolve_attr_prefixes: got {errors:?}");
 
-    let errors = compute_anonymous_identifiers_with_ctx(&ctx, &mut resources, &providers);
+    let canonical_resources =
+        carina_core::value::canonicalize_resources_with_schemas(&mut resources, ctx.schemas());
+    let errors = compute_anonymous_identifiers_with_ctx(&ctx, canonical_resources, &providers);
     assert!(
         errors.is_empty(),
         "compute_anonymous_identifiers: got {errors:?}",
@@ -946,10 +948,15 @@ fn compute_anonymous_identifiers_with_ctx_canonicalizes_provider_config_identity
 
     let mut resources_awscc = vec![anonymous_route_resource()];
     let mut resources_aws = vec![anonymous_route_resource()];
-    let errors =
-        compute_anonymous_identifiers_with_ctx(&ctx, &mut resources_awscc, &providers_awscc);
+    let canonical_awscc = carina_core::value::canonicalize_resources_with_schemas(
+        &mut resources_awscc,
+        ctx.schemas(),
+    );
+    let errors = compute_anonymous_identifiers_with_ctx(&ctx, canonical_awscc, &providers_awscc);
     assert!(errors.is_empty(), "awscc spelling errors: {errors:?}");
-    let errors = compute_anonymous_identifiers_with_ctx(&ctx, &mut resources_aws, &providers_aws);
+    let canonical_aws =
+        carina_core::value::canonicalize_resources_with_schemas(&mut resources_aws, ctx.schemas());
+    let errors = compute_anonymous_identifiers_with_ctx(&ctx, canonical_aws, &providers_aws);
     assert!(errors.is_empty(), "aws spelling errors: {errors:?}");
 
     assert_eq!(
@@ -968,7 +975,10 @@ fn apply_anonymous_to_named_renames_canonicalizes_provider_config_identity_enums
     let providers_aws = vec![region_provider_config("aws.Region.ap_northeast_1")];
 
     let mut anonymous = vec![anonymous_route_resource()];
-    let errors = compute_anonymous_identifiers_with_ctx(&ctx, &mut anonymous, &providers_awscc);
+    let canonical_anonymous =
+        carina_core::value::canonicalize_resources_with_schemas(&mut anonymous, ctx.schemas());
+    let errors =
+        compute_anonymous_identifiers_with_ctx(&ctx, canonical_anonymous, &providers_awscc);
     assert!(errors.is_empty(), "anonymous setup errors: {errors:?}");
     let old_name = anonymous[0].id.name_str().to_string();
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -830,6 +830,181 @@ fn dependency_chain_wrappers_return_vec_app_error() {
     );
 }
 
+struct RegionIdentityFactory;
+
+impl carina_core::provider::ProviderFactory for RegionIdentityFactory {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+
+    fn display_name(&self) -> &str {
+        "AWSCC region identity test provider"
+    }
+
+    fn provider_config_attribute_types(
+        &self,
+    ) -> HashMap<String, carina_core::schema::AttributeType> {
+        HashMap::from([(
+            "region".to_string(),
+            carina_core::schema::AttributeType::enum_(
+                carina_core::schema::TypeIdentity::new(
+                    Some("awscc"),
+                    Vec::<String>::new(),
+                    "Region",
+                ),
+                None,
+                Vec::new(),
+                None,
+                Some(carina_core::schema::DslTransform::HyphenToUnderscore),
+            ),
+        )])
+    }
+
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "ap-northeast-1".to_string()
+    }
+
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> carina_core::provider::BoxFuture<
+        '_,
+        carina_core::provider::ProviderResult<Box<dyn carina_core::provider::Provider>>,
+    > {
+        Box::pin(async {
+            Ok(Box::new(MockProvider::new()) as Box<dyn carina_core::provider::Provider>)
+        })
+    }
+
+    fn create_normalizer(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> carina_core::provider::BoxFuture<'_, Box<dyn carina_core::provider::ProviderNormalizer>>
+    {
+        Box::pin(async {
+            Box::new(carina_core::provider::NoopNormalizer)
+                as Box<dyn carina_core::provider::ProviderNormalizer>
+        })
+    }
+
+    fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {
+        vec![
+            carina_core::schema::ResourceSchema::new("ec2.Route").attribute(
+                carina_core::schema::AttributeSchema::new(
+                    "route_table_id",
+                    carina_core::schema::AttributeType::string(),
+                ),
+            ),
+        ]
+    }
+
+    fn identity_attributes(&self) -> Vec<&str> {
+        vec!["region"]
+    }
+}
+
+fn region_identity_ctx() -> WiringContext {
+    WiringContext::new(vec![Box::new(RegionIdentityFactory)])
+}
+
+fn region_provider_config(raw_region: &str) -> ProviderConfig {
+    ProviderConfig {
+        name: "awscc".to_string(),
+        attributes: indexmap::indexmap! {
+            "region".to_string() => Value::Concrete(ConcreteValue::enum_identifier(raw_region)),
+        },
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+        unresolved_attributes: IndexMap::new(),
+        binding: None,
+        is_default: true,
+    }
+}
+
+fn anonymous_route_resource() -> Resource {
+    let mut resource = Resource::with_provider("awscc", "ec2.Route", "", None);
+    resource.set_attr(
+        "route_table_id".to_string(),
+        Value::Concrete(ConcreteValue::String("rtb-123".to_string())),
+    );
+    resource
+}
+
+#[test]
+fn compute_anonymous_identifiers_with_ctx_canonicalizes_provider_config_identity_enums() {
+    let ctx = region_identity_ctx();
+    let providers_awscc = vec![region_provider_config("awscc.Region.ap_northeast_1")];
+    let providers_aws = vec![region_provider_config("aws.Region.ap_northeast_1")];
+
+    let mut resources_awscc = vec![anonymous_route_resource()];
+    let mut resources_aws = vec![anonymous_route_resource()];
+    let errors =
+        compute_anonymous_identifiers_with_ctx(&ctx, &mut resources_awscc, &providers_awscc);
+    assert!(errors.is_empty(), "awscc spelling errors: {errors:?}");
+    let errors = compute_anonymous_identifiers_with_ctx(&ctx, &mut resources_aws, &providers_aws);
+    assert!(errors.is_empty(), "aws spelling errors: {errors:?}");
+
+    assert_eq!(
+        resources_awscc[0].id.name_str(),
+        resources_aws[0].id.name_str(),
+        "provider config region spelling must canonicalize before anonymous hash"
+    );
+}
+
+#[test]
+fn apply_anonymous_to_named_renames_canonicalizes_provider_config_identity_enums() {
+    use carina_state::state::{ResourceState, StateFile};
+
+    let ctx = region_identity_ctx();
+    let providers_awscc = vec![region_provider_config("awscc.Region.ap_northeast_1")];
+    let providers_aws = vec![region_provider_config("aws.Region.ap_northeast_1")];
+
+    let mut anonymous = vec![anonymous_route_resource()];
+    let errors = compute_anonymous_identifiers_with_ctx(&ctx, &mut anonymous, &providers_awscc);
+    assert!(errors.is_empty(), "anonymous setup errors: {errors:?}");
+    let old_name = anonymous[0].id.name_str().to_string();
+
+    let mut named = anonymous_route_resource();
+    named.id = ResourceId::with_provider("awscc", "ec2.Route", "route", None);
+    named.binding = Some("route".to_string());
+    let resources = vec![named.clone()];
+
+    let mut state_file = StateFile::new();
+    state_file
+        .resources
+        .push(ResourceState::new("ec2.Route", &old_name, "awscc"));
+    let mut current_states = HashMap::new();
+    let mut prev_explicit = HashMap::new();
+    let mut saved_attrs = HashMap::new();
+
+    let renames = apply_anonymous_to_named_renames(
+        &ctx,
+        &resources,
+        &providers_aws,
+        &mut current_states,
+        &mut prev_explicit,
+        &mut saved_attrs,
+        &Some(state_file),
+    );
+
+    assert_eq!(
+        renames,
+        vec![(
+            ResourceId::with_provider("awscc", "ec2.Route", old_name, None),
+            named.id
+        )],
+        "provider config region spelling must canonicalize before rename simhash"
+    );
+}
+
 // Smoke test for the module/provider wrappers: empty input exercises
 // each wrapper and pins the `Vec<AppError>` return type. A regression
 // back to `Result` fails to compile here.

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -8,7 +8,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use crate::parser::ProviderConfig;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, Value};
 use crate::schema::{AttributeType, ResourceSchema, SchemaRegistry};
-use crate::utils::{extract_enum_value_with_values, validate_enum_namespace};
 use crate::validation::is_string_compatible_type;
 
 /// Generate a random 8-character lowercase hex suffix using UUID v4.
@@ -237,86 +236,20 @@ fn deterministic_value_string(value: &Value) -> String {
     }
 }
 
-fn enum_identifier_segments_match(
-    raw: &str,
-    attribute_type: &AttributeType,
-    allow_dotted_value: bool,
-) -> bool {
-    let Some((identity, _, _, _, _)) = attribute_type.enum_parts() else {
-        return false;
-    };
-    if !raw.contains('.') {
-        return true;
-    }
-
-    let parts: Vec<&str> = raw.split('.').collect();
-    let Some(kind_idx) = parts.iter().position(|part| *part == identity.kind) else {
-        return false;
-    };
-    if kind_idx + 1 >= parts.len() {
-        return false;
-    }
-    if !allow_dotted_value && parts.len() != kind_idx + 2 {
-        return false;
-    }
-
-    if !identity.segments.is_empty() {
-        let prefix = &parts[..kind_idx];
-        if prefix.len() < identity.segments.len() {
-            return false;
-        }
-        let segment_start = prefix.len() - identity.segments.len();
-        if !prefix[segment_start..]
-            .iter()
-            .copied()
-            .eq(identity.segments.iter().map(String::as_str))
-        {
-            return false;
-        }
-    }
-
-    validate_enum_namespace(raw, identity).is_ok()
-        || parts
-            .get(kind_idx)
-            .is_some_and(|kind| *kind == identity.kind)
-}
-
-/// Return the anonymous-hash feature string for a schema-known enum value.
+/// Return the anonymous-hash feature string for an already canonicalized value.
 ///
-/// Only parser-surface `EnumIdentifier` values are canonicalized. All other
-/// values deliberately keep the legacy deterministic representation so deferred
-/// bindings and non-enum hash inputs do not change.
+/// `CanonicalEnum` values hash by provider API text. Raw enum identifiers are
+/// intentionally not schema-resolved here; callers must canonicalize at schema
+/// boundaries before durable identity generation.
 pub(crate) fn canonical_enum_feature_string(
     value: &Value,
-    attribute_type: Option<&AttributeType>,
+    _attribute_type: Option<&AttributeType>,
 ) -> String {
     if let Value::Concrete(ConcreteValue::CanonicalEnum(c)) = value {
-        return format!("EnumApiValue({:?})", c.api_value());
+        format!("EnumApiValue({:?})", c.api_value())
+    } else {
+        deterministic_value_string(value)
     }
-    let Some(attribute_type) = attribute_type else {
-        return deterministic_value_string(value);
-    };
-    let Value::Concrete(ConcreteValue::EnumIdentifier(raw)) = value else {
-        return deterministic_value_string(value);
-    };
-    let Some((_identity, values, _aliases, _validate, dsl_map)) = attribute_type.enum_parts()
-    else {
-        return deterministic_value_string(value);
-    };
-    if !enum_identifier_segments_match(raw.as_str(), attribute_type, values.is_some()) {
-        return deterministic_value_string(value);
-    }
-
-    let valid_values: Vec<&str> = values.into_iter().flatten().map(String::as_str).collect();
-    let variant = extract_enum_value_with_values(raw.as_str(), &valid_values);
-    let api_value = dsl_map.api_for_hash_feature(variant);
-    if let Some(values) = values
-        && !values.iter().any(|v| v == &api_value)
-    {
-        return deterministic_value_string(value);
-    }
-
-    format!("EnumApiValue({:?})", api_value)
 }
 
 fn canonical_create_only_value_string(
@@ -327,9 +260,7 @@ fn canonical_create_only_value_string(
         Value::Concrete(ConcreteValue::String(s)) => {
             Some(canonical_create_only_text_string(s, attribute_type))
         }
-        Value::Concrete(ConcreteValue::EnumIdentifier(_)) => {
-            Some(canonical_enum_feature_string(value, attribute_type))
-        }
+        Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => Some(raw.as_str().to_string()),
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
             Some(format!("EnumApiValue({:?})", c.api_value()))
         }
@@ -381,27 +312,16 @@ fn canonical_create_only_feature_string(
 
 fn canonical_create_only_text_string(
     value: &str,
-    attribute_type: Option<&AttributeType>,
+    _attribute_type: Option<&AttributeType>,
 ) -> String {
-    if attribute_type.and_then(AttributeType::enum_parts).is_none() {
-        return value.to_string();
-    }
-
-    let enum_value = Value::Concrete(ConcreteValue::enum_identifier(value.to_string()));
-    let canonical = canonical_enum_feature_string(&enum_value, attribute_type);
-    if canonical == deterministic_value_string(&enum_value) {
-        value.to_string()
-    } else {
-        canonical
-    }
+    value.to_string()
 }
 
 /// Convert a persisted state JSON create-only attribute into the same canonical
 /// feature string used for desired-side anonymous identifier reconciliation.
 ///
-/// The JSON reader preserves typed enum objects as `CanonicalEnum` and ordinary
-/// legacy enum strings remain strings; `canonical_create_only_value_string`
-/// then applies schema-known List/Map/Enum normalization symmetrically.
+/// The JSON reader preserves typed enum objects as `CanonicalEnum`; ordinary
+/// legacy enum strings remain strings and are not schema-resolved here.
 pub fn canonical_create_only_state_json_string(
     value: &serde_json::Value,
     attribute_type: Option<&AttributeType>,
@@ -576,8 +496,6 @@ fn compute_resource_simhash(
     simhash_from_identity_and_resource(&identity_values, resource, registry.get_for(resource))
 }
 
-type ProviderConfigAttributeTypeFn<'a> = dyn Fn(&str, &str) -> Option<AttributeType> + 'a;
-
 /// Compute stable identifiers for anonymous resources (those with empty ResourceId.name).
 /// Uses create-only properties and provider identity attributes to generate a deterministic hash.
 ///
@@ -589,21 +507,19 @@ pub fn compute_anonymous_identifiers(
     registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> Result<(), String> {
-    compute_anonymous_identifiers_with_provider_config_types(
+    compute_anonymous_identifiers_with_provider_configs(
         resources,
         providers,
         registry,
         identity_attributes_fn,
-        &|_, _| None,
     )
 }
 
-pub fn compute_anonymous_identifiers_with_provider_config_types(
+pub fn compute_anonymous_identifiers_with_provider_configs(
     resources: &mut [Resource],
     providers: &[ProviderConfig],
     registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
-    provider_config_attribute_type_fn: &ProviderConfigAttributeTypeFn<'_>,
 ) -> Result<(), String> {
     use std::collections::BTreeMap;
     use std::hash::{Hash, Hasher};
@@ -635,11 +551,9 @@ pub fn compute_anonymous_identifiers_with_provider_config_types(
         if let Some(pc) = providers.iter().find(|p| p.name == *provider_name) {
             for attr_name in &identity_attrs {
                 if let Some(value) = pc.attributes.get(attr_name.as_str()) {
-                    let attribute_type =
-                        provider_config_attribute_type_fn(provider_name, attr_name);
                     identity_values.insert(
                         attr_name.clone(),
-                        canonical_enum_feature_string(value, attribute_type.as_ref()),
+                        canonical_enum_feature_string(value, None),
                     );
                 }
             }

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 #[cfg(test)]
 use crate::parser::ProviderConfig;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, Value};
-use crate::schema::{AttributeType, SchemaRegistry};
+use crate::schema::SchemaRegistry;
 use crate::validation::is_string_compatible_type;
 use crate::value::CanonicalizedProviderConfigs;
 
@@ -238,10 +238,7 @@ fn deterministic_value_string(value: &Value) -> String {
     }
 }
 
-fn canonical_create_only_value_string(
-    value: &Value,
-    attribute_type: Option<&AttributeType>,
-) -> Option<String> {
+fn canonical_create_only_value_string(value: &Value) -> Option<String> {
     match value {
         Value::Concrete(ConcreteValue::String(s)) => Some(s.to_string()),
         Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => Some(raw.as_str().to_string()),
@@ -249,35 +246,19 @@ fn canonical_create_only_value_string(
             Some(format!("EnumApiValue({:?})", c.api_value()))
         }
         Value::Concrete(ConcreteValue::List(items)) => {
-            let inner_type = attribute_type
-                .and_then(|attr| attr.shape_ref_free().ok())
-                .and_then(|shape| match shape {
-                    crate::schema::Shape::List { element_type, .. } => Some(element_type),
-                    _ => None,
-                });
             let parts: Vec<String> = items
                 .iter()
-                .map(|item| canonical_create_only_feature_string(item, inner_type))
+                .map(canonical_create_only_feature_string)
                 .collect();
             Some(format!("List([{}])", parts.join(", ")))
         }
         Value::Concrete(ConcreteValue::Map(map)) => {
-            let value_type = attribute_type
-                .and_then(|attr| attr.shape_ref_free().ok())
-                .and_then(|shape| match shape {
-                    crate::schema::Shape::Map { value, .. } => Some(value),
-                    _ => None,
-                });
             let mut entries: Vec<(&String, &Value)> = map.iter().collect();
             entries.sort_by_key(|(key, _)| *key);
             let parts: Vec<String> = entries
                 .iter()
                 .map(|(key, item)| {
-                    format!(
-                        "{:?}: {}",
-                        key,
-                        canonical_create_only_feature_string(item, value_type)
-                    )
+                    format!("{:?}: {}", key, canonical_create_only_feature_string(item))
                 })
                 .collect();
             Some(format!("Map({{{}}})", parts.join(", ")))
@@ -286,12 +267,8 @@ fn canonical_create_only_value_string(
     }
 }
 
-fn canonical_create_only_feature_string(
-    value: &Value,
-    attribute_type: Option<&AttributeType>,
-) -> String {
-    canonical_create_only_value_string(value, attribute_type)
-        .unwrap_or_else(|| deterministic_value_string(value))
+fn canonical_create_only_feature_string(value: &Value) -> String {
+    canonical_create_only_value_string(value).unwrap_or_else(|| deterministic_value_string(value))
 }
 
 /// Convert a persisted state JSON create-only attribute into the same canonical
@@ -299,13 +276,10 @@ fn canonical_create_only_feature_string(
 ///
 /// The JSON reader preserves typed enum objects as `CanonicalEnum`; ordinary
 /// legacy enum strings remain strings and are not schema-resolved here.
-pub fn canonical_create_only_state_json_string(
-    value: &serde_json::Value,
-    attribute_type: Option<&AttributeType>,
-) -> Option<String> {
+pub fn canonical_create_only_state_json_string(value: &serde_json::Value) -> Option<String> {
     crate::value::json_to_dsl_value(value)
         .as_ref()
-        .and_then(|value| canonical_create_only_value_string(value, attribute_type))
+        .and_then(canonical_create_only_value_string)
 }
 
 /// Maximum Hamming distance (out of 64 bits) for SimHash-based reconciliation.
@@ -743,14 +717,10 @@ pub fn reconcile_anonymous_identifiers(
         // Collect this resource's create-only values
         let mut resource_co_values: HashMap<&str, String> = HashMap::new();
         for attr_name in &create_only_attrs {
-            if let Some(value) = resource.get_attr(attr_name) {
-                let attribute_type = schema
-                    .attributes
-                    .get(*attr_name)
-                    .map(|attr| &attr.attr_type);
-                if let Some(value) = canonical_create_only_value_string(value, attribute_type) {
-                    resource_co_values.insert(attr_name, value);
-                }
+            if let Some(value) = resource.get_attr(attr_name)
+                && let Some(value) = canonical_create_only_value_string(value)
+            {
+                resource_co_values.insert(attr_name, value);
             }
         }
 

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -5,10 +5,12 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+#[cfg(test)]
 use crate::parser::ProviderConfig;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, Value};
 use crate::schema::{AttributeType, ResourceSchema, SchemaRegistry};
 use crate::validation::is_string_compatible_type;
+use crate::value::CanonicalizedProviderConfigs;
 
 /// Generate a random 8-character lowercase hex suffix using UUID v4.
 pub fn generate_random_suffix() -> String {
@@ -477,14 +479,18 @@ fn simhash_from_identity_and_resource(
 /// anonymous ID of a resource that has since been wrapped in a `let` binding.
 fn compute_resource_simhash(
     resource: &Resource,
-    providers: &[ProviderConfig],
+    providers: &CanonicalizedProviderConfigs,
     registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> u64 {
     let mut identity_values: BTreeMap<String, String> = BTreeMap::new();
     if !resource.id.provider.is_empty() {
         let identity_attrs = identity_attributes_fn(&resource.id.provider);
-        if let Some(pc) = providers.iter().find(|p| p.name == resource.id.provider) {
+        if let Some(pc) = providers
+            .as_slice()
+            .iter()
+            .find(|p| p.name == resource.id.provider)
+        {
             for attr_name in &identity_attrs {
                 if let Some(value) = pc.attributes.get(attr_name.as_str()) {
                     identity_values.insert(attr_name.clone(), deterministic_value_string(value));
@@ -503,7 +509,7 @@ fn compute_resource_simhash(
 /// for that provider (e.g., `["region"]`).
 pub fn compute_anonymous_identifiers(
     resources: &mut [Resource],
-    providers: &[ProviderConfig],
+    providers: &CanonicalizedProviderConfigs,
     registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> Result<(), String> {
@@ -515,9 +521,20 @@ pub fn compute_anonymous_identifiers(
     )
 }
 
-pub fn compute_anonymous_identifiers_with_provider_configs(
+#[cfg(test)]
+pub fn compute_anonymous_identifiers_for_test(
     resources: &mut [Resource],
     providers: &[ProviderConfig],
+    registry: &SchemaRegistry,
+    identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+) -> Result<(), String> {
+    let providers = CanonicalizedProviderConfigs::from_configs_for_test(providers.to_vec());
+    compute_anonymous_identifiers(resources, &providers, registry, identity_attributes_fn)
+}
+
+pub fn compute_anonymous_identifiers_with_provider_configs(
+    resources: &mut [Resource],
+    providers: &CanonicalizedProviderConfigs,
     registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> Result<(), String> {
@@ -548,7 +565,11 @@ pub fn compute_anonymous_identifiers_with_provider_configs(
         // Collect identity attribute values (e.g., region) from provider config
         let mut identity_values: BTreeMap<String, String> = BTreeMap::new();
         let identity_attrs = identity_attributes_fn(provider_name);
-        if let Some(pc) = providers.iter().find(|p| p.name == *provider_name) {
+        if let Some(pc) = providers
+            .as_slice()
+            .iter()
+            .find(|p| p.name == *provider_name)
+        {
             for attr_name in &identity_attrs {
                 if let Some(value) = pc.attributes.get(attr_name.as_str()) {
                     identity_values.insert(
@@ -685,6 +706,22 @@ pub fn compute_anonymous_identifiers_with_provider_configs(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+pub fn compute_anonymous_identifiers_with_provider_configs_for_test(
+    resources: &mut [Resource],
+    providers: &[ProviderConfig],
+    registry: &SchemaRegistry,
+    identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+) -> Result<(), String> {
+    let providers = CanonicalizedProviderConfigs::from_configs_for_test(providers.to_vec());
+    compute_anonymous_identifiers_with_provider_configs(
+        resources,
+        &providers,
+        registry,
+        identity_attributes_fn,
+    )
 }
 
 /// State information needed for anonymous identifier reconciliation.
@@ -926,7 +963,7 @@ pub fn detect_anonymous_to_named_renames(
     resources: &[Resource],
     registry: &SchemaRegistry,
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
-    providers: &[ProviderConfig],
+    providers: &CanonicalizedProviderConfigs,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> Vec<(ResourceId, ResourceId)> {
     // Collect the set of resource names currently used in the DSL per
@@ -1040,6 +1077,24 @@ pub fn detect_anonymous_to_named_renames(
     }
 
     renames
+}
+
+#[cfg(test)]
+pub fn detect_anonymous_to_named_renames_for_test(
+    resources: &[Resource],
+    registry: &SchemaRegistry,
+    find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
+    providers: &[ProviderConfig],
+    identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+) -> Vec<(ResourceId, ResourceId)> {
+    let providers = CanonicalizedProviderConfigs::from_configs_for_test(providers.to_vec());
+    detect_anonymous_to_named_renames(
+        resources,
+        registry,
+        find_state_by_type,
+        &providers,
+        identity_attributes_fn,
+    )
 }
 
 #[cfg(test)]

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 #[cfg(test)]
 use crate::parser::ProviderConfig;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, Value};
-use crate::schema::{AttributeType, ResourceSchema, SchemaRegistry};
+use crate::schema::{AttributeType, SchemaRegistry};
 use crate::validation::is_string_compatible_type;
 use crate::value::CanonicalizedProviderConfigs;
 
@@ -238,30 +238,12 @@ fn deterministic_value_string(value: &Value) -> String {
     }
 }
 
-/// Return the anonymous-hash feature string for an already canonicalized value.
-///
-/// `CanonicalEnum` values hash by provider API text. Raw enum identifiers are
-/// intentionally not schema-resolved here; callers must canonicalize at schema
-/// boundaries before durable identity generation.
-pub(crate) fn canonical_enum_feature_string(
-    value: &Value,
-    _attribute_type: Option<&AttributeType>,
-) -> String {
-    if let Value::Concrete(ConcreteValue::CanonicalEnum(c)) = value {
-        format!("EnumApiValue({:?})", c.api_value())
-    } else {
-        deterministic_value_string(value)
-    }
-}
-
 fn canonical_create_only_value_string(
     value: &Value,
     attribute_type: Option<&AttributeType>,
 ) -> Option<String> {
     match value {
-        Value::Concrete(ConcreteValue::String(s)) => {
-            Some(canonical_create_only_text_string(s, attribute_type))
-        }
+        Value::Concrete(ConcreteValue::String(s)) => Some(s.to_string()),
         Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => Some(raw.as_str().to_string()),
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
             Some(format!("EnumApiValue({:?})", c.api_value()))
@@ -309,14 +291,7 @@ fn canonical_create_only_feature_string(
     attribute_type: Option<&AttributeType>,
 ) -> String {
     canonical_create_only_value_string(value, attribute_type)
-        .unwrap_or_else(|| canonical_enum_feature_string(value, attribute_type))
-}
-
-fn canonical_create_only_text_string(
-    value: &str,
-    _attribute_type: Option<&AttributeType>,
-) -> String {
-    value.to_string()
+        .unwrap_or_else(|| deterministic_value_string(value))
 }
 
 /// Convert a persisted state JSON create-only attribute into the same canonical
@@ -380,26 +355,22 @@ pub(crate) fn flatten_value_for_simhash(
     prefix: &str,
     value: &Value,
     out: &mut std::collections::BTreeMap<String, String>,
-    attribute_type: Option<&AttributeType>,
 ) {
     match value {
         Value::Concrete(ConcreteValue::Map(map)) => {
             for (k, v) in map {
                 let key = format!("{}.{}", prefix, k);
-                flatten_value_for_simhash(&key, v, out, None);
+                flatten_value_for_simhash(&key, v, out);
             }
         }
         Value::Concrete(ConcreteValue::List(items)) => {
             for (i, item) in items.iter().enumerate() {
                 let key = format!("{}[{}]", prefix, i);
-                flatten_value_for_simhash(&key, item, out, None);
+                flatten_value_for_simhash(&key, item, out);
             }
         }
         _ => {
-            out.insert(
-                prefix.to_string(),
-                canonical_enum_feature_string(value, attribute_type),
-            );
+            out.insert(prefix.to_string(), deterministic_value_string(value));
         }
     }
 }
@@ -453,34 +424,29 @@ pub(crate) fn extract_hash_from_identifier(identifier: &str) -> Option<u64> {
 /// Build a SimHash over the combined set of provider identity values plus
 /// a resource's user-specified attributes (non-`_`-prefixed, flattened).
 ///
-/// This is the shared feature set used by both `compute_anonymous_identifiers`
+/// This is the shared feature set used by both anonymous identifier computation
 /// (when the schema has no create-only attributes) and `compute_resource_simhash`
 /// so the two always agree on what a resource's anonymous ID would be.
 fn simhash_from_identity_and_resource(
     identity_values: &BTreeMap<String, String>,
     resource: &Resource,
-    schema: Option<&ResourceSchema>,
 ) -> u64 {
     let mut simhash_values = identity_values.clone();
     for (key, value) in &resource.attributes {
         if key.starts_with('_') {
             continue;
         }
-        let attribute_type = schema
-            .and_then(|schema| schema.attributes.get(key))
-            .map(|attr| &attr.attr_type);
-        flatten_value_for_simhash(key, value, &mut simhash_values, attribute_type);
+        flatten_value_for_simhash(key, value, &mut simhash_values);
     }
     compute_simhash(&simhash_values)
 }
 
-/// Compute the SimHash `compute_anonymous_identifiers` would produce for a
+/// Compute the SimHash anonymous identifier generation would produce for a
 /// single resource. Used by `detect_anonymous_to_named_renames` to recover the
 /// anonymous ID of a resource that has since been wrapped in a `let` binding.
 fn compute_resource_simhash(
     resource: &Resource,
     providers: &CanonicalizedProviderConfigs,
-    registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> u64 {
     let mut identity_values: BTreeMap<String, String> = BTreeMap::new();
@@ -499,26 +465,7 @@ fn compute_resource_simhash(
         }
     }
 
-    simhash_from_identity_and_resource(&identity_values, resource, registry.get_for(resource))
-}
-
-/// Compute stable identifiers for anonymous resources (those with empty ResourceId.name).
-/// Uses create-only properties and provider identity attributes to generate a deterministic hash.
-///
-/// `identity_attributes_fn` takes a provider name and returns the list of identity attribute names
-/// for that provider (e.g., `["region"]`).
-pub fn compute_anonymous_identifiers(
-    resources: &mut [Resource],
-    providers: &CanonicalizedProviderConfigs,
-    registry: &SchemaRegistry,
-    identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
-) -> Result<(), String> {
-    compute_anonymous_identifiers_with_provider_configs(
-        resources,
-        providers,
-        registry,
-        identity_attributes_fn,
-    )
+    simhash_from_identity_and_resource(&identity_values, resource)
 }
 
 #[cfg(test)]
@@ -529,9 +476,19 @@ pub fn compute_anonymous_identifiers_for_test(
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> Result<(), String> {
     let providers = CanonicalizedProviderConfigs::from_configs_for_test(providers.to_vec());
-    compute_anonymous_identifiers(resources, &providers, registry, identity_attributes_fn)
+    compute_anonymous_identifiers_with_provider_configs(
+        resources,
+        &providers,
+        registry,
+        identity_attributes_fn,
+    )
 }
 
+/// Compute stable identifiers for anonymous resources (those with empty ResourceId.name).
+/// Uses create-only properties and provider identity attributes to generate a deterministic hash.
+///
+/// `identity_attributes_fn` takes a provider name and returns the list of identity attribute names
+/// for that provider (e.g., `["region"]`).
 pub fn compute_anonymous_identifiers_with_provider_configs(
     resources: &mut [Resource],
     providers: &CanonicalizedProviderConfigs,
@@ -572,10 +529,7 @@ pub fn compute_anonymous_identifiers_with_provider_configs(
         {
             for attr_name in &identity_attrs {
                 if let Some(value) = pc.attributes.get(attr_name.as_str()) {
-                    identity_values.insert(
-                        attr_name.clone(),
-                        canonical_enum_feature_string(value, None),
-                    );
+                    identity_values.insert(attr_name.clone(), deterministic_value_string(value));
                 }
             }
         }
@@ -593,14 +547,7 @@ pub fn compute_anonymous_identifiers_with_provider_configs(
                 // Use the prefix for hashing to produce a stable identifier
                 hash_values.insert(attr_name, format!("Prefix({:?})", prefix));
             } else if let Some(value) = resource.get_attr(attr_name) {
-                let attribute_type = schema
-                    .attributes
-                    .get(*attr_name)
-                    .map(|attr| &attr.attr_type);
-                hash_values.insert(
-                    attr_name,
-                    canonical_enum_feature_string(value, attribute_type),
-                );
+                hash_values.insert(attr_name, deterministic_value_string(value));
             }
         }
         // Also include schema-level identity attributes in the hash.
@@ -610,14 +557,7 @@ pub fn compute_anonymous_identifiers_with_provider_configs(
             if !hash_values.contains_key(attr_name)
                 && let Some(value) = resource.get_attr(attr_name)
             {
-                let attribute_type = schema
-                    .attributes
-                    .get(*attr_name)
-                    .map(|attr| &attr.attr_type);
-                hash_values.insert(
-                    attr_name,
-                    canonical_enum_feature_string(value, attribute_type),
-                );
+                hash_values.insert(attr_name, deterministic_value_string(value));
             }
         }
 
@@ -626,8 +566,7 @@ pub fn compute_anonymous_identifiers_with_provider_configs(
         let hash_str = if use_simhash {
             // Use SimHash for locality-sensitive hashing: similar inputs produce
             // similar hashes, enabling Hamming distance reconciliation.
-            let simhash =
-                simhash_from_identity_and_resource(&identity_values, resource, Some(schema));
+            let simhash = simhash_from_identity_and_resource(&identity_values, resource);
             format!("{:016x}", simhash)
         } else {
             // Use standard hash for create-only properties
@@ -891,9 +830,7 @@ pub fn reconcile_anonymous_identifiers(
             let mut mismatched = 0;
             for (attr, value) in &resource_co_values {
                 if let Some(state_value) = entry.create_only_values.get(*attr) {
-                    let attribute_type = schema.attributes.get(*attr).map(|attr| &attr.attr_type);
-                    let state_value =
-                        canonical_create_only_text_string(state_value, attribute_type);
+                    let state_value = state_value.to_string();
                     if &state_value == value {
                         matched += 1;
                     } else {
@@ -1050,7 +987,7 @@ pub fn detect_anonymous_to_named_renames(
             // SimHash fallback (rule 4 in the function doc). Pick the orphan
             // entry closest to the computed SimHash; tie → ambiguous, skip.
             let resource_hash =
-                compute_resource_simhash(resource, providers, registry, identity_attributes_fn);
+                compute_resource_simhash(resource, providers, identity_attributes_fn);
             let candidates = state_entries
                 .iter()
                 .filter(|e| !used_in_dsl.contains(&e.name))

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -153,7 +153,7 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
         resource
     };
 
-    let mut providers_awscc = vec![provider_config(
+    let providers_awscc = vec![provider_config(
         "awscc",
         vec![(
             "region",
@@ -162,7 +162,7 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
             )),
         )],
     )];
-    let mut providers_aws = vec![provider_config(
+    let providers_aws = vec![provider_config(
         "awscc",
         vec![(
             "region",
@@ -171,12 +171,12 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
             )),
         )],
     )];
-    crate::value::canonicalize_provider_configs_with_attribute_types(
-        &mut providers_awscc,
+    let providers_awscc = crate::value::canonicalize_provider_configs_with_attribute_types(
+        &providers_awscc,
         &|provider, attr| (provider == "awscc" && attr == "region").then(|| region_type("awscc")),
     );
-    crate::value::canonicalize_provider_configs_with_attribute_types(
-        &mut providers_aws,
+    let providers_aws = crate::value::canonicalize_provider_configs_with_attribute_types(
+        &providers_aws,
         &|provider, attr| (provider == "awscc" && attr == "region").then(|| region_type("awscc")),
     );
 
@@ -230,9 +230,15 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_attribute() {
 
     let mut resources_awscc = vec![make_resource("awscc.ec2.Eip.Domain.vpc")];
     let mut resources_aws = vec![make_resource("aws.ec2.Eip.Domain.vpc")];
-    compute_anonymous_identifiers(&mut resources_awscc, &providers, &schemas, &identity_fn)
+    compute_anonymous_identifiers_for_test(
+        &mut resources_awscc,
+        &providers,
+        &schemas,
+        &identity_fn,
+    )
+    .unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources_aws, &providers, &schemas, &identity_fn)
         .unwrap();
-    compute_anonymous_identifiers(&mut resources_aws, &providers, &schemas, &identity_fn).unwrap();
 
     assert_eq!(
         resources_awscc[0].id.name_str(),
@@ -275,9 +281,15 @@ fn test_anonymous_id_stable_for_nested_canonical_enum_create_only_values() {
 
     let mut resources_awscc = vec![make_resource("awscc", "awscc.ec2.Eip.Domain.vpc")];
     let mut resources_aws = vec![make_resource("aws", "aws.ec2.Eip.Domain.vpc")];
-    compute_anonymous_identifiers(&mut resources_awscc, &providers, &schemas, &identity_fn)
+    compute_anonymous_identifiers_for_test(
+        &mut resources_awscc,
+        &providers,
+        &schemas,
+        &identity_fn,
+    )
+    .unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources_aws, &providers, &schemas, &identity_fn)
         .unwrap();
-    compute_anonymous_identifiers(&mut resources_aws, &providers, &schemas, &identity_fn).unwrap();
 
     assert_eq!(
         resources_awscc[0].id.name_str(),
@@ -316,12 +328,18 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
     };
 
     let mut old_resources = vec![make_resource("awscc.ec2.Eip.Domain.vpc", "pool-a")];
-    compute_anonymous_identifiers(&mut old_resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
+        .unwrap();
     let state_name = old_resources[0].id.name_str().to_string();
 
     let mut desired_resources = vec![make_resource("aws.ec2.Eip.Domain.vpc", "pool-b")];
-    compute_anonymous_identifiers(&mut desired_resources, &providers, &schemas, &identity_fn)
-        .unwrap();
+    compute_anonymous_identifiers_for_test(
+        &mut desired_resources,
+        &providers,
+        &schemas,
+        &identity_fn,
+    )
+    .unwrap();
     assert_ne!(state_name, desired_resources[0].id.name_str());
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -387,12 +405,18 @@ fn test_reconcile_anonymous_id_after_nested_enum_create_only_hash_migration() {
     };
 
     let mut old_resources = vec![make_old_resource("pool-a")];
-    compute_anonymous_identifiers(&mut old_resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
+        .unwrap();
     let state_name = old_resources[0].id.name_str().to_string();
 
     let mut desired_resources = vec![make_new_resource("pool-b")];
-    compute_anonymous_identifiers(&mut desired_resources, &providers, &schemas, &identity_fn)
-        .unwrap();
+    compute_anonymous_identifiers_for_test(
+        &mut desired_resources,
+        &providers,
+        &schemas,
+        &identity_fn,
+    )
+    .unwrap();
     assert_ne!(state_name, desired_resources[0].id.name_str());
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -461,12 +485,18 @@ fn test_reconcile_anonymous_id_after_nested_enum_no_edit_upgrade_full_match() {
     };
 
     let mut old_resources = vec![make_old_resource()];
-    compute_anonymous_identifiers(&mut old_resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
+        .unwrap();
     let state_name = old_resources[0].id.name_str().to_string();
 
     let mut desired_resources = vec![make_new_resource()];
-    compute_anonymous_identifiers(&mut desired_resources, &providers, &schemas, &identity_fn)
-        .unwrap();
+    compute_anonymous_identifiers_for_test(
+        &mut desired_resources,
+        &providers,
+        &schemas,
+        &identity_fn,
+    )
+    .unwrap();
     assert_ne!(state_name, desired_resources[0].id.name_str());
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -795,7 +825,8 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
         Value::Concrete(ConcreteValue::String("/".to_string())),
     );
     let mut resources1 = vec![r1];
-    compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources1, &providers, &schemas, &identity_fn)
+        .unwrap();
     let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with path="/carina/" (changed create-only)
@@ -809,7 +840,8 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
         Value::Concrete(ConcreteValue::String("/carina/".to_string())),
     );
     let mut resources2 = vec![r2];
-    compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources2, &providers, &schemas, &identity_fn)
+        .unwrap();
     let step2_id = resources2[0].id.name_str().to_string();
 
     // Hash includes path, so identifiers differ
@@ -986,7 +1018,8 @@ fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
     });
 
     let mut resources = vec![r];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
 
     let name = resources[0].id.name_str();
     assert!(
@@ -1037,7 +1070,8 @@ fn test_anonymous_resource_no_create_only_properties() {
     );
 
     let mut resources = vec![r];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
 
     // Should have computed an identifier
     assert!(!resources[0].id.name_str().is_empty());
@@ -1080,8 +1114,10 @@ fn test_anonymous_resource_no_create_only_deterministic() {
 
     let mut resources1 = vec![make_resource()];
     let mut resources2 = vec![make_resource()];
-    compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
-    compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources1, &providers, &schemas, &identity_fn)
+        .unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources2, &providers, &schemas, &identity_fn)
+        .unwrap();
 
     assert_eq!(resources1[0].id.name_str(), resources2[0].id.name_str());
 }
@@ -1119,7 +1155,8 @@ fn test_anonymous_resource_no_create_only_collision() {
     );
 
     let mut resources = vec![r1, r2];
-    let result = compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn);
+    let result =
+        compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn);
 
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("collision"));
@@ -1184,7 +1221,7 @@ fn test_identity_attribute_prevents_collision() {
     );
 
     let mut resources = vec![r1, r2];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn)
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .expect("should not collide when identity attrs differ");
 
     // Both should have identifiers assigned
@@ -1209,7 +1246,7 @@ fn test_reconcile_anonymous_id_full_match_claims_state_entry_once() {
         route53_record_set_resource("A"),
         route53_record_set_resource("AAAA"),
     ];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn)
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .expect("identity attrs should produce distinct Route53 record identifiers");
 
     let old_state_name = "route53_record_set_11223344";
@@ -1244,7 +1281,7 @@ fn test_reconcile_anonymous_id_full_match_does_not_steal_live_entry() {
         route53_record_set_resource("A"),
         route53_record_set_resource("AAAA"),
     ];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn)
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .expect("identity attrs should produce distinct Route53 record identifiers");
 
     let live_a_name = resources[0].id.name_str().to_string();
@@ -1366,7 +1403,8 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         Value::Concrete(ConcreteValue::String("production".to_string())),
     );
     let mut resources1 = vec![r1];
-    compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources1, &providers, &schemas, &identity_fn)
+        .unwrap();
     let old_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with tag_env="staging" (one attribute changed)
@@ -1384,7 +1422,8 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         Value::Concrete(ConcreteValue::String("staging".to_string())),
     );
     let mut resources2 = vec![r2];
-    compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources2, &providers, &schemas, &identity_fn)
+        .unwrap();
     let new_id = resources2[0].id.name_str().to_string();
 
     // Identifiers should differ (different attributes)
@@ -1420,7 +1459,8 @@ fn test_reconcile_anonymous_id_simhash_does_not_steal_live_entry() {
         simhash_eip_resource("production"),
         simhash_eip_resource("staging"),
     ];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
     let live_name = resources[0].id.name_str().to_string();
     let new_name = resources[1].id.name_str().to_string();
 
@@ -1448,7 +1488,8 @@ fn test_reconcile_anonymous_id_simhash_claims_state_entry_once() {
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
     let mut old_resources = vec![simhash_eip_resource("production")];
-    compute_anonymous_identifiers(&mut old_resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
+        .unwrap();
     let old_name = old_resources[0].id.name_str().to_string();
     let old_hash = extract_hash_from_identifier(&old_name).unwrap();
 
@@ -1463,7 +1504,8 @@ fn test_reconcile_anonymous_id_simhash_claims_state_entry_once() {
         "canary",
     ] {
         let mut candidate = vec![simhash_eip_resource(tag_env)];
-        compute_anonymous_identifiers(&mut candidate, &providers, &schemas, &identity_fn).unwrap();
+        compute_anonymous_identifiers_for_test(&mut candidate, &providers, &schemas, &identity_fn)
+            .unwrap();
         let candidate_hash = extract_hash_from_identifier(candidate[0].id.name_str()).unwrap();
         if candidate[0].id.name_str() != old_name
             && (old_hash ^ candidate_hash).count_ones() < SIMHASH_HAMMING_THRESHOLD
@@ -1558,7 +1600,8 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
     );
     let mut resources = vec![r1];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
 
     // Should have computed an identifier (not errored)
     assert!(!resources[0].id.name_str().is_empty());
@@ -1762,19 +1805,30 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
 
     // Original: env=prod, team=infra
     let mut resources_orig = vec![make_resource("production", "infra")];
-    compute_anonymous_identifiers(&mut resources_orig, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources_orig, &providers, &schemas, &identity_fn)
+        .unwrap();
     let orig_id = resources_orig[0].id.name_str().to_string();
 
     // Distant: env=dev, team=frontend (2 attrs changed)
     let mut resources_distant = vec![make_resource("development", "frontend")];
-    compute_anonymous_identifiers(&mut resources_distant, &providers, &schemas, &identity_fn)
-        .unwrap();
+    compute_anonymous_identifiers_for_test(
+        &mut resources_distant,
+        &providers,
+        &schemas,
+        &identity_fn,
+    )
+    .unwrap();
     let distant_id = resources_distant[0].id.name_str().to_string();
 
     // Current: env=staging, team=infra (1 attr changed from orig)
     let mut resources_current = vec![make_resource("staging", "infra")];
-    compute_anonymous_identifiers(&mut resources_current, &providers, &schemas, &identity_fn)
-        .unwrap();
+    compute_anonymous_identifiers_for_test(
+        &mut resources_current,
+        &providers,
+        &schemas,
+        &identity_fn,
+    )
+    .unwrap();
 
     // State has both orig and distant entries
     let state_entries = vec![
@@ -1854,7 +1908,8 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
     );
     let mut resources = vec![r];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
     let id = resources[0].id.name_str().to_string();
 
     // State has the exact same identifier
@@ -1933,8 +1988,8 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
 
     let mut r1 = vec![make_resource("production")];
     let mut r2 = vec![make_resource("staging")];
-    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &identity_fn).unwrap();
-    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut r1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut r2, &providers, &schemas, &identity_fn).unwrap();
 
     // Different identifiers
     assert_ne!(r1[0].id.name_str(), r2[0].id.name_str());
@@ -1998,7 +2053,8 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
     );
 
     let mut resources = vec![vpc, eip];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
 
     // Both should have identifiers computed
     assert!(resources[0].id.name_str().starts_with("awscc_ec2_vpc_"));
@@ -2091,8 +2147,8 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
 
     let mut r1 = vec![make_resource("my-app-abc12345")];
     let mut r2 = vec![make_resource("my-app-xyz98765")];
-    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &identity_fn).unwrap();
-    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut r1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut r2, &providers, &schemas, &identity_fn).unwrap();
 
     // Same prefix should produce the same anonymous identifier
     assert_eq!(
@@ -2135,8 +2191,8 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
 
     let mut r1 = vec![make_resource("app-a-", "app-a-abc12345")];
     let mut r2 = vec![make_resource("app-b-", "app-b-xyz98765")];
-    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &identity_fn).unwrap();
-    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut r1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut r2, &providers, &schemas, &identity_fn).unwrap();
 
     // Different prefixes should produce different identifiers
     assert_ne!(
@@ -2334,7 +2390,8 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     );
 
     let mut resources1 = vec![r1];
-    compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources1, &providers, &schemas, &identity_fn)
+        .unwrap();
     let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: Change tag Environment=staging (only tags changed)
@@ -2358,7 +2415,8 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     );
 
     let mut resources2 = vec![r2];
-    compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources2, &providers, &schemas, &identity_fn)
+        .unwrap();
     let step2_id = resources2[0].id.name_str().to_string();
 
     // Identifiers should differ (different tag values)
@@ -2509,7 +2567,7 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
             .collect(),
     }];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2542,7 +2600,7 @@ fn test_detect_rename_skips_when_binding_already_in_state() {
             .collect(),
     }];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2572,7 +2630,7 @@ fn test_detect_rename_ignores_anonymous_resources() {
             .collect(),
     }];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2610,7 +2668,7 @@ fn test_detect_rename_skips_ambiguous_matches() {
         },
     ];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2641,7 +2699,7 @@ fn test_detect_rename_ignores_non_hash_state_names() {
             .collect(),
     }];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2679,7 +2737,8 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
     );
     let mut anon_vec = vec![anon];
-    compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut anon_vec, &providers, &schemas, &identity_fn)
+        .unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
     assert!(
         anonymous_name.starts_with("awscc_sso_instance_"),
@@ -2702,7 +2761,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     }];
 
     // Step 4: detect_anonymous_to_named_renames should match via SimHash.
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2745,7 +2804,8 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
         Value::Concrete(ConcreteValue::Map(tags)),
     );
     let mut anon_vec = vec![anon];
-    compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut anon_vec, &providers, &schemas, &identity_fn)
+        .unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
 
     // Let-bound resource with wildly different attributes.
@@ -2779,7 +2839,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
         create_only_values: HashMap::new(),
     }];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2809,7 +2869,8 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
     );
     let mut anon_vec = vec![anon];
-    compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut anon_vec, &providers, &schemas, &identity_fn)
+        .unwrap();
     let exact_name = anon_vec[0].id.name_str().to_string();
 
     // Construct a "close but not equal" orphan by flipping the last hex
@@ -2842,7 +2903,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
     );
     let resources = vec![let_bound];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2881,7 +2942,7 @@ fn test_detect_rename_no_create_only_skips_8_char_hash_entries() {
         create_only_values: HashMap::new(),
     }];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2910,7 +2971,8 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
         Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
     );
     let mut anon_vec = vec![anon];
-    compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut anon_vec, &providers, &schemas, &identity_fn)
+        .unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
 
     // Two state entries with the exact same name hash → same distance (0).
@@ -2933,7 +2995,7 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
     );
     let resources = vec![let_bound];
 
-    let renames = detect_anonymous_to_named_renames(
+    let renames = detect_anonymous_to_named_renames_for_test(
         &resources,
         &schemas,
         &|_provider, _rt| state_entries.clone(),
@@ -2972,7 +3034,8 @@ fn anonymous_identifier_includes_provider_prefix() {
         Value::Concrete(ConcreteValue::String("foo".to_string())),
     );
     let mut resources = vec![r];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
 
     let name = resources[0].id.name_str();
     assert!(
@@ -3010,7 +3073,8 @@ fn anonymous_identifier_provider_prefix_for_aws_provider() {
         Value::Concrete(ConcreteValue::String("example".to_string())),
     );
     let mut resources = vec![r];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
     assert!(
         resources[0].id.name_str().starts_with("aws_s3_bucket_"),
         "identifier should begin with `aws_s3_bucket_`, got: {}",
@@ -3046,7 +3110,8 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
         Value::Concrete(ConcreteValue::String("inline".to_string())),
     );
     let mut resources = vec![r];
-    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
+        .unwrap();
     let new_name = resources[0].id.name_str().to_string();
     assert!(new_name.starts_with("awscc_iam_role_policy_"));
 

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -53,6 +53,13 @@ fn eip_domain_type(provider: &str) -> AttributeType {
     )
 }
 
+fn canonical_eip_domain(provider: &str, raw: &str) -> crate::resource::CanonicalEnumValue {
+    let attr_type = eip_domain_type(provider);
+    crate::resource::EnumValueResolver::new(&attr_type)
+        .resolve_raw(&crate::resource::RawEnumIdentifier::parse(raw))
+        .unwrap()
+}
+
 fn route53_record_set_schema() -> ResourceSchema {
     ResourceSchema::new("route53.record_set")
         .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
@@ -132,9 +139,6 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", schema);
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
-    let provider_attr_type = |provider: &str, attr: &str| {
-        (provider == "awscc" && attr == "region").then(|| region_type("awscc"))
-    };
 
     let make_resource = || {
         let mut resource = Resource::with_provider("awscc", "ec2.Route", "", None);
@@ -149,7 +153,7 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
         resource
     };
 
-    let providers_awscc = vec![provider_config(
+    let mut providers_awscc = vec![provider_config(
         "awscc",
         vec![(
             "region",
@@ -158,7 +162,7 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
             )),
         )],
     )];
-    let providers_aws = vec![provider_config(
+    let mut providers_aws = vec![provider_config(
         "awscc",
         vec![(
             "region",
@@ -167,23 +171,29 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
             )),
         )],
     )];
+    crate::value::canonicalize_provider_configs_with_attribute_types(
+        &mut providers_awscc,
+        &|provider, attr| (provider == "awscc" && attr == "region").then(|| region_type("awscc")),
+    );
+    crate::value::canonicalize_provider_configs_with_attribute_types(
+        &mut providers_aws,
+        &|provider, attr| (provider == "awscc" && attr == "region").then(|| region_type("awscc")),
+    );
 
     let mut resources_awscc = vec![make_resource()];
     let mut resources_aws = vec![make_resource()];
-    compute_anonymous_identifiers_with_provider_config_types(
+    compute_anonymous_identifiers_with_provider_configs(
         &mut resources_awscc,
         &providers_awscc,
         &schemas,
         &identity_fn,
-        &provider_attr_type,
     )
     .unwrap();
-    compute_anonymous_identifiers_with_provider_config_types(
+    compute_anonymous_identifiers_with_provider_configs(
         &mut resources_aws,
         &providers_aws,
         &schemas,
         &identity_fn,
-        &provider_attr_type,
     )
     .unwrap();
 
@@ -206,7 +216,14 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_attribute() {
         let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
         resource.set_attr(
             "domain".to_string(),
-            Value::Concrete(ConcreteValue::enum_identifier(domain.to_string())),
+            Value::Concrete(ConcreteValue::CanonicalEnum(canonical_eip_domain(
+                if domain.starts_with("awscc.") {
+                    "awscc"
+                } else {
+                    "aws"
+                },
+                domain,
+            ))),
         );
         resource
     };
@@ -238,14 +255,10 @@ fn test_anonymous_id_stable_for_nested_canonical_enum_create_only_values() {
     let providers = vec![provider_config("awscc", vec![])];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
-    let canonical = |provider: &str, raw: &str| {
-        let attr_type = eip_domain_type(provider);
-        crate::resource::EnumValueResolver::new(&attr_type)
-            .resolve_raw(&crate::resource::RawEnumIdentifier::parse(raw))
-            .unwrap()
-    };
     let make_resource = |provider: &str, raw: &str| {
-        let enum_value = Value::Concrete(ConcreteValue::CanonicalEnum(canonical(provider, raw)));
+        let enum_value = Value::Concrete(ConcreteValue::CanonicalEnum(canonical_eip_domain(
+            provider, raw,
+        )));
         let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
         resource.set_attr(
             "domains".to_string(),
@@ -286,7 +299,14 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
         let mut resource = Resource::with_provider("awscc", "ec2.Eip", "", None);
         resource.set_attr(
             "domain".to_string(),
-            Value::Concrete(ConcreteValue::enum_identifier(domain.to_string())),
+            Value::Concrete(ConcreteValue::CanonicalEnum(canonical_eip_domain(
+                if domain.starts_with("awscc.") {
+                    "awscc"
+                } else {
+                    "aws"
+                },
+                domain,
+            ))),
         );
         resource.set_attr(
             "public_ipv4_pool".to_string(),
@@ -307,7 +327,7 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
     let state_entries = vec![AnonymousIdStateInfo {
         name: state_name.clone(),
         create_only_values: vec![
-            ("domain".to_string(), "awscc.ec2.Eip.Domain.vpc".to_string()),
+            ("domain".to_string(), "EnumApiValue(\"vpc\")".to_string()),
             ("public_ipv4_pool".to_string(), "pool-a".to_string()),
         ]
         .into_iter()

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -128,6 +128,7 @@ fn format_value(value: &Value) -> String {
         Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
             // Enum identifiers render unquoted to match how the user
             // typed them.
+            let s = s.as_str();
             if s.len() > 50 {
                 format!("{}...", &s[..47])
             } else {

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -979,7 +979,7 @@ pub fn instance_prefix_for_call(call: &ModuleCall) -> String {
     let mut features: BTreeMap<String, String> = BTreeMap::new();
     features.insert("_module".to_string(), call.module_name.clone());
     for (k, v) in &call.arguments {
-        crate::identifier::flatten_value_for_simhash(k, v, &mut features, None);
+        crate::identifier::flatten_value_for_simhash(k, v, &mut features);
     }
     let simhash = crate::identifier::compute_simhash(&features);
     format!("{}_{:016x}", call.module_name, simhash)

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -396,6 +396,7 @@ pub(crate) fn parse_for_expr(
                     format!("string \"{}\"", if s.len() > 50 { &s[..50] } else { s })
                 }
                 Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
+                    let s = s.as_str();
                     format!("identifier `{}`", if s.len() > 50 { &s[..50] } else { s })
                 }
                 Value::Concrete(ConcreteValue::Int(i)) => format!("int {}", i),

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -498,7 +498,7 @@ fn collect_reference_roots(
             // fallback (`EnumIdentifier("B.attr")`) both appear before the parser
             // classifies the RHS as a binding ref or resource ref.
             push_root(name.as_str(), variables, structural, roots);
-            if let Some((root, _)) = name.split_once('.') {
+            if let Some((root, _)) = name.as_str().split_once('.') {
                 push_root(root, variables, structural, roots);
             }
         }

--- a/carina-core/src/resource/enum_value.rs
+++ b/carina-core/src/resource/enum_value.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::ops::Deref;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -83,9 +82,10 @@ impl RawEnumIdentifier {
         &self.parsed
     }
 
-    /// TODO(carina#3438): remove in chain PR 5.
-    /// Temporary accessor for call sites that still consume enum identifiers
-    /// as parser-surface strings during the PR chain.
+    /// Parser-surface text for display, formatter, and diagnostics paths.
+    ///
+    /// Do not use this for durable identity comparison; use schema-resolved
+    /// [`CanonicalEnumValue`] instead.
     pub fn as_str(&self) -> &str {
         &self.text
     }
@@ -103,27 +103,9 @@ impl fmt::Debug for RawEnumIdentifier {
     }
 }
 
-// TODO(carina#3438): remove in chain PR 5.
-// Temporary string-like shim for existing display/formatter call sites.
-impl Deref for RawEnumIdentifier {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        self.as_str()
-    }
-}
-
 impl PartialEq for RawEnumIdentifier {
     fn eq(&self, other: &Self) -> bool {
         self.text == other.text
-    }
-}
-
-// TODO(carina#3438): remove in chain PR 5.
-// Temporary equality shim preserving old String/EnumIdentifier comparisons.
-impl PartialEq<RawEnumIdentifier> for String {
-    fn eq(&self, other: &RawEnumIdentifier) -> bool {
-        *self == other.text
     }
 }
 
@@ -289,12 +271,12 @@ impl<'a> EnumValueResolver<'a> {
         }
 
         let api_value = match phase {
-            EnumInputPhase::RawDsl => dsl_map.api_for_hash_feature(&variant),
+            EnumInputPhase::RawDsl => dsl_map.api_for(&variant),
             EnumInputPhase::StateText => {
                 if valid.contains(&text) {
                     text.to_string()
                 } else {
-                    dsl_map.api_for_hash_feature(&variant)
+                    dsl_map.api_for(&variant)
                 }
             }
         };

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -715,9 +715,10 @@ impl<'a> ConcreteValueRef<'a> {
 }
 
 impl ConcreteValue {
-    /// TODO(carina#3438): remove in chain PR 5.
-    /// Temporary constructor for call sites that still build parser-surface
-    /// enum identifiers from string text.
+    /// Build a parser-surface enum identifier from source/display text.
+    ///
+    /// This is a raw-value convenience API for parsers and tests. Durable
+    /// identity comparisons must use schema-resolved `CanonicalEnum` values.
     pub fn enum_identifier(text: impl Into<String>) -> Self {
         Self::EnumIdentifier(RawEnumIdentifier::parse(text))
     }
@@ -893,7 +894,7 @@ impl PartialEq for Value {
             (
                 Value::Concrete(ConcreteValue::String(a)),
                 Value::Concrete(ConcreteValue::EnumIdentifier(b)),
-            ) => a == b,
+            ) => a == b.as_str(),
             (
                 Value::Concrete(ConcreteValue::CanonicalEnum(a)),
                 Value::Concrete(ConcreteValue::CanonicalEnum(b)),

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -346,16 +346,6 @@ impl<'a> DslMap<'a> {
         self.aliases
             .iter()
             .find_map(|(a, d)| (d == dsl).then(|| a.clone()))
-            .unwrap_or_else(|| dsl.to_string())
-    }
-
-    /// Translate a DSL spelling back to its API-canonical spelling, using
-    /// inverse transforms for dynamic enum spaces where that inverse is
-    /// lossless enough for identity/hash consumers.
-    pub(crate) fn api_for_hash_feature(&self, dsl: &str) -> String {
-        self.aliases
-            .iter()
-            .find_map(|(a, d)| (d == dsl).then(|| a.clone()))
             .unwrap_or_else(|| match self.to_dsl {
                 Some(DslTransform::HyphenToUnderscore) => dsl.replace('_', "-"),
                 Some(DslTransform::ReplaceTable(table)) => table

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -5373,15 +5373,13 @@ mod dsl_map_api_for {
     }
 
     #[test]
-    fn closure_some_returns_input_unchanged() {
-        // The closure is one-way (api -> dsl); reversing it is not
-        // representable, so `api_for` is documented to return the input
-        // as-is for the Closure variant. Callers that go through a
-        // `Closure` (currently only Region with hyphen↔underscore) must
-        // reverse the mapping themselves.
+    fn transform_reverses_lossless_dsl_spelling() {
+        // HyphenToUnderscore is reversible enough for enum canonicalization:
+        // provider-facing API values use hyphens while DSL spelling uses
+        // underscores.
         let transform = crate::schema::DslTransform::HyphenToUnderscore;
         let map = DslMap::new(&[], Some(&transform));
-        assert_eq!(map.api_for("ap_northeast_1"), "ap_northeast_1");
+        assert_eq!(map.api_for("ap_northeast_1"), "ap-northeast-1");
     }
 
     #[test]

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -1243,7 +1243,7 @@ pub fn extract_region_from_attrs(
     use crate::resource::{ConcreteValue, Value};
     match attributes.get("region") {
         Some(Value::Concrete(ConcreteValue::String(s))) => convert_region_value(s),
-        Some(Value::Concrete(ConcreteValue::EnumIdentifier(s))) => convert_region_value(s),
+        Some(Value::Concrete(ConcreteValue::EnumIdentifier(s))) => convert_region_value(s.as_str()),
         _ => default_region.to_string(),
     }
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1602,6 +1602,27 @@ pub fn canonicalize_resources_with_schemas(
 
 type ProviderConfigAttributeTypeFn<'a> = dyn Fn(&str, &str) -> Option<AttributeType> + 'a;
 
+/// Provider configs whose schema-known attributes have been canonicalized.
+///
+/// Durable identity code accepts this wrapper rather than raw
+/// `ProviderConfig` slices, so callers cannot skip provider config enum
+/// canonicalization at the hash seam.
+#[derive(Debug, Clone)]
+pub struct CanonicalizedProviderConfigs {
+    providers: Vec<crate::parser::ProviderConfig>,
+}
+
+impl CanonicalizedProviderConfigs {
+    pub fn as_slice(&self) -> &[crate::parser::ProviderConfig] {
+        &self.providers
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_configs_for_test(providers: Vec<crate::parser::ProviderConfig>) -> Self {
+        Self { providers }
+    }
+}
+
 fn canonicalize_provider_config_with_type(value: Value, attr_type: &AttributeType) -> Value {
     let defs = crate::schema::empty_defs_for_schema_walks();
     let unwrapped = peel_custom(attr_type);
@@ -1680,9 +1701,10 @@ fn canonicalize_provider_config_with_type(value: Value, attr_type: &AttributeTyp
 /// such as provider identity `region` before those values feed durable
 /// identity hashing.
 pub fn canonicalize_provider_configs_with_attribute_types(
-    providers: &mut [crate::parser::ProviderConfig],
+    providers: &[crate::parser::ProviderConfig],
     provider_config_attribute_type_fn: &ProviderConfigAttributeTypeFn<'_>,
-) {
+) -> CanonicalizedProviderConfigs {
+    let mut providers = providers.to_vec();
     for provider in providers.iter_mut() {
         let mut new_attrs = indexmap::IndexMap::new();
         for (key, value) in std::mem::take(&mut provider.attributes) {
@@ -1694,6 +1716,7 @@ pub fn canonicalize_provider_configs_with_attribute_types(
         }
         provider.attributes = new_attrs;
     }
+    CanonicalizedProviderConfigs { providers }
 }
 
 /// [`DataSource`](crate::resource::DataSource) counterpart of
@@ -2785,7 +2808,7 @@ mod tests {
         use crate::parser::ProviderConfig;
         use crate::schema::{AttributeType, DslTransform, TypeIdentity};
 
-        let mut providers = vec![
+        let providers = vec![
             ProviderConfig {
                 name: "aws".to_string(),
                 attributes: indexmap::indexmap! {
@@ -2818,19 +2841,21 @@ mod tests {
             },
         ];
 
-        canonicalize_provider_configs_with_attribute_types(&mut providers, &|provider, attr| {
-            (attr == "region").then(|| {
-                AttributeType::enum_(
-                    TypeIdentity::new(Some(provider), Vec::<String>::new(), "Region"),
-                    None,
-                    Vec::new(),
-                    None,
-                    Some(DslTransform::HyphenToUnderscore),
-                )
-            })
-        });
+        let providers =
+            canonicalize_provider_configs_with_attribute_types(&providers, &|provider, attr| {
+                (attr == "region").then(|| {
+                    AttributeType::enum_(
+                        TypeIdentity::new(Some(provider), Vec::<String>::new(), "Region"),
+                        None,
+                        Vec::new(),
+                        None,
+                        Some(DslTransform::HyphenToUnderscore),
+                    )
+                })
+            });
 
         let api_values: Vec<_> = providers
+            .as_slice()
             .iter()
             .map(
                 |provider| match provider.attributes.get("region").unwrap() {

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1578,10 +1578,20 @@ fn canonicalize_to_string_list(value: Value) -> Value {
 /// Call this once after `resolver::resolve_refs_*` and before the
 /// differ runs, so every `Resource` flowing into the plan / state /
 /// provider boundary carries the canonical shape. See #2481, #2511.
-pub fn canonicalize_resources_with_schemas(
-    resources: &mut [crate::resource::Resource],
+pub struct CanonicalizedResources<'a> {
+    resources: &'a mut [crate::resource::Resource],
+}
+
+impl<'a> CanonicalizedResources<'a> {
+    pub fn as_mut_slice(&mut self) -> &mut [crate::resource::Resource] {
+        self.resources
+    }
+}
+
+pub fn canonicalize_resources_with_schemas<'a>(
+    resources: &'a mut [crate::resource::Resource],
     registry: &crate::schema::SchemaRegistry,
-) {
+) -> CanonicalizedResources<'a> {
     for resource in resources.iter_mut() {
         let Some(schema) = registry.get_for(resource) else {
             continue;
@@ -1598,6 +1608,8 @@ pub fn canonicalize_resources_with_schemas(
         }
         resource.attributes = new_attrs;
     }
+
+    CanonicalizedResources { resources }
 }
 
 type ProviderConfigAttributeTypeFn<'a> = dyn Fn(&str, &str) -> Option<AttributeType> + 'a;

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1444,6 +1444,21 @@ pub(crate) fn canonicalize_with_type(
     attr_type: &AttributeType,
     defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> Value {
+    canonicalize_with_type_for_enum_phase(value, attr_type, defs, EnumIdentifierPhase::RawDsl)
+}
+
+#[derive(Clone, Copy)]
+enum EnumIdentifierPhase {
+    RawDsl,
+    StateText,
+}
+
+fn canonicalize_with_type_for_enum_phase(
+    value: Value,
+    attr_type: &AttributeType,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
+    enum_identifier_phase: EnumIdentifierPhase,
+) -> Value {
     let unwrapped = peel_custom(attr_type);
     if is_string_or_list_of_strings(unwrapped) {
         return canonicalize_to_string_list(value);
@@ -1464,14 +1479,21 @@ pub(crate) fn canonicalize_with_type(
         ) => {
             let canonicalized = items
                 .into_iter()
-                .map(|v| canonicalize_with_type(v, inner, defs))
+                .map(|v| {
+                    canonicalize_with_type_for_enum_phase(v, inner, defs, enum_identifier_phase)
+                })
                 .collect();
             Value::Concrete(ConcreteValue::List(canonicalized))
         }
         (Value::Concrete(ConcreteValue::Map(map)), crate::schema::Shape::Map { value: vt, .. }) => {
             let canonicalized = map
                 .into_iter()
-                .map(|(k, v)| (k, canonicalize_with_type(v, vt, defs)))
+                .map(|(k, v)| {
+                    (
+                        k,
+                        canonicalize_with_type_for_enum_phase(v, vt, defs, enum_identifier_phase),
+                    )
+                })
                 .collect();
             Value::Concrete(ConcreteValue::Map(canonicalized))
         }
@@ -1486,7 +1508,12 @@ pub(crate) fn canonicalize_with_type(
                         .find(|f| f.name == k || f.provider_name.as_deref() == Some(k.as_str()))
                         .map(|f| &f.field_type);
                     let canon = match field_type {
-                        Some(ft) => canonicalize_with_type(v, ft, defs),
+                        Some(ft) => canonicalize_with_type_for_enum_phase(
+                            v,
+                            ft,
+                            defs,
+                            enum_identifier_phase,
+                        ),
                         None => v,
                     };
                     (k, canon)
@@ -1495,7 +1522,12 @@ pub(crate) fn canonicalize_with_type(
             Value::Concrete(ConcreteValue::Map(canonicalized))
         }
         (Value::Deferred(DeferredValue::Secret(inner)), _) => Value::Deferred(
-            DeferredValue::Secret(Box::new(canonicalize_with_type(*inner, attr_type, defs))),
+            DeferredValue::Secret(Box::new(canonicalize_with_type_for_enum_phase(
+                *inner,
+                attr_type,
+                defs,
+                enum_identifier_phase,
+            ))),
         ),
         // Enum must not fall through to the `(v, _) => v` wildcard.
         // That is the same failure mode as carina#3080's Union gap:
@@ -1504,10 +1536,15 @@ pub(crate) fn canonicalize_with_type(
         (val, crate::schema::Shape::Enum { .. }) => {
             let resolver = crate::resource::EnumValueResolver::with_defs(unwrapped, defs);
             match val {
-                Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => resolver
-                    .resolve_raw(&raw)
-                    .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
-                    .unwrap_or_else(|_| Value::Concrete(ConcreteValue::EnumIdentifier(raw))),
+                Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => {
+                    let resolved = match enum_identifier_phase {
+                        EnumIdentifierPhase::RawDsl => resolver.resolve_raw(&raw),
+                        EnumIdentifierPhase::StateText => resolver.resolve_state_text(raw.as_str()),
+                    };
+                    resolved
+                        .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
+                        .unwrap_or_else(|_| Value::Concrete(ConcreteValue::EnumIdentifier(raw)))
+                }
                 Value::Concrete(ConcreteValue::String(s)) => resolver
                     .resolve_state_text(&s)
                     .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
@@ -1534,7 +1571,9 @@ pub(crate) fn canonicalize_with_type(
             let members = crate::schema::union_members_with_defs(unwrapped, defs)
                 .expect("Shape::Union must expose union members internally");
             match crate::schema::select_union_member(members, &val) {
-                Some(member) => canonicalize_with_type(val, member, defs),
+                Some(member) => {
+                    canonicalize_with_type_for_enum_phase(val, member, defs, enum_identifier_phase)
+                }
                 None => val,
             }
         }
@@ -1569,15 +1608,13 @@ fn canonicalize_to_string_list(value: Value) -> Value {
     }
 }
 
-/// Walk every resource's attributes, canonicalizing values whose
-/// declared schema type is `Union[String, list(String)]` into
-/// `Value::Concrete(ConcreteValue::StringList)`. Resources whose schema is not in the registry
-/// (provider not loaded, unknown resource type) are skipped — schema
-/// validation surfaces the mismatch elsewhere.
+/// Witness holding an exclusive borrow of resources canonicalized
+/// against a specific schema registry.
 ///
-/// Call this once after `resolver::resolve_refs_*` and before the
-/// differ runs, so every `Resource` flowing into the plan / state /
-/// provider boundary carries the canonical shape. See #2481, #2511.
+/// The only producer is [`canonicalize_resources_with_schemas`]. While
+/// the witness is alive, callers cannot mutate the underlying resources
+/// through another borrow, so identity code can require this type as
+/// evidence that the canonicalize pass already ran.
 pub struct CanonicalizedResources<'a> {
     resources: &'a mut [crate::resource::Resource],
 }
@@ -1588,6 +1625,15 @@ impl<'a> CanonicalizedResources<'a> {
     }
 }
 
+/// Walk every resource's attributes, canonicalizing values whose
+/// declared schema type is `Union[String, list(String)]` into
+/// `Value::Concrete(ConcreteValue::StringList)`. Resources whose schema is not in the registry
+/// (provider not loaded, unknown resource type) are skipped — schema
+/// validation surfaces the mismatch elsewhere.
+///
+/// Call this once after `resolver::resolve_refs_*` and before the
+/// differ runs, so every `Resource` flowing into the plan / state /
+/// provider boundary carries the canonical shape. See #2481, #2511.
 pub fn canonicalize_resources_with_schemas<'a>(
     resources: &'a mut [crate::resource::Resource],
     registry: &crate::schema::SchemaRegistry,
@@ -1637,76 +1683,7 @@ impl CanonicalizedProviderConfigs {
 
 fn canonicalize_provider_config_with_type(value: Value, attr_type: &AttributeType) -> Value {
     let defs = crate::schema::empty_defs_for_schema_walks();
-    let unwrapped = peel_custom(attr_type);
-    if is_string_or_list_of_strings(unwrapped) {
-        return canonicalize_to_string_list(value);
-    }
-    match (value, unwrapped.shape_with_defs(defs)) {
-        (
-            Value::Concrete(ConcreteValue::List(items)),
-            crate::schema::Shape::List { element_type, .. },
-        ) => Value::Concrete(ConcreteValue::List(
-            items
-                .into_iter()
-                .map(|v| canonicalize_provider_config_with_type(v, element_type))
-                .collect(),
-        )),
-        (Value::Concrete(ConcreteValue::Map(map)), crate::schema::Shape::Map { value: vt, .. }) => {
-            Value::Concrete(ConcreteValue::Map(
-                map.into_iter()
-                    .map(|(k, v)| (k, canonicalize_provider_config_with_type(v, vt)))
-                    .collect(),
-            ))
-        }
-        (Value::Concrete(ConcreteValue::Map(map)), crate::schema::Shape::Struct { .. }) => {
-            let fields = crate::schema::struct_fields_with_defs(unwrapped, defs)
-                .expect("Shape::Struct must expose struct fields internally");
-            Value::Concrete(ConcreteValue::Map(
-                map.into_iter()
-                    .map(|(k, v)| {
-                        let field_type = fields
-                            .iter()
-                            .find(|f| f.name == k || f.provider_name.as_deref() == Some(k.as_str()))
-                            .map(|f| &f.field_type);
-                        let canon = match field_type {
-                            Some(ft) => canonicalize_provider_config_with_type(v, ft),
-                            None => v,
-                        };
-                        (k, canon)
-                    })
-                    .collect(),
-            ))
-        }
-        (Value::Deferred(DeferredValue::Secret(inner)), _) => {
-            Value::Deferred(DeferredValue::Secret(Box::new(
-                canonicalize_provider_config_with_type(*inner, attr_type),
-            )))
-        }
-        (val, crate::schema::Shape::Enum { .. }) => {
-            let resolver = crate::resource::EnumValueResolver::new(unwrapped);
-            match val {
-                Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => resolver
-                    .resolve_state_text(raw.as_str())
-                    .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
-                    .unwrap_or_else(|_| Value::Concrete(ConcreteValue::EnumIdentifier(raw))),
-                Value::Concrete(ConcreteValue::String(s)) => resolver
-                    .resolve_state_text(&s)
-                    .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
-                    .unwrap_or_else(|_| Value::Concrete(ConcreteValue::String(s))),
-                Value::Concrete(ConcreteValue::CanonicalEnum(_)) => val,
-                other => other,
-            }
-        }
-        (val, crate::schema::Shape::Union) => {
-            let members = crate::schema::union_members_with_defs(unwrapped, defs)
-                .expect("Shape::Union must expose union members internally");
-            match crate::schema::select_union_member(members, &val) {
-                Some(member) => canonicalize_provider_config_with_type(val, member),
-                None => val,
-            }
-        }
-        (v, _) => v,
-    }
+    canonicalize_with_type_for_enum_phase(value, attr_type, defs, EnumIdentifierPhase::StateText)
 }
 
 /// Walk every provider config's attributes, canonicalizing enum-typed leaves

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1600,6 +1600,102 @@ pub fn canonicalize_resources_with_schemas(
     }
 }
 
+type ProviderConfigAttributeTypeFn<'a> = dyn Fn(&str, &str) -> Option<AttributeType> + 'a;
+
+fn canonicalize_provider_config_with_type(value: Value, attr_type: &AttributeType) -> Value {
+    let defs = crate::schema::empty_defs_for_schema_walks();
+    let unwrapped = peel_custom(attr_type);
+    if is_string_or_list_of_strings(unwrapped) {
+        return canonicalize_to_string_list(value);
+    }
+    match (value, unwrapped.shape_with_defs(defs)) {
+        (
+            Value::Concrete(ConcreteValue::List(items)),
+            crate::schema::Shape::List { element_type, .. },
+        ) => Value::Concrete(ConcreteValue::List(
+            items
+                .into_iter()
+                .map(|v| canonicalize_provider_config_with_type(v, element_type))
+                .collect(),
+        )),
+        (Value::Concrete(ConcreteValue::Map(map)), crate::schema::Shape::Map { value: vt, .. }) => {
+            Value::Concrete(ConcreteValue::Map(
+                map.into_iter()
+                    .map(|(k, v)| (k, canonicalize_provider_config_with_type(v, vt)))
+                    .collect(),
+            ))
+        }
+        (Value::Concrete(ConcreteValue::Map(map)), crate::schema::Shape::Struct { .. }) => {
+            let fields = crate::schema::struct_fields_with_defs(unwrapped, defs)
+                .expect("Shape::Struct must expose struct fields internally");
+            Value::Concrete(ConcreteValue::Map(
+                map.into_iter()
+                    .map(|(k, v)| {
+                        let field_type = fields
+                            .iter()
+                            .find(|f| f.name == k || f.provider_name.as_deref() == Some(k.as_str()))
+                            .map(|f| &f.field_type);
+                        let canon = match field_type {
+                            Some(ft) => canonicalize_provider_config_with_type(v, ft),
+                            None => v,
+                        };
+                        (k, canon)
+                    })
+                    .collect(),
+            ))
+        }
+        (Value::Deferred(DeferredValue::Secret(inner)), _) => {
+            Value::Deferred(DeferredValue::Secret(Box::new(
+                canonicalize_provider_config_with_type(*inner, attr_type),
+            )))
+        }
+        (val, crate::schema::Shape::Enum { .. }) => {
+            let resolver = crate::resource::EnumValueResolver::new(unwrapped);
+            match val {
+                Value::Concrete(ConcreteValue::EnumIdentifier(raw)) => resolver
+                    .resolve_state_text(raw.as_str())
+                    .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
+                    .unwrap_or_else(|_| Value::Concrete(ConcreteValue::EnumIdentifier(raw))),
+                Value::Concrete(ConcreteValue::String(s)) => resolver
+                    .resolve_state_text(&s)
+                    .map(|c| Value::Concrete(ConcreteValue::CanonicalEnum(c)))
+                    .unwrap_or_else(|_| Value::Concrete(ConcreteValue::String(s))),
+                Value::Concrete(ConcreteValue::CanonicalEnum(_)) => val,
+                other => other,
+            }
+        }
+        (val, crate::schema::Shape::Union) => {
+            let members = crate::schema::union_members_with_defs(unwrapped, defs)
+                .expect("Shape::Union must expose union members internally");
+            match crate::schema::select_union_member(members, &val) {
+                Some(member) => canonicalize_provider_config_with_type(val, member),
+                None => val,
+            }
+        }
+        (v, _) => v,
+    }
+}
+
+/// Walk every provider config's attributes, canonicalizing enum-typed leaves
+/// such as provider identity `region` before those values feed durable
+/// identity hashing.
+pub fn canonicalize_provider_configs_with_attribute_types(
+    providers: &mut [crate::parser::ProviderConfig],
+    provider_config_attribute_type_fn: &ProviderConfigAttributeTypeFn<'_>,
+) {
+    for provider in providers.iter_mut() {
+        let mut new_attrs = indexmap::IndexMap::new();
+        for (key, value) in std::mem::take(&mut provider.attributes) {
+            let canon = match provider_config_attribute_type_fn(&provider.name, &key) {
+                Some(attr_type) => canonicalize_provider_config_with_type(value, &attr_type),
+                None => value,
+            };
+            new_attrs.insert(key, canon);
+        }
+        provider.attributes = new_attrs;
+    }
+}
+
 /// [`DataSource`](crate::resource::DataSource) counterpart of
 /// [`canonicalize_resources_with_schemas`]. Schema lookup routes through
 /// the data-source registry (`get_for_data_source`); data sources whose
@@ -2682,6 +2778,68 @@ mod tests {
             map.get("primary").unwrap(),
             Value::Concrete(ConcreteValue::CanonicalEnum(c)) if c.api_value() == "vpc"
         ));
+    }
+
+    #[test]
+    fn canonicalize_provider_configs_replaces_region_enum_with_canonical_api_value() {
+        use crate::parser::ProviderConfig;
+        use crate::schema::{AttributeType, DslTransform, TypeIdentity};
+
+        let mut providers = vec![
+            ProviderConfig {
+                name: "aws".to_string(),
+                attributes: indexmap::indexmap! {
+                    "region".to_string() => Value::Concrete(ConcreteValue::enum_identifier(
+                        "aws.Region.ap_northeast_1",
+                    )),
+                },
+                default_tags: indexmap::IndexMap::new(),
+                source: None,
+                version: None,
+                revision: None,
+                unresolved_attributes: indexmap::IndexMap::new(),
+                binding: None,
+                is_default: true,
+            },
+            ProviderConfig {
+                name: "awscc".to_string(),
+                attributes: indexmap::indexmap! {
+                    "region".to_string() => Value::Concrete(ConcreteValue::enum_identifier(
+                        "awscc.Region.ap_northeast_1",
+                    )),
+                },
+                default_tags: indexmap::IndexMap::new(),
+                source: None,
+                version: None,
+                revision: None,
+                unresolved_attributes: indexmap::IndexMap::new(),
+                binding: None,
+                is_default: true,
+            },
+        ];
+
+        canonicalize_provider_configs_with_attribute_types(&mut providers, &|provider, attr| {
+            (attr == "region").then(|| {
+                AttributeType::enum_(
+                    TypeIdentity::new(Some(provider), Vec::<String>::new(), "Region"),
+                    None,
+                    Vec::new(),
+                    None,
+                    Some(DslTransform::HyphenToUnderscore),
+                )
+            })
+        });
+
+        let api_values: Vec<_> = providers
+            .iter()
+            .map(
+                |provider| match provider.attributes.get("region").unwrap() {
+                    Value::Concrete(ConcreteValue::CanonicalEnum(c)) => c.api_value().to_string(),
+                    other => panic!("expected CanonicalEnum, got {other:?}"),
+                },
+            )
+            .collect();
+        assert_eq!(api_values, ["ap-northeast-1", "ap-northeast-1"]);
     }
 
     #[test]

--- a/notes/specs/2026-06-10-structured-enum-identifier-design.md
+++ b/notes/specs/2026-06-10-structured-enum-identifier-design.md
@@ -127,8 +127,7 @@ The design builds on these existing pieces:
   dotted values such as `ipsec.1`.
 - `TypeIdentity` stores provider, segments, and kind as structural axes; its
   dotted display is derived and is not source of truth.
-- `DslMap` owns API/DSL spelling conversion through `dsl_for`, `api_for`, and
-  the #3437 hash-specific `api_for_hash_feature`.
+- `DslMap` owns API/DSL spelling conversion through `dsl_for` and `api_for`.
 
 The proposed resolver should absorb namespace validation and value extraction as
 implementation details, consume `enum_parts` as schema input, and eventually
@@ -515,6 +514,10 @@ Provider config canonicalization is also represented as the
 `CanonicalizedProviderConfigs` typestate wrapper, so anonymous hash and
 anonymous-to-named rename code cannot be called with raw provider configs in
 normal builds.
+Resource canonicalization is represented by a `CanonicalizedResources` witness
+returned from `canonicalize_resources_with_schemas`, so the CLI
+`validate_and_resolve` path cannot call anonymous identity generation before
+resource enum leaves have been canonicalized.
 
 The cleanup makes several hazards unrepresentable or harder to write by
 accident:
@@ -529,10 +532,21 @@ accident:
 - anonymous hash features turn only `CanonicalEnumValue` into `EnumApiValue`;
   parser-surface enum text cannot be made canonical there by passing schema.
 
+Round-2 enforcement status:
+
+| Boundary | Enforcement |
+| --- | --- |
+| Hash feature rendering of enum API values | Compile-time: only `ConcreteValue::CanonicalEnum` renders as `EnumApiValue(...)`; raw enum text takes the deterministic fallback path. |
+| Provider config identity input | Compile-time at the seam: hash and rename detection require `CanonicalizedProviderConfigs`. The closure used to look up provider config attribute types is still a caller responsibility. |
+| Resource identity input in the CLI validation pipeline | Compile-time at the seam: `compute_anonymous_identifiers_with_ctx` requires `CanonicalizedResources`, which only `canonicalize_resources_with_schemas` returns. |
+| Raw/source text access | Convention: `RawEnumIdentifier::as_str()` remains for display, formatting, diagnostics, and explicit source-text comparisons. |
+| Unresolvable enum-like values | Runtime fallback: values that cannot be lifted to `CanonicalEnumValue` keep the deterministic representation rather than gaining inferred enum semantics. |
+
 The remaining convention is explicit rather than hidden: `as_str()` is a
-source/display API, not an identity API. Unresolvable enum-like values still use
-the deterministic fallback so invalid or unresolved inputs do not gain new
-semantic meaning during identity generation.
+source/display API, not an identity API. `DslMap::api_for` now covers the
+transform-bearing enum case that `api_for_hash_feature` handled during #3437;
+that is a public behavior change for provider repos that consume the shared
+schema API.
 
 This mirrors the #3371-style split: design first, core types second, consumers
 third, external repo follow-up fourth, cleanup last.

--- a/notes/specs/2026-06-10-structured-enum-identifier-design.md
+++ b/notes/specs/2026-06-10-structured-enum-identifier-design.md
@@ -511,6 +511,10 @@ config identity attributes and resource attributes are canonicalized before
 identity generation, and the hash feature path renders only
 `ConcreteValue::CanonicalEnum` as `EnumApiValue(...)`. Raw enum identifiers that
 somehow reach the hash path use the deterministic fallback representation.
+Provider config canonicalization is also represented as the
+`CanonicalizedProviderConfigs` typestate wrapper, so anonymous hash and
+anonymous-to-named rename code cannot be called with raw provider configs in
+normal builds.
 
 The cleanup makes several hazards unrepresentable or harder to write by
 accident:

--- a/notes/specs/2026-06-10-structured-enum-identifier-design.md
+++ b/notes/specs/2026-06-10-structured-enum-identifier-design.md
@@ -497,12 +497,38 @@ Recommended chain:
 4. Provider follow-up PRs. Update `carina-provider-aws`,
    `carina-provider-awscc`, and `carina-aws-types` construction/match sites, then
    bump revisions in Carina.
-5. Shim removal PR. Remove string-out hash helpers, raw-string enum extraction
-   APIs from durable identity paths, and any temporary constructors that let
-   production code mint canonical enum values without schema. This must happen
-   after provider config attributes such as `region` are canonicalized; otherwise
-   removing raw fallback and `api_for_hash_feature` would regress provider
-   config hash stability.
+5. Shim removal PR. Remove string-out hash helpers and raw-string enum
+   extraction APIs from durable identity paths. This must happen after provider
+   config attributes such as `region` are canonicalized; otherwise removing raw
+   fallback and `api_for_hash_feature` would regress provider config hash
+   stability.
+
+PR 5 implemented that final cleanup with one deliberately narrow exception:
+raw enum construction and `RawEnumIdentifier::as_str()` remain available for
+parser, display, formatter, and diagnostic surfaces. Durable identity no longer
+schema-resolves parser-surface enum text at the hash boundary. Instead, provider
+config identity attributes and resource attributes are canonicalized before
+identity generation, and the hash feature path renders only
+`ConcreteValue::CanonicalEnum` as `EnumApiValue(...)`. Raw enum identifiers that
+somehow reach the hash path use the deterministic fallback representation.
+
+The cleanup makes several hazards unrepresentable or harder to write by
+accident:
+
+- `DslMap::api_for_hash_feature` is gone; enum API spelling is produced by the
+  enum resolver and stored in `CanonicalEnumValue`.
+- `RawEnumIdentifier` no longer dereferences to `str`, so callers cannot
+  silently pass it into string operations, slicing, or `split_once` without
+  choosing `as_str()` explicitly.
+- `String == RawEnumIdentifier` cross-type equality is gone; remaining
+  text comparisons spell out `raw.as_str()` and are therefore reviewable.
+- anonymous hash features turn only `CanonicalEnumValue` into `EnumApiValue`;
+  parser-surface enum text cannot be made canonical there by passing schema.
+
+The remaining convention is explicit rather than hidden: `as_str()` is a
+source/display API, not an identity API. Unresolvable enum-like values still use
+the deterministic fallback so invalid or unresolved inputs do not gain new
+semantic meaning during identity generation.
 
 This mirrors the #3371-style split: design first, core types second, consumers
 third, external repo follow-up fourth, cleanup last.
@@ -574,4 +600,9 @@ Together, the two prior docs say:
 - schema-aware extraction should replace position-based dotted-string parsing;
 - raw enum source text and canonical enum semantics are different values.
 
-This document makes that last point enforceable in Rust types.
+The PR 5 implementation makes that last point enforceable for durable identity
+boundaries: hash generation and create-only reconciliation consume
+`CanonicalEnumValue` when they need enum API semantics, and they no longer carry
+schema-aware raw-text rescue logic. It does not outlaw raw text entirely:
+`RawEnumIdentifier::as_str()` remains the supported display/diagnostic escape
+hatch, and unresolved values deliberately keep deterministic fallback behavior.


### PR DESCRIPTION
Closes #3438

## Summary

Final PR of the structured enum identifier chain (design #3441, core types #3443, consumer conversion #3444, providers carina-provider-aws#424 / carina-provider-awscc#342). Removes the transitional shims and finishes the typestate so durable-identity code cannot compile against parser-surface enum text.

- Provider-config identity attributes (e.g. `region`) are canonicalized before anonymous hashing, and the hash/rename seams now require `CanonicalizedProviderConfigs` — a newtype only the canonicalizer produces.
- The CLI hash seam likewise requires `CanonicalizedResources`, a lifetime-bound witness over the canonicalized resource slice; reordering or dropping the canonicalize step is now a compile error, not a silently green mutation (both mutations were demonstrated green before the witnesses landed).
- The schema-aware raw-text rescue is gone from hash and create-only reconciliation: feature strings render `EnumApiValue(...)` only from `CanonicalEnum`; everything else uses the deterministic fallback. `DslMap::api_for_hash_feature` is removed (its transform-reversal folded into `api_for` — a public behavior change for transform-bearing enums; all provider call sites audited).
- Hazardous shims removed: `Deref<Target = str>` and the `String == RawEnumIdentifier` cross-equality. `as_str()` and `ConcreteValue::enum_identifier(...)` remain as documented display/construction APIs. `grep TODO(carina#3438)` is zero.
- The canonicalize walker is unified (phase-parameterized) instead of duplicated for resources vs provider configs; dead scaffolding left by the rescue removal was dropped.

## Enforcement summary (honest)

| Invariant | Enforcement |
|---|---|
| `EnumApiValue` hash features only from `CanonicalEnum`; `CanonicalEnumValue` mintable only by the resolver / trusted-state reader | Compile-time (visibility) |
| Provider configs canonicalized at the hash/rename seam | Compile-time (`CanonicalizedProviderConfigs`); the attribute-type closure's correctness stays the caller's responsibility |
| Resources canonicalized before anonymous hashing | Compile-time (`CanonicalizedResources` witness) + pipeline test from raw aws/awscc spellings |
| Raw/canonical text confusion | Compile-time (shims removed; `as_str()` is an explicit, reviewable opt-in) |
| Unresolvable / factory-missing enum values | Documented convention: deterministic fallback (pre-chain behavior) |

## Provider impact at next pin bump

carina-provider-aws needs two one-line `as_str()` insertions (`iam/role.rs:622`, `sqs/queue.rs:311` — former Deref users); carina-provider-awscc compiles clean. Verified by compiling both repos against this branch via a temporary patch.

## Verification

- `RUSTC_WRAPPER= cargo nextest run --workspace --all-features` — 3989 passed, 72 skipped
- `RUSTC_WRAPPER= cargo test --workspace --doc`; clippy `-D warnings`; `cargo fmt --check`; `bash scripts/check-*.sh` — all pass
- #3437/#3428/#3440 invariant tests: 135 passed
- Five review rounds, each finding fixed with failing tests first (seam mutation tests, witness types, walker unification, scaffolding removal)
