### PR TITLE
docs(claude): codify process-vs-design ask boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,18 @@ See the codex skill for the full subcontracting protocol.
 - When opening/merging a PR, always include the GitHub URL directly in the response.
 - No sycophantic phrasing ('Great question!', 'You're absolutely right!').
 - Do not over-explain hypothetical design options before checking the actual real-world case (screenshots, real output).
+- **Do not ask "how should I proceed" / "1 PR or 2 PRs" / "in what order".**
+  Process choices — PR splitting, implementation order, worktree
+  layout, commit granularity — are mine to decide. Pausing to ask is
+  what the user has called out as "進め方もいちいち聞くな". The
+  separate rule is: **design choices with a real trade-off** (option
+  A/B/C where lenses disagree) get asked once (pick-issue Step 4.5),
+  and the user has equally called out "勝手に設計判断されると困る".
+  The split is sharp — process: decide silently; design with
+  unresolved trade-off: ask once. When in doubt about which side a
+  question falls on, ask whether it changes any artifact the user
+  reviews (PR title, commit history, type shape) — if only the path
+  to the same artifact changes, it is process.
 
 ## 日本語の文章作法
 


### PR DESCRIPTION
## Summary

Codify the existing boundary between **process questions** (decide
silently) and **design questions with an unresolved trade-off**
(ask once) in the project-wide Communication Style.

Both sides have been called out in past sessions:

- "進め方もいちいち聞くなつってんだろが" — when stopping to ask
  whether a feature should land as 1 PR or 2 PRs, or in what order
  the dependent repos should ship.
- "勝手に設計判断されると困るんだが" — when picking option A vs B
  silently on a real type-shape trade-off (carina#2229).

The design side is already covered by pick-issue Step 4.5. This
commit captures the matching constraint for process choices.

## The boundary

- **Process** (decide silently): PR splitting, implementation order,
  worktree layout, commit granularity, which dependency to bump first.
- **Design with unresolved trade-off** (ask once): an A/B/C choice
  where the three lenses (long-term / type-safety / root-cause) do
  not point to the same option.

When the question is ambiguous, the check is: does the answer change
any artifact the user reviews (PR title, commit history, exposed type
shape)? If only the *path* to the same artifact changes, it is
process.

## Test plan

Documentation-only. No code changes, no tests required.