### PR TITLE
Demote extract_enum_value to pub(crate)

### DIFF
--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -62,6 +62,12 @@ fn single_schema_map(schema: ResourceSchema) -> SchemaRegistry {
     schemas
 }
 
+fn fixture_enum_segment_as_aws_value(s: &str) -> String {
+    // Mirrors the old last-dot-segment semantics for these dot-free fixture
+    // values, then rewrites DSL underscores to AWS hyphens.
+    s.split('.').next_back().unwrap_or(s).replace('_', "-")
+}
+
 /// Build a `ProviderFactory` set covering every provider name implied by
 /// the schemas. The CLI pipeline keys schemas by provider, so each
 /// distinct prefix (`test`, `aws`, ...) needs its own factory entry.
@@ -338,7 +344,7 @@ fn region_schemas() -> SchemaRegistry {
     fn validate_region(v: &Value) -> Result<(), String> {
         const VALID: &[&str] = &["ap-northeast-1", "us-west-2"];
         if let Value::Concrete(ConcreteValue::String(s)) = v {
-            let normalized = carina_core::utils::extract_enum_value(s).replace('_', "-");
+            let normalized = fixture_enum_segment_as_aws_value(s);
             if VALID.contains(&normalized.as_str()) {
                 return Ok(());
             }

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -345,20 +345,10 @@ fn is_type_name_segment(s: &str) -> bool {
 /// wire-value extractor. It mis-splits enum values that themselves contain
 /// dots, such as `awscc.ec2.vpn_gateway.Type.ipsec.1` -> `1`; use
 /// `extract_enum_value_with_values` internally when valid enum values are
-/// available. It must not be used for provider wire-out paths. Its remaining
-/// legitimate consumers are the provider read-normalize seam, and demotion is
-/// deferred to the carina#3409 enum-state-coherence implementation.
-///
-/// # Examples
-///
-/// ```
-/// use carina_core::utils::extract_enum_value;
-///
-/// assert_eq!(extract_enum_value("aws.Region.ap_northeast_1"), "ap_northeast_1");
-/// assert_eq!(extract_enum_value("aws.s3.Bucket.VersioningStatus.Enabled"), "Enabled");
-/// assert_eq!(extract_enum_value("Enabled"), "Enabled");
-/// ```
-pub fn extract_enum_value(s: &str) -> &str {
+/// available. It must not be used for provider wire-out paths. This helper is
+/// crate-internal and is used only as the no-match fallback of
+/// `extract_enum_value_with_values`.
+pub(crate) fn extract_enum_value(s: &str) -> &str {
     if s.contains('.') {
         s.split('.').next_back().unwrap_or(s)
     } else {

--- a/carina-lsp/tests/e2e_typecheck.rs
+++ b/carina-lsp/tests/e2e_typecheck.rs
@@ -34,6 +34,12 @@ fn messages_of(diags: &[tower_lsp::lsp_types::Diagnostic]) -> Vec<&String> {
     diags.iter().map(|d| &d.message).collect()
 }
 
+fn fixture_enum_segment_as_aws_value(s: &str) -> String {
+    // Mirrors the old last-dot-segment semantics for these dot-free fixture
+    // values, then rewrites DSL underscores to AWS hyphens.
+    s.split('.').next_back().unwrap_or(s).replace('_', "-")
+}
+
 // ---------------------------------------------------------------
 // Scenario 1: Enum with bare / TypeQualified / fully-qualified
 // ---------------------------------------------------------------
@@ -124,7 +130,7 @@ fn region_schemas() -> SchemaRegistry {
         {
             // Same shape as `aws_region()`: strip any namespace prefix
             // (DSL form) and rewrite `_` → `-` to get the AWS form.
-            let normalized = carina_core::utils::extract_enum_value(s).replace('_', "-");
+            let normalized = fixture_enum_segment_as_aws_value(s);
             if VALID.contains(&normalized.as_str()) {
                 return Ok(());
             }


### PR DESCRIPTION
## Summary

Closes #3452. With carina-rs/carina-provider-aws#431 and carina-rs/carina-provider-awscc#345 merged, no provider code uses `extract_enum_value` anymore — the read-normalize seam that depended on it was deleted (the host owns enum canonicalization post-#3438), and validators use exact identity-prefix strips. This demotes the last schema-free positional extractor out of the public API, completing the surface cleanup started in #3451.

## Changes

- `pub fn extract_enum_value` → `pub(crate)`; doc updated (crate-internal, no-match fallback of `extract_enum_value_with_values` only). Doctest examples already covered by unit tests.
- The two in-repo e2e typecheck helpers (integration tests = external crates) get a test-local 2-line equivalent.
- Sweep: every remaining `extract_enum_value` reference is inside `carina-core/src/utils.rs`.

## Verify

- `cargo check -p carina-core` / `nextest --workspace --all-features` (3989) / `cargo test --workspace --doc` / clippy `-D warnings` / `scripts/check-*.sh` / fmt — all ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)