### PR TITLE
Exclude operator-claimed state-block addresses from heuristic renames (carina#3454 RC2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ plan-moved-prev-keys:
 	$(PLAN_FIXTURE) moved_prev_keys
 plan-moved-pure:
 	$(PLAN_FIXTURE) moved_pure
+plan-moved-claims-precede-heuristics:
+	$(PLAN_FIXTURE) moved_claims_precede_heuristics
 plan-map-diff-tui:
 	$(PLAN_FIXTURE) map_key_diff --tui
 plan-all-create-tui:
@@ -172,6 +174,9 @@ plan-fixtures:
 	@echo ""
 	@echo "=== moved_pure ==="
 	@$(MAKE) plan-moved-pure
+	@echo ""
+	@echo "=== moved_claims_precede_heuristics ==="
+	@$(MAKE) plan-moved-claims-precede-heuristics
 	@echo ""
 	@echo "=== upstream_state ==="
 	@$(MAKE) plan-upstream-state
@@ -278,6 +283,7 @@ plan-multi-instance-module:
         plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
+        plan-moved-claims-precede-heuristics \
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
         plan-upstream-state-map-subscript plan-upstream-state-map-dot-notation \
         plan-deferred-for plan-exports plan-exports-multifile \

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -814,6 +814,12 @@ async fn run_apply_locked(
     let mut state_file = load_state_persist_if_migrated(backend, lock).await?;
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
+    let state_block_claims = crate::wiring::resolve_state_block_claims(
+        &parsed.state_blocks,
+        &state_file,
+        &parsed.resources,
+        ctx.schemas(),
+    );
     if let Some(sf) = state_file.as_ref() {
         carina_core::module_resolver::reconcile_anonymous_module_instances(
             &mut parsed.resources,
@@ -823,10 +829,16 @@ async fn run_apply_locked(
                     .map(|r| r.name.clone())
                     .collect()
             },
+            &state_block_claims,
         );
     }
     if let Some(sf) = state_file.as_mut() {
-        reconcile_anonymous_identifiers_with_ctx(ctx, &mut parsed.resources, sf);
+        reconcile_anonymous_identifiers_with_ctx(
+            ctx,
+            &mut parsed.resources,
+            sf,
+            &state_block_claims,
+        );
     }
     apply_name_overrides(&mut parsed.resources, &state_file);
 
@@ -1022,6 +1034,7 @@ async fn run_apply_locked(
             &mut prev_explicit,
             &mut saved_attrs,
             &state_file,
+            &state_block_claims,
         ));
         pairs
     };

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -147,6 +147,12 @@ async fn run_destroy_locked(
         crate::commands::apply::load_state_persist_if_migrated(backend, lock).await?;
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
+    let state_block_claims = crate::wiring::resolve_state_block_claims(
+        &parsed.state_blocks,
+        &state_file,
+        &parsed.resources,
+        ctx.schemas(),
+    );
     if let Some(sf) = state_file.as_ref() {
         carina_core::module_resolver::reconcile_anonymous_module_instances(
             &mut parsed.resources,
@@ -156,10 +162,16 @@ async fn run_destroy_locked(
                     .map(|r| r.name.clone())
                     .collect()
             },
+            &state_block_claims,
         );
     }
     if let Some(sf) = state_file.as_mut() {
-        reconcile_anonymous_identifiers_with_ctx(&ctx, &mut parsed.resources, sf);
+        reconcile_anonymous_identifiers_with_ctx(
+            &ctx,
+            &mut parsed.resources,
+            sf,
+            &state_block_claims,
+        );
     }
     apply_name_overrides(&mut parsed.resources, &state_file);
 

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -559,6 +559,12 @@ pub async fn run_plan(
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let wiring = WiringContext::new(factories);
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
+    let state_block_claims = crate::wiring::resolve_state_block_claims(
+        &parsed.state_blocks,
+        &state_file,
+        &parsed.resources,
+        wiring.schemas(),
+    );
     if let Some(sf) = state_file.as_ref() {
         carina_core::module_resolver::reconcile_anonymous_module_instances(
             &mut parsed.resources,
@@ -568,10 +574,16 @@ pub async fn run_plan(
                     .map(|r| r.name.clone())
                     .collect()
             },
+            &state_block_claims,
         );
     }
     if let Some(sf) = state_file.as_mut() {
-        reconcile_anonymous_identifiers_with_ctx(&wiring, &mut parsed.resources, sf);
+        reconcile_anonymous_identifiers_with_ctx(
+            &wiring,
+            &mut parsed.resources,
+            sf,
+            &state_block_claims,
+        );
     }
     apply_name_overrides(&mut parsed.resources, &state_file);
 
@@ -614,6 +626,7 @@ pub async fn run_plan(
         &state_file,
         refresh,
         &remote_bindings,
+        &state_block_claims,
         base_dir,
     )
     .await?;

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -912,8 +912,19 @@ pub(crate) async fn run_state_refresh_locked(
     }
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
+    let state_block_claims = crate::wiring::resolve_state_block_claims(
+        &parsed.state_blocks,
+        &state_file,
+        &parsed.resources,
+        ctx.schemas(),
+    );
     if let Some(sf) = state_file.as_mut() {
-        reconcile_anonymous_identifiers_with_ctx(&ctx, &mut parsed.resources, sf);
+        reconcile_anonymous_identifiers_with_ctx(
+            &ctx,
+            &mut parsed.resources,
+            sf,
+            &state_block_claims,
+        );
     }
     apply_name_overrides(&mut parsed.resources, &state_file);
 

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -21,8 +21,8 @@ use carina_state::{StateFile, check_and_migrate};
 
 use crate::commands::validate_and_resolve;
 use crate::wiring::{
-    WiringContext, normalize_desired_with_ctx, normalize_state_with_ctx,
-    reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
+    WiringContext, compute_anonymous_identifiers_with_ctx, normalize_desired_with_ctx,
+    normalize_state_with_ctx, reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
     resolve_enum_aliases_in_states, resolve_enum_aliases_with_ctx,
 };
 
@@ -85,7 +85,27 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
     };
 
     let wiring = WiringContext::new(fixture_provider_factories(&fixture_pathbuf));
+    if fixture_pathbuf
+        .file_name()
+        .is_some_and(|name| name == "moved_claims_precede_heuristics")
+    {
+        // This fixture writes moved.to as the literal schema-derived anonymous
+        // hash name, so compute the desired anonymous id before claims resolve.
+        let canonical_resources = carina_core::value::canonicalize_resources_with_schemas(
+            &mut parsed.resources,
+            wiring.schemas(),
+        );
+        let errors =
+            compute_anonymous_identifiers_with_ctx(&wiring, canonical_resources, &parsed.providers);
+        assert!(errors.is_empty(), "{errors:?}");
+    }
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
+    let state_block_claims = crate::wiring::resolve_state_block_claims(
+        &parsed.state_blocks,
+        &state_file,
+        &parsed.resources,
+        wiring.schemas(),
+    );
     if let Some(sf) = state_file.as_ref() {
         carina_core::module_resolver::reconcile_anonymous_module_instances(
             &mut parsed.resources,
@@ -95,10 +115,16 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
                     .map(|r| r.name.clone())
                     .collect()
             },
+            &state_block_claims,
         );
     }
     if let Some(sf) = state_file.as_mut() {
-        reconcile_anonymous_identifiers_with_ctx(&wiring, &mut parsed.resources, sf);
+        reconcile_anonymous_identifiers_with_ctx(
+            &wiring,
+            &mut parsed.resources,
+            sf,
+            &state_block_claims,
+        );
     }
 
     // carina#3181: `parsed.resources` is managed-only; data sources live
@@ -356,10 +382,54 @@ fn fixture_provider_factories(fixture_path: &Path) -> Vec<Box<dyn ProviderFactor
     match fixture_path.file_name().and_then(|name| name.to_str()) {
         Some("dynamic_enum_az_no_diff") => vec![Box::new(DynamicEnumFixtureFactory)],
         Some("enum_display") => vec![Box::new(EnumDisplayFixtureFactory)],
+        Some("moved_claims_precede_heuristics") => {
+            vec![Box::new(MovedClaimsPrecedeHeuristicsFixtureFactory)]
+        }
         Some("route53_hosted_zone_name_strip_suffix_no_diff") => {
             vec![Box::new(Route53HostedZoneFixtureFactory)]
         }
         _ => vec![],
+    }
+}
+
+struct MovedClaimsPrecedeHeuristicsFixtureFactory;
+
+impl ProviderFactory for MovedClaimsPrecedeHeuristicsFixtureFactory {
+    fn name(&self) -> &str {
+        "awscc"
+    }
+
+    fn display_name(&self) -> &str {
+        "AWS Cloud Control fixture provider"
+    }
+
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+
+    fn validate_config(
+        &self,
+        _attributes: &indexmap::IndexMap<String, Value>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn extract_region(&self, _attributes: &indexmap::IndexMap<String, Value>) -> String {
+        "ap-northeast-1".to_string()
+    }
+
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &indexmap::IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { unreachable!("plan fixture does not instantiate providers") })
+    }
+
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![ResourceSchema::new("test.Widget").attribute(
+            AttributeSchema::new("external_name", AttributeType::string()).create_only(),
+        )]
     }
 }
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -893,6 +893,35 @@ fn snapshot_moved_pure() {
     insta::assert_snapshot!(output);
 }
 
+/// Production-ordered fixture for RC2 claims precedence: the state row's
+/// create-only values would make anonymous reconciliation adopt the old hash
+/// name if the moved block did not claim it first.
+#[test]
+fn snapshot_moved_claims_precede_heuristics() {
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("moved_claims_precede_heuristics");
+    assert_eq!(plan.summary().create, 0);
+    assert_eq!(plan.summary().delete, 0);
+    assert_eq!(plan.summary().moved, 1);
+    assert!(
+        plan.effects()
+            .iter()
+            .any(|e| matches!(e, carina_core::effect::Effect::Move { .. })),
+        "claims-precedence fixture should produce a Move effect"
+    );
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &[],
+        &[],
+        None,
+        None,
+    ));
+    insta::assert_snapshot!(output);
+}
+
 /// Compact (`DetailLevel::None`) rendering of a moved Update effect.
 ///
 /// Locks in the `(moved from: <name>)` annotation form on the

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_claims_precede_heuristics.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_claims_precede_heuristics.snap
@@ -1,0 +1,9 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  -> awscc.test.Widget awscc_test_widget_58cf4fed (moved from: test_widget_11111111)
+
+Plan: 0 to add, 0 to change, 0 to destroy, 1 to move.

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -15,7 +15,7 @@ use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
 use carina_core::identifier::{
-    self, AnonymousIdBindingStateInfo, AnonymousIdStateInfo, PrefixStateInfo,
+    self, AnonymousIdBindingStateInfo, AnonymousIdStateInfo, PrefixStateInfo, StateBlockClaims,
 };
 use carina_core::module_resolver;
 use carina_core::parser::{ProviderConfig, StateBlock, StateBlockAddress};
@@ -431,6 +431,7 @@ fn provider_config_attribute_type_for(
 /// by `identifier::detect_anonymous_to_named_renames`. Transfers state,
 /// `prev_explicit`, and `saved_attrs` from the old anonymous name to the
 /// new binding name so the differ sees the resource under its new identity.
+#[allow(clippy::too_many_arguments)]
 pub fn apply_anonymous_to_named_renames(
     ctx: &WiringContext,
     resources: &[Resource],
@@ -439,6 +440,7 @@ pub fn apply_anonymous_to_named_renames(
     prev_explicit: &mut HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
     saved_attrs: &mut HashMap<ResourceId, HashMap<String, Value>>,
     state_file: &Option<StateFile>,
+    claims: &StateBlockClaims,
 ) -> Vec<(ResourceId, ResourceId)> {
     let Some(sf) = state_file.as_ref() else {
         return Vec::new();
@@ -486,6 +488,7 @@ pub fn apply_anonymous_to_named_renames(
         },
         &canonical_providers,
         &|name| identity_attributes_for_provider(ctx, name),
+        claims,
     );
 
     for (from, to) in &renames {
@@ -508,6 +511,7 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
     ctx: &WiringContext,
     resources: &mut [Resource],
     state_file: &mut StateFile,
+    claims: &StateBlockClaims,
 ) {
     let state_by_binding: HashMap<String, Vec<AnonymousIdBindingStateInfo>> = state_file
         .resources
@@ -569,6 +573,7 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
                 .collect()
         },
         &|binding| state_by_binding.get(binding).cloned().unwrap_or_default(),
+        claims,
     );
 
     apply_provider_prefix_renames(&renames, state_file);
@@ -1692,10 +1697,18 @@ pub async fn create_plan_from_parsed<E: Clone>(
     parsed: &carina_core::parser::File<E>,
     state_file: &Option<StateFile>,
     refresh: bool,
+    state_block_claims: &StateBlockClaims,
     base_dir: &Path,
 ) -> Result<PlanContext, AppError> {
-    create_plan_from_parsed_with_upstream(parsed, state_file, refresh, &HashMap::new(), base_dir)
-        .await
+    create_plan_from_parsed_with_upstream(
+        parsed,
+        state_file,
+        refresh,
+        &HashMap::new(),
+        state_block_claims,
+        base_dir,
+    )
+    .await
 }
 
 pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
@@ -1703,6 +1716,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     state_file: &Option<StateFile>,
     refresh: bool,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    state_block_claims: &StateBlockClaims,
     base_dir: &Path,
 ) -> Result<PlanContext, AppError> {
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
@@ -1895,6 +1909,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
             &mut prev_explicit,
             &mut saved_attrs,
             state_file,
+            state_block_claims,
         ));
 
         // Phase 2: resolve data source refs against the consolidated
@@ -1974,6 +1989,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
                 &mut prev_explicit,
                 &mut saved_attrs,
                 state_file,
+                state_block_claims,
             ));
         } else {
             // No state file: all resources are new (not found)
@@ -2239,6 +2255,24 @@ pub fn materialize_moved_states(
     state_blocks: &[StateBlock],
     state_file: &Option<StateFile>,
 ) -> Vec<(ResourceId, ResourceId)> {
+    materialize_moved_states_with_warning_sink(
+        current_states,
+        prev_explicit,
+        saved_attrs,
+        state_blocks,
+        state_file,
+        &mut |warning| eprintln!("{}", warning.yellow()),
+    )
+}
+
+fn materialize_moved_states_with_warning_sink(
+    current_states: &mut HashMap<ResourceId, State>,
+    prev_explicit: &mut HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
+    saved_attrs: &mut HashMap<ResourceId, HashMap<String, Value>>,
+    state_blocks: &[StateBlock],
+    state_file: &Option<StateFile>,
+    warn_missing: &mut dyn FnMut(String),
+) -> Vec<(ResourceId, ResourceId)> {
     let mut moved_pairs = Vec::new();
 
     for block in state_blocks {
@@ -2266,6 +2300,20 @@ pub fn materialize_moved_states(
                     })
             });
             let Some(resolved_from) = resolved_from else {
+                let to_exists = state_file.as_ref().is_some_and(|sf| {
+                    sf.find_resource(&to.provider, &to.resource_type, to.name_str())
+                        .is_some()
+                });
+                if !to_exists {
+                    warn_missing(format!(
+                        "warning: moved block from {} '{}' to {} '{}' was not applied: {} not found in state",
+                        from.display_type(),
+                        from.name_str(),
+                        to.display_type(),
+                        to.name_str(),
+                        from.name_str()
+                    ));
+                }
                 continue;
             };
             // For `to`, look up the destination key by
@@ -2311,6 +2359,69 @@ pub fn materialize_moved_states(
     moved_pairs
 }
 
+pub fn resolve_state_block_claims(
+    blocks: &[StateBlock],
+    state_file: &Option<StateFile>,
+    desired: &[Resource],
+    registry: &SchemaRegistry,
+) -> StateBlockClaims {
+    let mut from = HashSet::new();
+    let mut to = HashSet::new();
+
+    for block in blocks {
+        match block {
+            StateBlock::Moved {
+                from: moved_from,
+                to: moved_to,
+            } => {
+                if state_file.as_ref().is_some_and(|sf| {
+                    sf.find_resource(
+                        &moved_from.provider,
+                        &moved_from.resource_type,
+                        moved_from.name_str(),
+                    )
+                    .is_some()
+                }) {
+                    from.insert(moved_from.clone());
+                    to.insert(moved_to.clone());
+                }
+            }
+            StateBlock::Removed { from: removed_from } => {
+                if state_file.as_ref().is_some_and(|sf| {
+                    sf.find_resource(
+                        &removed_from.provider,
+                        &removed_from.resource_type,
+                        removed_from.name_str(),
+                    )
+                    .is_some()
+                }) {
+                    from.insert(removed_from.clone());
+                }
+            }
+            StateBlock::Import { to: import_to, .. } => {
+                let Some(resolved_to) =
+                    resolve_import_target_in_desired(import_to, desired, registry)
+                else {
+                    continue;
+                };
+                let already_in_state = state_file.as_ref().is_some_and(|sf| {
+                    sf.find_resource(
+                        &resolved_to.provider,
+                        &resolved_to.resource_type,
+                        resolved_to.name_str(),
+                    )
+                    .is_some()
+                });
+                if !already_in_state {
+                    to.insert(resolved_to);
+                }
+            }
+        }
+    }
+
+    StateBlockClaims::new(from, to)
+}
+
 /// Look up `to`'s full id (with any routed `provider_instance`) in
 /// `desired` by matching a [`StateBlockAddress`] against the routed
 /// `ResourceId` keys. `StateBlockAddress` is routing-agnostic by
@@ -2330,6 +2441,21 @@ fn find_desired_id<V>(
                 && k.name_str() == to.name_str()
         })
         .cloned()
+}
+
+fn resolve_import_target_in_desired(
+    to: &StateBlockAddress,
+    desired: &[Resource],
+    registry: &SchemaRegistry,
+) -> Option<StateBlockAddress> {
+    let name_attr = import_target_name_attribute(to, registry);
+    match_import_target(to, name_attr, desired.iter()).map(|resource| {
+        StateBlockAddress::new(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            resource.id.name_str(),
+        )
+    })
 }
 
 /// Add state block effects (import/removed/moved) to the plan.
@@ -2511,47 +2637,16 @@ fn resolve_import_target(
     state_file: &Option<StateFile>,
     registry: &SchemaRegistry,
 ) -> ResourceId {
-    let name_attr = registry
-        .get(
-            &to.provider,
-            &to.resource_type,
-            carina_core::schema::SchemaKind::Resource,
-        )
-        .and_then(|s| s.name_attribute.as_deref());
-
-    // Address-equality test: `StateBlockAddress` has no
-    // `provider_instance`, so equality is naturally the 3-tuple match
-    // we want — no risk of `Eq` silently including routing.
-    let same_address = |id: &ResourceId| {
-        id.provider == to.provider
-            && id.resource_type == to.resource_type
-            && id.name_str() == to.name_str()
-    };
-
-    // Single pass: prefer exact id match, otherwise remember the first name_attribute match.
-    let mut fallback_id: Option<ResourceId> = None;
-    for effect in plan.effects() {
-        let Effect::Create(resource) = effect else {
-            continue;
-        };
-        if same_address(&resource.id) {
-            return resource.id.clone();
-        }
-        if fallback_id.is_some() {
-            continue;
-        }
-        if resource.id.provider != to.provider || resource.id.resource_type != to.resource_type {
-            continue;
-        }
-        if let Some(attr) = name_attr
-            && let Some(Value::Concrete(ConcreteValue::String(s))) = resource.get_attr(attr)
-            && s == to.name_str()
-        {
-            fallback_id = Some(resource.id.clone());
-        }
-    }
-    if let Some(id) = fallback_id {
-        return id;
+    let name_attr = import_target_name_attribute(to, registry);
+    if let Some(resource) = match_import_target(
+        to,
+        name_attr,
+        plan.effects().iter().filter_map(|effect| match effect {
+            Effect::Create(resource) => Some(resource),
+            _ => None,
+        }),
+    ) {
+        return resource.id.clone();
     }
 
     // Fallback: match by name_attribute value in state file (already-imported case)
@@ -2573,6 +2668,43 @@ fn resolve_import_target(
     }
 
     to.to_unrouted_resource_id()
+}
+
+fn import_target_name_attribute<'a>(
+    to: &StateBlockAddress,
+    registry: &'a SchemaRegistry,
+) -> Option<&'a str> {
+    registry
+        .get(
+            &to.provider,
+            &to.resource_type,
+            carina_core::schema::SchemaKind::Resource,
+        )
+        .and_then(|s| s.name_attribute.as_deref())
+}
+
+fn match_import_target<'a>(
+    to: &StateBlockAddress,
+    name_attr: Option<&str>,
+    resources: impl Iterator<Item = &'a Resource>,
+) -> Option<&'a Resource> {
+    let mut fallback = None;
+    for resource in resources {
+        if resource.id.provider != to.provider || resource.id.resource_type != to.resource_type {
+            continue;
+        }
+        if resource.id.name_str() == to.name_str() {
+            return Some(resource);
+        }
+        if fallback.is_none()
+            && let Some(attr) = name_attr
+            && let Some(Value::Concrete(ConcreteValue::String(s))) = resource.get_attr(attr)
+            && s == to.name_str()
+        {
+            fallback = Some(resource);
+        }
+    }
+    fallback
 }
 
 /// Check whether a `ProviderError` is an AWS throttling error that should be retried.

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -711,6 +711,106 @@ fn import_fallback_skips_when_already_in_state_by_name_attribute() {
     );
 }
 
+#[test]
+fn import_claims_resolve_name_attribute_target_and_skip_noop_targets() {
+    use carina_core::schema::ResourceSchema;
+    use carina_state::state::{ResourceState, StateFile};
+
+    let bucket_schema = ResourceSchema::new("s3.Bucket").with_name_attribute("bucket_name");
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", bucket_schema);
+
+    let mut desired = Resource::with_provider("awscc", "s3.Bucket", "s3_bucket_1d43a664", None);
+    desired.set_attr(
+        "bucket_name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
+    );
+    let block = StateBlock::Import {
+        to: StateBlockAddress::new("awscc", "s3.Bucket", "carina-rs-state"),
+        id: Value::Concrete(ConcreteValue::String("carina-rs-state".to_string())),
+    };
+
+    let claims = resolve_state_block_claims(
+        std::slice::from_ref(&block),
+        &None,
+        std::slice::from_ref(&desired),
+        &schemas,
+    );
+    assert!(
+        claims.claims_to("awscc", "s3.Bucket", "s3_bucket_1d43a664"),
+        "name_attribute import target must claim the resolved desired address"
+    );
+
+    let mut state_file = StateFile::new();
+    state_file.resources.push(ResourceState::new(
+        "s3.Bucket",
+        "s3_bucket_1d43a664",
+        "awscc",
+    ));
+    let claims = resolve_state_block_claims(
+        std::slice::from_ref(&block),
+        &Some(state_file),
+        std::slice::from_ref(&desired),
+        &schemas,
+    );
+    assert!(
+        !claims.claims_to("awscc", "s3.Bucket", "s3_bucket_1d43a664"),
+        "already-in-state import target must claim nothing"
+    );
+
+    let claims = resolve_state_block_claims(&[block], &None, &[], &schemas);
+    assert!(
+        !claims.claims_to("awscc", "s3.Bucket", "s3_bucket_1d43a664"),
+        "unresolvable import target must claim nothing"
+    );
+}
+
+#[test]
+fn test_materialize_moved_states_warns_on_missing_from() {
+    use carina_state::state::{ResourceState, StateFile};
+
+    let state_blocks = vec![StateBlock::Moved {
+        from: StateBlockAddress::new("awscc", "s3.Bucket", "old_bucket"),
+        to: StateBlockAddress::new("awscc", "s3.Bucket", "new_bucket"),
+    }];
+    let mut warnings = Vec::new();
+    let moved_pairs = materialize_moved_states_with_warning_sink(
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        &state_blocks,
+        &Some(StateFile::new()),
+        &mut |warning| warnings.push(warning),
+    );
+    assert!(moved_pairs.is_empty());
+    assert_eq!(
+        warnings,
+        vec![
+            "warning: moved block from awscc.s3.Bucket 'old_bucket' to awscc.s3.Bucket 'new_bucket' was not applied: old_bucket not found in state"
+                .to_string()
+        ],
+    );
+
+    let mut state_file = StateFile::new();
+    state_file
+        .resources
+        .push(ResourceState::new("s3.Bucket", "new_bucket", "awscc"));
+    let mut warnings = Vec::new();
+    let moved_pairs = materialize_moved_states_with_warning_sink(
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        &state_blocks,
+        &Some(state_file),
+        &mut |warning| warnings.push(warning),
+    );
+    assert!(moved_pairs.is_empty());
+    assert!(
+        warnings.is_empty(),
+        "already-applied from-absent/to-present moved block stays silent"
+    );
+}
+
 struct AssociationCreateOnlyFactory;
 
 impl ProviderFactory for AssociationCreateOnlyFactory {
@@ -765,6 +865,11 @@ impl ProviderFactory for AssociationCreateOnlyFactory {
         use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
         vec![
+            ResourceSchema::new("s3.Bucket")
+                .with_name_attribute("bucket_name")
+                .attribute(
+                    AttributeSchema::new("bucket_name", AttributeType::string()).create_only(),
+                ),
             ResourceSchema::new("ec2.SubnetRouteTableAssociation")
                 .attribute(
                     AttributeSchema::new("route_table_id", AttributeType::string()).create_only(),
@@ -821,6 +926,121 @@ fn desired_association(name: &str, route_table_binding: &str, subnet_id: &str) -
     resource
 }
 
+fn bucket_state(name: &str, bucket_name: &str) -> carina_state::state::ResourceState {
+    let mut state = carina_state::state::ResourceState::new("s3.Bucket", name, "awscc");
+    state.attributes.insert(
+        "bucket_name".to_string(),
+        serde_json::Value::String(bucket_name.to_string()),
+    );
+    state
+}
+
+fn desired_bucket(name: &str, bucket_name: &str) -> Resource {
+    let mut resource = Resource::with_provider("awscc", "s3.Bucket", name, None);
+    resource.set_attr(
+        "bucket_name".to_string(),
+        Value::Concrete(ConcreteValue::String(bucket_name.to_string())),
+    );
+    resource
+}
+
+#[test]
+fn import_claimed_name_attribute_target_excludes_desired_from_reconciliation() {
+    use carina_state::state::StateFile;
+
+    let ctx = WiringContext::new(vec![Box::new(AssociationCreateOnlyFactory)]);
+    let old_name = "s3_bucket_1d43a664";
+    let desired_name = "s3_bucket_desired";
+    let bucket_name = "carina-rs-state";
+    let mut state_file = StateFile::new();
+    state_file
+        .resources
+        .push(bucket_state(old_name, bucket_name));
+    let mut resources = vec![desired_bucket(desired_name, bucket_name)];
+    let state_blocks = vec![StateBlock::Import {
+        to: StateBlockAddress::new("awscc", "s3.Bucket", bucket_name),
+        id: Value::Concrete(ConcreteValue::String(bucket_name.to_string())),
+    }];
+
+    let claims = resolve_state_block_claims(
+        &state_blocks,
+        &Some(state_file.clone()),
+        &resources,
+        ctx.schemas(),
+    );
+    assert!(
+        claims.claims_to("awscc", "s3.Bucket", desired_name),
+        "name_attribute import target must claim the resolved desired resource"
+    );
+
+    reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file, &claims);
+
+    assert_eq!(
+        resources[0].id.name_str(),
+        desired_name,
+        "import-claimed desired resource must not adopt the matching old hash name"
+    );
+    assert!(
+        state_file
+            .find_resource("awscc", "s3.Bucket", old_name)
+            .is_some(),
+        "old hash state entry must stay put for the orphan path"
+    );
+}
+
+fn assert_claimed_association_stays_orphaned_after_reconcile() {
+    use carina_state::state::StateFile;
+
+    let ctx = WiringContext::new(vec![Box::new(AssociationCreateOnlyFactory)]);
+    let old_name = "ec2_subnet_route_table_association_11111111";
+    let desired_name = "ec2_subnet_route_table_association_aaaaaaaa";
+    let mut state_file = StateFile::new();
+    state_file
+        .resources
+        .push(route_table_state("private_rtb", "rtb-private"));
+    state_file
+        .resources
+        .push(association_state(old_name, "rtb-private", "subnet-a"));
+    let mut resources = vec![desired_association(desired_name, "private_rtb", "subnet-a")];
+    let state_blocks = vec![StateBlock::Removed {
+        from: StateBlockAddress::new("awscc", "ec2.SubnetRouteTableAssociation", old_name),
+    }];
+    let claims = resolve_state_block_claims(
+        &state_blocks,
+        &Some(state_file.clone()),
+        &resources,
+        ctx.schemas(),
+    );
+
+    assert!(
+        claims.claims_from("awscc", "ec2.SubnetRouteTableAssociation", old_name),
+        "effective removed block must claim its state entry"
+    );
+    reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file, &claims);
+
+    assert_eq!(
+        resources[0].id.name_str(),
+        desired_name,
+        "claimed state entry must not be rebound to the desired resource"
+    );
+    assert!(
+        state_file
+            .find_resource("awscc", "ec2.SubnetRouteTableAssociation", old_name)
+            .is_some(),
+        "claimed state entry must survive under its old name for the orphan path"
+    );
+}
+
+#[test]
+fn claimed_state_entry_survives_orphan_reconcile_for_destroy_and_refresh() {
+    // Both command shapes reach the same
+    // `reconcile_anonymous_identifiers_with_ctx` exclusion seam:
+    // destroy sends the claimed entry through the orphan-delete path under
+    // its old name, while state refresh refreshes it in place under that
+    // old name.
+    assert_claimed_association_stays_orphaned_after_reconcile();
+}
+
 #[test]
 fn reconcile_anonymous_identifiers_with_ctx_resolves_deferred_create_only_from_state_bindings() {
     use carina_state::state::StateFile;
@@ -867,7 +1087,12 @@ fn reconcile_anonymous_identifiers_with_ctx_resolves_deferred_create_only_from_s
         ),
     ];
 
-    reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file);
+    reconcile_anonymous_identifiers_with_ctx(
+        &ctx,
+        &mut resources,
+        &mut state_file,
+        &carina_core::identifier::StateBlockClaims::empty(),
+    );
 
     let names: Vec<_> = resources
         .iter()
@@ -881,6 +1106,223 @@ fn reconcile_anonymous_identifiers_with_ctx_resolves_deferred_create_only_from_s
             "ec2_subnet_route_table_association_33333333",
         ],
         "desired anonymous associations must adopt state names by resolved create-only values",
+    );
+}
+
+#[test]
+fn test_stale_moved_block_releases_claims() {
+    use carina_state::state::StateFile;
+
+    let ctx = WiringContext::new(vec![Box::new(AssociationCreateOnlyFactory)]);
+    let mut state_file = StateFile::new();
+    state_file
+        .resources
+        .push(route_table_state("private_rtb", "rtb-private"));
+    state_file.resources.push(association_state(
+        "ec2_subnet_route_table_association_11111111",
+        "rtb-private",
+        "subnet-a",
+    ));
+
+    let mut resources = vec![desired_association(
+        "ec2_subnet_route_table_association_aaaaaaaa",
+        "private_rtb",
+        "subnet-a",
+    )];
+    let state_blocks = vec![StateBlock::Moved {
+        from: StateBlockAddress::new("awscc", "ec2.SubnetRouteTableAssociation", "does_not_exist"),
+        to: StateBlockAddress::new(
+            "awscc",
+            "ec2.SubnetRouteTableAssociation",
+            "ec2_subnet_route_table_association_aaaaaaaa",
+        ),
+    }];
+    let claims = resolve_state_block_claims(
+        &state_blocks,
+        &Some(state_file.clone()),
+        &resources,
+        ctx.schemas(),
+    );
+
+    assert!(
+        !claims.claims_to(
+            "awscc",
+            "ec2.SubnetRouteTableAssociation",
+            "ec2_subnet_route_table_association_aaaaaaaa",
+        ),
+        "ineffective moved block must not pin its to address"
+    );
+    reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file, &claims);
+
+    assert_eq!(
+        resources[0].id.name_str(),
+        "ec2_subnet_route_table_association_11111111",
+        "stale moved block must release claims so meaning-based matching can preserve the no-op"
+    );
+}
+
+#[test]
+fn moved_blocks_are_honored_before_heuristic_reconciliation_for_five_renames() {
+    use carina_core::resource::{ResourceId, State};
+    use carina_state::state::StateFile;
+
+    let ctx = WiringContext::new(vec![Box::new(AssociationCreateOnlyFactory)]);
+    let mut state_file = StateFile::new();
+    let mut resources = Vec::new();
+    let mut state_blocks = Vec::new();
+    let mut current_states = HashMap::new();
+    let mut old_names = Vec::new();
+    let mut desired_names = Vec::new();
+
+    for idx in 0..5 {
+        let binding = format!("rtb_{idx}");
+        let route_table_id = format!("rtb-{idx}");
+        let subnet_id = format!("subnet-{idx}");
+        let old_name = format!("ec2_subnet_route_table_association_old_{idx:08x}");
+        let desired_name = format!("ec2_subnet_route_table_association_new_{idx:08x}");
+
+        state_file
+            .resources
+            .push(route_table_state(&binding, &route_table_id));
+        state_file
+            .resources
+            .push(association_state(&old_name, &route_table_id, &subnet_id));
+        resources.push(desired_association(&desired_name, &binding, &subnet_id));
+        state_blocks.push(StateBlock::Moved {
+            from: StateBlockAddress::new("awscc", "ec2.SubnetRouteTableAssociation", &old_name),
+            to: StateBlockAddress::new("awscc", "ec2.SubnetRouteTableAssociation", &desired_name),
+        });
+
+        let old_id =
+            ResourceId::with_provider("awscc", "ec2.SubnetRouteTableAssociation", &old_name, None);
+        current_states.insert(old_id.clone(), State::not_found(old_id));
+        old_names.push(old_name);
+        desired_names.push(desired_name);
+    }
+
+    let claims = resolve_state_block_claims(
+        &state_blocks,
+        &Some(state_file.clone()),
+        &resources,
+        ctx.schemas(),
+    );
+    reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file, &claims);
+    assert_eq!(
+        resources
+            .iter()
+            .map(|resource| resource.id.name_str().to_string())
+            .collect::<Vec<_>>(),
+        desired_names,
+        "heuristics must not re-key desired resources whose names are moved.to claims"
+    );
+
+    let moved_pairs = materialize_moved_states(
+        &mut current_states,
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        &state_blocks,
+        &Some(state_file),
+    );
+    assert_eq!(moved_pairs.len(), 5);
+    for (idx, (from, to)) in moved_pairs.iter().enumerate() {
+        assert_eq!(from.name_str(), old_names[idx]);
+        assert_eq!(to.name_str(), desired_names[idx]);
+    }
+    for name in old_names {
+        let id = ResourceId::with_provider("awscc", "ec2.SubnetRouteTableAssociation", name, None);
+        assert!(
+            !current_states.contains_key(&id),
+            "old state key must be removed after materialized move"
+        );
+    }
+    for name in desired_names {
+        let id = ResourceId::with_provider("awscc", "ec2.SubnetRouteTableAssociation", name, None);
+        assert!(
+            current_states.contains_key(&id),
+            "desired state key must exist after materialized move"
+        );
+    }
+}
+
+#[tokio::test]
+async fn moved_blocks_plan_level_fixture_emits_five_moves_only() {
+    use carina_core::effect::Effect;
+    use carina_core::parser::{ProviderContext, parse};
+    use carina_state::state::{ResourceState, StateFile};
+
+    // This plan-level fixture pins moved materialization and Move-effect
+    // emission at the `create_plan_from_parsed_with_upstream` seam. The
+    // claims-precedence ordering itself is covered by
+    // `moved_blocks_are_honored_before_heuristic_reconciliation_for_five_renames`.
+    let mut source = String::new();
+    let mut state_file = StateFile::new();
+    for idx in 0..5 {
+        let old_name = format!("old_assoc_{idx}");
+        let desired_name = format!("desired_assoc_{idx}");
+        let route_table_id = format!("rtb-{idx}");
+        let subnet_id = format!("subnet-{idx}");
+
+        source.push_str(&format!(
+            r#"
+let {desired_name} = awscc.ec2.SubnetRouteTableAssociation {{
+    route_table_id = "{route_table_id}"
+    subnet_id      = "{subnet_id}"
+}}
+
+moved {{
+    from = awscc.ec2.SubnetRouteTableAssociation "{old_name}"
+    to   = awscc.ec2.SubnetRouteTableAssociation "{desired_name}"
+}}
+"#
+        ));
+
+        state_file.resources.push(
+            ResourceState::new("ec2.SubnetRouteTableAssociation", &old_name, "awscc")
+                .with_identifier(format!("assoc-{idx}"))
+                .with_attribute("route_table_id", serde_json::Value::String(route_table_id))
+                .with_attribute("subnet_id", serde_json::Value::String(subnet_id)),
+        );
+    }
+
+    let parsed = parse(&source, &ProviderContext::default()).expect("parse fixture");
+    let state_block_claims = resolve_state_block_claims(
+        &parsed.state_blocks,
+        &Some(state_file.clone()),
+        &parsed.resources,
+        &carina_core::schema::SchemaRegistry::new(),
+    );
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let ctx = create_plan_from_parsed_with_upstream(
+        &parsed,
+        &Some(state_file),
+        false,
+        &HashMap::new(),
+        &state_block_claims,
+        tmp.path(),
+    )
+    .await
+    .expect("plan fixture");
+
+    let summary = ctx.plan.summary();
+    assert_eq!(summary.create, 0, "moved fixture must not add resources");
+    assert_eq!(
+        summary.delete, 0,
+        "moved fixture must not destroy resources"
+    );
+    assert_eq!(
+        summary.replace, 0,
+        "moved fixture must not replace resources"
+    );
+    assert_eq!(summary.update, 0, "moved fixture must not update resources");
+    assert_eq!(summary.moved, 5, "all five moved blocks must be honored");
+    assert_eq!(ctx.plan.mutation_count(), 5);
+    assert!(
+        ctx.plan
+            .effects()
+            .iter()
+            .all(|effect| matches!(effect, Effect::Move { .. })),
+        "plan must contain only Move effects, got {:?}",
+        ctx.plan.effects()
     );
 }
 
@@ -1176,6 +1618,7 @@ fn apply_anonymous_to_named_renames_canonicalizes_provider_config_identity_enums
         &mut prev_explicit,
         &mut saved_attrs,
         &Some(state_file),
+        &carina_core::identifier::StateBlockClaims::empty(),
     );
 
     assert_eq!(

--- a/carina-cli/tests/fixtures/plan_display/moved_claims_precede_heuristics/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_claims_precede_heuristics/carina.state.json
@@ -1,0 +1,35 @@
+{
+  "version": 7,
+  "serial": 1,
+  "lineage": "test-moved-claims-precede-heuristics",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "test.Widget",
+      "name": "test_widget_11111111",
+      "provider": "awscc",
+      "identifier": "widget-live-1",
+      "attributes": {
+        "id": "widget-live-1",
+        "external_name": "claimed-widget"
+      },
+      "protected": false,
+      "directives": {
+        "force_delete": false,
+        "create_before_destroy": false
+      },
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": null,
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "external_name": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/moved_claims_precede_heuristics/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/moved_claims_precede_heuristics/main.crn
@@ -1,0 +1,15 @@
+# Moved block must win before meaning-based anonymous reconciliation.
+# The state row has matching create-only values under an old hash name.
+
+provider awscc {
+  region = "ap-northeast-1"
+}
+
+moved {
+  from = awscc.test.Widget "test_widget_11111111"
+  to   = awscc.test.Widget "awscc_test_widget_58cf4fed"
+}
+
+awscc.test.Widget {
+  external_name = "claimed-widget"
+}

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -7,10 +7,53 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 #[cfg(test)]
 use crate::parser::ProviderConfig;
+use crate::parser::StateBlockAddress;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, Value};
 use crate::schema::SchemaRegistry;
 use crate::validation::is_string_compatible_type;
 use crate::value::CanonicalizedProviderConfigs;
+
+/// Addresses claimed by operator-written state blocks. Heuristic rename
+/// passes must not consume a claimed `from` state entry nor synthesize a
+/// rename onto a claimed `to` name — operator intent always wins over
+/// similarity heuristics.
+///
+/// `from` claims: `moved.from`, `removed.from`.
+/// `to` claims: `moved.to`, `import.to`.
+#[derive(Debug, Clone, Default)]
+pub struct StateBlockClaims {
+    from: HashSet<StateBlockAddress>,
+    to: HashSet<StateBlockAddress>,
+}
+
+impl StateBlockClaims {
+    pub fn new(from: HashSet<StateBlockAddress>, to: HashSet<StateBlockAddress>) -> Self {
+        Self { from, to }
+    }
+
+    // Test-only convenience. Production call sites must resolve operator
+    // claims from parsed state blocks instead of defaulting to no claims.
+    #[doc(hidden)]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn claims_from(&self, provider: &str, resource_type: &str, name: &str) -> bool {
+        if self.from.is_empty() {
+            return false;
+        }
+        self.from
+            .contains(&StateBlockAddress::new(provider, resource_type, name))
+    }
+
+    pub fn claims_to(&self, provider: &str, resource_type: &str, name: &str) -> bool {
+        if self.to.is_empty() {
+            return false;
+        }
+        self.to
+            .contains(&StateBlockAddress::new(provider, resource_type, name))
+    }
+}
 
 /// Generate a random 8-character lowercase hex suffix using UUID v4.
 pub fn generate_random_suffix() -> String {
@@ -774,6 +817,7 @@ pub fn reconcile_anonymous_identifiers(
     registry: &SchemaRegistry,
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
     find_state_by_binding: &dyn Fn(&str) -> Vec<AnonymousIdBindingStateInfo>,
+    claims: &StateBlockClaims,
 ) -> Vec<(String, String)> {
     let mut renames: Vec<(String, String)> = Vec::new();
     let mut used_names: HashMap<(String, String), HashSet<String>> = HashMap::new();
@@ -799,6 +843,14 @@ pub fn reconcile_anonymous_identifiers(
         // meaningful for anonymous hash-derived identifiers. Named resources
         // should never be rebound to a different state entry.
         if resource.binding.is_some() {
+            continue;
+        }
+
+        if claims.claims_to(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            resource.id.name_str(),
+        ) {
             continue;
         }
 
@@ -844,6 +896,13 @@ pub fn reconcile_anonymous_identifiers(
             let candidates = state_entries
                 .iter()
                 .filter(|entry| entry.name != resource.id.name_str())
+                .filter(|entry| {
+                    !claims.claims_from(
+                        &resource.id.provider,
+                        &resource.id.resource_type,
+                        &entry.name,
+                    )
+                })
                 .filter(|entry| {
                     !used_names
                         .get(&key)
@@ -894,6 +953,11 @@ pub fn reconcile_anonymous_identifiers(
                 || claimed_names
                     .get(&key)
                     .is_some_and(|names| names.contains(&entry.name))
+                || claims.claims_from(
+                    &resource.id.provider,
+                    &resource.id.resource_type,
+                    &entry.name,
+                )
             {
                 continue;
             }
@@ -975,6 +1039,7 @@ pub fn detect_anonymous_to_named_renames(
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
     providers: &CanonicalizedProviderConfigs,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+    claims: &StateBlockClaims,
 ) -> Vec<(ResourceId, ResourceId)> {
     // Collect the set of resource names currently used in the DSL per
     // (provider, resource_type). Any state entry not in this set is an orphan.
@@ -995,6 +1060,13 @@ pub fn detect_anonymous_to_named_renames(
     for resource in resources {
         // Only rename let-bound resources whose binding was previously anonymous.
         if resource.binding.is_none() {
+            continue;
+        }
+        if claims.claims_to(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            resource.id.name_str(),
+        ) {
             continue;
         }
 
@@ -1037,6 +1109,13 @@ pub fn detect_anonymous_to_named_renames(
                 if used_in_dsl.contains(&entry.name) {
                     continue;
                 }
+                if claims.claims_from(
+                    &resource.id.provider,
+                    &resource.id.resource_type,
+                    &entry.name,
+                ) {
+                    continue;
+                }
                 if extract_hash_from_identifier(&entry.name).is_none() {
                     continue;
                 }
@@ -1064,6 +1143,9 @@ pub fn detect_anonymous_to_named_renames(
             let candidates = state_entries
                 .iter()
                 .filter(|e| !used_in_dsl.contains(&e.name))
+                .filter(|e| {
+                    !claims.claims_from(&resource.id.provider, &resource.id.resource_type, &e.name)
+                })
                 .filter_map(|e| match extract_hash_from_identifier(&e.name) {
                     Some(AnonymousHashSuffix::SimHash(hash)) => Some((e.name.as_str(), hash)),
                     _ => None,
@@ -1093,6 +1175,7 @@ pub fn detect_anonymous_to_named_renames_for_test(
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
     providers: &[ProviderConfig],
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+    claims: &StateBlockClaims,
 ) -> Vec<(ResourceId, ResourceId)> {
     let providers = CanonicalizedProviderConfigs::from_configs_for_test(providers.to_vec());
     detect_anonymous_to_named_renames(
@@ -1101,6 +1184,7 @@ pub fn detect_anonymous_to_named_renames_for_test(
         find_state_by_type,
         &providers,
         identity_attributes_fn,
+        claims,
     )
 }
 

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -1,9 +1,42 @@
 use super::*;
+use crate::parser::StateBlockAddress;
 use crate::resource::Resource;
 use crate::schema::{
     AttributeSchema, AttributeType, DslTransform, ResourceSchema, SchemaRegistry, enum_identity,
 };
 use indexmap::IndexMap;
+
+fn reconcile_anonymous_identifiers(
+    resources: &mut [Resource],
+    registry: &SchemaRegistry,
+    find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
+    find_state_by_binding: &dyn Fn(&str) -> Vec<AnonymousIdBindingStateInfo>,
+) -> Vec<(String, String)> {
+    super::reconcile_anonymous_identifiers(
+        resources,
+        registry,
+        find_state_by_type,
+        find_state_by_binding,
+        &StateBlockClaims::empty(),
+    )
+}
+
+fn detect_anonymous_to_named_renames_for_test(
+    resources: &[Resource],
+    registry: &SchemaRegistry,
+    find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
+    providers: &[ProviderConfig],
+    identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+) -> Vec<(ResourceId, ResourceId)> {
+    super::detect_anonymous_to_named_renames_for_test(
+        resources,
+        registry,
+        find_state_by_type,
+        providers,
+        identity_attributes_fn,
+        &StateBlockClaims::empty(),
+    )
+}
 
 fn make_s3_bucket_schema() -> ResourceSchema {
     ResourceSchema::new("s3.Bucket")
@@ -1612,6 +1645,127 @@ fn test_reconcile_resolves_deferred_create_only_via_state_bindings() {
 }
 
 #[test]
+fn test_reconcile_skips_state_entry_claimed_by_moved_from() {
+    let mut simhash_schemas = SchemaRegistry::new();
+    simhash_schemas.insert("awscc", simhash_eip_schema());
+    let mut simhash_resources = vec![Resource::with_provider(
+        "awscc",
+        "ec2.eip",
+        "awscc_ec2_eip_0000000000000002",
+        None,
+    )];
+    let simhash_state = vec![AnonymousIdStateInfo {
+        name: "awscc_ec2_eip_0000000000000003".to_string(),
+        create_only_values: HashMap::new(),
+    }];
+    let claims = StateBlockClaims::new(
+        [StateBlockAddress::new(
+            "awscc",
+            "ec2.eip",
+            "awscc_ec2_eip_0000000000000003",
+        )]
+        .into_iter()
+        .collect(),
+        HashSet::new(),
+    );
+
+    let simhash_renames = super::reconcile_anonymous_identifiers(
+        &mut simhash_resources,
+        &simhash_schemas,
+        &|_, _| simhash_state.clone(),
+        &|_| Vec::new(),
+        &claims,
+    );
+    assert!(
+        simhash_renames.is_empty(),
+        "claimed moved.from state row must be excluded from SimHash candidates"
+    );
+
+    let mut create_only_schemas = SchemaRegistry::new();
+    create_only_schemas.insert("awscc", route_schema_with_create_only_route_table());
+    let mut create_only_resources = vec![route_with_deferred_route_table(
+        "awscc_ec2_route_aaaaaaaa",
+        "private_rtb",
+    )];
+    let create_only_state = vec![route_state_entry("awscc_ec2_route_11111111", "rtb-private")];
+    let binding_entries = [binding_state_entry(
+        "private_rtb",
+        "private_rtb",
+        &[("id", "rtb-private")],
+    )];
+    let claims = StateBlockClaims::new(
+        [StateBlockAddress::new(
+            "awscc",
+            "ec2.Route",
+            "awscc_ec2_route_11111111",
+        )]
+        .into_iter()
+        .collect(),
+        HashSet::new(),
+    );
+
+    let create_only_renames = super::reconcile_anonymous_identifiers(
+        &mut create_only_resources,
+        &create_only_schemas,
+        &|_, _| create_only_state.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+        &claims,
+    );
+    assert!(create_only_renames.is_empty());
+    assert_eq!(
+        create_only_resources[0].id.name_str(),
+        "awscc_ec2_route_aaaaaaaa",
+        "claimed moved.from state row must be excluded from create-only full matches"
+    );
+}
+
+#[test]
+fn test_reconcile_skips_desired_name_claimed_by_moved_to() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", route_schema_with_create_only_route_table());
+    let desired_name = "awscc_ec2_route_aaaaaaaa";
+    let mut resources = vec![route_with_deferred_route_table(desired_name, "private_rtb")];
+    let state_entries = vec![route_state_entry("awscc_ec2_route_11111111", "rtb-private")];
+    let binding_entries = [binding_state_entry(
+        "private_rtb",
+        "private_rtb",
+        &[("id", "rtb-private")],
+    )];
+    let claims = StateBlockClaims::new(
+        HashSet::new(),
+        [StateBlockAddress::new("awscc", "ec2.Route", desired_name)]
+            .into_iter()
+            .collect(),
+    );
+
+    super::reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_, _| state_entries.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+        &claims,
+    );
+
+    assert_eq!(
+        resources[0].id.name_str(),
+        desired_name,
+        "desired name claimed as moved.to must skip heuristic reconciliation"
+    );
+}
+
+#[test]
 fn test_reconcile_deferred_create_only_ambiguous_refuses() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", subnet_route_table_association_schema());
@@ -3159,6 +3313,128 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
     assert_eq!(renames.len(), 1);
     assert_eq!(renames[0].0.name_str(), "sso_instance_0ac0620303071530");
     assert_eq!(renames[0].1.name_str(), "sso");
+}
+
+#[test]
+fn test_detect_anonymous_to_named_skips_claimed_from() {
+    let schemas = make_sso_instance_registry();
+
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
+    resource.binding = Some("sso".to_string());
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
+    let resources = vec![resource];
+    let state_name = "sso_instance_0ac0620303071530";
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: state_name.to_string(),
+        create_only_values: vec![("name".to_string(), "carina-rs".to_string())]
+            .into_iter()
+            .collect(),
+    }];
+    let claims = StateBlockClaims::new(
+        [StateBlockAddress::new("awscc", "sso.Instance", state_name)]
+            .into_iter()
+            .collect(),
+        HashSet::new(),
+    );
+
+    let renames = super::detect_anonymous_to_named_renames_for_test(
+        &resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &[],
+        &|_provider| Vec::new(),
+        &claims,
+    );
+
+    assert!(
+        renames.is_empty(),
+        "anonymous-to-named detector must not synthesize a rename from a claimed from"
+    );
+}
+
+#[test]
+fn test_detect_anonymous_to_named_skips_claimed_to() {
+    let schemas = make_sso_instance_registry();
+
+    let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso", None);
+    resource.binding = Some("sso".to_string());
+    resource.set_attr(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("carina-rs".to_string())),
+    );
+    let resources = vec![resource];
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: "sso_instance_0ac0620303071530".to_string(),
+        create_only_values: vec![("name".to_string(), "carina-rs".to_string())]
+            .into_iter()
+            .collect(),
+    }];
+    let claims = StateBlockClaims::new(
+        HashSet::new(),
+        [StateBlockAddress::new("awscc", "sso.Instance", "sso")]
+            .into_iter()
+            .collect(),
+    );
+
+    let renames = super::detect_anonymous_to_named_renames_for_test(
+        &resources,
+        &schemas,
+        &|_provider, _rt| state_entries.clone(),
+        &[],
+        &|_provider| Vec::new(),
+        &claims,
+    );
+
+    assert!(
+        renames.is_empty(),
+        "anonymous-to-named detector must not synthesize a rename onto a claimed to"
+    );
+}
+
+#[test]
+fn test_reconcile_skips_state_entry_claimed_by_removed_from() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", route_schema_with_create_only_route_table());
+    let mut resources = vec![route_with_deferred_route_table(
+        "awscc_ec2_route_aaaaaaaa",
+        "private_rtb",
+    )];
+    let state_name = "awscc_ec2_route_11111111";
+    let state_entries = vec![route_state_entry(state_name, "rtb-private")];
+    let binding_entries = [binding_state_entry(
+        "private_rtb",
+        "private_rtb",
+        &[("id", "rtb-private")],
+    )];
+    let claims = StateBlockClaims::new(
+        [StateBlockAddress::new("awscc", "ec2.Route", state_name)]
+            .into_iter()
+            .collect(),
+        HashSet::new(),
+    );
+
+    super::reconcile_anonymous_identifiers(
+        &mut resources,
+        &schemas,
+        &|_, _| state_entries.clone(),
+        &|binding| {
+            binding_entries
+                .iter()
+                .filter(|(entry_binding, _)| entry_binding == binding)
+                .map(|(_, entry)| entry.clone())
+                .collect()
+        },
+        &claims,
+    );
+
+    assert_eq!(
+        resources[0].id.name_str(),
+        "awscc_ec2_route_aaaaaaaa",
+        "effective removed.from state row must be excluded from heuristic matching"
+    );
 }
 
 #[test]

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -1021,6 +1021,7 @@ pub(super) fn split_instance_prefix(name: &str) -> Option<(&str, &str)> {
 pub fn reconcile_anonymous_module_instances(
     resources: &mut [Resource],
     find_state_names_by_type: &dyn Fn(&str, &str) -> Vec<String>,
+    claims: &crate::identifier::StateBlockClaims,
 ) {
     use std::collections::{HashMap, HashSet};
 
@@ -1042,6 +1043,7 @@ pub fn reconcile_anonymous_module_instances(
     // distinct prefix (a multi-resource module instance shares one prefix
     // across all of its resources).
     let mut current_synthetic_by_module: HashMap<String, HashSet<SimHash>> = HashMap::new();
+    let mut claimed_current_by_module: HashMap<String, HashSet<SimHash>> = HashMap::new();
     for r in resources.iter() {
         let Some((prefix, _)) = split_instance_prefix(r.id.name_str()) else {
             continue;
@@ -1053,6 +1055,12 @@ pub fn reconcile_anonymous_module_instances(
             .entry(module.to_string())
             .or_default()
             .insert(simhash);
+        if claims.claims_to(&r.id.provider, &r.id.resource_type, r.id.name_str()) {
+            claimed_current_by_module
+                .entry(module.to_string())
+                .or_default()
+                .insert(simhash);
+        }
     }
 
     // State synthetic prefixes per module. Use a set so a multi-resource
@@ -1062,6 +1070,7 @@ pub fn reconcile_anonymous_module_instances(
     // search below would mistake duplicates for ambiguous candidates and
     // refuse to remap (#2211).
     let mut state_synthetic_by_module: HashMap<String, HashSet<SimHash>> = HashMap::new();
+    let mut claimed_state_by_module: HashMap<String, HashSet<SimHash>> = HashMap::new();
 
     for (provider, resource_type) in &touched_types {
         for name in find_state_names_by_type(provider, resource_type) {
@@ -1075,6 +1084,12 @@ pub fn reconcile_anonymous_module_instances(
                 .entry(module.to_string())
                 .or_default()
                 .insert(simhash);
+            if claims.claims_from(provider, resource_type, &name) {
+                claimed_state_by_module
+                    .entry(module.to_string())
+                    .or_default()
+                    .insert(simhash);
+            }
         }
     }
 
@@ -1092,12 +1107,23 @@ pub fn reconcile_anonymous_module_instances(
             .iter()
             .copied()
             .filter(|h| !current_hashes.contains(h))
+            .filter(|h| {
+                !claimed_state_by_module
+                    .get(module)
+                    .is_some_and(|hashes| hashes.contains(h))
+            })
             .collect();
         if orphan_state_hashes.is_empty() {
             continue;
         }
         for current_hash in current_hashes {
             if state_hashes.contains(current_hash) {
+                continue;
+            }
+            if claimed_current_by_module
+                .get(module)
+                .is_some_and(|hashes| hashes.contains(current_hash))
+            {
                 continue;
             }
             if let Some(state_hash) = crate::identifier::closest_unique_simhash_match(

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -16,6 +16,17 @@ use crate::parser::{ArgumentParameter, ModuleCall, ParsedFile, ProviderContext, 
 use crate::resource::{ConcreteValue, DeferredValue, Directives, Resource, ResourceId, Value};
 use crate::schema::TypeIdentity;
 
+fn reconcile_anonymous_module_instances(
+    resources: &mut [Resource],
+    find_state_names_by_type: &dyn Fn(&str, &str) -> Vec<String>,
+) {
+    crate::module_resolver::reconcile_anonymous_module_instances(
+        resources,
+        find_state_names_by_type,
+        &crate::identifier::StateBlockClaims::empty(),
+    );
+}
+
 fn create_test_module() -> ParsedFile {
     ParsedFile {
         providers: vec![],
@@ -1259,6 +1270,105 @@ thing { name = 'after-edit' }
         role.binding.as_deref(),
         Some(format!("thing_{:016x}.role", state_hash).as_str()),
         "binding should be remapped too",
+    );
+}
+
+#[test]
+fn test_module_instance_reconcile_skips_claimed_prefix() {
+    let mut claimed_from = resolve_thing_fixture(
+        r#"
+let thing = use { source = '../modules/thing' }
+
+thing { name = 'after-edit' }
+"#,
+    );
+    let before_name = claimed_from
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "iam.Role")
+        .unwrap()
+        .id
+        .name_str()
+        .to_string();
+    let (current_prefix, _) = before_name.split_once('.').unwrap();
+    let (_, current_hash) = parse_synthetic_instance_prefix(current_prefix).unwrap();
+    let state_hash = current_hash.with_flipped_mask_for_test(1);
+    let state_name = format!("thing_{:016x}.role", state_hash);
+    let state_lookup = |_: &str, _: &str| vec![state_name.clone()];
+    let claims = crate::identifier::StateBlockClaims::new(
+        [crate::parser::StateBlockAddress::new(
+            "awscc",
+            "iam.Role",
+            &state_name,
+        )]
+        .into_iter()
+        .collect(),
+        HashSet::new(),
+    );
+
+    crate::module_resolver::reconcile_anonymous_module_instances(
+        &mut claimed_from.resources,
+        &state_lookup,
+        &claims,
+    );
+    assert_eq!(
+        claimed_from
+            .resources
+            .iter()
+            .find(|r| r.id.resource_type == "iam.Role")
+            .unwrap()
+            .id
+            .name_str(),
+        before_name,
+        "a claimed state child must exclude the whole state prefix from orphan candidates",
+    );
+
+    let mut claimed_to = resolve_thing_fixture(
+        r#"
+let thing = use { source = '../modules/thing' }
+
+thing { name = 'after-edit' }
+"#,
+    );
+    let before_name = claimed_to
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "iam.Role")
+        .unwrap()
+        .id
+        .name_str()
+        .to_string();
+    let (current_prefix, _) = before_name.split_once('.').unwrap();
+    let (_, current_hash) = parse_synthetic_instance_prefix(current_prefix).unwrap();
+    let state_hash = current_hash.with_flipped_mask_for_test(1);
+    let state_name = format!("thing_{:016x}.role", state_hash);
+    let state_lookup = |_: &str, _: &str| vec![state_name.clone()];
+    let claims = crate::identifier::StateBlockClaims::new(
+        HashSet::new(),
+        [crate::parser::StateBlockAddress::new(
+            "awscc",
+            "iam.Role",
+            &before_name,
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    crate::module_resolver::reconcile_anonymous_module_instances(
+        &mut claimed_to.resources,
+        &state_lookup,
+        &claims,
+    );
+    assert_eq!(
+        claimed_to
+            .resources
+            .iter()
+            .find(|r| r.id.resource_type == "iam.Role")
+            .unwrap()
+            .id
+            .name_str(),
+        before_name,
+        "a claimed desired child must pin the whole current prefix",
     );
 }
 


### PR DESCRIPTION
## Summary

PR 2 of 3 implementing the carina#3454 design (`notes/specs/2026-06-11-anonymous-rename-moved-safety-design.md`): RC2 — operator-claimed addresses are excluded from heuristics, by signature.

Refs #3454

## Problem

The heuristic rename passes run before `moved` materialization in every command and re-key the very state entries operator-written blocks address. In infra#138 this meant hand-written 1:1 `moved` blocks were silently partly applied: blocks whose `from` the heuristic had already consumed no-oped without a diagnostic, and a surviving block's transfer could overwrite a re-keyed row in `current_states` — silently dropping a state row (orphaning live infrastructure from state).

## Changes

- **`StateBlockClaims`** (carina-core): claimed `from` (`moved.from`, `removed.from`) and `to` (`moved.to`, `import.to`) address sets over `StateBlockAddress`. A required, non-`Option` parameter on all three heuristic passes — `reconcile_anonymous_identifiers`, `detect_anonymous_to_named_renames`, `reconcile_anonymous_module_instances` — so no future caller can run heuristics without stating the operator's claims. Claimed `from` entries are excluded as match candidates in every branch; desired names matching a claimed `to` skip heuristic reconciliation. The module-instance pass lifts the rules to prefix granularity: any claimed name under a prefix excludes (state side) or pins (desired side) the whole prefix.
- **Effectiveness-gated resolution** (`resolve_state_block_claims`, wiring layer): a `moved` block claims only when its `from` resolves in the state file as read; `removed` likewise; `import` claims its resolved desired target (by name, then `name_attribute`, sharing the matching helper with `resolve_import_target`) only when not already in state. Claims are resolved once per command, after `reconcile_prefixed_names`, before any heuristic pass; the plan path threads the same T0 instance into `create_plan_from_parsed_with_upstream`.
- **Ineffective `moved` blocks warn** (stderr): `from` absent and `to` absent from state → warning; `from` absent but `to` present → today's silent already-applied no-op. An ineffective block also claims nothing, so a stale `moved.crn` cannot pin its `to` and degrade a would-be no-op plan into add+destroy of live resources (the infra#138 committed-file shape now self-resolves with warnings).

## Tests

All design-doc RC2 tests: claimed-from skips in both reconcile branches and both detector paths, claimed-to skips in all three passes, module prefix group semantics, warning/idempotency split, stale-claim release, removed-from claims, import resolution (name_attribute / already-in-state / unresolvable / accepted trade-off shape), destroy/refresh claimed-entry survival, a wiring-level five-rename ordering test, a plan-level five-`Move`-effects test, and a production-ordered plan-display fixture (`moved_claims_precede_heuristics`, snapshot + Makefile target) proven differentiating: disabling claims flips it from `1 move` to `1 create`.

## Verification

- `cargo nextest run --workspace --all-features`: 4014 passed
- `cargo test --workspace --doc`: ok
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `scripts/check-*.sh`: all OK (incl. plan-fixtures parity)
- 5 review rounds (fixed: detector `claims_to` gap, three missing spec-named tests, claims-ordering unification across commands, T0 claims threading replacing an internal rebuild, fixture-level production-order coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
