### PR TITLE
Remove schema-free public enum extraction API (refs carina-provider-aws#423)

### DIFF
--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -27,8 +27,8 @@ fn test_resolve_enum_aliases_ip_protocol_all() {
 
 #[test]
 fn test_resolve_enum_aliases_no_alias() {
-    // "tcp" has no alias mapping, so it should be converted from DSL enum
-    // to its raw form by convert_enum_value but not further changed.
+    // "tcp" has no alias mapping here, so schema-free extraction must not
+    // rewrite the namespaced DSL value.
     let mut resource =
         Resource::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
     resource.set_attr(
@@ -2715,7 +2715,7 @@ mod wait_until_enum_alias {
     use carina_core::provider::{
         BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
     };
-    use carina_core::schema::{AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, enum_identity};
 
     /// Minimal aws-like factory that mirrors the REAL
     /// `carina-provider-aws` ACM `status` enum reverse alias:
@@ -2723,12 +2723,13 @@ mod wait_until_enum_alias {
     /// canonical AWS value; verified against
     /// `carina-provider-aws/.../acm/certificate.rs`). The DSL value
     /// `aws.acm.Certificate.Status.issued` — the exact form in the
-    /// reopened issue #3358 — passes through `convert_enum_value` to the
-    /// trailing segment `"issued"`, which is the alias-map key. Keying on
+    /// reopened issue #3358 — is shortened by
+    /// `resolve_value_alias_with_schemas` to the trailing segment `"issued"`,
+    /// which is the alias-map key. Keying on
     /// PascalCase `"Issued"` would NOT match the real provider, so the
     /// test would prove a path production never exercises. Everything
-    /// else is stubbed to the minimum the helper needs (it only consults
-    /// `get_enum_alias_reverse`).
+    /// else is stubbed to the minimum the helper needs: an enum schema for
+    /// `status` and `get_enum_alias_reverse`.
     struct AcmAliasFactory;
 
     impl ProviderFactory for AcmAliasFactory {
@@ -2762,7 +2763,18 @@ mod wait_until_enum_alias {
             Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
         }
         fn schemas(&self) -> Vec<ResourceSchema> {
-            vec![ResourceSchema::new("acm.Certificate")]
+            vec![
+                ResourceSchema::new("acm.Certificate").attribute(AttributeSchema::new(
+                    "status",
+                    AttributeType::enum_(
+                        enum_identity("Status", Some("aws.acm.Certificate")),
+                        Some(vec!["issued".to_string(), "pending_validation".to_string()]),
+                        Vec::new(),
+                        None,
+                        None,
+                    ),
+                )),
+            ]
         }
         fn get_enum_alias_reverse(
             &self,
@@ -2777,9 +2789,8 @@ mod wait_until_enum_alias {
         }
     }
 
-    // The helper only consults `factory.get_enum_alias_reverse`; the
-    // provider is never instantiated. These methods exist only to
-    // satisfy the trait and are unreachable in these tests.
+    // The provider is never instantiated. These methods exist only to satisfy
+    // the trait and are unreachable in these tests.
     struct StubProvider;
     impl Provider for StubProvider {
         fn name(&self) -> &str {

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -360,7 +360,18 @@ impl ProviderFactory for AliasFactory {
         unreachable!("test factory does not create providers")
     }
     fn schemas(&self) -> Vec<crate::schema::ResourceSchema> {
-        Vec::new()
+        use crate::schema::{AttributeSchema, AttributeType, ResourceSchema, enum_identity};
+
+        vec![ResourceSchema::new("sg").attribute(AttributeSchema::new(
+            "ip_protocol",
+            AttributeType::enum_(
+                enum_identity("IpProtocol", Some("test.ec2.SecurityGroup")),
+                Some(vec!["all".to_string(), "tcp".to_string()]),
+                Vec::new(),
+                None,
+                None,
+            ),
+        ))]
     }
     fn get_enum_alias_reverse(
         &self,

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -13,7 +13,7 @@ use crate::deps::get_resource_value_ref_dependencies;
 use crate::effect::Effect;
 use crate::plan::Plan;
 use crate::resource::{ConcreteValue, DeferredValue, Value};
-use crate::utils::{convert_enum_value, is_dsl_enum_format};
+use crate::utils::enum_display_value;
 
 /// Intermediate data for tree-building: maps from effect indices to their
 /// bindings, dependency sets, and resource types.
@@ -301,12 +301,8 @@ pub fn extract_compact_hint(
         {
             let short_key = shorten_attr_name(key);
             // Strip namespace from DSL enum identifiers (e.g., awscc.AvailabilityZone.ap_northeast_1a -> "ap_northeast_1a")
-            let resolved = if is_dsl_enum_format(s) {
-                Cow::Borrowed(convert_enum_value(s))
-            } else {
-                Cow::Borrowed(s.as_str())
-            };
-            let display_value = shorten_service_name(key, &resolved);
+            let resolved = enum_display_value(s).unwrap_or(s);
+            let display_value = shorten_service_name(key, resolved);
             return Some(format!("{}: {}", short_key, display_value));
         }
     }

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -239,7 +239,7 @@ fn is_provider_segment(s: &str) -> bool {
 }
 
 /// A `service` segment (5+ part shape, sits at index 1) — lowercase ASCII
-/// or digits; mirrors the original `is_dsl_enum_format` rule.
+/// or digits; mirrors the legacy namespaced-text rule.
 fn is_service_segment(s: &str) -> bool {
     !s.is_empty()
         && s.chars()
@@ -286,9 +286,9 @@ pub fn expand_enum_shorthand(value: &Value, identity: &crate::schema::TypeIdenti
     // payload as `String` (only the source-shape tag differs) and goes
     // through the same namespace expansion. The result is materialized as
     // `String` because every downstream consumer
-    // (`validate_enum`, the LSP completion helpers, the
-    // builtin-result coercion in `convert_enum_value`) reads through the
-    // `Value::Concrete(ConcreteValue::String)` arm. The `EnumIdentifier`
+    // (`validate_enum`, the LSP completion helpers, and display shortening)
+    // reads through the `Value::Concrete(ConcreteValue::String)` arm. The
+    // `EnumIdentifier`
     // distinction is a parser-level signal used for strict shape
     // enforcement at the validator entry, not a wire-level form.
     //
@@ -341,6 +341,14 @@ fn is_type_name_segment(s: &str) -> bool {
 /// Extract the last dot-separated part from a namespaced identifier.
 /// Returns the original string if no dots are present.
 ///
+/// This is a legacy read-normalization helper, not a general-purpose enum
+/// wire-value extractor. It mis-splits enum values that themselves contain
+/// dots, such as `awscc.ec2.vpn_gateway.Type.ipsec.1` -> `1`; use
+/// `extract_enum_value_with_values` internally when valid enum values are
+/// available. It must not be used for provider wire-out paths. Its remaining
+/// legitimate consumers are the provider read-normalize seam, and demotion is
+/// deferred to the carina#3409 enum-state-coherence implementation.
+///
 /// # Examples
 ///
 /// ```
@@ -367,25 +375,7 @@ pub fn extract_enum_value(s: &str) -> &str {
 /// to find the correct enum value.
 ///
 /// Falls back to [`extract_enum_value`] if no valid values match.
-///
-/// # Examples
-///
-/// ```
-/// use carina_core::utils::extract_enum_value_with_values;
-///
-/// let values = &["ipsec.1"];
-/// assert_eq!(
-///     extract_enum_value_with_values("awscc.ec2.vpn_gateway.Type.ipsec.1", values),
-///     "ipsec.1"
-/// );
-///
-/// let values = &["default", "dedicated", "host"];
-/// assert_eq!(
-///     extract_enum_value_with_values("awscc.ec2.Vpc.InstanceTenancy.default", values),
-///     "default"
-/// );
-/// ```
-pub fn extract_enum_value_with_values<'a>(s: &'a str, valid_values: &[&str]) -> &'a str {
+pub(crate) fn extract_enum_value_with_values<'a>(s: &'a str, valid_values: &[&str]) -> &'a str {
     if !s.contains('.') {
         return s;
     }
@@ -418,7 +408,7 @@ pub fn extract_enum_value_with_values<'a>(s: &'a str, valid_values: &[&str]) -> 
 }
 
 /// Canonicalize one `Enum` value to its API spelling: strip any
-/// namespace prefix ([`extract_enum_value_with_values`]) then map the
+/// namespace prefix with `extract_enum_value_with_values` then map the
 /// DSL alias to the API form via [`crate::schema::DslMap::api_for`].
 ///
 /// This is the exact-match canonicalization used by the plan renderer's
@@ -452,7 +442,7 @@ pub fn canonicalize_enum_to_api(
     dsl_map.api_for(extract_enum_value_with_values(s, valid_values))
 }
 
-/// Strip the namespace prefix from a DSL enum identifier and return the raw value.
+/// Return the display value for namespaced enum text.
 ///
 /// Handles the following patterns:
 /// - 2-part: `TypeName.value_name` -> `value_name`
@@ -461,45 +451,15 @@ pub fn canonicalize_enum_to_api(
 /// - 5-part: `provider.service.resource.TypeName.value_name` -> `value_name`
 ///
 /// The first component of TypeName must be uppercase.
-/// The extracted value is returned as-is without any transformation.
-/// Returns the original value unchanged if it doesn't match any pattern.
+/// The extracted value is returned as-is without any transformation. Returns
+/// `None` if the input doesn't match any pattern.
 ///
-/// # Examples
-///
-/// ```
-/// use carina_core::utils::convert_enum_value;
-///
-/// assert_eq!(convert_enum_value("aws.Region.ap_northeast_1"), "ap_northeast_1");
-/// assert_eq!(convert_enum_value("Region.ap_northeast_1"), "ap_northeast_1");
-/// assert_eq!(convert_enum_value("awscc.ec2.ipam.Tier.advanced"), "advanced");
-/// assert_eq!(convert_enum_value("eu-west-1"), "eu-west-1");
-/// ```
-pub fn convert_enum_value(value: &str) -> &str {
-    NamespacedId::parse(value).map_or(value, |id| id.value())
-}
-
-/// Check if a string is in DSL enum format (a namespaced identifier).
-///
-/// Recognizes the following patterns:
-/// - `TypeName.value` (2-part, e.g., `Region.ap_northeast_1`)
-/// - `provider.TypeName.value` (3-part, e.g., `aws.Region.ap_northeast_1`)
-/// - `provider.resource.TypeName.value` (4-part, e.g., `aws.s3.VersioningStatus.Enabled`)
-/// - `provider.service.resource.TypeName.value` (5-part, e.g., `awscc.ec2.Vpc.InstanceTenancy.default`)
-///
-/// # Examples
-///
-/// ```
-/// use carina_core::utils::is_dsl_enum_format;
-///
-/// assert!(is_dsl_enum_format("Region.ap_northeast_1"));
-/// assert!(is_dsl_enum_format("aws.Region.ap_northeast_1"));
-/// assert!(is_dsl_enum_format("aws.s3.VersioningStatus.Enabled"));
-/// assert!(is_dsl_enum_format("awscc.ec2.Vpc.InstanceTenancy.default"));
-/// assert!(!is_dsl_enum_format("my-bucket"));
-/// assert!(!is_dsl_enum_format("some.random.string"));
-/// ```
-pub fn is_dsl_enum_format(s: &str) -> bool {
-    NamespacedId::parse(s).is_some()
+/// This uses the positional [`NamespacedId::parse`] legacy shape, where the
+/// 5+-segment branch pins `TypeName` at index 3. Structural identities with
+/// intermediate struct segments can therefore mis-split 6+-segment values, so
+/// this helper is display-only and must never feed a provider wire path.
+pub(crate) fn enum_display_value(s: &str) -> Option<&str> {
+    NamespacedId::parse(s).map(|id| id.value())
 }
 
 /// Validate namespace format for an enum identifier.
@@ -1126,7 +1086,7 @@ fn dynamic_enum_member_is_structural(
         .dotted_prefix()
         .map(|prefix| format!("{}.{}.{}", prefix, identity.kind, dsl))
         .unwrap_or_else(|| format!("{}.{}", identity.kind, dsl));
-    if !is_dsl_enum_format(&full) || !is_dynamic_dsl_member_segment(dsl) {
+    if NamespacedId::parse(&full).is_none() || !is_dynamic_dsl_member_segment(dsl) {
         return false;
     }
     match source {
@@ -1399,68 +1359,69 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_enum_value_2_part() {
+    fn test_enum_display_value_extracts_2_part() {
         assert_eq!(
-            convert_enum_value("Region.ap_northeast_1"),
-            "ap_northeast_1"
+            enum_display_value("Region.ap_northeast_1"),
+            Some("ap_northeast_1")
         );
     }
 
     #[test]
-    fn test_convert_enum_value_3_part() {
+    fn test_enum_display_value_extracts_3_part() {
         assert_eq!(
-            convert_enum_value("aws.Region.ap_northeast_1"),
-            "ap_northeast_1"
-        );
-        assert_eq!(convert_enum_value("aws.Region.us_east_1"), "us_east_1");
-        assert_eq!(
-            convert_enum_value("aws.AvailabilityZone.ap_northeast_1a"),
-            "ap_northeast_1a"
+            enum_display_value("aws.Region.ap_northeast_1"),
+            Some("ap_northeast_1")
         );
         assert_eq!(
-            convert_enum_value("aws.AvailabilityZone.us_east_1b"),
-            "us_east_1b"
-        );
-    }
-
-    #[test]
-    fn test_convert_enum_value_4_part() {
-        assert_eq!(
-            convert_enum_value("aws.s3.VersioningStatus.Enabled"),
-            "Enabled"
-        );
-        assert_eq!(convert_enum_value("aws.ec2.IpProtocol.tcp"), "tcp");
-    }
-
-    #[test]
-    fn test_convert_enum_value_5_part() {
-        assert_eq!(
-            convert_enum_value("awscc.ec2.ipam.Tier.advanced"),
-            "advanced"
+            enum_display_value("aws.Region.us_east_1"),
+            Some("us_east_1")
         );
         assert_eq!(
-            convert_enum_value("awscc.ec2.ipam_pool.AddressFamily.IPv4"),
-            "IPv4"
+            enum_display_value("aws.AvailabilityZone.ap_northeast_1a"),
+            Some("ap_northeast_1a")
         );
         assert_eq!(
-            convert_enum_value("awscc.ec2.Vpc.InstanceTenancy.default"),
-            "default"
+            enum_display_value("aws.AvailabilityZone.us_east_1b"),
+            Some("us_east_1b")
         );
     }
 
     #[test]
-    fn test_convert_enum_value_passthrough() {
-        // Already in SDK format - should be returned unchanged
-        assert_eq!(convert_enum_value("eu-west-1"), "eu-west-1");
-        assert_eq!(convert_enum_value("ap-northeast-1a"), "ap-northeast-1a");
+    fn test_enum_display_value_extracts_4_part() {
+        assert_eq!(
+            enum_display_value("aws.s3.VersioningStatus.Enabled"),
+            Some("Enabled")
+        );
+        assert_eq!(enum_display_value("aws.ec2.IpProtocol.tcp"), Some("tcp"));
     }
 
     #[test]
-    fn test_convert_enum_value_invalid_patterns() {
+    fn test_enum_display_value_extracts_5_part() {
+        assert_eq!(
+            enum_display_value("awscc.ec2.ipam.Tier.advanced"),
+            Some("advanced")
+        );
+        assert_eq!(
+            enum_display_value("awscc.ec2.ipam_pool.AddressFamily.IPv4"),
+            Some("IPv4")
+        );
+        assert_eq!(
+            enum_display_value("awscc.ec2.Vpc.InstanceTenancy.default"),
+            Some("default")
+        );
+    }
+
+    #[test]
+    fn test_enum_display_value_passthrough_is_none() {
+        assert_eq!(enum_display_value("eu-west-1"), None);
+        assert_eq!(enum_display_value("ap-northeast-1a"), None);
+    }
+
+    #[test]
+    fn test_enum_display_value_invalid_patterns_are_none() {
         // lowercase first part in 2-part -> not a TypeName pattern
-        assert_eq!(convert_enum_value("region.us_east_1"), "region.us_east_1");
-        // single value -> passthrough
-        assert_eq!(convert_enum_value("Enabled"), "Enabled");
+        assert_eq!(enum_display_value("region.us_east_1"), None);
+        assert_eq!(enum_display_value("Enabled"), None);
     }
 
     // validate_enum_namespace tests
@@ -1734,59 +1695,60 @@ mod tests {
         );
     }
 
-    // is_dsl_enum_format tests
+    // enum_display_value shape-detection tests
 
     #[test]
-    fn test_is_dsl_enum_format_2_part() {
-        assert!(is_dsl_enum_format("Region.ap_northeast_1"));
-        assert!(is_dsl_enum_format("VersioningStatus.Enabled"));
+    fn test_enum_display_value_detects_2_part() {
+        assert!(enum_display_value("Region.ap_northeast_1").is_some());
+        assert!(enum_display_value("VersioningStatus.Enabled").is_some());
         // lowercase first part → not a TypeName
-        assert!(!is_dsl_enum_format("region.ap_northeast_1"));
+        assert!(enum_display_value("region.ap_northeast_1").is_none());
     }
 
     #[test]
-    fn test_is_dsl_enum_format_3_part() {
-        assert!(is_dsl_enum_format("aws.Region.ap_northeast_1"));
-        assert!(is_dsl_enum_format("gcp.Region.us_central1"));
+    fn test_enum_display_value_detects_3_part() {
+        assert!(enum_display_value("aws.Region.ap_northeast_1").is_some());
+        assert!(enum_display_value("gcp.Region.us_central1").is_some());
         // uppercase provider → not valid
-        assert!(!is_dsl_enum_format("AWS.Region.ap_northeast_1"));
+        assert!(enum_display_value("AWS.Region.ap_northeast_1").is_none());
         // lowercase TypeName → not valid
-        assert!(!is_dsl_enum_format("aws.region.ap_northeast_1"));
+        assert!(enum_display_value("aws.region.ap_northeast_1").is_none());
     }
 
     #[test]
-    fn test_is_dsl_enum_format_4_part() {
-        assert!(is_dsl_enum_format("aws.s3.VersioningStatus.Enabled"));
-        assert!(is_dsl_enum_format("aws.ec2.IpProtocol.tcp"));
+    fn test_enum_display_value_detects_4_part() {
+        assert!(enum_display_value("aws.s3.VersioningStatus.Enabled").is_some());
+        assert!(enum_display_value("aws.ec2.IpProtocol.tcp").is_some());
         // resource with digits
-        assert!(is_dsl_enum_format("aws.s3.VersioningStatus.Suspended"));
+        assert!(enum_display_value("aws.s3.VersioningStatus.Suspended").is_some());
     }
 
     #[test]
-    fn test_is_dsl_enum_format_5_part() {
-        assert!(is_dsl_enum_format("awscc.ec2.Vpc.InstanceTenancy.default"));
-        assert!(is_dsl_enum_format("awscc.ec2.ipam_pool.AddressFamily.IPv4"));
+    fn test_enum_display_value_detects_5_part() {
+        assert!(enum_display_value("awscc.ec2.Vpc.InstanceTenancy.default").is_some());
+        assert!(enum_display_value("awscc.ec2.ipam_pool.AddressFamily.IPv4").is_some());
     }
 
     #[test]
-    fn test_is_dsl_enum_format_6_part_dotted_value() {
+    fn test_enum_display_value_detects_6_part_dotted_value() {
         // 6-part: provider.service.resource.TypeName.value.with.dots
-        assert!(is_dsl_enum_format("awscc.ec2.vpn_gateway.Type.ipsec.1"));
+        assert!(enum_display_value("awscc.ec2.vpn_gateway.Type.ipsec.1").is_some());
     }
 
     #[test]
-    fn test_is_dsl_enum_format_deep_structural_plain_value() {
-        assert!(is_dsl_enum_format(
-            "aws.s3.BucketLifecycleConfiguration.Rules.Status.enabled"
-        ));
+    fn test_enum_display_value_detects_deep_structural_plain_value() {
+        assert!(
+            enum_display_value("aws.s3.BucketLifecycleConfiguration.Rules.Status.enabled")
+                .is_some()
+        );
     }
 
     #[test]
-    fn test_is_dsl_enum_format_non_matching() {
-        assert!(!is_dsl_enum_format("my-bucket"));
-        assert!(!is_dsl_enum_format("ap-northeast-1"));
-        assert!(!is_dsl_enum_format("some.random.string"));
-        assert!(!is_dsl_enum_format("a.b.c.d.e.f"));
+    fn test_enum_display_value_non_matching() {
+        assert!(enum_display_value("my-bucket").is_none());
+        assert!(enum_display_value("ap-northeast-1").is_none());
+        assert!(enum_display_value("some.random.string").is_none());
+        assert!(enum_display_value("a.b.c.d.e.f").is_none());
     }
 
     // extract_enum_value_with_values tests
@@ -1875,29 +1837,32 @@ mod tests {
         );
     }
 
-    // convert_enum_value with dotted values
+    // enum_display_value with dotted values
 
     #[test]
-    fn test_convert_enum_value_6_part_dotted_value() {
+    fn test_enum_display_value_6_part_dotted_value() {
         assert_eq!(
-            convert_enum_value("awscc.ec2.vpn_gateway.Type.ipsec.1"),
-            "ipsec.1"
+            enum_display_value("awscc.ec2.vpn_gateway.Type.ipsec.1"),
+            Some("ipsec.1")
         );
     }
 
-    // convert_enum_value: underscores in enum values must be preserved (#1675)
+    // enum_display_value: underscores in enum values must be preserved (#1675)
 
     #[test]
-    fn test_convert_enum_value_preserves_underscores() {
+    fn test_enum_display_value_preserves_underscores() {
         // Enum values like AWS_ACCOUNT must not have underscores converted to hyphens
         assert_eq!(
-            convert_enum_value("awscc.sso.Assignment.TargetType.AWS_ACCOUNT"),
-            "AWS_ACCOUNT"
+            enum_display_value("awscc.sso.Assignment.TargetType.AWS_ACCOUNT"),
+            Some("AWS_ACCOUNT")
         );
-        assert_eq!(convert_enum_value("TargetType.AWS_ACCOUNT"), "AWS_ACCOUNT");
         assert_eq!(
-            convert_enum_value("awscc.sso.Assignment.PrincipalType.GROUP"),
-            "GROUP"
+            enum_display_value("TargetType.AWS_ACCOUNT"),
+            Some("AWS_ACCOUNT")
+        );
+        assert_eq!(
+            enum_display_value("awscc.sso.Assignment.PrincipalType.GROUP"),
+            Some("GROUP")
         );
     }
 
@@ -1974,7 +1939,7 @@ mod tests {
     }
 
     #[test]
-    fn is_dsl_enum_format_table() {
+    fn enum_display_value_detection_table() {
         let cases: &[(&str, bool)] = &[
             ("Type.gp2", true),
             ("Iops.100", true),
@@ -1990,28 +1955,35 @@ mod tests {
             ("aws.s3.versioningstatus.Enabled", false),
         ];
         for (input, expected) in cases {
-            assert_eq!(is_dsl_enum_format(input), *expected, "input={input:?}");
+            assert_eq!(
+                enum_display_value(input).is_some(),
+                *expected,
+                "input={input:?}"
+            );
         }
     }
 
     #[test]
-    fn convert_enum_value_table() {
-        let cases: &[(&str, &str)] = &[
-            ("Type.gp2", "gp2"),
-            ("Iops.100", "100"),
-            ("aws.Region.ap_northeast_1", "ap_northeast_1"),
-            ("aws.route53.RecordType.AAAA", "AAAA"),
-            ("aws.ec2.Volume.Iops.100", "100"),
-            ("awscc.ec2.vpn_gateway.Type.ipsec.1", "ipsec.1"),
-            ("awscc.ec2.Vpc.InstanceTenancy.default", "default"),
-            ("TargetType.AWS_ACCOUNT", "AWS_ACCOUNT"),
-            ("awscc.sso.Assignment.TargetType.AWS_ACCOUNT", "AWS_ACCOUNT"),
-            ("eu-west-1", "eu-west-1"),
-            ("region.us_east_1", "region.us_east_1"),
-            ("Enabled", "Enabled"),
+    fn enum_display_value_table() {
+        let cases: &[(&str, Option<&str>)] = &[
+            ("Type.gp2", Some("gp2")),
+            ("Iops.100", Some("100")),
+            ("aws.Region.ap_northeast_1", Some("ap_northeast_1")),
+            ("aws.route53.RecordType.AAAA", Some("AAAA")),
+            ("aws.ec2.Volume.Iops.100", Some("100")),
+            ("awscc.ec2.vpn_gateway.Type.ipsec.1", Some("ipsec.1")),
+            ("awscc.ec2.Vpc.InstanceTenancy.default", Some("default")),
+            ("TargetType.AWS_ACCOUNT", Some("AWS_ACCOUNT")),
+            (
+                "awscc.sso.Assignment.TargetType.AWS_ACCOUNT",
+                Some("AWS_ACCOUNT"),
+            ),
+            ("eu-west-1", None),
+            ("region.us_east_1", None),
+            ("Enabled", None),
         ];
         for (input, expected) in cases {
-            assert_eq!(convert_enum_value(input), *expected, "input={input:?}");
+            assert_eq!(enum_display_value(input), *expected, "input={input:?}");
         }
     }
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -10,7 +10,7 @@ use crate::resource::{
     CanonicalEnumValue, ConcreteValue, DeferredValue, InterpolationPart, UnknownReason, Value,
 };
 use crate::schema::{AttrTypeKind, AttributeType, TypeIdentity};
-use crate::utils::{convert_enum_value, extract_enum_value_with_values, is_dsl_enum_format};
+use crate::utils::{enum_display_value, extract_enum_value_with_values};
 
 /// Where in the pipeline a `Value` is being serialized. Used so the
 /// caller of a failing serialization (e.g. `--out plan.json`) can
@@ -524,10 +524,8 @@ pub(crate) fn format_value_into<S: FormatSink>(
             if s.starts_with(SECRET_PREFIX) {
                 return sink.write_str("(secret)");
             }
-            // DSL enum format (namespaced identifiers): resolve to
-            // provider value before quoting.
-            if is_dsl_enum_format(s) {
-                let resolved = convert_enum_value(s);
+            // Namespaced enum text: shorten for display before quoting.
+            if let Some(resolved) = enum_display_value(s) {
                 sink.write_str("\"")?;
                 sink.write_str(resolved)?;
                 return sink.write_str("\"");
@@ -1814,27 +1812,24 @@ pub fn resolve_value_alias_with_schemas(
     schemas: &[crate::schema::ResourceSchema],
 ) {
     match value {
-        Value::Concrete(ConcreteValue::String(s)) if is_dsl_enum_format(s) => {
+        Value::Concrete(ConcreteValue::String(s)) if enum_display_value(s).is_some() => {
             let valid_values: Vec<String> = schemas
                 .iter()
                 .filter(|schema| schema.resource_type == resource_type)
                 .flat_map(|schema| schema.enum_valid_values_for_attr_alias(attr_name, s))
                 .collect();
-            let raw = if valid_values.is_empty() {
-                // Schema-free fallback for attributes that are not known enum
-                // fields in the schema snapshot. This is fail-closed: unknown
-                // `(resource_type, attr_name)` pairs should not have reverse
-                // alias entries, so even a lossy extraction leaves `s`
-                // unchanged. Keep `convert_enum_value` here rather than
-                // last-segment extraction to preserve dotted enum values like
-                // `awscc.ec2.vpn_gateway.Type.ipsec.1`.
-                convert_enum_value(s)
-            } else {
+            // If the schema snapshot does not know `(resource_type, attr_name)`
+            // as an enum field, a reverse-alias hit would mean the schema and
+            // factory have drifted. Do not heal that silently with schema-free
+            // extraction; leave the value unchanged.
+            if !valid_values.is_empty() {
                 let valid_refs: Vec<&str> = valid_values.iter().map(String::as_str).collect();
-                extract_enum_value_with_values(s, &valid_refs)
-            };
-            if let Some(canonical) = factory.get_enum_alias_reverse(resource_type, attr_name, raw) {
-                *s = canonical;
+                let raw = extract_enum_value_with_values(s, &valid_refs);
+                if let Some(canonical) =
+                    factory.get_enum_alias_reverse(resource_type, attr_name, raw)
+                {
+                    *s = canonical;
+                }
             }
         }
         Value::Concrete(ConcreteValue::List(items)) => {
@@ -1992,28 +1987,18 @@ mod tests {
     }
 
     #[test]
-    fn resolve_value_alias_fail_closed_when_valid_values_empty() {
-        let schema = schema_with_attr(
-            "s3.BucketLifecycleConfiguration",
-            "known_status",
-            status_enum(Some("aws.s3.BucketLifecycleConfiguration.Rules")),
-        );
+    fn resolve_value_alias_skips_schema_free_fallback_when_valid_values_empty() {
         let factory = SchemaAliasFactory {
-            schemas: vec![schema],
-            resource_type: "s3.BucketLifecycleConfiguration",
-            attr_name: "missing_status",
-            alias_value: "disabled",
-            canonical: None,
+            schemas: Vec::new(),
+            resource_type: "ec2.Subnet",
+            attr_name: "hostname_type",
+            alias_value: "HostnameType.ip_name",
+            canonical: Some("ip-name"),
         };
-        let original = "aws.s3.BucketLifecycleConfiguration.Rules.Status.disabled";
+        let original = "aws.ec2.Subnet.PrivateDnsNameOptionsOnLaunch.HostnameType.ip_name";
         let mut value = Value::Concrete(ConcreteValue::String(original.to_string()));
 
-        resolve_value_alias(
-            &mut value,
-            "s3.BucketLifecycleConfiguration",
-            "missing_status",
-            &factory,
-        );
+        resolve_value_alias_with_schemas(&mut value, "ec2.Subnet", "hostname_type", &factory, &[]);
 
         assert_eq!(
             value,
@@ -2026,7 +2011,7 @@ mod tests {
         let schema = schema_with_attr(
             "svc.Resource",
             "statuses",
-            AttributeType::list(status_enum(Some("aws.svc.Resource.Status"))),
+            AttributeType::list(status_enum(Some("aws.svc.Resource"))),
         );
 
         assert_eq!(
@@ -2045,7 +2030,7 @@ mod tests {
         let schema = schema_with_attr(
             "svc.Resource",
             "status_by_name",
-            AttributeType::map(status_enum(Some("aws.svc.Resource.Status"))),
+            AttributeType::map(status_enum(Some("aws.svc.Resource"))),
         );
 
         assert_eq!(
@@ -2066,7 +2051,7 @@ mod tests {
             "status",
             AttributeType::union(vec![
                 AttributeType::string(),
-                status_enum(Some("aws.svc.Resource.Status")),
+                status_enum(Some("aws.svc.Resource")),
             ]),
         );
 
@@ -2657,7 +2642,7 @@ mod tests {
     #[test]
     fn test_format_value_two_part_enum_string() {
         // Two-part enum strings like "InstanceTenancy.dedicated" are formatted
-        // through convert_enum_value which extracts the value part
+        // through the display-shortening helper, which extracts the value part.
         let v = Value::Concrete(ConcreteValue::String(
             "InstanceTenancy.dedicated".to_string(),
         ));


### PR DESCRIPTION
## Summary

Implements the deletion half of the merged design doc `notes/specs/2026-06-10-schema-aware-enum-value-extraction-design.md` (PR #3436). The addition half — schema-aware, resolver-gated extraction — already landed via the carina#3438 chain (`EnumValueResolver` + `CanonicalEnumValue` with `pub(crate)` construction), which subsumed the design doc's proposed `extract_enum_wire_value`/`EnumWireValue` under different names. What remained was removing the schema-free public surface whose positional parse (TypeName pinned at index 3) mis-splits 6-segment structural identities — the root of carina-rs/carina-provider-aws#423.

## Changes

- **Delete `pub fn convert_enum_value` and `pub fn is_dsl_enum_format`.** Display shortening (their only legitimate remaining role) lives on as one `pub(crate) fn enum_display_value(s) -> Option<&str>` with an explicit 6+-segment mis-split caveat. Call sites (`format_value_into`, `extract_compact_hint`) now parse once instead of twice (the old guard+strip pair ran `NamespacedId::parse` twice per string, each allocating a `Vec`).
- **Demote `extract_enum_value_with_values` to `pub(crate)`.** All callers are in-crate. Deleted doctests are covered 1:1 by unit tests.
- **`resolve_value_alias_with_schemas`: drop the schema-free fallback** per the design doc ("schema が見つからない場合は alias 解決を諦めるか、schema 不備として扱うべき"). When the schema snapshot does not know `(resource_type, attr)` as an enum, alias resolution is skipped — a reverse-alias hit for a pair the schema doesn't know is a schema/factory desync, not something to heal silently with a lossy positional split. Regression test: a 6-segment structural identity with an empty schema snapshot stays byte-identical even when the factory carries a reverse alias keyed on the old mis-split string `"HostnameType.ip_name"`.
- **`dynamic_enum_member_is_structural` uses `NamespacedId::parse` directly** — it is validation gating, not display; the old helper's doc misdescribed this caller.
- **`pub fn extract_enum_value` stays public** with a new caveat doc. Its remaining consumers are the provider read-normalize seam (aws codegen template emits calls into generated schemas; awscc `schemas/config.rs`; in-repo e2e typecheck helpers). That seam is owned by the carina#3409 enum-state-coherence work; demotion is deferred there (follow-up issue filed: see PR comment thread).

## Why providers don't break

Provider repos pin carina by git rev, so this PR compiles them unchanged. The sweep PRs (provider-aws, then provider-awscc) bump the pin and migrate their call sites in the same PR:
- carina-provider-aws: `convert_enum_value` at subnet.rs:85/:203, ec2_security_group_rules.rs:369, s3/bucket.rs:84, s3/bucket_acl.rs:172 **and** `extract_enum_value_with_values` at normalizer.rs:168/:233, iam/role.rs:467/:473.
- carina-provider-awscc: conversion.rs:281/:287/:306.

## Verify

- `cargo check -p carina-core` ✓
- `cargo nextest run --workspace --all-features` ✓ (3989 passed, 72 skipped)
- `cargo test --workspace --doc` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `scripts/check-*.sh` all ✓
- `cargo fmt --check` ✓

Review: 7-angle finder fan-out + verification; round-2 fixes (fallback removal, helper unification, doc accuracy, comment re-anchoring) applied and re-verified; round-3 clean.

Refs carina-rs/carina-provider-aws#423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
