### PR TITLE
feat(schema): add redirect_{protocol,host,port,path,query} string types

### DIFF
--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -12,7 +12,8 @@ use crate::eval_value::EvalValue;
 use crate::resource::{ConcreteValue, DeferredValue, UnknownReason, Value};
 use crate::schema::{
     TypeIdentity, validate_http_response_status_code, validate_ipv4_address, validate_ipv4_cidr,
-    validate_ipv6_address, validate_ipv6_cidr,
+    validate_ipv6_address, validate_ipv6_cidr, validate_redirect_host, validate_redirect_path,
+    validate_redirect_port, validate_redirect_protocol, validate_redirect_query,
 };
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -248,6 +249,21 @@ pub fn validate_custom_type(
         }
         (Some("HttpResponseStatusCode"), value) if text(value).is_some() => {
             validate_http_response_status_code(text(value).unwrap())
+        }
+        (Some("RedirectHost"), value) if text(value).is_some() => {
+            validate_redirect_host(text(value).unwrap())
+        }
+        (Some("RedirectPath"), value) if text(value).is_some() => {
+            validate_redirect_path(text(value).unwrap())
+        }
+        (Some("RedirectPort"), value) if text(value).is_some() => {
+            validate_redirect_port(text(value).unwrap())
+        }
+        (Some("RedirectProtocol"), value) if text(value).is_some() => {
+            validate_redirect_protocol(text(value).unwrap())
+        }
+        (Some("RedirectQuery"), value) if text(value).is_some() => {
+            validate_redirect_query(text(value).unwrap())
         }
         (_, Value::Deferred(DeferredValue::ResourceRef { .. })) => Ok(()), // will be resolved later
         (_, Value::Deferred(DeferredValue::FunctionCall { .. })) => Ok(()), // will be resolved later

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -6355,6 +6355,141 @@ fn user_fn_custom_type_http_response_status_code_arg_invalid() {
 }
 
 #[test]
+fn user_fn_custom_type_redirect_protocol_arg_valid_invalid() {
+    let valid = r##"
+        fn f(x: RedirectProtocol) { x }
+
+        let b = aws.s3_bucket {
+            name = f("#{protocol}")
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(x: RedirectProtocol) { x }
+
+        let b = aws.s3_bucket {
+            name = f("#{path}")
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("type 'redirect_protocol' validation failed"),
+        "Expected redirect_protocol validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_redirect_host_arg_valid_invalid() {
+    let valid = r##"
+        fn f(x: RedirectHost) { x }
+
+        let b = aws.s3_bucket {
+            name = f("www-#{host}")
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(x: RedirectHost) { x }
+
+        let b = aws.s3_bucket {
+            name = f("#{path}")
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("type 'redirect_host' validation failed"),
+        "Expected redirect_host validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_redirect_port_arg_valid_invalid() {
+    let valid = r##"
+        fn f(x: RedirectPort) { x }
+
+        let b = aws.s3_bucket {
+            name = f("#{port}")
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(x: RedirectPort) { x }
+
+        let b = aws.s3_bucket {
+            name = f("65536")
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("type 'redirect_port' validation failed"),
+        "Expected redirect_port validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_redirect_path_arg_valid_invalid() {
+    let valid = r##"
+        fn f(x: RedirectPath) { x }
+
+        let b = aws.s3_bucket {
+            name = f("/#{host}/#{path}")
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(x: RedirectPath) { x }
+
+        let b = aws.s3_bucket {
+            name = f("#{path}")
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("type 'redirect_path' validation failed"),
+        "Expected redirect_path validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_redirect_query_arg_valid_invalid() {
+    let valid = r##"
+        fn f(x: RedirectQuery) { x }
+
+        let b = aws.s3_bucket {
+            name = f("next=#{path}&q=#{query}")
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(x: RedirectQuery) { x }
+
+        let b = aws.s3_bucket {
+            name = f("#{bogus}")
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("type 'redirect_query' validation failed"),
+        "Expected redirect_query validation error, got: {msg}"
+    );
+}
+
+#[test]
 fn user_fn_custom_type_ipv6_address_arg_invalid() {
     let input = r#"
         fn f(x: Ipv6Address) { x }
@@ -6479,6 +6614,141 @@ fn user_fn_custom_type_return_http_response_status_code_invalid() {
     assert!(
         msg.contains("return type 'http_response_status_code' validation failed"),
         "Expected http_response_status_code validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_return_redirect_protocol_valid_invalid() {
+    let valid = r##"
+        fn f(): RedirectProtocol { "HTTPS" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(): RedirectProtocol { "#{path}" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("return type 'redirect_protocol' validation failed"),
+        "Expected redirect_protocol validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_return_redirect_host_valid_invalid() {
+    let valid = r##"
+        fn f(): RedirectHost { "api-#{host}" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(): RedirectHost { "#{path}" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("return type 'redirect_host' validation failed"),
+        "Expected redirect_host validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_return_redirect_port_valid_invalid() {
+    let valid = r##"
+        fn f(): RedirectPort { "443" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(): RedirectPort { "0" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("return type 'redirect_port' validation failed"),
+        "Expected redirect_port validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_return_redirect_path_valid_invalid() {
+    let valid = r##"
+        fn f(): RedirectPath { "/#{path}" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(): RedirectPath { "relative" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("return type 'redirect_path' validation failed"),
+        "Expected redirect_path validation error, got: {msg}"
+    );
+}
+
+#[test]
+fn user_fn_custom_type_return_redirect_query_valid_invalid() {
+    let valid = r##"
+        fn f(): RedirectQuery { "next=#{path}&q=#{query}" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let result = parse(valid, &ProviderContext::default());
+    assert!(result.is_ok(), "Expected OK, got: {:?}", result.err());
+
+    let invalid = r##"
+        fn f(): RedirectQuery { "#{bogus}" }
+
+        let b = aws.s3_bucket {
+            name = f()
+        }
+    "##;
+    let err = parse(invalid, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("return type 'redirect_query' validation failed"),
+        "Expected redirect_query validation error, got: {msg}"
     );
 }
 

--- a/carina-core/src/parser/types.rs
+++ b/carina-core/src/parser/types.rs
@@ -77,6 +77,11 @@ pub const BUILTIN_BARE_CUSTOM_TYPES: &[&str] = &[
     "ipv6_cidr",
     "ipv6_address",
     "http_response_status_code",
+    "redirect_host",
+    "redirect_path",
+    "redirect_port",
+    "redirect_protocol",
+    "redirect_query",
 ];
 
 /// True iff a snake-cased bare type name resolves to a known custom

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -4956,6 +4956,122 @@ pub mod types {
             None,
         )
     }
+
+    /// ELBv2 redirect protocol restricted to `HTTP`, `HTTPS`, or `#{protocol}`.
+    ///
+    /// ```
+    /// # use carina_core::schema::validate_redirect_protocol;
+    /// assert!(validate_redirect_protocol("HTTPS").is_ok());
+    /// assert!(validate_redirect_protocol("#{protocol}").is_ok());
+    /// assert!(validate_redirect_protocol("#{path}").is_err());
+    /// ```
+    pub fn redirect_protocol() -> AttributeType {
+        AttributeType::refined_string_with_validator(
+            Some(TypeIdentity::bare("RedirectProtocol")),
+            None,
+            None,
+            legacy_validator(|value| {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
+                    validate_redirect_protocol(s)
+                } else {
+                    Err("Expected string".to_string())
+                }
+            }),
+            None,
+        )
+    }
+
+    /// ELBv2 redirect host, including wildcards and `#{host}`.
+    ///
+    /// ```
+    /// # use carina_core::schema::validate_redirect_host;
+    /// assert!(validate_redirect_host("example.com").is_ok());
+    /// assert!(validate_redirect_host("#{path}").is_err());
+    /// ```
+    pub fn redirect_host() -> AttributeType {
+        AttributeType::refined_string_with_validator(
+            Some(TypeIdentity::bare("RedirectHost")),
+            None,
+            None,
+            legacy_validator(|value| {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
+                    validate_redirect_host(s)
+                } else {
+                    Err("Expected string".to_string())
+                }
+            }),
+            None,
+        )
+    }
+
+    /// ELBv2 redirect port restricted to `1..=65535` or `#{port}`.
+    ///
+    /// ```
+    /// # use carina_core::schema::validate_redirect_port;
+    /// assert!(validate_redirect_port("443").is_ok());
+    /// assert!(validate_redirect_port("#{path}").is_err());
+    /// ```
+    pub fn redirect_port() -> AttributeType {
+        AttributeType::refined_string_with_validator(
+            Some(TypeIdentity::bare("RedirectPort")),
+            None,
+            None,
+            legacy_validator(|value| {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
+                    validate_redirect_port(s)
+                } else {
+                    Err("Expected string".to_string())
+                }
+            }),
+            None,
+        )
+    }
+
+    /// ELBv2 redirect path, including wildcards and ELBv2 redirect placeholders.
+    ///
+    /// ```
+    /// # use carina_core::schema::validate_redirect_path;
+    /// assert!(validate_redirect_path("/#{host}/#{path}").is_ok());
+    /// assert!(validate_redirect_path("relative").is_err());
+    /// ```
+    pub fn redirect_path() -> AttributeType {
+        AttributeType::refined_string_with_validator(
+            Some(TypeIdentity::bare("RedirectPath")),
+            None,
+            None,
+            legacy_validator(|value| {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
+                    validate_redirect_path(s)
+                } else {
+                    Err("Expected string".to_string())
+                }
+            }),
+            None,
+        )
+    }
+
+    /// ELBv2 redirect query string, including ELBv2 redirect placeholders.
+    ///
+    /// ```
+    /// # use carina_core::schema::validate_redirect_query;
+    /// assert!(validate_redirect_query("next=#{path}&q=#{query}").is_ok());
+    /// assert!(validate_redirect_query(&"a".repeat(129)).is_err());
+    /// ```
+    pub fn redirect_query() -> AttributeType {
+        AttributeType::refined_string_with_validator(
+            Some(TypeIdentity::bare("RedirectQuery")),
+            None,
+            None,
+            legacy_validator(|value| {
+                if let Value::Concrete(ConcreteValue::String(s)) = value {
+                    validate_redirect_query(s)
+                } else {
+                    Err("Expected string".to_string())
+                }
+            }),
+            None,
+        )
+    }
 }
 
 /// Validate an IPv4 address (e.g., "10.0.1.5", "192.168.0.1")
@@ -5170,6 +5286,91 @@ pub fn validate_http_response_status_code(code: &str) -> Result<(), String> {
     let first = code.chars().next().expect("length checked above");
     if !matches!(first, '2' | '4' | '5') {
         return Err(format!("must start with 2, 4, or 5 (got '{first}')"));
+    }
+    Ok(())
+}
+
+/// Validate an ELBv2 redirect protocol value.
+pub fn validate_redirect_protocol(protocol: &str) -> Result<(), String> {
+    if matches!(protocol, "HTTP" | "HTTPS" | "#{protocol}") {
+        return Ok(());
+    }
+    Err(format!(
+        "Invalid redirect protocol '{protocol}': expected HTTP, HTTPS, or #{{protocol}}"
+    ))
+}
+
+/// Validate an ELBv2 redirect host value.
+pub fn validate_redirect_host(host: &str) -> Result<(), String> {
+    validate_char_length(host, 1, 128, "redirect host")?;
+    validate_known_placeholders(host, &["#{host}"], "redirect host")
+}
+
+/// Validate an ELBv2 redirect port value.
+pub fn validate_redirect_port(port: &str) -> Result<(), String> {
+    if port == "#{port}" {
+        return Ok(());
+    }
+    if port.starts_with('+') || (port.len() > 1 && port.starts_with('0')) {
+        return Err(format!(
+            "Invalid redirect port '{port}': expected decimal integer or #{{port}}"
+        ));
+    }
+    match port.parse::<u32>() {
+        Ok(value) if (1..=65535).contains(&value) => Ok(()),
+        Ok(value) => Err(format!(
+            "Invalid redirect port '{port}': expected 1..=65535, got {value}"
+        )),
+        Err(_) => Err(format!(
+            "Invalid redirect port '{port}': expected decimal integer or #{{port}}"
+        )),
+    }
+}
+
+/// Validate an ELBv2 redirect path value.
+pub fn validate_redirect_path(path: &str) -> Result<(), String> {
+    validate_char_length(path, 1, 128, "redirect path")?;
+    if !path.starts_with('/') {
+        return Err("Invalid redirect path: must start with '/'".to_string());
+    }
+    let placeholders = ["#{host}", "#{port}", "#{path}"];
+    validate_known_placeholders(path, &placeholders, "redirect path")
+}
+
+/// Validate an ELBv2 redirect query value.
+pub fn validate_redirect_query(query: &str) -> Result<(), String> {
+    validate_char_length(query, 0, 128, "redirect query")?;
+    validate_known_placeholders(
+        query,
+        &["#{protocol}", "#{host}", "#{port}", "#{path}", "#{query}"],
+        "redirect query",
+    )
+}
+
+fn validate_char_length(value: &str, min: usize, max: usize, field: &str) -> Result<(), String> {
+    let len = value.chars().count();
+    if len < min || len > max {
+        return Err(format!(
+            "Invalid {field}: expected {min}..={max} characters, got {len}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_known_placeholders(value: &str, allowed: &[&str], field: &str) -> Result<(), String> {
+    let mut rest = value;
+    while let Some(start) = rest.find("#{") {
+        let candidate = &rest[start..];
+        let Some(end) = candidate.find('}') else {
+            return Err(format!("Invalid {field}: malformed placeholder"));
+        };
+        let placeholder = &candidate[..=end];
+        if !allowed.contains(&placeholder) {
+            return Err(format!(
+                "Invalid {field}: placeholder {placeholder} is not allowed"
+            ));
+        }
+        rest = &candidate[end + 1..];
     }
     Ok(())
 }

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -4051,6 +4051,86 @@ fn validate_http_response_status_code_function_directly() {
 }
 
 #[test]
+fn validate_redirect_protocol_function_directly() {
+    assert!(validate_redirect_protocol("HTTP").is_ok());
+    assert!(validate_redirect_protocol("HTTPS").is_ok());
+    assert!(validate_redirect_protocol("#{protocol}").is_ok());
+
+    assert!(validate_redirect_protocol("").is_err());
+    assert!(validate_redirect_protocol("http").is_err());
+    assert!(validate_redirect_protocol("#{host}").is_err());
+    assert!(validate_redirect_protocol("#{port}").is_err());
+    assert!(validate_redirect_protocol("#{path}").is_err());
+    assert!(validate_redirect_protocol("#{query}").is_err());
+}
+
+#[test]
+fn validate_redirect_host_function_directly() {
+    assert!(validate_redirect_host("example").is_ok());
+    assert!(validate_redirect_host("bad.example.com").is_ok());
+    assert!(validate_redirect_host("www-#{host}").is_ok());
+    assert!(validate_redirect_host("*-api?").is_ok());
+    assert!(validate_redirect_host("https://example.com:443").is_ok());
+
+    assert!(validate_redirect_host("").is_err());
+    assert!(validate_redirect_host(&"a".repeat(128)).is_ok());
+    assert!(validate_redirect_host(&"a".repeat(129)).is_err());
+    assert!(validate_redirect_host("#{protocol}").is_err());
+    assert!(validate_redirect_host("#{path}").is_err());
+}
+
+#[test]
+fn validate_redirect_port_function_directly() {
+    assert!(validate_redirect_port("1").is_ok());
+    assert!(validate_redirect_port("443").is_ok());
+    assert!(validate_redirect_port("65535").is_ok());
+    assert!(validate_redirect_port("#{port}").is_ok());
+
+    assert!(validate_redirect_port("").is_err());
+    assert!(validate_redirect_port("0").is_err());
+    assert!(validate_redirect_port("65536").is_err());
+    // Non-decimal forms must be rejected even though u32::from_str accepts them.
+    assert!(validate_redirect_port("+443").is_err());
+    assert!(validate_redirect_port("0443").is_err());
+    assert!(validate_redirect_port("#{path}").is_err());
+    assert!(validate_redirect_port("443?").is_err());
+}
+
+#[test]
+fn validate_redirect_path_function_directly() {
+    assert!(validate_redirect_path("/").is_ok());
+    assert!(validate_redirect_path("/#{host}:#{port}/#{path}").is_ok());
+    assert!(validate_redirect_path("/a*b?&-._$~\"'@:+/").is_ok());
+    assert!(validate_redirect_path("/encoded/%2F?x=1").is_ok());
+    assert!(validate_redirect_path("/bad#path").is_ok());
+
+    assert!(validate_redirect_path("").is_err());
+    assert!(validate_redirect_path(&format!("/{}", "a".repeat(127))).is_ok());
+    assert!(validate_redirect_path(&format!("/{}", "a".repeat(128))).is_err());
+    assert!(validate_redirect_path("#{path}").is_err());
+    assert!(validate_redirect_path("/#{protocol}").is_err());
+    assert!(validate_redirect_path("/#{query}").is_err());
+}
+
+#[test]
+fn validate_redirect_query_function_directly() {
+    assert!(validate_redirect_query("").is_ok());
+    assert!(validate_redirect_query("next=#{path}&q=#{query}").is_ok());
+    assert!(validate_redirect_query("proto=#{protocol}&host=#{host}&port=#{port}").is_ok());
+    assert!(validate_redirect_query("spaces and arbitrary chars !%[]").is_ok());
+    assert!(validate_redirect_query(&"a".repeat(128)).is_ok());
+    // Confirm every documented placeholder is accepted.
+    assert!(validate_redirect_query("#{protocol}").is_ok());
+    assert!(validate_redirect_query("#{host}").is_ok());
+    assert!(validate_redirect_query("#{port}").is_ok());
+    assert!(validate_redirect_query("#{path}").is_ok());
+    assert!(validate_redirect_query("#{query}").is_ok());
+
+    assert!(validate_redirect_query(&"a".repeat(129)).is_err());
+    assert!(validate_redirect_query("#{bogus}").is_err());
+}
+
+#[test]
 fn validate_http_response_status_code_type() {
     let t = types::http_response_status_code();
 


### PR DESCRIPTION
## Summary

carina-core side of [awscc#363](https://github.com/carina-rs/carina-provider-awscc/issues/363). Adds five sibling refined-string helpers in `carina_core::schema::types` for the ELBv2 Listener `RedirectConfig` fields:

- `redirect_protocol()` — accepts `HTTP`, `HTTPS`, or `#{protocol}`
- `redirect_host()` — 1..=128 chars, plus the `#{host}` placeholder
- `redirect_port()` — decimal 1..=65535 or `#{port}`
- `redirect_path()` — 1..=128 chars, starts with `/`, plus `#{host}` / `#{port}` / `#{path}`
- `redirect_query()` — 0..=128 chars, plus all five ELBv2 placeholders

Mirrors the `http_response_status_code()` precedent introduced in awscc#356 and lives next to it in the `types` module. The awscc-side override switch (replacing `TypeOverride::Enum(["HTTP","HTTPS"])` with `TypeOverride::StringType("carina_core::schema::types::redirect_protocol()")` etc.) follows in a separate PR after this lands.

## Why option C (sibling string type) instead of A or B

The decision is recorded on [awscc#363](https://github.com/carina-rs/carina-provider-awscc/issues/363#issuecomment-4700161899). The three lenses (root-cause / long-term / type-safety) all selected C:

- **A** (loosen DSL enum grammar to admit `#{ident}`) cannot encode per-component placeholder rules — `RedirectConfig.Protocol` would accept `#{path}`, which AWS rejects.
- **B** (per-resource overlay with `HTTP, HTTPS, #{protocol}` as enum members) is a per-site carve-out that violates the CLAUDE.md root-cause rule — every new placeholder needs an overlay edit, and `#{path}` legal-in-query / illegal-in-protocol is unrepresentable.
- **C** encodes the per-component placeholder table in each validator. The enum framing for `Protocol` was the original miscategorization (the field is a constrained string admitting two literals, not a closed identifier set); dropping it restores the correct typing.

## Validator design notes

- **No character-class allowlist for `host` / `path` / `query`.** AWS doc text suggests one (e.g. host = alphanumeric + wildcards + hyphens) but real values include dots (`example.com`), percent-encoded segments, etc. CDK L1, Terraform, and awscc's own untyped path all accept arbitrary strings; rejecting them at validate time creates false positives on common authoring patterns. The contribution of these types is the *placeholder allow-set*, not URL safety policing.
- **Length caps preserved** where AWS doc is explicit (1..=128 for host / path / query; 1..=65535 numeric range for port).
- **Port** rejects `+443` and `0443` before `u32::from_str` to prevent CloudControl-time apply failures from leaking past validate (`u32::from_str` accepts both as 443).
- **Placeholder loop** scans `#{` -> `}` linearly, validates each match against the per-field allow-set, and reports both unknown placeholders and malformed (unclosed) ones.

## Parser bridge + LSP

- `BUILTIN_BARE_CUSTOM_TYPES` in `parser/types.rs` gets five new entries, so DSL `fn f(x: redirect_protocol) -> redirect_query { ... }` parses and validates.
- `validate_custom_type` in `parser/functions.rs` gets five explicit dispatch arms (no wildcard).
- LSP completion + diagnostics already iterate the same registry, so the new types surface in completion automatically.

## Test plan

- [x] `cargo nextest run -p carina-core` — 2471 passed, 1 skipped
- [x] `cargo test -p carina-core --doc` — all five doctests pass (each demonstrates one OK + one Err case)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` — all green
- Coverage: per-validator boundary tests (128 OK / 129 NG), cross-rejection (e.g. `redirect_protocol` rejects `#{host}` / `#{port}` / `#{path}` / `#{query}`), per-placeholder positive confirmations for the five accepted in `redirect_query`, and the `+443` / `0443` reject cases.

## Out of scope (separate PRs)

- awscc rev-bump + override switch — follow-up PR on `carina-rs/carina-provider-awscc` closes awscc#363.
- Refactoring the existing built-in helpers into a shared factory (current shape is 5 explicit copies, consistent with `http_response_status_code` and the IPv4/IPv6/email siblings). Deliberately not done here to keep the PR focused.

Refs awscc#363.