### PR TITLE
Add http_response_status_code as a built-in DSL custom type

### DIFF
--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -11,8 +11,8 @@ use super::{ProviderContext, Rule, parse_expression};
 use crate::eval_value::EvalValue;
 use crate::resource::{ConcreteValue, DeferredValue, UnknownReason, Value};
 use crate::schema::{
-    TypeIdentity, validate_ipv4_address, validate_ipv4_cidr, validate_ipv6_address,
-    validate_ipv6_cidr,
+    TypeIdentity, validate_http_response_status_code, validate_ipv4_address, validate_ipv4_cidr,
+    validate_ipv6_address, validate_ipv6_cidr,
 };
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -245,6 +245,9 @@ pub fn validate_custom_type(
         }
         (Some("Ipv6Address"), value) if text(value).is_some() => {
             validate_ipv6_address(text(value).unwrap())
+        }
+        (Some("HttpResponseStatusCode"), value) if text(value).is_some() => {
+            validate_http_response_status_code(text(value).unwrap())
         }
         (_, Value::Deferred(DeferredValue::ResourceRef { .. })) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::FunctionCall { .. })) => Ok(()), // will be resolved later

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -39,6 +39,7 @@ pub use resolve::{
 pub(crate) use resolve::{
     collect_seed_bindings_from_parts, reject_cyclic_let_bindings_in_variables,
 };
+pub use types::BUILTIN_BARE_CUSTOM_TYPES;
 pub use types::parse_type_expr_str;
 pub(crate) use types::{is_known_bare_custom_type, unknown_custom_type_message};
 pub(crate) use util::{eval_type_name, value_type_name};

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -6325,6 +6325,36 @@ fn user_fn_custom_type_ipv6_address_arg_valid() {
 }
 
 #[test]
+fn user_fn_custom_type_http_response_status_code_arg_valid() {
+    let input = r#"
+        fn f(x: HttpResponseStatusCode) { x }
+
+        let b = aws.s3_bucket {
+            name = f("200")
+        }
+    "#;
+    let result = parse(input, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+}
+
+#[test]
+fn user_fn_custom_type_http_response_status_code_arg_invalid() {
+    let input = r#"
+        fn f(x: HttpResponseStatusCode) { x }
+
+        let b = aws.s3_bucket {
+            name = f("nonsense")
+        }
+    "#;
+    let err = parse(input, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("type 'http_response_status_code' validation failed"),
+        "Expected http_response_status_code validation error, got: {msg}"
+    );
+}
+
+#[test]
 fn user_fn_custom_type_ipv6_address_arg_invalid() {
     let input = r#"
         fn f(x: Ipv6Address) { x }
@@ -6419,6 +6449,36 @@ fn user_fn_custom_type_return_ipv4_address_invalid() {
     assert!(
         msg.contains("return type 'ipv4_address' validation failed"),
         "Expected ipv4_address validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_return_http_response_status_code_valid() {
+    let input = r#"
+        fn f(): HttpResponseStatusCode { "200" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "#;
+    let result = parse(input, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+}
+
+#[test]
+fn user_fn_custom_type_return_http_response_status_code_invalid() {
+    let input = r#"
+        fn f(): HttpResponseStatusCode { "100" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "#;
+    let err = parse(input, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("return type 'http_response_status_code' validation failed"),
+        "Expected http_response_status_code validation error, got: {msg}"
     );
 }
 

--- a/carina-core/src/parser/types.rs
+++ b/carina-core/src/parser/types.rs
@@ -71,8 +71,13 @@ pub(super) fn parse_type_expr(
 /// (if any) have registered, because their validators live in
 /// `carina-core` rather than in any provider — see the matching arms in
 /// [`crate::parser::functions::validate_custom_type`].
-const BUILTIN_BARE_CUSTOM_TYPES: &[&str] =
-    &["ipv4_cidr", "ipv4_address", "ipv6_cidr", "ipv6_address"];
+pub const BUILTIN_BARE_CUSTOM_TYPES: &[&str] = &[
+    "ipv4_cidr",
+    "ipv4_address",
+    "ipv6_cidr",
+    "ipv6_address",
+    "http_response_status_code",
+];
 
 /// True iff a snake-cased bare type name resolves to a known custom
 /// type — either a `carina-core` built-in or an identity registered in
@@ -382,26 +387,27 @@ mod tests {
             customs_loaded: true,
             ..Default::default()
         };
-        // No validators registered → only the four built-ins are valid.
-        // A clearly-fake name is rejected.
+        // No validators registered → only the BUILTIN_BARE_CUSTOM_TYPES
+        // set is valid. A clearly-fake name is rejected.
         assert_eq!(parse_type_expr_str("TotallyMadeUpType", &ctx), None);
         // A historical-but-removed name is rejected the same way — the
         // bug-headline example from carina#3239.
         assert_eq!(parse_type_expr_str("IamOidcProviderArn", &ctx), None);
     }
 
-    /// Built-in DSL custom types (`Ipv4Cidr`, `Ipv4Address`, `Ipv6Cidr`,
-    /// `Ipv6Address`) are always accepted, even when no provider has
-    /// registered any validators — they are part of `carina-core` itself.
+    /// Built-in DSL custom types (the `BUILTIN_BARE_CUSTOM_TYPES` set)
+    /// are always accepted, even when no provider has registered any
+    /// validators — they are part of `carina-core` itself.
     #[test]
     fn parse_type_expr_str_accepts_builtins_when_customs_loaded() {
         let ctx = ProviderContext {
             customs_loaded: true,
             ..Default::default()
         };
-        for name in ["Ipv4Cidr", "Ipv4Address", "Ipv6Cidr", "Ipv6Address"] {
+        for snake in BUILTIN_BARE_CUSTOM_TYPES {
+            let name = snake_to_pascal(snake);
             assert!(
-                matches!(parse_type_expr_str(name, &ctx), Some(TypeExpr::Simple(_))),
+                matches!(parse_type_expr_str(&name, &ctx), Some(TypeExpr::Simple(_))),
                 "built-in custom type '{name}' must parse with customs_loaded=true"
             );
         }

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -4934,6 +4934,28 @@ pub mod types {
             None,
         )
     }
+
+    /// HTTP response status code restricted to 2XX/4XX/5XX (3-digit string).
+    ///
+    /// Informational (1XX) and redirect (3XX) codes are excluded by design —
+    /// this matches the constraint AWS documents for ELBv2 fixed-response
+    /// actions. A future generic `http_status_code()` covering 1XX–5XX can be
+    /// added as a sibling if a non-restricted consumer appears.
+    pub fn http_response_status_code() -> AttributeType {
+        AttributeType::refined_string_with_validator(
+            Some(TypeIdentity::bare("HttpResponseStatusCode")),
+            None,
+            None,
+            legacy_validator(|value| {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
+                    validate_http_response_status_code(s)
+                } else {
+                    Err("Expected string".to_string())
+                }
+            }),
+            None,
+        )
+    }
 }
 
 /// Validate an IPv4 address (e.g., "10.0.1.5", "192.168.0.1")
@@ -5131,6 +5153,24 @@ pub fn validate_email(email: &str) -> Result<(), String> {
         }
     }
 
+    Ok(())
+}
+
+/// Validate a 3-digit HTTP response status code restricted to 2XX/4XX/5XX.
+pub fn validate_http_response_status_code(code: &str) -> Result<(), String> {
+    if code.len() != 3 {
+        return Err(format!(
+            "must be exactly 3 digits, got {} characters",
+            code.len()
+        ));
+    }
+    if !code.chars().all(|c| c.is_ascii_digit()) {
+        return Err("must contain only digits".to_string());
+    }
+    let first = code.chars().next().expect("length checked above");
+    if !matches!(first, '2' | '4' | '5') {
+        return Err(format!("must start with 2, 4, or 5 (got '{first}')"));
+    }
     Ok(())
 }
 

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -4023,6 +4023,76 @@ fn validate_email_type() {
     );
 }
 
+#[test]
+fn validate_http_response_status_code_function_directly() {
+    // Valid: 2XX/4XX/5XX
+    assert!(validate_http_response_status_code("200").is_ok());
+    assert!(validate_http_response_status_code("299").is_ok());
+    assert!(validate_http_response_status_code("400").is_ok());
+    assert!(validate_http_response_status_code("499").is_ok());
+    assert!(validate_http_response_status_code("500").is_ok());
+    assert!(validate_http_response_status_code("599").is_ok());
+
+    // Invalid: disallowed leading digit (fence-post boundaries pin the
+    // excluded 1XX/3XX/6XX ranges explicitly).
+    assert!(validate_http_response_status_code("100").is_err());
+    assert!(validate_http_response_status_code("199").is_err());
+    assert!(validate_http_response_status_code("300").is_err());
+    assert!(validate_http_response_status_code("301").is_err());
+    assert!(validate_http_response_status_code("399").is_err());
+    assert!(validate_http_response_status_code("600").is_err());
+    // Invalid: wrong length
+    assert!(validate_http_response_status_code("20").is_err());
+    assert!(validate_http_response_status_code("2000").is_err());
+    assert!(validate_http_response_status_code("").is_err());
+    // Invalid: non-digit
+    assert!(validate_http_response_status_code("nonsense").is_err());
+    assert!(validate_http_response_status_code("12a").is_err());
+}
+
+#[test]
+fn validate_http_response_status_code_type() {
+    let t = types::http_response_status_code();
+
+    // Type identity: refined String with kind "HttpResponseStatusCode"
+    match t.kind() {
+        AttrTypeKind::String { identity, .. } => {
+            assert_eq!(
+                identity.as_ref().map(|id| id.kind.as_str()),
+                Some("HttpResponseStatusCode")
+            );
+        }
+        other => panic!("Expected refined String, got: {:?}", other),
+    }
+
+    // Valid
+    for ok in ["200", "299", "400", "499", "500", "599"] {
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(ok.to_string())))
+                .is_ok(),
+            "Expected {ok} to validate"
+        );
+    }
+
+    // Invalid (includes fence-post boundaries 199/300/399 for the
+    // excluded 1XX/3XX ranges).
+    for bad in [
+        "100", "199", "300", "301", "399", "600", "nonsense", "20", "2000", "12a", "",
+    ] {
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(bad.to_string())))
+                .is_err(),
+            "Expected {bad} to fail validation"
+        );
+    }
+
+    // Wrong type
+    assert!(
+        t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            .is_err()
+    );
+}
+
 #[cfg(test)]
 mod validate_collect_tests {
     use super::*;

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -3256,11 +3256,11 @@ fn validate_argument_custom_types_is_independent_of_customs_loaded_flag() {
     // walker delegates to `is_known_bare_custom_type`, whose contract
     // is "true iff snake matches a built-in or a bare-registered
     // validator"; on an empty validator set the only accepted names
-    // are the four built-ins, so an unknown name still produces a
-    // finding even with the parser gate inactive. This pins that the
-    // walker is *independent* of `customs_loaded` — only the parser
-    // is gated; the post-parse walker always reports. Callers that
-    // need the bootstrap-context exemption (e.g. LSP orphaned-file
+    // are the BUILTIN_BARE_CUSTOM_TYPES set, so an unknown name still
+    // produces a finding even with the parser gate inactive. This pins
+    // that the walker is *independent* of `customs_loaded` — only the
+    // parser is gated; the post-parse walker always reports. Callers
+    // that need the bootstrap-context exemption (e.g. LSP orphaned-file
     // diagnostics) must withhold the call themselves.
     let mut ctx = ProviderContext::default();
     assert!(!ctx.customs_loaded);

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -902,9 +902,10 @@ fn type_completion_includes_basic_types() {
     );
 
     // Built-in custom types should always appear (no provider needed)
-    for builtin_custom in &["Ipv4Cidr", "Ipv4Address", "Ipv6Cidr", "Ipv6Address"] {
+    for snake in carina_core::parser::BUILTIN_BARE_CUSTOM_TYPES {
+        let builtin_custom = carina_core::parser::snake_to_pascal(snake);
         assert!(
-            labels.contains(builtin_custom),
+            labels.contains(&builtin_custom.as_str()),
             "Type completions should include built-in custom type '{}'. Got: {:?}",
             builtin_custom,
             labels

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -1711,9 +1711,8 @@ impl CompletionProvider {
 
         // Custom types: built-in types + provider-extracted types (deduplicated).
         // Internal registry is snake_case; the LSP surface is PascalCase.
-        let builtin_custom = ["ipv4_cidr", "ipv4_address", "ipv6_cidr", "ipv6_address"];
         let mut seen_custom = std::collections::HashSet::new();
-        let custom: Vec<CompletionItem> = builtin_custom
+        let custom: Vec<CompletionItem> = carina_core::parser::BUILTIN_BARE_CUSTOM_TYPES
             .iter()
             .map(|s| s.to_string())
             .chain(self.custom_type_names.iter().cloned())

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1489,8 +1489,7 @@ impl DiagnosticEngine {
     fn check_unknown_type_names(&self, type_expr: &TypeExpr) -> Option<String> {
         match type_expr {
             TypeExpr::Simple(name) => {
-                let builtin = ["ipv4_cidr", "ipv4_address", "ipv6_cidr", "ipv6_address"];
-                if builtin.contains(&name.as_str()) {
+                if carina_core::parser::BUILTIN_BARE_CUSTOM_TYPES.contains(&name.as_str()) {
                     return None;
                 }
                 // `Simple` annotations name a built-in custom type; key


### PR DESCRIPTION
## Summary

Adds `http_response_status_code` to the carina-core built-in DSL custom type set, alongside `ipv4_cidr` / `ipv4_address` / `ipv6_cidr` / `ipv6_address`. Identity is `TypeIdentity::bare("HttpResponseStatusCode")` (no provider axis). The validator restricts the value to a 3-digit ASCII string whose leading digit is 2, 4, or 5 — informational (1XX) and redirect (3XX) codes are excluded by design, matching the constraint AWS documents for ELBv2 fixed-response actions.

This is the first half of fixing carina-rs/carina-provider-awscc#353. The awscc-side PR will land separately and attach this type to `AWS::ElasticLoadBalancingV2::Listener` `FixedResponseConfig.StatusCode` via the existing `resource_type_overrides` mechanism, so `carina validate` rejects `'nonsense'` instead of waiting for an apply-time CloudControl `ValidationException`.

## Why carina-core, not carina-aws-types

HTTP status codes are a protocol concept, not an AWS concept. Any future non-AWS provider (github, cloudflare, kubernetes) that needs the same constraint should be able to import the type from carina-core, just like `ipv4_cidr`. Placing the type in `carina-aws-types` would have either forced unrelated providers to depend on the AWS types crate or led to duplicate validators — exactly the sibling-bug shape CLAUDE.md warns against.

## Built-in seam cleanup (root cause)

While wiring the new built-in I noticed `BUILTIN_BARE_CUSTOM_TYPES` was duplicated as hardcoded arrays at three sites: the canonical constant in `parser/types.rs`, the LSP completion list, and the LSP diagnostic guard. A new built-in had to be added in all three or the LSP would silently emit an "unknown type" diagnostic and skip the type from completion. That is the convention-only seam CLAUDE.md flags as the wrong shape — the type system should answer the ""new caller tomorrow"" question, not documentation.

The fix in this PR:

- `BUILTIN_BARE_CUSTOM_TYPES` is promoted to `pub` and re-exported from `carina_core::parser`.
- Both LSP sites (`completion/values.rs`, `diagnostics/checks.rs`) consume the canonical constant.
- The two tests that previously hardcoded their own `[Ipv4Cidr, ...]` arrays now iterate the canonical constant via `snake_to_pascal`.

A future built-in is now a one-line addition to the constant; everything else follows from the type system.

## Test plan

- [x] `cargo nextest run -p carina-core` (2422 passed)
- [x] `cargo nextest run -p carina-lsp` (522 passed)
- [x] `cargo nextest run --workspace` (4074 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all check scripts pass)
- [x] Boundary tests: 200/299/400/499/500/599 valid; 100/199/300/301/399/600/non-digit/wrong-length invalid.
- [x] DSL-level smoke: `fn f(x: http_response_status_code)` parses; bad literals raise "type 'http_response_status_code' validation failed".