### PR TITLE
fix(executor): fail-fast wait when no mutator can satisfy it

### DIFF
--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -161,6 +161,22 @@ fn handle_tty(
                 eprintln!("  {}", msg);
             }
         }
+        ExecutionEvent::WaitPolling {
+            binding,
+            elapsed,
+            last_attrs,
+            ..
+        } => {
+            let observed = format_wait_observed_attr(last_attrs);
+            multi
+                .println(format!(
+                    "  ~ {}: waited {}, {}",
+                    binding,
+                    format_duration(*elapsed),
+                    observed
+                ))
+                .ok();
+        }
         ExecutionEvent::CascadeUpdateSucceeded { id } => {
             multi
                 .println(format!("  {} Update {} (cascade)", "✓".green(), id))
@@ -268,6 +284,20 @@ fn format_plain(event: &ExecutionEvent) -> Vec<String> {
                 counter
             )]
         }
+        ExecutionEvent::WaitPolling {
+            binding,
+            elapsed,
+            last_attrs,
+            ..
+        } => {
+            let observed = format_wait_observed_attr(last_attrs);
+            vec![format!(
+                "  ~ {}: waited {}, {}",
+                binding,
+                format_duration(*elapsed),
+                observed
+            )]
+        }
         ExecutionEvent::CascadeUpdateSucceeded { id } => {
             vec![format!("  ✓ Update {} (cascade)", id)]
         }
@@ -292,15 +322,43 @@ fn format_plain(event: &ExecutionEvent) -> Vec<String> {
     }
 }
 
+fn format_wait_observed_attr(last_attrs: &HashMap<String, carina_core::resource::Value>) -> String {
+    let mut observed: Vec<_> = last_attrs.iter().collect();
+    observed.sort_by_key(|(key, _)| *key);
+    let Some((key, value)) = observed.first() else {
+        return "no observed attributes".to_string();
+    };
+    format!("{key}={value:?}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::executor::ProgressInfo;
-    use carina_core::resource::Resource;
+    use carina_core::resource::{ConcreteValue, Resource, Value};
 
     fn dummy_create_effect() -> Effect {
         Effect::Create(Resource::new("aws.s3.Bucket", "demo"))
+    }
+
+    #[test]
+    fn wait_observed_attr_is_deterministic() {
+        let attrs = HashMap::from([
+            (
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("pending".to_string())),
+            ),
+            (
+                "arn".to_string(),
+                Value::Concrete(ConcreteValue::String("arn:demo".to_string())),
+            ),
+        ]);
+
+        assert_eq!(
+            format_wait_observed_attr(&attrs),
+            "arn=Concrete(String(\"arn:demo\"))"
+        );
     }
 
     #[test]

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -20,7 +20,7 @@ argon2 = "0.5"
 thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 indexmap = { version = "2", features = ["serde"] }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-util = "0.7"
 
 [dev-dependencies]

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -313,6 +313,17 @@ pub fn find_failed_dependency(
     effect: &Effect,
     failed_bindings: &HashSet<String>,
 ) -> Option<String> {
+    if let Effect::Wait {
+        explicit_dependencies,
+        ..
+    } = effect
+    {
+        return explicit_dependencies
+            .iter()
+            .find(|dep| failed_bindings.contains(*dep))
+            .cloned();
+    }
+
     // carina#3181 PR D: `Effect` payloads are typestate structs, so the
     // dependency set is assembled from the `ResourceLike` view (value
     // refs + `dependency_bindings`) plus the effect's explicit
@@ -349,7 +360,27 @@ pub fn find_failed_dependent<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::effect::WaitTarget;
     use crate::resource::{DeferredValue, Directives, Resource, ResourceId, Value};
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    fn wait_effect_with_explicit_dependency(binding: &str) -> Effect {
+        Effect::Wait {
+            binding: "cert_issued".to_string(),
+            target_id: ResourceId::new("acm.Certificate", "cert"),
+            target: WaitTarget::Known("cert-id".to_string()),
+            until: WaitPredicate::Equals {
+                attr: AttrPath::single("status"),
+                value: Value::Concrete(crate::resource::ConcreteValue::String(
+                    "ISSUED".to_string(),
+                )),
+            },
+            until_surface: "cert.status == ISSUED".to_string(),
+            timeout: std::time::Duration::from_secs(60),
+            interval: std::time::Duration::from_millis(1),
+            explicit_dependencies: HashSet::from([binding.to_string()]),
+        }
+    }
 
     fn make_resource(binding: &str, deps: &[&str]) -> Resource {
         let mut r = Resource::new("test", binding);
@@ -576,6 +607,26 @@ mod tests {
 
         let result = find_failed_dependency(&effect, &failed);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn find_failed_dependency_returns_wait_explicit_dependency_when_failed() {
+        let effect = wait_effect_with_explicit_dependency("failed_binding");
+        let failed_bindings: HashSet<String> =
+            ["failed_binding"].into_iter().map(String::from).collect();
+
+        assert_eq!(
+            find_failed_dependency(&effect, &failed_bindings),
+            Some("failed_binding".to_string())
+        );
+    }
+
+    #[test]
+    fn find_failed_dependency_returns_none_when_wait_explicit_dependency_did_not_fail() {
+        let effect = wait_effect_with_explicit_dependency("failed_binding");
+        let failed_bindings: HashSet<String> = HashSet::new();
+
+        assert_eq!(find_failed_dependency(&effect, &failed_bindings), None);
     }
 
     #[test]

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -31,7 +31,7 @@ use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
 use crate::parser::ProviderConfig;
 use crate::provider::{Provider, ProviderNormalizer};
-use crate::resource::{ResourceId, State};
+use crate::resource::{ResourceId, State, Value};
 
 use parallel::execute_effects_sequential;
 use phased::{execute_effects_phased, has_interdependent_replaces};
@@ -126,6 +126,16 @@ pub enum ExecutionEvent<'a> {
         effect: &'a Effect,
         reason: &'a str,
         progress: ProgressInfo,
+    },
+    /// Heartbeat emitted while a wait poll loop is still alive.
+    ///
+    /// Emitted at `max(30s, interval * 5)` cadence with the elapsed time and
+    /// last observed attributes so operators can see what the wait is reading.
+    WaitPolling {
+        binding: &'a str,
+        target_id: &'a ResourceId,
+        elapsed: Duration,
+        last_attrs: &'a HashMap<String, Value>,
     },
     CascadeUpdateSucceeded {
         id: &'a ResourceId,

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -17,6 +17,10 @@ use super::basic::{
     execute_basic_effect, process_basic_result, refresh_pending_states,
 };
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
+use super::wait::{
+    InFlightKind, UnsatisfiableReason, WaitOutcome, cancel_waits_if_terminal,
+    unsatisfiable_reason_message, wait_failure_message,
+};
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
 
 #[derive(Debug, Clone)]
@@ -552,6 +556,8 @@ pub(super) async fn execute_effects_sequential(
     }
 
     let mut in_flight = FuturesUnordered::new();
+    let mut in_flight_kinds: HashMap<usize, InFlightKind> = HashMap::new();
+    let mut wait_cancellers: HashMap<usize, tokio::sync::watch::Sender<bool>> = HashMap::new();
 
     loop {
         // Find newly ready effects: all deps completed and not yet dispatched
@@ -598,7 +604,15 @@ pub(super) async fn execute_effects_sequential(
 
             if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
                 let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
-                let reason = format!("dependency '{}' failed", failed_dep);
+                let reason = if matches!(effect, Effect::Wait { .. }) {
+                    let detail =
+                        unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
+                            binding: failed_dep,
+                        });
+                    format!("unsatisfiable: {detail}")
+                } else {
+                    format!("dependency '{}' failed", failed_dep)
+                };
                 observer.on_event(&ExecutionEvent::EffectSkipped {
                     effect,
                     reason: &reason,
@@ -646,6 +660,15 @@ pub(super) async fn execute_effects_sequential(
                 schemas: input.schemas,
             };
             let completed_ref = &completed;
+            let wait_cancel_rx = if matches!(effect, Effect::Wait { .. }) {
+                let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+                wait_cancellers.insert(idx, cancel_tx);
+                in_flight_kinds.insert(idx, InFlightKind::Wait);
+                Some(cancel_rx)
+            } else {
+                in_flight_kinds.insert(idx, InFlightKind::NonWait);
+                None
+            };
 
             in_flight.push(async move {
                 let result = match effect.as_basic() {
@@ -735,43 +758,22 @@ pub(super) async fn execute_effects_sequential(
                                 completed: c,
                                 total,
                             };
-                            match super::wait::execute_wait_effect(
+                            let outcome = super::wait::execute_wait_effect(
                                 provider,
                                 target_id,
                                 wait_identifier.as_deref(),
                                 until,
                                 *timeout,
                                 *interval,
+                                wait_cancel_rx.expect("wait dispatch must have a cancel receiver"),
+                                observer,
                             )
-                            .await
-                            {
-                                Ok(state) => {
-                                    observer.on_event(&ExecutionEvent::EffectSucceeded {
-                                        effect,
-                                        state: Some(&state),
-                                        duration: started.elapsed(),
-                                        progress,
-                                    });
-                                    SingleEffectResult::Wait {
-                                        success: true,
-                                        binding: binding.clone(),
-                                        target_state: Some(state),
-                                    }
-                                }
-                                Err(e) => {
-                                    let err_msg = e.to_string();
-                                    observer.on_event(&ExecutionEvent::EffectFailed {
-                                        effect,
-                                        error: &err_msg,
-                                        duration: started.elapsed(),
-                                        progress,
-                                    });
-                                    SingleEffectResult::Wait {
-                                        success: false,
-                                        binding: binding.clone(),
-                                        target_state: None,
-                                    }
-                                }
+                            .await;
+                            SingleEffectResult::Wait {
+                                binding: binding.clone(),
+                                outcome,
+                                duration: started.elapsed(),
+                                progress,
                             }
                         }
                     },
@@ -779,6 +781,12 @@ pub(super) async fn execute_effects_sequential(
                 (idx, result)
             });
         }
+
+        let undispatched_count = actionable_indices
+            .iter()
+            .filter(|&&idx| !dispatched.contains(&idx))
+            .count();
+        cancel_waits_if_terminal(&in_flight_kinds, undispatched_count, &wait_cancellers);
 
         // If nothing is in flight, we're done (or stuck in a cycle)
         if in_flight.is_empty() {
@@ -803,6 +811,8 @@ pub(super) async fn execute_effects_sequential(
         // Wait for the next effect to complete
         let (finished_idx, result) = in_flight.next().await.unwrap();
         completed_indices.insert(finished_idx);
+        in_flight_kinds.remove(&finished_idx);
+        wait_cancellers.remove(&finished_idx);
 
         // Process the result and update shared state immediately
         match result {
@@ -856,37 +866,69 @@ pub(super) async fn execute_effects_sequential(
             }
             SingleEffectResult::ReadNoOp => {}
             SingleEffectResult::Wait {
-                success,
                 binding,
-                target_state,
-            } => {
-                if success {
+                outcome,
+                duration,
+                progress,
+            } => match outcome {
+                WaitOutcome::Satisfied { state } => {
+                    observer.on_event(&ExecutionEvent::EffectSucceeded {
+                        effect: &effects[finished_idx],
+                        state: Some(&state),
+                        duration,
+                        progress,
+                    });
                     success_count += 1;
-                    if let Some(state) = target_state {
-                        // Register the captured target snapshot under the
-                        // wait's *synthetic* ResourceId so the downstream
-                        // resolution layer can deref `<binding>.<attr>` —
-                        // and under the binding name in `bindings` so
-                        // resolve_refs sees the same attribute map. Wait
-                        // effects do not persist to the state file
-                        // (handled by `state_writeback_should_skip`).
-                        let synthetic = ResourceId::new("__wait", &binding);
-                        let attrs: HashMap<String, Value> = state
-                            .attributes
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect();
-                        input
-                            .bindings
-                            .record_applied(Some(&binding), &attrs, &state);
-                        applied_states.insert(synthetic, state);
-                    }
-                } else {
+                    // Register the captured target snapshot under the
+                    // wait's *synthetic* ResourceId so the downstream
+                    // resolution layer can deref `<binding>.<attr>` —
+                    // and under the binding name in `bindings` so
+                    // resolve_refs sees the same attribute map. Wait
+                    // effects do not persist to the state file
+                    // (handled by `state_writeback_should_skip`).
+                    let synthetic = ResourceId::new("__wait", &binding);
+                    let attrs: HashMap<String, Value> = state
+                        .attributes
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    input
+                        .bindings
+                        .record_applied(Some(&binding), &attrs, &state);
+                    applied_states.insert(synthetic, state);
+                }
+                WaitOutcome::Unsatisfiable(reason) => {
+                    let detail = unsatisfiable_reason_message(&reason);
+                    let reason = format!("unsatisfiable: {detail}");
+                    observer.on_event(&ExecutionEvent::EffectSkipped {
+                        effect: &effects[finished_idx],
+                        reason: &reason,
+                        progress,
+                    });
+                    skip_count += 1;
+                    failed_bindings.insert(binding);
+                }
+                outcome @ (WaitOutcome::Timeout { .. }
+                | WaitOutcome::NotFound(_)
+                | WaitOutcome::ReadFailed(_)) => {
+                    let error = wait_failure_message(&outcome, effects[finished_idx].resource_id());
+                    observer.on_event(&ExecutionEvent::EffectFailed {
+                        effect: &effects[finished_idx],
+                        error: &error,
+                        duration,
+                        progress,
+                    });
                     failure_count += 1;
                     failed_bindings.insert(binding);
                 }
-            }
+            },
         }
+
+        let undispatched_count = actionable_indices
+            .iter()
+            .filter(|&&idx| !dispatched.contains(&idx))
+            .count();
+        cancel_waits_if_terminal(&in_flight_kinds, undispatched_count, &wait_cancellers);
     }
 
     let failed_refreshes = refresh_pending_states(
@@ -913,8 +955,16 @@ pub(super) async fn execute_effects_sequential(
 mod tests {
     use super::*;
     use crate::effect::ChangedCreateOnly;
-    use crate::resource::{Composition, Value};
+    use crate::plan::Plan;
+    use crate::provider::{
+        BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
+        ReadRequest, UpdateRequest,
+    };
+    use crate::resource::{Composition, ConcreteValue, DataSource, Value};
+    use crate::schema::SchemaRegistry;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
     use std::collections::BTreeSet;
+    use std::sync::Mutex;
 
     fn set(items: &[&str]) -> BTreeSet<String> {
         items.iter().map(|item| (*item).to_string()).collect()
@@ -964,6 +1014,133 @@ mod tests {
         }
     }
 
+    struct TerminalWaitProvider {
+        create_log: Mutex<Vec<String>>,
+    }
+
+    impl TerminalWaitProvider {
+        fn new() -> Self {
+            Self {
+                create_log: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl Provider for TerminalWaitProvider {
+        fn name(&self) -> &str {
+            "terminal-wait"
+        }
+
+        fn read(
+            &self,
+            id: &ResourceId,
+            _identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let mut attrs = HashMap::new();
+            attrs.insert(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("PENDING_VALIDATION".to_string())),
+            );
+            let state = State::existing(id.clone(), attrs).with_identifier("cert-id");
+            Box::pin(async move { Ok(state) })
+        }
+
+        fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+            self.read(&resource.id, None, ReadRequest)
+        }
+
+        fn create(
+            &self,
+            id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            self.create_log
+                .lock()
+                .unwrap()
+                .push(id.name_str().to_string());
+            let id = id.clone();
+            Box::pin(async move {
+                if id.name_str() == "alb" {
+                    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                    Err(ProviderError::api_error("alb create failed"))
+                } else {
+                    Ok(State::existing(id, HashMap::new()).with_identifier("cert-id"))
+                }
+            })
+        }
+
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("update not used")) })
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async { Err(ProviderError::internal("delete not used")) })
+        }
+    }
+
+    struct RecordingSkipObserver {
+        skipped: Mutex<Vec<String>>,
+        failures: Mutex<Vec<String>>,
+    }
+
+    impl RecordingSkipObserver {
+        fn new() -> Self {
+            Self {
+                skipped: Mutex::new(Vec::new()),
+                failures: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn skipped(&self) -> Vec<String> {
+            self.skipped.lock().unwrap().clone()
+        }
+
+        fn failures(&self) -> Vec<String> {
+            self.failures.lock().unwrap().clone()
+        }
+    }
+
+    impl ExecutionObserver for RecordingSkipObserver {
+        fn on_event(&self, event: &ExecutionEvent) {
+            match event {
+                ExecutionEvent::EffectSkipped { effect, reason, .. } => {
+                    self.skipped
+                        .lock()
+                        .unwrap()
+                        .push(format!("{}:{reason}", effect.resource_id()));
+                }
+                ExecutionEvent::EffectFailed { effect, error, .. } => {
+                    self.failures
+                        .lock()
+                        .unwrap()
+                        .push(format!("{}:{error}", effect.resource_id()));
+                }
+                ExecutionEvent::Waiting { .. }
+                | ExecutionEvent::EffectStarted { .. }
+                | ExecutionEvent::EffectSucceeded { .. }
+                | ExecutionEvent::WaitPolling { .. }
+                | ExecutionEvent::CascadeUpdateSucceeded { .. }
+                | ExecutionEvent::CascadeUpdateFailed { .. }
+                | ExecutionEvent::RenameSucceeded { .. }
+                | ExecutionEvent::RenameFailed { .. }
+                | ExecutionEvent::RefreshStarted
+                | ExecutionEvent::RefreshSucceeded { .. }
+                | ExecutionEvent::RefreshFailed { .. } => {}
+            }
+        }
+    }
+
     fn dependency_after_relax(parent: Effect, child: Effect) -> HashSet<usize> {
         let effects = vec![parent, child];
         let unresolved: HashMap<ResourceId, UnresolvedResource> = effects
@@ -981,6 +1158,88 @@ mod tests {
         let mut analysis = build_dependency_analysis(&effects, &unresolved, &[]);
         relax_update_update_edges(&effects, &mut analysis);
         analysis.into_deps_of().remove(&1).unwrap()
+    }
+
+    #[tokio::test]
+    async fn wait_marked_unsatisfiable_when_only_waits_in_flight() {
+        let provider = TerminalWaitProvider::new();
+
+        let mut cert = Resource::new("test", "cert");
+        cert.binding = Some("cert".to_string());
+        let cert_id = cert.id.clone();
+
+        let mut alb = Resource::new("test", "alb");
+        alb.binding = Some("alb".to_string());
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(cert.clone()));
+        plan.add(Effect::Wait {
+            binding: "cert_issued".to_string(),
+            target_id: cert_id.clone(),
+            target: WaitTarget::ResolvedAtApply,
+            until: WaitPredicate::Equals {
+                attr: AttrPath::single("status"),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+            },
+            until_surface: "cert.status == ISSUED".to_string(),
+            timeout: std::time::Duration::from_secs(60),
+            interval: std::time::Duration::from_millis(1),
+            explicit_dependencies: std::collections::HashSet::new(),
+        });
+        plan.add(Effect::Create(alb.clone()));
+
+        let unresolved = HashMap::from([
+            (
+                cert.id.clone(),
+                UnresolvedResource::from_pre_resolve(cert.clone()),
+            ),
+            (
+                alb.id.clone(),
+                UnresolvedResource::from_pre_resolve(alb.clone()),
+            ),
+        ]);
+        let schemas = SchemaRegistry::new();
+        let mut input = ExecutionInput {
+            plan: &plan,
+            unresolved_resources: &unresolved,
+            compositions: &[],
+            bindings: Default::default(),
+            current_states: HashMap::new(),
+            normalizer: &NoopNormalizer,
+            provider_configs: &[],
+            factories: &[],
+            schemas: &schemas,
+            parallelism: std::num::NonZeroUsize::new(2).unwrap(),
+        };
+        let observer = RecordingSkipObserver::new();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            execute_effects_sequential(&provider, &mut input, &observer),
+        )
+        .await
+        .expect("wait should be skipped as unsatisfiable instead of timing out");
+
+        assert_eq!(result.failure_count, 1, "alb create should fail");
+        assert_eq!(
+            result.skip_count, 1,
+            "wait should be skipped when only waits remain in flight"
+        );
+        assert!(
+            observer
+                .failures()
+                .iter()
+                .any(|event| event.contains("alb")),
+            "test setup should fail alb create; failures: {:?}",
+            observer.failures()
+        );
+        assert!(
+            observer.skipped().iter().any(|event| {
+                event.contains("cert") && event.to_ascii_lowercase().contains("unsatisfiable")
+            }),
+            "wait skip reason should contain unsatisfiable, skipped: {:?}",
+            observer.skipped()
+        );
     }
 
     #[test]

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -2,12 +2,12 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures::stream::{FuturesUnordered, StreamExt};
 
 use crate::deps::{find_failed_dependency, get_resource_dependencies};
-use crate::effect::Effect;
+use crate::effect::{Effect, WaitTarget};
 use crate::provider::{CreateRequest, DeleteRequest, Provider, UpdateRequest};
 use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
@@ -17,6 +17,10 @@ use super::basic::{
     refresh_pending_states, resolve_resource, resolve_resource_with_source,
 };
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
+use super::wait::{
+    InFlightKind, UnsatisfiableReason, WaitOutcome, cancel_waits_if_terminal,
+    unsatisfiable_reason_message, wait_failure_message,
+};
 use super::{
     ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo,
     UnresolvedResource,
@@ -296,6 +300,13 @@ impl<'a> DepResolver<'a> {
 pub(super) enum PhaseEffectResult {
     /// Phase 1: Create/Update/Delete completed (wraps BasicEffectResult)
     Basic(BasicEffectResult),
+    /// Phase 1: Wait completed.
+    Wait {
+        binding: String,
+        outcome: WaitOutcome,
+        duration: Duration,
+        progress: ProgressInfo,
+    },
     /// Phase 2: CBD create succeeded
     CbdCreateSuccess {
         idx: usize,
@@ -382,7 +393,11 @@ pub(super) async fn execute_effects_phased(
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
-        let mut in_flight = FuturesUnordered::new();
+        type PhaseFuture<'a> =
+            std::pin::Pin<Box<dyn std::future::Future<Output = (usize, PhaseEffectResult)> + 'a>>;
+        let mut in_flight: FuturesUnordered<PhaseFuture<'_>> = FuturesUnordered::new();
+        let mut in_flight_kinds: HashMap<usize, InFlightKind> = HashMap::new();
+        let mut wait_cancellers: HashMap<usize, tokio::sync::watch::Sender<bool>> = HashMap::new();
 
         loop {
             let mut newly_ready: Vec<usize> = Vec::new();
@@ -403,7 +418,15 @@ pub(super) async fn execute_effects_phased(
 
                 if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
                     let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
-                    let reason = format!("dependency '{}' failed", failed_dep);
+                    let reason = if matches!(effect, Effect::Wait { .. }) {
+                        let detail =
+                            unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
+                                binding: failed_dep,
+                            });
+                        format!("unsatisfiable: {detail}")
+                    } else {
+                        format!("dependency '{}' failed", failed_dep)
+                    };
                     observer.on_event(&ExecutionEvent::EffectSkipped {
                         effect,
                         reason: &reason,
@@ -420,11 +443,67 @@ pub(super) async fn execute_effects_phased(
                     continue;
                 }
 
+                let wait_identifier: Option<String> = match effect {
+                    Effect::Wait {
+                        target_id, target, ..
+                    } => match target {
+                        WaitTarget::Known(id) => Some(id.clone()),
+                        WaitTarget::ResolvedAtApply => applied_states
+                            .get(target_id)
+                            .and_then(|state| state.identifier.clone()),
+                    },
+                    _ => None,
+                };
+
+                if let Effect::Wait {
+                    binding,
+                    target_id,
+                    until,
+                    timeout,
+                    interval,
+                    ..
+                } = effect
+                {
+                    let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                    let progress = ProgressInfo {
+                        completed: c,
+                        total,
+                    };
+                    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+                    wait_cancellers.insert(idx, cancel_tx);
+                    in_flight_kinds.insert(idx, InFlightKind::Wait);
+
+                    in_flight.push(Box::pin(async move {
+                        let started = Instant::now();
+                        observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                        let outcome = super::wait::execute_wait_effect(
+                            provider,
+                            target_id,
+                            wait_identifier.as_deref(),
+                            until,
+                            *timeout,
+                            *interval,
+                            cancel_rx,
+                            observer,
+                        )
+                        .await;
+                        (
+                            idx,
+                            PhaseEffectResult::Wait {
+                                binding: binding.clone(),
+                                outcome,
+                                duration: started.elapsed(),
+                                progress,
+                            },
+                        )
+                    }));
+                    continue;
+                }
+
                 // Phase 1 only dispatches `Create`/`Update`/`Delete` to
                 // `execute_basic_effect`. State-only effects (`Move`/
-                // `Import`/`Remove`) and `Wait` are routed elsewhere
-                // (the CLI's `execute_state_only_effects` step, or the
-                // sequential path's Wait branch). The previous
+                // `Import`/`Remove`) are routed elsewhere (the CLI's
+                // `execute_state_only_effects` step). The previous
                 // `&Effect` signature let them slip through and trip an
                 // `unreachable!()` (carina#3164); narrowing via
                 // `as_basic()` makes the contract type-level. The
@@ -447,8 +526,9 @@ pub(super) async fn execute_effects_phased(
                     schemas: input.schemas,
                 };
                 let completed_ref = &completed;
+                in_flight_kinds.insert(idx, InFlightKind::NonWait);
 
-                in_flight.push(async move {
+                in_flight.push(Box::pin(async move {
                     let basic = execute_basic_effect(
                         basic_effect,
                         &BasicEffectCtx {
@@ -463,8 +543,14 @@ pub(super) async fn execute_effects_phased(
                     )
                     .await;
                     (idx, PhaseEffectResult::Basic(basic))
-                });
+                }));
             }
+
+            let undispatched_count = phase1_indices
+                .iter()
+                .filter(|&&idx| !dispatched.contains(&idx))
+                .count();
+            cancel_waits_if_terminal(&in_flight_kinds, undispatched_count, &wait_cancellers);
 
             if in_flight.is_empty() {
                 break;
@@ -472,6 +558,8 @@ pub(super) async fn execute_effects_phased(
 
             let (finished_idx, result) = in_flight.next().await.unwrap();
             completed_indices.insert(finished_idx);
+            in_flight_kinds.remove(&finished_idx);
+            wait_cancellers.remove(&finished_idx);
 
             match result {
                 PhaseEffectResult::Basic(basic) => {
@@ -488,8 +576,65 @@ pub(super) async fn execute_effects_phased(
                         },
                     );
                 }
+                PhaseEffectResult::Wait {
+                    binding,
+                    outcome,
+                    duration,
+                    progress,
+                } => match outcome {
+                    WaitOutcome::Satisfied { state } => {
+                        observer.on_event(&ExecutionEvent::EffectSucceeded {
+                            effect: &effects[finished_idx],
+                            state: Some(&state),
+                            duration,
+                            progress,
+                        });
+                        success_count += 1;
+                        let synthetic = ResourceId::new("__wait", &binding);
+                        let attrs: HashMap<String, Value> = state
+                            .attributes
+                            .iter()
+                            .map(|(key, value)| (key.clone(), value.clone()))
+                            .collect();
+                        input
+                            .bindings
+                            .record_applied(Some(&binding), &attrs, &state);
+                        applied_states.insert(synthetic, state);
+                    }
+                    WaitOutcome::Unsatisfiable(reason) => {
+                        let detail = unsatisfiable_reason_message(&reason);
+                        let reason = format!("unsatisfiable: {detail}");
+                        observer.on_event(&ExecutionEvent::EffectSkipped {
+                            effect: &effects[finished_idx],
+                            reason: &reason,
+                            progress,
+                        });
+                        skip_count += 1;
+                        failed_bindings.insert(binding);
+                    }
+                    outcome @ (WaitOutcome::Timeout { .. }
+                    | WaitOutcome::NotFound(_)
+                    | WaitOutcome::ReadFailed(_)) => {
+                        let error =
+                            wait_failure_message(&outcome, effects[finished_idx].resource_id());
+                        observer.on_event(&ExecutionEvent::EffectFailed {
+                            effect: &effects[finished_idx],
+                            error: &error,
+                            duration,
+                            progress,
+                        });
+                        failure_count += 1;
+                        failed_bindings.insert(binding);
+                    }
+                },
                 _ => unreachable!(),
             }
+
+            let undispatched_count = phase1_indices
+                .iter()
+                .filter(|&&idx| !dispatched.contains(&idx))
+                .count();
+            cancel_waits_if_terminal(&in_flight_kinds, undispatched_count, &wait_cancellers);
         }
     }
 
@@ -1357,7 +1502,142 @@ pub(super) async fn execute_effects_phased(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{Composition, ResourceId, Value};
+    use crate::plan::Plan;
+    use crate::provider::{
+        BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
+        ReadRequest, UpdateRequest,
+    };
+    use crate::resource::{Composition, ConcreteValue, DataSource, ResourceId, Value};
+    use crate::schema::SchemaRegistry;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+    use std::sync::Mutex;
+
+    struct TerminalWaitProvider {
+        create_log: Mutex<Vec<String>>,
+    }
+
+    impl TerminalWaitProvider {
+        fn new() -> Self {
+            Self {
+                create_log: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl Provider for TerminalWaitProvider {
+        fn name(&self) -> &str {
+            "terminal-wait"
+        }
+
+        fn read(
+            &self,
+            id: &ResourceId,
+            _identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let mut attrs = HashMap::new();
+            attrs.insert(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("PENDING_VALIDATION".to_string())),
+            );
+            let state = State::existing(id.clone(), attrs).with_identifier("cert-id");
+            Box::pin(async move { Ok(state) })
+        }
+
+        fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+            self.read(&resource.id, None, ReadRequest)
+        }
+
+        fn create(
+            &self,
+            id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            self.create_log
+                .lock()
+                .unwrap()
+                .push(id.name_str().to_string());
+            let id = id.clone();
+            Box::pin(async move {
+                if id.name_str() == "alb" {
+                    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                    Err(ProviderError::api_error("alb create failed"))
+                } else {
+                    Ok(State::existing(id, HashMap::new()).with_identifier("cert-id"))
+                }
+            })
+        }
+
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("update not used")) })
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async { Err(ProviderError::internal("delete not used")) })
+        }
+    }
+
+    struct RecordingSkipObserver {
+        skipped: Mutex<Vec<String>>,
+        failures: Mutex<Vec<String>>,
+    }
+
+    impl RecordingSkipObserver {
+        fn new() -> Self {
+            Self {
+                skipped: Mutex::new(Vec::new()),
+                failures: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn skipped(&self) -> Vec<String> {
+            self.skipped.lock().unwrap().clone()
+        }
+
+        fn failures(&self) -> Vec<String> {
+            self.failures.lock().unwrap().clone()
+        }
+    }
+
+    impl ExecutionObserver for RecordingSkipObserver {
+        fn on_event(&self, event: &ExecutionEvent) {
+            match event {
+                ExecutionEvent::EffectSkipped { effect, reason, .. } => {
+                    self.skipped
+                        .lock()
+                        .unwrap()
+                        .push(format!("{}:{reason}", effect.resource_id()));
+                }
+                ExecutionEvent::EffectFailed { effect, error, .. } => {
+                    self.failures
+                        .lock()
+                        .unwrap()
+                        .push(format!("{}:{error}", effect.resource_id()));
+                }
+                ExecutionEvent::Waiting { .. }
+                | ExecutionEvent::EffectStarted { .. }
+                | ExecutionEvent::EffectSucceeded { .. }
+                | ExecutionEvent::WaitPolling { .. }
+                | ExecutionEvent::CascadeUpdateSucceeded { .. }
+                | ExecutionEvent::CascadeUpdateFailed { .. }
+                | ExecutionEvent::RenameSucceeded { .. }
+                | ExecutionEvent::RenameFailed { .. }
+                | ExecutionEvent::RefreshStarted
+                | ExecutionEvent::RefreshSucceeded { .. }
+                | ExecutionEvent::RefreshFailed { .. } => {}
+            }
+        }
+    }
 
     /// Reproduces #2543: when a resource depends on `<module-instance>.<attr>`
     /// (where the module-instance binding is a `Virtual` resource exposing the
@@ -1394,6 +1674,91 @@ mod tests {
             instance: binding.to_string(),
             quoted_string_attrs: std::collections::HashSet::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn phased_wait_marked_unsatisfiable_when_only_waits_in_flight() {
+        let provider = TerminalWaitProvider::new();
+
+        let mut cert = Resource::new("test", "cert");
+        cert.binding = Some("cert".to_string());
+        let cert_id = cert.id.clone();
+
+        let mut alb = Resource::new("test", "alb");
+        alb.binding = Some("alb".to_string());
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(cert.clone()));
+        plan.add(Effect::Wait {
+            binding: "cert_issued".to_string(),
+            target_id: cert_id.clone(),
+            target: WaitTarget::ResolvedAtApply,
+            until: WaitPredicate::Equals {
+                attr: AttrPath::single("status"),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+            },
+            until_surface: "cert.status == ISSUED".to_string(),
+            timeout: std::time::Duration::from_secs(60),
+            interval: std::time::Duration::from_millis(1),
+            explicit_dependencies: std::collections::HashSet::new(),
+        });
+        plan.add(Effect::Create(alb.clone()));
+
+        let unresolved = HashMap::from([
+            (
+                cert.id.clone(),
+                UnresolvedResource::from_pre_resolve(cert.clone()),
+            ),
+            (
+                alb.id.clone(),
+                UnresolvedResource::from_pre_resolve(alb.clone()),
+            ),
+        ]);
+        let schemas = SchemaRegistry::new();
+        let mut input = ExecutionInput {
+            plan: &plan,
+            unresolved_resources: &unresolved,
+            compositions: &[],
+            bindings: Default::default(),
+            current_states: HashMap::new(),
+            normalizer: &NoopNormalizer,
+            provider_configs: &[],
+            factories: &[],
+            schemas: &schemas,
+            parallelism: std::num::NonZeroUsize::new(2).unwrap(),
+        };
+        let observer = RecordingSkipObserver::new();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            execute_effects_phased(&provider, &mut input, &observer),
+        )
+        .await
+        .expect("wait should be skipped as unsatisfiable instead of timing out");
+
+        assert!(
+            result.failure_count >= 1,
+            "alb create should fail in phased execution"
+        );
+        assert_eq!(
+            result.skip_count, 1,
+            "wait should be skipped when only waits remain in flight"
+        );
+        assert!(
+            observer
+                .failures()
+                .iter()
+                .any(|event| event.contains("alb")),
+            "test setup should fail alb create; failures: {:?}",
+            observer.failures()
+        );
+        assert!(
+            observer.skipped().iter().any(|event| {
+                event.contains("cert") && event.to_ascii_lowercase().contains("unsatisfiable")
+            }),
+            "wait skip reason should contain unsatisfiable, skipped: {:?}",
+            observer.skipped()
+        );
     }
 
     #[test]

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -1,7 +1,7 @@
 //! Replace effect execution: Create-Before-Destroy (CBD) and Destroy-Before-Create (DBD).
 
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::binding_index::ResolvedBindings;
 use crate::differ::{
@@ -21,6 +21,7 @@ use crate::value::SecretHashContext;
 use super::basic::{
     BasicEffectResult, RenormalizePipeline, resolve_resource, resolve_resource_with_source,
 };
+use super::wait::WaitOutcome;
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 
 /// Build a full attribute-diff [`UpdatePatch`] between an existing
@@ -113,9 +114,10 @@ pub(super) enum SingleEffectResult {
     /// under the wait binding for downstream resolution. On failure
     /// carries the wait binding so dependents can be marked failed.
     Wait {
-        success: bool,
         binding: String,
-        target_state: Option<State>,
+        outcome: WaitOutcome,
+        duration: Duration,
+        progress: ProgressInfo,
     },
 }
 

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -191,6 +191,11 @@ impl ExecutionObserver for MockObserver {
             ExecutionEvent::EffectSkipped { effect, reason, .. } => {
                 format!("skipped:{}:{}", effect.resource_id(), reason)
             }
+            ExecutionEvent::WaitPolling {
+                binding, target_id, ..
+            } => {
+                format!("wait_polling:{}:{}", binding, target_id)
+            }
             ExecutionEvent::CascadeUpdateSucceeded { id } => {
                 format!("cascade_ok:{}", id)
             }

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -7,11 +7,94 @@
 //!
 //! See `notes/specs/2026-05-09-wait-construct-design.md` §Executor logic.
 
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use crate::provider::{Provider, ProviderError, ProviderResult, ReadRequest};
-use crate::resource::{ResourceId, State};
+use crate::executor::{ExecutionEvent, ExecutionObserver};
+use crate::provider::{Provider, ProviderError, ReadRequest};
+use crate::resource::{ResourceId, State, Value};
 use crate::wait::predicate::WaitPredicate;
+
+/// Terminal result of a wait polling loop.
+///
+/// `Satisfied` carries the observed target snapshot, `Unsatisfiable`
+/// represents a static or dynamic skip reason, `Timeout` is real-time
+/// exhaustion, and read-side failures distinguish deletion from other errors.
+#[derive(Debug)]
+pub enum WaitOutcome {
+    Satisfied {
+        state: State,
+    },
+    Unsatisfiable(UnsatisfiableReason),
+    Timeout {
+        last_attrs: HashMap<String, Value>,
+        elapsed: Duration,
+    },
+    NotFound(ProviderError),
+    ReadFailed(ProviderError),
+}
+
+/// Why a wait condition cannot become true.
+///
+/// `DependencyFailed` is found before dispatch from failed explicit
+/// dependencies. `NoMutatorRemaining` is found dynamically when only waits
+/// remain in flight and no other effect can still dispatch.
+#[derive(Debug)]
+pub enum UnsatisfiableReason {
+    DependencyFailed { binding: String },
+    NoMutatorRemaining,
+}
+
+pub(crate) fn default_heartbeat_gap(interval: Duration) -> Duration {
+    Duration::from_secs(30).max(interval * 5)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InFlightKind {
+    Wait,
+    NonWait,
+}
+
+pub(super) fn unsatisfiable_reason_message(reason: &UnsatisfiableReason) -> String {
+    match reason {
+        UnsatisfiableReason::DependencyFailed { binding } => {
+            format!("dependency '{binding}' failed")
+        }
+        UnsatisfiableReason::NoMutatorRemaining => "no mutator remaining".to_string(),
+    }
+}
+
+pub(super) fn wait_failure_message(outcome: &WaitOutcome, target_id: &ResourceId) -> String {
+    match outcome {
+        WaitOutcome::Timeout {
+            last_attrs,
+            elapsed,
+        } => format!(
+            "wait on {} timed out after {:?} (last observed attributes: {:?})",
+            target_id, elapsed, last_attrs
+        ),
+        WaitOutcome::NotFound(err) | WaitOutcome::ReadFailed(err) => err.to_string(),
+        WaitOutcome::Satisfied { .. } | WaitOutcome::Unsatisfiable(_) => {
+            unreachable!("satisfied and unsatisfiable waits are not failures")
+        }
+    }
+}
+
+pub(super) fn cancel_waits_if_terminal(
+    in_flight_kinds: &HashMap<usize, InFlightKind>,
+    undispatched_count: usize,
+    wait_cancellers: &HashMap<usize, tokio::sync::watch::Sender<bool>>,
+) {
+    let only_waits = !in_flight_kinds.is_empty()
+        && in_flight_kinds
+            .values()
+            .all(|kind| matches!(kind, InFlightKind::Wait));
+    if only_waits && undispatched_count == 0 {
+        for cancel in wait_cancellers.values() {
+            let _ = cancel.send(true);
+        }
+    }
+}
 
 /// Run the wait polling loop:
 ///
@@ -26,6 +109,7 @@ use crate::wait::predicate::WaitPredicate;
 ///    predicate, the last observed attribute snapshot, and the
 ///    elapsed time.
 /// 6. Otherwise, sleep for `interval` and repeat.
+#[allow(clippy::too_many_arguments)]
 pub async fn execute_wait_effect(
     provider: &dyn Provider,
     target_id: &ResourceId,
@@ -33,42 +117,106 @@ pub async fn execute_wait_effect(
     until: &WaitPredicate,
     timeout: Duration,
     interval: Duration,
-) -> ProviderResult<State> {
+    cancel: tokio::sync::watch::Receiver<bool>,
+    observer: &dyn ExecutionObserver,
+) -> WaitOutcome {
+    execute_wait_effect_with_heartbeat_gap(
+        provider,
+        target_id.name_str(),
+        target_id,
+        target_identifier,
+        until,
+        timeout,
+        interval,
+        cancel,
+        observer,
+        default_heartbeat_gap(interval),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn execute_wait_effect_with_heartbeat_gap(
+    provider: &dyn Provider,
+    binding: &str,
+    target_id: &ResourceId,
+    target_identifier: Option<&str>,
+    until: &WaitPredicate,
+    timeout: Duration,
+    interval: Duration,
+    mut cancel: tokio::sync::watch::Receiver<bool>,
+    observer: &dyn ExecutionObserver,
+    heartbeat_gap: Duration,
+) -> WaitOutcome {
     let start = Instant::now();
+    let mut last_heartbeat_at: Option<Instant> = None;
     loop {
-        let state = provider
+        let state = match provider
             .read(target_id, target_identifier, ReadRequest)
-            .await?;
+            .await
+        {
+            Ok(state) => state,
+            Err(err @ ProviderError::NotFound(_)) => return WaitOutcome::NotFound(err),
+            Err(err) => return WaitOutcome::ReadFailed(err),
+        };
         if !state.exists {
-            return Err(ProviderError::not_found(format!(
-                "wait target {} not found (deleted out-of-band?)",
-                target_id
-            ))
-            .for_resource(target_id.clone()));
+            return WaitOutcome::NotFound(
+                ProviderError::not_found(format!(
+                    "wait target {} not found (deleted out-of-band?)",
+                    target_id
+                ))
+                .for_resource(target_id.clone()),
+            );
         }
+
+        let now = Instant::now();
+        let should_emit_heartbeat = last_heartbeat_at
+            .map(|last| now.duration_since(last) >= heartbeat_gap)
+            .unwrap_or(true);
+        if should_emit_heartbeat {
+            observer.on_event(&ExecutionEvent::WaitPolling {
+                binding,
+                target_id,
+                elapsed: start.elapsed(),
+                last_attrs: &state.attributes,
+            });
+            last_heartbeat_at = Some(now);
+        }
+
         if until.evaluate(&state.attributes) {
-            return Ok(state);
+            return WaitOutcome::Satisfied { state };
         }
         let elapsed = start.elapsed();
         if elapsed >= timeout {
-            return Err(ProviderError::timeout(format!(
-                "wait on {} timed out after {:?}; predicate `{:?}` never became true (last observed attributes: {:?})",
-                target_id, timeout, until, state.attributes
-            ))
-            .for_resource(target_id.clone()));
+            return WaitOutcome::Timeout {
+                last_attrs: state.attributes,
+                elapsed,
+            };
         }
-        tokio::time::sleep(interval).await;
+        tokio::select! {
+            changed = cancel.changed() => {
+                if changed.is_ok() && *cancel.borrow() {
+                    return WaitOutcome::Unsatisfiable(UnsatisfiableReason::NoMutatorRemaining);
+                }
+            }
+            () = tokio::time::sleep(interval) => {}
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::{BoxFuture, CreateRequest, DeleteRequest, ReadRequest, UpdateRequest};
+    use crate::executor::{ExecutionEvent, ExecutionObserver};
+    use crate::provider::{
+        BoxFuture, CreateRequest, DeleteRequest, ProviderResult, ReadRequest, UpdateRequest,
+    };
     use crate::resource::{ConcreteValue, DataSource, Value};
     use crate::wait::predicate::{AttrPath, WaitPredicate};
     use std::collections::HashMap;
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::watch;
 
     /// Minimal test provider: returns a queue of pre-canned read
     /// responses in order, then repeats the last one. Counts every
@@ -166,11 +314,55 @@ mod tests {
         }
     }
 
+    struct NoopWaitObserver;
+
+    impl ExecutionObserver for NoopWaitObserver {
+        fn on_event(&self, _event: &ExecutionEvent) {}
+    }
+
+    struct HeartbeatObserver {
+        heartbeats: Mutex<Vec<Instant>>,
+    }
+
+    impl HeartbeatObserver {
+        fn new() -> Self {
+            Self {
+                heartbeats: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn heartbeats(&self) -> Vec<Instant> {
+            self.heartbeats.lock().unwrap().clone()
+        }
+    }
+
+    impl ExecutionObserver for HeartbeatObserver {
+        fn on_event(&self, event: &ExecutionEvent) {
+            if let ExecutionEvent::WaitPolling { .. } = event {
+                self.heartbeats.lock().unwrap().push(Instant::now());
+            }
+        }
+    }
+
+    #[test]
+    fn default_heartbeat_gap_uses_maximum_of_floor_and_interval_multiple() {
+        assert_eq!(
+            default_heartbeat_gap(Duration::from_millis(1)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            default_heartbeat_gap(Duration::from_secs(60)),
+            Duration::from_secs(300)
+        );
+    }
+
     #[tokio::test]
     async fn wait_returns_immediately_when_until_already_true() {
         let provider = ReadSequenceProvider::new(vec![state_with_status("ISSUED")]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let observer = NoopWaitObserver;
         let result = execute_wait_effect(
             &provider,
             &target,
@@ -178,9 +370,13 @@ mod tests {
             &pred,
             Duration::from_secs(60),
             Duration::from_millis(10),
+            cancel_rx,
+            &observer,
         )
         .await;
-        let state = result.expect("wait should succeed");
+        let WaitOutcome::Satisfied { state } = result else {
+            panic!("expected satisfied wait, got {result:?}");
+        };
         assert_eq!(
             state.attributes.get("status"),
             Some(&Value::Concrete(ConcreteValue::String(
@@ -199,6 +395,8 @@ mod tests {
         ]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let observer = NoopWaitObserver;
         let result = execute_wait_effect(
             &provider,
             &target,
@@ -206,9 +404,14 @@ mod tests {
             &pred,
             Duration::from_secs(60),
             Duration::from_millis(1),
+            cancel_rx,
+            &observer,
         )
         .await;
-        assert!(result.is_ok(), "wait should succeed after 3 reads");
+        assert!(
+            matches!(result, WaitOutcome::Satisfied { .. }),
+            "wait should succeed after 3 reads, got {result:?}"
+        );
         assert_eq!(provider.read_count(), 3);
     }
 
@@ -217,6 +420,8 @@ mod tests {
         let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let observer = NoopWaitObserver;
         let result = execute_wait_effect(
             &provider,
             &target,
@@ -224,18 +429,26 @@ mod tests {
             &pred,
             Duration::from_millis(10),
             Duration::from_millis(2),
+            cancel_rx,
+            &observer,
         )
         .await;
-        let err = result.expect_err("should time out");
+        let WaitOutcome::Timeout {
+            last_attrs,
+            elapsed,
+        } = result
+        else {
+            panic!("expected Timeout, got {result:?}");
+        };
         assert!(
-            matches!(err, ProviderError::Timeout(_)),
-            "expected Timeout, got {:?}",
-            err
+            elapsed >= Duration::from_millis(10),
+            "timeout should report elapsed time, got {elapsed:?}"
         );
-        assert!(
-            err.to_string().contains("PENDING_VALIDATION"),
-            "error message should include last observed value, got: {}",
-            err
+        assert_eq!(
+            last_attrs.get("status"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "PENDING_VALIDATION".to_string()
+            )))
         );
     }
 
@@ -247,6 +460,8 @@ mod tests {
         ]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let observer = NoopWaitObserver;
         let result = execute_wait_effect(
             &provider,
             &target,
@@ -254,13 +469,99 @@ mod tests {
             &pred,
             Duration::from_secs(60),
             Duration::from_millis(1),
+            cancel_rx,
+            &observer,
         )
         .await;
-        let err = result.expect_err("should fail with NotFound");
         assert!(
-            matches!(err, ProviderError::NotFound(_)),
-            "expected NotFound, got {:?}",
-            err
+            matches!(result, WaitOutcome::NotFound(_)),
+            "expected NotFound, got {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn wait_returns_unsatisfiable_when_cancelled() {
+        let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
+        let pred = equals_status("ISSUED");
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let observer = NoopWaitObserver;
+        let reads_seen = AtomicUsize::new(0);
+
+        let result = tokio::join!(
+            async {
+                loop {
+                    if provider.read_count() >= 3 {
+                        reads_seen.store(provider.read_count(), Ordering::SeqCst);
+                        let _ = cancel_tx.send(true);
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+            },
+            execute_wait_effect(
+                &provider,
+                &target,
+                None,
+                &pred,
+                Duration::from_secs(60),
+                Duration::from_millis(1),
+                cancel_rx,
+                &observer,
+            )
+        )
+        .1;
+
+        assert!(
+            reads_seen.load(Ordering::SeqCst) >= 3,
+            "test should cancel only after a few polls"
+        );
+        assert!(
+            matches!(
+                result,
+                WaitOutcome::Unsatisfiable(UnsatisfiableReason::NoMutatorRemaining)
+            ),
+            "expected unsatisfiable wait after cancellation, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_emits_heartbeat_at_max_interval() {
+        let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
+        let pred = equals_status("ISSUED");
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let observer = HeartbeatObserver::new();
+
+        let result = execute_wait_effect_with_heartbeat_gap(
+            &provider,
+            "cert_issued",
+            &target,
+            None,
+            &pred,
+            Duration::from_millis(100),
+            Duration::from_millis(1),
+            cancel_rx,
+            &observer,
+            Duration::from_millis(5),
+        )
+        .await;
+
+        assert!(
+            matches!(result, WaitOutcome::Timeout { .. }),
+            "heartbeat test should end by timeout, got {result:?}"
+        );
+        let heartbeats = observer.heartbeats();
+        assert!(
+            !heartbeats.is_empty(),
+            "wait should emit at least one WaitPolling heartbeat"
+        );
+        for pair in heartbeats.windows(2) {
+            let gap = pair[1].duration_since(pair[0]);
+            assert!(
+                gap >= Duration::from_millis(5),
+                "heartbeat gap should respect max(30s, interval * 5) with test seam, got {gap:?}"
+            );
+        }
     }
 }

--- a/notes/specs/2026-06-14-wait-fail-fast-design.md
+++ b/notes/specs/2026-06-14-wait-fail-fast-design.md
@@ -1,0 +1,211 @@
+# wait fail-fast on unsatisfiable conditions — 設計
+
+Issue: carina#3497
+ブランチ: `issue-3497-wait-fail-fast`
+
+## 何を解決するか
+
+`wait` ブロックの `until` 条件が、他のリソース失敗の結果として
+**もはや真にならないことが確定した** 時点で、ポーリングを打ち切って
+`Skipped(Unsatisfiable)` として終了させる。現状は `timeout`
+(75min など) まで silently poll し続ける。
+
+副次対応として、ポーリング中の **観測性向上** のため heartbeat
+イベントを出す。
+
+## 根本原因
+
+`Effect::Wait` の executor は次の前提で動いている。
+
+1. wait の依存(`target` と `explicit_dependencies`)が **すべて完了
+   または失敗**するまで dispatch を保留する
+2. dispatch 後はひたすら `until` を poll する
+3. `until` が真にならないまま `timeout` を超えたら `ProviderError::Timeout`
+
+しかし `wait` の `until` を真にする経路は **plan 時に静的に決まらない**:
+
+- `until: cert.status == issued` は `cert` の attribute を読むが、
+  この属性を変化させるのは **別のリソース** (この issue の例では
+  `for opt in cert.domain_validation_options` から展開される
+  `route53.RecordSet` 群) であり、これらは plan 時点で deferred 展開
+  状態のまま `?` 行として表示される
+- ユーザは `depends_on = [validation_records]` で正しく明示している
+  が、`validation_records` 自体が **deferred-for binding** であり、
+  apply pre-refresh 時点で `cert.domain_validation_options` がまだ
+  unknown なので **展開されないまま** apply ループに入る
+- 加えて、deferred-for 展開を駆動する `cert` 周辺のリソース
+  (ALB, ListenerなどLB系) が IAM 不足等で失敗した場合、validation
+  records 経路はもはや実行されない
+
+executor の **「他に dispatch すべき effect が無い、in_flight には wait
+しか残っていない」** 状態は、wait の `until` を真にする世界の変化が
+もう起こらないことを意味する。が、現状の loop はこの状態を
+unsatisfiable と認識せず、 wait の poll を `timeout` まで放置する。
+
+## 設計の核
+
+executor の loop に **terminal-with-pending-waits** 検出を追加し、
+その状態に到達した瞬間に in_flight 中の wait に **cancel シグナル**
+を送る。wait は cancel シグナルを受けて `WaitOutcome::Unsatisfiable`
+を返し、observer に `EffectSkipped` を `reason: "unsatisfiable: …"`
+で emit する。
+
+### 型レベルの不変条件
+
+`execute_wait_effect` の戻り値を整理する。現在は
+`ProviderResult<State>`(`Ok(State) | Err(ProviderError)`)で、
+unsatisfiable を表せず Timeout に押し込めるしかない。
+
+```rust
+pub enum WaitOutcome {
+    Satisfied(State),
+    Unsatisfiable(UnsatisfiableReason),  // executor が cancel を送った
+    Timeout { last_attrs: HashMap<String, Value>, elapsed: Duration },
+    NotFound(ProviderError),
+    ReadFailed(ProviderError),
+}
+
+pub enum UnsatisfiableReason {
+    /// 静的に判定された: dispatch する前に depends_on のどれかが failed
+    DependencyFailed { binding: String },
+    /// 動的に判定された: in_flight が wait のみになった
+    NoMutatorRemaining,
+}
+```
+
+呼び出し側は `match outcome` で網羅的に処理する。`_ =>` で
+Unsatisfiable を漏らすことが型として不可能になる。
+
+`SingleEffectResult::Wait` も同様に変える。現在の
+`{ success: bool, … }` という bool 表現は Satisfied / Unsatisfiable /
+Timeout を区別できず、observer が表示すべきメッセージを呼び出し側で
+組み立てないといけない。これを `outcome: WaitOutcome` に置き換える。
+
+### Cancel の伝播
+
+`execute_wait_effect` は `CancellationToken` を引数で受ける。poll loop
+は `tokio::select!` で「次の interval」「cancel」を同時に待つ。
+cancel が来たら `Unsatisfiable(NoMutatorRemaining)` を返す。
+
+executor 側は `in_flight` に push する各 wait 用に
+`CancellationToken` を持ち、loop の各 iteration で:
+
+```text
+1. newly_ready を計算
+2. dispatch
+3. in_flight.next() を await して 1 件処理
+4. terminal-with-pending-waits 判定:
+   - newly_ready が空(計算済み)
+   - actionable_indices のうち未 dispatch が 0
+   - in_flight が空でない、かつ in_flight の全要素が Wait
+   なら、それら wait の cancellation_token を cancel
+5. 通常通り次の loop へ
+```
+
+判定 4 は **アイドルな wait しか残っていない** 状態。これを発見した
+時点で速やかに cancel シグナルが伝播する。wait 側は次の `select!`
+で cancel を観測し `Unsatisfiable(NoMutatorRemaining)` で返す。
+
+### Heartbeat イベント
+
+`execute_wait_effect` の poll loop に observer 呼び出しを 1 つ足す:
+
+```rust
+observer.on_event(&ExecutionEvent::WaitPolling {
+    effect,
+    elapsed,
+    last_attrs: &state.attributes,
+});
+```
+
+これだけだと **すべての poll で出してうるさい** ので、最後の emit
+からの経過時間が `max(30s, interval * 5)` を超えたときだけ出す。
+interval が 5s ならおおむね 30s 間隔、interval が 60s なら
+5min 間隔。
+
+`ExecutionEvent::WaitPolling` を `ExecutionEvent` に追加し、CLI 表示
+側で「`~ N秒経過 (cert.status = pending_validation)`」のような行を
+1 行だけ出す(改行はせず、上書き or 短く)。
+
+### Dispatch 前の depends_on 失敗チェック
+
+これは既存の `find_failed_dependency` で動作している(Phase 1 の
+404 行, Phase 4 の 1052 行, parallel の 599 行)。`depends_on` に書か
+れた binding が `failed_bindings` に入っていれば dispatch 前に
+EffectSkipped で完了する。**この経路は触らない**。
+
+ただし `find_failed_dependency` が Wait の `explicit_dependencies` を
+ちゃんと見ているか確認する。`deps.rs:312` の実装次第。見ていなければ
+そこは修正(これは別の根本的な seam なので、この PR の射程内)。
+
+## 何が unrepresentable になるか
+
+- `execute_wait_effect` の戻り値が **bool ではなく typed enum** に
+  なり、「Satisfied と Unsatisfiable と Timeout を取り違える」
+  バグはコンパイル時に消える
+- executor の loop が **terminal-with-pending-waits** という状態を
+  陽に持つので、「他に動くものが無くなった瞬間に wait を放置」
+  という silent hang はコードパスとして書けなくなる
+- `SingleEffectResult::Wait { success: bool, … }` の bool 表現が
+  消える(後方互換は無視してよいプロジェクト方針)
+
+## 何を 1 PR でやり、何をやらないか
+
+1 PR でやる:
+
+1. `WaitOutcome` enum 導入と `execute_wait_effect` のシグネチャ変更
+2. `CancellationToken` を `execute_wait_effect` に渡す
+3. executor の loop に terminal-with-pending-waits 判定を追加
+4. `SingleEffectResult::Wait` を `WaitOutcome` を持つ形に変更
+5. observer に `EffectSkipped(reason="unsatisfiable: …")` を emit
+6. `ExecutionEvent::WaitPolling` 追加と CLI 表示の heartbeat
+7. reproducing test:
+   - in_flight の最後の非 wait effect が失敗 → wait は即 Skip
+   - 通常 satisfied → 既存挙動を保つ
+   - 通常 timeout → 既存挙動を保つ
+   - heartbeat イベントが期待間隔で出ること
+
+1 PR ではやらない:
+
+- `wait` の `until` 表現を拡張して mutator 集合を静的解析する話
+  (= Issue 本文の選択肢 #1 の精密版)。これは別 issue。
+  今回の terminal-with-pending-waits 判定は、その将来の精密化が
+  入っても **deep-defense として有効**な不変条件。
+- deferred-for 展開のタイミング再設計
+  (apply ループ中に再展開を試みる)。これは別 issue。
+
+## テスト戦略
+
+1. **単体 (executor)**: in-flight に「成功する create 1 件」と
+   「指定 binding を mutate する wait 1 件」を投げて、create が
+   失敗してから 1 interval 以内に wait が `Unsatisfiable` で
+   終わることを assert。Issue の構造を最小化したもの。
+
+2. **単体 (wait.rs)**: `CancellationToken` を `cancel()` した時に
+   `Unsatisfiable(NoMutatorRemaining)` が返ることを assert。
+
+3. **単体 (wait.rs)**: 既存テスト 4 件
+   (`wait_returns_immediately_when_until_already_true` /
+    `wait_polls_until_predicate_becomes_true` /
+    `wait_returns_timeout_when_predicate_stays_false` /
+    `wait_returns_not_found_when_target_disappears`)
+   をすべて `WaitOutcome` で書き直し、戻り値の match が網羅される
+   ことを確認。
+
+4. **observer**: heartbeat が `max(30s, interval*5)` 間隔で出ることを
+   mock observer で assert。短い timeout でテストしやすいよう
+   interval を 1ms に設定したケースでは heartbeat は 1 回だけ
+   (1ms * 5 = 5ms 間隔)。
+
+5. **E2E (carina-cli)**: 既存の wait 関連の integration test (あれば)
+   に「上流リソース失敗 → wait 即 fail」のシナリオを追加。
+
+## 段階
+
+1. 設計レビュー(この doc を読む)
+2. 失敗する test を書く
+3. `WaitOutcome` 型を入れる
+4. executor の terminal 判定を入れる
+5. heartbeat を入れる
+6. observer / CLI 表示を更新
+7. verify → simplify → 5 round review → PR


### PR DESCRIPTION
## Summary

`wait` ブロックの上流リソースが失敗した時、wait は `until` の条件を満たすリソースがもう動かないにもかかわらず、ユーザ指定の `timeout`(本件では 75 分)まで poll を続けて出力も無く沈黙していた。Operator にはハングしているようにしか見えず、CI を手動キャンセルして調査するしかなかった。

このコードパスをすべて型と executor の不変条件で塞ぐ。

## なぜ起きるか

`wait cert_issued { until = cert.status == issued depends_on = [validation_records] }` のような構造で、`validation_records` は `for opt in cert.domain_validation_options { route53.RecordSet { ... } }` の deferred-for binding。apply の最初の state-refresh 時点では `cert.domain_validation_options` が未知なので展開されず、`?` の deferred 行として plan に残る。

その後、サイドの ALB 作成が IAM 不足で失敗 → cascade で関連リソースが skip → `validation_records` の展開を駆動する経路が消える → `cert.status` を `ISSUED` に変える主体がもう plan 内に居ない。しかし executor 側はそれを知らず、wait は timeout まで poll し続ける。

## 対応

Executor の loop に新しい状態遷移を入れた:

`in_flight` に Wait しか残っていない、かつ未 dispatch effect がゼロ、になった瞬間に「世界はもう変化しない」ので、現役の Wait 全部に cancel signal (per-wait の `tokio::sync::watch` channel) を送る。Wait は `tokio::select!` で読み取り待ちと cancel を並行で待ち、cancel を観測したら `WaitOutcome::Unsatisfiable(NoMutatorRemaining)` で抜ける。observer は `EffectSkipped` を `reason: "unsatisfiable: no mutator remaining"` で emit する。

戻り値の型を強制シェイプ化して、Unsatisfiable を Timeout に紛れさせるバグを compile error にする:

```rust
pub enum WaitOutcome {
    Satisfied { state: State },
    Unsatisfiable(UnsatisfiableReason),
    Timeout { last_attrs, elapsed },
    NotFound(ProviderError),
    ReadFailed(ProviderError),
}
pub enum UnsatisfiableReason {
    DependencyFailed { binding: String },  // 静的に検出
    NoMutatorRemaining,                     // 動的に検出
}
```

合わせて:

- `find_failed_dependency` が Wait の `explicit_dependencies` を見るよう修正。静的に分かるケースは dispatch 前に skip。
- `ExecutionEvent::WaitPolling` を heartbeat として `max(30s, interval*5)` 間隔で emit。Operator は wait が生きているか、最後に何を観測したかを CLI で確認できる。
- terminal-with-pending-waits 検出は parallel/phased 両方の executor の Phase 1 に同じ shared helper で配置。

## Out of scope

- 「`until` predicate から mutator 集合を plan 時点で静的解析する」精密版(Issue 本文の option #1)。本 PR の terminal check はその精密版が将来入っても deep-defense として有効。
- deferred-for 展開のタイミング再設計。
- 「executor の新コードパスが terminal-check を忘れる」型レベル防止(Round 1 review で指摘)。これは別 issue で追跡(Effect への `is_wait()` 追加 + 必要なら typestate 化)。

## Test plan

- [x] `cargo nextest run -p carina-core --all-features` — 2478 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`(5 本)
- [x] `cargo build --release`
- [x] 新規 test:
  - `executor::wait::tests::wait_returns_unsatisfiable_when_cancelled`
  - `executor::wait::tests::wait_emits_heartbeat_at_max_interval`
  - `executor::wait::tests::default_heartbeat_gap_uses_maximum_of_floor_and_interval_multiple`
  - `executor::parallel::tests::wait_marked_unsatisfiable_when_only_waits_in_flight`
  - `executor::phased::tests::phased_wait_marked_unsatisfiable_when_only_waits_in_flight`
  - `deps::tests::find_failed_dependency_returns_wait_explicit_dependency_when_failed`
  - `deps::tests::find_failed_dependency_returns_none_when_wait_explicit_dependency_did_not_fail`
  - `commands::shared::observer::tests::wait_observed_attr_is_deterministic`

設計: notes/specs/2026-06-14-wait-fail-fast-design.md

Closes #3497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
