### PR TITLE
fix(executor): unify changed-attribute decision across plan, apply, and cascade-update paths

### DIFF
--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -1,5 +1,6 @@
 //! Type-aware comparison logic for diffing resource attributes.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 
 use indexmap::IndexMap;
@@ -488,6 +489,129 @@ fn secret_matches_state(
     }
 }
 
+pub(crate) struct TypedAttr<'a> {
+    pub(crate) attr_type: &'a AttributeType,
+    pub(crate) defs: &'a BTreeMap<String, AttributeType>,
+}
+
+pub(crate) struct AttrComparison<'a> {
+    pub(crate) from: Option<&'a Value>,
+    pub(crate) to: &'a Value,
+    pub(crate) saved: Option<&'a Value>,
+    pub(crate) type_info: Option<TypedAttr<'a>>,
+    pub(crate) secret_ctx: Option<&'a SecretHashContext>,
+}
+
+/// Return whether a single attribute's values differ semantically.
+pub(crate) fn should_patch_attr(cmp: AttrComparison<'_>) -> bool {
+    let Some(from_value) = cmp.from else {
+        return true;
+    };
+    let (attr_type, defs) = cmp
+        .type_info
+        .map(|info| (Some(info.attr_type), info.defs))
+        .unwrap_or((None, empty_defs_for_schema_walks()));
+
+    match cmp.saved {
+        Some(saved_value) => {
+            let effective_to = merge_with_saved(cmp.to, saved_value);
+            !type_aware_equal(from_value, &effective_to, attr_type, defs, cmp.secret_ctx)
+        }
+        None => !type_aware_equal(from_value, cmp.to, attr_type, defs, cmp.secret_ctx),
+    }
+}
+
+/// Return whether a key is eligible for a provider patch and semantically changed.
+pub(crate) fn key_should_enter_patch(
+    key: &str,
+    schema: Option<&ResourceSchema>,
+    cmp: AttrComparison<'_>,
+) -> bool {
+    if key.starts_with('_') {
+        return false;
+    }
+    if schema
+        .and_then(|s| s.attributes.get(key))
+        .is_some_and(|attr| attr.write_only && cmp.from.is_none())
+    {
+        return false;
+    }
+    should_patch_attr(cmp)
+}
+
+/// Build a comparison-only view that grafts `Secret` wrappers from source.
+///
+/// Apply-time resolution unwraps secrets before provider calls. Re-wrapping the
+/// comparison view lets the same hash semantics as plan-time diffing run without
+/// changing the normalized value sent to the provider patch.
+///
+/// Matching `(Map, Map)` and equal-length `(List, List)` shapes are walked
+/// recursively. Resolved-only map keys are retained as resolved values; source-only
+/// keys are ignored unless they contain a secret that cannot be grafted. If a
+/// source secret sits behind a divergent shape, there is no unambiguous resolved
+/// position to graft it into, so callers get `None` and must fail closed by not
+/// patching that key. Callers on normalization paths that change container shape
+/// must not assume secret hash comparison remains available.
+pub(crate) fn secret_grafted_comparison_view<'a>(
+    resolved: &'a Value,
+    source: Option<&'a Value>,
+) -> Option<Cow<'a, Value>> {
+    let Some(source) = source else {
+        return Some(Cow::Borrowed(resolved));
+    };
+    if !contains_secret(source) {
+        return Some(Cow::Borrowed(resolved));
+    }
+    let view = match (resolved, source) {
+        (_, Value::Deferred(DeferredValue::Secret(_))) => Cow::Borrowed(source),
+        (
+            Value::Concrete(ConcreteValue::Map(resolved)),
+            Value::Concrete(ConcreteValue::Map(source)),
+        ) => {
+            let mut out = resolved.clone();
+            for (key, resolved_value) in resolved {
+                if let Some(source_value) = source.get(key) {
+                    out.insert(
+                        key.clone(),
+                        secret_grafted_comparison_view(resolved_value, Some(source_value))?
+                            .into_owned(),
+                    );
+                }
+            }
+            if source.iter().any(|(key, source_value)| {
+                !resolved.contains_key(key) && contains_secret(source_value)
+            }) {
+                return None;
+            }
+            Cow::Owned(Value::Concrete(ConcreteValue::Map(out)))
+        }
+        (
+            Value::Concrete(ConcreteValue::List(resolved)),
+            Value::Concrete(ConcreteValue::List(source)),
+        ) if resolved.len() == source.len() => Cow::Owned(Value::Concrete(ConcreteValue::List(
+            resolved
+                .iter()
+                .zip(source)
+                .map(|(resolved_value, source_value)| {
+                    secret_grafted_comparison_view(resolved_value, Some(source_value))
+                        .map(Cow::into_owned)
+                })
+                .collect::<Option<Vec<_>>>()?,
+        ))),
+        _ => return None,
+    };
+    Some(view)
+}
+
+fn contains_secret(value: &Value) -> bool {
+    match value {
+        Value::Deferred(DeferredValue::Secret(_)) => true,
+        Value::Concrete(ConcreteValue::Map(map)) => map.values().any(contains_secret),
+        Value::Concrete(ConcreteValue::List(items)) => items.iter().any(contains_secret),
+        _ => false,
+    }
+}
+
 /// Find changed attributes between desired and current state.
 /// If `saved` is provided, each desired value is merged with the saved value
 /// before comparison, filling in unmanaged nested fields.
@@ -544,52 +668,28 @@ pub(super) fn find_changed_attributes(
     let saved = projected_saved.as_ref().or(saved);
 
     for (key, desired_value) in desired {
-        // Skip internal attributes (starting with _)
-        if key.starts_with('_') {
-            continue;
-        }
-
-        // Skip write-only attributes not present in current state.
-        // CloudControl API does not return write-only properties, so their
-        // absence from state is expected and should not trigger a diff.
-        if schema
-            .and_then(|s| s.attributes.get(key))
-            .is_some_and(|attr| attr.write_only && !projected_current.contains_key(key))
-        {
-            continue;
-        }
-
-        let attr_type = schema
-            .and_then(|s| s.attributes.get(key))
-            .map(|a| &a.attr_type);
+        let type_info = schema.and_then(|s| {
+            s.attributes.get(key).map(|attr| TypedAttr {
+                attr_type: &attr.attr_type,
+                defs,
+            })
+        });
 
         // Build secret hash context from resource ID and attribute key
         let secret_ctx =
             resource_id.map(|id| SecretHashContext::new(id.display_type(), id.name_str(), key));
 
-        let is_equal = match saved.and_then(|s| s.get(key)) {
-            Some(saved_value) => {
-                let effective_desired = merge_with_saved(desired_value, saved_value);
-                projected_current
-                    .get(key)
-                    .map(|cv| {
-                        type_aware_equal(
-                            cv,
-                            &effective_desired,
-                            attr_type,
-                            defs,
-                            secret_ctx.as_ref(),
-                        )
-                    })
-                    .unwrap_or(false)
-            }
-            None => projected_current
-                .get(key)
-                .map(|cv| type_aware_equal(cv, desired_value, attr_type, defs, secret_ctx.as_ref()))
-                .unwrap_or(false),
-        };
-
-        if !is_equal {
+        if key_should_enter_patch(
+            key,
+            schema,
+            AttrComparison {
+                from: projected_current.get(key),
+                to: desired_value,
+                saved: saved.and_then(|s| s.get(key)),
+                type_info,
+                secret_ctx: secret_ctx.as_ref(),
+            },
+        ) {
             changed.push(key.clone());
         }
     }

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -922,6 +922,50 @@ fn secret_in_find_changed_attributes_changed() {
 }
 
 #[test]
+fn key_should_enter_patch_saved_merge_preserves_unmanaged_nested_fields() {
+    let attr_type = AttributeType::map(AttributeType::string());
+    let current = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("new".to_string())),
+        ),
+        (
+            "ManagedBy".to_string(),
+            Value::Concrete(ConcreteValue::String("carina".to_string())),
+        ),
+    ])));
+    let desired = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+        "Name".to_string(),
+        Value::Concrete(ConcreteValue::String("new".to_string())),
+    )])));
+    let saved = Value::Concrete(ConcreteValue::Map(IndexMap::from([
+        (
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("old".to_string())),
+        ),
+        (
+            "ManagedBy".to_string(),
+            Value::Concrete(ConcreteValue::String("carina".to_string())),
+        ),
+    ])));
+
+    assert!(!key_should_enter_patch(
+        "tags",
+        None,
+        AttrComparison {
+            from: Some(&current),
+            to: &desired,
+            saved: Some(&saved),
+            type_info: Some(TypedAttr {
+                attr_type: &attr_type,
+                defs: crate::schema::empty_defs_for_schema_walks(),
+            }),
+            secret_ctx: None,
+        },
+    ));
+}
+
+#[test]
 fn secret_in_map_no_change_when_hash_matches() {
     use crate::value::value_to_json;
 

--- a/carina-core/src/differ/mod.rs
+++ b/carina-core/src/differ/mod.rs
@@ -25,11 +25,13 @@ use crate::schema::{AttributeType, SchemaRegistry};
 #[cfg(test)]
 use comparison::find_changed_attributes;
 
-// Re-exported for the plan detail-row renderer (carina#3073): the
-// renderer must reuse the differ's own type-aware equality so the
-// rendered rows agree with `find_changed_attributes`. Also covers
-// the differ's own tests, which previously imported it under cfg(test).
-pub(crate) use comparison::type_aware_equal;
+// Re-export comparison primitives for consumers that must agree with
+// `find_changed_attributes`: detail rows render with the same equality,
+// and executor patch construction uses the same key/value gate.
+pub(crate) use comparison::{
+    AttrComparison, TypedAttr, key_should_enter_patch, secret_grafted_comparison_view,
+    type_aware_equal,
+};
 
 /// Result of a diff operation
 #[derive(Debug, Clone, PartialEq)]

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -6,6 +6,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use crate::binding_index::ResolvedBindings;
+use crate::differ::{
+    AttrComparison, TypedAttr, key_should_enter_patch, secret_grafted_comparison_view,
+};
 use crate::effect::{BasicEffect, Effect};
 use crate::executor::normalized::{NormalizedResource, apply_desired_normalization};
 use crate::parser::ProviderConfig;
@@ -15,6 +18,7 @@ use crate::provider::{
 };
 use crate::resolver::resolve_ref_value;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};
+use crate::value::SecretHashContext;
 
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 
@@ -586,11 +590,39 @@ pub(super) async fn execute_basic_effect<'a>(
             // reference value and the provider would never be told
             // to update it.
             let mut effective_changed: Vec<String> = changed_attributes.to_vec();
-            for (key, new_value) in &resolved_to.as_resource().attributes {
+            let resolved_resource = resolved_to.as_resource();
+            let schema = pipeline.schemas.get_for(resolved_resource);
+            for (key, new_value) in &resolved_resource.attributes {
                 if effective_changed.iter().any(|k| k == key) {
                     continue;
                 }
-                if from.attributes.get(key) != Some(new_value) {
+                let type_info = schema.and_then(|s| {
+                    s.attributes.get(key).map(|attr| TypedAttr {
+                        attr_type: &attr.attr_type,
+                        defs: &s.defs,
+                    })
+                });
+                let secret_ctx = Some(SecretHashContext::new(
+                    id.display_type(),
+                    id.name_str(),
+                    key,
+                ));
+                let Some(comparison_value) =
+                    secret_grafted_comparison_view(new_value, resolve_source.attributes.get(key))
+                else {
+                    continue;
+                };
+                if key_should_enter_patch(
+                    key,
+                    schema,
+                    AttrComparison {
+                        from: from.attributes.get(key),
+                        to: comparison_value.as_ref(),
+                        saved: None,
+                        type_info,
+                        secret_ctx: secret_ctx.as_ref(),
+                    },
+                ) {
                     effective_changed.push(key.clone());
                 }
             }

--- a/carina-core/src/executor/normalized.rs
+++ b/carina-core/src/executor/normalized.rs
@@ -20,7 +20,7 @@
 //! use carina_core::resource::{Resource, State};
 //! let from: State = unimplemented!();
 //! let to: Resource = unimplemented!();
-//! compute_full_diff_patch(&from, &to);   // must not compile
+//! compute_full_diff_patch(&from, &to);   // must not compile: raw Resource has no schema-aware diff
 //! ```
 
 use std::collections::HashMap;

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -659,8 +659,13 @@ pub(super) async fn execute_effects_phased(
                                     };
                                     let cascade_identifier =
                                         cascade.from.identifier.as_deref().unwrap_or("");
-                                    let cascade_patch =
-                                        compute_full_diff_patch(&cascade.from, &resolved_to);
+                                    let cascade_patch = compute_full_diff_patch(
+                                        &cascade.from,
+                                        &resolved_to,
+                                        &cascade.to,
+                                        pipeline.schemas,
+                                        &cascade.id,
+                                    );
                                     let cascade_request = UpdateRequest {
                                         from: (*cascade.from).clone(),
                                         patch: cascade_patch,

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -4,6 +4,9 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::binding_index::ResolvedBindings;
+use crate::differ::{
+    AttrComparison, TypedAttr, key_should_enter_patch, secret_grafted_comparison_view,
+};
 use crate::effect::Effect;
 use crate::executor::normalized::NormalizedResource;
 use crate::provider::{
@@ -11,6 +14,8 @@ use crate::provider::{
     build_update_patch,
 };
 use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use crate::schema::SchemaRegistry;
+use crate::value::SecretHashContext;
 
 use super::basic::{
     BasicEffectResult, RenormalizePipeline, resolve_resource, resolve_resource_with_source,
@@ -22,10 +27,17 @@ use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 /// path of replacements (cascade has no precomputed
 /// `changed_attributes` list, so the patch is derived from the
 /// from/to comparison directly).
-pub fn compute_full_diff_patch(from: &State, to: &NormalizedResource) -> UpdatePatch {
+pub fn compute_full_diff_patch(
+    from: &State,
+    to: &NormalizedResource,
+    to_source: &Resource,
+    schemas: &SchemaRegistry,
+    resource_id: &ResourceId,
+) -> UpdatePatch {
     use std::collections::HashSet;
 
     let to_resource = to.as_resource();
+    let schema = schemas.get_for(to_resource);
     let mut keys: HashSet<&str> = HashSet::new();
     keys.extend(from.attributes.keys().map(String::as_str));
     keys.extend(to_resource.attributes.keys().map(String::as_str));
@@ -34,8 +46,36 @@ pub fn compute_full_diff_patch(from: &State, to: &NormalizedResource) -> UpdateP
 
     let changed: Vec<String> = sorted_keys
         .into_iter()
-        .filter(|k| from.attributes.get(*k) != to_resource.attributes.get(*k))
-        .map(|k| k.to_string())
+        .filter_map(|key| match to_resource.attributes.get(key) {
+            Some(new_value) => {
+                let type_info = schema.and_then(|s| {
+                    s.attributes.get(key).map(|attr| TypedAttr {
+                        attr_type: &attr.attr_type,
+                        defs: &s.defs,
+                    })
+                });
+                let secret_ctx = Some(SecretHashContext::new(
+                    resource_id.display_type(),
+                    resource_id.name_str(),
+                    key,
+                ));
+                let comparison_value =
+                    secret_grafted_comparison_view(new_value, to_source.attributes.get(key))?;
+                key_should_enter_patch(
+                    key,
+                    schema,
+                    AttrComparison {
+                        from: from.attributes.get(key),
+                        to: comparison_value.as_ref(),
+                        saved: None,
+                        type_info,
+                        secret_ctx: secret_ctx.as_ref(),
+                    },
+                )
+                .then(|| key.to_string())
+            }
+            None => (!key.starts_with('_')).then(|| key.to_string()),
+        })
         .collect();
     build_update_patch(&changed, to, from)
 }
@@ -166,7 +206,13 @@ pub(super) async fn execute_cbd_replace_parallel(
                     }
                 };
                 let cascade_identifier = cascade.from.identifier.as_deref().unwrap_or("");
-                let cascade_patch = compute_full_diff_patch(&cascade.from, &resolved_to);
+                let cascade_patch = compute_full_diff_patch(
+                    &cascade.from,
+                    &resolved_to,
+                    &cascade.to,
+                    ctx.pipeline.schemas,
+                    &cascade.id,
+                );
                 let cascade_request = UpdateRequest {
                     from: (*cascade.from).clone(),
                     patch: cascade_patch,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -347,6 +347,53 @@ impl crate::provider::ProviderNormalizer for DefaultTagsNormalizer {
     }
 }
 
+struct SecretListToScalarNormalizer;
+
+impl crate::provider::ProviderNormalizer for SecretListToScalarNormalizer {
+    fn normalize_desired<'a>(
+        &'a self,
+        resources: &'a mut [Resource],
+    ) -> crate::provider::BoxFuture<'a, ()> {
+        Box::pin(async move {
+            for resource in resources {
+                if let Some(Value::Concrete(ConcreteValue::List(items))) =
+                    resource.get_attr("master_password")
+                    && let Some(Value::Concrete(ConcreteValue::String(first))) = items.first()
+                {
+                    resource.set_attr(
+                        "master_password",
+                        Value::Concrete(ConcreteValue::String(first.clone())),
+                    );
+                }
+            }
+        })
+    }
+
+    fn normalize_state<'a>(
+        &'a self,
+        _current_states: &'a mut HashMap<ResourceId, State>,
+    ) -> crate::provider::BoxFuture<'a, ()> {
+        crate::provider::ready_noop()
+    }
+
+    fn hydrate_read_state<'a>(
+        &'a self,
+        _current_states: &'a mut HashMap<ResourceId, State>,
+        _saved_attrs: &'a crate::provider::SavedAttrs,
+    ) -> crate::provider::BoxFuture<'a, ()> {
+        crate::provider::ready_noop()
+    }
+
+    fn merge_default_tags<'a>(
+        &'a self,
+        _resources: &'a mut [Resource],
+        _default_tags: &'a indexmap::IndexMap<String, Value>,
+        _registry: &'a crate::schema::SchemaRegistry,
+    ) -> crate::provider::BoxFuture<'a, ()> {
+        crate::provider::ready_noop()
+    }
+}
+
 // -----------------------------------------------------------------------
 // Mock ProviderFactory + shared test fixtures
 // -----------------------------------------------------------------------
@@ -374,6 +421,44 @@ static CANON_SCHEMAS: LazyLock<SchemaRegistry> = LazyLock::new(|| {
             AttributeType::list(AttributeType::string()),
         ]),
     ));
+    reg.insert("test", schema);
+    reg
+});
+
+static AUGMENT_COMPARISON_SCHEMAS: LazyLock<SchemaRegistry> = LazyLock::new(|| {
+    use crate::schema::{
+        AttributeSchema, AttributeType, ResourceSchema, StructField, enum_identity,
+    };
+
+    let mut reg = SchemaRegistry::new();
+    let schema = ResourceSchema::new("a")
+        .attribute(AttributeSchema::new("description", AttributeType::string()))
+        .attribute(AttributeSchema::new("size", AttributeType::float()))
+        .attribute(AttributeSchema::new(
+            "options",
+            AttributeType::struct_(
+                "Options",
+                vec![
+                    StructField::new("enabled", AttributeType::bool()),
+                    StructField::new("label", AttributeType::string()),
+                ],
+            ),
+        ))
+        .attribute(AttributeSchema::new(
+            "mode",
+            AttributeType::enum_(
+                enum_identity("Mode", Some("test")),
+                Some(vec!["AES256".to_string(), "aws:kms".to_string()]),
+                Vec::new(),
+                None,
+                None,
+            ),
+        ))
+        .attribute(AttributeSchema::new("write_only_token", AttributeType::string()).write_only())
+        .attribute(AttributeSchema::new(
+            "master_password",
+            AttributeType::string(),
+        ));
     reg.insert("test", schema);
     reg
 });
@@ -910,6 +995,271 @@ async fn test_apply_update_patch_preserves_provider_default_tags() {
     );
 }
 
+#[tokio::test]
+async fn test_apply_effective_changed_uses_plan_time_comparison_semantics() {
+    let provider = MockProvider::new();
+    let mut to_resource = Resource::with_provider("test", "a", "a", None);
+    to_resource.binding = Some("a".to_string());
+    let rid = to_resource.id.clone();
+
+    to_resource.set_attr(
+        "description",
+        Value::Concrete(ConcreteValue::String("new".to_string())),
+    );
+    to_resource.set_attr("size", Value::Concrete(ConcreteValue::Float(1.0)));
+    let mut desired_options = indexmap::IndexMap::new();
+    desired_options.insert(
+        "label".to_string(),
+        Value::Concrete(ConcreteValue::String("stable".to_string())),
+    );
+    to_resource.set_attr(
+        "options",
+        Value::Concrete(ConcreteValue::Map(desired_options)),
+    );
+    to_resource.set_attr(
+        "mode",
+        Value::Concrete(ConcreteValue::enum_identifier("test.Mode.AES256")),
+    );
+
+    let mut from_attrs = HashMap::new();
+    from_attrs.insert(
+        "description".to_string(),
+        Value::Concrete(ConcreteValue::String("old".to_string())),
+    );
+    from_attrs.insert("size".to_string(), Value::Concrete(ConcreteValue::Int(1)));
+    let mut current_options = indexmap::IndexMap::new();
+    current_options.insert(
+        "label".to_string(),
+        Value::Concrete(ConcreteValue::String("stable".to_string())),
+    );
+    current_options.insert(
+        "enabled".to_string(),
+        Value::Concrete(ConcreteValue::Bool(false)),
+    );
+    from_attrs.insert(
+        "options".to_string(),
+        Value::Concrete(ConcreteValue::Map(current_options)),
+    );
+    from_attrs.insert(
+        "mode".to_string(),
+        Value::Concrete(ConcreteValue::String("AES256".to_string())),
+    );
+    let from_state = State::existing(rid.clone(), from_attrs).with_identifier("id-123");
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Update {
+        id: rid.clone(),
+        from: Box::new(from_state),
+        to: to_resource,
+        changed_attributes: vec!["description".to_string()],
+    });
+    provider.push_update(Ok(ok_state(&rid)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &AUGMENT_COMPARISON_SCHEMAS,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 1);
+
+    let reqs = provider.captured_update_requests();
+    assert_eq!(reqs.len(), 1);
+    let patched_keys: Vec<&str> = reqs[0].patch.ops.iter().map(|op| op.key.as_str()).collect();
+    assert_eq!(patched_keys, vec!["description"]);
+}
+
+#[tokio::test]
+async fn test_apply_effective_changed_skips_internal_and_write_only_attributes() {
+    let provider = MockProvider::new();
+    let mut to_resource = Resource::with_provider("test", "a", "a", None);
+    to_resource.binding = Some("a".to_string());
+    let rid = to_resource.id.clone();
+
+    to_resource.set_attr(
+        "description",
+        Value::Concrete(ConcreteValue::String("new".to_string())),
+    );
+    to_resource.set_attr(
+        "_provider_only",
+        Value::Concrete(ConcreteValue::String("metadata".to_string())),
+    );
+    to_resource.set_attr(
+        "write_only_token",
+        Value::Concrete(ConcreteValue::String("secret-token".to_string())),
+    );
+
+    let mut from_attrs = HashMap::new();
+    from_attrs.insert(
+        "description".to_string(),
+        Value::Concrete(ConcreteValue::String("old".to_string())),
+    );
+    let from_state = State::existing(rid.clone(), from_attrs).with_identifier("id-123");
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Update {
+        id: rid.clone(),
+        from: Box::new(from_state),
+        to: to_resource,
+        changed_attributes: vec!["description".to_string()],
+    });
+    provider.push_update(Ok(ok_state(&rid)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &AUGMENT_COMPARISON_SCHEMAS,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 1);
+
+    let reqs = provider.captured_update_requests();
+    assert_eq!(reqs.len(), 1);
+    let patched_keys: Vec<&str> = reqs[0].patch.ops.iter().map(|op| op.key.as_str()).collect();
+    assert_eq!(patched_keys, vec!["description"]);
+}
+
+#[tokio::test]
+async fn test_apply_effective_changed_skips_matching_unwrapped_secret_hash() {
+    let provider = MockProvider::new();
+    let mut to_resource = Resource::with_provider("test", "a", "a", None);
+    to_resource.binding = Some("a".to_string());
+    let rid = to_resource.id.clone();
+
+    let secret_value = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("my-password".to_string()),
+    ))));
+    to_resource.set_attr("master_password", secret_value.clone());
+
+    let secret_ctx =
+        crate::value::SecretHashContext::new(rid.display_type(), rid.name_str(), "master_password");
+    let hash_json = crate::value::value_to_json_with_context(&secret_value, Some(&secret_ctx))
+        .expect("secret hash must serialize");
+    let hash_str = hash_json
+        .as_str()
+        .expect("secret hash must serialize to a string")
+        .to_string();
+
+    let mut from_attrs = HashMap::new();
+    from_attrs.insert(
+        "master_password".to_string(),
+        Value::Concrete(ConcreteValue::String(hash_str)),
+    );
+    let from_state = State::existing(rid.clone(), from_attrs).with_identifier("id-123");
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Update {
+        id: rid.clone(),
+        from: Box::new(from_state),
+        to: to_resource,
+        changed_attributes: vec![],
+    });
+    provider.push_update(Ok(ok_state(&rid)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &AUGMENT_COMPARISON_SCHEMAS,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 1);
+
+    let reqs = provider.captured_update_requests();
+    assert_eq!(reqs.len(), 1);
+    assert!(reqs[0].patch.ops.is_empty());
+}
+
+#[tokio::test]
+async fn test_apply_effective_changed_skips_secret_shape_divergence() {
+    let provider = MockProvider::new();
+    let mut to_resource = Resource::with_provider("test", "a", "a", None);
+    to_resource.binding = Some("a".to_string());
+    let rid = to_resource.id.clone();
+
+    let secret_value = Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
+        ConcreteValue::String("my-password".to_string()),
+    ))));
+    to_resource.set_attr(
+        "master_password",
+        Value::Concrete(ConcreteValue::List(vec![
+            secret_value.clone(),
+            secret_value.clone(),
+        ])),
+    );
+
+    let secret_ctx =
+        crate::value::SecretHashContext::new(rid.display_type(), rid.name_str(), "master_password");
+    let hash_json = crate::value::value_to_json_with_context(&secret_value, Some(&secret_ctx))
+        .expect("secret hash must serialize");
+    let hash_str = hash_json
+        .as_str()
+        .expect("secret hash must serialize to a string")
+        .to_string();
+
+    let mut from_attrs = HashMap::new();
+    from_attrs.insert(
+        "master_password".to_string(),
+        Value::Concrete(ConcreteValue::String(hash_str)),
+    );
+    let from_state = State::existing(rid.clone(), from_attrs).with_identifier("id-123");
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Update {
+        id: rid.clone(),
+        from: Box::new(from_state),
+        to: to_resource,
+        changed_attributes: vec![],
+    });
+    provider.push_update(Ok(ok_state(&rid)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &SecretListToScalarNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &AUGMENT_COMPARISON_SCHEMAS,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 1);
+
+    let reqs = provider.captured_update_requests();
+    assert_eq!(reqs.len(), 1);
+    assert!(
+        reqs[0].patch.ops.is_empty(),
+        "shape-divergent secret comparison must fail closed instead of patching plaintext"
+    );
+}
+
 /// carina#3060 acceptance, exact shape: a normalizable value nested
 /// under a struct attribute *on a resource that also has a
 /// ResourceRef*. This is the real aws#315 regression shape — the ref
@@ -1248,6 +1598,79 @@ async fn test_cbd_creates_before_deletes() {
     let calls = provider.calls();
     assert_eq!(calls[0].0, "create");
     assert_eq!(calls[1].0, "delete");
+}
+
+#[tokio::test]
+async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
+    let provider = MockProvider::new();
+    let replace_id = ResourceId::with_provider("test", "replace", "replace", None);
+    let replace_from =
+        State::existing(replace_id.clone(), HashMap::new()).with_identifier("replace-old");
+    let mut replace_to = Resource::with_provider("test", "replace", "replace", None);
+    replace_to.binding = Some("replace".to_string());
+
+    let cascade_id = ResourceId::with_provider("test", "a", "a", None);
+    let mut cascade_from_attrs = HashMap::new();
+    cascade_from_attrs.insert(
+        "description".to_string(),
+        Value::Concrete(ConcreteValue::String("old".to_string())),
+    );
+    cascade_from_attrs.insert("size".to_string(), Value::Concrete(ConcreteValue::Int(1)));
+    let cascade_from =
+        State::existing(cascade_id.clone(), cascade_from_attrs).with_identifier("cascade-old");
+
+    let mut cascade_to = Resource::with_provider("test", "a", "a", None);
+    cascade_to.binding = Some("a".to_string());
+    cascade_to.set_attr(
+        "description",
+        Value::Concrete(ConcreteValue::String("new".to_string())),
+    );
+    cascade_to.set_attr("size", Value::Concrete(ConcreteValue::Float(1.0)));
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: replace_id.clone(),
+        from: Box::new(replace_from),
+        to: replace_to,
+        directives: Directives {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
+            .unwrap(),
+        cascading_updates: vec![crate::effect::CascadingUpdate {
+            id: cascade_id.clone(),
+            from: Box::new(cascade_from),
+            to: cascade_to,
+        }],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+
+    provider.push_create(Ok(ok_state(&replace_id)));
+    provider.push_update(Ok(ok_state(&cascade_id)));
+    provider.push_delete(Ok(()));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &AUGMENT_COMPARISON_SCHEMAS,
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 1);
+
+    let reqs = provider.captured_update_requests();
+    assert_eq!(reqs.len(), 1);
+    let patched_keys: Vec<&str> = reqs[0].patch.ops.iter().map(|op| op.key.as_str()).collect();
+    assert_eq!(patched_keys, vec!["description"]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Plan-time `find_changed_attributes` used type-aware equality + projection + saved-merge + secret hash; apply-time `effective_changed` augmentation and the CBD cascade `compute_full_diff_patch` each open-coded their own raw `!=` comparison. The asymmetry let attributes the plan classified as unchanged enter the provider patch at apply time — Int/Float coercion, struct default tolerance, enum representation differences, and matching secret hashes all produced phantom patch ops.

This PR introduces `AttrComparison` + `TypedAttr` typed bundles and a single `key_should_enter_patch` gate wrapping the type-aware diff with the `_`-prefix and `write_only` filters. Plan, apply augmentation, and the CBD cascade now share the same seam, and the raw-`!=` shape is unrepresentable at the public surface: `compute_full_diff_patch` now requires `schemas` + `ResourceId` + the unresolved source resource.

Secret values need a comparison view that re-attaches the source-side `Secret` wrappers after apply-time unwrap. `secret_grafted_comparison_view` does this recursively for shape-equivalent Map/List values and fail-closes (returns `None`) when the shape diverges and a secret is present — fail-closing skips the patch op instead of risking a plaintext secret in the provider call.

This unblocks the carina#3486 design's writes-set invariant: `Effect::Update.changed_attributes` is now the complete write set that `Provider::update` will patch, not a subset that apply could silently extend.

## Why this is a root-cause fix and not a per-site filter

The three call sites previously each carried their own comparison loop. A symptom-level fix would have patched each one; instead the seam is now one helper that all three callers go through, and the only way to construct an `UpdatePatch` directly from `(from, to)` is via the new typed entry points. A future caller cannot write `from.attributes.get(k) != to.attributes.get(k)` and rebuild the regressed path — the helper signature is the only way in.

## Test plan

- [x] `cargo nextest run -p carina-core` — pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass
- [x] `bash scripts/check-*.sh` — pass (all 5)
- [x] New regression tests cover:
  - apply augmentation respects plan-time semantics (Int/Float, struct default, enum representation)
  - apply augmentation skips `_`-prefix and `write_only` keys
  - apply augmentation skips matching unwrapped secret hashes
  - apply augmentation fail-closes on shape-divergent secrets
  - CBD cascade `compute_full_diff_patch` uses the same comparison semantics
  - `key_should_enter_patch` saved-merge preserves unmanaged nested fields

Closes #3490
Refs #3486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
