### PR TITLE
apply: surface total wall-clock and clarify per-resource timing label

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use colored::Colorize;
 
@@ -31,10 +32,8 @@ use crate::commands::shared::effect_execution::{
     execute_import_effects, execute_state_only_effects,
 };
 use crate::commands::shared::observer::CliObserver;
-#[cfg(test)]
-use crate::commands::shared::progress::format_duration;
 use crate::commands::shared::progress::{
-    RefreshProgress, emit_newline_on_interrupt, refresh_multi_progress,
+    RefreshProgress, emit_newline_on_interrupt, format_duration, refresh_multi_progress,
 };
 use crate::commands::shared::state_writeback::{
     ApplyStateSave, FinalizeApplyInput, PostApplyStates, apply_name_overrides,
@@ -53,6 +52,10 @@ use crate::wiring::{
 
 /// Re-export ExecutionResult as the public API for apply results.
 pub type ApplyResult = ExecutionResult;
+
+fn format_total_apply_line(elapsed: Duration) -> String {
+    format!("Done in {}.", format_duration(elapsed))
+}
 
 /// Execute all effects in a plan, resolving references dynamically.
 ///
@@ -802,10 +805,15 @@ pub async fn run_apply(
             println!("  {} Lock released", "✓".green());
         }
 
-        op_result?;
+        let timing = op_result?;
         release_result?;
+        if let Some(elapsed) = timing {
+            println!("{}", format_total_apply_line(elapsed));
+        }
     } else {
-        op_result?;
+        if let Some(timing) = op_result? {
+            println!("{}", format_total_apply_line(timing));
+        }
     }
 
     Ok(())
@@ -819,7 +827,7 @@ async fn run_apply_locked(
     lock: Option<&LockInfo>,
     base_dir: &std::path::Path,
     provider_context: &ProviderContext,
-) -> Result<(), AppError> {
+) -> Result<Option<Duration>, AppError> {
     // Read current state from backend. carina#3315: if `check_and_migrate`
     // lifted an older on-disk schema in memory, persist the upgrade
     // under the current lock before any short-circuit path can return
@@ -1312,7 +1320,7 @@ async fn run_apply_locked(
 
         if export_changes.is_empty() {
             println!("{}", "No changes needed.".green());
-            return Ok(());
+            return Ok(None);
         }
 
         print_plan(
@@ -1332,7 +1340,7 @@ async fn run_apply_locked(
             let _ = tokio::signal::ctrl_c().await;
         };
         if confirm_apply(stdin, interrupt, auto_approve).await? == ApplyConfirmation::Cancelled {
-            return Ok(());
+            return Ok(None);
         }
 
         println!(
@@ -1362,7 +1370,7 @@ async fn run_apply_locked(
             &current_states,
         )
         .await?;
-        return Ok(());
+        return Ok(None);
     }
 
     // Build delete attributes map from current states for display
@@ -1416,9 +1424,10 @@ async fn run_apply_locked(
         let _ = tokio::signal::ctrl_c().await;
     };
     if confirm_apply(stdin, interrupt, auto_approve).await? == ApplyConfirmation::Cancelled {
-        return Ok(());
+        return Ok(None);
     }
 
+    let apply_phase_started = Instant::now();
     println!("{}", "Applying changes...".cyan().bold());
     println!();
 
@@ -1451,6 +1460,7 @@ async fn run_apply_locked(
 
     // Execute remove and move effects (state-only, logged for user feedback)
     execute_state_only_effects(&plan, &mut result);
+    let resources_finished = Instant::now();
 
     // Use `resources_for_plan` (post-default_tags merge, post-canonicalize)
     // for state writeback so the per-resource `explicit` tree includes
@@ -1481,7 +1491,7 @@ async fn run_apply_locked(
                 .green()
                 .bold()
         );
-        Ok(())
+        Ok(Some(resources_finished.duration_since(apply_phase_started)))
     } else {
         let mut parts = vec![format!("{} succeeded", result.success_count)];
         if result.failure_count > 0 {
@@ -1635,10 +1645,15 @@ pub async fn run_apply_from_plan(
             println!("  {} Lock released", "✓".green());
         }
 
-        op_result?;
+        let timing = op_result?;
         release_result?;
+        if let Some(elapsed) = timing {
+            println!("{}", format_total_apply_line(elapsed));
+        }
     } else {
-        op_result?;
+        if let Some(timing) = op_result? {
+            println!("{}", format_total_apply_line(timing));
+        }
     }
 
     Ok(())
@@ -1650,7 +1665,7 @@ async fn run_apply_from_plan_locked(
     backend: &dyn StateBackend,
     lock: Option<&LockInfo>,
     base_dir: &std::path::Path,
-) -> Result<(), AppError> {
+) -> Result<Option<Duration>, AppError> {
     // Read current state and validate lineage. carina#3315: a
     // pending in-memory schema migration must be persisted under
     // the apply lock so the carina#3283 warning text matches
@@ -1771,7 +1786,7 @@ async fn run_apply_from_plan_locked(
         // path's gate (carina#3270 → run_apply_locked).
         // carina#3275.
         println!("{}", "No changes needed.".green());
-        return Ok(());
+        return Ok(None);
     }
 
     // Build delete attributes map from current states for display
@@ -1806,7 +1821,7 @@ async fn run_apply_from_plan_locked(
         let _ = tokio::signal::ctrl_c().await;
     };
     if confirm_apply(stdin, interrupt, auto_approve).await? == ApplyConfirmation::Cancelled {
-        return Ok(());
+        return Ok(None);
     }
 
     // Verify upstream-state bindings have not drifted since `carina
@@ -1851,6 +1866,7 @@ async fn run_apply_from_plan_locked(
         wait_aliases: &wait_aliases,
     });
 
+    let apply_phase_started = Instant::now();
     println!("{}", "Applying changes...".cyan().bold());
     println!();
 
@@ -1882,6 +1898,7 @@ async fn run_apply_from_plan_locked(
 
     // Execute remove and move effects (state-only, logged for user feedback)
     execute_state_only_effects(plan, &mut result);
+    let resources_finished = Instant::now();
 
     // Build schemas for write-only attribute persistence
     let (factories, _) = build_factories_from_providers(&plan_file.provider_configs, base_dir);
@@ -1921,7 +1938,7 @@ async fn run_apply_from_plan_locked(
                 .green()
                 .bold()
         );
-        Ok(())
+        Ok(Some(resources_finished.duration_since(apply_phase_started)))
     } else {
         let mut parts = vec![format!("{} succeeded", result.success_count)];
         if result.failure_count > 0 {

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -2,6 +2,14 @@ use super::*;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
 use std::time::Duration;
 
+#[test]
+fn total_apply_line_formats_duration() {
+    assert_eq!(
+        format_total_apply_line(Duration::from_secs(5)),
+        "Done in 5.0s."
+    );
+}
+
 fn s3_backend_config_with_encrypt(encrypt: bool) -> carina_core::parser::BackendConfig {
     let mut attributes = HashMap::new();
     attributes.insert(

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -801,7 +801,7 @@ async fn run_destroy_locked(
 
         match delete_result {
             Ok(()) => {
-                let timing = format!("[{}]", format_duration(started.elapsed())).dimmed();
+                let timing = format!("took {}", format_duration(started.elapsed())).dimmed();
                 let msg = format!(
                     "{} {} {} {}",
                     "✓".green(),
@@ -847,7 +847,7 @@ async fn run_destroy_locked(
                     );
                     finish_spinner(&mut spinners, finished_idx, msg);
                 } else {
-                    let timing = format!("[{}]", format_duration(started.elapsed())).dimmed();
+                    let timing = format!("took {}", format_duration(started.elapsed())).dimmed();
                     let msg = format!(
                         "{} {} {} {}\n      {} {}",
                         "✗".red(),

--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -94,7 +94,7 @@ fn handle_tty(
             ..
         } => {
             let key = format_effect(effect);
-            let timing = format!("[{}]", format_duration(*duration)).dimmed();
+            let timing = format!("took {}", format_duration(*duration)).dimmed();
             let counter = format_progress(progress).dimmed();
             let msg = format!(
                 "{} {} {} {}",
@@ -118,7 +118,7 @@ fn handle_tty(
             progress,
         } => {
             let key = format_effect(effect);
-            let timing = format!("[{}]", format_duration(*duration)).dimmed();
+            let timing = format!("took {}", format_duration(*duration)).dimmed();
             let counter = format_progress(progress).dimmed();
             let msg = format!(
                 "{} {} {} {}\n      {} {}",
@@ -233,7 +233,7 @@ fn format_plain(event: &ExecutionEvent) -> Vec<String> {
             progress,
             ..
         } => {
-            let timing = format!("[{}]", format_duration(*duration));
+            let timing = format!("took {}", format_duration(*duration));
             let counter = format_progress(progress);
             vec![format!(
                 "  ✓ {} {} {}",
@@ -248,7 +248,7 @@ fn format_plain(event: &ExecutionEvent) -> Vec<String> {
             duration,
             progress,
         } => {
-            let timing = format!("[{}]", format_duration(*duration));
+            let timing = format!("took {}", format_duration(*duration));
             let counter = format_progress(progress);
             vec![
                 format!("  ✗ {} {} {}", format_effect(effect), timing, counter),
@@ -333,6 +333,7 @@ mod tests {
         assert!(line.contains("✓"), "missing check mark: {line}");
         assert!(line.contains("Create"), "missing verb: {line}");
         assert!(line.contains("demo"), "missing resource name: {line}");
+        assert!(line.contains("took"), "missing `took` label: {line}");
         assert!(line.contains("1/3"), "missing counter: {line}");
     }
 
@@ -350,6 +351,11 @@ mod tests {
         });
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains("✗"));
+        assert!(
+            lines[0].contains("took"),
+            "missing `took` label: {}",
+            lines[0]
+        );
         assert!(lines[1].contains("boom"));
     }
 

--- a/carina-cli/src/commands/shared/progress.rs
+++ b/carina-cli/src/commands/shared/progress.rs
@@ -66,7 +66,7 @@ impl RefreshProgress {
     /// Finish the spinner with a success checkmark and elapsed time.
     pub fn finish(self) {
         let elapsed = self.start.elapsed();
-        let timing = format!("[{}]", format_duration(elapsed)).dimmed();
+        let timing = format!("took {}", format_duration(elapsed)).dimmed();
         let msg = format!("{} {} {}", "✓".green(), self.pb.message(), timing);
         self.pb
             .set_style(ProgressStyle::with_template("  {msg}").unwrap());


### PR DESCRIPTION
Closes #3487

## Summary

Two rough edges in `carina apply` output:

1. **No total wall-clock line.** After `Lock released`, the run exited
   without telling you how long apply took. You had to subtract log
   timestamps by hand.
2. **`[N.Ns]` per-resource label was ambiguous.** The bracket made it
   read like a cumulative counter even though the value was already a
   per-resource API duration — Issue #3487's reporter genuinely
   misread it that way.

## Changes

### `Done in <duration>.` after `Lock released`

Emit a single trailing line on the success path:

```
Apply complete! 12 changes applied.

  ✓ State saved (serial: 5)
  ✓ Lock released
Done in 1m 41s.
```

The window measured is `Applying changes...` → end of effect execution
(`execute_effects` + `execute_import_effects` + `execute_state_only_effects`).
`finalize_apply` (state writeback) and lock release are intentionally
excluded — they're not "resource work."

The line does not include a resource count. The Issue's mockup showed
``Applied N resources in T``, but the row directly above
(`Apply complete! N changes applied.`) already prints the count, and
keeping a second count introduces a real mismatch bug: a plan with
only `Move`/`Remove`/`Import` effects passes ``has_mutations`` (their
``success_count`` increments) but those effects are excluded from the
executor's actionable-effects total, so the two lines disagree
(``1 changes applied. / Applied 0 resources``). Dropping the count
makes the bug unrepresentable.

Failure, cancel, and ``No changes needed.`` paths return ``Ok(None)`` /
``Err(...)`` and do not emit the line.

### `[N.Ns]` → `took N.Ns` everywhere a per-resource duration is rendered

Per the project's root-cause rule, this is one ambiguous label at
several sibling sites, not several independent typos. All CLI
per-resource success/failure/refresh rows now use ``took`` so a future
operator reading any of them sees the same verb:

- ``carina-cli/src/commands/shared/observer.rs`` — apply TTY + Plain
  success/failure rows (4 sites)
- ``carina-cli/src/commands/destroy.rs`` — destroy success + failure rows (2 sites)
- ``carina-cli/src/commands/shared/progress.rs`` — ``RefreshProgress::finish``
  (used during apply's own refresh phase and ``carina refresh``) (1 site)

### Collapse the lock-release match block

The success-path lock-release handling was a 14-line ``match`` that
re-implemented ``?`` manually. Replaced with the equivalent 4 lines at
both call sites:

```rust
let timing = op_result?;
release_result?;
if let Some(elapsed) = timing {
    println!(\"{}\", format_total_apply_line(elapsed));
}
```

Apply-error-wins semantics is preserved by ``?`` short-circuit ordering.

## Test plan

- [x] ``cargo nextest run --workspace --all-features`` (4093 passed)
- [x] ``cargo test --workspace --doc``
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``bash scripts/check-*.sh``
- [x] Unit test: ``format_total_apply_line(Duration::from_secs(5)) == \"Done in 5.0s.\"``
- [x] Unit tests in ``observer.rs`` assert ``took`` substring on success/failure rows
- [x] 5-round self-review (1 real finding: an unrelated whitespace
      removal accidentally introduced by the editor — fixed)