### PR TITLE
Detect nested references in differ create-only cascade (carina#3469)

### DIFF
--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -596,6 +596,375 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
 }
 
 #[test]
+fn cascade_generates_replace_when_create_only_list_contains_nested_ref() {
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
+    let attachment_id = ResourceId::new("ec2.RouteTableAssociation", "my-assoc");
+
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
+        .with_binding("vpc")
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
+
+    let attachment = Resource::new("ec2.RouteTableAssociation", "my-assoc")
+        .with_binding("attachment")
+        .with_attribute(
+            "subnet_ids",
+            Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
+                "vpc".to_string(),
+                "vpc_id".to_string(),
+                vec![],
+            )])),
+        )
+        .with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("main".to_string())),
+        );
+
+    let unresolved_resources = vec![vpc.clone(), attachment.clone()];
+
+    let mut current_states = HashMap::new();
+    let mut vpc_attrs = HashMap::new();
+    vpc_attrs.insert(
+        "cidr_block".to_string(),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+    );
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
+    current_states.insert(
+        vpc_id.clone(),
+        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
+    );
+
+    let mut attachment_attrs = HashMap::new();
+    attachment_attrs.insert(
+        "subnet_ids".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("vpc-old".to_string()),
+        )])),
+    );
+    attachment_attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("main".to_string())),
+    );
+    current_states.insert(
+        attachment_id.clone(),
+        State::existing(attachment_id.clone(), attachment_attrs).with_identifier("assoc-123"),
+    );
+
+    let attachment_schema = ResourceSchema::new("ec2.RouteTableAssociation")
+        .attribute(
+            AttributeSchema::new("subnet_ids", AttributeType::list(AttributeType::string()))
+                .required()
+                .create_only(),
+        )
+        .attribute(AttributeSchema::new("name", AttributeType::string()).required());
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", attachment_schema);
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: vpc_id.clone(),
+        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
+        to: vpc.clone().with_binding("vpc"),
+        directives: Directives {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+
+    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+
+    let effects = plan.effects();
+    assert_eq!(
+        effects.len(),
+        2,
+        "Expected nested list ref on create-only attribute to promote dependent to Replace, got: {:?}",
+        effects
+            .iter()
+            .map(|e| format!("{} {}", e.kind(), e.resource_id()))
+            .collect::<Vec<_>>()
+    );
+
+    match &effects[1] {
+        Effect::Replace {
+            id,
+            changed_create_only,
+            cascade_ref_hints,
+            ..
+        } => {
+            assert_eq!(id, &attachment_id);
+            assert!(changed_create_only.contains("subnet_ids"));
+            assert!(
+                cascade_ref_hints.contains(&("subnet_ids".to_string(), "vpc.vpc_id".to_string()))
+            );
+        }
+        other => panic!(
+            "Expected nested list dependent to be Replace, got {}",
+            other.kind()
+        ),
+    }
+}
+
+#[test]
+fn cascade_generates_replace_when_create_only_map_contains_nested_ref() {
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
+    let tagged_id = ResourceId::new("ec2.TaggedResource", "my-tagged");
+
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
+        .with_binding("vpc")
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
+
+    let mut desired_tags = indexmap::IndexMap::new();
+    desired_tags.insert(
+        "vpc_ref".to_string(),
+        Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+    );
+    desired_tags.insert(
+        "env".to_string(),
+        Value::Concrete(ConcreteValue::String("prod".to_string())),
+    );
+
+    let tagged = Resource::new("ec2.TaggedResource", "my-tagged")
+        .with_binding("tagged")
+        .with_attribute("tags", Value::Concrete(ConcreteValue::Map(desired_tags)))
+        .with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("main".to_string())),
+        );
+
+    let unresolved_resources = vec![vpc.clone(), tagged.clone()];
+
+    let mut current_states = HashMap::new();
+    let mut vpc_attrs = HashMap::new();
+    vpc_attrs.insert(
+        "cidr_block".to_string(),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+    );
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
+    current_states.insert(
+        vpc_id.clone(),
+        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
+    );
+
+    let mut state_tags = indexmap::IndexMap::new();
+    state_tags.insert(
+        "vpc_ref".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
+    state_tags.insert(
+        "env".to_string(),
+        Value::Concrete(ConcreteValue::String("prod".to_string())),
+    );
+    let mut tagged_attrs = HashMap::new();
+    tagged_attrs.insert(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(state_tags)),
+    );
+    tagged_attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("main".to_string())),
+    );
+    current_states.insert(
+        tagged_id.clone(),
+        State::existing(tagged_id.clone(), tagged_attrs).with_identifier("tagged-123"),
+    );
+
+    let tagged_schema = ResourceSchema::new("ec2.TaggedResource")
+        .attribute(
+            AttributeSchema::new("tags", AttributeType::map(AttributeType::string()))
+                .required()
+                .create_only(),
+        )
+        .attribute(AttributeSchema::new("name", AttributeType::string()).required());
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", tagged_schema);
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: vpc_id.clone(),
+        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
+        to: vpc.clone().with_binding("vpc"),
+        directives: Directives {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+
+    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+
+    let effects = plan.effects();
+    assert_eq!(
+        effects.len(),
+        2,
+        "Expected nested map ref on create-only attribute to promote dependent to Replace, got: {:?}",
+        effects
+            .iter()
+            .map(|e| format!("{} {}", e.kind(), e.resource_id()))
+            .collect::<Vec<_>>()
+    );
+
+    match &effects[1] {
+        Effect::Replace {
+            id,
+            changed_create_only,
+            cascade_ref_hints,
+            ..
+        } => {
+            assert_eq!(id, &tagged_id);
+            assert!(changed_create_only.contains("tags"));
+            assert!(
+                cascade_ref_hints.contains(&("tags".to_string(), "vpc.vpc_id".to_string())),
+                "Expected tags cascade hint from nested map ref, got: {:?}",
+                cascade_ref_hints
+            );
+        }
+        other => panic!(
+            "Expected nested map dependent to be Replace, got {}",
+            other.kind()
+        ),
+    }
+}
+
+#[test]
+fn cascade_prevent_destroy_blocks_nested_map_ref_promotion_to_replace() {
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
+    let tagged_id = ResourceId::new("ec2.TaggedResource", "my-tagged");
+
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
+        .with_binding("vpc")
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
+
+    let mut desired_tags = indexmap::IndexMap::new();
+    desired_tags.insert(
+        "vpc_ref".to_string(),
+        Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+    );
+
+    let mut tagged = Resource::new("ec2.TaggedResource", "my-tagged")
+        .with_binding("tagged")
+        .with_attribute("tags", Value::Concrete(ConcreteValue::Map(desired_tags)))
+        .with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("main".to_string())),
+        );
+    tagged.directives.prevent_destroy = true;
+
+    let unresolved_resources = vec![vpc.clone(), tagged.clone()];
+
+    let mut current_states = HashMap::new();
+    let mut vpc_attrs = HashMap::new();
+    vpc_attrs.insert(
+        "cidr_block".to_string(),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+    );
+    vpc_attrs.insert(
+        "vpc_id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
+    current_states.insert(
+        vpc_id.clone(),
+        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
+    );
+
+    let mut state_tags = indexmap::IndexMap::new();
+    state_tags.insert(
+        "vpc_ref".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
+    let mut tagged_attrs = HashMap::new();
+    tagged_attrs.insert(
+        "tags".to_string(),
+        Value::Concrete(ConcreteValue::Map(state_tags)),
+    );
+    tagged_attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("main".to_string())),
+    );
+    current_states.insert(
+        tagged_id.clone(),
+        State::existing(tagged_id.clone(), tagged_attrs).with_identifier("tagged-123"),
+    );
+
+    let tagged_schema = ResourceSchema::new("ec2.TaggedResource")
+        .attribute(
+            AttributeSchema::new("tags", AttributeType::map(AttributeType::string()))
+                .required()
+                .create_only(),
+        )
+        .attribute(AttributeSchema::new("name", AttributeType::string()).required());
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", tagged_schema);
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: vpc_id.clone(),
+        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
+        to: vpc.clone().with_binding("vpc"),
+        directives: Directives {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+
+    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+
+    assert!(
+        plan.has_errors(),
+        "Expected PlanError for nested map ref promotion blocked by prevent_destroy"
+    );
+    assert_eq!(plan.errors().len(), 1);
+    assert_eq!(plan.errors()[0].resource_id, tagged_id);
+    assert!(plan.errors()[0].message.contains("prevent_destroy"));
+
+    let tagged_effects: Vec<_> = plan
+        .effects()
+        .iter()
+        .filter(|e| *e.resource_id() == tagged_id)
+        .collect();
+    assert!(
+        tagged_effects.is_empty(),
+        "Dependent should not be promoted when prevent_destroy blocks nested map ref cascade"
+    );
+}
+
+#[test]
 fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     // Pattern 2: Direct change + cascade
     //

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -8,7 +8,8 @@ use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
 use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, Directives, Resource, ResourceId, State, Value,
+    ConcreteValue, DataSource, DeferredValue, Directives, InterpolationPart, Resource, ResourceId,
+    State, Value,
 };
 use crate::schema::{
     ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
@@ -23,6 +24,11 @@ struct CascadeMerge {
     create_only_attrs: ChangedCreateOnly,
     directives: Directives,
     ref_hints: Vec<(String, String)>,
+}
+
+struct RefAttr {
+    attribute: String,
+    hint: String,
 }
 
 /// Check which changed attributes are create-only according to the schema
@@ -42,6 +48,75 @@ fn find_changed_create_only(
         .filter(|attr| create_only_attrs.contains(&attr.as_str()))
         .cloned()
         .collect()
+}
+
+fn cascade_ref_attrs(
+    attrs: &indexmap::IndexMap<String, Value>,
+    target_binding: &str,
+) -> Vec<RefAttr> {
+    attrs
+        .iter()
+        .filter_map(|(attribute, value)| {
+            cascade_ref_hint(value, target_binding).map(|hint| RefAttr {
+                attribute: attribute.clone(),
+                hint,
+            })
+        })
+        .collect()
+}
+
+fn cascade_ref_hint(value: &Value, target_binding: &str) -> Option<String> {
+    let mut hit: Option<String> = None;
+
+    // Multi-ref attributes report the first target-binding ref in list/IndexMap/source order.
+    value.visit_refs(&mut |path| {
+        if hit.is_none() && path.binding() == target_binding {
+            hit = Some(format!("{}.{}", path.binding(), path.attribute()));
+        }
+    });
+
+    if hit.is_some() {
+        return hit;
+    }
+
+    visit_binding_refs(value, target_binding)
+}
+
+/// BindingRef companion for the `visit_refs` gap. Tracked by carina#3476 for unification.
+fn visit_binding_refs(value: &Value, target_binding: &str) -> Option<String> {
+    match value {
+        Value::Deferred(DeferredValue::BindingRef { binding }) if binding == target_binding => {
+            Some(binding.clone())
+        }
+        Value::Concrete(ConcreteValue::List(items)) => items
+            .iter()
+            .find_map(|value| visit_binding_refs(value, target_binding)),
+        Value::Concrete(ConcreteValue::Map(map)) => map
+            .values()
+            .find_map(|value| visit_binding_refs(value, target_binding)),
+        Value::Deferred(DeferredValue::Interpolation(parts)) => parts.iter().find_map(|part| {
+            if let InterpolationPart::Expr(value) = part {
+                visit_binding_refs(value, target_binding)
+            } else {
+                None
+            }
+        }),
+        Value::Deferred(DeferredValue::FunctionCall { args, .. }) => args
+            .iter()
+            .find_map(|value| visit_binding_refs(value, target_binding)),
+        Value::Deferred(DeferredValue::Secret(inner)) => visit_binding_refs(inner, target_binding),
+        Value::Deferred(DeferredValue::ResourceRef { .. })
+        | Value::Deferred(DeferredValue::BindingRef { .. })
+        | Value::Concrete(ConcreteValue::String(_))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+        | Value::Concrete(ConcreteValue::CanonicalEnum(_))
+        | Value::Concrete(ConcreteValue::Int(_))
+        | Value::Concrete(ConcreteValue::Float(_))
+        | Value::Concrete(ConcreteValue::Bool(_))
+        | Value::Concrete(ConcreteValue::Duration(_))
+        | Value::Concrete(ConcreteValue::StringList(_))
+        | Value::Deferred(DeferredValue::Unknown(_)) => None,
+    }
 }
 
 /// Filter out non-removable attribute removals from the changed list.
@@ -689,36 +764,17 @@ pub fn cascade_dependent_updates(
                 continue;
             }
 
-            // Find which attributes on this resource hold a ResourceRef
-            // pointing to the replaced binding, and extract ref hints
-            let ref_attrs: Vec<String> = resource
-                .attributes
+            let ref_attrs = cascade_ref_attrs(&resource.attributes, dep);
+            let ref_attr_names: Vec<String> = ref_attrs
                 .iter()
-                .filter(|(_, v)| matches!(v, Value::Deferred(DeferredValue::ResourceRef{ path }) if path.binding() == dep))
-                .map(|(k, _)| k.clone())
-                .collect();
-
-            let ref_hints: Vec<(String, String)> = resource
-                .attributes
-                .iter()
-                .filter_map(|(k, v)| match v {
-                    Value::Deferred(DeferredValue::ResourceRef { path })
-                        if path.binding() == dep =>
-                    {
-                        Some((
-                            k.clone(),
-                            format!("{}.{}", path.binding(), path.attribute()),
-                        ))
-                    }
-                    _ => None,
-                })
+                .map(|ref_attr| ref_attr.attribute.clone())
                 .collect();
 
             // Check if any of those attributes are create-only
             let create_only_refs = find_changed_create_only(
                 &resource.id.provider,
                 &resource.id.resource_type,
-                &ref_attrs,
+                &ref_attr_names,
                 registry,
             );
 
@@ -740,9 +796,10 @@ pub fn cascade_dependent_updates(
                 }
 
                 // Only keep hints for attributes that are actually create-only
-                let filtered_hints: Vec<(String, String)> = ref_hints
+                let filtered_hints: Vec<(String, String)> = ref_attrs
                     .into_iter()
-                    .filter(|(attr, _)| create_only_attrs.contains(attr))
+                    .filter(|ref_attr| create_only_attrs.contains(&ref_attr.attribute))
+                    .map(|ref_attr| (ref_attr.attribute, ref_attr.hint))
                     .collect();
                 merge_operations.push(CascadeMerge {
                     resource_id: resource.id.clone(),
@@ -782,22 +839,17 @@ pub fn cascade_dependent_updates(
                     continue;
                 }
 
-                // Find which attributes on this dependent hold a ResourceRef
-                // pointing to the replaced binding
-                let ref_attrs: Vec<String> = unresolved
-                    .attributes
+                let ref_attrs = cascade_ref_attrs(&unresolved.attributes, replaced_binding);
+                let ref_attr_names: Vec<String> = ref_attrs
                     .iter()
-                    .filter(|(_, v)| {
-                        matches!(v, Value::Deferred(DeferredValue::ResourceRef{ path }) if path.binding() == replaced_binding)
-                    })
-                    .map(|(k, _)| k.clone())
+                    .map(|ref_attr| ref_attr.attribute.clone())
                     .collect();
 
                 // Check if any of those attributes are create-only
                 let create_only_refs = find_changed_create_only(
                     &unresolved.id.provider,
                     &unresolved.id.resource_type,
-                    &ref_attrs,
+                    &ref_attr_names,
                     registry,
                 );
 
@@ -812,22 +864,10 @@ pub fn cascade_dependent_updates(
                                     .to_string(),
                         });
                     } else {
-                        // Extract ref hints for attributes being promoted
-                        let ref_hints: Vec<(String, String)> = unresolved
-                            .attributes
-                            .iter()
-                            .filter_map(|(k, v)| match v {
-                                Value::Deferred(DeferredValue::ResourceRef { path })
-                                    if path.binding() == replaced_binding
-                                        && changed_create_only.contains(k) =>
-                                {
-                                    Some((
-                                        k.clone(),
-                                        format!("{}.{}", path.binding(), path.attribute()),
-                                    ))
-                                }
-                                _ => None,
-                            })
+                        let ref_hints: Vec<(String, String)> = ref_attrs
+                            .into_iter()
+                            .filter(|ref_attr| changed_create_only.contains(&ref_attr.attribute))
+                            .map(|ref_attr| (ref_attr.attribute, ref_attr.hint))
                             .collect();
 
                         // Promote to a separate Replace effect

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1151,8 +1151,8 @@ impl Value {
             | Value::Concrete(ConcreteValue::StringList(_)) => {}
             // `BindingRef` carries no attribute, so attribute-walking
             // visitors have nothing to do. Callers that *do* care about
-            // bare-binding references walk them explicitly via
-            // `visit_binding_refs`.
+            // bare-binding references need explicit traversal until a
+            // binding-aware visitor is added.
             Value::Deferred(DeferredValue::BindingRef { .. }) => {}
             // `Value::Unknown` is what a previously-unresolved
             // `ResourceRef` was *replaced with* by `stamp_unresolved_upstream`.


### PR DESCRIPTION
Closes #3469

## Problem

`carina-core/src/differ/plan.rs` had four inline matches that asked "which attribute on this resource references the replaced binding?" using a top-level-only `Value::Deferred(DeferredValue::ResourceRef)` pattern. A create-only attribute holding the ref nested — for example `subnet_ids = [vpc.id]`, `tags = { vpc_ref = vpc.id }`, `name = "vpc-${vpc.id}"` — was invisible to `ref_attrs` localization, so `find_changed_create_only` saw no candidate and the cascade classified the resource as a normal Update instead of promoting it to a Replace.

The dependency edge from `deps::get_resource_dependencies` was unaffected; only `ref_attrs` / `ref_hints` recording was wrong.

## Fix — use the canonical walker, not a fourth copy

The codebase already has `Value::visit_refs` (`carina-core/src/resource/mod.rs:1118`), the canonical recursive walker for `ResourceRef` sites used by 8 consumers across `upstream_exports`, `detail_rows`, `parser/resolve`, the LSP, etc. A first iteration of this fix introduced a new `cascade_ref_hint` walker that duplicated the recursion structure — review pointed out that adding a third walker undoes the unification work done in #3465 and #3467.

The final shape uses `Value::visit_refs` for the `ResourceRef` half and a small local `visit_binding_refs` companion for the bare `BindingRef` case the primitive does not yet surface. A stale doc comment in `Value::visit_refs` that referenced a non-existent `visit_binding_refs` companion is also corrected.

Multi-ref attributes report the first target-binding ref in list / IndexMap / source order — a stable, deterministic choice for the cascade hint display.

## Follow-up

#3476: extend `Value::visit_refs` (or add `visit_refs_and_bindings`) to surface `BindingRef` so the local companion here, `deps::collect_dependencies`'s `BindingRef` arm, and `display/mod.rs::value_references_binding` can all consume one primitive.

## Tests (red→green confirmed)

- `cascade_generates_replace_when_create_only_list_contains_nested_ref` — pins `subnet_ids = [vpc.id]`
- `cascade_generates_replace_when_create_only_map_contains_nested_ref` — pins `tags = { vpc_ref = vpc.id }`
- `cascade_prevent_destroy_blocks_nested_map_ref_promotion_to_replace` — pins that `prevent_destroy` flags the nested-ref case as a PlanError

Each fails on HEAD pre-fix because the top-level-only match returns empty `ref_attrs` for nested values, so no `ChangedCreateOnly` is produced and no Replace promotion / prevent_destroy error occurs.

## Verify

`cargo nextest run --workspace --all-features` 4059 passed / 72 skipped; doctests, clippy `-D warnings`, and all `scripts/check-*.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
