### PR TITLE
Make reference-walking matches over Value exhaustive (carina#3467)

### DIFF
--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -508,7 +508,25 @@ impl RootConfigSignature {
                     Self::collect_typed_dependencies(from, attr_key, arg, graph, binding_types);
                 }
             }
-            _ => {}
+            Value::Concrete(
+                ConcreteValue::String(_)
+                | ConcreteValue::Int(_)
+                | ConcreteValue::Float(_)
+                | ConcreteValue::Bool(_)
+                | ConcreteValue::Duration(_)
+                | ConcreteValue::EnumIdentifier(_)
+                | ConcreteValue::CanonicalEnum(_)
+                | ConcreteValue::StringList(_),
+            ) => {
+                // Scalar leaves carry no references.
+            }
+            Value::Deferred(DeferredValue::Secret(inner)) => {
+                // Mirror deps::collect_dependencies for secret-wrapped values.
+                Self::collect_typed_dependencies(from, attr_key, inner, graph, binding_types);
+            }
+            Value::Deferred(DeferredValue::Unknown(_)) => {
+                // Unknown is upstream-deferred and carries no resource-binding edge.
+            }
         }
     }
 
@@ -1022,7 +1040,32 @@ impl ModuleSignature {
                     );
                 }
             }
-            _ => {}
+            Value::Concrete(
+                ConcreteValue::String(_)
+                | ConcreteValue::Int(_)
+                | ConcreteValue::Float(_)
+                | ConcreteValue::Bool(_)
+                | ConcreteValue::Duration(_)
+                | ConcreteValue::EnumIdentifier(_)
+                | ConcreteValue::CanonicalEnum(_)
+                | ConcreteValue::StringList(_),
+            ) => {
+                // Scalar leaves carry no references.
+            }
+            Value::Deferred(DeferredValue::Secret(inner)) => {
+                // Mirror deps::collect_dependencies for secret-wrapped values.
+                Self::collect_typed_dependencies(
+                    from,
+                    attr_key,
+                    inner,
+                    graph,
+                    binding_types,
+                    argument_types,
+                );
+            }
+            Value::Deferred(DeferredValue::Unknown(_)) => {
+                // Unknown is upstream-deferred and carries no resource-binding edge.
+            }
         }
     }
 

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -202,7 +202,22 @@ fn collect_unsynchronized_refs(
                 out,
             );
         }
-        _ => {}
+        Value::Concrete(
+            ConcreteValue::String(_)
+            | ConcreteValue::Int(_)
+            | ConcreteValue::Float(_)
+            | ConcreteValue::Bool(_)
+            | ConcreteValue::Duration(_)
+            | ConcreteValue::EnumIdentifier(_)
+            | ConcreteValue::CanonicalEnum(_)
+            | ConcreteValue::StringList(_),
+        ) => {
+            // Scalar leaves carry no references.
+        }
+        Value::Deferred(DeferredValue::Unknown(_) | DeferredValue::BindingRef { .. }) => {
+            // BindingRef lacks the attribute path check_ref needs for deferred_populate.
+            // Unknown is parser-deferred and likewise carries no resource attribute path.
+        }
     }
 }
 


### PR DESCRIPTION
Closes #3467

## Problem

Three reference-walking `match` over `Value` ended in `_ => {}` and would silently swallow a future `DeferredValue` / `ConcreteValue` variant — exactly the walker-drift hazard #3465 closed for `collect_resource_refs`:

- `validation/deferred_populate.rs::collect_unsynchronized_refs`
- `module.rs::RootConfigSignature::collect_typed_dependencies`
- `module.rs::ModuleSignature::collect_typed_dependencies`

## Fix

Each wildcard is replaced with two explicit no-op arms: a scalar `ConcreteValue` OR-pattern, and the intentionally ignored `DeferredValue` variants. The next variant added to either enum now fails to compile at all three walkers until each makes a deliberate decision.

While at it, both `module.rs` overloads now recurse through `Secret(inner)`, matching every other reference walker in carina-core (`deps::collect_dependencies`, `Value::visit_refs`, the sibling `collect_unsynchronized_refs`). The walkers run post-resolution today and `Secret` inner is concrete there, so the recursion is a no-op — the change removes a load-bearing dependency on the resolver invariant for future-proofing.

`deferred_populate.rs` keeps ignoring `BindingRef`: `check_ref` requires an attribute path that a bare binding reference does not carry, and concrete `ResourceRef` uses of the same target still trigger the diagnostic.

## Tests

This is a compile-time-decision change, not a behavior change. No new runtime tests — the type system itself is the test, exactly the property this PR strengthens. Existing tests stay green.

## Verify

`cargo nextest run --workspace --all-features` 4056 passed / 72 skipped; doctests, clippy `-D warnings`, and all `scripts/check-*.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
