### PR TITLE
docs(claude.md): require cross-repo provider check before declaring a PR complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,6 +456,18 @@ Carina is split across multiple repositories under [carina-rs](https://github.co
 
 Provider repositories depend on this repo's crates via `git` dependencies.
 
+**Cross-repo changes: never assume the sibling provider is unaffected.**
+When touching anything that crosses the provider boundary — WIT / wasi:http
+protocol, `carina-provider-protocol`, `carina-aws-types`, host↔plugin
+serialization, shared schema or differ logic — explicitly check whether
+`carina-provider-aws` *and* `carina-provider-awscc` both need a
+counterpart PR (and a rev bump in this repo afterwards). Past breakage
+(carina#3364, awscc#346) was a wasi:http / protocol mismatch where one
+provider had pinned an older rev and silently degraded; "this only
+touches aws" / "awscc looks unrelated" intuitions kept being wrong.
+Search both provider repos for the symbol or protocol surface you
+changed before declaring a PR complete.
+
 ## Crate Structure (this repo)
 
 - **carina-core**: Core library with parser, types, and traits. No AWS dependencies.


### PR DESCRIPTION
## Summary

- Polyrepo セクションに「provider 境界をまたぐ変更時は awscc / aws の counterpart PR が必要か必ず確認する」ルールを追加
- wasi:http / WIT、`carina-provider-protocol`、`carina-aws-types`、host↔plugin serialization、共有 schema / differ を例示
- 過去事例として carina#3364 と awscc#346 を引用（片方の provider が古い rev を pin して silently degrade した事例）

## Why

既存の「Provider crates ... may require updating those repos」という記述は曖昧で、「片方の provider が無影響」と仮定して片側だけ PR を出し、wasi:http 不整合で silently degrade するケースが繰り返されていた。明文化して「両 repo を grep してから PR 完了と宣言する」を必須化する。

## Test plan

- [ ] docs-only。`scripts/check-docs-use-new-spellings.sh` 通過済み