### PR TITLE
deps: add tokio-util as direct dep (T1, #3501)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tower-lsp",
  "winterbaume-core",
  "winterbaume-kms",
@@ -903,6 +904,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "uuid",
 ]
 

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -47,6 +47,7 @@ similar = "2"
 thiserror = "2"
 futures = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "io-std", "io-util"] }
+tokio-util = "0.7"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 indexmap = { version = "2", features = ["serde"] }
 tokio = { version = "1", features = ["time"] }
+tokio-util = "0.7"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync"] }


### PR DESCRIPTION
Closes #3501. Refs #3498.

T1 of the apply interruption resilience series — a dependency-only change. Subsequent tasks (T2/T3) will introduce `tokio_util::sync::CancellationToken` in production code.

## Diff

- `carina-core/Cargo.toml`: `+ tokio-util = "0.7"`
- `carina-cli/Cargo.toml`: `+ tokio-util = "0.7"`
- `Cargo.lock`: corresponding dependency-list updates; no new package introduced (tokio-util 0.7.18 was already transitive).

## Why no features list

The plan flagged this as a Codex judgement call. `tokio_util::sync::CancellationToken` is reachable with the default feature set in 0.7.18, so no `features = [...]` is needed.

## Verify

- `cargo check -p carina-core` PASS
- `cargo check -p carina-cli` PASS

5-round self-review all clean.