### PR TITLE
Remove force_replace; type Replace's create-only list as non-empty

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -618,7 +618,11 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
         from: Box::new(State::existing(from_id.clone(), HashMap::new())),
         to: sorted_resources[0].clone(),
         directives: Directives::default(),
-        changed_create_only: vec!["role_name".to_string(), "policy_name".to_string()],
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
+            "role_name".to_string(),
+            "policy_name".to_string(),
+        ])
+        .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -783,7 +783,10 @@ fn test_cascading_update_shows_attribute_diffs() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
+            "cidr_block".to_string(),
+        ])
+        .unwrap(),
         cascading_updates: vec![CascadingUpdate {
             id: ResourceId::new("ec2.Subnet", "subnet"),
             from: Box::new(subnet_from),
@@ -1156,7 +1159,10 @@ fn test_mixed_plan_tree_with_delete_effect() {
         from: Box::new(sg_from),
         to: sg_to,
         directives: Directives::default(),
-        changed_create_only: vec!["ref_vpc".to_string()],
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
+            "ref_vpc".to_string(),
+        ])
+        .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -1351,7 +1357,8 @@ fn format_effect_replace_separates_type_and_name_with_space() {
         ))),
         to,
         directives: Directives::default(),
-        changed_create_only: Vec::new(),
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
         cascading_updates: Vec::<CascadingUpdate>::new(),
         temporary_name: None,
         cascade_ref_hints: Vec::new(),

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1781,7 +1781,10 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["bucket_name".to_string()],
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
+            "bucket_name".to_string(),
+        ])
+        .unwrap(),
         cascading_updates: vec![],
         temporary_name: Some(TemporaryName {
             attribute: "bucket_name".to_string(),
@@ -1911,7 +1914,10 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
+            "cidr_block".to_string(),
+        ])
+        .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -2078,7 +2078,10 @@ mod tests {
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
-            changed_create_only: vec!["cidr_block".to_string()],
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+                "cidr_block".to_string(),
+            ])
+            .unwrap(),
             cascading_updates: vec![],
             temporary_name: None,
             cascade_ref_hints: vec![],

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -71,7 +71,8 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -169,7 +170,8 @@ fn cascade_skips_resources_already_in_plan() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -237,7 +239,8 @@ fn cascade_no_op_without_create_before_destroy() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone()),
         directives: Directives::default(), // create_before_destroy = false
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -332,7 +335,8 @@ fn cascade_transitive_dependencies() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -411,7 +415,8 @@ fn cascade_anonymous_resource_dependent() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -521,7 +526,8 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -573,7 +579,7 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
     {
         assert_eq!(id, &subnet_id);
         assert!(
-            changed_create_only.contains(&"vpc_id".to_string()),
+            changed_create_only.contains("vpc_id"),
             "Subnet Replace should list vpc_id as a changed create-only attribute"
         );
         assert!(
@@ -692,7 +698,8 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -702,7 +709,10 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
         to: (subnet.clone().with_binding("subnet")),
         directives: Directives::default(),
-        changed_create_only: vec!["availability_zone".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+            "availability_zone".to_string(),
+        ])
+        .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -726,12 +736,12 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     } = subnet_effect.unwrap()
     {
         assert!(
-            changed_create_only.contains(&"availability_zone".to_string()),
+            changed_create_only.contains("availability_zone"),
             "changed_create_only should contain availability_zone (direct change), got: {:?}",
             changed_create_only
         );
         assert!(
-            changed_create_only.contains(&"vpc_id".to_string()),
+            changed_create_only.contains("vpc_id"),
             "changed_create_only should contain vpc_id (cascade from VPC replace), got: {:?}",
             changed_create_only
         );
@@ -834,7 +844,8 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone().with_binding("vpc")),
         directives: Directives::default(), // create_before_destroy = false (user didn't set it)
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -962,7 +973,8 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -990,7 +1002,7 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
             ..
         } => {
             assert!(
-                changed_create_only.contains(&"vpc_id".to_string()),
+                changed_create_only.contains("vpc_id"),
                 "Subnet Replace should list vpc_id as changed create-only (cascade from VPC replace), got: {:?}",
                 changed_create_only
             );
@@ -1087,7 +1099,8 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -1215,7 +1228,8 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr_block".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -350,7 +350,7 @@ fn replace_when_create_only_attr_changed() {
             changed_create_only,
             ..
         } => {
-            assert_eq!(changed_create_only, &vec!["cidr_block".to_string()]);
+            assert_eq!(&changed_create_only[..], &["cidr_block".to_string()]);
         }
         other => panic!("Expected Replace, got {:?}", other),
     }
@@ -404,75 +404,6 @@ fn normal_update_when_non_create_only_attr_changed() {
     assert!(
         matches!(plan.effects()[0], Effect::Update { .. }),
         "Expected Update, got {:?}",
-        plan.effects()[0]
-    );
-}
-
-#[test]
-fn replace_when_schema_force_replace() {
-    use crate::schema::AttributeType;
-
-    // Resource has changed attributes but NO create-only attributes
-    let resources = vec![
-        Resource::new("ec2.internet_gateway", "my-igw").with_attribute(
-            "tags",
-            Value::Concrete(ConcreteValue::Map(
-                vec![(
-                    "Name".to_string(),
-                    Value::Concrete(ConcreteValue::String("new-name".to_string())),
-                )]
-                .into_iter()
-                .collect(),
-            )),
-        ),
-    ];
-
-    let mut current_states = HashMap::new();
-    let mut attrs = HashMap::new();
-    attrs.insert(
-        "tags".to_string(),
-        Value::Concrete(ConcreteValue::Map(
-            vec![(
-                "Name".to_string(),
-                Value::Concrete(ConcreteValue::String("old-name".to_string())),
-            )]
-            .into_iter()
-            .collect(),
-        )),
-    );
-    current_states.insert(
-        ResourceId::new("ec2.internet_gateway", "my-igw"),
-        State::existing(ResourceId::new("ec2.internet_gateway", "my-igw"), attrs),
-    );
-
-    // Schema has force_replace=true (no create-only attributes)
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert(
-        "",
-        crate::schema::ResourceSchema::new("ec2.internet_gateway")
-            .attribute(crate::schema::AttributeSchema::new(
-                "tags",
-                AttributeType::string(),
-            ))
-            .force_replace(),
-    );
-
-    let plan = create_plan(
-        &resources,
-        &[],
-        &current_states,
-        &HashMap::new(),
-        &schemas,
-        &HashMap::new(),
-        &HashMap::new(),
-        &HashMap::new(),
-        &[],
-    );
-
-    assert_eq!(plan.effects().len(), 1);
-    assert!(
-        matches!(plan.effects()[0], Effect::Replace { .. }),
-        "Expected Replace for force_replace schema, got {:?}",
         plan.effects()[0]
     );
 }
@@ -537,7 +468,7 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
             changed_create_only,
             ..
         } => {
-            assert_eq!(changed_create_only, &vec!["cidr_block".to_string()]);
+            assert_eq!(&changed_create_only[..], &["cidr_block".to_string()]);
         }
         other => panic!("Expected Replace, got {:?}", other),
     }
@@ -593,7 +524,7 @@ fn replace_carries_create_before_destroy_directives() {
             ..
         } => {
             assert!(directives.create_before_destroy);
-            assert_eq!(changed_create_only, &vec!["cidr_block".to_string()]);
+            assert_eq!(&changed_create_only[..], &["cidr_block".to_string()]);
         }
         other => panic!("Expected Replace, got {:?}", other),
     }

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::deps::get_resource_dependencies;
-use crate::effect::{CascadingUpdate, Effect, TemporaryName, WaitTarget};
+use crate::effect::{CascadingUpdate, ChangedCreateOnly, Effect, TemporaryName, WaitTarget};
 use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
@@ -20,7 +20,7 @@ use super::{Diff, diff};
 /// A pending merge operation: cascade-triggered create-only attributes to add to an existing effect.
 struct CascadeMerge {
     resource_id: ResourceId,
-    create_only_attrs: Vec<String>,
+    create_only_attrs: ChangedCreateOnly,
     directives: Directives,
     ref_hints: Vec<(String, String)>,
 }
@@ -252,23 +252,7 @@ pub fn create_plan(
                     registry,
                 );
 
-                // Check if the resource type forces replacement (no update support)
-                let schema_force_replace = registry
-                    .get(
-                        &resource.id.provider,
-                        &resource.id.resource_type,
-                        SchemaKind::Resource,
-                    )
-                    .is_some_and(|s| s.force_replace);
-
-                if changed_create_only.is_empty() && !schema_force_replace {
-                    plan.add(Effect::Update {
-                        id,
-                        from,
-                        to,
-                        changed_attributes,
-                    });
-                } else {
+                if let Some(changed_create_only) = ChangedCreateOnly::new(changed_create_only) {
                     // Replace involves destroying the old resource
                     if resource.directives.prevent_destroy {
                         plan.add_error(PlanError {
@@ -313,6 +297,13 @@ pub fn create_plan(
                         cascading_updates: vec![],
                         temporary_name,
                         cascade_ref_hints: vec![],
+                    });
+                } else {
+                    plan.add(Effect::Update {
+                        id,
+                        from,
+                        to,
+                        changed_attributes,
                     });
                 }
             }
@@ -731,7 +722,7 @@ pub fn cascade_dependent_updates(
                 registry,
             );
 
-            if !create_only_refs.is_empty() {
+            if let Some(create_only_attrs) = ChangedCreateOnly::new(create_only_refs) {
                 // Check if this merge would upgrade an Update to Replace.
                 // If the resource has prevent_destroy, block the upgrade.
                 let is_update_in_plan = plan
@@ -751,11 +742,11 @@ pub fn cascade_dependent_updates(
                 // Only keep hints for attributes that are actually create-only
                 let filtered_hints: Vec<(String, String)> = ref_hints
                     .into_iter()
-                    .filter(|(attr, _)| create_only_refs.contains(attr))
+                    .filter(|(attr, _)| create_only_attrs.contains(attr))
                     .collect();
                 merge_operations.push(CascadeMerge {
                     resource_id: resource.id.clone(),
-                    create_only_attrs: create_only_refs,
+                    create_only_attrs,
                     directives: resource.directives.clone(),
                     ref_hints: filtered_hints,
                 });
@@ -810,7 +801,48 @@ pub fn cascade_dependent_updates(
                     registry,
                 );
 
-                if create_only_refs.is_empty() {
+                if let Some(changed_create_only) = ChangedCreateOnly::new(create_only_refs) {
+                    if unresolved.directives.prevent_destroy {
+                        // Cascade would promote to Replace (destroy + recreate),
+                        // but prevent_destroy blocks this.
+                        plan.add_error(PlanError {
+                            resource_id: unresolved.id.clone(),
+                            message:
+                                "resource has prevent_destroy set, but cascade from a replaced dependency would replace it (which requires destroying the old resource)"
+                                    .to_string(),
+                        });
+                    } else {
+                        // Extract ref hints for attributes being promoted
+                        let ref_hints: Vec<(String, String)> = unresolved
+                            .attributes
+                            .iter()
+                            .filter_map(|(k, v)| match v {
+                                Value::Deferred(DeferredValue::ResourceRef { path })
+                                    if path.binding() == replaced_binding
+                                        && changed_create_only.contains(k) =>
+                                {
+                                    Some((
+                                        k.clone(),
+                                        format!("{}.{}", path.binding(), path.attribute()),
+                                    ))
+                                }
+                                _ => None,
+                            })
+                            .collect();
+
+                        // Promote to a separate Replace effect
+                        promoted_replaces.push(Effect::Replace {
+                            id: unresolved.id.clone(),
+                            from: Box::new(from),
+                            to: (*unresolved).clone(),
+                            directives: unresolved.directives.clone(),
+                            changed_create_only,
+                            cascading_updates: vec![],
+                            temporary_name: None,
+                            cascade_ref_hints: ref_hints,
+                        });
+                    }
+                } else {
                     // Normal cascading update
                     updates_by_replaced_binding
                         .entry(replaced_binding.clone())
@@ -820,45 +852,6 @@ pub fn cascade_dependent_updates(
                             from: Box::new(from),
                             to: (*unresolved).clone(),
                         });
-                } else if unresolved.directives.prevent_destroy {
-                    // Cascade would promote to Replace (destroy + recreate),
-                    // but prevent_destroy blocks this.
-                    plan.add_error(PlanError {
-                        resource_id: unresolved.id.clone(),
-                        message:
-                            "resource has prevent_destroy set, but cascade from a replaced dependency would replace it (which requires destroying the old resource)"
-                                .to_string(),
-                    });
-                } else {
-                    // Extract ref hints for attributes being promoted
-                    let ref_hints: Vec<(String, String)> = unresolved
-                        .attributes
-                        .iter()
-                        .filter_map(|(k, v)| match v {
-                            Value::Deferred(DeferredValue::ResourceRef { path })
-                                if path.binding() == replaced_binding
-                                    && create_only_refs.contains(k) =>
-                            {
-                                Some((
-                                    k.clone(),
-                                    format!("{}.{}", path.binding(), path.attribute()),
-                                ))
-                            }
-                            _ => None,
-                        })
-                        .collect();
-
-                    // Promote to a separate Replace effect
-                    promoted_replaces.push(Effect::Replace {
-                        id: unresolved.id.clone(),
-                        from: Box::new(from),
-                        to: (*unresolved).clone(),
-                        directives: unresolved.directives.clone(),
-                        changed_create_only: create_only_refs,
-                        cascading_updates: vec![],
-                        temporary_name: None,
-                        cascade_ref_hints: ref_hints,
-                    });
                 }
             }
         }

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -3,10 +3,11 @@
 //! An Effect describes "what to do" without actually performing the side effect.
 //! Side effects only occur when they are executed via a Provider.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, ops::Deref};
 
 use serde::{Deserialize, Serialize};
 
+use crate::non_empty::NonEmptyVec;
 use crate::resource::{DataSource, Directives, Resource, ResourceId, State};
 use crate::wait::predicate::WaitPredicate;
 
@@ -38,6 +39,64 @@ pub struct CascadingUpdate {
     pub id: ResourceId,
     pub from: Box<State>,
     pub to: Resource,
+}
+
+/// Non-empty create-only attribute list for [`Effect::Replace`].
+///
+/// An empty list would render a destroy-and-recreate plan with no visible
+/// reason: the unexplained-replacement bug class (carina#3471) this type makes
+/// unrepresentable.
+///
+/// A replace must name at least one create-only attribute that forced it.
+/// Constructing this type from a possibly empty `Vec<String>` requires the
+/// fallible [`ChangedCreateOnly::new`] constructor:
+///
+/// ```compile_fail
+/// use carina_core::effect::ChangedCreateOnly;
+///
+/// let attrs: Vec<String> = Vec::new();
+/// let _changed = ChangedCreateOnly(attrs);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "Vec<String>", into = "Vec<String>")]
+pub struct ChangedCreateOnly(NonEmptyVec<String>);
+
+impl ChangedCreateOnly {
+    pub fn new(attrs: Vec<String>) -> Option<Self> {
+        NonEmptyVec::from_vec(attrs).map(Self)
+    }
+
+    pub fn push(&mut self, attr: String) {
+        self.0.push(attr);
+    }
+
+    pub fn contains(&self, attr: &str) -> bool {
+        self.0.iter().any(|a| a == attr)
+    }
+}
+
+impl Deref for ChangedCreateOnly {
+    type Target = [String];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl TryFrom<Vec<String>> for ChangedCreateOnly {
+    type Error = String;
+
+    fn try_from(attrs: Vec<String>) -> Result<Self, Self::Error> {
+        Self::new(attrs).ok_or_else(|| {
+            "Replace effect requires at least one changed create-only attribute".to_string()
+        })
+    }
+}
+
+impl From<ChangedCreateOnly> for Vec<String> {
+    fn from(attrs: ChangedCreateOnly) -> Self {
+        attrs.0.into_vec()
+    }
 }
 
 /// How an [`Effect::Wait`] obtains the cloud provider identifier its
@@ -104,7 +163,7 @@ pub enum Effect {
         #[serde(default)]
         directives: Directives,
         /// Which create-only attributes forced the replacement
-        changed_create_only: Vec<String>,
+        changed_create_only: ChangedCreateOnly,
         /// Dependent resources to update between create and delete (create_before_destroy only)
         #[serde(default)]
         cascading_updates: Vec<CascadingUpdate>,
@@ -719,7 +778,10 @@ mod tests {
                     Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
                 ),
                 directives: Directives::default(),
-                changed_create_only: vec!["cidr_block".to_string()],
+                changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+                    "cidr_block".to_string(),
+                ])
+                .unwrap(),
                 // carina#3181 PR D: cover `CascadingUpdate.to:
                 // Resource` in the serde round-trip.
                 cascading_updates: vec![CascadingUpdate {
@@ -748,6 +810,80 @@ mod tests {
             let deserialized: Effect = serde_json::from_str(&json).unwrap();
             assert_eq!(effect, deserialized, "Round-trip failed for {:?}", effect);
         }
+    }
+
+    #[test]
+    fn changed_create_only_constructor_rejects_empty() {
+        assert!(ChangedCreateOnly::new(Vec::new()).is_none());
+        assert_eq!(
+            &ChangedCreateOnly::new(vec!["cidr_block".to_string()]).unwrap()[..],
+            ["cidr_block".to_string()]
+        );
+    }
+
+    #[test]
+    fn changed_create_only_push_preserves_non_empty() {
+        let mut changed = ChangedCreateOnly::new(vec!["cidr_block".to_string()]).unwrap();
+        changed.push("vpc_id".to_string());
+        assert_eq!(
+            &changed[..],
+            ["cidr_block".to_string(), "vpc_id".to_string()]
+        );
+    }
+
+    #[test]
+    fn replace_changed_create_only_serializes_as_plain_array() {
+        let effect = Effect::Replace {
+            id: ResourceId::new("test", "x"),
+            from: Box::new(State::not_found(ResourceId::new("test", "x"))),
+            to: Resource::new("test", "x"),
+            directives: Directives::default(),
+            changed_create_only: ChangedCreateOnly::new(vec!["x".to_string()]).unwrap(),
+            cascading_updates: vec![],
+            temporary_name: None,
+            cascade_ref_hints: vec![],
+        };
+
+        let json = serde_json::to_value(&effect).unwrap();
+        assert_eq!(
+            json["Replace"]["changed_create_only"],
+            serde_json::json!(["x"])
+        );
+        let decoded: Effect = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded, effect);
+    }
+
+    #[test]
+    fn replace_deserialize_rejects_empty_changed_create_only() {
+        let json = serde_json::json!({
+            "Replace": {
+                "id": {"provider": "", "resource_type": "test", "name": "x"},
+                "from": {
+                    "id": {"provider": "", "resource_type": "test", "name": "x"},
+                    "identifier": "x-1",
+                    "attributes": {},
+                    "exists": true,
+                    "dependency_bindings": []
+                },
+                "to": {
+                    "id": {"provider": "", "resource_type": "test", "name": "x"},
+                    "attributes": {}
+                },
+                "directives": {},
+                "changed_create_only": [],
+                "cascading_updates": [],
+                "temporary_name": null,
+                "cascade_ref_hints": []
+            }
+        });
+
+        let err = serde_json::from_value::<Effect>(json)
+            .expect_err("empty changed_create_only must not deserialize as Replace");
+        assert!(
+            err.to_string()
+                .contains("Replace effect requires at least one changed create-only attribute"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -979,7 +1115,7 @@ mod tests {
             from: Box::new(ResState::not_found(rid.clone())),
             to: Resource::new("test", "x"),
             directives: Directives::default(),
-            changed_create_only: vec![],
+            changed_create_only: ChangedCreateOnly::new(vec!["attr".to_string()]).unwrap(),
             cascading_updates: vec![],
             temporary_name: None,
             cascade_ref_hints: vec![],

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1495,7 +1495,10 @@ mod tests {
             from: Box::new(role_state),
             to: role.clone(),
             directives: Directives::default(),
-            changed_create_only: vec!["role_name".to_string()],
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+                "role_name".to_string(),
+            ])
+            .unwrap(),
             cascading_updates: vec![],
             temporary_name: None,
             cascade_ref_hints: vec![],
@@ -1505,7 +1508,10 @@ mod tests {
             from: Box::new(bucket_state),
             to: bucket.clone(),
             directives: Directives::default(),
-            changed_create_only: vec!["bucket_name".to_string()],
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+                "bucket_name".to_string(),
+            ])
+            .unwrap(),
             cascading_updates: vec![],
             temporary_name: None,
             cascade_ref_hints: vec![],

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -1042,7 +1042,8 @@ async fn test_cbd_creates_before_deletes() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["attr".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -1087,7 +1088,8 @@ async fn test_dbd_deletes_before_creates() {
         from: Box::new(from),
         to,
         directives: Directives::default(),
-        changed_create_only: vec!["attr".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -1151,7 +1153,8 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
         from: Box::new(vpc_from),
         to: vpc_to,
         directives: cbd_directives.clone(),
-        changed_create_only: vec!["attr".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -1161,7 +1164,8 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
         from: Box::new(subnet_from),
         to: subnet_to,
         directives: cbd_directives,
-        changed_create_only: vec!["attr".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -1228,7 +1232,8 @@ async fn test_phased_noncbd_creates_after_deletes() {
         from: Box::new(vpc_from),
         to: vpc_to,
         directives: dbd_directives.clone(),
-        changed_create_only: vec!["attr".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -1238,7 +1243,8 @@ async fn test_phased_noncbd_creates_after_deletes() {
         from: Box::new(subnet_from),
         to: subnet_to,
         directives: dbd_directives,
-        changed_create_only: vec!["attr".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -2189,7 +2195,10 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
         from: Box::new(attachment_from),
         to: attachment_to,
         directives: cbd_directives,
-        changed_create_only: vec!["transit_gateway_id".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+            "transit_gateway_id".to_string(),
+        ])
+        .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -2283,7 +2292,10 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
         from: Box::new(attachment_from),
         to: attachment_to,
         directives: cbd_directives,
-        changed_create_only: vec!["transit_gateway_id".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+            "transit_gateway_id".to_string(),
+        ])
+        .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -3178,7 +3190,8 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
         from: Box::new(role_from),
         to: role_to,
         directives: Directives::default(),
-        changed_create_only: vec!["role_name".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["role_name".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -3192,7 +3205,8 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
         from: Box::new(policy_from),
         to: policy_to,
         directives: Directives::default(),
-        changed_create_only: vec!["policy_name".to_string()],
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["policy_name".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],

--- a/carina-core/src/non_empty.rs
+++ b/carina-core/src/non_empty.rs
@@ -18,6 +18,14 @@ impl<T> NonEmptyVec<T> {
         }
     }
 
+    pub fn push(&mut self, item: T) {
+        self.inner.push(item);
+    }
+
+    pub fn into_vec(self) -> Vec<T> {
+        self.inner
+    }
+
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.inner.iter()
     }
@@ -42,5 +50,12 @@ mod tests {
         let collected: Vec<_> = nev.iter().copied().collect();
         assert_eq!(collected, vec![1, 2, 3]);
         assert_eq!(nev.as_slice(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn push_preserves_non_empty_and_into_vec_returns_inner() {
+        let mut nev = NonEmptyVec::from_vec(vec![1]).unwrap();
+        nev.push(2);
+        assert_eq!(nev.into_vec(), vec![1, 2]);
     }
 }

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::effect::Effect;
+use crate::effect::{ChangedCreateOnly, Effect};
 use crate::module::DependencyGraph;
 pub use crate::resource::ModuleSource;
 use crate::resource::ResourceId;
@@ -114,7 +114,7 @@ impl Plan {
     pub fn merge_cascade_create_only(
         &mut self,
         resource_id: &crate::resource::ResourceId,
-        cascade_attrs: Vec<String>,
+        cascade_attrs: ChangedCreateOnly,
         directives: crate::resource::Directives,
         ref_hints: Vec<(String, String)>,
     ) {
@@ -126,9 +126,9 @@ impl Plan {
                     cascade_ref_hints,
                     ..
                 } if id == resource_id => {
-                    for attr in &cascade_attrs {
+                    for attr in cascade_attrs.iter() {
                         if !changed_create_only.contains(attr) {
-                            changed_create_only.push(attr.clone());
+                            changed_create_only.push(attr.to_string());
                         }
                     }
                     for hint in &ref_hints {
@@ -649,7 +649,10 @@ mod tests {
             from: Box::new(from),
             to,
             directives: Directives::default(),
-            changed_create_only: vec!["cidr_block".to_string()],
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+                "cidr_block".to_string(),
+            ])
+            .unwrap(),
             cascading_updates: vec![cascading],
             temporary_name: None,
             cascade_ref_hints: vec![],
@@ -685,7 +688,10 @@ mod tests {
             from: Box::new(from),
             to,
             directives: Directives::default(),
-            changed_create_only: vec!["cidr_block".to_string()],
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+                "cidr_block".to_string(),
+            ])
+            .unwrap(),
             cascading_updates: vec![cascading],
             temporary_name: None,
             cascade_ref_hints: vec![],

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -4055,11 +4055,6 @@ pub struct ResourceSchema {
     /// Used for automatic unique name generation during create-before-destroy replacement.
     /// (e.g., "bucket_name" for s3.bucket, "log_group_name" for logs.log_group)
     pub name_attribute: Option<String>,
-    /// If true, updates are not supported for this resource type.
-    /// The differ will always generate Replace instead of Update.
-    /// Used for resource types where the provider API rejects updates
-    /// despite the schema indicating update support.
-    pub force_replace: bool,
     /// Per-resource operational config (timeouts, retries).
     /// When None, provider defaults are used.
     pub operation_config: Option<OperationConfig>,
@@ -4110,7 +4105,6 @@ impl ResourceSchema {
             validator: None,
             kind: SchemaKind::Resource,
             name_attribute: None,
-            force_replace: false,
             operation_config: None,
             exclusive_required: Vec::new(),
             default_wait_timeout: None,
@@ -4284,11 +4278,6 @@ impl ResourceSchema {
 
     pub fn with_name_attribute(mut self, attr: impl Into<String>) -> Self {
         self.name_attribute = Some(attr.into());
-        self
-    }
-
-    pub fn force_replace(mut self) -> Self {
-        self.force_replace = true;
         self
     }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -446,7 +446,6 @@ fn make_schema(resource_type: &str, attrs: Vec<(&str, AttributeType)>) -> Resour
         validator: None,
         kind: crate::schema::SchemaKind::Resource,
         name_attribute: None,
-        force_replace: false,
         operation_config: None,
         exclusive_required: Vec::new(),
         default_wait_timeout: None,

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -690,7 +690,6 @@ fn proto_schema_to_core(
             proto::SchemaKind::DataSource => carina_core::schema::SchemaKind::DataSource,
         },
         name_attribute: s.name_attribute.clone(),
-        force_replace: s.force_replace,
         operation_config: s.operation_config.as_ref().map(|c| {
             carina_core::schema::OperationConfig {
                 delete_timeout_secs: c.delete_timeout_secs,
@@ -1633,7 +1632,6 @@ mod tests {
             "resource_type": "ec2.SecurityGroup",
             "description": "EC2 Security Group",
             "name_attribute": "group_name",
-            "force_replace": true,
             "attributes": {
               "ingress": {
                 "name": "ingress",
@@ -1717,7 +1715,6 @@ mod tests {
         assert_eq!(schema.description.as_deref(), Some("EC2 Security Group"));
         assert!(!schema.is_data_source());
         assert_eq!(schema.name_attribute.as_deref(), Some("group_name"));
-        assert!(schema.force_replace);
 
         // Basic attribute types
         let desc_attr = schema
@@ -1917,7 +1914,6 @@ mod tests {
             description: None,
             kind: proto::SchemaKind::Managed,
             name_attribute: None,
-            force_replace: false,
             operation_config: None,
             validators: vec![proto::ValidatorType::TagsKeyValueCheck],
             exclusive_required: vec![],
@@ -1935,7 +1931,6 @@ mod tests {
             description: None,
             kind: proto::SchemaKind::Managed,
             name_attribute: None,
-            force_replace: false,
             operation_config: None,
             validators: vec![],
             exclusive_required: vec![],
@@ -1955,7 +1950,6 @@ mod tests {
             description: None,
             kind: proto::SchemaKind::Managed,
             name_attribute: None,
-            force_replace: false,
             operation_config: None,
             validators: vec![],
             exclusive_required: vec![vec![
@@ -1994,7 +1988,6 @@ mod tests {
             description: None,
             kind: proto::SchemaKind::Managed,
             name_attribute: None,
-            force_replace: false,
             operation_config: None,
             validators: vec![],
             exclusive_required: vec![vec!["a".to_string(), "b".to_string()]],
@@ -2650,7 +2643,6 @@ mod tests {
             description: None,
             kind: proto::SchemaKind::Managed,
             name_attribute: None,
-            force_replace: false,
             operation_config: None,
             validators: vec![proto::ValidatorType::TagsKeyValueCheck],
             exclusive_required: vec![],

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -326,8 +326,6 @@ pub struct ResourceSchema {
     pub kind: SchemaKind,
     #[serde(default)]
     pub name_attribute: Option<String>,
-    #[serde(default)]
-    pub force_replace: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub operation_config: Option<OperationConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -850,7 +848,6 @@ mod tests {
             description: None,
             kind: SchemaKind::Managed,
             name_attribute: None,
-            force_replace: false,
             operation_config: None,
             validators: vec![],
             exclusive_required: vec![],

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -188,7 +188,8 @@ fn replace_effect_symbols() {
             create_before_destroy: true,
             ..Default::default()
         },
-        changed_create_only: vec!["cidr".to_string()],
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec!["cidr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -200,7 +201,8 @@ fn replace_effect_symbols() {
         from,
         to: Resource::new("ec2.Vpc", "my-vpc2"),
         directives: Directives::default(),
-        changed_create_only: vec!["cidr".to_string()],
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec!["cidr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -746,7 +748,8 @@ fn move_suppressed_when_replace_exists_for_same_target() {
         )),
         to: Resource::new("ec2.Vpc", "new-vpc"),
         directives: Directives::default(),
-        changed_create_only: vec!["cidr".to_string()],
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec!["cidr".to_string()])
+            .unwrap(),
         cascading_updates: vec![],
         temporary_name: None,
         cascade_ref_hints: vec![],


### PR DESCRIPTION
Closes #3471

## What

Two changes, one invariant:

1. **Remove the resource-level `force_replace` mechanism.** Its only setters were two awscc generated schemas, removed in carina-provider-awscc#347 after live-AWS verification showed the original "CloudControl API rejects updates" rationale (#595) was a misread of the provider's own old hardcoded VPC-only update check. Removed end-to-end: `ResourceSchema` field + `force_replace()` builder, the differ's `schema_force_replace` branch + its test, the protocol wire field, the plugin-host mapping + boundary-test assertions.
2. **Make `Effect::Replace.changed_create_only` non-empty by type.** The flag was the only producer of a Replace with an empty `changed_create_only` — i.e. the only source of a `must be replaced` plan with no `(forces replacement)` attribute line (carina-provider-awscc#346 expected-2). `ChangedCreateOnly` is a domain wrapper over the existing `NonEmptyVec<String>` primitive (which gains `push`/`into_vec`); the fallible constructor is the proof, and all three Replace producers branch on it:
   - differ main branch: `if let Some(c) = ChangedCreateOnly::new(...)` → Replace, else → Update
   - promoted cascade replaces: same constructor-as-proof shape
   - cascade merge: `CascadeMerge.create_only_attrs` and `Plan::merge_cascade_create_only` carry the typed value, so the Update→Replace upgrade consumes a proven-non-empty list with no runtime fallback

## Wire compatibility

- Protocol: no `deny_unknown_fields`, so pinned providers still serializing `force_replace` stay wire-compatible; both provider repos drop their `convert.rs` mappings at the next rev bump (they never set it — verified).
- Saved plans: the JSON shape stays a plain array (`serde(try_from/into)`, round-trip tested). A saved plan containing `"changed_create_only": []` — only producible by the removed force_replace path — now fails to load with `Replace effect requires at least one changed create-only attribute` instead of applying an unexplained replacement.

## Tests

- TDD red observed: `replace_deserialize_rejects_empty_changed_create_only` failed (empty list accepted) before the newtype landed.
- Wire-shape round-trip test; constructor/push unit tests; `compile_fail` doctest pinning private construction (verified standalone: fails with E0423 private-fields, the intended reason).
- `replace_when_schema_force_replace` deleted (behavior no longer exists); all other tests adapted.

## Follow-ups

- #3472 (filed from this PR's review): display-seam totality — `build_replace_rows` pre-filters removal-typed forcing attributes (latent, requires a create-only+removable schema combination no schema has), and no e2e plan-display fixture exercises Replace (needs a create-only attribute in carina-provider-mock).
- Provider repos: 2-line `convert.rs` mapping removal each at next rev bump.

## Verification

- `cargo nextest run --workspace --all-features`: 4044 passed, 0 failed
- `cargo test --workspace --doc`: pass (incl. compile_fail doctests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean
- `scripts/check-*.sh`: all 5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)