### PR TITLE
feat(provider): add required_permissions trait + plan --check-iam flag (#3496)

### DIFF
--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -1037,6 +1037,14 @@ mod tests {
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { unreachable!() })
         }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: carina_core::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     #[test]

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -411,6 +411,8 @@ pub async fn run_plan(
     tui: bool,
     refresh: bool,
     json: bool,
+    _check_iam: bool,
+    _strict_iam: bool,
     provider_context: &ProviderContext,
 ) -> Result<bool, AppError> {
     let loaded = load_configuration_with_config(
@@ -1584,6 +1586,8 @@ exports { region: String = "ap-northeast-1" }"#,
             false,
             false,
             true,
+            false,
+            false,
             &ProviderContext::default(),
         )
         .await
@@ -1644,6 +1648,8 @@ mod run_plan_out_tests {
             false,
             false,
             true,
+            false,
+            false,
             &ProviderContext::default(),
         )
         .await

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -193,6 +193,14 @@ mod tests {
         ) -> BoxFuture<'_, ProviderResult<()>> {
             unreachable!("import path must not call delete")
         }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: carina_core::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     /// carina#3329: an `Effect::Import` whose `identifier` is still a

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -75,6 +75,12 @@ enum Commands {
         /// Output plan as JSON
         #[arg(long)]
         json: bool,
+
+        #[arg(long)]
+        check_iam: bool,
+
+        #[arg(long, requires = "check_iam")]
+        strict_iam: bool,
     },
     /// Apply changes to reach the desired state
     Apply {
@@ -318,6 +324,8 @@ async fn main() {
         tui,
         refresh,
         json,
+        check_iam,
+        strict_iam,
     } = cli.command
     {
         match run_plan(
@@ -327,6 +335,8 @@ async fn main() {
             tui,
             refresh,
             json,
+            check_iam,
+            strict_iam,
             &provider_context,
         )
         .await
@@ -659,5 +669,20 @@ mod error_format_tests {
         let r = render_app_error(&error::AppError::Interrupted);
         assert_eq!(r.exit_code, 130);
         assert!(r.stderr.is_empty(), "interrupted stderr: {}", r.stderr);
+    }
+
+    #[test]
+    fn plan_check_iam_flag_parses() {
+        assert!(Cli::try_parse_from(["carina", "plan", "--check-iam"]).is_ok());
+    }
+
+    #[test]
+    fn plan_strict_iam_requires_check_iam() {
+        assert!(Cli::try_parse_from(["carina", "plan", "--strict-iam"]).is_err());
+    }
+
+    #[test]
+    fn plan_check_iam_with_strict_iam_parses() {
+        assert!(Cli::try_parse_from(["carina", "plan", "--check-iam", "--strict-iam"]).is_ok());
     }
 }

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -103,6 +103,14 @@ impl Provider for TestProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async { Err(ProviderError::internal("unexpected delete")) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 #[tokio::test]
@@ -1698,6 +1706,14 @@ impl Provider for RecordingProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 /// Mock provider where create and delete succeed but update (rename) fails.
@@ -1751,6 +1767,14 @@ impl Provider for RenameFailProvider {
         _request: carina_core::provider::DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async { Ok(()) })
+    }
+
+    fn required_permissions(
+        &self,
+        _id: &ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
     }
 }
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -2302,6 +2302,14 @@ mod read_with_retry_identifier_tests {
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Ok(()) })
         }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: carina_core::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     #[tokio::test]
@@ -3412,6 +3420,14 @@ mod wait_until_enum_alias {
             _r: carina_core::provider::DeleteRequest,
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async move { Ok(()) })
+        }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: carina_core::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
         }
     }
 

--- a/carina-cli/tests/composition_binding_resolve_e2e.rs
+++ b/carina-cli/tests/composition_binding_resolve_e2e.rs
@@ -135,6 +135,14 @@ impl Provider for NoopProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 fn factories() -> Vec<Box<dyn ProviderFactory>> {

--- a/carina-cli/tests/deferred_populate_validate_e2e.rs
+++ b/carina-cli/tests/deferred_populate_validate_e2e.rs
@@ -171,6 +171,14 @@ impl Provider for NoopProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 fn factories() -> Vec<Box<dyn ProviderFactory>> {

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use carina_core::provider::{
     BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer,
 };
-use carina_core::resource::{ConcreteValue, DataSource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, DataSource, State, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField, legacy_validator,
 };
@@ -214,7 +214,7 @@ impl Provider for NoopProvider {
     }
     fn read(
         &self,
-        _id: &ResourceId,
+        _id: &carina_core::resource::ResourceId,
         _identifier: Option<&str>,
         _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
@@ -228,14 +228,14 @@ impl Provider for NoopProvider {
     }
     fn create(
         &self,
-        _id: &ResourceId,
+        _id: &carina_core::resource::ResourceId,
         _request: carina_core::provider::CreateRequest,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
     }
     fn update(
         &self,
-        _id: &ResourceId,
+        _id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
@@ -243,11 +243,19 @@ impl Provider for NoopProvider {
     }
     fn delete(
         &self,
-        _id: &ResourceId,
+        _id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::DeleteRequest,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<()>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
+    }
+
+    fn required_permissions(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
     }
 }
 

--- a/carina-cli/tests/nested_module_call_ref_e2e.rs
+++ b/carina-cli/tests/nested_module_call_ref_e2e.rs
@@ -132,6 +132,14 @@ impl Provider for NoopProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 fn factories() -> Vec<Box<dyn ProviderFactory>> {

--- a/carina-cli/tests/validate_deferred_for_enumeration_e2e.rs
+++ b/carina-cli/tests/validate_deferred_for_enumeration_e2e.rs
@@ -157,6 +157,14 @@ impl Provider for NoopProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 fn factories() -> Vec<Box<dyn ProviderFactory>> {

--- a/carina-cli/tests/validate_unknown_custom_type_e2e.rs
+++ b/carina-cli/tests/validate_unknown_custom_type_e2e.rs
@@ -154,6 +154,14 @@ impl Provider for NoopProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 fn factories() -> Vec<Box<dyn ProviderFactory>> {

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -195,6 +195,14 @@ impl Provider for NoopProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 fn fixture(name: &str) -> PathBuf {

--- a/carina-cli/tests/wait_validate_e2e.rs
+++ b/carina-cli/tests/wait_validate_e2e.rs
@@ -127,6 +127,14 @@ impl Provider for NoopProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 fn factories() -> Vec<Box<dyn ProviderFactory>> {

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -11,6 +11,14 @@ use crate::non_empty::NonEmptyVec;
 use crate::resource::{DataSource, Directives, Resource, ResourceId, State};
 use crate::wait::predicate::WaitPredicate;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PlanOp {
+    Create,
+    Read,
+    Update,
+    Delete,
+}
+
 /// Temporary name used during create-before-destroy replacement.
 ///
 /// When a resource with a unique name constraint is replaced with create-before-destroy,
@@ -602,6 +610,18 @@ pub fn resolve_import_identifier(identifier: &crate::resource::Value) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn plan_op_supports_debug_eq_and_hash() {
+        let op = PlanOp::Create;
+        assert_eq!(op, PlanOp::Create);
+        assert_eq!(format!("{op:?}"), "Create");
+
+        let mut ops = HashSet::new();
+        ops.insert(op);
+        assert!(ops.contains(&PlanOp::Create));
+    }
 
     #[test]
     fn format_import_identifier_recurses_into_nested_interpolation() {

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -144,6 +144,10 @@ impl Provider for MockProvider {
         let result = self.delete_results.lock().unwrap().remove(0);
         Box::pin(async move { result })
     }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: crate::effect::PlanOp) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 // -----------------------------------------------------------------------
@@ -2300,6 +2304,14 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Err(ProviderError::internal("not implemented")) })
         }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: crate::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     let mut delays = HashMap::new();
@@ -2453,6 +2465,10 @@ impl Provider for DelayedUpdateProvider {
         _request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async { Err(ProviderError::internal("not implemented")) })
+    }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: crate::effect::PlanOp) -> Vec<String> {
+        Vec::new()
     }
 }
 
@@ -3081,6 +3097,10 @@ impl Provider for RecordingMockProvider {
         _request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async { Err(ProviderError::internal("not implemented")) })
+    }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: crate::effect::PlanOp) -> Vec<String> {
+        Vec::new()
     }
 }
 
@@ -4035,6 +4055,10 @@ impl Provider for IdentifierAwareProvider {
         _request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Err(ProviderError::api_error("delete not expected")) })
+    }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: crate::effect::PlanOp) -> Vec<String> {
+        Vec::new()
     }
 }
 

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -148,6 +148,14 @@ mod tests {
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async move { Ok(()) })
         }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: crate::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     fn state_with_status(status: &str) -> State {

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -9,6 +9,7 @@ use indexmap::IndexMap;
 use std::future::Future;
 use std::pin::Pin;
 
+use crate::effect::PlanOp;
 use crate::executor::normalized::NormalizedResource;
 use crate::resource::{ConcreteValue, DataSource, Directives, Resource, ResourceId, State, Value};
 use crate::schema::{SchemaRegistry, TypeIdentity};
@@ -588,6 +589,10 @@ pub trait Provider: Send + Sync {
         identifier: &str,
         request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>>;
+
+    /// Permissions this provider needs to perform `op` on `id`.
+    /// Empty vec means the provider declares no permissions for this resource/op pair.
+    fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String>;
 }
 
 /// Convenience for a `ProviderNormalizer` method that does nothing.
@@ -900,6 +905,13 @@ impl Provider for ProviderRouter {
         match self.get_provider_or_error(id) {
             Ok(provider) => provider.delete(id, identifier, request),
             Err(e) => Box::pin(async move { Err(e) }),
+        }
+    }
+
+    fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String> {
+        match self.get_provider_or_error(id) {
+            Ok(provider) => provider.required_permissions(id, op),
+            Err(_) => Vec::new(),
         }
     }
 }
@@ -1308,6 +1320,10 @@ impl Provider for Box<dyn Provider> {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         (**self).delete(id, identifier, request)
     }
+
+    fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String> {
+        (**self).required_permissions(id, op)
+    }
 }
 
 #[cfg(test)]
@@ -1395,6 +1411,10 @@ mod tests {
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Ok(()) })
         }
+
+        fn required_permissions(&self, _id: &ResourceId, _op: PlanOp) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     #[tokio::test]
@@ -1468,6 +1488,10 @@ mod tests {
             _request: DeleteRequest,
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Ok(()) })
+        }
+
+        fn required_permissions(&self, _id: &ResourceId, _op: PlanOp) -> Vec<String> {
+            Vec::new()
         }
     }
 
@@ -2132,6 +2156,10 @@ mod tests {
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Ok(()) })
         }
+
+        fn required_permissions(&self, _id: &ResourceId, _op: PlanOp) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     #[tokio::test]
@@ -2473,6 +2501,10 @@ mod tests {
                 _request: DeleteRequest,
             ) -> BoxFuture<'_, ProviderResult<()>> {
                 Box::pin(async { Ok(()) })
+            }
+
+            fn required_permissions(&self, _id: &ResourceId, _op: PlanOp) -> Vec<String> {
+                Vec::new()
             }
         }
 

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -125,6 +125,14 @@ impl Provider for MockProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async move { Ok(()) })
     }
+
+    fn required_permissions(
+        &self,
+        _id: &ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 struct CollectingObserver {

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use carina_core::effect::PlanOp as CorePlanOp;
 use carina_core::provider::{
     CreateRequest as CoreCreateRequest, DeleteRequest as CoreDeleteRequest,
     ErrorDetail as CoreErrorDetail, PatchOp as CorePatchOp, PatchOpKind as CorePatchOpKind,
@@ -22,6 +23,7 @@ use carina_core::value::{SerializationContext, SerializationError};
 use carina_provider_protocol::types as proto;
 
 use crate::wasm_bindings::carina::provider::types as wit;
+use crate::wasm_bindings::exports::carina::provider::provider as wit_provider;
 
 /// Error raised when provider-emitted schema wire data cannot be decoded.
 ///
@@ -209,6 +211,15 @@ pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
             let inner = json_to_core_value(&inner_json);
             CoreValue::Deferred(DeferredValue::Secret(Box::new(inner)))
         }
+    }
+}
+
+pub fn core_to_wit_plan_op(op: CorePlanOp) -> wit_provider::PlanOp {
+    match op {
+        CorePlanOp::Create => wit_provider::PlanOp::Create,
+        CorePlanOp::Read => wit_provider::PlanOp::Read,
+        CorePlanOp::Update => wit_provider::PlanOp::Update,
+        CorePlanOp::Delete => wit_provider::PlanOp::Delete,
     }
 }
 

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -20,6 +20,7 @@ use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
 
+use carina_core::effect::PlanOp;
 use carina_core::provider::{
     BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderFactory,
     ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
@@ -863,6 +864,54 @@ impl WasmBindings {
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
                     .call_delete(store, id, identifier, request)
+                    .await
+            }
+        }
+    }
+
+    async fn call_required_permissions(
+        &self,
+        store: &mut Store<HostState>,
+        id: &wit_types::ResourceId,
+        operation: PlanOp,
+    ) -> wasmtime::Result<Vec<String>> {
+        match self {
+            WasmBindings::Basic(b) => {
+                let operation = match operation {
+                    PlanOp::Create => {
+                        crate::wasm_bindings::exports::carina::provider::provider::PlanOp::Create
+                    }
+                    PlanOp::Read => {
+                        crate::wasm_bindings::exports::carina::provider::provider::PlanOp::Read
+                    }
+                    PlanOp::Update => {
+                        crate::wasm_bindings::exports::carina::provider::provider::PlanOp::Update
+                    }
+                    PlanOp::Delete => {
+                        crate::wasm_bindings::exports::carina::provider::provider::PlanOp::Delete
+                    }
+                };
+                b.carina_provider_provider()
+                    .call_required_permissions(store, id, operation)
+                    .await
+            }
+            WasmBindings::Http(b) => {
+                let operation = match operation {
+                    PlanOp::Create => {
+                        crate::wasm_bindings_http::exports::carina::provider::provider::PlanOp::Create
+                    }
+                    PlanOp::Read => {
+                        crate::wasm_bindings_http::exports::carina::provider::provider::PlanOp::Read
+                    }
+                    PlanOp::Update => {
+                        crate::wasm_bindings_http::exports::carina::provider::provider::PlanOp::Update
+                    }
+                    PlanOp::Delete => {
+                        crate::wasm_bindings_http::exports::carina::provider::provider::PlanOp::Delete
+                    }
+                };
+                b.carina_provider_provider()
+                    .call_required_permissions(store, id, operation)
                     .await
             }
         }
@@ -2049,6 +2098,35 @@ impl Provider for WasmProvider {
                 }
             },
         ))
+    }
+
+    fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String> {
+        let wit_id = wasm_convert::core_to_wit_resource_id(id);
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                let mut locked =
+                    match LockedStore::acquire(&self.instance, "required_permissions").await {
+                        Ok(locked) => locked,
+                        Err(e) => {
+                            log::error!("WASM required_permissions lock failed: {e}");
+                            return Vec::new();
+                        }
+                    };
+                let call = self
+                    .instance
+                    .bindings
+                    .call_required_permissions(locked.store(), &wit_id, op)
+                    .await;
+                locked.disarm();
+                match call {
+                    Ok(permissions) => permissions,
+                    Err(e) => {
+                        log::error!("WASM trap in required_permissions: {e}");
+                        Vec::new()
+                    }
+                }
+            })
+        })
     }
 }
 

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use carina_core::effect::PlanOp;
 use carina_core::provider::{
     CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, ProviderFactory, ReadRequest,
     UpdatePatch, UpdateRequest,
@@ -477,5 +478,21 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
         Some(&Value::Concrete(ConcreteValue::String(
             "alice@example.com".into()
         ))),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wasm_mock_provider_required_permissions_dispatches_through_wit() {
+    let path = skip_if_no_wasm!();
+    let (factory, _cache) = load_factory(&path).await;
+    let provider = factory
+        .create_provider(None, &indexmap::IndexMap::new())
+        .await
+        .expect("provider should init");
+    let id = ResourceId::with_provider("mock", "test.resource", "example", None);
+
+    assert_eq!(
+        provider.required_permissions(&id, PlanOp::Create),
+        Vec::<String>::new()
     );
 }

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -59,6 +59,14 @@ use carina_provider_protocol::types::*;
 use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PlanOp {
+    Create,
+    Read,
+    Update,
+    Delete,
+}
+
 /// Trait that provider authors implement.
 #[allow(clippy::result_large_err)]
 pub trait CarinaProvider {
@@ -143,6 +151,10 @@ pub trait CarinaProvider {
         identifier: &str,
         request: DeleteRequest,
     ) -> Result<(), ProviderError>;
+
+    /// Permissions this provider needs to perform `op` on `id`.
+    /// Empty vec means the provider declares no permissions for this resource/op pair.
+    fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String>;
 
     /// Return provider config attribute completions.
     /// Key is attribute name (e.g., "region"), value is list of completion candidates.

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -338,6 +338,17 @@ macro_rules! export_provider {
                 }
             }
 
+            fn wit_to_sdk_plan_op(
+                op: exports::carina::provider::provider::PlanOp,
+            ) -> $crate::PlanOp {
+                match op {
+                    exports::carina::provider::provider::PlanOp::Create => $crate::PlanOp::Create,
+                    exports::carina::provider::provider::PlanOp::Read => $crate::PlanOp::Read,
+                    exports::carina::provider::provider::PlanOp::Update => $crate::PlanOp::Update,
+                    exports::carina::provider::provider::PlanOp::Delete => $crate::PlanOp::Delete,
+                }
+            }
+
             struct WasmGuest;
 
             impl exports::carina::provider::provider::Guest for WasmGuest {
@@ -461,6 +472,19 @@ macro_rules! export_provider {
                         Ok(()) => Ok(()),
                         Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
+                }
+
+                fn required_permissions(
+                    id: wit_types::ResourceId,
+                    operation: exports::carina::provider::provider::PlanOp,
+                ) -> Vec<String> {
+                    let provider = get_provider().lock().unwrap();
+                    let proto_id = wit_to_proto_resource_id(&id);
+                    $crate::CarinaProvider::required_permissions(
+                        &*provider,
+                        &proto_id,
+                        wit_to_sdk_plan_op(operation),
+                    )
                 }
 
                 fn provider_config_completions() -> String {
@@ -833,6 +857,17 @@ macro_rules! export_provider {
                 }
             }
 
+            fn wit_to_sdk_plan_op(
+                op: exports::carina::provider::provider::PlanOp,
+            ) -> $crate::PlanOp {
+                match op {
+                    exports::carina::provider::provider::PlanOp::Create => $crate::PlanOp::Create,
+                    exports::carina::provider::provider::PlanOp::Read => $crate::PlanOp::Read,
+                    exports::carina::provider::provider::PlanOp::Update => $crate::PlanOp::Update,
+                    exports::carina::provider::provider::PlanOp::Delete => $crate::PlanOp::Delete,
+                }
+            }
+
             struct WasmGuest;
 
             impl exports::carina::provider::provider::Guest for WasmGuest {
@@ -956,6 +991,19 @@ macro_rules! export_provider {
                         Ok(()) => Ok(()),
                         Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
+                }
+
+                fn required_permissions(
+                    id: wit_types::ResourceId,
+                    operation: exports::carina::provider::provider::PlanOp,
+                ) -> Vec<String> {
+                    let provider = get_provider().lock().unwrap();
+                    let proto_id = wit_to_proto_resource_id(&id);
+                    $crate::CarinaProvider::required_permissions(
+                        &*provider,
+                        &proto_id,
+                        wit_to_sdk_plan_op(operation),
+                    )
                 }
 
                 fn provider_config_completions() -> String {

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use carina_core::effect::PlanOp;
 use carina_core::provider::{
     BoxFuture, CreateRequest, DeleteRequest, PatchOpKind, Provider, ProviderError, ProviderResult,
     ReadRequest, UpdateRequest,
@@ -219,6 +220,10 @@ impl Provider for MockProvider {
             Ok(())
         })
     }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: PlanOp) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 #[cfg(test)]
@@ -246,6 +251,16 @@ mod tests {
             Some(b'\n'),
             "MockProvider state file must end with a trailing newline; got {:?}",
             bytes.last().map(|b| *b as char),
+        );
+    }
+
+    #[test]
+    fn required_permissions_returns_empty_vec() {
+        let provider = MockProvider::default();
+        let id = ResourceId::with_provider("mock", "foo", "example", None);
+        assert_eq!(
+            provider.required_permissions(&id, carina_core::effect::PlanOp::Create),
+            Vec::<String>::new()
         );
     }
 }

--- a/carina-provider-mock/src/main.rs
+++ b/carina-provider-mock/src/main.rs
@@ -160,6 +160,14 @@ impl CarinaProvider for MockProcessProvider {
         Ok(())
     }
 
+    fn required_permissions(
+        &self,
+        _id: &ResourceId,
+        _op: carina_plugin_sdk::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Echo the host-provided `default_tags` back into each resource's
     /// attributes under a sentinel `__mock_merged_default_tags__` key so
     /// integration tests can verify the WIT bridge dispatched the call.


### PR DESCRIPTION
Refs #3496

PR#1 of a 4-PR chain for #3496 (plan-time IAM permission check). Design doc: `notes/specs/2026-06-14-iam-preflight-design.md` (merged in #3499).

Adds the provider boundary and CLI flag scaffolding. No IAM check is performed yet — all providers return `Vec::new()`, so `--check-iam` is a no-op until PR#2/#3/#4 land. Issue closes in PR#4.

## Chain

1. **PR#1 (this)** — carina: trait + WIT + host + sdk + mock + CLI flag
2. carina-provider-awscc: handlers extraction + `required_permissions` impl
3. carina-provider-aws: empty impl
4. carina: provider rev bump + `iam_preflight` body. **Closes #3496.**

## Changes

- `carina-core`: new `PlanOp` enum in `effect.rs`; `Provider::required_permissions(&ResourceId, PlanOp) -> Vec<String>` with no default impl (each impl is forced — type-safety over convention). `ProviderRouter` dispatches the same way as sibling lifecycle methods via `get_provider_or_error(id)`.
- WIT (submodule bumped, includes both [WIT#21](https://github.com/carina-rs/carina-plugin-wit/pull/21) and [WIT#22](https://github.com/carina-rs/carina-plugin-wit/pull/22)): `plan-op` enum, `required-permissions(id: resource-id, operation: plan-op) -> list<string>`.
- `carina-plugin-host` / `carina-plugin-sdk`: WIT bridges mirror existing lifecycle conversions.
- `carina-provider-mock`: empty `Vec` impl.
- `carina-cli`: `Plan` clap struct gets `--check-iam` and `--strict-iam` (the latter `requires = "check_iam"`). Threaded through `run_plan` but currently no-op.

## Tests

- `PlanOp` Debug/Eq/Hash sanity
- Mock provider contract (empty `Vec` for any resource/op pair)
- Host WASM round-trip via `wasm_integration_test`
- clap parse tests verifying:
  - `--check-iam` parses
  - `--strict-iam` alone is rejected (clap `requires`)
  - `--check-iam --strict-iam` parses

## Verify

- `cargo check -p` for touched crates
- `cargo nextest run --workspace`: 4139 passed
- `cargo test --workspace --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- all `scripts/check-*.sh`
