### PR TITLE
Validate state-block collisions at plan time (carina#3454 RC3)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -814,7 +814,10 @@ async fn run_apply_locked(
     let mut state_file = load_state_persist_if_migrated(backend, lock).await?;
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
-    let state_block_claims = crate::wiring::resolve_state_block_claims(
+    let crate::wiring::StateBlockResolution {
+        claims: state_block_claims,
+        targets: resolved_state_block_targets,
+    } = crate::wiring::resolve_state_blocks(
         &parsed.state_blocks,
         &state_file,
         &parsed.resources,
@@ -1038,7 +1041,6 @@ async fn run_apply_locked(
         ));
         pairs
     };
-
     // Wait bindings become passthrough aliases to their targets
     // (carina#3085). Built once here so every resolution phase below
     // (data-source refresh, initial bindings, ref resolution, exports)
@@ -1126,6 +1128,12 @@ async fn run_apply_locked(
     })
     .await?;
     sorted_resources = resorted;
+    crate::wiring::validate_plan_time_state_block_collisions(
+        &sorted_resources,
+        &moved_pairs,
+        &resolved_state_block_targets,
+        &state_file,
+    )?;
     // Expansion borrows `parsed` immutably (expands a clone), so
     // `parsed.deferred_for_expressions` is NOT drained of resolved
     // loops the way the old `&mut self` call drained it. `print_plan`

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -559,7 +559,10 @@ pub async fn run_plan(
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let wiring = WiringContext::new(factories);
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
-    let state_block_claims = crate::wiring::resolve_state_block_claims(
+    let crate::wiring::StateBlockResolution {
+        claims: state_block_claims,
+        targets: resolved_state_block_targets,
+    } = crate::wiring::resolve_state_blocks(
         &parsed.state_blocks,
         &state_file,
         &parsed.resources,
@@ -627,6 +630,7 @@ pub async fn run_plan(
         refresh,
         &remote_bindings,
         &state_block_claims,
+        &resolved_state_block_targets,
         base_dir,
     )
     .await?;

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -100,7 +100,10 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         assert!(errors.is_empty(), "{errors:?}");
     }
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
-    let state_block_claims = crate::wiring::resolve_state_block_claims(
+    let crate::wiring::StateBlockResolution {
+        claims: state_block_claims,
+        targets: resolved_state_block_targets,
+    } = crate::wiring::resolve_state_blocks(
         &parsed.state_blocks,
         &state_file,
         &parsed.resources,
@@ -305,6 +308,13 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &parsed.state_blocks,
         &state_file,
     );
+    crate::wiring::validate_plan_time_state_block_collisions(
+        &sorted_resources,
+        &moved_pairs,
+        &resolved_state_block_targets,
+        &state_file,
+    )
+    .expect("state block collision validation failed");
 
     // carina#3358: resolve `until` predicate enum aliases before the
     // differ lowers the wait, the same step the plan/apply pipelines run.

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::IsTerminal;
 use std::path::Path;
@@ -66,6 +67,22 @@ pub struct PlanContext {
     /// that produced them (#3306, #3307). Forwarded to the display
     /// layer so the rendered tree folds leaves under composition rows.
     pub expansion_trace: carina_core::resource::ExpansionTrace,
+}
+
+/// State-block targets resolved while constructing [`StateBlockClaims`].
+///
+/// This keeps plan-time collision checks on the same effectiveness
+/// resolution as the heuristic-claim pass. In particular, `removed`
+/// targets are resolved here once and then consumed by the RC3 predicate.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedStateBlockTargets {
+    pub removed_from: Vec<ResourceId>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateBlockResolution {
+    pub claims: StateBlockClaims,
+    pub targets: ResolvedStateBlockTargets,
 }
 
 /// Cached provider factories and schemas, constructed once per CLI invocation.
@@ -1698,6 +1715,7 @@ pub async fn create_plan_from_parsed<E: Clone>(
     state_file: &Option<StateFile>,
     refresh: bool,
     state_block_claims: &StateBlockClaims,
+    resolved_state_block_targets: &ResolvedStateBlockTargets,
     base_dir: &Path,
 ) -> Result<PlanContext, AppError> {
     create_plan_from_parsed_with_upstream(
@@ -1706,6 +1724,7 @@ pub async fn create_plan_from_parsed<E: Clone>(
         refresh,
         &HashMap::new(),
         state_block_claims,
+        resolved_state_block_targets,
         base_dir,
     )
     .await
@@ -1717,6 +1736,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     refresh: bool,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
     state_block_claims: &StateBlockClaims,
+    resolved_state_block_targets: &ResolvedStateBlockTargets,
     base_dir: &Path,
 ) -> Result<PlanContext, AppError> {
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
@@ -1911,7 +1931,6 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
             state_file,
             state_block_claims,
         ));
-
         // Phase 2: resolve data source refs against the consolidated
         // `current_states`, then refresh each via `read_data_source`.
         let ds_wait_aliases: Vec<WaitAliasSpec> = parsed
@@ -2029,6 +2048,12 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         &orphan_refreshed_ids,
     )?;
     sorted_resources = resorted;
+    validate_plan_time_state_block_collisions(
+        &sorted_resources,
+        &moved_pairs,
+        resolved_state_block_targets,
+        state_file,
+    )?;
 
     // A printed `⚠` warning is newline-terminated and is written on top of
     // indicatif's open spinner bar line, so it closes the bar region the
@@ -2365,8 +2390,18 @@ pub fn resolve_state_block_claims(
     desired: &[Resource],
     registry: &SchemaRegistry,
 ) -> StateBlockClaims {
+    resolve_state_blocks(blocks, state_file, desired, registry).claims
+}
+
+pub fn resolve_state_blocks(
+    blocks: &[StateBlock],
+    state_file: &Option<StateFile>,
+    desired: &[Resource],
+    registry: &SchemaRegistry,
+) -> StateBlockResolution {
     let mut from = HashSet::new();
     let mut to = HashSet::new();
+    let mut resolved_removed_from = Vec::new();
 
     for block in blocks {
         match block {
@@ -2387,15 +2422,23 @@ pub fn resolve_state_block_claims(
                 }
             }
             StateBlock::Removed { from: removed_from } => {
-                if state_file.as_ref().is_some_and(|sf| {
+                if let Some(id) = state_file.as_ref().and_then(|sf| {
                     sf.find_resource(
                         &removed_from.provider,
                         &removed_from.resource_type,
                         removed_from.name_str(),
                     )
-                    .is_some()
+                    .map(|rs| {
+                        ResourceId::with_provider(
+                            &rs.provider,
+                            &rs.resource_type,
+                            &rs.name,
+                            rs.directives.provider_instance.clone(),
+                        )
+                    })
                 }) {
                     from.insert(removed_from.clone());
+                    resolved_removed_from.push(id);
                 }
             }
             StateBlock::Import { to: import_to, .. } => {
@@ -2419,7 +2462,106 @@ pub fn resolve_state_block_claims(
         }
     }
 
-    StateBlockClaims::new(from, to)
+    StateBlockResolution {
+        claims: StateBlockClaims::new(from, to),
+        targets: ResolvedStateBlockTargets {
+            removed_from: resolved_removed_from,
+        },
+    }
+}
+
+pub fn validate_plan_time_state_block_collisions(
+    desired: &[Resource],
+    moved_pairs: &[(ResourceId, ResourceId)],
+    resolved_targets: &ResolvedStateBlockTargets,
+    state_file: &Option<StateFile>,
+) -> Result<(), AppError> {
+    let desired_ids: HashSet<ResourceId> =
+        desired.iter().map(|resource| resource.id.clone()).collect();
+
+    for (from, _to) in moved_pairs {
+        if desired_ids.contains(from) {
+            return Err(AppError::Validation(format!(
+                "moved/rename pair from {} collides with a desired resource: applying this plan would both upsert and clean up the same resource id",
+                from.human()
+            )));
+        }
+    }
+
+    for from in &resolved_targets.removed_from {
+        if desired_ids.contains(from) {
+            return Err(AppError::Validation(format!(
+                "removed block from {} collides with desired resource {}: applying this plan would both upsert and clean up the same resource id",
+                from.human(),
+                from.human()
+            )));
+        }
+    }
+
+    let mut seen_to: HashMap<&ResourceId, &ResourceId> = HashMap::new();
+    let mut seen_from: HashMap<&ResourceId, &ResourceId> = HashMap::new();
+    for (from, to) in moved_pairs {
+        match seen_to.entry(to) {
+            Entry::Occupied(first) => {
+                return Err(AppError::Validation(format!(
+                    "two moved/rename pairs resolve to the same target {}: {} -> {} and {} -> {} would overwrite state during plan application",
+                    to.human(),
+                    first.get().human(),
+                    to.human(),
+                    from.human(),
+                    to.human()
+                )));
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(from);
+            }
+        }
+
+        match seen_from.entry(from) {
+            Entry::Occupied(first_to) => {
+                return Err(AppError::Validation(format!(
+                    "two moved/rename pairs share the same source {}: {} -> {} and {} -> {} cannot both transfer the same state entry",
+                    from.human(),
+                    from.human(),
+                    first_to.get().human(),
+                    from.human(),
+                    to.human()
+                )));
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(to);
+            }
+        }
+    }
+
+    let Some(sf) = state_file.as_ref() else {
+        return Ok(());
+    };
+
+    for (from, to) in moved_pairs {
+        let from_exists = sf
+            .find_resource(&from.provider, &from.resource_type, from.name_str())
+            .is_some();
+        if from == to && from_exists {
+            return Err(AppError::Validation(format!(
+                "moved block from and to name the same address {}: a self-move cannot transfer state",
+                from.human()
+            )));
+        }
+        let to_exists = sf
+            .find_resource(&to.provider, &to.resource_type, to.name_str())
+            .is_some();
+        if from_exists && to_exists {
+            return Err(AppError::Validation(format!(
+                "moved/rename pair {} -> {} would overwrite an existing state entry at {}: applying this plan would drop the occupied target state row",
+                from.human(),
+                to.human(),
+                to.human()
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 /// Look up `to`'s full id (with any routed `provider_instance`) in

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -811,6 +811,345 @@ fn test_materialize_moved_states_warns_on_missing_from() {
     );
 }
 
+fn bucket_id(name: &str) -> ResourceId {
+    ResourceId::with_provider("awscc", "s3.Bucket", name, None)
+}
+
+fn bucket_resource(name: &str) -> Resource {
+    Resource::with_provider("awscc", "s3.Bucket", name, None)
+}
+
+fn bucket_state_file(names: &[&str]) -> carina_state::state::StateFile {
+    use carina_state::state::{ResourceState, StateFile};
+
+    let mut state_file = StateFile::new();
+    for name in names {
+        state_file
+            .resources
+            .push(ResourceState::new("s3.Bucket", *name, "awscc"));
+    }
+    state_file
+}
+
+fn assert_collision_contains(result: Result<(), AppError>, needle: &str) {
+    let err = result.expect_err("expected collision error");
+    assert!(
+        matches!(err, AppError::Validation(_)),
+        "collision errors must be validation errors, got {err:?}"
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains(needle),
+        "expected error to contain {needle:?}, got {message:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_plan_fails_on_moved_from_colliding_with_desired() {
+    use carina_core::parser::{ProviderContext, parse};
+
+    let source = r#"
+let live = awscc.s3.Bucket {
+    bucket_name = "live"
+}
+
+moved {
+    from = awscc.s3.Bucket "live"
+    to   = awscc.s3.Bucket "renamed"
+}
+"#;
+    let parsed = parse(source, &ProviderContext::default()).expect("parse fixture");
+    let state_file = Some(bucket_state_file(&["live"]));
+    let StateBlockResolution {
+        claims: state_block_claims,
+        targets: resolved_state_block_targets,
+    } = resolve_state_blocks(
+        &parsed.state_blocks,
+        &state_file,
+        &parsed.resources,
+        &carina_core::schema::SchemaRegistry::new(),
+    );
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let err = match create_plan_from_parsed_with_upstream(
+        &parsed,
+        &state_file,
+        false,
+        &HashMap::new(),
+        &state_block_claims,
+        &resolved_state_block_targets,
+        tmp.path(),
+    )
+    .await
+    {
+        Ok(_) => panic!("plan must fail before producing a green move plan"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+    assert!(
+        matches!(err, AppError::Validation(_)),
+        "plan collision errors must be validation errors, got {err:?}"
+    );
+    assert!(
+        message.contains(
+            "moved/rename pair from awscc.s3.Bucket live collides with a desired resource"
+        ),
+        "unexpected plan error: {message}"
+    );
+}
+
+#[tokio::test]
+async fn test_plan_fails_on_removed_from_colliding_with_expanded_loop_child() {
+    use carina_core::parser::{ProviderContext, parse};
+    use carina_state::state::{ResourceState, StateFile};
+
+    let source = r#"
+let cert = aws.acm.Certificate {
+    domain_name       = "r.example.com"
+    validation_method = "DNS"
+}
+
+let records = for (_, opt) in cert.domain_validation_options {
+    aws.route53.RecordSet {
+        name             = opt.resource_record.name
+        type             = "CNAME"
+        resource_records = [opt.resource_record.value]
+    }
+}
+
+removed {
+    from = aws.route53.RecordSet "records[0]"
+}
+"#;
+    let parsed = parse(source, &ProviderContext::default()).expect("parse removed fixture");
+    let state_file = {
+        let mut sf = StateFile::new();
+        sf.resources.push(
+            ResourceState::new("acm.Certificate", "cert", "aws")
+                .with_identifier("cert-arn")
+                .with_attribute(
+                    "domain_validation_options",
+                    serde_json::json!([
+                        {
+                            "resource_record": {
+                                "name": "_a1.r.example.com",
+                                "value": "_a1.acm-validations.aws."
+                            }
+                        }
+                    ]),
+                ),
+        );
+        sf.resources.push(
+            ResourceState::new("route53.RecordSet", "records[0]", "aws")
+                .with_identifier("record-set-id"),
+        );
+        Some(sf)
+    };
+    let StateBlockResolution {
+        claims: state_block_claims,
+        targets: resolved_state_block_targets,
+    } = resolve_state_blocks(
+        &parsed.state_blocks,
+        &state_file,
+        &parsed.resources,
+        &carina_core::schema::SchemaRegistry::new(),
+    );
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let err = match create_plan_from_parsed_with_upstream(
+        &parsed,
+        &state_file,
+        false,
+        &HashMap::new(),
+        &state_block_claims,
+        &resolved_state_block_targets,
+        tmp.path(),
+    )
+    .await
+    {
+        Ok(_) => panic!("plan must fail once deferred-for children are in the desired set"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("removed block from aws.route53.RecordSet"),
+        "unexpected plan error: {message}"
+    );
+    assert!(
+        message.contains("collides with desired resource"),
+        "unexpected plan error: {message}"
+    );
+}
+
+#[test]
+fn test_plan_fails_on_two_moves_to_same_target() {
+    let desired = Vec::new();
+    let state_file = Some(bucket_state_file(&["old_a", "old_b"]));
+    let moved_pairs = vec![
+        (bucket_id("old_a"), bucket_id("target")),
+        (bucket_id("old_b"), bucket_id("target")),
+    ];
+
+    assert_collision_contains(
+        validate_plan_time_state_block_collisions(
+            &desired,
+            &moved_pairs,
+            &ResolvedStateBlockTargets::default(),
+            &state_file,
+        ),
+        "two moved/rename pairs resolve to the same target awscc.s3.Bucket target",
+    );
+}
+
+#[test]
+fn test_plan_fails_on_two_moves_from_same_source() {
+    let desired = Vec::new();
+    let state_file = Some(bucket_state_file(&["old"]));
+    let moved_pairs = vec![
+        (bucket_id("old"), bucket_id("target_a")),
+        (bucket_id("old"), bucket_id("target_b")),
+    ];
+
+    assert_collision_contains(
+        validate_plan_time_state_block_collisions(
+            &desired,
+            &moved_pairs,
+            &ResolvedStateBlockTargets::default(),
+            &state_file,
+        ),
+        "two moved/rename pairs share the same source awscc.s3.Bucket old",
+    );
+}
+
+#[test]
+fn test_plan_fails_on_removed_from_colliding_with_desired() {
+    let desired = vec![bucket_resource("live")];
+    let state_file = Some(bucket_state_file(&["live"]));
+    let blocks = vec![StateBlock::Removed {
+        from: StateBlockAddress::new("awscc", "s3.Bucket", "live"),
+    }];
+    let resolution = resolve_state_blocks(
+        &blocks,
+        &state_file,
+        &desired,
+        &carina_core::schema::SchemaRegistry::new(),
+    );
+
+    assert_collision_contains(
+        validate_plan_time_state_block_collisions(&desired, &[], &resolution.targets, &state_file),
+        "removed block from awscc.s3.Bucket live collides with desired resource awscc.s3.Bucket live",
+    );
+}
+
+#[test]
+fn test_plan_fails_on_move_onto_occupied_state_entry() {
+    let desired = Vec::new();
+    let state_file = Some(bucket_state_file(&["old", "occupied"]));
+    let moved_pairs = vec![(bucket_id("old"), bucket_id("occupied"))];
+
+    assert_collision_contains(
+        validate_plan_time_state_block_collisions(
+            &desired,
+            &moved_pairs,
+            &ResolvedStateBlockTargets::default(),
+            &state_file,
+        ),
+        "moved/rename pair awscc.s3.Bucket old -> awscc.s3.Bucket occupied would overwrite an existing state entry",
+    );
+}
+
+#[test]
+fn test_plan_allows_from_absent_to_present_idempotent_noop() {
+    let desired = Vec::new();
+    let state_file = Some(bucket_state_file(&["already_moved"]));
+    let state_blocks = vec![StateBlock::Moved {
+        from: StateBlockAddress::new("awscc", "s3.Bucket", "old_name"),
+        to: StateBlockAddress::new("awscc", "s3.Bucket", "already_moved"),
+    }];
+    let mut warnings = Vec::new();
+
+    let moved_pairs = materialize_moved_states_with_warning_sink(
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        &state_blocks,
+        &state_file,
+        &mut |warning| warnings.push(warning),
+    );
+    assert!(
+        moved_pairs.is_empty(),
+        "already-applied moved block must not produce a move pair"
+    );
+    assert!(
+        warnings.is_empty(),
+        "already-applied moved block must stay silent"
+    );
+
+    validate_plan_time_state_block_collisions(
+        &desired,
+        &moved_pairs,
+        &ResolvedStateBlockTargets::default(),
+        &state_file,
+    )
+    .expect("from-absent/to-present no-op must not error");
+}
+
+#[test]
+fn test_plan_fails_on_synthesized_rename_colliding_with_moved_to() {
+    let desired = Vec::new();
+    let state_file = Some(bucket_state_file(&["operator_source", "anonymous_source"]));
+    let operator_moved_pair = (bucket_id("operator_source"), bucket_id("named"));
+    let synthesized_rename_pair = (bucket_id("anonymous_source"), bucket_id("named"));
+    let moved_pairs = vec![operator_moved_pair, synthesized_rename_pair];
+
+    assert_collision_contains(
+        validate_plan_time_state_block_collisions(
+            &desired,
+            &moved_pairs,
+            &ResolvedStateBlockTargets::default(),
+            &state_file,
+        ),
+        "two moved/rename pairs resolve to the same target awscc.s3.Bucket named",
+    );
+}
+
+#[test]
+fn test_plan_fails_on_orphan_self_move() {
+    let desired = Vec::new();
+    let state_file = Some(bucket_state_file(&["orphan"]));
+    let moved_pairs = vec![(bucket_id("orphan"), bucket_id("orphan"))];
+
+    assert_collision_contains(
+        validate_plan_time_state_block_collisions(
+            &desired,
+            &moved_pairs,
+            &ResolvedStateBlockTargets::default(),
+            &state_file,
+        ),
+        "moved block from and to name the same address awscc.s3.Bucket orphan: a self-move cannot transfer state",
+    );
+}
+
+#[test]
+fn test_plan_fails_on_rotation_shape() {
+    let desired = vec![bucket_resource("b"), bucket_resource("c")];
+    let state_file = Some(bucket_state_file(&["a", "b"]));
+    let moved_pairs = vec![
+        (bucket_id("a"), bucket_id("b")),
+        (bucket_id("b"), bucket_id("c")),
+    ];
+
+    assert_collision_contains(
+        validate_plan_time_state_block_collisions(
+            &desired,
+            &moved_pairs,
+            &ResolvedStateBlockTargets::default(),
+            &state_file,
+        ),
+        "moved/rename pair from awscc.s3.Bucket b collides with a desired resource",
+    );
+}
+
 struct AssociationCreateOnlyFactory;
 
 impl ProviderFactory for AssociationCreateOnlyFactory {
@@ -1285,7 +1624,10 @@ moved {{
     }
 
     let parsed = parse(&source, &ProviderContext::default()).expect("parse fixture");
-    let state_block_claims = resolve_state_block_claims(
+    let StateBlockResolution {
+        claims: state_block_claims,
+        targets: resolved_state_block_targets,
+    } = resolve_state_blocks(
         &parsed.state_blocks,
         &Some(state_file.clone()),
         &parsed.resources,
@@ -1298,6 +1640,7 @@ moved {{
         false,
         &HashMap::new(),
         &state_block_claims,
+        &resolved_state_block_targets,
         tmp.path(),
     )
     .await

--- a/notes/specs/2026-06-11-anonymous-rename-moved-safety-design.md
+++ b/notes/specs/2026-06-11-anonymous-rename-moved-safety-design.md
@@ -465,7 +465,9 @@ Introduce a collision predicate over plan-time data — the desired
 resource id set, the combined `(from, to)` move-pair vector (operator
 `moved` pairs plus synthesized anonymous→named rename pairs), and the
 resolved `removed` targets. `plan` and `apply` call it right after the
-pairs are produced and **fail** (hard error, not a warning) on:
+pairs are produced and deferred-for expansion has finalized the desired
+id set, so loop-child addresses are present, then **fail** (hard error,
+not a warning) on:
 
 - a move `from` that is also a desired resource id (the infra#138 shape:
   upsert and cleanup of the same id at writeback);
@@ -480,8 +482,10 @@ pairs are produced and **fail** (hard error, not a warning) on:
   vector scan to detect);
 - a pair whose `from` resolves in state while its `to` is *also* already
   occupied in state (the transfer would overwrite a live, refreshed row —
-  today an unwarned state-row drop; distinct from the from-absent /
-  to-present shape, which stays the idempotent already-applied no-op).
+  today an unwarned state-row drop; a pair whose `from == to` resolves in
+  state errors as a self-move with a dedicated message; distinct from the
+  from-absent / to-present shape, which stays the idempotent
+  already-applied no-op).
 
 This is a new early check, not an extraction: writeback's structural
 `WritebackPlan` enforcement is interwoven with apply-only inputs


### PR DESCRIPTION
## Summary

PR 3 of 3 implementing the carina#3454 design (`notes/specs/2026-06-11-anonymous-rename-moved-safety-design.md`): RC3 — a plan-time collision predicate over the move pairs. This completes the chain (PR 1: #3456, PR 2: #3457).

Closes #3454

## Problem

An invalid `moved.crn` produced a green plan and a guaranteed-broken apply: the upsert/cleanup collision was only detected at the end of apply, at state writeback — after providers may already have mutated resources. In infra#138 this left CI stuck failing on every run. Two further collision shapes (duplicate `to`, occupied `to`) were caught nowhere at all and silently dropped state rows.

## Changes

- **`validate_plan_time_state_block_collisions`** (wiring): hard-errors on five shapes over plan-time data — a move `from` that is also a desired resource id (the infra#138 shape), a resolved `removed` `from` that is also a desired id, two pairs sharing a `to` (previously a silent overwrite even at writeback), two pairs sharing a `from`, and a pair whose `from` resolves while its `to` is already occupied in state (with a dedicated self-move message for `from == to`). Error messages name the offending addresses and mirror the writeback wording.
- **Placement**: `plan` and `apply` run the predicate over the combined pair vector (operator `moved` pairs + synthesized anonymous→named rename pairs) after deferred-for expansion finalizes the desired id set — so for-loop child addresses are covered — and strictly before any provider mutation. The fixture-plan display path runs it too. `destroy`/`state refresh` never materialize moves and stay vacuous.
- **Same-resolution pin**: resolved `removed` targets come from `resolve_state_blocks`, the same effectiveness resolution that builds `StateBlockClaims` — no third `find_resource` site. Writeback's structural `WritebackPlan` enforcement is untouched as defense in depth.
- Spec amended in-PR for the post-expansion timing and the self-move clause.

## Tests

All design-doc RC3 tests plus extras: each of the five rules (including an integration test through `create_plan_from_parsed_with_upstream` asserting the plan errors instead of printing a green move plan), the cross-source synthesized-rename × `moved.to` collision, the expanded-loop-child collision (differentiating for the post-expansion placement), rotation/swap rejection, orphan self-move, and the negative chain (from-absent/to-present stays a silent idempotent no-op, not an error). Writeback's existing collision tests are untouched and green.

## Verification

- `cargo nextest run --workspace --all-features`: 4024 passed
- `cargo test --workspace --doc`: ok
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `scripts/check-*.sh`: all OK
- 5 review rounds (fixed: differentiating no-op test, self-move message, predicate relocated post-expansion to cover loop children, `AppError::Validation`, message wording, spec amendments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
