### PR TITLE
Render removal-typed forcing attributes; add e2e Replace plan fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ plan-empty-explicit-children-no-changes:
 	$(PLAN_FIXTURE) empty_explicit_children_no_changes
 plan-mixed:
 	$(PLAN_FIXTURE) mixed_operations
+plan-replace-create-only:
+	$(PLAN_FIXTURE) replace_create_only
 plan-delete:
 	$(PLAN_FIXTURE) delete_orphan
 plan-delete-list-of-maps:
@@ -277,7 +279,8 @@ plan-multi-instance-create:
 plan-multi-instance-module:
 	$(PLAN_FIXTURE) multi_instance_module
 .PHONY: plan-all-create plan-no-changes plan-empty-explicit-children-no-changes plan-no-changes-enum plan-dynamic-enum-az-no-diff plan-route53-hosted-zone-name-strip-suffix-no-diff plan-mixed plan-delete plan-delete-list-of-maps plan-compact plan-import-deferred-interpolation \
-        plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
+        plan-map-diff plan-replace-create-only \
+        plan-list-diff-added-struct plan-list-diff-removed-struct \
         plan-list-diff-modified-with-unchanged \
         plan-list-diff-modified-with-unchanged-nested \
         plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -8,8 +8,6 @@ use carina_core::detail_rows::{
     ListOfMapsDiffModified, MapDiffEntryIR, build_detail_rows, hidden_unchanged_summary,
 };
 #[cfg(test)]
-use carina_core::diff_helpers::compute_map_diff;
-#[cfg(test)]
 use carina_core::effect::CascadingUpdate;
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
@@ -22,7 +20,7 @@ use carina_core::resource::{ConcreteValue, DeferredValue, ResourceId, Value};
 use carina_core::schema::SchemaRegistry;
 use carina_core::value::format_value_pretty;
 #[cfg(test)]
-use carina_core::value::{format_value, format_value_with_key, is_list_of_maps, map_similarity};
+use carina_core::value::format_value_with_key;
 
 use crate::DetailLevel;
 
@@ -1516,6 +1514,18 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
             )
             .unwrap();
         }
+        DetailRow::ReplaceRemoved { key, old } => {
+            writeln!(
+                out,
+                "{}{}: {} → {} {}",
+                attr_prefix,
+                key,
+                old.red().strikethrough(),
+                "(removed)".red().strikethrough(),
+                "(forces replacement)".magenta()
+            )
+            .unwrap();
+        }
         DetailRow::ReplaceCascade { key, old, new } => {
             writeln!(
                 out,
@@ -1964,351 +1974,6 @@ pub fn format_effect(effect: &Effect) -> String {
             format!("Wait {} (until {})", binding, until_surface)
         }
     }
-}
-
-/// Check if both old and new values are `Value::Concrete(ConcreteValue::Map)`.
-#[cfg(test)]
-fn is_both_maps(old_value: Option<&Value>, new_value: &Value) -> bool {
-    matches!(
-        (old_value, new_value),
-        (
-            Some(Value::Concrete(ConcreteValue::Map(_))),
-            Value::Concrete(ConcreteValue::Map(_))
-        )
-    )
-}
-
-/// Format a key-level diff between two map values.
-///
-/// Shows only the keys that changed:
-/// - `+ key: "value"` for added keys
-/// - `- key: "value"` for removed keys
-/// - `~ key: "old" -> "new"` for changed keys
-///
-/// Unchanged keys are not shown.
-#[cfg(test)]
-fn format_map_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &str) -> String {
-    let new_map = match new_value {
-        Value::Concrete(ConcreteValue::Map(m)) => m,
-        _ => return format_value(new_value),
-    };
-    let old_map = match old_value {
-        Some(Value::Concrete(ConcreteValue::Map(m))) => m,
-        _ => {
-            // No old map; treat all new keys as added
-            let empty = indexmap::IndexMap::new();
-            let diff = compute_map_diff(&empty, new_map);
-            let mut lines = Vec::new();
-            for entry in &diff.added {
-                lines.push(format!(
-                    "{}  {} {}: {}",
-                    attr_prefix,
-                    "+".green(),
-                    entry.key,
-                    format_value_with_key(&entry.value, Some(&entry.key)).green()
-                ));
-            }
-            return lines.join("\n");
-        }
-    };
-
-    let diff = compute_map_diff(old_map, new_map);
-    let mut lines = Vec::new();
-
-    // Merge all entries into a single list sorted by key (preserving original ordering)
-    for entry in diff.iter_by_key() {
-        match entry {
-            carina_core::diff_helpers::MapDiffItem::Changed(e) => {
-                lines.push(format!(
-                    "{}  {} {}: {} → {}",
-                    attr_prefix,
-                    "~".yellow(),
-                    e.key,
-                    format_value_with_key(&e.old_value, Some(&e.key))
-                        .red()
-                        .strikethrough(),
-                    format_value_with_key(&e.new_value, Some(&e.key)).green()
-                ));
-            }
-            carina_core::diff_helpers::MapDiffItem::Added(e) => {
-                lines.push(format!(
-                    "{}  {} {}: {}",
-                    attr_prefix,
-                    "+".green(),
-                    e.key,
-                    format_value_with_key(&e.value, Some(&e.key)).green()
-                ));
-            }
-            carina_core::diff_helpers::MapDiffItem::Removed(e) => {
-                lines.push(format!(
-                    "{}  {} {}: {}",
-                    attr_prefix,
-                    "-".red().strikethrough(),
-                    e.key,
-                    format_value_with_key(&e.value, Some(&e.key))
-                        .red()
-                        .strikethrough()
-                ));
-            }
-        }
-    }
-
-    lines.join("\n")
-}
-
-/// Format a list-of-maps diff for Update effect display.
-/// Uses content-matched comparison (multiset matching) instead of index-based.
-/// 1. Find exact matches between old and new items
-/// 2. Pair remaining unmatched items by similarity for field-level diffs
-/// 3. Display unchanged, modified (~), added (+), and removed (-) items
-#[cfg(test)]
-fn format_list_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &str) -> String {
-    let new_items = match new_value {
-        Value::Concrete(ConcreteValue::List(items)) => items,
-        _ => return format_value(new_value),
-    };
-    let old_items = match old_value {
-        Some(Value::Concrete(ConcreteValue::List(items))) => items,
-        _ => &vec![] as &Vec<Value>,
-    };
-
-    let mut old_matched = vec![false; old_items.len()];
-    let mut new_matched = vec![false; new_items.len()];
-
-    // Phase 1: Find exact matches (semantically equal items)
-    for (ni, new_item) in new_items.iter().enumerate() {
-        for (oi, old_item) in old_items.iter().enumerate() {
-            if !old_matched[oi] && old_item.semantically_equal(new_item) {
-                old_matched[oi] = true;
-                new_matched[ni] = true;
-                break;
-            }
-        }
-    }
-
-    // Collect unmatched items
-    let unmatched_old: Vec<usize> = old_matched
-        .iter()
-        .enumerate()
-        .filter(|(_, m)| !**m)
-        .map(|(i, _)| i)
-        .collect();
-    let unmatched_new: Vec<usize> = new_matched
-        .iter()
-        .enumerate()
-        .filter(|(_, m)| !**m)
-        .map(|(i, _)| i)
-        .collect();
-
-    // Phase 2: Pair unmatched items by similarity (most shared key-value pairs)
-    let mut paired: Vec<(usize, usize)> = Vec::new();
-    let mut paired_old = vec![false; unmatched_old.len()];
-    let mut paired_new = vec![false; unmatched_new.len()];
-
-    for (ui_new, &ni) in unmatched_new.iter().enumerate() {
-        let mut best_oi_idx = None;
-        let mut best_sim = 0usize;
-        for (ui_old, &oi) in unmatched_old.iter().enumerate() {
-            if paired_old[ui_old] {
-                continue;
-            }
-            let sim = map_similarity(&old_items[oi], &new_items[ni]);
-            if sim > best_sim {
-                best_sim = sim;
-                best_oi_idx = Some(ui_old);
-            }
-        }
-        if let Some(ui_old) = best_oi_idx.filter(|_| best_sim > 0) {
-            paired.push((unmatched_old[ui_old], ni));
-            paired_old[ui_old] = true;
-            paired_new[ui_new] = true;
-        }
-    }
-
-    // Remaining truly added/removed items
-    let added: Vec<usize> = unmatched_new
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| !paired_new[*i])
-        .map(|(_, &ni)| ni)
-        .collect();
-    let removed: Vec<usize> = unmatched_old
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| !paired_old[*i])
-        .map(|(_, &oi)| oi)
-        .collect();
-
-    // Phase 3: Build output
-    let mut lines = Vec::new();
-
-    // Show unchanged items (exact matches from new list order)
-    for (ni, new_item) in new_items.iter().enumerate() {
-        if let Value::Concrete(ConcreteValue::Map(map)) = new_item
-            && new_matched[ni]
-        {
-            let mut keys: Vec<_> = map.keys().collect();
-            keys.sort();
-            let fields: Vec<String> = keys
-                .iter()
-                .map(|k| format!("{}: {}", k, format_value(&map[*k])))
-                .collect();
-            lines.push(format!("{}    {{{}}}", attr_prefix, fields.join(", ")));
-        }
-    }
-
-    // Show modified items (paired by similarity)
-    for &(oi, ni) in &paired {
-        if let (
-            Value::Concrete(ConcreteValue::Map(old_map)),
-            Value::Concrete(ConcreteValue::Map(new_map)),
-        ) = (&old_items[oi], &new_items[ni])
-        {
-            let mut keys: Vec<_> = new_map.keys().collect();
-            keys.sort();
-            let fields: Vec<String> = keys
-                .iter()
-                .map(|k| {
-                    let new_v = format_value(&new_map[*k]);
-                    let field_same = old_map
-                        .get(*k)
-                        .map(|ov| ov.semantically_equal(&new_map[*k]))
-                        .unwrap_or(false);
-                    if !field_same {
-                        let old_v = old_map
-                            .get(*k)
-                            .map(format_value)
-                            .unwrap_or_else(|| "(none)".to_string());
-                        format!("{}: {} → {}", k, old_v.red().strikethrough(), new_v.green())
-                    } else {
-                        format!("{}: {}", k, new_v)
-                    }
-                })
-                .collect();
-            lines.push(format!(
-                "{}  {} {{{}}}",
-                attr_prefix,
-                "~".yellow().bold(),
-                fields.join(", ")
-            ));
-        }
-    }
-
-    // Show added items
-    for &ni in &added {
-        if let Value::Concrete(ConcreteValue::Map(map)) = &new_items[ni] {
-            let mut keys: Vec<_> = map.keys().collect();
-            keys.sort();
-            let fields: Vec<String> = keys
-                .iter()
-                .map(|k| format!("{}: {}", k, format_value(&map[*k])))
-                .collect();
-            lines.push(format!(
-                "{}  {} {{{}}}",
-                attr_prefix,
-                "+".green().bold(),
-                fields.join(", ")
-            ));
-        }
-    }
-
-    // Show removed items
-    for &oi in &removed {
-        if let Value::Concrete(ConcreteValue::Map(map)) = &old_items[oi] {
-            let mut keys: Vec<_> = map.keys().collect();
-            keys.sort();
-            let fields: Vec<String> = keys
-                .iter()
-                .map(|k| format!("{}: {}", k, format_value(&map[*k])))
-                .collect();
-            lines.push(format!(
-                "{}  {} {{{}}}",
-                attr_prefix,
-                "-".red().bold().strikethrough(),
-                fields.join(", ").red().strikethrough()
-            ));
-        }
-    }
-
-    lines.join("\n")
-}
-
-/// Format the changed_create_only attributes for a Replace effect.
-///
-/// Only shows attributes listed in `changed_create_only` that exist in `to_attrs`.
-/// When the old and new values are semantically equal (cascade-triggered replacement
-/// where the new value is not yet known), the attribute is shown with
-/// "(forces replacement, known after apply)" instead of being hidden.
-#[cfg(test)]
-fn format_replace_changed_attrs(
-    from_attrs: &std::collections::HashMap<String, Value>,
-    to_attrs: &std::collections::HashMap<String, Value>,
-    changed_create_only: &[String],
-    attr_prefix: &str,
-    cascade_ref_hints: &[(String, String)],
-) -> String {
-    let mut lines = Vec::new();
-    let mut keys: Vec<_> = changed_create_only
-        .iter()
-        .filter(|k| to_attrs.contains_key(k.as_str()))
-        .collect();
-    keys.sort();
-    for key in keys {
-        let new_value = &to_attrs[key.as_str()];
-        let old_value = from_attrs.get(key.as_str());
-        let is_same = old_value
-            .map(|ov| ov.semantically_equal(new_value))
-            .unwrap_or(false);
-        if is_same {
-            // Value hasn't visibly changed yet — this is a cascade-triggered
-            // create-only attr whose new value is unknown until the
-            // depended-upon resource is replaced.
-            let old_str = old_value
-                .map(|v| format_value_with_key(v, Some(key)))
-                .unwrap_or_else(|| "(none)".to_string());
-            // Use the original ResourceRef hint if available, otherwise show the resolved value
-            let new_str = cascade_ref_hints
-                .iter()
-                .find(|(attr, _)| attr == key)
-                .map(|(_, hint)| hint.clone())
-                .unwrap_or_else(|| format_value_with_key(new_value, Some(key)));
-            lines.push(format!(
-                "{}{}: {} → {} {}\n",
-                attr_prefix,
-                key,
-                old_str.red().strikethrough(),
-                new_str.green(),
-                "(forces replacement, known after apply)".magenta()
-            ));
-        } else if is_list_of_maps(new_value) {
-            let suffix = format!(" {}", "(forces replacement)".magenta());
-            lines.push(format!("{}{}:{}\n", attr_prefix, key, suffix));
-            lines.push(format!(
-                "{}\n",
-                format_list_diff(old_value, new_value, attr_prefix)
-            ));
-        } else if is_both_maps(old_value, new_value) {
-            let suffix = format!(" {}", "(forces replacement)".magenta());
-            lines.push(format!("{}{}:{}\n", attr_prefix, key, suffix));
-            lines.push(format!(
-                "{}\n",
-                format_map_diff(old_value, new_value, attr_prefix)
-            ));
-        } else {
-            let old_str = old_value
-                .map(|v| format_value_with_key(v, Some(key)))
-                .unwrap_or_else(|| "(none)".to_string());
-            lines.push(format!(
-                "{}{}: {} → {} {}\n",
-                attr_prefix,
-                key,
-                old_str.red().strikethrough(),
-                format_value_with_key(new_value, Some(key)).green(),
-                "(forces replacement)".magenta()
-            ));
-        }
-    }
-    lines.concat()
 }
 
 #[cfg(test)]

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -878,32 +878,32 @@ fn test_format_cascading_update_attr_diff() {
 /// NOT be hidden even though `semantically_equal` returns true.
 #[test]
 fn test_replace_changed_create_only_same_value_shown_as_known_after_apply() {
-    use std::collections::HashMap;
-
-    let from_attrs = HashMap::from([
-        (
-            "vpc_id".to_string(),
+    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "subnet", None);
+    let from = State::existing(
+        id.clone(),
+        [
+            (
+                "vpc_id".to_string(),
+                Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+            ),
+            (
+                "cidr_block".to_string(),
+                Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    let mut to = Resource::new("ec2.Subnet", "subnet")
+        .with_attribute(
+            "vpc_id",
             Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
-        ),
-        (
-            "cidr_block".to_string(),
+        )
+        .with_attribute(
+            "cidr_block",
             Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
-        ),
-    ]);
-    let to_attrs = HashMap::from([
-        (
-            "_binding".to_string(),
-            Value::Concrete(ConcreteValue::String("subnet".to_string())),
-        ),
-        (
-            "vpc_id".to_string(),
-            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
-        ),
-        (
-            "cidr_block".to_string(),
-            Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
-        ),
-    ]);
+        );
+    to.id = id.clone();
 
     // Verify the precondition: the values are semantically equal
     assert!(
@@ -913,8 +913,32 @@ fn test_replace_changed_create_only_same_value_shown_as_known_after_apply() {
         "precondition: old and new vpc_id should be semantically equal"
     );
 
-    let output =
-        format_replace_changed_attrs(&from_attrs, &to_attrs, &["vpc_id".to_string()], "    ", &[]);
+    let effect = Effect::Replace {
+        id,
+        from: Box::new(from),
+        to,
+        directives: Directives::default(),
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
+            "vpc_id".to_string(),
+        ])
+        .unwrap(),
+        cascading_updates: Vec::<CascadingUpdate>::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    };
+    let mut plan = Plan::new();
+    plan.add(effect);
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        None,
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        None,
+    );
 
     // vpc_id must appear in output, not be hidden
     assert!(
@@ -946,25 +970,47 @@ fn test_replace_changed_create_only_same_value_shown_as_known_after_apply() {
 /// binding instead of the resolved value for cascade-triggered same-value attributes.
 #[test]
 fn test_replace_cascade_ref_hints_show_binding() {
-    use std::collections::HashMap;
-
-    let from_attrs = HashMap::from([(
-        "vpc_id".to_string(),
+    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "subnet", None);
+    let from = State::existing(
+        id.clone(),
+        [(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-0bf023ff87bf1aa0c".to_string())),
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let mut to = Resource::new("ec2.Subnet", "subnet").with_attribute(
+        "vpc_id",
         Value::Concrete(ConcreteValue::String("vpc-0bf023ff87bf1aa0c".to_string())),
-    )]);
-    let to_attrs = HashMap::from([(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-0bf023ff87bf1aa0c".to_string())),
-    )]);
+    );
+    to.id = id.clone();
 
-    let hints = vec![("vpc_id".to_string(), "vpc.vpc_id".to_string())];
-
-    let output = format_replace_changed_attrs(
-        &from_attrs,
-        &to_attrs,
-        &["vpc_id".to_string()],
-        "    ",
-        &hints,
+    let effect = Effect::Replace {
+        id,
+        from: Box::new(from),
+        to,
+        directives: Directives::default(),
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
+            "vpc_id".to_string(),
+        ])
+        .unwrap(),
+        cascading_updates: Vec::<CascadingUpdate>::new(),
+        temporary_name: None,
+        cascade_ref_hints: vec![("vpc_id".to_string(), "vpc.vpc_id".to_string())],
+    };
+    let mut plan = Plan::new();
+    plan.add(effect);
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        None,
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        None,
     );
 
     // Must show the ResourceRef hint instead of the resolved value on the right side
@@ -1364,6 +1410,58 @@ fn format_effect_replace_separates_type_and_name_with_space() {
         cascade_ref_hints: Vec::new(),
     };
     assert_eq!(format_effect(&effect), "Replace awscc.ec2.Vpc vpc");
+}
+
+#[test]
+fn format_replace_with_removed_create_only_attribute_shows_forcing_detail() {
+    let id = ResourceId::with_provider("test", "Widget", "beta", None);
+    let from = State::existing(
+        id.clone(),
+        [(
+            "legacy_token".to_string(),
+            Value::Concrete(ConcreteValue::String("tok".to_string())),
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let mut to = Resource::new("Widget", "beta");
+    to.id = id.clone();
+    let effect = Effect::Replace {
+        id,
+        from: Box::new(from),
+        to,
+        directives: Directives::default(),
+        changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
+            "legacy_token".to_string(),
+        ])
+        .unwrap(),
+        cascading_updates: Vec::<CascadingUpdate>::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    };
+    let mut plan = Plan::new();
+    plan.add(effect);
+
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        None,
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        None,
+    );
+
+    assert!(
+        output.contains("legacy_token"),
+        "expected removed create-only key in replace details, got:\n{output}"
+    );
+    assert!(
+        output.contains("(forces replacement)"),
+        "expected forcing annotation in replace details, got:\n{output}"
+    );
 }
 
 #[test]

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -395,10 +395,60 @@ fn fixture_provider_factories(fixture_path: &Path) -> Vec<Box<dyn ProviderFactor
         Some("moved_claims_precede_heuristics") => {
             vec![Box::new(MovedClaimsPrecedeHeuristicsFixtureFactory)]
         }
+        Some("replace_create_only") => vec![Box::new(ReplaceCreateOnlyFixtureFactory)],
         Some("route53_hosted_zone_name_strip_suffix_no_diff") => {
             vec![Box::new(Route53HostedZoneFixtureFactory)]
         }
         _ => vec![],
+    }
+}
+
+struct ReplaceCreateOnlyFixtureFactory;
+
+impl ProviderFactory for ReplaceCreateOnlyFixtureFactory {
+    fn name(&self) -> &str {
+        "test"
+    }
+
+    fn display_name(&self) -> &str {
+        "Test fixture provider"
+    }
+
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+
+    fn validate_config(
+        &self,
+        _attributes: &indexmap::IndexMap<String, Value>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn extract_region(&self, _attributes: &indexmap::IndexMap<String, Value>) -> String {
+        "test-region".to_string()
+    }
+
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &indexmap::IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { unreachable!("plan fixture does not instantiate providers") })
+    }
+
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![
+            ResourceSchema::new("test.Widget")
+                .attribute(
+                    AttributeSchema::new("external_name", AttributeType::string()).create_only(),
+                )
+                .attribute(
+                    AttributeSchema::new("legacy_token", AttributeType::string())
+                        .create_only()
+                        .removable(),
+                ),
+        ]
     }
 }
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -412,6 +412,23 @@ fn snapshot_mixed_operations() {
 }
 
 #[test]
+fn snapshot_replace_create_only() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("replace_create_only");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        None,
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn snapshot_delete_orphan() {
     use carina_core::resource::Value;
     let (plan, current_states, schemas, _moved) =
@@ -970,7 +987,6 @@ fn collect_unused_let_bindings_in_fixtures(
             continue;
         }
         let fixture_name = entry.file_name().to_string_lossy().to_string();
-
         let loaded = load_configuration(&fixture_dir).unwrap();
         let unused = crate::wiring::check_unused_bindings(&loaded.unresolved_parsed);
         if unused.is_empty() {

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_prev_keys.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_prev_keys.snap
@@ -5,7 +5,11 @@ expression: output
 Execution Plan:
 
   ~ awscc.ec2.Vpc new_vpc (moved from: old_vpc)
-      tags: [{key: "Name", value: "old"}] → (removed)
+      tags:
+        - {
+            key: "Name"
+            value: "old"
+          }
       # (1 unchanged attribute hidden)
         │
         └─ + awscc.ec2.Subnet 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_replace_create_only.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_replace_create_only.snap
@@ -1,0 +1,12 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  -/+ test.test.Widget alpha (must be replaced)
+      external_name: "old" → "new" (forces replacement)
+  -/+ test.test.Widget beta (must be replaced)
+      legacy_token: "tok" → (removed) (forces replacement)
+
+Plan: 0 to add, 0 to change, 2 to replace, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/replace_create_only/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/replace_create_only/carina.state.json
@@ -1,0 +1,62 @@
+{
+  "version": 7,
+  "serial": 1,
+  "lineage": "test-replace-create-only",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "test.Widget",
+      "name": "alpha",
+      "provider": "test",
+      "identifier": "widget-alpha-live",
+      "attributes": {
+        "id": "widget-alpha-live",
+        "external_name": "old"
+      },
+      "protected": false,
+      "directives": {
+        "force_delete": false,
+        "create_before_destroy": false
+      },
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "alpha",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "external_name": {
+            "kind": "leaf"
+          }
+        }
+      }
+    },
+    {
+      "resource_type": "test.Widget",
+      "name": "beta",
+      "provider": "test",
+      "identifier": "widget-beta-live",
+      "attributes": {
+        "id": "widget-beta-live",
+        "legacy_token": "tok"
+      },
+      "protected": false,
+      "directives": {
+        "force_delete": false,
+        "create_before_destroy": false
+      },
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "beta",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "legacy_token": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/replace_create_only/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/replace_create_only/main.crn
@@ -1,0 +1,12 @@
+provider test {}
+
+let alpha = test.test.Widget {
+  external_name = "new"
+}
+
+let beta = test.test.Widget {}
+
+exports {
+  alpha_name = alpha.external_name
+  beta_token = beta.legacy_token
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -92,6 +92,8 @@ pub enum DetailRow {
         old: String,
         new: String,
     },
+    /// A removed create-only attribute that forces replacement.
+    ReplaceRemoved { key: String, old: String },
     /// A cascade-triggered create-only attribute (value not yet known)
     ReplaceCascade {
         key: String,
@@ -726,6 +728,9 @@ fn build_update_rows(
     removed_keys.sort();
     for key in removed_keys {
         if let Some(old_value) = from_attrs_projected.get(key.as_str()) {
+            let attr_type = schema
+                .and_then(|s| s.attributes.get(key.as_str()))
+                .map(|a| &a.attr_type);
             // Mirror the addition direction (#2936): when a Map
             // attribute is dropped entirely, route through `MapDiff`
             // so each key renders on its own line as `- key: "value"`
@@ -734,6 +739,30 @@ fn build_update_rows(
             if let Some(row) = build_map_removed_row(key, old_value) {
                 rows.push(row);
                 continue;
+            }
+            if is_list_of_maps(old_value) {
+                let empty_list = Value::Concrete(ConcreteValue::List(Vec::new()));
+                let (unchanged, modified, added, removed) = compute_list_of_maps_diff_parts(
+                    Some(old_value),
+                    &empty_list,
+                    attr_type,
+                    defs,
+                    detail,
+                );
+                if !(unchanged.is_empty()
+                    && modified.is_empty()
+                    && added.is_empty()
+                    && removed.is_empty())
+                {
+                    rows.push(DetailRow::ListOfMapsDiff {
+                        key: key.to_string(),
+                        unchanged,
+                        modified,
+                        added,
+                        removed,
+                    });
+                    continue;
+                }
             }
             rows.push(DetailRow::Removed {
                 key: key.to_string(),
@@ -778,15 +807,20 @@ fn build_replace_rows(
         .unwrap_or(empty_defs_for_schema_walks());
 
     // Show changed create-only attributes
-    let mut keys: Vec<_> = changed_create_only
-        .iter()
-        .filter(|k| to.attributes.contains_key(k.as_str()))
-        .collect();
+    let mut keys: Vec<_> = changed_create_only.iter().collect();
     keys.sort();
 
     for key in keys {
-        let new_value = &to.attributes[key.as_str()];
         let old_value = from.attributes.get(key.as_str());
+        let Some(new_value) = to.attributes.get(key.as_str()) else {
+            let attr_type = schema
+                .and_then(|s| s.attributes.get(key.as_str()))
+                .map(|a| &a.attr_type);
+            rows.push(build_replace_removed_row(
+                key, old_value, attr_type, defs, detail,
+            ));
+            continue;
+        };
         let attr_type = schema
             .and_then(|s| s.attributes.get(key.as_str()))
             .map(|a| &a.attr_type);
@@ -923,6 +957,49 @@ fn build_replace_rows(
     }
 
     rows
+}
+
+fn build_replace_removed_row(
+    key: &str,
+    old_value: Option<&Value>,
+    attr_type: Option<&AttributeType>,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
+    detail: DetailLevel,
+) -> DetailRow {
+    let Some(old_value) = old_value else {
+        return DetailRow::ReplaceRemoved {
+            key: key.to_string(),
+            old: "(none)".to_string(),
+        };
+    };
+
+    if let Some(DetailRow::MapDiff { entries, .. }) = build_map_removed_row(key, old_value) {
+        return DetailRow::ReplaceMapDiff {
+            key: key.to_string(),
+            entries: entries.into_vec(),
+        };
+    }
+
+    if is_list_of_maps(old_value) {
+        let empty_list = Value::Concrete(ConcreteValue::List(Vec::new()));
+        let (unchanged, modified, added, removed) =
+            compute_list_of_maps_diff_parts(Some(old_value), &empty_list, attr_type, defs, detail);
+        if !(unchanged.is_empty() && modified.is_empty() && added.is_empty() && removed.is_empty())
+        {
+            return DetailRow::ReplaceListOfMapsDiff {
+                key: key.to_string(),
+                unchanged,
+                modified,
+                added,
+                removed,
+            };
+        }
+    }
+
+    DetailRow::ReplaceRemoved {
+        key: key.to_string(),
+        old: format_value_with_key(old_value, Some(key)),
+    }
 }
 
 fn build_delete_rows(
@@ -1851,6 +1928,57 @@ mod tests {
     }
 
     #[test]
+    fn update_removed_list_of_maps_attribute_emits_list_diff_row() {
+        let mut rule = IndexMap::new();
+        rule.insert(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("legacy".to_string())),
+        );
+        rule.insert(
+            "priority".to_string(),
+            Value::Concrete(ConcreteValue::Int(10)),
+        );
+        let old_rules = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(rule.clone()),
+        )]));
+        let from = State::existing(
+            ResourceId::new("test.Widget", "beta"),
+            [("rules".to_string(), old_rules)].into_iter().collect(),
+        );
+        let to = Resource::new("test.Widget", "beta");
+        let effect = Effect::Update {
+            id: ResourceId::new("test.Widget", "beta"),
+            from: Box::new(from),
+            to,
+            changed_attributes: vec!["rules".to_string()],
+        };
+
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
+
+        assert_eq!(
+            rows,
+            vec![DetailRow::ListOfMapsDiff {
+                key: "rules".to_string(),
+                unchanged: vec![],
+                modified: vec![],
+                added: vec![],
+                removed: vec![ListOfMapsDiffItem {
+                    fields: vec![
+                        (
+                            "name".to_string(),
+                            Value::Concrete(ConcreteValue::String("legacy".to_string())),
+                        ),
+                        (
+                            "priority".to_string(),
+                            Value::Concrete(ConcreteValue::Int(10))
+                        ),
+                    ],
+                }],
+            }]
+        );
+    }
+
+    #[test]
     fn test_create_map_expanded() {
         let mut tags = IndexMap::new();
         tags.insert(
@@ -2089,6 +2217,154 @@ mod tests {
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert_eq!(rows.len(), 1);
         assert!(matches!(&rows[0], DetailRow::ReplaceChanged { key, .. } if key == "cidr_block"));
+    }
+
+    #[test]
+    fn replace_removed_create_only_attribute_emits_detail_row() {
+        let from = State::existing(
+            ResourceId::new("test.Widget", "beta"),
+            [(
+                "legacy_token".to_string(),
+                Value::Concrete(ConcreteValue::String("tok".to_string())),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let to = Resource::new("test.Widget", "beta");
+        let effect = Effect::Replace {
+            id: ResourceId::new("test.Widget", "beta"),
+            from: Box::new(from),
+            to,
+            directives: crate::resource::Directives::default(),
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+                "legacy_token".to_string(),
+            ])
+            .unwrap(),
+            cascading_updates: vec![],
+            temporary_name: None,
+            cascade_ref_hints: vec![],
+        };
+
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
+
+        assert_eq!(
+            rows,
+            vec![DetailRow::ReplaceRemoved {
+                key: "legacy_token".to_string(),
+                old: "\"tok\"".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn replace_removed_create_only_map_attribute_emits_map_diff_row() {
+        let mut settings = IndexMap::new();
+        settings.insert(
+            "mode".to_string(),
+            Value::Concrete(ConcreteValue::String("legacy".to_string())),
+        );
+        settings.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::Int(1)),
+        );
+        let from = State::existing(
+            ResourceId::new("test.Widget", "beta"),
+            [(
+                "settings".to_string(),
+                Value::Concrete(ConcreteValue::Map(settings)),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let to = Resource::new("test.Widget", "beta");
+        let effect = Effect::Replace {
+            id: ResourceId::new("test.Widget", "beta"),
+            from: Box::new(from),
+            to,
+            directives: crate::resource::Directives::default(),
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
+                "settings".to_string(),
+            ])
+            .unwrap(),
+            cascading_updates: vec![],
+            temporary_name: None,
+            cascade_ref_hints: vec![],
+        };
+
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
+
+        assert_eq!(
+            rows,
+            vec![DetailRow::ReplaceMapDiff {
+                key: "settings".to_string(),
+                entries: vec![
+                    MapDiffEntryIR::Removed {
+                        key: "mode".to_string(),
+                        value: "\"legacy\"".to_string(),
+                    },
+                    MapDiffEntryIR::Removed {
+                        key: "version".to_string(),
+                        value: "1".to_string(),
+                    },
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn replace_removed_create_only_list_of_maps_attribute_emits_list_diff_row() {
+        let mut rule = IndexMap::new();
+        rule.insert(
+            "name".to_string(),
+            Value::Concrete(ConcreteValue::String("legacy".to_string())),
+        );
+        rule.insert(
+            "priority".to_string(),
+            Value::Concrete(ConcreteValue::Int(10)),
+        );
+        let old_rules = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(rule.clone()),
+        )]));
+        let from = State::existing(
+            ResourceId::new("test.Widget", "beta"),
+            [("rules".to_string(), old_rules)].into_iter().collect(),
+        );
+        let to = Resource::new("test.Widget", "beta");
+        let effect = Effect::Replace {
+            id: ResourceId::new("test.Widget", "beta"),
+            from: Box::new(from),
+            to,
+            directives: crate::resource::Directives::default(),
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["rules".to_string()])
+                .unwrap(),
+            cascading_updates: vec![],
+            temporary_name: None,
+            cascade_ref_hints: vec![],
+        };
+
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
+
+        assert_eq!(
+            rows,
+            vec![DetailRow::ReplaceListOfMapsDiff {
+                key: "rules".to_string(),
+                unchanged: vec![],
+                modified: vec![],
+                added: vec![],
+                removed: vec![ListOfMapsDiffItem {
+                    fields: vec![
+                        (
+                            "name".to_string(),
+                            Value::Concrete(ConcreteValue::String("legacy".to_string())),
+                        ),
+                        (
+                            "priority".to_string(),
+                            Value::Concrete(ConcreteValue::Int(10))
+                        ),
+                    ],
+                }],
+            }]
+        );
     }
 
     /// The pre-#1971 hand-rolled walker only descended into `List` and `Map`,

--- a/carina-tui/src/ui/detail.rs
+++ b/carina-tui/src/ui/detail.rs
@@ -276,6 +276,28 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
             }
             lines.push(line);
         }
+        DetailRow::ReplaceRemoved { key, old } => {
+            let mut line = Line::from(vec![
+                Span::raw(format!("  {}: ", key)),
+                Span::styled(
+                    old.clone(),
+                    Style::default()
+                        .fg(Color::Red)
+                        .add_modifier(Modifier::CROSSED_OUT),
+                ),
+                Span::raw(" -> "),
+                Span::styled(
+                    "(removed)",
+                    Style::default()
+                        .fg(Color::Red)
+                        .add_modifier(Modifier::CROSSED_OUT),
+                ),
+            ]);
+            if is_selected {
+                line = line.style(Style::default().bg(Color::DarkGray));
+            }
+            lines.push(line);
+        }
         DetailRow::ReplaceCascade { key, old, new } => {
             let mut line = Line::from(vec![
                 Span::raw(format!("  {}: ", key)),


### PR DESCRIPTION
Closes #3472

## What

#3473 made `Effect::Replace.changed_create_only` non-empty by type, closing the data-level side of the unexplained-replacement bug class (awscc#346 expected-2). This PR closes the display seam.

### 1. Removal-typed forcing attributes now render

`build_replace_rows` pre-filtered `changed_create_only` keys absent from the desired resource, so a create-only **and explicitly removable** attribute whose removal forced the replacement rendered zero rows — `must be replaced` with no `(forces replacement)` line. The pre-filter is gone; missing-from-desired keys route through a new shape-classifying `build_replace_removed_row`, mirroring the Update side's removal handling:

| old value shape | rendering |
|---|---|
| scalar | new `DetailRow::ReplaceRemoved` — CLI `key: old → (removed) (forces replacement)`; TUI annotation-free, matching its sibling arms |
| map | `ReplaceMapDiff` with all entries removed (reuses `build_map_removed_row`, the #2939 shape fix) |
| list of maps | `ReplaceListOfMapsDiff` with all items removed |

While mirroring, the Update side's own asymmetry surfaced and is fixed too: a removed list-of-maps attribute on **Update** now renders the same structured all-removed block instead of an overflowing inline `[{...}] → (removed)` line (`snapshot_moved_prev_keys` updated — reviewed, matches the established removed-struct rendering with tree bars intact).

### 2. First e2e Replace plan-display fixture

`replace_create_only` drives the **real differ** (not hand-built effects) through a fixture-local `test.Widget` schema: `external_name` (create-only) changed on one resource, `legacy_token` (create-only + removable) removed on another. Snapshot pins that every `must be replaced` plan shows at least one `(forces replacement)` line, including the removal-typed case. Makefile target `plan-replace-create-only` added (gated by `check-plan-fixtures.sh`). The issue suggested extending carina-provider-mock; the fixture-factory pattern (`Route53…`/`MovedClaims…` precedent) achieves the same differ-path coverage without touching the WASM mock.

### 3. Fossil cleanup

`format_replace_changed_attrs` (test-only) duplicated the old filtering logic — including the exact pre-filter this PR removes — so its tests pinned dead code. Deleted it (plus its dead `format_map_diff`/`format_list_diff` dependents); the two tests now assert through the production `format_plan` path with all original assertions preserved.

## Tests

TDD red observed for: the core ReplaceRemoved row test (variant didn't exist), the CLI symptom test (no forcing line rendered), the map/list-of-maps removal classification tests (got inline `ReplaceRemoved`/`Removed`), and the Update-side list-of-maps test. Edge cases verified: empty old list/map fall back to the inline row (consistent with Update), absent-from-both renders a defensive `(none)` row, no panic paths.

## Verification

- `cargo nextest run --workspace --all-features`: 4050 passed, 0 failed
- `cargo test --workspace --doc`: pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean
- `scripts/check-*.sh`: all 5 pass
- `make plan-replace-create-only` reproduces the snapshot byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)