### PR TITLE
apply interruption resilience: design and implementation plan (#3498)

### DIFF
--- a/docs/plans/2026-06-14-apply-interruption-resilience.md
+++ b/docs/plans/2026-06-14-apply-interruption-resilience.md
@@ -1,0 +1,915 @@
+# Apply interruption resilience TDD plan
+<!-- derived-from ../specs/2026-06-14-apply-interruption-resilience-design.md -->
+
+対応 issue: https://github.com/carina-rs/carina/issues/3498
+設計仕様書: `docs/specs/2026-06-14-apply-interruption-resilience-design.md`
+Codex 実装担当者はこの plan の順番どおりに Red -> Green -> Refactor を 1 タスクずつ進める。
+この plan は実装作業を含まない。実装時は state 永続化、lock release、provider in-flight 待機の順序を崩さない。
+
+## T1. CancellationToken 依存の選定
+
+依存タスク: なし
+
+**Goal**: `carina-core` と `carina-cli` の両方で同じ cancel token 型を使えるようにする。
+
+**Files**:
+
+- modify `carina-core/Cargo.toml`
+- modify `carina-cli/Cargo.toml`
+
+**Test**:
+
+このタスクでは Rust test は追加しない。依存追加後の compile check を Red/Green の確認にする。
+
+**Implementation**:
+
+`tokio-util::sync::CancellationToken` を採用する。`tokio-util` は既に `Cargo.lock` に存在し、workspace へ新しい crate family を増やさない。API は `clone()`, `cancel()`, `is_cancelled()`, `cancelled().await` を持ち、executor の loop と confirm prompt の `tokio::select!` の両方にそのまま使える。自前 token は `Future` 化、wake 管理、clone 間共有、二重 cancel の順序を実装する必要があり、今回の修正範囲より大きい。`carina-core` は executor の public signature に token を出すため直接依存、`carina-cli` は signal listener と prompt で token を生成・待機するため直接依存にする。
+
+```toml
+# carina-core/Cargo.toml
+[dependencies]
+tokio-util = "0.7"
+```
+
+```toml
+# carina-cli/Cargo.toml
+[dependencies]
+tokio-util = "0.7"
+```
+
+**Verify**:
+
+```bash
+cargo check -p carina-core
+cargo check -p carina-cli
+```
+
+## T2. ExecutionOutcome enum を追加する
+
+依存タスク: T1
+
+**Goal**: executor の結果が通常完了か cancel 完了かを型で表現できる。
+
+**Files**:
+
+- modify `carina-core/src/executor/mod.rs`
+- modify `carina-core/src/executor/tests.rs`
+
+**Test**:
+
+```rust
+#[test]
+fn execution_outcome_completed_and_cancelled_are_matchable() {
+    let completed = ExecutionOutcome::Completed(empty_execution_result());
+    let cancelled = ExecutionOutcome::Cancelled(empty_execution_result());
+
+    match completed {
+        ExecutionOutcome::Completed(result) => {
+            assert_eq!(result.success_count, 0);
+            assert!(result.applied_states.is_empty());
+        }
+        ExecutionOutcome::Cancelled(_) => panic!("completed outcome changed variant"),
+    }
+
+    match cancelled {
+        ExecutionOutcome::Cancelled(result) => {
+            assert_eq!(result.failure_count, 0);
+            assert!(result.successfully_deleted.is_empty());
+        }
+        ExecutionOutcome::Completed(_) => panic!("cancelled outcome changed variant"),
+    }
+}
+```
+
+型レベルの negative property は test note として残す。`ExecutionOutcome` から `Result<ExecutionResult, _>` への `From` / `Into` impl は作らない。`execute_plan(...).await?` が compile しない状態を設計上の証拠にする。
+
+```rust
+/// ```compile_fail
+/// use carina_core::executor::{execute_plan, ExecutionResult};
+///
+/// async fn cannot_question_mark_execution_outcome(
+///     provider: &dyn carina_core::provider::Provider,
+///     input: carina_core::executor::ExecutionInput<'_>,
+///     observer: &dyn carina_core::executor::ExecutionObserver,
+///     cancel: tokio_util::sync::CancellationToken,
+/// ) -> Result<ExecutionResult, String> {
+///     let result = execute_plan(provider, input, observer, cancel).await?;
+///     Ok(result)
+/// }
+/// ```
+pub struct ExecutionOutcomeCannotBeQuestionMarked;
+```
+
+**Implementation**:
+
+`carina-core::executor` に仕様書の enum を追加する。accessor は追加しない。caller が `match` で両 variant を明示する形を固定する。`From<ExecutionOutcome> for Result<ExecutionResult, _>` と `Try` 相当の逃げ道は作らない。
+
+```rust
+pub enum ExecutionOutcome {
+    Completed(ExecutionResult),
+    Cancelled(ExecutionResult),
+}
+```
+
+test 用に `empty_execution_result()` を `carina-core/src/executor/tests.rs` の既存 test module 内へ置く。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-core execution_outcome_completed_and_cancelled_are_matchable
+cargo test -p carina-core --doc ExecutionOutcomeCannotBeQuestionMarked
+```
+
+## T3. execute_plan の signature を変更する
+
+依存タスク: T2
+
+**Goal**: cancel token 引数を受け取るが、まだ監視せず通常経路では `ExecutionOutcome::Completed` を返す。
+
+**Files**:
+
+- modify `carina-core/src/executor/mod.rs`
+- modify `carina-core/src/executor/tests.rs`
+- modify `carina-core/tests/wait_downstream_apply.rs`
+- modify `carina-cli/tests/wait_apply_module_path.rs`
+- modify `carina-cli/src/commands/apply/mod.rs`
+
+**Test**:
+
+```rust
+#[tokio::test]
+async fn execute_plan_returns_completed_when_not_cancelled() {
+    let provider = MockProvider::default();
+    let observer = NoopObserver;
+    let mut state_file = StateFile::default();
+    let plan = create_single_resource_plan("test", "one");
+    let input = ExecutionInput::new_mut_state(&plan, &mut state_file);
+    let cancel = CancellationToken::new();
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    match outcome {
+        ExecutionOutcome::Completed(result) => {
+            assert_eq!(result.failure_count, 0);
+            assert_eq!(result.success_count, 1);
+        }
+        ExecutionOutcome::Cancelled(_) => panic!("uncancelled execution returned Cancelled"),
+    }
+}
+```
+
+**Implementation**:
+
+`execute_plan` の signature を仕様書どおりに変える。`cancel` は `_cancel` として受け取り、phased / sequential の戻り値を `Completed` に包む。
+
+```rust
+pub async fn execute_plan(
+    provider: &dyn Provider,
+    mut input: ExecutionInput<'_>,
+    observer: &dyn ExecutionObserver,
+    _cancel: CancellationToken,
+) -> ExecutionOutcome {
+    let result = if has_interdependent_replaces(input.plan.effects()) {
+        execute_effects_phased(provider, &mut input, observer).await
+    } else {
+        execute_effects_sequential(provider, &mut input, observer).await
+    };
+    ExecutionOutcome::Completed(result)
+}
+```
+
+既存の `execute_plan(&provider, input, &observer).await` 呼び出しは `CancellationToken::new()` を渡す形に直す。T3 は signature 変更で workspace を壊したまま終わらせない。
+
+caller 追従対象:
+
+- `carina-core/src/executor/tests.rs`: `execute_plan(` を呼ぶ全 test
+- `carina-core/tests/wait_downstream_apply.rs`: line 284 と line 431 の 2 箇所
+- `carina-cli/tests/wait_apply_module_path.rs`: line 463 の 1 箇所
+- `carina-cli/src/commands/apply/mod.rs`: `execute_effects` wrapper 内の `carina_core::executor::execute_plan(provider, input, &observer).await`
+
+T3 の caller 追従は token を伝播しない。各 caller の局所修正は `CancellationToken::new()` を渡すだけにする。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-core execute_plan_returns_completed_when_not_cancelled
+cargo check --workspace
+```
+
+## T4. executor loop で cancel token を監視する
+
+依存タスク: T3
+
+**Goal**: cancel 後は新しい effect を投入せず、in-flight effect は完了まで待って `Cancelled(result)` に含める。
+
+**Files**:
+
+- modify `carina-core/src/executor/mod.rs`
+- modify `carina-core/src/executor/parallel.rs`
+- modify `carina-core/src/executor/phased.rs`
+- modify `carina-core/src/executor/tests.rs`
+
+**Test**:
+
+```rust
+#[tokio::test(start_paused = true)]
+async fn execute_plan_cancelled_after_three_completed_keeps_in_flight_and_drops_pending() {
+    let provider = DelayedCountingProvider::new(Duration::from_secs(10));
+    let observer = CancelsAfterSuccesses::new(3);
+    let cancel = observer.token();
+    let mut state_file = StateFile::default();
+    let plan = create_independent_create_plan(["r1", "r2", "r3", "r4", "r5"]);
+    let input = ExecutionInput::new_mut_state(&plan, &mut state_file)
+        .with_parallelism(NonZeroUsize::new(1).unwrap());
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("cancelled run returned Completed"),
+    };
+    assert_eq!(result.applied_states.len(), 3);
+    assert_eq!(provider.started_names(), vec!["r1", "r2", "r3"]);
+}
+```
+
+```rust
+#[tokio::test(start_paused = true)]
+async fn execute_plan_cancelled_while_effect_in_flight_records_that_effect() {
+    let provider = BlockingProvider::new("r2", Duration::from_secs(60));
+    let observer = CancelsWhenStarted::new("r2");
+    let cancel = observer.token();
+    let mut state_file = StateFile::default();
+    let plan = create_independent_create_plan(["r1", "r2", "r3"]);
+    let input = ExecutionInput::new_mut_state(&plan, &mut state_file)
+        .with_parallelism(NonZeroUsize::new(1).unwrap());
+
+    let task = tokio::spawn(async move { execute_plan(&provider, input, &observer, cancel).await });
+    tokio::time::advance(Duration::from_secs(60)).await;
+    let outcome = task.await.unwrap();
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("cancelled run returned Completed"),
+    };
+    assert!(result.applied_states.contains_key(&ResourceId::new("test", "r2")));
+}
+```
+
+```rust
+#[tokio::test(start_paused = true)]
+async fn execute_plan_phased_cancelled_between_phases_keeps_completed_resources_in_state() {
+    let provider = CancellingReplaceProvider::new(Duration::from_secs(5));
+    let observer = CancelsAfterReplacePhase::new(ReplacePhase::CreateTemporary);
+    let cancel = observer.token();
+    let mut state_file = StateFile::default();
+    let plan = create_interdependent_replace_plan();
+    assert!(has_interdependent_replaces(plan.effects()));
+    let input = ExecutionInput::new_mut_state(&plan, &mut state_file)
+        .with_parallelism(NonZeroUsize::new(2).unwrap());
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("phased cancel returned Completed"),
+    };
+    assert!(result.applied_states.contains_key(&ResourceId::new("test", "a")));
+    assert!(!provider.started_phase(ReplacePhase::DeleteOld));
+}
+```
+
+**Implementation**:
+
+`execute_effects_sequential` の戻り値を `ExecutionOutcome` に変え、loop の dispatch 前で `cancel.is_cancelled()` を見て `newly_ready.clear()` する。`in_flight` が空になった時点で `cancelled` flag が true なら `ExecutionOutcome::Cancelled(result)`、false なら `Completed(result)` を返す。
+
+```rust
+let mut cancelled = false;
+loop {
+    if cancel.is_cancelled() {
+        cancelled = true;
+    }
+    if !cancelled {
+        dispatch_newly_ready_effects(...);
+    }
+    if in_flight.is_empty() {
+        break;
+    }
+    let (finished_idx, result) = in_flight.next().await.unwrap();
+    process_single_effect_result(...);
+}
+let result = build_execution_result(...).await;
+if cancelled {
+    ExecutionOutcome::Cancelled(result)
+} else {
+    ExecutionOutcome::Completed(result)
+}
+```
+
+`phased.rs` は T4 で `cancel` を受け取る signature に揃え、phase 1 の create temporary が終わった後、phase 2 の delete old を投入する前に `cancel.is_cancelled()` を見る。`create_interdependent_replace_plan()` は `has_interdependent_replaces(plan.effects()) == true` になる Replace effect を 2 件作る helper として `carina-core/src/executor/tests.rs` に置く。`parallel.rs` の loop は effect 単位の cancel semantics を担う。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-core execute_plan_cancelled_after_three_completed_keeps_in_flight_and_drops_pending
+cargo nextest run -p carina-core execute_plan_cancelled_while_effect_in_flight_records_that_effect
+cargo nextest run -p carina-core execute_plan_phased_cancelled_between_phases_keeps_completed_resources_in_state
+```
+
+## T5. apply.rs で ExecutionOutcome を match し Cancelled でも finalize_apply を走らせる
+
+依存タスク: T4
+
+**Goal**: apply 中の cancel で完了済み state を保存し、lock を release し、最後に `AppError::Interrupted` を返す。
+
+**Files**:
+
+- modify `carina-cli/src/commands/apply/mod.rs`
+- modify `carina-cli/src/commands/apply/tests.rs`
+- create `carina-cli/src/commands/apply/tests/cancellation_fixture.rs`
+
+**Test**:
+
+```rust
+#[tokio::test]
+async fn run_apply_cancelled_after_partial_execution_persists_state_and_releases_lock() {
+    let fixture = ApplyCancellationFixture::new()
+        .with_resources(["first", "second", "third"])
+        .cancel_after_successes(1);
+    let token = fixture.cancel_token();
+
+    let err = run_apply(
+        fixture.config_path(),
+        true,
+        true,
+        NonZeroUsize::new(1).unwrap(),
+        fixture.provider_context(),
+        token,
+    )
+    .await
+    .unwrap_err();
+
+assert!(matches!(err, AppError::Interrupted));
+    let state = fixture.backend().read_state().await.unwrap().unwrap().into_state();
+    assert!(state.resource(ResourceId::new("mock", "first")).is_some());
+    assert!(state.resource(ResourceId::new("mock", "second")).is_none());
+    assert!(!fixture.backend().lock_path().exists());
+}
+```
+
+**Implementation**:
+
+`run_apply`, `run_apply_locked`, `run_apply_from_plan`, `run_apply_from_plan_locked`, `execute_effects` に `CancellationToken` を通す。`execute_effects` は `ExecutionOutcome` を返す。`run_apply_locked` は outcome を match して `finalize_apply` に `&result` を渡し、finalize 完了後に cancelled なら `Err(AppError::Interrupted)` を返す。
+
+fixture interface:
+
+- `ApplyCancellationFixture::new() -> Self`
+- `with_resources<const N: usize>(self, names: [&str; N]) -> Self`
+- `cancel_after_successes(self, count: usize) -> Self`
+- `cancel_token(&self) -> CancellationToken`
+- `read_state(&self) -> impl Future<Output = StateFile>`
+- `lock_path(&self) -> &Path`
+- `provider_context(&self) -> &ProviderContext`
+- `config_path(&self) -> &Path`
+- `backend(&self) -> &LocalStateBackendForTest`
+
+`ResourceId::new("mock", name)` は `carina-provider-mock` の `ProviderInfo { name: "mock", ... }` に合わせる。fixture が生成する `.crn` には `provider "mock" {}` と `resource "mock.<type>" "<name>" {}` を含め、`ProviderContext` には mock provider factory を登録する。
+
+```rust
+let outcome = execute_effects(..., cancel.clone()).await;
+let (mut result, cancelled) = match outcome {
+    ExecutionOutcome::Completed(result) => (result, false),
+    ExecutionOutcome::Cancelled(result) => (result, true),
+};
+execute_import_effects(&plan, &provider, &mut result).await;
+execute_state_only_effects(&plan, &mut result);
+finalize_apply(FinalizeApplyInput { result: &result, ... }).await?;
+if cancelled {
+    return Err(AppError::Interrupted);
+}
+```
+
+`run_apply` の lock release は `op_result` が `Interrupted` でも release する既存 pattern を維持する。T5 では saved-plan apply にも同じ token を渡す。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-cli run_apply_cancelled_after_partial_execution_persists_state_and_releases_lock
+```
+
+## T6. destroy.rs の独自 loop を cancel token 対応にし state 書き戻しを走らせる
+
+依存タスク: T5
+
+**Goal**: destroy 中の cancel で削除済み resource を state から反映し、lock を release し、最後に `AppError::Interrupted` を返す。
+
+**Files**:
+
+- modify `carina-cli/src/commands/destroy.rs`
+- modify `carina-cli/src/tests.rs`
+- create `carina-cli/src/commands/destroy/tests/cancellation_fixture.rs`
+
+**Test**:
+
+```rust
+#[tokio::test]
+async fn run_destroy_cancelled_after_partial_execution_persists_deletions_and_releases_lock() {
+    let fixture = DestroyCancellationFixture::new()
+        .with_existing_resources(["first", "second"])
+        .cancel_after_successes(1);
+    let token = fixture.cancel_token();
+
+    let err = run_destroy(
+        fixture.config_path(),
+        true,
+        true,
+        false,
+        false,
+        NonZeroUsize::new(1).unwrap(),
+        fixture.provider_context(),
+        token,
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, AppError::Interrupted));
+    let state = fixture.backend().read_state().await.unwrap().unwrap().into_state();
+    assert!(state.resource(ResourceId::new("mock", "first")).is_none());
+    assert!(state.resource(ResourceId::new("mock", "second")).is_some());
+    assert!(!fixture.backend().lock_path().exists());
+}
+```
+
+**Implementation**:
+
+`run_destroy` と `run_destroy_locked` に `CancellationToken` を追加する。`destroy.rs` には現存する state writeback helper が無く、`run_destroy_locked` 末尾で `apply_destroy_to_state(&mut state, &destroyed_ids)` と `save_state_locked` / `save_state_unlocked` を直接呼んでいる。T6 で新規 `finalize_destroy` helper を追加し、cancelled でもその helper を必ず通る形にする。
+
+fixture interface:
+
+- `DestroyCancellationFixture::new() -> Self`
+- `with_existing_resources<const N: usize>(self, names: [&str; N]) -> Self`
+- `cancel_after_successes(self, count: usize) -> Self`
+- `cancel_token(&self) -> CancellationToken`
+- `read_state(&self) -> impl Future<Output = StateFile>`
+- `lock_path(&self) -> &Path`
+- `provider_context(&self) -> &ProviderContext`
+- `config_path(&self) -> &Path`
+- `backend(&self) -> &LocalStateBackendForTest`
+
+`ResourceId::new("mock", name)` は `carina-provider-mock` の provider name に合わせる。fixture は initial state に mock resource を入れ、`.crn` 側にも同じ mock provider configuration を生成する。
+
+```rust
+let cancelled = cancel.is_cancelled();
+finalize_destroy(FinalizeDestroyInput {
+    backend,
+    lock,
+    state_file,
+    destroyed_ids: &destroyed_ids,
+    success_count,
+    failure_count,
+    skip_count,
+}).await?;
+if cancelled {
+    return Err(AppError::Interrupted);
+}
+```
+
+`run_destroy` の outer lock release は T5 と同じく `Err(AppError::Interrupted)` を release 対象として扱う。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-cli run_destroy_cancelled_after_partial_execution_persists_deletions_and_releases_lock
+```
+
+## T7. signal.rs を CancellationToken 駆動に書き換える
+
+依存タスク: T6
+
+**Goal**: SIGINT と SIGTERM の初回で token を cancel し、2 回目で cursor restore 後に exit 130 する統一 listener を持つ。
+
+**Files**:
+
+- modify `carina-cli/src/signal.rs`
+
+**Test**:
+
+```rust
+#[tokio::test]
+async fn signal_listener_cancels_token_on_interrupt_event() {
+    let token = CancellationToken::new();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let exit = RecordingExit::default();
+
+    let task = tokio::spawn(listen_for_shutdown_events(
+        token.clone(),
+        SignalEvents::from_receiver(rx),
+        exit.clone(),
+    ));
+    tx.send(ShutdownSignal::Interrupt).unwrap();
+
+    token.cancelled().await;
+    assert!(!exit.was_called());
+    task.abort();
+}
+```
+
+```rust
+#[tokio::test]
+async fn signal_listener_cancels_token_on_terminate_event() {
+    let token = CancellationToken::new();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let exit = RecordingExit::default();
+
+    tokio::spawn(listen_for_shutdown_events(
+        token.clone(),
+        SignalEvents::from_receiver(rx),
+        exit.clone(),
+    ));
+    tx.send(ShutdownSignal::Terminate).unwrap();
+
+    token.cancelled().await;
+    assert!(!exit.was_called());
+}
+```
+
+```rust
+#[tokio::test]
+async fn signal_listener_calls_exit_130_on_second_interrupt() {
+    let token = CancellationToken::new();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let exit = RecordingExit::default();
+
+    let task = tokio::spawn(listen_for_shutdown_events(
+        token.clone(),
+        SignalEvents::from_receiver(rx),
+        exit.clone(),
+    ));
+    tx.send(ShutdownSignal::Interrupt).unwrap();
+    token.cancelled().await;
+    tx.send(ShutdownSignal::Interrupt).unwrap();
+    task.await.unwrap();
+
+    assert_eq!(exit.calls(), vec![130]);
+}
+```
+
+**Implementation**:
+
+`run_with_ctrl_c` を削除し、test 可能な内部関数を置く。production は `tokio::signal::unix::signal(SignalKind::interrupt())` と `SignalKind::terminate()` から `ShutdownSignal` を流す。
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ShutdownSignal {
+    Interrupt,
+    Terminate,
+}
+
+pub fn spawn_shutdown_listener(token: CancellationToken) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let events = SignalEvents::unix().expect("install unix signal handlers");
+        listen_for_shutdown_events(token, events, ProcessExit).await;
+    })
+}
+
+async fn listen_for_shutdown_events<E, X>(token: CancellationToken, mut events: E, exit: X)
+where
+    E: ShutdownEvents,
+    X: ExitProcess,
+{
+    let _first = events.recv().await;
+    token.cancel();
+    let _second = events.recv().await;
+    crate::cursor::restore_cursor();
+    exit.exit(130);
+}
+```
+
+`read_line_with_interrupt` は T10 で扱うため T7 では残す。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-cli signal_listener_cancels_token_on_interrupt_event
+cargo nextest run -p carina-cli signal_listener_cancels_token_on_terminate_event
+cargo nextest run -p carina-cli signal_listener_calls_exit_130_on_second_interrupt
+```
+
+## T8. main.rs で CancellationToken を生成して apply/destroy に渡す
+
+依存タスク: T7
+
+**Goal**: CLI entrypoint が signal listener を 1 回だけ spawn し、apply / apply-from-plan / destroy が同じ token を受け取る。
+
+**Files**:
+
+- modify `carina-cli/src/main.rs`
+- modify `carina-cli/src/commands/apply/mod.rs`
+- modify `carina-cli/src/commands/destroy.rs`
+
+**Test**:
+
+このタスクでは main binary の Rust test は追加しない。public handler signature の compile check を Red/Green の確認にする。
+
+**Implementation**:
+
+`main` の `Cli::parse()` 後、`CursorGuard::stdout()` 前に token を作り、signal listener を spawn する。help/version/parse error では token も listener も作らない。
+
+```rust
+let cli = Cli::parse();
+let cancel_token = CancellationToken::new();
+let _shutdown_listener = carina_cli::signal::spawn_shutdown_listener(cancel_token.clone());
+let _cursor_guard = carina_cli::cursor::CursorGuard::stdout();
+
+Commands::Apply { ... } => {
+    if path.extension().is_some_and(|ext| ext == "json") {
+        run_apply_from_plan(&path, auto_approve, lock, parallelism, &provider_context, cancel_token.clone()).await
+    } else {
+        run_apply(&path, auto_approve, lock, parallelism, &provider_context, cancel_token.clone()).await
+    }
+}
+Commands::Destroy { ... } => {
+    run_destroy(&path, auto_approve, lock, refresh, force, parallelism, &provider_context, cancel_token.clone()).await
+}
+```
+
+**Verify**:
+
+```bash
+cargo check -p carina-cli
+```
+
+## T9. cursor.rs の独立シグナルハンドラ登録を撤去する
+
+依存タスク: T8
+
+**Goal**: cursor restore の signal 経路を `signal.rs` の統一 handler に集約し、panic hook は残す。
+
+**Files**:
+
+- modify `carina-cli/src/cursor.rs`
+- modify `carina-cli/src/main.rs`
+- modify `carina-cli/src/signal.rs`
+
+**Test**:
+
+```rust
+#[test]
+fn install_panic_restore_hook_restores_hidden_cursor_once() {
+    let _guard = TEST_LOCK.lock().unwrap();
+    reset_cursor_hidden_for_test(true);
+    install_panic_restore_hook_for_test();
+
+    let result = std::panic::catch_unwind(|| {
+        panic!("cursor restore hook test");
+    });
+
+    assert!(result.is_err());
+    assert!(!is_cursor_hidden_for_test());
+}
+```
+
+**Implementation**:
+
+`install_restore_handlers` を `install_panic_restore_hook` に rename し、`signal_hook::low_level::register` と `emulate_default_handler` の loop を削除する。`signal.rs` の二回目 signal 経路で `crate::cursor::restore_cursor()` を呼ぶため、SIGINT/SIGTERM restore はそこへ集約される。
+
+```rust
+pub fn install_panic_restore_hook() {
+    if !std::io::stdout().is_terminal() {
+        return;
+    }
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_cursor_once(false);
+        prev(info);
+    }));
+}
+```
+
+`main.rs` は `carina_cli::cursor::install_panic_restore_hook();` を呼ぶ。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-cli install_panic_restore_hook_restores_hidden_cursor_once
+```
+
+## T10. confirm prompt を CancellationToken 駆動にする
+
+依存タスク: T9
+
+**Goal**: apply confirmation prompt が `CancellationToken` を待ち、`tokio::signal::ctrl_c()` を直接作らない。
+
+**Files**:
+
+- modify `carina-cli/src/signal.rs`
+- modify `carina-cli/src/commands/apply/mod.rs`
+
+**Test**:
+
+```rust
+#[tokio::test]
+async fn read_line_until_cancelled_returns_interrupted_when_token_is_cancelled() {
+    let token = CancellationToken::new();
+    token.cancel();
+    let reader = tokio::io::BufReader::new(NeverReady);
+
+    let err = read_line_until_cancelled(reader, token)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, AppError::Interrupted));
+}
+```
+
+```rust
+#[tokio::test]
+async fn confirm_apply_returns_interrupted_when_cancel_token_fires() {
+    let token = CancellationToken::new();
+    token.cancel();
+    let reader = tokio::io::BufReader::new(NeverReady);
+
+    let err = confirm_apply(reader, token, false).await.unwrap_err();
+
+    assert!(matches!(err, AppError::Interrupted));
+}
+```
+
+```rust
+#[tokio::test]
+async fn read_line_until_cancelled_returns_interrupted_when_cancel_fires_after_subscription() {
+    let token = CancellationToken::new();
+    let reader = tokio::io::BufReader::new(NeverReady);
+    let waiting = tokio::spawn(read_line_until_cancelled(reader, token.clone()));
+
+    tokio::task::yield_now().await;
+    token.cancel();
+
+    let err = waiting.await.unwrap().unwrap_err();
+    assert!(matches!(err, AppError::Interrupted));
+}
+```
+
+**Implementation**:
+
+`read_line_with_interrupt<R, F>` を `read_line_until_cancelled<R>(reader, cancel: CancellationToken)` に置き換える。互換 wrapper は残さない。`confirm_apply` の generic `F` も削除して token を受ける。
+
+```rust
+pub async fn read_line_until_cancelled<R>(
+    reader: R,
+    cancel: CancellationToken,
+) -> Result<String, AppError>
+where
+    R: AsyncBufRead + Unpin,
+{
+    tokio::pin!(reader);
+    let mut buf = String::new();
+    tokio::select! {
+        result = reader.read_line(&mut buf) => strip_line(result, buf),
+        _ = cancel.cancelled() => Err(AppError::Interrupted),
+    }
+}
+```
+
+`run_apply_locked` と `run_apply_from_plan_locked` の confirm 呼び出しは `confirm_apply(stdin, cancel.clone(), auto_approve).await?` に変える。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-cli read_line_until_cancelled_returns_interrupted_when_token_is_cancelled
+cargo nextest run -p carina-cli confirm_apply_returns_interrupted_when_cancel_token_fires
+cargo nextest run -p carina-cli read_line_until_cancelled_returns_interrupted_when_cancel_fires_after_subscription
+```
+
+## T11. apply の SIGINT 中断統合テスト
+
+依存タスク: T10
+
+**Goal**: signal module を経由せず token を直接 cancel して、apply が state 保存、lock release、Interrupted をすべて満たすことを統合テストで固定する。
+
+**Files**:
+
+- modify `carina-cli/src/commands/apply/tests.rs`
+
+**Test**:
+
+```rust
+#[tokio::test]
+async fn apply_cancel_token_integration_persists_completed_state_releases_lock_and_returns_interrupted() {
+    let fixture = ApplyCancellationFixture::new()
+        .with_resources(["alb", "listener", "target_group"])
+        .cancel_after_successes(1);
+    let token = fixture.cancel_token();
+
+    let err = run_apply(
+        fixture.config_path(),
+        true,
+        true,
+        NonZeroUsize::new(1).unwrap(),
+        fixture.provider_context(),
+        token,
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, AppError::Interrupted));
+    let state = fixture.read_state().await;
+    assert!(state.resource(ResourceId::new("mock", "alb")).is_some());
+    assert!(state.resource(ResourceId::new("mock", "listener")).is_none());
+    assert!(!fixture.lock_file_exists());
+}
+```
+
+**Implementation**:
+
+T5 の focused unit/integration helper を再利用し、test 名を issue #3498 の regression として残す。T11 は apply layer の責務だけを見るため、exit code 130 は assert しない。exit code は `signal.rs` / main error rendering の layer で扱う。
+
+このタスクの末尾で doctest も確認する。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-cli apply_cancel_token_integration_persists_completed_state_releases_lock_and_returns_interrupted
+cargo test --workspace --doc
+```
+
+## T12. SIGTERM の扱いを固定する
+
+依存タスク: T11
+
+**Goal**: SIGTERM は SIGINT と同じ token 駆動で cover され、apply/destroy の state rescue test を重複させない設計を test で示す。
+
+**Files**:
+
+- modify `carina-cli/src/signal.rs`
+
+**Test**:
+
+```rust
+#[tokio::test]
+async fn terminate_and_interrupt_events_share_the_same_cancel_path() {
+    for signal in [ShutdownSignal::Interrupt, ShutdownSignal::Terminate] {
+        let token = CancellationToken::new();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let exit = RecordingExit::default();
+        let task = tokio::spawn(listen_for_shutdown_events(
+            token.clone(),
+            SignalEvents::from_receiver(rx),
+            exit.clone(),
+        ));
+
+        tx.send(signal).unwrap();
+        token.cancelled().await;
+
+        assert!(token.is_cancelled());
+        assert!(!exit.was_called());
+        task.abort();
+    }
+}
+```
+
+**Implementation**:
+
+`SignalEvents::unix()` で `SignalKind::interrupt()` と `SignalKind::terminate()` を同じ `tokio::select!` に入れ、どちらも `ShutdownSignal` に変換する。
+
+```rust
+tokio::select! {
+    _ = interrupt.recv() => Some(ShutdownSignal::Interrupt),
+    _ = terminate.recv() => Some(ShutdownSignal::Terminate),
+}
+```
+
+SIGTERM の apply 挙動は T11 で token fire 経路を cover している。OS signal 経由の apply test は CI の signal timing に依存するため追加しない。
+
+**Verify**:
+
+```bash
+cargo nextest run -p carina-cli terminate_and_interrupt_events_share_the_same_cancel_path
+```
+
+## T13. 全 verify 一括
+
+依存タスク: T12
+
+**Goal**: workspace 全体で test、doctest、clippy、repository scripts が通ることを確認する。
+
+**Files**:
+
+- modify なし
+
+**Test**:
+
+このタスクでは Rust test は追加しない。T1 から T12 の tests と workspace checks をまとめて実行する。
+
+**Implementation**:
+
+実装コードは書かない。T12 までの変更がすべて入った worktree で verify だけを実行する。
+
+**Verify**:
+
+```bash
+cargo nextest run --workspace
+cargo test --workspace --doc
+cargo clippy --workspace --all-targets -- -D warnings
+for f in scripts/check-*.sh; do bash "$f" || exit 1; done
+```

--- a/docs/specs/2026-06-14-apply-interruption-resilience-design.md
+++ b/docs/specs/2026-06-14-apply-interruption-resilience-design.md
@@ -1,0 +1,258 @@
+# Apply 中断時のリソース永続化とロック解放（設計）
+
+対象 issue: [carina-rs/carina#3498](https://github.com/carina-rs/carina/issues/3498)
+
+## 解こうとしていること
+
+`carina apply` が途中で止められた場合に、それまでに成功したリソースが
+state ファイルに残らず、backend のロックも解放されないことがある。次の
+`plan` は古い state を見て「まだ何もしていない」という前提の差分を出し、
+実 AWS には半分作られたリソースが孤立する。最終的にはオペレータが手作業で
+リソースを片付けてロックを破る以外に復旧経路が無くなる。
+
+issue #3498 が想定している中断のきっかけは、サブ依存リソースが落ちて apply
+ループが早期に抜ける場合、ユーザーが Ctrl+C を押す場合、GitHub Actions の
+step が時間切れでキャンセルされる場合、の 3 通り。前者 2 つは SIGINT、最後は
+SIGTERM が引き金になる。
+
+## 現状の挙動と何が起きているか
+
+apply の流れは大まかに「ロックを取る → ユーザーへ確認 → `execute_plan` で
+Effect を順に流す → 戻り値の `applied_states` を元に `finalize_apply` で
+state ファイルを書く → ロックを解放する」の順。
+
+state を書くのはこの 1 か所だけで、ループ中には書き込みが入らない。
+
+中断の経路は次のようになっている。
+
+SIGINT が来た場合は、`signal::run_with_ctrl_c` の中の `tokio::select!` が
+`execute_plan` の future を drop してエラーを返す。drop された
+`execute_plan` はローカルの `applied_states` HashMap を返さないので、
+それまでに成功した effect の結果は呼び出し側に届かない。`finalize_apply`
+は呼ばれず、state ファイルは書き換わらないまま終わる。ロックは
+`run_apply` の末尾で `Interrupted` でも解放されるので残らない。
+
+SIGTERM の場合は、`tokio::signal::ctrl_c` が拾うのは SIGINT だけなので、
+SIGTERM は素通りで OS のデフォルト処理に渡され、carina プロセスは即死する。
+ロックも state も何も書かれない。issue #3498 が報告している
+「ロックが残ったまま」「state が古いまま」の publish-ALB のケースは、
+キャンセル経由でこのパスに入った可能性が高い。
+
+サブリソース失敗で apply ループが早期に抜けた場合は、`execute_plan` 自体は
+通常 return するので `finalize_apply` まで届き、成功分の state は書ける。
+ここは現状で正しく動いている。
+
+このうち SIGTERM 裸透が一番表面的だが、本質は「`execute_plan` の戻り値が
+中断時に消えるという broken invariant」が `signal` の経路で表に出ている、
+の方。SIGTERM ハンドラだけ足しても、`tokio::select!` で future を drop する
+seam が残る限り state は救えない。
+
+## 採用案
+
+`execute_plan` の戻り値の型を変えて、「中断したかどうか」を呼び出し側が
+必ず判定しないとコンパイルが通らない形にする。中断のセマンティクスは
+「新規 effect は投入しない、in-flight effect は完了まで待つ」に固定する。
+
+### `ExecutionOutcome` enum
+
+```rust
+// carina-core::executor
+
+pub enum ExecutionOutcome {
+    Completed(ExecutionResult),
+    Cancelled(ExecutionResult),
+}
+
+pub async fn execute_plan(
+    provider: &dyn Provider,
+    input: ExecutionInput<'_>,
+    observer: &dyn ExecutionObserver,
+    cancel: CancellationToken,
+) -> ExecutionOutcome
+```
+
+`Completed` と `Cancelled` のどちらも `ExecutionResult` を持つ。
+`Cancelled` 側に詰める `ExecutionResult` には、cancel 通知が来るまでに
+完了済みだった effect の結果（成功分の `applied_states`、失敗分のカウント、
+削除済み集合、その他）が入る。in-flight だった effect は、完了まで待った
+うえで結果を `Completed` と同じルールで詰める。実 AWS API call の冪等性が
+保てない以上、in-flight を途中で諦める seam は持たない方が誠実。
+
+呼び出し側は次のように書く。
+
+```rust
+let outcome = execute_plan(provider, input, &observer, token).await;
+let (result, cancelled) = match outcome {
+    ExecutionOutcome::Completed(r) => (r, false),
+    ExecutionOutcome::Cancelled(r) => (r, true),
+};
+finalize_apply(state_file, result, ...).await?;
+backend.release_lock(&lock_info).await?;
+if cancelled {
+    return Err(AppError::Interrupted);
+}
+```
+
+`?` で握り潰せる単純な `Result<ExecutionResult, _>` ではないので、
+caller が cancel を見落とすとコンパイルエラーになる。`was_cancelled: bool`
+を生やすだけの代替案は、フラグを参照しない caller が書けてしまう点で同じ
+broken state を再現できるため採らない。observer に hook を生やす案も
+同様で、observer 実装ごとに「state を回収するのは自分の仕事か」を覚える
+必要が出るので採らない。
+
+apply.rs / destroy.rs どちらも同じ seam を通る。**この点が単なる
+「per-site で書き換える」ではなく「seam を 1 つに揃える」になっている**
+ので、将来 import などの新しい mutating コマンドが追加されても、
+`execute_plan` を呼ぶ caller である以上 `Cancelled` を必ず捌くことに
+なる。runtime convention に依存しない。
+
+### Cancel のセマンティクス
+
+cancel token が fire したら:
+
+- まだ投入していない effect は捨てる
+- in-flight の effect は完了まで `await` する
+- 完了した結果は `Completed` と同じ判定基準で `applied_states` に詰める
+- すべての in-flight が捌けたら `Cancelled(result)` を返す
+
+「in-flight も即座に諦める」案は、AWS API call を発行した時点で
+リソースが AWS 側に物理的に生まれている可能性があり、その生成を
+state に記録しないと issue #3498 の症状を再現する。AWS API call は
+HTTP リクエストを送ってしまえば carina から止められないという物理的
+制約があるので、「呼んだ以上は結果を待って state に書く」を正しい
+方針とする。
+
+cancel から見て「shutdown が長引く」問題は CI のキャンセル猶予側で
+吸収する話で、carina の seam にこの種の制約を漏らさない。実運用上は
+in-flight が完了する数十秒〜数分のうちに次のシグナルが来ない限り、
+2 段階目の `process::exit(130)` には届かない。届いた場合は次節の
+「2 回目のシグナル」に倣う。
+
+### 統一シグナルハンドラ
+
+SIGINT と SIGTERM の両方で同じ `CancellationToken` を fire する
+ハンドラに置き換える。現在の `signal::run_with_ctrl_c` の
+`tokio::select!` を使う実装は捨てる。
+
+具体的な形:
+
+- `main.rs` 立ち上がりで `CancellationToken` を生成し、apply/destroy
+  などのトップレベルに引き渡す
+- `signal_hook` あるいは `tokio::signal::unix` の `SignalKind` で
+  SIGINT と SIGTERM を待つ tokio task を 1 本立て、初回シグナルで
+  `token.cancel()` を呼ぶ
+- 同じ task の中で 2 回目のシグナルを待ち、来たら
+  `crate::cursor::restore_cursor()` + `std::process::exit(130)` を実行
+- カーソル復元のための `signal_hook` ハンドラはこの中に統合する。
+  cursor.rs の独立した signal ハンドラ登録は撤去できる
+
+`run_with_ctrl_c` は `Future` 単体を select でラップする抽象だった
+ので、呼び出し側を `cancel_token.clone()` を渡す形に書き換える際に
+撤去する。confirm prompt 中の cancel も同じ token を見るように
+`read_line_with_interrupt` を `read_line_until_cancelled` 風に
+変える。
+
+### apply.rs の流れ
+
+```text
+ロック取得
+  └─ execute_plan(cancel_token).await
+       ├─ Completed(result) → finalize_apply → state 保存 → ロック解放
+       └─ Cancelled(result) → finalize_apply → state 保存 → ロック解放 → Interrupted
+```
+
+state 保存とロック解放は中断経路でも同じコードパス。
+`Cancelled` の場合だけは最後に `AppError::Interrupted` を返して、終了
+コードに反映させる。
+
+destroy.rs にも同じ書き換えを入れる。両者は plan を実行する mutating
+コマンドという点で同じ shape を持つ。
+
+## 何を直さないか
+
+streaming state save、すなわち 1 effect ごとの state flush は今回の
+スコープから外す。「graceful な cancel 後に in-flight 完了を待つ」を
+入れた時点で、CI step の猶予内で起きる SIGTERM / SIGINT による損失は
+カバーできる。SIGKILL や kernel OOM、ホスト消失のような「猶予が無い」
+中断はそもそも graceful な cleanup の対象外で、streaming save でも
+完全には救えない。streaming にすると S3 への CAS 書き込みや serial bump
+の頻度設計、トランザクション境界の見直しが必要になり、性質の違う仕事
+なので別 issue で扱う。
+
+issue #3498 本文に書いてある「force-unlock サブコマンド」は既存
+（`carina force-unlock <lock-id>`）。新規実装は不要。今回の修正でロック
+残留の頻度自体が落ちる前提なので、エラー文言の `force-unlock` 案内は
+そのまま流用する。
+
+drift 検出や live AWS との reconciliation も別議論。今回は「carina が
+自分で作ったリソースを state に書き残す」だけを担保する。
+
+## 影響範囲
+
+主に手を入れる場所:
+
+- `carina-core/src/executor/`: `execute_plan` のシグネチャ、戻り値型
+  `ExecutionOutcome` の追加、cancel token を見る制御フロー
+- `carina-cli/src/signal.rs`: `run_with_ctrl_c` 撤去、cancel token を
+  fire する統一ハンドラ
+- `carina-cli/src/commands/apply/mod.rs`: 戻り値 match、finalize 経路の
+  整理
+- `carina-cli/src/commands/destroy.rs`: 同上
+- `carina-cli/src/cursor.rs`: cursor restore のシグナルハンドラを統一
+  ハンドラに統合（独立登録の撤去）
+- `carina-cli/src/main.rs`: cancel token の生成と引き渡し
+- `Cargo.toml`: `tokio-util` を `carina-cli` と `carina-core` の依存
+  に追加（あるいは自前の軽量 CancellationToken を carina-core 内に置く
+  かは実装フェーズで Codex に判断させる）
+
+import / state surgery 系コマンドは `execute_plan` を呼んでいないため
+影響無し。ただし将来 mutating コマンドを追加するときは同じ seam を通る
+ので、自動的に救済される。
+
+## テスト戦略
+
+中断の seam そのものを compile-time で守れる設計なので、テストは
+「seam が起動した時に何が起きるか」を確かめる単純な統合テストになる。
+
+`carina-core` 側で:
+
+- `execute_plan` が cancel 通知を受けて `Cancelled(result)` を返すこと
+- `Cancelled.0.applied_states` に cancel 前に完了済みだった effect の
+  結果が含まれること
+- in-flight だった effect の完了結果も含まれること
+- まだ投入していない effect は含まれないこと
+
+`carina-cli` 側で:
+
+- SIGINT で `finalize_apply` 経路が走り、state ファイルが更新されている
+  こと、ロックが解放されていること、終了コードが `Interrupted` 由来で
+  あること
+- SIGTERM でも同じこと
+- 2 回目の同じシグナルで `process::exit(130)` 経由で即死すること
+  （カーソル復元は通っていること）
+
+state バックエンド側のテストは現状の `acquire_lock` / `release_lock` を
+追加変更しないので不要。
+
+issue #3498 を厳密に再現するには直接 mock provider を使った
+`carina apply` の統合テストで cancel token を fire させ、その後 state
+ファイルが正しく書かれていることを assert する。CI で reliable に
+シグナルを送るのは難しいので、`signal` モジュールを経由しない直接の
+cancel token fire でテストを書く形になる。
+
+## 失敗モードと残るリスク
+
+- in-flight effect が API レイヤで stuck している場合、cancel 後の
+  shutdown が in-flight 完了までかかる。これは AWS 側の挙動依存で、
+  carina で短くするには provider trait に cancel を流す別設計が必要。
+  scope 外。
+- SIGKILL / kernel OOM では graceful shutdown 自体が走らないので、
+  state も書かれないし、ロックも残る。これは TTL ベースのロック自動
+  期限切れと既存の `force-unlock` で復旧する想定で、コードでは追加
+  対応しない。
+- `Cancelled(result)` の `finalize_apply` 中に二度目のシグナルが来て
+  `process::exit(130)` した場合、state 書き込みの途中で死ぬ可能性が
+  ある。state ファイル書き込みは local backend では tempfile + rename
+  で atomic、S3 backend では単発 PutObject なので、結果としては
+  「途中で死んだら state は古いまま」になる。これは現状と同じ挙動で
+  退行ではない。


### PR DESCRIPTION
Refs #3498.

This PR contains design and planning artifacts only — no implementation code. Implementation will land via the per-task issues created after this PR merges.

## Problem

When `carina apply` is interrupted (downstream resource failure, user cancel, GitHub Actions step cancellation), resources that completed successfully are not persisted to state, and the backend lock can be left in place. The next `plan` reads the pre-apply state, presenting the work as if nothing had been done, while the underlying AWS account already contains the half-built infrastructure.

Investigation found two distinct contributors:

- SIGINT path: `tokio::select!` drops the `execute_plan` future on first Ctrl+C, discarding the in-progress `applied_states` HashMap. Lock release does run, but state is silently lost.
- SIGTERM path: `tokio::signal::ctrl_c` does not catch SIGTERM. The existing `signal_hook` handler only restores the cursor, then lets the process die under the default disposition. Neither state nor lock is touched.

## Design

A new enum at the executor seam forces every caller to handle cancellation at the type level:

`````rust
pub enum ExecutionOutcome {
    Completed(ExecutionResult),
    Cancelled(ExecutionResult),
}

pub async fn execute_plan(
    provider: &dyn Provider,
    input: ExecutionInput<'_>,
    observer: &dyn ExecutionObserver,
    cancel: CancellationToken,
) -> ExecutionOutcome
`````

Both variants carry `ExecutionResult`. `Cancelled` includes the results of every effect that had completed (including in-flight ones, which are awaited rather than dropped) at the time cancellation was requested. The `?` shortcut is intentionally unavailable, so a caller that forgets to handle cancellation will not compile.

Cancellation semantics: stop dispatching new effects, await in-flight to completion, then return. AWS API calls are not cancellable in any meaningful sense once dispatched, so awaiting in-flight is what keeps state honest about what the run actually did.

SIGINT and SIGTERM are unified behind a single `CancellationToken` listener task; a second signal triggers `process::exit(130)` after restoring the cursor. The existing `run_with_ctrl_c` / `tokio::select!` drop design is removed.

`apply.rs` and `destroy.rs` route both `Completed` and `Cancelled` through the same finalize path, so state flush and lock release happen on every termination path the process can survive.

Out of scope (deliberate):

- Streaming per-effect state save (would require backend CAS work; tracked separately if needed).
- `force-unlock` subcommand (already exists).
- Live AWS drift reconciliation.

## Artifacts

- Design: `docs/specs/2026-06-14-apply-interruption-resilience-design.md`
- Implementation plan: `docs/plans/2026-06-14-apply-interruption-resilience.md` (T1-T13, TDD-sized tasks)

## Next steps

After this PR merges, per-task implementation issues (task-1/13 … task-13/13) will be filed and picked up via the normal `pick-issue` workflow.