### PR TITLE
Unify validation reference collection on deps::collect_dependencies (carina#3465)

### DIFF
--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -377,7 +377,7 @@ pub fn find_failed_dependent<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{Directives, Resource, ResourceId, Value};
+    use crate::resource::{DeferredValue, Directives, Resource, ResourceId, Value};
 
     fn make_resource(binding: &str, deps: &[&str]) -> Resource {
         let mut r = Resource::new("test", binding);
@@ -444,6 +444,22 @@ mod tests {
             "expected pre-recorded dependency `explicit_dep`, got {deps:?}",
         );
         assert_eq!(deps.len(), 2);
+    }
+
+    #[test]
+    fn collect_dependencies_recurses_into_secret_inner_value() {
+        // `Deferred(Secret(_))` is reachable after resolution wraps a value
+        // (for example in parser/resolve.rs), so pin this walker arm directly.
+        let value = Value::Deferred(DeferredValue::Secret(Box::new(Value::resource_ref(
+            "role",
+            "arn",
+            vec![],
+        ))));
+        let mut deps = HashSet::new();
+
+        collect_dependencies(&value, &mut deps);
+
+        assert_eq!(deps, HashSet::from(["role".to_string()]));
     }
 
     // Closure-in-attribute regression test deleted: `Value::Closure` no

--- a/carina-core/src/validation/depends_on.rs
+++ b/carina-core/src/validation/depends_on.rs
@@ -13,9 +13,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::deps::sort_resources_by_dependencies;
+use crate::deps::{collect_dependencies, sort_resources_by_dependencies};
 use crate::parser::{File, ResourceRef};
-use crate::validation::collect_resource_refs;
 
 /// Severity of a depends_on diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -120,7 +119,7 @@ pub fn validate_depends_on<E>(parsed: &File<E>) -> Vec<DependsOnDiagnostic> {
 
         let mut value_ref_deps: HashSet<String> = HashSet::new();
         for value in resource.attributes().values() {
-            collect_resource_refs(value, &mut value_ref_deps);
+            collect_dependencies(value, &mut value_ref_deps);
         }
         for name in resource.dependency_bindings() {
             value_ref_deps.insert(name.clone());
@@ -224,7 +223,7 @@ pub fn validate_depends_on<E>(parsed: &File<E>) -> Vec<DependsOnDiagnostic> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::parse_and_resolve;
+    use crate::parser::{ProviderContext, parse, parse_and_resolve};
 
     fn diag_messages(diags: &[DependsOnDiagnostic], sev: Severity) -> Vec<String> {
         diags
@@ -440,6 +439,30 @@ mod tests {
                 .iter()
                 .any(|m| m.contains("redundant") && m.contains("'role'")),
             "expected redundant-edge warning for value ref, got {:?}",
+            warnings
+        );
+    }
+
+    #[test]
+    fn redundant_edge_via_interpolation_ref_is_diagnosed_as_warning() {
+        let src = r#"
+            let role = aws.iam.Role {
+                role_name = "r"
+                assume_role_policy_document = "{}"
+            }
+            let bucket = aws.s3.Bucket {
+                bucket_name = "acct-${role.arn}"
+                directives { depends_on = [role] }
+            }
+        "#;
+        let parsed = parse(src, &ProviderContext::default()).unwrap();
+        let diags = validate_depends_on(&parsed);
+        let warnings = diag_messages(&diags, Severity::Warning);
+        assert!(
+            warnings
+                .iter()
+                .any(|m| m.contains("redundant") && m.contains("'role'")),
+            "expected redundant-edge warning for interpolation ref, got {:?}",
             warnings
         );
     }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet};
 use indexmap::IndexMap;
 
 use crate::binding_index::BindingIndex;
+use crate::deps::collect_dependencies;
 use crate::parser::{
     ModuleCall, ProviderContext, ResourceRef, ResourceTypePath, TypeExpr, validate_custom_type,
 };
@@ -1136,8 +1137,11 @@ pub fn validate_export_params(
 
 /// Check for unused `let` bindings and return the unused binding names.
 ///
-/// A binding is unused if its name never appears as a `ResourceRef.binding_name`
-/// in any resource attribute, module call argument, or attribute parameter value.
+/// A binding is unused if its name never appears as a value-carried reference:
+/// attribute refs, bare refs, interpolation expressions, function arguments, or
+/// secret inner values in resource attributes, module call arguments, attribute
+/// parameters, export parameters, `directives.depends_on`, wait targets, or wait
+/// `depends_on` entries.
 ///
 /// Generic over the export-parameter shape so both `ParsedFile` (parser
 /// phase) and `InferredFile` (post-loader phase) can drive it without
@@ -1172,7 +1176,7 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
             if attr_name.starts_with('_') {
                 continue;
             }
-            collect_resource_refs(value, &mut referenced);
+            collect_dependencies(value, &mut referenced);
         }
         // `Composition` has no directives — `directives()` is `None`
         // for that arm, so the depends_on walk is simply skipped.
@@ -1182,17 +1186,17 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
     }
     for call in &parsed.module_calls {
         for value in call.arguments.values() {
-            collect_resource_refs(value, &mut referenced);
+            collect_dependencies(value, &mut referenced);
         }
     }
     for attr_param in &parsed.attribute_params {
         if let Some(value) = &attr_param.value {
-            collect_resource_refs(value, &mut referenced);
+            collect_dependencies(value, &mut referenced);
         }
     }
     for export_param in &parsed.export_params {
         if let Some(value) = export_param.value() {
-            collect_resource_refs(value, &mut referenced);
+            collect_dependencies(value, &mut referenced);
         }
     }
     // Each `wait <target> { ... }` declaration references its target
@@ -1216,26 +1220,6 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
                 && !binding.contains('[')
         })
         .collect()
-}
-
-/// Recursively collect all `ResourceRef` binding names from a value tree.
-pub(crate) fn collect_resource_refs(value: &Value, refs: &mut HashSet<String>) {
-    match value {
-        Value::Deferred(DeferredValue::ResourceRef { path }) => {
-            refs.insert(path.binding().to_string());
-        }
-        Value::Concrete(ConcreteValue::List(items)) => {
-            for item in items {
-                collect_resource_refs(item, refs);
-            }
-        }
-        Value::Concrete(ConcreteValue::Map(map)) => {
-            for v in map.values() {
-                collect_resource_refs(v, refs);
-            }
-        }
-        _ => {}
-    }
 }
 
 /// Validate a value against a TypeExpr, returning an error message if invalid.

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -153,6 +153,79 @@ fn binding_referenced_in_nested_value() {
 }
 
 #[test]
+fn binding_referenced_in_interpolation_is_not_unused() {
+    let src = r#"
+        let role = aws.iam.Role {
+            role_name = "r"
+            assume_role_policy_document = "{}"
+        }
+        let _ = aws.s3.Bucket {
+            bucket_name = "acct-${role.arn}"
+        }
+    "#;
+    let parsed = crate::parser::parse(src, &crate::parser::ProviderContext::default()).unwrap();
+
+    assert!(check_unused_bindings(&parsed).is_empty());
+}
+
+#[test]
+fn binding_referenced_in_function_call_arg_is_not_unused() {
+    let src = r#"
+        let role = aws.iam.Role {
+            role_name = "r"
+            assume_role_policy_document = "{}"
+        }
+        let _ = aws.s3.Bucket {
+            bucket_name = sibling_fn(role.arn)
+        }
+    "#;
+    let parsed = crate::parser::parse(src, &crate::parser::ProviderContext::default()).unwrap();
+
+    assert!(check_unused_bindings(&parsed).is_empty());
+}
+
+#[test]
+fn binding_referenced_in_secret_builtin_function_call_is_not_unused() {
+    let src = r#"
+        let role = aws.iam.Role {
+            role_name = "r"
+            assume_role_policy_document = "{}"
+        }
+        let _ = aws.s3.Bucket {
+            bucket_name = secret(role.arn)
+        }
+    "#;
+    // `secret(role.arn)` stays deferred as a FunctionCall while its arg is
+    // unresolved, so this source-level fixture pins function-call recursion.
+    let parsed = crate::parser::parse(src, &crate::parser::ProviderContext::default()).unwrap();
+
+    assert!(check_unused_bindings(&parsed).is_empty());
+}
+
+#[test]
+fn bare_binding_ref_is_not_unused() {
+    let src = r#"
+        let _ = aws.s3.Bucket {
+            bucket_name = role
+        }
+        let role = aws.iam.Role {
+            role_name = "r"
+            assume_role_policy_document = "{}"
+        }
+    "#;
+    // Seeded structural bindings are the directory-loader path that keeps
+    // a bare sibling reference as `Deferred(BindingRef)` in the parsed file.
+    let parsed = crate::parser::parse_with_seeded_bindings(
+        src,
+        &crate::parser::ProviderContext::default(),
+        &[crate::parser::BindingSeed::structural("role")],
+    )
+    .unwrap();
+
+    assert!(check_unused_bindings(&parsed).is_empty());
+}
+
+#[test]
 fn binding_referenced_in_module_call() {
     let mut parsed = empty_parsed();
 


### PR DESCRIPTION
Closes #3465

## Problem

`check_unused_bindings` and `validate_depends_on`'s redundant-edge check collected value-carried references through a private walker (`collect_resource_refs`) that only matched `ResourceRef`, `List`, and `Map`. A binding referenced only inside an interpolation (`label = "acct-${role.arn}"`), a function-call argument, a `secret()` inner value, or as a bare binding reference was falsely reported unused — and the redundant-edge warning missed such edges on the unresolved-parse path (the LSP buffer fallback, where `dependency_bindings` is empty).

## Root cause — walker drift, not a missing arm

`deps::collect_dependencies` already walks all of these shapes exhaustively; the validation copy fell behind. Hand-syncing the copy would leave the drift class reachable (two exhaustive matches, nothing forcing the same decision). Instead the private walker is **deleted** and all five validation call sites use `deps::collect_dependencies` — one walker, so this drift class is no longer representable, and its exhaustive no-wildcard match forces a compile-time decision for any future `Value` variant.

The redundant-edge behavior change is parity, not new policy: the resolved path already saw these references via the resolver's `dependency_bindings` snapshot (computed by the same walker); only the raw-parse path lagged. Lint and the engine's real ordering graph now agree by construction.

## Tests (red→green confirmed; mutation-verified)

- `binding_referenced_in_interpolation_is_not_unused` / `_in_function_call_arg_` / `_in_secret_builtin_function_call_` / `bare_binding_ref_is_not_unused` — raw `parse()` fixtures (the bare-ref one via directory seeding, the only path that keeps `BindingRef` in the parsed file); each fails without its walker arm (mutation-tested 0/6 → 6/6)
- `redundant_edge_via_interpolation_ref_is_diagnosed_as_warning` — raw `parse()` so the warning flows only through the collector (the `parse_and_resolve` variant was vacuous: `dependency_bindings` already covered it)
- `collect_dependencies_recurses_into_secret_inner_value` — direct pin of the `Secret` arm in deps.rs (source-level `secret(x)` with a non-static arg parses as `FunctionCall`, so this arm is only reachable post-resolution)

## Review follow-ups filed

- #3467 (updated): remaining reference-walker wildcards (`collect_unsynchronized_refs`, `module.rs` `collect_typed_dependencies`)
- #3469: differ create-only cascade localizes referencing attributes with a top-level-only match

## Verify

`cargo nextest run --workspace --all-features` 4046 passed / 72 skipped; doctests, clippy `-D warnings`, and all `scripts/check-*.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
