### PR TITLE
docs(claude): codex codegen delegations must include docs regen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,21 @@ directly; it reads, thinks, reviews, and writes docs only.
 - Opus writing the plan, the implementation, or the refactor edits
   itself is forbidden; docs are the only thing Opus writes.
 
+**Codegen delegations always include the docs regen step.** Whenever a
+Codex task touches anything that drives schema codegen
+(`carina-provider-aws*/src/bin/codegen.rs`, `resource_type_overrides()`,
+`generate-schemas.sh`, or the generated `schemas/` tree), the
+delegation prompt MUST instruct Codex to run BOTH `generate-schemas.sh`
+AND `generate-docs.sh` (cache-only mode is fine) and verify the
+`generated-docs/` tree is clean before declaring done. CI's `Check
+Docs Content` runs `generate-docs.sh --from-cache-only` and fails if
+the docs tree drifts; only running `generate-schemas.sh` locally
+passes Opus-side verify but trips that CI gate. The pair is
+load-bearing — never instruct one without the other. Past failure
+mode: awscc#364 burned a CI cycle on this exact mistake (the
+`RedirectConfig.Protocol` enum block was still in `generated-docs/`
+after the schema lost its enum framing).
+
 See the codex skill for the full subcontracting protocol.
 
 ## Communication Style


### PR DESCRIPTION
## Summary

Codify in the codex delegation rules that any task touching codegen-driving code (`carina-provider-aws*/src/bin/codegen.rs`, `resource_type_overrides()`, `generate-schemas.sh`, or the generated `schemas/` tree) MUST instruct Codex to run BOTH `generate-schemas.sh` AND `generate-docs.sh` (cache-only mode is fine) and verify `generated-docs/` is clean before declaring done.

## Why

awscc#364 burned a CI cycle on this exact mistake: the Codex delegation prompt only said "regenerate schemas". The `RedirectConfig.Protocol` enum block stayed in `generated-docs/awscc/elasticloadbalancingv2/listener.md` after the schema side lost its enum framing, and CI's `Check Docs Content` (which runs `generate-docs.sh --from-cache-only` and diffs the working tree) failed.

Local `cargo nextest run` + `clippy` + `cargo test --doc` all pass with just the schema regen — the docs gate is invisible to Opus-side verify because it runs as a separate workflow step. The pair is load-bearing: one without the other passes locally and fails CI.

There's existing memory (`feedback_codegen_verification`: "generate-schemas.sh AND generate-docs.sh, always as a pair") but it was framed as a developer-side rule, not as something to write into every Codex delegation. This PR pulls it into the codex delegation contract so the instruction is part of every prompt that touches codegen.

## Test plan

Documentation-only.