### PR TITLE
Remove string-shape reference sniffing; type fn placeholders (carina#3464)

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1127,9 +1127,9 @@ fn format_duration_zero() {
 }
 
 #[test]
-fn resolve_exports_resolves_cross_file_dot_notation_strings() {
+fn resolve_exports_resolves_cross_file_resource_refs() {
     use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
-    use carina_core::resource::{ConcreteValue, Value};
+    use carina_core::resource::Value;
     use carina_state::StateFile;
 
     // Build a state file with a resource that has a binding and attributes
@@ -1156,15 +1156,16 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
         serde_json::from_value::<StateFile>(json).unwrap()
     };
 
-    // Export param references registry_prod.account_id as a dot-notation string
-    // (this is how cross-file references are parsed: exports.crn doesn't see
-    // the let binding in main.crn, so the parser emits a plain string)
+    // Export param references registry_prod.account_id using the
+    // parser-produced ResourceRef shape.
     let export_params = vec![ExportParameter {
         name: "account_id".to_string(),
         type_expr: TypeExpr::Unknown,
-        value: Some(Value::Concrete(ConcreteValue::String(
-            "registry_prod.account_id".to_string(),
-        ))),
+        value: Some(Value::resource_ref(
+            "registry_prod".to_string(),
+            "account_id".to_string(),
+            vec![],
+        )),
     }];
 
     // Mirror production callers: the resource is in sorted_resources
@@ -1193,7 +1194,7 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     assert_eq!(
         exports.get("account_id"),
         Some(&serde_json::Value::String("459524413166".to_string())),
-        "resolve_exports should resolve dot-notation strings to actual values. Got: {:?}",
+        "resolve_exports should resolve ResourceRef values to actual values. Got: {:?}",
         exports
     );
 }

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -839,7 +839,7 @@ pub(crate) fn resolve_export_values_for_display(
         .collect()
 }
 
-/// Resolve a single export value, handling both ResourceRef and dot-notation strings.
+/// Resolve a single export value, walking ResourceRef values inside lists and maps.
 pub(crate) fn resolve_export_value(
     value: &Value,
     bindings: &carina_core::binding_index::ResolvedBindings,
@@ -849,17 +849,6 @@ pub(crate) fn resolve_export_value(
     match value {
         Value::Deferred(DeferredValue::ResourceRef { .. }) => {
             resolve_ref_value(value, bindings).unwrap_or_else(|_| value.clone())
-        }
-        // Cross-file: "binding.attr" parsed as String instead of ResourceRef
-        Value::Concrete(ConcreteValue::String(s)) if s.contains('.') && !s.contains(' ') => {
-            let parts: Vec<&str> = s.splitn(2, '.').collect();
-            if parts.len() == 2
-                && let Some(attrs) = bindings.get(parts[0])
-                && let Some(resolved) = attrs.get(parts[1])
-            {
-                return resolved.clone();
-            }
-            value.clone()
         }
         Value::Concrete(ConcreteValue::List(items)) => {
             let resolved: Vec<Value> = items
@@ -1698,6 +1687,29 @@ mod export_diff_tests {
         assert_eq!(changes[0].name(), "added");
         assert_eq!(changes[1].name(), "modified");
         assert_eq!(changes[2].name(), "removed");
+    }
+
+    #[test]
+    fn resolve_export_value_preserves_dotted_string_literal() {
+        let resource = Resource::with_provider("test", "r.Vpc", "vpc", None)
+            .with_binding("vpc")
+            .with_attribute(
+                "vpc_id",
+                Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+            );
+        let bindings = carina_core::binding_index::ResolvedBindings::pre_apply(
+            carina_core::binding_index::PreApplyInputs {
+                managed: &[resource],
+                compositions: &[],
+                data_sources: &[],
+                current_states: &HashMap::new(),
+                remote_bindings: &HashMap::new(),
+                wait_aliases: &[],
+            },
+        );
+        let value = Value::Concrete(ConcreteValue::String("vpc.vpc_id".to_string()));
+
+        assert_eq!(resolve_export_value(&value, &bindings), value);
     }
 }
 

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -295,8 +295,6 @@ pub(crate) fn resolve_exports(
     let mut exports = HashMap::new();
     for param in export_params {
         if let Some(ref value) = param.value {
-            // Resolve both ResourceRef and cross-file dot-notation strings
-            // (e.g., "registry_prod.account_id" parsed from a different .crn file).
             let resolved = crate::commands::plan::resolve_export_value(value, &bindings);
             if let Some(json) = dsl_value_to_json(&resolved)? {
                 exports.insert(param.name.clone(), json);

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -167,11 +167,8 @@ pub fn load_configuration_with_config(
             return Err(parse_errors.join("\n"));
         }
 
-        // Resolve cross-file forward references on the merged result.
-        // Per-file resolve_resource_refs_with_config (line 78) only sees
-        // bindings within each file; cross-file dot-notation strings in
-        // export_params (e.g., "registry_prod.account_id") remain as
-        // Value::Concrete(ConcreteValue::String). This second pass converts them to ResourceRef.
+        // Resolve references on the merged result so cross-file
+        // `ResourceRef`s can see every sibling binding.
         if let Err(e) = parser::resolve_resource_refs_with_config(&mut merged, config) {
             return Err(e.to_string());
         }
@@ -213,9 +210,6 @@ pub fn load_configuration_with_config(
 /// individually, results are merged, and cross-file references are
 /// resolved against the combined binding map. Both CLI and LSP should
 /// use this to ensure consistent results.
-///
-/// Returns `None` for `export_params` values that are cross-file string
-/// references (e.g. `"registry_prod.account_id"`) resolved to `ResourceRef`.
 pub fn parse_directory(dir: &Path, config: &ProviderContext) -> Result<ParsedFile, String> {
     parse_directory_with_overrides(dir, config, &HashMap::new())
 }

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -406,7 +406,7 @@ pub fn create_plan(
     //
     // Target resolution: the parser has already pinned the target name;
     // here we look it up in `desired` (the live resource set after
-    // forward-ref resolution) to recover the resolved `ResourceId`. If
+    // `resolve_resource_refs`) to recover the resolved `ResourceId`. If
     // the target is missing — typo, scoped-out binding, etc. — the
     // wait is skipped with a plan-level error so downstream resources
     // referencing the wait binding still fail loudly.

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -272,6 +272,12 @@ fn deterministic_value_string(value: &Value) -> String {
                 UnknownReason::ForKey => "Unknown(ForKey)".to_string(),
                 UnknownReason::ForIndex => "Unknown(ForIndex)".to_string(),
                 UnknownReason::ForValue => "Unknown(ForValue)".to_string(),
+                UnknownReason::FnParam { name } => {
+                    format!("Unknown(FnParam({name}))")
+                }
+                UnknownReason::FnLocal { name } => {
+                    format!("Unknown(FnLocal({name}))")
+                }
                 UnknownReason::ForValuePath { path } => {
                     format!("Unknown(ForValuePath({}))", path.to_dot_string())
                 }

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -1446,35 +1446,40 @@ pub(super) fn substitute_placeholder(
     value: &Value,
 ) {
     match v {
-        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)) => {
-            *v = value.clone();
-        }
-        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath { path })) => {
-            // carina#3136: a field access on the loop variable
-            // (`opt.resource_record.name`). The element is now known
-            // (`value`); re-navigate it along the remembered path via
-            // the *same* navigator the parse-time resolved case uses
-            // (single source of truth). If it does not navigate (the
-            // element genuinely lacks that path), leave the placeholder
-            // so the existing "unresolved" surfacing applies rather
-            // than silently substituting a wrong value.
-            if let Some(resolved) = crate::resource::navigate_value_path(value, path) {
-                *v = resolved;
+        Value::Deferred(DeferredValue::Unknown(reason)) => match reason.clone() {
+            UnknownReason::ForValue => {
+                *v = value.clone();
             }
-        }
-        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForKey)) => {
-            if let Some(k) = key {
-                *v = Value::Concrete(ConcreteValue::String(k.to_string()));
+            UnknownReason::ForValuePath { path } => {
+                // carina#3136: a field access on the loop variable
+                // (`opt.resource_record.name`). The element is now known
+                // (`value`); re-navigate it along the remembered path via
+                // the *same* navigator the parse-time resolved case uses
+                // (single source of truth). If it does not navigate (the
+                // element genuinely lacks that path), leave the placeholder
+                // so the existing "unresolved" surfacing applies rather
+                // than silently substituting a wrong value.
+                if let Some(resolved) = crate::resource::navigate_value_path(value, &path) {
+                    *v = resolved;
+                }
             }
-        }
-        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForIndex)) => {
-            if let Some(i) = index {
-                *v = Value::Concrete(ConcreteValue::Int(i));
+            UnknownReason::ForKey => {
+                if let Some(k) = key {
+                    *v = Value::Concrete(ConcreteValue::String(k.to_string()));
+                }
             }
-        }
-        // Explicit arm (not wildcard) so a new `UnknownReason` variant
-        // forces a compile-error decision here.
-        Value::Deferred(DeferredValue::Unknown(UnknownReason::UpstreamRef { .. })) => {}
+            UnknownReason::ForIndex => {
+                if let Some(i) = index {
+                    *v = Value::Concrete(ConcreteValue::Int(i));
+                }
+            }
+            // Upstream and empty-interpolation unknowns are not for-expansion placeholders.
+            UnknownReason::UpstreamRef { .. }
+            | UnknownReason::UpstreamBareRef { .. }
+            | UnknownReason::EmptyInterpolation => {}
+            // Function placeholders are substituted by user-function evaluation, not for expansion.
+            UnknownReason::FnParam { .. } | UnknownReason::FnLocal { .. } => {}
+        },
         Value::Concrete(ConcreteValue::List(items)) => {
             for item in items.iter_mut() {
                 substitute_placeholder(item, index, key, value);

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -23,8 +23,7 @@ use super::expressions::pipe::parse_coalesce_expr;
 use super::functions::parse_fn_def;
 use super::let_binding::parse_let_binding_extended;
 use super::resolve::{
-    finalize_provider_configs, resolve_forward_references, resolve_provider_unresolved_attributes,
-    resolve_resource_refs,
+    finalize_provider_configs, resolve_provider_unresolved_attributes, resolve_resource_refs,
 };
 use crate::eval_value::EvalValue;
 use crate::resource::{DataSource, DeferredValue, Resource, Value};
@@ -392,21 +391,6 @@ pub fn parse_with_seeded_bindings(
     }
 
     providers.extend(std::mem::take(&mut ctx.named_provider_instances));
-
-    // Second pass: resolve forward references.
-    // During parsing, unknown 2-part identifiers (e.g., vpc.vpc_id where vpc is
-    // declared later) become String values like "vpc.vpc_id". Now that we have the
-    // full binding set, convert matching ones to ResourceRef.
-    let resource_binding_names: std::collections::HashSet<String> =
-        ctx.resource_bindings.keys().cloned().collect();
-    resolve_forward_references(
-        &resource_binding_names,
-        &mut resources,
-        &mut data_sources,
-        &mut attribute_params,
-        &mut module_calls,
-        &mut export_params,
-    );
 
     // "Is every ResourceRef root declared somewhere?" is a semantic
     // question the per-file parse cannot answer: the referent may live

--- a/carina-core/src/parser/expressions/string_literal.rs
+++ b/carina-core/src/parser/expressions/string_literal.rs
@@ -84,14 +84,13 @@ pub(crate) fn parse_string_value(
     }
 
     if has_interpolation {
-        // Deliberately do *not* call `Value::canonicalize` here. The
-        // deferred-for placeholder substitution in
-        // `parser/ast.rs::substitute_placeholder` walks the `Expr`
-        // parts to replace `Value::Deferred(DeferredValue::Unknown(For*))` placeholders with the
-        // resolved iterable element, so the parts must stay intact
-        // through parse → for-expansion. Canonicalization runs later,
-        // after resolution (see #2227).
-        Ok(Value::Deferred(DeferredValue::Interpolation(parts)))
+        // Canonicalization only folds concrete scalar interpolation
+        // parts and preserves deferred refs/placeholders as Expr parts,
+        // so for-expansion substitution still finds them intact
+        // (covered by expand_deferred_for_substitutes_placeholder_inside_interpolation).
+        // Folding fully concrete interpolations here preserves #2227's
+        // canonical shape without the removed #3464 forward-ref pass.
+        Ok(Value::Deferred(DeferredValue::Interpolation(parts)).canonicalize())
     } else {
         // No interpolation — collapse to a plain String
         let s = parts

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -9,7 +9,7 @@ use super::types::parse_type_expr;
 use super::util::{snake_to_pascal, value_type_name};
 use super::{ProviderContext, Rule, parse_expression};
 use crate::eval_value::EvalValue;
-use crate::resource::{ConcreteValue, DeferredValue, Value};
+use crate::resource::{ConcreteValue, DeferredValue, UnknownReason, Value};
 use crate::schema::{
     TypeIdentity, validate_ipv4_address, validate_ipv4_cidr, validate_ipv6_address,
     validate_ipv6_cidr,
@@ -91,7 +91,9 @@ pub(super) fn parse_fn_def(
     for p in &params {
         body_ctx.set_variable(
             p.name.clone(),
-            Value::Concrete(ConcreteValue::String(format!("__fn_param_{}", p.name))),
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::FnParam {
+                name: p.name.clone(),
+            })),
         );
     }
 
@@ -108,7 +110,9 @@ pub(super) fn parse_fn_def(
                 )?;
                 body_ctx.set_variable(
                     let_name.clone(),
-                    Value::Concrete(ConcreteValue::String(format!("__fn_local_{let_name}"))),
+                    Value::Deferred(DeferredValue::Unknown(UnknownReason::FnLocal {
+                        name: let_name.clone(),
+                    })),
                 );
                 local_lets.push((let_name, let_expr));
             }
@@ -559,7 +563,7 @@ pub(crate) fn evaluate_user_function(
 
     let UserFunctionBody(body) = &func.body;
     let substituted_body = substitute_fn_params(body, &substitutions);
-    let result = try_evaluate_fn_value(substituted_body, &child_ctx)?;
+    let result = try_evaluate_fn_value(substituted_body, &child_ctx)?.canonicalize();
     // Check return type if annotated
     if let Some(ref return_type) = func.return_type {
         check_fn_return_type(&func.name, return_type, &result, child_ctx.config)?;
@@ -570,20 +574,11 @@ pub(crate) fn evaluate_user_function(
 /// Recursively substitute function parameter placeholders with actual values
 fn substitute_fn_params(value: &Value, substitutions: &HashMap<String, Value>) -> Value {
     match value {
-        Value::Concrete(ConcreteValue::String(s)) => {
-            // Check if this is a parameter placeholder
-            if let Some(param_name) = s.strip_prefix("__fn_param_")
-                && let Some(sub) = substitutions.get(param_name)
-            {
-                return sub.clone();
-            }
-            if let Some(local_name) = s.strip_prefix("__fn_local_")
-                && let Some(sub) = substitutions.get(local_name)
-            {
-                return sub.clone();
-            }
-            Value::Concrete(ConcreteValue::String(s.clone()))
-        }
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::FnParam { name }))
+        | Value::Deferred(DeferredValue::Unknown(UnknownReason::FnLocal { name })) => substitutions
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| value.clone()),
         Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
             items
                 .iter()
@@ -623,7 +618,6 @@ fn substitute_fn_params(value: &Value, substitutions: &HashMap<String, Value>) -
         Value::Deferred(DeferredValue::Secret(inner)) => Value::Deferred(DeferredValue::Secret(
             Box::new(substitute_fn_params(inner, substitutions)),
         )),
-        // `Value::Deferred(DeferredValue::Unknown)` is not a function-param placeholder. Pass through.
         Value::Deferred(DeferredValue::Unknown(_)) => value.clone(),
         other => other.clone(),
     }

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -3,7 +3,7 @@
 //! Extracted from `parser/mod.rs` per #2263 (part 2/2).
 
 use super::ProviderContext;
-use super::ast::{AttributeParameter, ExportParameter, ModuleCall, ParsedFile};
+use super::ast::ParsedFile;
 use super::entry::BindingSeed;
 use super::error::{ParseError, undefined_identifier_error};
 use super::static_eval::is_static_value;
@@ -79,122 +79,6 @@ fn iter_pre_apply_resources_mut(
                 .iter_mut()
                 .map(|d| d as &mut dyn PreApplyResourceMut),
         )
-}
-
-/// Resolve forward references after the full binding set is known.
-///
-/// During single-pass parsing, `identifier.member` forms where `identifier` is
-/// not yet a known binding are stored as `String("identifier.member")`.
-/// This function walks all resource attributes, module call arguments, and attribute
-/// parameter values, converting matching strings to `ResourceRef`.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn resolve_forward_references(
-    resource_bindings: &HashSet<String>,
-    resources: &mut [Resource],
-    data_sources: &mut [DataSource],
-    attribute_params: &mut [AttributeParameter],
-    module_calls: &mut [ModuleCall],
-    export_params: &mut [ExportParameter],
-) {
-    for resource in resources.iter_mut() {
-        // In-place replace via `iter_mut`: avoids the O(n²) cost of
-        // `shift_remove` + re-insert per key, and naturally preserves
-        // the user-authored attribute order without a key-collection
-        // round-trip. The placeholder is overwritten on the next line,
-        // so its identity doesn't matter.
-        for (_, attr) in resource.attributes.iter_mut() {
-            let placeholder = Value::Concrete(ConcreteValue::Bool(false));
-            let value = std::mem::replace(attr, placeholder);
-            *attr = resolve_forward_ref_in_value(value, resource_bindings);
-        }
-    }
-    for data_source in data_sources.iter_mut() {
-        for (_, attr) in data_source.attributes.iter_mut() {
-            let placeholder = Value::Concrete(ConcreteValue::Bool(false));
-            let value = std::mem::replace(attr, placeholder);
-            *attr = resolve_forward_ref_in_value(value, resource_bindings);
-        }
-    }
-    for attr_param in attribute_params.iter_mut() {
-        if let Some(value) = attr_param.value.take() {
-            attr_param.value = Some(resolve_forward_ref_in_value(value, resource_bindings));
-        }
-    }
-    for call in module_calls.iter_mut() {
-        let keys: Vec<String> = call.arguments.keys().cloned().collect();
-        for key in keys {
-            if let Some(value) = call.arguments.remove(&key) {
-                let resolved = resolve_forward_ref_in_value(value, resource_bindings);
-                call.arguments.insert(key, resolved);
-            }
-        }
-    }
-    for export_param in export_params.iter_mut() {
-        if let Some(value) = export_param.value.take() {
-            export_param.value = Some(resolve_forward_ref_in_value(value, resource_bindings));
-        }
-    }
-}
-
-/// Recursively resolve forward references in a single Value.
-///
-/// Strings in `"name.member"` format where `name` is a known resource binding
-/// are resolved to `ResourceRef`. This handles forward references that were
-/// stored as strings during single-pass parsing.
-fn resolve_forward_ref_in_value(value: Value, resource_bindings: &HashSet<String>) -> Value {
-    match value {
-        Value::Concrete(ConcreteValue::String(ref s)) => {
-            // A dotted string like "vpc.vpc_id" or "vpc.attr.nested" may be a
-            // forward reference that was stored as a string during single-pass
-            // parsing. Resolve it to ResourceRef if the first segment is a known
-            // resource binding. Parts after the second become field_path.
-            let parts: Vec<&str> = s.splitn(3, '.').collect();
-            if parts.len() >= 2 && resource_bindings.contains(parts[0]) {
-                let field_path = parts
-                    .get(2)
-                    .map(|rest| rest.split('.').map(|s| s.to_string()).collect())
-                    .unwrap_or_default();
-                return Value::resource_ref(parts[0].to_string(), parts[1].to_string(), field_path);
-            }
-            value
-        }
-        Value::Concrete(ConcreteValue::List(items)) => Value::Concrete(ConcreteValue::List(
-            items
-                .into_iter()
-                .map(|v| resolve_forward_ref_in_value(v, resource_bindings))
-                .collect(),
-        )),
-        Value::Concrete(ConcreteValue::Map(map)) => Value::Concrete(ConcreteValue::Map(
-            map.into_iter()
-                .map(|(k, v)| (k, resolve_forward_ref_in_value(v, resource_bindings)))
-                .collect(),
-        )),
-        Value::Deferred(DeferredValue::Interpolation(parts)) => {
-            use crate::resource::InterpolationPart;
-            Value::Deferred(DeferredValue::Interpolation(
-                parts
-                    .into_iter()
-                    .map(|p| match p {
-                        InterpolationPart::Expr(v) => InterpolationPart::Expr(
-                            resolve_forward_ref_in_value(v, resource_bindings),
-                        ),
-                        other => other,
-                    })
-                    .collect(),
-            ))
-            .canonicalize()
-        }
-        Value::Deferred(DeferredValue::FunctionCall { name, args }) => {
-            Value::Deferred(DeferredValue::FunctionCall {
-                name,
-                args: args
-                    .into_iter()
-                    .map(|v| resolve_forward_ref_in_value(v, resource_bindings))
-                    .collect(),
-            })
-        }
-        other => other,
-    }
 }
 
 /// Resolve resource references in a ParsedFile
@@ -319,24 +203,6 @@ pub fn resolve_resource_refs_with_config(
         let expr = parsed.variables[&key].clone();
         let resolved = resolve_function_calls_only(&expr, &binding_map, &fn_ctx)?;
         parsed.variables[&key] = resolved;
-    }
-
-    // Resolve cross-file forward references in export_params.
-    // During per-file parsing, "binding.attribute" strings from sibling files
-    // remain as Value::Concrete(ConcreteValue::String). Convert them to ResourceRef now that the full
-    // binding map is available.
-    // carina#3181: include data sources and compositions — a sibling-file
-    // export can forward-reference any top-level binding. Only the
-    // binding-name set is needed (forward-ref resolution is keyed on
-    // the name).
-    let resource_bindings: HashSet<String> = parsed
-        .iter_top_level_resources()
-        .filter_map(|rref| rref.binding().map(|b| b.to_string()))
-        .collect();
-    for export_param in &mut parsed.export_params {
-        if let Some(value) = export_param.value.take() {
-            export_param.value = Some(resolve_forward_ref_in_value(value, &resource_bindings));
-        }
     }
 
     // Provider attribute resolution lives in

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2213,8 +2213,8 @@ fn forward_reference_in_nested_value() {
 
 #[test]
 fn forward_reference_chained_three_parts() {
-    // Issue #1259: Chained forward references like "later.attr.nested" should
-    // be resolved to ResourceRef with field_path, not left as a plain string.
+    // Issue #1259: chained forward references parse as ResourceRef
+    // values with a field path.
     let input = r#"
         let subnet = awscc.ec2.Subnet {
             vpc_id     = vpc.encryption_specification.status
@@ -2241,8 +2241,8 @@ fn forward_reference_chained_three_parts() {
 
 #[test]
 fn forward_reference_chained_four_parts() {
-    // Issue #1259: Deep chained forward references like "later.attr.deep.nested"
-    // should be resolved to ResourceRef with multiple field_path entries.
+    // Issue #1259: deep chained forward references parse as ResourceRef
+    // values with multiple field path entries.
     let input = r#"
         let subnet = awscc.ec2.Subnet {
             vpc_id     = vpc.config.deep.nested
@@ -5781,6 +5781,49 @@ fn user_fn_with_string_interpolation() {
 }
 
 #[test]
+fn user_fn_interpolation_substitutes_param_inside_string() {
+    let input = r#"
+        fn bucket_name(env) {
+            "myapp-${env}-bucket"
+        }
+
+        let bucket = aws.s3_bucket {
+            name = bucket_name("prod")
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(
+        result.resources[0].get_attr("name"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "myapp-prod-bucket".to_string()
+        ))),
+    );
+}
+
+#[test]
+fn user_fn_interpolation_substitutes_local_inside_string() {
+    let input = r#"
+        fn bucket_name(env) {
+            let prefix = "myapp-${env}"
+            "${prefix}-bucket"
+        }
+
+        let bucket = aws.s3_bucket {
+            name = bucket_name("prod")
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(
+        result.resources[0].get_attr("name"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "myapp-prod-bucket".to_string()
+        ))),
+    );
+}
+
+#[test]
 fn user_fn_typed_param_string() {
     let input = r#"
         fn greet(name: String) {
@@ -8098,8 +8141,7 @@ fn bare_identifier_iterable_is_reported_as_undefined_not_string() {
 #[test]
 fn forward_reference_to_later_let_is_allowed() {
     // `foo.id` refers to `let foo = ...` declared after the first resource.
-    // This is a legitimate forward reference that the second-pass resolver
-    // handles.
+    // This is a legitimate forward reference parsed structurally as a ResourceRef.
     let input = r#"
         let bucket = aws.s3_bucket {
             name = foo.id
@@ -8998,6 +9040,209 @@ fn parse_directory_files_preserves_sibling_resource_ref_rhs() {
     }
 }
 
+#[test]
+fn parse_directory_preserves_module_arg_dotted_string_literal() {
+    use crate::config_loader::parse_directory;
+    use crate::module_resolver::resolve_modules;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let module_dir = tmp.path().join("uc");
+    std::fs::create_dir_all(&module_dir).unwrap();
+    std::fs::write(
+        module_dir.join("main.crn"),
+        r#"
+            arguments {
+                domain_name: String
+            }
+
+            test.r.record {
+                domain_name = domain_name
+            }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            provider test {
+                source = "x/y"
+                version = "0.1"
+            }
+
+            let publish = use { source = "./uc" }
+            let r = publish {
+                domain_name = 'publish.example.com'
+            }
+        "#,
+    )
+    .unwrap();
+
+    let mut parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("directory fixture must parse");
+    resolve_modules(&mut parsed, tmp.path()).expect("module expansion must succeed");
+    let record = parsed
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "r.record")
+        .expect("expanded module resource present");
+
+    assert_eq!(
+        record.attributes.get("domain_name"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "publish.example.com".to_string()
+        )))
+    );
+}
+
+#[test]
+fn parse_directory_preserves_direct_attr_dotted_string_literal() {
+    use crate::config_loader::parse_directory;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            provider test {
+                source = "x/y"
+                version = "0.1"
+            }
+
+            let publish = test.r.source {
+                name = "publish"
+            }
+
+            test.r.target {
+                x = "publish.example.com"
+            }
+        "#,
+    )
+    .unwrap();
+
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("directory fixture must parse");
+    let target = parsed
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "r.target")
+        .expect("target resource present");
+
+    assert_eq!(
+        target.attributes.get("x"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "publish.example.com".to_string()
+        )))
+    );
+}
+
+#[test]
+fn parse_directory_preserves_export_param_dotted_string_literal() {
+    use crate::config_loader::parse_directory;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            provider test {
+                source = "x/y"
+                version = "0.1"
+            }
+
+            let publish = test.r.source {
+                name = "publish"
+            }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("exports.crn"),
+        r#"
+            exports {
+                domain = 'publish.example.com'
+            }
+        "#,
+    )
+    .unwrap();
+
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("directory fixture must parse");
+    let export = parsed
+        .export_params
+        .iter()
+        .find(|export| export.name == "domain")
+        .expect("domain export present");
+
+    assert_eq!(
+        export.value.as_ref(),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "publish.example.com".to_string()
+        )))
+    );
+}
+
+#[test]
+fn parse_preserves_data_source_attr_dotted_string_literal() {
+    let input = r#"
+        provider test {
+            source = "x/y"
+            version = "0.1"
+        }
+
+        let publish = test.r.source {
+            name = "publish"
+        }
+
+        let lookup = read test.r.lookup {
+            x = 'publish.example.com'
+        }
+    "#;
+
+    let parsed = parse(input, &ProviderContext::default()).expect("fixture must parse");
+    let data_source = parsed
+        .data_sources
+        .iter()
+        .find(|r| r.id.resource_type == "r.lookup")
+        .expect("data source present");
+
+    assert_eq!(
+        data_source.attributes.get("x"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "publish.example.com".to_string()
+        )))
+    );
+}
+
+#[test]
+fn parse_preserves_attribute_param_default_dotted_string_literal() {
+    let input = r#"
+        attributes {
+            domain: String = "publish.example.com"
+        }
+
+        provider test {
+            source = "x/y"
+            version = "0.1"
+        }
+
+        let publish = test.r.source {
+            name = "publish"
+        }
+    "#;
+
+    let parsed = parse(input, &ProviderContext::default()).expect("fixture must parse");
+    let attr = parsed
+        .attribute_params
+        .iter()
+        .find(|attr| attr.name == "domain")
+        .expect("domain attribute param present");
+
+    assert_eq!(
+        attr.value.as_ref(),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "publish.example.com".to_string()
+        )))
+    );
+}
+
 // ================================================================
 // #2435: upstream_state map subscript across sibling files
 //
@@ -9136,9 +9381,7 @@ fn parse_subscript_on_upstream_state_inside_string_interpolation_sibling_file() 
 //
 // Symmetric with the #2435 subscript fixes above: `${orgs.accounts.k}` must
 // also lower to `Value::Deferred(DeferredValue::ResourceRef)` when the `let orgs = upstream_state{...}`
-// declaration lives in a sibling .crn. Without this, the dotted form falls
-// through to a `Value::Concrete(ConcreteValue::String("orgs.accounts.k"))` literal and the literal
-// flows through the resolver into the rendered plan.
+// declaration lives in a sibling .crn.
 // ================================================================
 
 #[test]

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -825,6 +825,14 @@ pub enum UnknownReason {
     /// Loop-variable value in a deferred for-expression
     /// (`for v in iterable`). Substituted with the actual element.
     ForValue,
+    /// Function parameter placeholder while parsing a user-defined
+    /// function body. Substituted with the call argument when the
+    /// function is evaluated.
+    FnParam { name: String },
+    /// Function-local let placeholder while parsing a user-defined
+    /// function body. Substituted after local lets are evaluated for a
+    /// call.
+    FnLocal { name: String },
     /// Field access on a deferred for-expression's loop variable
     /// (`for (_, opt) in iterable { … opt.resource_record.name … }`).
     /// Carries the navigation path past the loop variable. The
@@ -1306,6 +1314,9 @@ impl Value {
                     // allocation.
                     UnknownReason::UpstreamRef { path } => path.hash(hasher),
                     UnknownReason::UpstreamBareRef { binding } => binding.hash(hasher),
+                    UnknownReason::FnParam { name } | UnknownReason::FnLocal { name } => {
+                        name.hash(hasher);
+                    }
                     // Carries an `AccessPath` payload — hash it like
                     // `UpstreamRef` so two distinct loop-var paths get
                     // distinct hashes.

--- a/carina-core/src/validation/depends_on.rs
+++ b/carina-core/src/validation/depends_on.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::deps::sort_resources_by_dependencies;
 use crate::parser::{File, ResourceRef};
-use crate::validation::{collect_dot_notation_refs, collect_resource_refs};
+use crate::validation::collect_resource_refs;
 
 /// Severity of a depends_on diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,7 +121,6 @@ pub fn validate_depends_on<E>(parsed: &File<E>) -> Vec<DependsOnDiagnostic> {
         let mut value_ref_deps: HashSet<String> = HashSet::new();
         for value in resource.attributes().values() {
             collect_resource_refs(value, &mut value_ref_deps);
-            collect_dot_notation_refs(value, &mut value_ref_deps);
         }
         for name in resource.dependency_bindings() {
             value_ref_deps.insert(name.clone());
@@ -419,13 +418,9 @@ mod tests {
     }
 
     #[test]
-    fn redundant_edge_via_dot_notation_string_is_diagnosed_as_warning() {
-        // Ensures the redundant-edge check matches what `check_unused_bindings`
-        // sees: dot-notation strings inside collections (e.g.
-        // `principals = [role.arn]`) survive resolution as
-        // `Value::Concrete(ConcreteValue::String("role.arn"))`, not `Value::Deferred(DeferredValue::ResourceRef)`. Without
-        // `collect_dot_notation_refs` here, the warning would silently
-        // miss this shape.
+    fn redundant_edge_via_value_ref_is_diagnosed_as_warning() {
+        // The redundant-edge check walks structural value references,
+        // including nested map/list attribute values.
         let src = r#"
             let role = aws.iam.Role {
                 role_name = "r"
@@ -444,7 +439,7 @@ mod tests {
             warnings
                 .iter()
                 .any(|m| m.contains("redundant") && m.contains("'role'")),
-            "expected redundant-edge warning for dot-notation ref, got {:?}",
+            "expected redundant-edge warning for value ref, got {:?}",
             warnings
         );
     }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -1165,15 +1165,6 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     // Collect all referenced binding names. Walk both top-level resources
     // and for-body template resources so bindings referenced only inside a
     // `for` loop are counted as used.
-    //
-    // `collect_dot_notation_refs` also runs on resource attributes: when
-    // a resource in file A references `binding.attr` where `binding` is
-    // declared in sibling file B, per-file parse stores it as
-    // `Value::Concrete(ConcreteValue::String("binding.attr"))`. `resolve_resource_refs_with_config`
-    // lifts those to `ResourceRef` only when the value sits at the top
-    // level of an attribute; inside a list / map / interpolation the
-    // string form survives, so a reference nested in
-    // `principals = [binding.attr]` would otherwise be missed.
     let mut referenced: HashSet<String> = HashSet::new();
     for rref in parsed.iter_all_resources() {
         let attrs = rref.attributes();
@@ -1182,7 +1173,6 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
                 continue;
             }
             collect_resource_refs(value, &mut referenced);
-            collect_dot_notation_refs(value, &mut referenced);
         }
         // `Composition` has no directives — `directives()` is `None`
         // for that arm, so the depends_on walk is simply skipped.
@@ -1193,7 +1183,6 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     for call in &parsed.module_calls {
         for value in call.arguments.values() {
             collect_resource_refs(value, &mut referenced);
-            collect_dot_notation_refs(value, &mut referenced);
         }
     }
     for attr_param in &parsed.attribute_params {
@@ -1204,15 +1193,6 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     for export_param in &parsed.export_params {
         if let Some(value) = export_param.value() {
             collect_resource_refs(value, &mut referenced);
-            // Cross-file: when exports.crn is parsed without the binding context,
-            // "vpc.vpc_id" becomes String("vpc.vpc_id") instead of ResourceRef.
-            // Extract the binding name from such dot-notation strings.
-            collect_dot_notation_refs(value, &mut referenced);
-        }
-    }
-    for attr_param in &parsed.attribute_params {
-        if let Some(value) = &attr_param.value {
-            collect_dot_notation_refs(value, &mut referenced);
         }
     }
     // Each `wait <target> { ... }` declaration references its target
@@ -1252,39 +1232,6 @@ pub(crate) fn collect_resource_refs(value: &Value, refs: &mut HashSet<String>) {
         Value::Concrete(ConcreteValue::Map(map)) => {
             for v in map.values() {
                 collect_resource_refs(v, refs);
-            }
-        }
-        _ => {}
-    }
-}
-
-/// Extract binding names from dot-notation string values (e.g., "vpc.vpc_id" → "vpc").
-///
-/// When files are parsed independently, cross-file references like `vpc.vpc_id`
-/// become `String("vpc.vpc_id")` instead of `ResourceRef`. This function extracts
-/// the first component as a potential binding name.
-pub(crate) fn collect_dot_notation_refs(value: &Value, refs: &mut HashSet<String>) {
-    match value {
-        Value::Concrete(ConcreteValue::String(s))
-            if s.contains('.') && !s.contains(' ') && !s.starts_with('/') =>
-        {
-            if let Some(binding) = s.split('.').next()
-                && !binding.is_empty()
-                && binding
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '_')
-            {
-                refs.insert(binding.to_string());
-            }
-        }
-        Value::Concrete(ConcreteValue::List(items)) => {
-            for item in items {
-                collect_dot_notation_refs(item, refs);
-            }
-        }
-        Value::Concrete(ConcreteValue::Map(map)) => {
-            for v in map.values() {
-                collect_dot_notation_refs(v, refs);
             }
         }
         _ => {}

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -97,6 +97,24 @@ fn unused_binding_warns() {
 }
 
 #[test]
+fn dotted_string_literal_does_not_count_as_binding_use() {
+    let mut parsed = empty_parsed();
+
+    let publish =
+        Resource::with_provider("test", "r.Source", "publish", None).with_binding("publish");
+    parsed.resources.push(publish); // allow: direct — fixture test inspection
+
+    let target = Resource::with_provider("test", "r.Target", "target", None).with_attribute(
+        "x",
+        Value::Concrete(ConcreteValue::String("publish.example.com".to_string())),
+    );
+    parsed.resources.push(target); // allow: direct — fixture test inspection
+
+    let unused = check_unused_bindings(&parsed);
+    assert_eq!(unused, vec!["publish"]);
+}
+
+#[test]
 fn anonymous_resource_no_warning() {
     let mut parsed = empty_parsed();
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -115,6 +115,8 @@ impl std::fmt::Display for UnknownReason {
             UnknownReason::ForKey => write!(f, "deferred for-binding key"),
             UnknownReason::ForIndex => write!(f, "deferred for-binding index"),
             UnknownReason::ForValue => write!(f, "deferred for-binding value"),
+            UnknownReason::FnParam { name } => write!(f, "function parameter {name}"),
+            UnknownReason::FnLocal { name } => write!(f, "function local {name}"),
             UnknownReason::ForValuePath { path } => {
                 write!(f, "deferred for-binding value {}", path.to_dot_string())
             }
@@ -135,6 +137,8 @@ pub fn render_unknown(reason: &UnknownReason) -> String {
         UnknownReason::ForKey => "(known after upstream apply: key)".to_string(),
         UnknownReason::ForIndex => "(known after upstream apply: index)".to_string(),
         UnknownReason::ForValue => "(known after upstream apply)".to_string(),
+        UnknownReason::FnParam { name } => format!("(unresolved function parameter: {name})"),
+        UnknownReason::FnLocal { name } => format!("(unresolved function local: {name})"),
         UnknownReason::ForValuePath { path } => {
             format!("(known after upstream apply: {})", path.to_dot_string())
         }

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -154,20 +154,6 @@ fn deferred_in_current_file(
         == Some(current)
 }
 
-/// Check if a string looks like an unresolved cross-file reference ("binding.attribute").
-fn is_dot_notation_ref(s: &str) -> bool {
-    let parts: Vec<&str> = s.split('.').collect();
-    parts.len() == 2
-        && !s.contains(' ')
-        && !s.starts_with('/')
-        && parts[0]
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
-        && parts[1]
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
-}
-
 impl DiagnosticEngine {
     /// Flag `arguments` blocks placed in a root configuration.
     ///
@@ -1206,17 +1192,6 @@ impl DiagnosticEngine {
         sibling_bindings: &HashMap<String, String>,
     ) -> Option<String> {
         match (type_expr, value) {
-            // Cross-file ref: look up schema type via sibling bindings.
-            // Two shapes reach this arm. The string form covers values
-            // not produced by the .crn parser — synthetic test inputs
-            // and any caller that hands us a raw `"binding.attr"` —
-            // since the parser itself now lowers dotted IDs to
-            // `Value::Deferred(DeferredValue::ResourceRef)` (#2447). The ResourceRef arm below
-            // is the parser-produced path; both must agree.
-            (_, Value::Concrete(ConcreteValue::String(s))) if is_dot_notation_ref(s) => {
-                let parts: Vec<&str> = s.split('.').collect();
-                self.check_cross_file_ref_type(type_expr, parts[0], parts[1], sibling_bindings)
-            }
             // Bare `binding.attribute` ref: check the head's schema type.
             // Refs with subscripts or a field_path narrow inside the
             // head's type and would need a positional walker to compare

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1829,9 +1829,9 @@ target_id = caller.account_id
 #[test]
 fn exports_cross_file_ref_no_false_positive() {
     // Regression: when exports.crn references a binding from a sibling file,
-    // single-file parsing leaves the reference as Value::Concrete(ConcreteValue::String("binding.attr")).
+    // the parser produces a ResourceRef for `binding.attr`.
     // The custom type validator (e.g., aws_account_id: 12-digit check) must
-    // skip these dot-notation strings to avoid false positives.
+    // skip ResourceRefs to avoid false positives.
     use carina_core::resource::{ConcreteValue, Value};
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
@@ -1859,7 +1859,6 @@ fn exports_cross_file_ref_no_false_positive() {
     schemas.insert("awscc", schema);
     let engine = custom_engine(schemas);
 
-    // exports.crn parsed alone: "registry_prod.account_id" stays as String
     let doc = create_document(
         r#"exports {
   accounts: list(AwsAccountId) = [
@@ -1876,6 +1875,39 @@ fn exports_cross_file_ref_no_false_positive() {
     assert!(
         false_positive.is_none(),
         "Dot-notation cross-file ref should be skipped by type validator. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn exports_dotted_string_literal_is_not_ref_type_checked() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let schema = ResourceSchema::new("organizations.account")
+        .attribute(AttributeSchema::new("account_id", AttributeType::int()));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let engine = custom_engine(schemas);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("main.crn"),
+        "let registry_prod = awscc.organizations.account {\n  name = 'prod'\n}\n",
+    )
+    .unwrap();
+    let exports = "exports {\n  account: String = \"registry_prod.account_id\"\n}\n";
+    std::fs::write(base.join("exports.crn"), exports).unwrap();
+
+    let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
+
+    let ref_type_warning = diagnostics.iter().find(|d| {
+        d.message.contains("type mismatch") && d.message.contains("registry_prod.account_id")
+    });
+    assert!(
+        ref_type_warning.is_none(),
+        "quoted dotted string literal must not be checked as a ResourceRef. Got: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
@@ -2040,12 +2072,9 @@ fn exports_type_warning_after_format_with_cross_file_ref() {
     );
     let diagnostics = engine.analyze(&doc, None);
 
-    // "registry_prod.account_id" is a cross-file ref (dot-notation string).
-    // It should NOT produce a false positive (12-digit check etc.).
-    // But list(bool) is wrong because the ref resolves to a string, not bool.
-    // For now, since we can't resolve cross-file refs in the LSP,
-    // at minimum we should NOT crash or hang.
-    // The type mismatch may or may not be caught depending on schema availability.
+    // The entries parse as ResourceRef values. At minimum, this path
+    // must not crash or produce custom-validator false positives.
+    // A type mismatch may or may not be caught depending on schema availability.
     eprintln!(
         "diagnostics after format+type-change: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()


### PR DESCRIPTION
Closes #3464

## Problem

A genuine string literal whose first dot-segment is a lexically valid identifier matching a binding name was reinterpreted as a reference. With `let publish = use { source = './uc' }`, the module argument `domain_name = 'publish.example.com'` failed validation with `unknown binding 'publish' in reference publish.example` — and if the leading segment had resolved, the literal would have been silently replaced with a wrong value.

## Root cause

The parser has lowered every dotted identifier structurally (`ResourceRef` / `EnumIdentifier`) since #2435 / #2447 / #2817, so a `ConcreteValue::String` can only originate from a real string literal. Several legacy consumers still re-derived reference-ness from string *shape* ("dotted + first segment is a binding → it's a reference"). Since no parse path produces String-encoded references anymore, those consumers could only ever corrupt genuine literals. Neutralizing them broke zero existing tests — the lifting they performed is fully covered by parse-time structural handling.

## Fix — delete every text→reference reinterpretation

- parser pass-2 forward-reference lifting (`resolve_forward_references` / `resolve_forward_ref_in_value`) and the export_param lifting loop in `resolve_resource_refs_with_config`
- `collect_dot_notation_refs` in core validation (`check_unused_bindings`, depends_on redundant-edge check) — a literal sharing a binding's first segment no longer suppresses a legitimate unused-binding warning
- the String-sniffing arm in carina-cli `resolve_export_value` — this was the issue's silent-wrong-value path: an export string literal like `"vpc.vpc_id"` was substituted with the binding's attribute value and persisted via state writeback
- the `is_dot_notation_ref` arm in carina-lsp type diagnostics (validate/LSP parity)

## Interpolation canonicalization moved to the parse seam

The deleted pass incidentally canonicalized interpolations. That now happens in `parse_string_value`. Canonicalization folds only concrete scalar parts and preserves deferred parts as `Expr`, so for-expansion placeholder substitution is unaffected (pinned by `expand_deferred_for_substitutes_placeholder_inside_interpolation`).

## Fn placeholders typed (same invariant, found in review round 4)

Parse-time canonicalization exposed the same invariant violation inside user-function bodies: params/locals were registered as String sentinels (`__fn_param_X` / `__fn_local_X`), which canonicalize folded into literals, breaking interpolated fn bodies (`fn bucket_name(env) { "myapp-${env}-bucket" }` leaked the sentinel). The sentinels are replaced with typed `UnknownReason::FnParam` / `FnLocal` variants — mirroring the `For*` placeholder precedent — which canonicalization structurally cannot fold; the evaluated fn result is canonicalized once at its exit seam. `substitute_placeholder` now matches `UnknownReason` exhaustively, so the next variant forces a compile-time decision instead of falling through a wildcard.

## Tests (red→green confirmed on pre-fix code)

- `parse_directory_preserves_module_arg_dotted_string_literal` — the issue repro verbatim (directory + module expansion)
- `parse_directory_preserves_direct_attr_dotted_string_literal` / `_export_param_` / data-source / attribute-default variants — every value position the deleted pass walked
- `dotted_string_literal_does_not_count_as_binding_use`
- `resolve_export_value_preserves_dotted_string_literal` (CLI, silent-wrong-value path)
- `exports_dotted_string_literal_is_not_ref_type_checked` (LSP)
- `user_fn_interpolation_substitutes_param_inside_string` / `_local_inside_string` (fn sentinel regression)

## Verify

`cargo nextest run --workspace --all-features` 4040 passed / 72 skipped; doctests, clippy `-D warnings`, and all `scripts/check-*.sh` green.

Follow-up filed during review: #3465 (`collect_resource_refs` does not recurse into interpolations/function calls — pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
