### PR TITLE
Split Value::visit_refs into two binding-form-specific methods (carina#3476)

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -2012,22 +2012,21 @@ fn format_cascading_update_diff(
     lines.join("\n")
 }
 
-/// Check whether a Value references the given binding name.
-///
-/// Returns true for `Value::Deferred(DeferredValue::ResourceRef)` with matching `binding_name`,
-/// or `Value::Concrete(ConcreteValue::List)` / `Value::Concrete(ConcreteValue::Map)` containing such a reference.
 #[cfg(test)]
+/// Check whether a Value references the given binding name (either ResourceRef or bare BindingRef).
 fn value_references_binding(value: &Value, binding: &str) -> bool {
-    match value {
-        Value::Deferred(DeferredValue::ResourceRef { path }) => path.binding() == binding,
-        Value::Concrete(ConcreteValue::List(items)) => {
-            items.iter().any(|v| value_references_binding(v, binding))
+    let mut found = false;
+    value.visit_resource_refs(&mut |path| {
+        if path.binding() == binding {
+            found = true;
         }
-        Value::Concrete(ConcreteValue::Map(map)) => {
-            map.values().any(|v| value_references_binding(v, binding))
+    });
+    value.visit_binding_refs(&mut |bare_binding| {
+        if bare_binding == binding {
+            found = true;
         }
-        _ => false,
-    }
+    });
+    found
 }
 
 #[cfg(test)]

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::effect::Effect;
-use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
+use crate::resource::{Resource, Value};
 
 /// Extract binding names that a resource depends on.
 ///
@@ -84,40 +84,12 @@ pub fn get_data_source_dependencies(data_source: &crate::resource::DataSource) -
 /// `Value` variants since #2847 (`ResourceRef` vs. `BindingRef`), so
 /// the walker visits both forms here.
 pub(crate) fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
-    fn walk(value: &Value, deps: &mut HashSet<String>) {
-        match value {
-            Value::Deferred(DeferredValue::ResourceRef { path }) => {
-                deps.insert(path.binding().to_string());
-            }
-            Value::Deferred(DeferredValue::BindingRef { binding }) => {
-                deps.insert(binding.clone());
-            }
-            Value::Concrete(ConcreteValue::List(items)) => items.iter().for_each(|v| walk(v, deps)),
-            Value::Concrete(ConcreteValue::Map(map)) => map.values().for_each(|v| walk(v, deps)),
-            Value::Deferred(DeferredValue::Interpolation(parts)) => {
-                use crate::resource::InterpolationPart;
-                for part in parts {
-                    if let InterpolationPart::Expr(v) = part {
-                        walk(v, deps);
-                    }
-                }
-            }
-            Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
-                args.iter().for_each(|v| walk(v, deps))
-            }
-            Value::Deferred(DeferredValue::Secret(inner)) => walk(inner, deps),
-            Value::Concrete(ConcreteValue::String(_))
-            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
-            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
-            | Value::Concrete(ConcreteValue::Int(_))
-            | Value::Concrete(ConcreteValue::Float(_))
-            | Value::Concrete(ConcreteValue::Bool(_))
-            | Value::Concrete(ConcreteValue::Duration(_))
-            | Value::Concrete(ConcreteValue::StringList(_))
-            | Value::Deferred(DeferredValue::Unknown(_)) => {}
-        }
-    }
-    walk(value, deps);
+    value.visit_resource_refs(&mut |path| {
+        deps.insert(path.binding().to_string());
+    });
+    value.visit_binding_refs(&mut |binding| {
+        deps.insert(binding.to_string());
+    });
 }
 
 /// Like [`get_resource_dependencies`], but excludes `directives.depends_on`.

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -1649,8 +1649,13 @@ fn string_list_inner_type(attr_type: &AttributeType) -> Option<&AttributeType> {
 /// Check whether a Value references the given binding name.
 fn value_references_binding(value: &Value, binding: &str) -> bool {
     let mut found = false;
-    value.visit_refs(&mut |path| {
+    value.visit_resource_refs(&mut |path| {
         if path.binding() == binding {
+            found = true;
+        }
+    });
+    value.visit_binding_refs(&mut |bare_binding| {
+        if bare_binding == binding {
             found = true;
         }
     });
@@ -2371,7 +2376,7 @@ mod tests {
     /// so a ResourceRef nested inside `Interpolation` / `FunctionCall` /
     /// `Secret` / `Closure` would fail to mark the attribute as referencing
     /// the binding. Guard against regressing that after migrating to
-    /// `Value::visit_refs`.
+    /// `Value::visit_resource_refs` / `Value::visit_binding_refs`.
     #[test]
     fn value_references_binding_covers_non_container_variants() {
         use crate::resource::InterpolationPart;
@@ -2395,6 +2400,39 @@ mod tests {
 
         let secret = Value::Deferred(DeferredValue::Secret(Box::new(refs_vpc)));
         assert!(value_references_binding(&secret, "vpc"));
+
+        let binding_ref = || {
+            Value::Deferred(DeferredValue::BindingRef {
+                binding: "vpc".to_string(),
+            })
+        };
+
+        let list_binding = Value::Concrete(ConcreteValue::List(vec![binding_ref()]));
+        assert!(value_references_binding(&list_binding, "vpc"));
+
+        let map_binding = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+            "k".to_string(),
+            binding_ref(),
+        )])));
+        assert!(value_references_binding(&map_binding, "vpc"));
+
+        let interpolation_binding = Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("vpc-".to_string()),
+            InterpolationPart::Expr(binding_ref()),
+        ]));
+        assert!(value_references_binding(&interpolation_binding, "vpc"));
+
+        let function_call_binding = Value::Deferred(DeferredValue::FunctionCall {
+            name: "join".to_string(),
+            args: vec![
+                Value::Concrete(ConcreteValue::String(",".to_string())),
+                binding_ref(),
+            ],
+        });
+        assert!(value_references_binding(&function_call_binding, "vpc"));
+
+        let secret_binding = Value::Deferred(DeferredValue::Secret(Box::new(binding_ref())));
+        assert!(value_references_binding(&secret_binding, "vpc"));
 
         // Closure variant removed from `Value` (issue #2230): closures
         // live on `EvalValue` and never reach this code path.

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -718,6 +718,106 @@ fn cascade_generates_replace_when_create_only_list_contains_nested_ref() {
 }
 
 #[test]
+fn cascade_hint_prefers_resource_ref_over_binding_ref_in_mixed_list() {
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
+    let attachment_id = ResourceId::new("ec2.RouteTableAssociation", "my-assoc");
+
+    let vpc = Resource::new("ec2.Vpc", "my-vpc")
+        .with_binding("vpc")
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
+
+    let attachment = Resource::new("ec2.RouteTableAssociation", "my-assoc")
+        .with_binding("attachment")
+        .with_attribute(
+            "targets",
+            Value::Concrete(ConcreteValue::List(vec![
+                Value::Deferred(DeferredValue::BindingRef {
+                    binding: "vpc".to_string(),
+                }),
+                Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
+            ])),
+        );
+
+    let unresolved_resources = vec![vpc.clone(), attachment.clone()];
+
+    let mut current_states = HashMap::new();
+    let mut vpc_attrs = HashMap::new();
+    vpc_attrs.insert(
+        "cidr_block".to_string(),
+        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+    );
+    vpc_attrs.insert(
+        "id".to_string(),
+        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+    );
+    current_states.insert(
+        vpc_id.clone(),
+        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
+    );
+
+    let mut attachment_attrs = HashMap::new();
+    attachment_attrs.insert(
+        "targets".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![
+            Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+            Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
+        ])),
+    );
+    current_states.insert(
+        attachment_id.clone(),
+        State::existing(attachment_id.clone(), attachment_attrs).with_identifier("assoc-123"),
+    );
+
+    let attachment_schema = ResourceSchema::new("ec2.RouteTableAssociation").attribute(
+        AttributeSchema::new("targets", AttributeType::list(AttributeType::string()))
+            .required()
+            .create_only(),
+    );
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", attachment_schema);
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: vpc_id.clone(),
+        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
+        to: vpc.clone().with_binding("vpc"),
+        directives: Directives {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
+            .unwrap(),
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+
+    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+
+    match &plan.effects()[1] {
+        Effect::Replace {
+            cascade_ref_hints, ..
+        } => {
+            assert!(
+                cascade_ref_hints.contains(&("targets".to_string(), "vpc.id".to_string())),
+                "ResourceRef hint should win over BindingRef fallback, got: {:?}",
+                cascade_ref_hints
+            );
+        }
+        other => panic!(
+            "Expected mixed-list dependent to be Replace, got {}",
+            other.kind()
+        ),
+    }
+}
+
+#[test]
 fn cascade_generates_replace_when_create_only_map_contains_nested_ref() {
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -7,10 +7,7 @@ use crate::effect::{CascadingUpdate, ChangedCreateOnly, Effect, TemporaryName, W
 use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
-use crate::resource::{
-    ConcreteValue, DataSource, DeferredValue, Directives, InterpolationPart, Resource, ResourceId,
-    State, Value,
-};
+use crate::resource::{ConcreteValue, DataSource, Directives, Resource, ResourceId, State, Value};
 use crate::schema::{
     ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
 };
@@ -69,7 +66,7 @@ fn cascade_ref_hint(value: &Value, target_binding: &str) -> Option<String> {
     let mut hit: Option<String> = None;
 
     // Multi-ref attributes report the first target-binding ref in list/IndexMap/source order.
-    value.visit_refs(&mut |path| {
+    value.visit_resource_refs(&mut |path| {
         if hit.is_none() && path.binding() == target_binding {
             hit = Some(format!("{}.{}", path.binding(), path.attribute()));
         }
@@ -79,44 +76,13 @@ fn cascade_ref_hint(value: &Value, target_binding: &str) -> Option<String> {
         return hit;
     }
 
-    visit_binding_refs(value, target_binding)
-}
-
-/// BindingRef companion for the `visit_refs` gap. Tracked by carina#3476 for unification.
-fn visit_binding_refs(value: &Value, target_binding: &str) -> Option<String> {
-    match value {
-        Value::Deferred(DeferredValue::BindingRef { binding }) if binding == target_binding => {
-            Some(binding.clone())
+    value.visit_binding_refs(&mut |binding| {
+        if hit.is_none() && binding == target_binding {
+            hit = Some(binding.to_string());
         }
-        Value::Concrete(ConcreteValue::List(items)) => items
-            .iter()
-            .find_map(|value| visit_binding_refs(value, target_binding)),
-        Value::Concrete(ConcreteValue::Map(map)) => map
-            .values()
-            .find_map(|value| visit_binding_refs(value, target_binding)),
-        Value::Deferred(DeferredValue::Interpolation(parts)) => parts.iter().find_map(|part| {
-            if let InterpolationPart::Expr(value) = part {
-                visit_binding_refs(value, target_binding)
-            } else {
-                None
-            }
-        }),
-        Value::Deferred(DeferredValue::FunctionCall { args, .. }) => args
-            .iter()
-            .find_map(|value| visit_binding_refs(value, target_binding)),
-        Value::Deferred(DeferredValue::Secret(inner)) => visit_binding_refs(inner, target_binding),
-        Value::Deferred(DeferredValue::ResourceRef { .. })
-        | Value::Deferred(DeferredValue::BindingRef { .. })
-        | Value::Concrete(ConcreteValue::String(_))
-        | Value::Concrete(ConcreteValue::EnumIdentifier(_))
-        | Value::Concrete(ConcreteValue::CanonicalEnum(_))
-        | Value::Concrete(ConcreteValue::Int(_))
-        | Value::Concrete(ConcreteValue::Float(_))
-        | Value::Concrete(ConcreteValue::Bool(_))
-        | Value::Concrete(ConcreteValue::Duration(_))
-        | Value::Concrete(ConcreteValue::StringList(_))
-        | Value::Deferred(DeferredValue::Unknown(_)) => None,
-    }
+    });
+
+    hit
 }
 
 /// Filter out non-removable attribute removals from the changed list.

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -556,7 +556,7 @@ fn accumulate_undefined_reference_errors(
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     let mut check = |value: &Value| {
-        value.visit_refs(&mut |path| {
+        value.visit_resource_refs(&mut |path| {
             let root = path.binding();
             let root_ident = root.split(['[', ']']).next().unwrap_or(root);
             if !known.contains(root_ident) && seen.insert(root_ident.to_string()) {

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1114,33 +1114,37 @@ impl Value {
         }
     }
 
-    /// Recursively walk this value, invoking `f` on each `ResourceRef`'s `AccessPath`.
-    pub fn visit_refs(&self, f: &mut impl FnMut(&AccessPath)) {
+    /// Recursively walk this value, invoking `f` on each `ResourceRef` access path.
+    ///
+    /// Companion: `visit_binding_refs` for bare `BindingRef` names. A consumer that
+    /// needs both must call both — drift is visible at the call site.
+    pub fn visit_resource_refs(&self, f: &mut impl FnMut(&AccessPath)) {
         match self {
             Value::Deferred(DeferredValue::ResourceRef { path }) => f(path),
             Value::Concrete(ConcreteValue::List(items)) => {
                 for v in items {
-                    v.visit_refs(f);
+                    v.visit_resource_refs(f);
                 }
             }
             Value::Concrete(ConcreteValue::Map(map)) => {
                 for v in map.values() {
-                    v.visit_refs(f);
+                    v.visit_resource_refs(f);
                 }
             }
             Value::Deferred(DeferredValue::Interpolation(parts)) => {
                 for part in parts {
-                    if let InterpolationPart::Expr(v) = part {
-                        v.visit_refs(f);
+                    match part {
+                        InterpolationPart::Literal(_) => {}
+                        InterpolationPart::Expr(v) => v.visit_resource_refs(f),
                     }
                 }
             }
             Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
                 for arg in args {
-                    arg.visit_refs(f);
+                    arg.visit_resource_refs(f);
                 }
             }
-            Value::Deferred(DeferredValue::Secret(inner)) => inner.visit_refs(f),
+            Value::Deferred(DeferredValue::Secret(inner)) => inner.visit_resource_refs(f),
             Value::Concrete(ConcreteValue::String(_))
             | Value::Concrete(ConcreteValue::EnumIdentifier(_))
             | Value::Concrete(ConcreteValue::CanonicalEnum(_))
@@ -1148,17 +1152,60 @@ impl Value {
             | Value::Concrete(ConcreteValue::Float(_))
             | Value::Concrete(ConcreteValue::Bool(_))
             | Value::Concrete(ConcreteValue::Duration(_))
-            | Value::Concrete(ConcreteValue::StringList(_)) => {}
-            // `BindingRef` carries no attribute, so attribute-walking
-            // visitors have nothing to do. Callers that *do* care about
-            // bare-binding references need explicit traversal until a
-            // binding-aware visitor is added.
-            Value::Deferred(DeferredValue::BindingRef { .. }) => {}
+            | Value::Concrete(ConcreteValue::StringList(_))
+            | Value::Deferred(DeferredValue::BindingRef { .. }) => {}
             // `Value::Unknown` is what a previously-unresolved
             // `ResourceRef` was *replaced with* by `stamp_unresolved_upstream`.
             // It carries an `AccessPath` for display, but it is no longer
             // a live reference to walk — dependency analysis happens
             // upstream of the stamping pass.
+            Value::Deferred(DeferredValue::Unknown(_)) => {}
+        }
+    }
+
+    /// Recursively walk this value, invoking `f` on each bare `BindingRef` name.
+    ///
+    /// Companion: `visit_resource_refs` for `ResourceRef` access paths. A consumer
+    /// that needs both must call both — drift is visible at the call site.
+    pub fn visit_binding_refs(&self, f: &mut impl FnMut(&str)) {
+        match self {
+            Value::Deferred(DeferredValue::BindingRef { binding }) => f(binding),
+            Value::Concrete(ConcreteValue::List(items)) => {
+                for v in items {
+                    v.visit_binding_refs(f);
+                }
+            }
+            Value::Concrete(ConcreteValue::Map(map)) => {
+                for v in map.values() {
+                    v.visit_binding_refs(f);
+                }
+            }
+            Value::Deferred(DeferredValue::Interpolation(parts)) => {
+                for part in parts {
+                    match part {
+                        InterpolationPart::Literal(_) => {}
+                        InterpolationPart::Expr(v) => v.visit_binding_refs(f),
+                    }
+                }
+            }
+            Value::Deferred(DeferredValue::FunctionCall { args, .. }) => {
+                for arg in args {
+                    arg.visit_binding_refs(f);
+                }
+            }
+            Value::Deferred(DeferredValue::Secret(inner)) => inner.visit_binding_refs(f),
+            Value::Concrete(ConcreteValue::String(_))
+            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
+            | Value::Concrete(ConcreteValue::Int(_))
+            | Value::Concrete(ConcreteValue::Float(_))
+            | Value::Concrete(ConcreteValue::Bool(_))
+            | Value::Concrete(ConcreteValue::Duration(_))
+            | Value::Concrete(ConcreteValue::StringList(_))
+            | Value::Deferred(DeferredValue::ResourceRef { .. }) => {}
+            // `Value::Unknown` is what a previously-unresolved reference was
+            // *replaced with* by stamping passes. It is no longer a live
+            // reference to walk.
             Value::Deferred(DeferredValue::Unknown(_)) => {}
         }
     }
@@ -1185,7 +1232,7 @@ pub fn attrs_to_hashmap(attrs: &IndexMap<String, Value>) -> HashMap<String, Valu
 /// Check if a Value contains any ResourceRef (possibly nested)
 pub fn contains_resource_ref(value: &Value) -> bool {
     let mut found = false;
-    value.visit_refs(&mut |_| found = true);
+    value.visit_resource_refs(&mut |_| found = true);
     found
 }
 

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -923,7 +923,7 @@ fn value_ref_helpers() {
 // properties of `EvalValue`, exercised in `eval_value.rs`.
 
 #[test]
-fn visit_refs_collects_from_all_nested_variants() {
+fn visit_resource_refs_collects_from_all_nested_variants() {
     let value = Value::Concrete(ConcreteValue::List(vec![
         Value::resource_ref("a", "id", vec![]),
         Value::Concrete(ConcreteValue::Map(IndexMap::from([(
@@ -947,7 +947,7 @@ fn visit_refs_collects_from_all_nested_variants() {
     ]));
 
     let mut collected: Vec<String> = Vec::new();
-    value.visit_refs(&mut |path| {
+    value.visit_resource_refs(&mut |path| {
         collected.push(path.binding().to_string());
     });
     collected.sort();
@@ -955,7 +955,47 @@ fn visit_refs_collects_from_all_nested_variants() {
 }
 
 #[test]
-fn visit_refs_on_leaf_variants_calls_nothing() {
+fn visit_binding_refs_collects_from_all_nested_variants() {
+    let value = Value::Concrete(ConcreteValue::List(vec![
+        Value::Deferred(DeferredValue::BindingRef {
+            binding: "a".to_string(),
+        }),
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+            "k".to_string(),
+            Value::Deferred(DeferredValue::BindingRef {
+                binding: "b".to_string(),
+            }),
+        )]))),
+        Value::Deferred(DeferredValue::Interpolation(vec![
+            InterpolationPart::Literal("x".to_string()),
+            InterpolationPart::Expr(Value::Deferred(DeferredValue::BindingRef {
+                binding: "c".to_string(),
+            })),
+        ])),
+        Value::Deferred(DeferredValue::FunctionCall {
+            name: "join".to_string(),
+            args: vec![Value::Deferred(DeferredValue::BindingRef {
+                binding: "d".to_string(),
+            })],
+        }),
+        Value::Deferred(DeferredValue::Secret(Box::new(Value::Deferred(
+            DeferredValue::BindingRef {
+                binding: "e".to_string(),
+            },
+        )))),
+    ]));
+
+    let mut collected = Vec::new();
+    value.visit_binding_refs(&mut |binding| {
+        collected.push(binding.to_string());
+    });
+    collected.sort();
+
+    assert_eq!(collected, vec!["a", "b", "c", "d", "e"]);
+}
+
+#[test]
+fn visit_resource_refs_on_leaf_variants_calls_nothing() {
     for v in [
         Value::Concrete(ConcreteValue::String("s".into())),
         Value::Concrete(ConcreteValue::Int(1)),
@@ -963,7 +1003,7 @@ fn visit_refs_on_leaf_variants_calls_nothing() {
         Value::Concrete(ConcreteValue::Bool(true)),
     ] {
         let mut count = 0;
-        v.visit_refs(&mut |_| count += 1);
+        v.visit_resource_refs(&mut |_| count += 1);
         assert_eq!(count, 0);
     }
 }

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -404,7 +404,7 @@ pub fn check_upstream_state_field_references<E: crate::parser::ExportParamLike>(
     // errors directly below.
     {
         let mut check = |value: &Value, location: &str| {
-            value.visit_refs(&mut |path| {
+            value.visit_resource_refs(&mut |path| {
                 let binding = path.binding();
                 let field = path.attribute();
                 let Some(keys) = exports.get(binding) else {
@@ -1096,7 +1096,7 @@ fn visit_attribute_access(
     location: &str,
     errors: &mut Vec<UpstreamAttributeAccessShapeError>,
 ) {
-    value.visit_refs(&mut |path| {
+    value.visit_resource_refs(&mut |path| {
         let leading: Vec<String> = path.leading_field_path();
         if leading.is_empty() {
             return;
@@ -1256,7 +1256,7 @@ fn visit_subscript_access(
     location: &str,
     errors: &mut Vec<UpstreamSubscriptShapeError>,
 ) {
-    value.visit_refs(&mut |path| {
+    value.visit_resource_refs(&mut |path| {
         // Chained access (`cert.foo[0].bar`) is not yet exercised by
         // this checker — see #3025 for the planned segments-driven
         // walker. Skip the path here; the resolver still surfaces

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1783,7 +1783,7 @@ impl DiagnosticEngine {
         binding_schema_map: &HashMap<&str, &ResourceSchema>,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
-        value.visit_refs(&mut |path| {
+        value.visit_resource_refs(&mut |path| {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let Some(ref_schema) = binding_schema_map.get(binding_name) else {


### PR DESCRIPTION
Closes #3476

## Problem

`Value::visit_refs` was the canonical recursive ref walker but only surfaced `ResourceRef`; bare `BindingRef` values were silently dropped. Three consumers had to compensate: `differ/plan.rs` carried a private `visit_binding_refs` companion (PR #3477), `deps::collect_dependencies` rolled an independent walker, and `display/mod.rs::value_references_binding` ran a non-exhaustive List/Map-only walker. Each was a drift hazard of the same class #3465 and #3467 closed elsewhere.

## Design — split into two methods

```rust
Value::visit_resource_refs(&mut impl FnMut(&AccessPath))
Value::visit_binding_refs(&mut impl FnMut(&str))
```

Each is exhaustive over `Value` variants with no wildcard arm, so a new `Value` variant forces a compile-time decision in both methods.

A consumer that needs both kinds of references must call both methods. Drift is then visible at the call site (`grep visit_resource_refs` vs `grep visit_binding_refs`), not hidden in a `_ =>` arm.

### Why not a `RefKind` enum with `#[non_exhaustive]`

An earlier draft of this PR did exactly that — a single `visit_refs(FnMut(RefKind<'_>))` with `#[non_exhaustive]` on the enum. It was rejected because the user pointed out a closure can still write `match kind { RefKind::Resource(p) => ..., _ => {} }` and silently drop Binding without compiler help. `#[non_exhaustive]` converts a type-safety bug into a documentation convention (grep `_ =>` arms in review), which the project rule against type-shape-weakening compromises (CLAUDE.md, just-merged #3478) explicitly forbids. The two-method split has the desired property: a consumer that ignores `BindingRef` writes only `visit_resource_refs`, and that omission is grep-visible — no API permits silently dropping a variant.

## Callsite changes

- The 6 existing `visit_refs` consumers (`upstream_exports` ×3, `detail_rows`, `parser/resolve`, LSP diagnostics) rename to `visit_resource_refs`. They were resource-only by intent; the callback signature stays `FnMut(&AccessPath)`.
- `deps::collect_dependencies` and both `value_references_binding` helpers now call both methods. Previously divergent semantics between `carina-cli/display::value_references_binding` (List/Map only) and `carina-core/detail_rows::value_references_binding` (ResourceRef only via visit_refs) are unified.
- `differ/plan.rs::cascade_ref_hint` keeps its ResourceRef-first ordering (richer hint wins) by calling `visit_resource_refs` first and falling back to `visit_binding_refs` only on a miss. The private companion is deleted.

## Tests added

- `visit_binding_refs_collects_from_all_nested_variants` — mirrors the existing resource-side test for List/Map/Interpolation/FunctionCall/Secret nesting
- `cascade_hint_prefers_resource_ref_over_binding_ref_in_mixed_list` — pins ResourceRef-wins as intentional, not implementation-incidental. Note: this regression-guards the rejected interleaved-walker design more than it distinguishes from the prior two-pass code (both old and new shapes pass this).
- `value_references_binding_covers_non_container_variants` extended to assert the BindingRef dispatch in the helper

## Verify

`cargo nextest run --workspace --all-features` 4061 passed / 72 skipped; doctests, clippy `-D warnings`, and all `scripts/check-*.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
