### PR TITLE
Typed SimHash + meaning-based anonymous-rename matching (carina#3454 RC1)

### DIFF
--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -14,7 +14,9 @@ use carina_core::binding_index::{PreApplyInputs, ResolvedBindings, WaitAliasSpec
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
-use carina_core::identifier::{self, AnonymousIdStateInfo, PrefixStateInfo};
+use carina_core::identifier::{
+    self, AnonymousIdBindingStateInfo, AnonymousIdStateInfo, PrefixStateInfo,
+};
 use carina_core::module_resolver;
 use carina_core::parser::{ProviderConfig, StateBlock, StateBlockAddress};
 use carina_core::plan::Plan;
@@ -507,6 +509,31 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
     resources: &mut [Resource],
     state_file: &mut StateFile,
 ) {
+    let state_by_binding: HashMap<String, Vec<AnonymousIdBindingStateInfo>> = state_file
+        .resources
+        .iter()
+        .filter_map(|sr| {
+            let binding = sr.binding.as_ref()?;
+            Some((
+                binding.clone(),
+                AnonymousIdBindingStateInfo {
+                    name: sr.name.clone(),
+                    attribute_values: sr
+                        .attributes
+                        .iter()
+                        .filter_map(|(attr, value)| {
+                            identifier::canonical_create_only_state_json_string(value)
+                                .map(|s| (attr.clone(), s))
+                        })
+                        .collect(),
+                },
+            ))
+        })
+        .fold(HashMap::new(), |mut acc, (binding, info)| {
+            acc.entry(binding).or_default().push(info);
+            acc
+        });
+
     let renames = identifier::reconcile_anonymous_identifiers(
         resources,
         ctx.schemas(),
@@ -541,6 +568,7 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
                 })
                 .collect()
         },
+        &|binding| state_by_binding.get(binding).cloned().unwrap_or_default(),
     );
 
     apply_provider_prefix_renames(&renames, state_file);

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -711,6 +711,179 @@ fn import_fallback_skips_when_already_in_state_by_name_attribute() {
     );
 }
 
+struct AssociationCreateOnlyFactory;
+
+impl ProviderFactory for AssociationCreateOnlyFactory {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+
+    fn display_name(&self) -> &str {
+        "AWSCC association create-only test provider"
+    }
+
+    fn provider_config_attribute_types(
+        &self,
+    ) -> HashMap<String, carina_core::schema::AttributeType> {
+        HashMap::new()
+    }
+
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "ap-northeast-1".to_string()
+    }
+
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> carina_core::provider::BoxFuture<
+        '_,
+        carina_core::provider::ProviderResult<Box<dyn carina_core::provider::Provider>>,
+    > {
+        Box::pin(async {
+            Ok(Box::new(MockProvider::new()) as Box<dyn carina_core::provider::Provider>)
+        })
+    }
+
+    fn create_normalizer(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> carina_core::provider::BoxFuture<'_, Box<dyn carina_core::provider::ProviderNormalizer>>
+    {
+        Box::pin(async {
+            Box::new(carina_core::provider::NoopNormalizer)
+                as Box<dyn carina_core::provider::ProviderNormalizer>
+        })
+    }
+
+    fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {
+        use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+        vec![
+            ResourceSchema::new("ec2.SubnetRouteTableAssociation")
+                .attribute(
+                    AttributeSchema::new("route_table_id", AttributeType::string()).create_only(),
+                )
+                .attribute(
+                    AttributeSchema::new("subnet_id", AttributeType::string()).create_only(),
+                ),
+        ]
+    }
+}
+
+fn route_table_state(binding: &str, id: &str) -> carina_state::state::ResourceState {
+    let mut state = carina_state::state::ResourceState::new("ec2.RouteTable", binding, "awscc");
+    state.binding = Some(binding.to_string());
+    state
+        .attributes
+        .insert("id".to_string(), serde_json::Value::String(id.to_string()));
+    state
+}
+
+fn association_state(
+    name: &str,
+    route_table_id: &str,
+    subnet_id: &str,
+) -> carina_state::state::ResourceState {
+    let mut state =
+        carina_state::state::ResourceState::new("ec2.SubnetRouteTableAssociation", name, "awscc");
+    state.attributes.insert(
+        "route_table_id".to_string(),
+        serde_json::Value::String(route_table_id.to_string()),
+    );
+    state.attributes.insert(
+        "subnet_id".to_string(),
+        serde_json::Value::String(subnet_id.to_string()),
+    );
+    state
+}
+
+fn desired_association(name: &str, route_table_binding: &str, subnet_id: &str) -> Resource {
+    use carina_core::resource::AccessPath;
+
+    let mut resource =
+        Resource::with_provider("awscc", "ec2.SubnetRouteTableAssociation", name, None);
+    resource.set_attr(
+        "route_table_id".to_string(),
+        Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new(route_table_binding, "id"),
+        }),
+    );
+    resource.set_attr(
+        "subnet_id".to_string(),
+        Value::Concrete(ConcreteValue::String(subnet_id.to_string())),
+    );
+    resource
+}
+
+#[test]
+fn reconcile_anonymous_identifiers_with_ctx_resolves_deferred_create_only_from_state_bindings() {
+    use carina_state::state::StateFile;
+
+    let ctx = WiringContext::new(vec![Box::new(AssociationCreateOnlyFactory)]);
+    let mut state_file = StateFile::new();
+    state_file
+        .resources
+        .push(route_table_state("private_rtb", "rtb-private"));
+    state_file
+        .resources
+        .push(route_table_state("public_rtb", "rtb-public"));
+    state_file.resources.push(association_state(
+        "ec2_subnet_route_table_association_11111111",
+        "rtb-private",
+        "subnet-a",
+    ));
+    state_file.resources.push(association_state(
+        "ec2_subnet_route_table_association_22222222",
+        "rtb-public",
+        "subnet-a",
+    ));
+    state_file.resources.push(association_state(
+        "ec2_subnet_route_table_association_33333333",
+        "rtb-private",
+        "subnet-c",
+    ));
+
+    let mut resources = vec![
+        desired_association(
+            "ec2_subnet_route_table_association_aaaaaaaa",
+            "private_rtb",
+            "subnet-a",
+        ),
+        desired_association(
+            "ec2_subnet_route_table_association_bbbbbbbb",
+            "public_rtb",
+            "subnet-a",
+        ),
+        desired_association(
+            "ec2_subnet_route_table_association_cccccccc",
+            "private_rtb",
+            "subnet-c",
+        ),
+    ];
+
+    reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file);
+
+    let names: Vec<_> = resources
+        .iter()
+        .map(|resource| resource.id.name_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "ec2_subnet_route_table_association_11111111",
+            "ec2_subnet_route_table_association_22222222",
+            "ec2_subnet_route_table_association_33333333",
+        ],
+        "desired anonymous associations must adopt state names by resolved create-only values",
+    );
+}
+
 /// Regression test for carina#1683: data source input attributes that
 /// reference another resource must be resolved against current state
 /// *before* being passed to `read_data_source_with_retry`. Without

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -245,12 +245,23 @@ fn canonical_create_only_value_string(value: &Value) -> Option<String> {
         Value::Concrete(ConcreteValue::CanonicalEnum(c)) => {
             Some(format!("EnumApiValue({:?})", c.api_value()))
         }
+        Value::Concrete(ConcreteValue::Int(i)) => Some(format!("Int({})", i)),
+        Value::Concrete(ConcreteValue::Float(f)) => Some(format!("Float({})", f)),
+        Value::Concrete(ConcreteValue::Bool(b)) => Some(format!("Bool({})", b)),
+        // State JSON stores durations as integer seconds, so the comparison
+        // channel must use the same form as the state-side Int round-trip.
+        Value::Concrete(ConcreteValue::Duration(d)) => Some(format!("Int({})", d.as_secs())),
         Value::Concrete(ConcreteValue::List(items)) => {
             let parts: Vec<String> = items
                 .iter()
                 .map(canonical_create_only_feature_string)
                 .collect();
             Some(format!("List([{}])", parts.join(", ")))
+        }
+        // State JSON cannot distinguish StringList from List, so the
+        // canonical comparison channel uses the List form.
+        Value::Concrete(ConcreteValue::StringList(items)) => {
+            Some(format!("List([{}])", items.join(", ")))
         }
         Value::Concrete(ConcreteValue::Map(map)) => {
             let mut entries: Vec<(&String, &Value)> = map.iter().collect();
@@ -287,6 +298,46 @@ pub fn canonical_create_only_state_json_string(value: &serde_json::Value) -> Opt
 /// with modified attributes.
 pub(crate) const SIMHASH_HAMMING_THRESHOLD: u32 = 20;
 
+/// A 64-bit SimHash value. The field is private so standard create-only
+/// hashes cannot be smuggled into Hamming-distance comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SimHash(u64);
+
+impl SimHash {
+    pub(crate) fn parse_16_hex(identifier_suffix: &str) -> Option<Self> {
+        if identifier_suffix.len() != 16 {
+            return None;
+        }
+        u64::from_str_radix(identifier_suffix, 16).ok().map(Self)
+    }
+
+    pub(crate) fn distance(self, other: SimHash) -> u32 {
+        (self.0 ^ other.0).count_ones()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_flipped_mask_for_test(self, mask: u64) -> Self {
+        Self(self.0 ^ mask)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_zero_for_test(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl std::fmt::LowerHex for SimHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AnonymousHashSuffix {
+    Standard(u32),
+    SimHash(SimHash),
+}
+
 /// Find the unique candidate closest (by Hamming distance) to `target` SimHash
 /// among `candidates`, below `SIMHASH_HAMMING_THRESHOLD`. Returns `None` when
 /// no candidate qualifies, or when two or more candidates tie at the minimum
@@ -294,14 +345,14 @@ pub(crate) const SIMHASH_HAMMING_THRESHOLD: u32 = 20;
 /// commit to (rebinding to the wrong state entry would silently corrupt
 /// addresses).
 pub(crate) fn closest_unique_simhash_match<C: Copy>(
-    target: u64,
+    target: SimHash,
     candidates: impl IntoIterator<Item = C>,
-    hash_of: impl Fn(C) -> u64,
+    hash_of: impl Fn(C) -> SimHash,
 ) -> Option<C> {
     let mut best: Option<(C, u32)> = None;
     let mut unique = true;
     for c in candidates {
-        let distance = (target ^ hash_of(c)).count_ones();
+        let distance = target.distance(hash_of(c));
         if distance >= SIMHASH_HAMMING_THRESHOLD {
             continue;
         }
@@ -356,7 +407,7 @@ pub(crate) fn flatten_value_for_simhash(
 /// using Hamming distance on the identifier alone.
 pub(crate) fn compute_simhash<K: std::fmt::Display>(
     attributes: &std::collections::BTreeMap<K, String>,
-) -> u64 {
+) -> SimHash {
     use std::hash::{Hash, Hasher};
 
     let mut v = [0i32; 64];
@@ -379,18 +430,20 @@ pub(crate) fn compute_simhash<K: std::fmt::Display>(
             result |= 1 << i;
         }
     }
-    result
+    SimHash(result)
 }
 
 /// Extract the hash portion from an anonymous resource identifier.
 ///
 /// Supports both 8 hex chars (standard hash, u32) and 16 hex chars (SimHash, u64).
 /// Identifier format: `{resource_type}_{hex}` (e.g., `ec2_eip_a3f2b1c8d79f1524`).
-pub(crate) fn extract_hash_from_identifier(identifier: &str) -> Option<u64> {
+pub(crate) fn extract_hash_from_identifier(identifier: &str) -> Option<AnonymousHashSuffix> {
     let hex_part = identifier.rsplit('_').next()?;
     match hex_part.len() {
-        16 => u64::from_str_radix(hex_part, 16).ok(),
-        8 => u32::from_str_radix(hex_part, 16).ok().map(|v| v as u64),
+        16 => SimHash::parse_16_hex(hex_part).map(AnonymousHashSuffix::SimHash),
+        8 => u32::from_str_radix(hex_part, 16)
+            .ok()
+            .map(AnonymousHashSuffix::Standard),
         _ => None,
     }
 }
@@ -404,7 +457,7 @@ pub(crate) fn extract_hash_from_identifier(identifier: &str) -> Option<u64> {
 fn simhash_from_identity_and_resource(
     identity_values: &BTreeMap<String, String>,
     resource: &Resource,
-) -> u64 {
+) -> SimHash {
     let mut simhash_values = identity_values.clone();
     for (key, value) in &resource.attributes {
         if key.starts_with('_') {
@@ -422,7 +475,7 @@ fn compute_resource_simhash(
     resource: &Resource,
     providers: &CanonicalizedProviderConfigs,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
-) -> u64 {
+) -> SimHash {
     let mut identity_values: BTreeMap<String, String> = BTreeMap::new();
     if !resource.id.provider.is_empty() {
         let identity_attrs = identity_attributes_fn(&resource.id.provider);
@@ -646,6 +699,51 @@ pub struct AnonymousIdStateInfo {
     pub create_only_values: HashMap<String, String>,
 }
 
+/// Cross-resource state information used to resolve simple deferred
+/// create-only references like `route_table_id = private_rtb.id`.
+#[derive(Clone)]
+pub struct AnonymousIdBindingStateInfo {
+    /// The resource name stored in state. Let-bound resources are usually
+    /// named by their binding (`private_rtb`, `inst.x`).
+    pub name: String,
+    /// Canonical attribute values from state, keyed by DSL attribute name
+    /// (the state JSON attribute key).
+    pub attribute_values: HashMap<String, String>,
+}
+
+fn state_entry_matches_binding_scope(binding: &str, state_name: &str) -> bool {
+    binding.contains('.') || !state_name.contains('.')
+}
+
+fn resolve_deferred_create_only_value_string(
+    value: &Value,
+    find_state_by_binding: &dyn Fn(&str) -> Vec<AnonymousIdBindingStateInfo>,
+) -> Option<String> {
+    let Value::Deferred(DeferredValue::ResourceRef { path }) = value else {
+        return None;
+    };
+    if !path.segments().is_empty() {
+        return None;
+    }
+
+    let candidates: Vec<AnonymousIdBindingStateInfo> = find_state_by_binding(path.binding())
+        .into_iter()
+        .filter(|entry| state_entry_matches_binding_scope(path.binding(), &entry.name))
+        .collect();
+    let [entry] = candidates.as_slice() else {
+        return None;
+    };
+    entry.attribute_values.get(path.attribute()).cloned()
+}
+
+fn canonical_or_resolved_create_only_value_string(
+    value: &Value,
+    find_state_by_binding: &dyn Fn(&str) -> Vec<AnonymousIdBindingStateInfo>,
+) -> Option<String> {
+    canonical_create_only_value_string(value)
+        .or_else(|| resolve_deferred_create_only_value_string(value, find_state_by_binding))
+}
+
 /// Reconcile anonymous resource identifiers with existing state.
 ///
 /// When a create-only property changes on an anonymous resource, the computed
@@ -656,6 +754,14 @@ pub struct AnonymousIdStateInfo {
 ///
 /// `find_state_by_type` takes (provider, resource_type) and returns all state
 /// entries for that resource type with their create-only attribute values.
+/// `find_state_by_binding` takes a binding name and returns state entries
+/// carrying that binding across resource types, for resolving single-hop
+/// deferred create-only refs of the exact form `binding.attr`. Binding
+/// resolution is unresolvable when zero state entries match and ambiguous when
+/// multiple state entries with the same binding are visible in scope; both
+/// cases yield no value and are not errors. Dotted bindings are already
+/// module-qualified by their binding string, while bare bindings only resolve
+/// against dot-free root state entry names.
 ///
 /// Returns a list of `(old_state_name, new_resource_name)` pairs that the
 /// caller should apply to state-keyed maps. These are emitted when a SimHash
@@ -667,6 +773,7 @@ pub fn reconcile_anonymous_identifiers(
     resources: &mut [Resource],
     registry: &SchemaRegistry,
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
+    find_state_by_binding: &dyn Fn(&str) -> Vec<AnonymousIdBindingStateInfo>,
 ) -> Vec<(String, String)> {
     let mut renames: Vec<(String, String)> = Vec::new();
     let mut used_names: HashMap<(String, String), HashSet<String>> = HashMap::new();
@@ -718,7 +825,8 @@ pub fn reconcile_anonymous_identifiers(
         let mut resource_co_values: HashMap<&str, String> = HashMap::new();
         for attr_name in &create_only_attrs {
             if let Some(value) = resource.get_attr(attr_name)
-                && let Some(value) = canonical_create_only_value_string(value)
+                && let Some(value) =
+                    canonical_or_resolved_create_only_value_string(value, find_state_by_binding)
             {
                 resource_co_values.insert(attr_name, value);
             }
@@ -727,36 +835,31 @@ pub fn reconcile_anonymous_identifiers(
         if create_only_attrs.is_empty() || resource_co_values.is_empty() {
             // No create-only properties or none set: use SimHash-based Hamming distance
             // matching to find the closest state entry.
-            let Some(resource_hash) = extract_hash_from_identifier(resource.id.name_str()) else {
+            let Some(AnonymousHashSuffix::SimHash(resource_hash)) =
+                extract_hash_from_identifier(resource.id.name_str())
+            else {
                 continue;
             };
 
-            let mut best_match: Option<(&str, u32)> = None;
-            for entry in &state_entries {
-                if entry.name == resource.id.name_str() {
-                    continue;
-                }
-                if used_names
-                    .get(&key)
-                    .is_some_and(|names| names.contains(&entry.name))
-                    || claimed_names
+            let candidates = state_entries
+                .iter()
+                .filter(|entry| entry.name != resource.id.name_str())
+                .filter(|entry| {
+                    !used_names
                         .get(&key)
                         .is_some_and(|names| names.contains(&entry.name))
-                {
-                    continue;
-                }
-                let Some(state_hash) = extract_hash_from_identifier(&entry.name) else {
-                    continue;
-                };
-                let distance = (resource_hash ^ state_hash).count_ones();
-                if distance < SIMHASH_HAMMING_THRESHOLD
-                    && (best_match.is_none() || distance < best_match.unwrap().1)
-                {
-                    best_match = Some((&entry.name, distance));
-                }
-            }
+                        && !claimed_names
+                            .get(&key)
+                            .is_some_and(|names| names.contains(&entry.name))
+                })
+                .filter_map(|entry| match extract_hash_from_identifier(&entry.name) {
+                    Some(AnonymousHashSuffix::SimHash(hash)) => Some((entry.name.as_str(), hash)),
+                    _ => None,
+                });
 
-            if let Some((state_name, _)) = best_match {
+            if let Some((state_name, _)) =
+                closest_unique_simhash_match(resource_hash, candidates, |(_, hash)| hash)
+            {
                 // The state entry may use an older identifier format (e.g.
                 // pre-provider-prefix). Keep our freshly-computed new-format
                 // name on the resource and record a rename so the wiring
@@ -961,12 +1064,9 @@ pub fn detect_anonymous_to_named_renames(
             let candidates = state_entries
                 .iter()
                 .filter(|e| !used_in_dsl.contains(&e.name))
-                // Only consider state entries written via the SimHash path
-                // (16-hex suffix). 8-hex entries come from the create-only
-                // hash scheme and are meaningless to XOR with a 64-bit SimHash.
-                .filter(|e| e.name.rsplit('_').next().map(str::len) == Some(16))
-                .filter_map(|e| {
-                    extract_hash_from_identifier(&e.name).map(|h| (e.name.as_str(), h))
+                .filter_map(|e| match extract_hash_from_identifier(&e.name) {
+                    Some(AnonymousHashSuffix::SimHash(hash)) => Some((e.name.as_str(), hash)),
+                    _ => None,
                 });
             closest_unique_simhash_match(resource_hash, candidates, |(_, h)| h)
                 .map(|(name, _)| name)

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -125,6 +125,13 @@ fn simhash_eip_resource(tag_env: &str) -> Resource {
     resource
 }
 
+fn simhash_suffix_for_test(identifier: &str) -> SimHash {
+    match extract_hash_from_identifier(identifier).expect("identifier should have hash suffix") {
+        AnonymousHashSuffix::SimHash(hash) => hash,
+        AnonymousHashSuffix::Standard(_) => panic!("expected SimHash suffix: {identifier}"),
+    }
+}
+
 #[test]
 fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
     let schema = ResourceSchema::new("ec2.Route")
@@ -351,9 +358,12 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(&mut desired_resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut desired_resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(desired_resources[0].id.name_str(), state_name);
 }
@@ -431,9 +441,12 @@ fn test_reconcile_anonymous_id_after_nested_enum_create_only_hash_migration() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(&mut desired_resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut desired_resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(desired_resources[0].id.name_str(), state_name);
 }
@@ -511,9 +524,12 @@ fn test_reconcile_anonymous_id_after_nested_enum_no_edit_upgrade_full_match() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(&mut desired_resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut desired_resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(desired_resources[0].id.name_str(), state_name);
 }
@@ -566,9 +582,12 @@ fn test_reconcile_anonymous_id_nested_enum_full_match_ambiguous_skips() {
             create_only_values,
         },
     ];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(resources[0].id.name_str(), original_id);
 }
@@ -603,9 +622,12 @@ fn test_reconcile_anonymous_id_mixed_string_and_enum_identifier_for_enum_attribu
         .collect(),
     }];
     let mut resources = vec![resource];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(resources[0].id.name_str(), state_name);
 }
@@ -857,9 +879,12 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources2,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // After reconciliation, step2 resource should have step1's identifier
     assert_eq!(resources2[0].id.name_str(), step1_id);
@@ -897,9 +922,12 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // Identifier should remain unchanged
     assert_eq!(resources[0].id.name_str(), original_id);
@@ -937,9 +965,12 @@ fn test_reconcile_anonymous_id_unique_full_match_rebinds() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(resources[0].id.name_str(), "iam_role_11223344");
 }
@@ -968,9 +999,12 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
             .into_iter()
             .collect(),
     }];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // No reconciliation: only one create-only prop and it changed
     assert_eq!(resources[0].id.name_str(), original_id);
@@ -1254,9 +1288,12 @@ fn test_reconcile_anonymous_id_full_match_claims_state_entry_once() {
     assert_ne!(resources[1].id.name_str(), old_state_name);
 
     let state_entries = vec![route53_state_entry(old_state_name)];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     let names: HashSet<&str> = resources.iter().map(|r| r.id.name_str()).collect();
     assert_eq!(names.len(), 2, "reconcile must not duplicate ResourceIds");
@@ -1288,9 +1325,12 @@ fn test_reconcile_anonymous_id_full_match_does_not_steal_live_entry() {
     let new_aaaa_name = resources[1].id.name_str().to_string();
     let state_entries = vec![route53_state_entry(&live_a_name)];
 
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(resources[0].id.name_str(), live_a_name);
     assert_eq!(
@@ -1321,7 +1361,7 @@ fn test_simhash_similar_inputs_close_distance() {
 
     let hash1 = compute_simhash(&attrs1);
     let hash2 = compute_simhash(&attrs2);
-    let distance = (hash1 ^ hash2).count_ones();
+    let distance = hash1.distance(hash2);
 
     // Similar inputs (1 of 5 changed) should have small Hamming distance
     assert!(
@@ -1350,14 +1390,516 @@ fn test_extract_hash_from_identifier() {
     // 16 hex chars (SimHash, 64-bit)
     assert_eq!(
         extract_hash_from_identifier("ec2_eip_a3f2b1c8d79f1524"),
-        Some(0xa3f2b1c8d79f1524)
+        Some(AnonymousHashSuffix::SimHash(
+            SimHash::parse_16_hex("a3f2b1c8d79f1524").unwrap()
+        ))
     );
     // 8 hex chars (standard hash, 32-bit) - still supported
-    assert_eq!(extract_hash_from_identifier("ec2_vpc_00000000"), Some(0));
+    assert_eq!(
+        extract_hash_from_identifier("ec2_vpc_00000000"),
+        Some(AnonymousHashSuffix::Standard(0))
+    );
     assert_eq!(extract_hash_from_identifier("short"), None);
     assert_eq!(extract_hash_from_identifier("bad_zzzzzzzz"), None);
     // 12 hex chars (neither 8 nor 16) - rejected
     assert_eq!(extract_hash_from_identifier("ec2_eip_aabbccddeeff"), None);
+}
+
+fn subnet_route_table_association_schema() -> ResourceSchema {
+    ResourceSchema::new("ec2.SubnetRouteTableAssociation")
+        .attribute(AttributeSchema::new("route_table_id", AttributeType::string()).create_only())
+        .attribute(AttributeSchema::new("subnet_id", AttributeType::string()).create_only())
+}
+
+fn subnet_route_table_association_resource(
+    name: &str,
+    route_table_binding: &str,
+    subnet_binding: &str,
+) -> Resource {
+    use crate::resource::AccessPath;
+
+    let mut resource =
+        Resource::with_provider("awscc", "ec2.SubnetRouteTableAssociation", name, None);
+    resource.set_attr(
+        "route_table_id".to_string(),
+        Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new(route_table_binding, "id"),
+        }),
+    );
+    resource.set_attr(
+        "subnet_id".to_string(),
+        Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new(subnet_binding, "id"),
+        }),
+    );
+    resource
+}
+
+fn binding_state_entry(
+    binding: &str,
+    name: &str,
+    attrs: &[(&str, &str)],
+) -> (String, AnonymousIdBindingStateInfo) {
+    (
+        binding.to_string(),
+        AnonymousIdBindingStateInfo {
+            name: name.to_string(),
+            attribute_values: attrs
+                .iter()
+                .map(|(attr, value)| ((*attr).to_string(), (*value).to_string()))
+                .collect(),
+        },
+    )
+}
+
+fn association_state_entry(
+    name: &str,
+    route_table_id: &str,
+    subnet_id: &str,
+) -> AnonymousIdStateInfo {
+    AnonymousIdStateInfo {
+        name: name.to_string(),
+        create_only_values: vec![
+            ("route_table_id".to_string(), route_table_id.to_string()),
+            ("subnet_id".to_string(), subnet_id.to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    }
+}
+
+fn route_with_deferred_route_table(name: &str, route_table_binding: &str) -> Resource {
+    use crate::resource::{AccessPath, ModuleSource};
+
+    let mut resource = Resource::with_provider("awscc", "ec2.Route", name, None);
+    resource.module_source = Some(ModuleSource::Module {
+        name: "mymod".to_string(),
+        instance: "inst".to_string(),
+    });
+    resource.set_attr(
+        "route_table_id".to_string(),
+        Value::Deferred(DeferredValue::ResourceRef {
+            path: AccessPath::new(route_table_binding, "id"),
+        }),
+    );
+    resource
+}
+
+fn route_schema_with_create_only_route_table() -> ResourceSchema {
+    ResourceSchema::new("ec2.Route")
+        .attribute(AttributeSchema::new("route_table_id", AttributeType::string()).create_only())
+}
+
+fn route_state_entry(name: &str, route_table_id: &str) -> AnonymousIdStateInfo {
+    AnonymousIdStateInfo {
+        name: name.to_string(),
+        create_only_values: vec![("route_table_id".to_string(), route_table_id.to_string())]
+            .into_iter()
+            .collect(),
+    }
+}
+
+#[test]
+fn test_reconcile_does_not_hamming_match_standard_hash_names() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", subnet_route_table_association_schema());
+
+    let original_names = [
+        "awscc_ec2_subnet_route_table_association_aaaaaaaa",
+        "awscc_ec2_subnet_route_table_association_bbbbbbbb",
+        "awscc_ec2_subnet_route_table_association_cccccccc",
+    ];
+    let mut resources = vec![
+        subnet_route_table_association_resource(original_names[0], "private_rtb", "private_subnet"),
+        subnet_route_table_association_resource(original_names[1], "db_rtb", "db_subnet"),
+        subnet_route_table_association_resource(original_names[2], "public_rtb", "public_subnet"),
+    ];
+
+    let state_entries = vec![
+        AnonymousIdStateInfo {
+            name: "awscc_ec2_subnet_route_table_association_aaaaaaab".to_string(),
+            create_only_values: HashMap::new(),
+        },
+        AnonymousIdStateInfo {
+            name: "awscc_ec2_subnet_route_table_association_bbbbbbba".to_string(),
+            create_only_values: HashMap::new(),
+        },
+        AnonymousIdStateInfo {
+            name: "awscc_ec2_subnet_route_table_association_cccccccd".to_string(),
+            create_only_values: HashMap::new(),
+        },
+    ];
+
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
+
+    assert!(
+        renames.is_empty(),
+        "8-hex standard hashes must never be used for SimHash Hamming renames"
+    );
+    assert_eq!(
+        resources
+            .iter()
+            .map(|r| r.id.name_str())
+            .collect::<Vec<_>>(),
+        original_names
+    );
+}
+
+#[test]
+fn test_reconcile_resolves_deferred_create_only_via_state_bindings() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", subnet_route_table_association_schema());
+
+    let desired_names = [
+        "awscc_ec2_subnet_route_table_association_aaaaaaaa",
+        "awscc_ec2_subnet_route_table_association_bbbbbbbb",
+        "awscc_ec2_subnet_route_table_association_cccccccc",
+    ];
+    let state_names = [
+        "awscc_ec2_subnet_route_table_association_11111111",
+        "awscc_ec2_subnet_route_table_association_22222222",
+        "awscc_ec2_subnet_route_table_association_33333333",
+    ];
+    let mut resources = vec![
+        subnet_route_table_association_resource(desired_names[0], "private_rtb", "private_subnet"),
+        subnet_route_table_association_resource(desired_names[1], "db_rtb", "db_subnet"),
+        subnet_route_table_association_resource(desired_names[2], "public_rtb", "public_subnet"),
+    ];
+    let state_entries = vec![
+        association_state_entry(state_names[0], "rtb-private", "subnet-private"),
+        association_state_entry(state_names[1], "rtb-db", "subnet-db"),
+        association_state_entry(state_names[2], "rtb-public", "subnet-public"),
+    ];
+    let binding_entries = [
+        binding_state_entry("private_rtb", "private_rtb", &[("id", "rtb-private")]),
+        binding_state_entry(
+            "private_subnet",
+            "private_subnet",
+            &[("id", "subnet-private")],
+        ),
+        binding_state_entry("db_rtb", "db_rtb", &[("id", "rtb-db")]),
+        binding_state_entry("db_subnet", "db_subnet", &[("id", "subnet-db")]),
+        binding_state_entry("public_rtb", "public_rtb", &[("id", "rtb-public")]),
+        binding_state_entry("public_subnet", "public_subnet", &[("id", "subnet-public")]),
+    ];
+
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+    );
+
+    assert!(renames.is_empty());
+    assert_eq!(
+        resources
+            .iter()
+            .map(|resource| resource.id.name_str())
+            .collect::<Vec<_>>(),
+        state_names
+    );
+}
+
+#[test]
+fn test_reconcile_deferred_create_only_ambiguous_refuses() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", subnet_route_table_association_schema());
+
+    let original_name = "awscc_ec2_subnet_route_table_association_aaaaaaaa";
+    let mut resources = vec![subnet_route_table_association_resource(
+        original_name,
+        "private_rtb",
+        "private_subnet",
+    )];
+    let state_entries = vec![
+        association_state_entry(
+            "awscc_ec2_subnet_route_table_association_11111111",
+            "rtb-private",
+            "subnet-private",
+        ),
+        association_state_entry(
+            "awscc_ec2_subnet_route_table_association_22222222",
+            "rtb-private",
+            "subnet-private",
+        ),
+    ];
+    let binding_entries = [
+        binding_state_entry("private_rtb", "private_rtb", &[("id", "rtb-private")]),
+        binding_state_entry(
+            "private_subnet",
+            "private_subnet",
+            &[("id", "subnet-private")],
+        ),
+    ];
+
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+    );
+
+    assert!(renames.is_empty());
+    assert_eq!(resources[0].id.name_str(), original_name);
+}
+
+#[test]
+fn test_reconcile_deferred_binding_ambiguous_yields_no_value() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", route_schema_with_create_only_route_table());
+
+    let original_name = "awscc_ec2_route_aaaaaaaa";
+    let mut resource = Resource::with_provider("awscc", "ec2.Route", original_name, None);
+    resource.set_attr(
+        "route_table_id".to_string(),
+        Value::Deferred(DeferredValue::ResourceRef {
+            path: crate::resource::AccessPath::new("private_rtb", "id"),
+        }),
+    );
+    let mut resources = vec![resource];
+    let state_entries = vec![association_state_entry(
+        "awscc_ec2_route_11111111",
+        "rtb-private",
+        "unused",
+    )];
+    let binding_entries = [
+        binding_state_entry("private_rtb", "private_rtb_a", &[("id", "rtb-private")]),
+        binding_state_entry("private_rtb", "private_rtb_b", &[("id", "rtb-private")]),
+    ];
+
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+    );
+
+    assert!(renames.is_empty());
+    assert_eq!(resources[0].id.name_str(), original_name);
+}
+
+#[test]
+fn test_reconcile_module_argument_passed_root_binding_resolves() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", route_schema_with_create_only_route_table());
+
+    let desired_name = "inst.awscc_ec2_route_aaaaaaaa";
+    let state_name = "inst.awscc_ec2_route_11111111";
+    let mut resources = vec![route_with_deferred_route_table(desired_name, "private_rtb")];
+    let state_entries = vec![route_state_entry(state_name, "rtb-private")];
+    let binding_entries = [binding_state_entry(
+        "private_rtb",
+        "private_rtb",
+        &[("id", "rtb-private")],
+    )];
+
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+    );
+
+    assert!(renames.is_empty());
+    assert_eq!(resources[0].id.name_str(), state_name);
+}
+
+#[test]
+fn test_reconcile_module_intra_module_binding_resolves() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", route_schema_with_create_only_route_table());
+
+    let desired_name = "inst.awscc_ec2_route_aaaaaaaa";
+    let state_name = "inst.awscc_ec2_route_11111111";
+    let mut resources = vec![route_with_deferred_route_table(desired_name, "inst.x")];
+    let state_entries = vec![route_state_entry(state_name, "rtb-private")];
+    let binding_entries = [binding_state_entry(
+        "inst.x",
+        "inst.x",
+        &[("id", "rtb-private")],
+    )];
+
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+    );
+
+    assert!(renames.is_empty());
+    assert_eq!(resources[0].id.name_str(), state_name);
+}
+
+#[test]
+fn test_reconcile_bare_binding_does_not_resolve_module_prefixed_state_entry() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", route_schema_with_create_only_route_table());
+
+    let desired_name = "inst.awscc_ec2_route_aaaaaaaa";
+    let state_name = "inst.awscc_ec2_route_11111111";
+    let mut resources = vec![route_with_deferred_route_table(desired_name, "private_rtb")];
+    let state_entries = vec![route_state_entry(state_name, "rtb-private")];
+    let binding_entries = [binding_state_entry(
+        "private_rtb",
+        "inst.private_rtb",
+        &[("id", "rtb-private")],
+    )];
+
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+    );
+
+    assert!(renames.is_empty());
+    assert_eq!(resources[0].id.name_str(), desired_name);
+}
+
+#[test]
+fn test_reconcile_simhash_tie_refused() {
+    let schema = ResourceSchema::new("ec2.eip")
+        .attribute(AttributeSchema::new("domain", AttributeType::string()));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let original_name = "awscc_ec2_eip_0000000000000000";
+    let mut resources = vec![Resource::with_provider(
+        "awscc",
+        "ec2.eip",
+        original_name,
+        None,
+    )];
+    let state_entries = vec![
+        AnonymousIdStateInfo {
+            name: "awscc_ec2_eip_0000000000000001".to_string(),
+            create_only_values: HashMap::new(),
+        },
+        AnonymousIdStateInfo {
+            name: "awscc_ec2_eip_0000000000000002".to_string(),
+            create_only_values: HashMap::new(),
+        },
+    ];
+
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
+
+    assert!(renames.is_empty());
+    assert_eq!(resources[0].id.name_str(), original_name);
+}
+
+#[test]
+fn test_canonical_create_only_string_covers_concrete_scalars() {
+    assert_eq!(
+        canonical_create_only_value_string(&Value::Concrete(ConcreteValue::Int(42))),
+        Some("Int(42)".to_string())
+    );
+    assert_eq!(
+        canonical_create_only_value_string(&Value::Concrete(ConcreteValue::Float(3.5))),
+        Some("Float(3.5)".to_string())
+    );
+    assert_eq!(
+        canonical_create_only_value_string(&Value::Concrete(ConcreteValue::Bool(true))),
+        Some("Bool(true)".to_string())
+    );
+    assert_eq!(
+        canonical_create_only_value_string(&Value::Concrete(ConcreteValue::Duration(
+            std::time::Duration::from_secs(90)
+        ))),
+        Some("Int(90)".to_string())
+    );
+    assert_eq!(
+        canonical_create_only_value_string(&Value::Concrete(ConcreteValue::StringList(vec![
+            "alpha".to_string(),
+            "beta".to_string(),
+        ]))),
+        Some("List([alpha, beta])".to_string())
+    );
+}
+
+#[test]
+fn test_canonical_create_only_string_matches_state_round_trip() {
+    let values = {
+        let mut map = IndexMap::new();
+        map.insert(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("alpha".to_string())),
+        );
+        map.insert("count".to_string(), Value::Concrete(ConcreteValue::Int(2)));
+
+        vec![
+            Value::Concrete(ConcreteValue::String("alpha".to_string())),
+            Value::Concrete(ConcreteValue::Int(42)),
+            Value::Concrete(ConcreteValue::Float(3.5)),
+            Value::Concrete(ConcreteValue::Bool(true)),
+            Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(300))),
+            Value::Concrete(ConcreteValue::StringList(vec![
+                "alpha".to_string(),
+                "beta".to_string(),
+            ])),
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String("alpha".to_string())),
+                Value::Concrete(ConcreteValue::Int(2)),
+            ])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::StringList(vec!["alpha".to_string(), "beta".to_string()]),
+            )])),
+            Value::Concrete(ConcreteValue::Map(map)),
+        ]
+    };
+
+    for value in values {
+        let state_json = crate::value::value_to_json(&value).expect("value should serialize");
+        assert_eq!(
+            canonical_create_only_value_string(&value),
+            canonical_create_only_state_json_string(&state_json),
+            "round-trip canonical mismatch for {value:?}",
+        );
+    }
 }
 
 #[test]
@@ -1434,9 +1976,12 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         name: old_id.clone(),
         create_only_values: HashMap::new(),
     }];
-    let renames = reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources2,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // After reconciliation: the resource keeps its freshly-computed
     // (new) identifier and a rename pair is emitted so the wiring
@@ -1468,9 +2013,12 @@ fn test_reconcile_anonymous_id_simhash_does_not_steal_live_entry() {
         name: live_name.clone(),
         create_only_values: HashMap::new(),
     }];
-    let renames = reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(resources[0].id.name_str(), live_name);
     assert_eq!(resources[1].id.name_str(), new_name);
@@ -1491,7 +2039,7 @@ fn test_reconcile_anonymous_id_simhash_claims_state_entry_once() {
     compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
         .unwrap();
     let old_name = old_resources[0].id.name_str().to_string();
-    let old_hash = extract_hash_from_identifier(&old_name).unwrap();
+    let old_hash = simhash_suffix_for_test(&old_name);
 
     let mut nearby_resources: Vec<Resource> = Vec::new();
     for tag_env in [
@@ -1506,9 +2054,9 @@ fn test_reconcile_anonymous_id_simhash_claims_state_entry_once() {
         let mut candidate = vec![simhash_eip_resource(tag_env)];
         compute_anonymous_identifiers_for_test(&mut candidate, &providers, &schemas, &identity_fn)
             .unwrap();
-        let candidate_hash = extract_hash_from_identifier(candidate[0].id.name_str()).unwrap();
+        let candidate_hash = simhash_suffix_for_test(candidate[0].id.name_str());
         if candidate[0].id.name_str() != old_name
-            && (old_hash ^ candidate_hash).count_ones() < SIMHASH_HAMMING_THRESHOLD
+            && old_hash.distance(candidate_hash) < SIMHASH_HAMMING_THRESHOLD
         {
             nearby_resources.push(candidate.remove(0));
         }
@@ -1526,10 +2074,12 @@ fn test_reconcile_anonymous_id_simhash_claims_state_entry_once() {
         name: old_name.clone(),
         create_only_values: HashMap::new(),
     }];
-    let renames =
-        reconcile_anonymous_identifiers(&mut nearby_resources, &schemas, &|_provider, _rt| {
-            state_entries.clone()
-        });
+    let renames = reconcile_anonymous_identifiers(
+        &mut nearby_resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(
         renames.len(),
@@ -1563,9 +2113,12 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
         name: "ec2_eip_5544332266778899".to_string(),
         create_only_values: HashMap::new(),
     }];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // Identifier should remain unchanged (too distant)
     assert_eq!(resources[0].id.name_str(), original_id);
@@ -1614,9 +2167,12 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
         name: state_id,
         create_only_values: HashMap::new(),
     }];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // Same identifier in state, no change needed
     assert_eq!(resources[0].id.name_str(), current_id);
@@ -1685,7 +2241,7 @@ fn test_simhash_empty_attributes() {
 
     let attrs: BTreeMap<&str, String> = BTreeMap::new();
     // Empty attributes should produce 0 (all vote counters remain 0, all bits off)
-    assert_eq!(compute_simhash(&attrs), 0);
+    assert!(compute_simhash(&attrs).is_zero_for_test());
 }
 
 #[test]
@@ -1697,7 +2253,7 @@ fn test_simhash_single_attribute() {
 
     let hash = compute_simhash(&attrs);
     // Single attribute: hash should be non-zero and deterministic
-    assert_ne!(hash, 0);
+    assert!(!hash.is_zero_for_test());
     assert_eq!(hash, compute_simhash(&attrs));
 }
 
@@ -1719,7 +2275,7 @@ fn test_simhash_many_attributes_one_change_close_distance() {
 
     let hash1 = compute_simhash(&attrs1);
     let hash2 = compute_simhash(&attrs2);
-    let distance = (hash1 ^ hash2).count_ones();
+    let distance = hash1.distance(hash2);
 
     assert!(
         distance < SIMHASH_HAMMING_THRESHOLD,
@@ -1843,10 +2399,12 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
     ];
 
     let current_id_before = resources_current[0].id.name_str().to_string();
-    let renames =
-        reconcile_anonymous_identifiers(&mut resources_current, &schemas, &|_provider, _rt| {
-            state_entries.clone()
-        });
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources_current,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // Resource keeps its freshly-computed identifier; the rename pair (if any)
     // points from the closest state entry to the new identifier so the wiring
@@ -1857,11 +2415,11 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         "Resource should retain its freshly-computed identifier",
     );
 
-    let current_hash = extract_hash_from_identifier(&current_id_before).unwrap();
-    let orig_hash = extract_hash_from_identifier(&orig_id).unwrap();
-    let distant_hash = extract_hash_from_identifier(&distant_id).unwrap();
-    let dist_to_orig = (current_hash ^ orig_hash).count_ones();
-    let dist_to_distant = (current_hash ^ distant_hash).count_ones();
+    let current_hash = simhash_suffix_for_test(&current_id_before);
+    let orig_hash = simhash_suffix_for_test(&orig_id);
+    let distant_hash = simhash_suffix_for_test(&distant_id);
+    let dist_to_orig = current_hash.distance(orig_hash);
+    let dist_to_distant = current_hash.distance(distant_hash);
 
     if dist_to_orig < SIMHASH_HAMMING_THRESHOLD && dist_to_orig <= dist_to_distant {
         // Orig is within threshold and at least as close as distant: rename pair
@@ -1917,9 +2475,12 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
         name: id.clone(),
         create_only_values: HashMap::new(),
     }];
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // Should remain unchanged
     assert_eq!(resources[0].id.name_str(), id);
@@ -1942,7 +2503,12 @@ fn test_reconcile_no_create_only_empty_state() {
     let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| vec![]);
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| vec![],
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(resources[0].id.name_str(), original_id);
 }
@@ -1995,9 +2561,9 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
     assert_ne!(r1[0].id.name_str(), r2[0].id.name_str());
 
     // But nearby (SimHash locality-sensitive property)
-    let hash1 = extract_hash_from_identifier(r1[0].id.name_str()).unwrap();
-    let hash2 = extract_hash_from_identifier(r2[0].id.name_str()).unwrap();
-    let distance = (hash1 ^ hash2).count_ones();
+    let hash1 = simhash_suffix_for_test(r1[0].id.name_str());
+    let hash2 = simhash_suffix_for_test(r2[0].id.name_str());
+    let distance = hash1.distance(hash2);
     assert!(
         distance < SIMHASH_HAMMING_THRESHOLD,
         "Single attribute change should produce close SimHash (distance={}, threshold={})",
@@ -2102,9 +2668,12 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
         .collect(),
     }];
 
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // Should reconcile via partial create-only match (not Hamming distance)
     assert_eq!(resources[0].id.name_str(), "iam_role_11223344");
@@ -2245,9 +2814,12 @@ fn test_reconcile_skips_let_bound_resources() {
         .collect(),
     }];
 
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // Named resource must keep its original name
     assert_eq!(
@@ -2317,9 +2889,12 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
         },
     ];
 
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // With multiple partial matches, reconciliation should be skipped
     assert_eq!(
@@ -2427,9 +3002,12 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
         name: step1_id.clone(),
         create_only_values: HashMap::new(), // No create-only values in state either
     }];
-    let renames = reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources2,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // After reconciliation, step2 keeps its freshly-computed identifier
     // and emits a rename pair so the wiring layer re-keys the state
@@ -2519,9 +3097,12 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
         },
     ];
 
-    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     // Names must remain unchanged - no swapping
     assert_eq!(
@@ -3126,8 +3707,12 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
         create_only_values: HashMap::new(),
     }];
 
-    let renames =
-        reconcile_anonymous_identifiers(&mut resources, &schemas, &|_p, _rt| state_entries.clone());
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_p, _rt| state_entries.clone(),
+        &|_binding| Vec::new(),
+    );
 
     assert_eq!(
         resources[0].id.name_str(),

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use indexmap::IndexMap;
 
+use crate::identifier::SimHash;
 use crate::parser::{
     ArgumentParameter, BindingName, DeferredForExpression, ModuleCall, ParsedFile, WaitBinding,
 };
@@ -988,12 +989,9 @@ pub fn instance_prefix_for_call(call: &ModuleCall) -> String {
 /// Split a module-instance prefix into `(module_name, simhash)` when the
 /// tail looks like a 16-hex SimHash. Returns `None` for non-synthetic prefixes
 /// (user-written binding names, pre-SimHash state formats, etc.).
-pub(super) fn parse_synthetic_instance_prefix(prefix: &str) -> Option<(&str, u64)> {
+pub(super) fn parse_synthetic_instance_prefix(prefix: &str) -> Option<(&str, SimHash)> {
     let (module, hex) = prefix.rsplit_once('_')?;
-    if hex.len() != 16 {
-        return None;
-    }
-    let simhash = u64::from_str_radix(hex, 16).ok()?;
+    let simhash = SimHash::parse_16_hex(hex)?;
     if module.is_empty() {
         return None;
     }
@@ -1043,7 +1041,7 @@ pub fn reconcile_anonymous_module_instances(
     // Current DSL synthetic prefixes per module — only one entry per
     // distinct prefix (a multi-resource module instance shares one prefix
     // across all of its resources).
-    let mut current_synthetic_by_module: HashMap<String, HashSet<u64>> = HashMap::new();
+    let mut current_synthetic_by_module: HashMap<String, HashSet<SimHash>> = HashMap::new();
     for r in resources.iter() {
         let Some((prefix, _)) = split_instance_prefix(r.id.name_str()) else {
             continue;
@@ -1063,7 +1061,7 @@ pub fn reconcile_anonymous_module_instances(
     // Vec the same hash would appear N times and the Hamming-distance
     // search below would mistake duplicates for ambiguous candidates and
     // refuse to remap (#2211).
-    let mut state_synthetic_by_module: HashMap<String, HashSet<u64>> = HashMap::new();
+    let mut state_synthetic_by_module: HashMap<String, HashSet<SimHash>> = HashMap::new();
 
     for (provider, resource_type) in &touched_types {
         for name in find_state_names_by_type(provider, resource_type) {
@@ -1085,12 +1083,12 @@ pub fn reconcile_anonymous_module_instances(
     // exclude any prefix already used by a current DSL instance — without
     // that filter, two distinct anonymous calls could collapse onto the same
     // state entry when only one of them existed before.
-    let mut prefix_remap: HashMap<(String, u64), u64> = HashMap::new();
+    let mut prefix_remap: HashMap<(String, SimHash), SimHash> = HashMap::new();
     for (module, current_hashes) in &current_synthetic_by_module {
         let Some(state_hashes) = state_synthetic_by_module.get(module) else {
             continue;
         };
-        let orphan_state_hashes: Vec<u64> = state_hashes
+        let orphan_state_hashes: Vec<SimHash> = state_hashes
             .iter()
             .copied()
             .filter(|h| !current_hashes.contains(h))
@@ -1163,7 +1161,7 @@ pub fn reconcile_anonymous_module_instances(
 
 fn rewrite_ref_prefixes(
     value: &Value,
-    remap: &std::collections::HashMap<(String, u64), u64>,
+    remap: &std::collections::HashMap<(String, SimHash), SimHash>,
 ) -> Value {
     match value {
         Value::Deferred(DeferredValue::ResourceRef { path }) => {

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -370,8 +370,9 @@ fn test_reconcile_anonymous_module_instances_preserves_provider_instance() {
     // assert that the named-instance routing survives the rewrite.
     use crate::resource::{ConcreteValue, Resource, ResourceId, Value};
 
-    let current_prefix = format!("thing_{:016x}", 0xABCDu64);
-    let state_hash = 0xABCDu64 ^ 1; // flip one bit — within SimHash threshold
+    let current_hash = crate::identifier::SimHash::parse_16_hex("000000000000abcd").unwrap();
+    let current_prefix = format!("thing_{:016x}", current_hash);
+    let state_hash = current_hash.with_flipped_mask_for_test(1);
     let state_name = format!("thing_{:016x}.role", state_hash);
 
     let mut resources = vec![Resource {
@@ -1135,7 +1136,7 @@ fn test_anonymous_module_call_prefix_is_locality_sensitive() {
     let a = instance_prefix_for_call(&make("carina-rs/infra"));
     let b = instance_prefix_for_call(&make("carina-rs/other"));
     let parse = |p: &str| parse_synthetic_instance_prefix(p).unwrap().1;
-    let distance = (parse(&a) ^ parse(&b)).count_ones();
+    let distance = parse(&a).distance(parse(&b));
     assert!(
         distance < crate::identifier::SIMHASH_HAMMING_THRESHOLD,
         "small edit should stay inside the reconciliation threshold, got distance {distance}",
@@ -1232,7 +1233,7 @@ thing { name = 'after-edit' }
 
     // Fabricate a state entry whose SimHash is within threshold of the
     // current one (flip one bit).
-    let state_hash = new_hash ^ 1;
+    let state_hash = new_hash.with_flipped_mask_for_test(1);
     let state_name = format!("thing_{:016x}.role", state_hash);
     let state_lookup = |_: &str, _: &str| vec![state_name.clone()];
 
@@ -1358,7 +1359,7 @@ thing { name = 'after-edit' }
 
     // State holds the *same* instance prefix at two resource types, one
     // bit away from the current SimHash — i.e. a small argument edit.
-    let state_hash = new_hash ^ 1;
+    let state_hash = new_hash.with_flipped_mask_for_test(1);
     let state_lookup = move |_: &str, resource_type: &str| match resource_type {
         "iam.OidcProvider" => vec![format!("thing_{:016x}.provider_res", state_hash)],
         "iam.Role" => vec![format!("thing_{:016x}.role", state_hash)],
@@ -1416,8 +1417,14 @@ thing { name = 'a' }
     // Two state entries at the same Hamming distance — ambiguous.
     let state_lookup = move |_: &str, _: &str| {
         vec![
-            format!("thing_{:016x}.role", cur_hash ^ 0b1),
-            format!("thing_{:016x}.role", cur_hash ^ 0b10),
+            format!(
+                "thing_{:016x}.role",
+                cur_hash.with_flipped_mask_for_test(0b1)
+            ),
+            format!(
+                "thing_{:016x}.role",
+                cur_hash.with_flipped_mask_for_test(0b10)
+            ),
         ]
     };
     reconcile_anonymous_module_instances(&mut parsed.resources, &state_lookup);

--- a/notes/specs/2026-06-11-anonymous-rename-moved-safety-design.md
+++ b/notes/specs/2026-06-11-anonymous-rename-moved-safety-design.md
@@ -220,11 +220,15 @@ resolution step before comparison instead of giving up:
 
 - Exactly one form is resolved: a single-hop
   `ResourceRef(<binding>.<attr>)`. Find the state entry whose `binding`
-  field equals `<binding>` (scoped to the same module instance prefix
-  when the referring resource has one), and read `<attr>` from its
-  `attributes`, converted through the same canonical string used for
-  state-side create-only values
+  field equals `<binding>`, and read `<attr>` from its `attributes`,
+  converted through the same canonical string used for state-side
+  create-only values
   (`canonical_create_only_state_json_string`).
+  Scope is decided from the binding string itself: a dotted binding
+  (`inst.x`) is already instance-qualified by construction, so equality
+  suffices; a bare binding is a root binding and must match a dot-free
+  state entry name. Referrer-based scoping was rejected because
+  argument-passed root refs keep the bare root binding and would be excluded.
 - Everything else stays unresolved by design: `Interpolation`,
   `BindingRef`, multi-hop paths (`binding.attr.sub`), function calls.
   Unresolved means no value for that attribute, exactly like an


### PR DESCRIPTION
## Summary

PR 1 of 3 implementing the carina#3454 design (`notes/specs/2026-06-11-anonymous-rename-moved-safety-design.md`): RC1 — typed hash kinds and meaning-based matching.

Refs #3454

## Problem

`reconcile_anonymous_identifiers`'s Hamming-distance fallback engaged whenever desired-side create-only values could not be stringified — which includes the dominant real-world shape, deferred `let`-binding refs (`route_table_id = private_rtb.id`). The names being compared carry 8-hex **standard** hashes (u32, zero-extended to u64): expected distance 16 against a threshold of 20 means ~89% of unrelated sibling pairs "match", and the winner is coincidental hex proximity. In infra#138 this scrambled three sibling `SubnetRouteTableAssociation`s into `forces_replacement` plans against live AWS resources.

## Changes

- **Opaque `SimHash` newtype** (private field; only producers: `compute_simhash`, `SimHash::parse_16_hex`; Hamming distance is a method on the type). `extract_hash_from_identifier` returns `AnonymousHashSuffix { Standard(u32), SimHash(SimHash) }`, and `closest_unique_simhash_match` accepts only `SimHash` — feeding a standard hash into Hamming comparison is now unwritable, not a per-call-site filter. The hand-rolled 16-hex string filter in `detect_anonymous_to_named_renames` is replaced by the same typed seam.
- **Hamming fallback restricted**: engages only when both the desired name and the state candidate carry SimHash suffixes, routed through the tie-refusing helper (ties now refuse instead of keeping first-found-min — pinned by test).
- **Meaning-based matching**: standard-hash resources with deferred create-only values resolve single-hop `binding.attr` refs through state's persisted `binding` field. Scope is decided by the binding string (dotted = instance-qualified by construction; bare = root entries only — the spec's RC1 prose is amended accordingly in this PR, since referrer-based scoping would have excluded argument-passed root refs). Duplicate bindings and unresolvable forms yield no value, never an error. Resolved values flow through the existing unique-full-match logic, recovering the infra#138 1:1 mapping with no `moved.crn`.
- **Canonical comparison channel** gains `Int`/`Float`/`Bool`/`Duration`/`StringList` coverage in state-JSON round-trip form (`Duration` → integer seconds, `StringList` → the `List` shape state arrays decode to), pinned by a round-trip symmetry test against the real serializers.

## Tests

All design-doc RC1 tests plus extras: no-Hamming-on-standard-hashes (red before the fix), binding resolution (3 module-scope directional tests), duplicate-value and duplicate-binding ambiguity refusal, SimHash tie refusal, canonical scalar round-trip (incl. nested), and a wiring-level test through `reconcile_anonymous_identifiers_with_ctx` with real `StateFile` fixtures where the binding index is load-bearing.

## Verification

- `cargo nextest run --workspace --all-features`: 4000 passed
- `cargo test --workspace --doc`: ok
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `scripts/check-*.sh`: all OK
- 5 review rounds (all findings fixed: canonical-channel asymmetries for Duration/StringList, binding-string scoping replacing referrer-based scoping, wiring-level integration coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
