### PR TITLE
executor: add ExecutionOutcome enum (T2, #3502)

### DIFF
--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -90,6 +90,38 @@ pub struct ExecutionResult {
     pub failed_refreshes: HashSet<ResourceId>,
 }
 
+/// Outcome of executing a plan: either it ran to completion, or a
+/// cancel request was observed and the run unwound after in-flight
+/// effects finished. Both variants carry the `ExecutionResult` of
+/// whatever the run produced; callers must destructure to decide
+/// whether to surface an `Interrupted` error after persisting state.
+///
+/// The enum intentionally provides no `?` shortcut and no `From` /
+/// `Into` to `Result<ExecutionResult, _>`. A future caller cannot
+/// silently drop the `Cancelled` arm — the compiler forces explicit
+/// handling. See [`ExecutionOutcomeCannotBeQuestionMarked`] for the
+/// compile-fail evidence.
+pub enum ExecutionOutcome {
+    Completed(ExecutionResult),
+    Cancelled(ExecutionResult),
+}
+
+/// Marker type whose `compile_fail` doctest is the type-safety evidence
+/// that `ExecutionOutcome` cannot be `?`-ed into a `Result`. The marker
+/// is hidden from rustdoc — it exists only so `cargo test --doc
+/// ExecutionOutcomeCannotBeQuestionMarked` runs the guard.
+///
+/// ```compile_fail
+/// use carina_core::executor::{ExecutionOutcome, ExecutionResult};
+///
+/// fn must_not_compile(outcome: ExecutionOutcome) -> Result<ExecutionResult, String> {
+///     let result = outcome?;
+///     Ok(result)
+/// }
+/// ```
+#[doc(hidden)]
+pub struct ExecutionOutcomeCannotBeQuestionMarked;
+
 /// Progress information for effect execution.
 #[derive(Debug, Clone, Copy)]
 pub struct ProgressInfo {

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -552,6 +552,19 @@ fn ok_state(id: &ResourceId) -> State {
     State::existing(id.clone(), attrs).with_identifier("id-123")
 }
 
+fn empty_execution_result() -> ExecutionResult {
+    ExecutionResult {
+        success_count: 0,
+        failure_count: 0,
+        skip_count: 0,
+        applied_states: HashMap::new(),
+        successfully_deleted: HashSet::new(),
+        permanent_name_overrides: HashMap::new(),
+        current_states: HashMap::new(),
+        failed_refreshes: HashSet::new(),
+    }
+}
+
 fn provider_config_with_default_tags(
     tags: indexmap::IndexMap<String, Value>,
 ) -> crate::parser::ProviderConfig {
@@ -571,6 +584,28 @@ fn provider_config_with_default_tags(
 // -----------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------
+
+#[test]
+fn execution_outcome_completed_and_cancelled_are_matchable() {
+    let completed = ExecutionOutcome::Completed(empty_execution_result());
+    let cancelled = ExecutionOutcome::Cancelled(empty_execution_result());
+
+    match completed {
+        ExecutionOutcome::Completed(result) => {
+            assert_eq!(result.success_count, 0);
+            assert!(result.applied_states.is_empty());
+        }
+        ExecutionOutcome::Cancelled(_) => panic!("completed outcome changed variant"),
+    }
+
+    match cancelled {
+        ExecutionOutcome::Cancelled(result) => {
+            assert_eq!(result.failure_count, 0);
+            assert!(result.successfully_deleted.is_empty());
+        }
+        ExecutionOutcome::Completed(_) => panic!("cancelled outcome changed variant"),
+    }
+}
 
 #[tokio::test]
 async fn test_simple_create() {


### PR DESCRIPTION
Closes #3502. Refs #3498.

T2 of the apply interruption resilience series. Adds the `ExecutionOutcome` enum that T3 will route `execute_plan` through. No callers wire the cancel token yet.

## What changes

- `ExecutionOutcome { Completed(ExecutionResult) | Cancelled(ExecutionResult) }` lives in `carina_core::executor`.
- A `#[doc(hidden)] pub struct ExecutionOutcomeCannotBeQuestionMarked` sentinel hosts a `compile_fail` doctest whose body applies `?` directly to `ExecutionOutcome`. The sentinel is hidden from rustdoc but the doctest still runs, so `cargo test -p carina-core --doc ExecutionOutcomeCannotBeQuestionMarked` matches it.
- `execution_outcome_completed_and_cancelled_are_matchable` exercises the runtime match shape.
- A test-only `empty_execution_result()` helper sits with the other helpers in `tests.rs`.

## Why a sentinel + `compile_fail` instead of `#[non_exhaustive]` or `#[must_use]`

CLAUDE.md forbids attributes that turn type-safety invariants into runtime conventions. Both arms of the enum carry the full `ExecutionResult`, and the doctest proves at compile time that `outcome?` does not type-check. A future `From<ExecutionOutcome> for Result<_, _>` or `Try` impl that re-opens the shortcut would immediately fail the `compile_fail` expectation.

The sentinel's body refers to `ExecutionOutcome` directly (not via `execute_plan`), so the guard is independent of T3's signature change.

## Verify

- `cargo nextest run -p carina-core execution_outcome_completed_and_cancelled_are_matchable` PASS
- `cargo test -p carina-core --doc ExecutionOutcomeCannotBeQuestionMarked` PASS (1 passed, compile_fail)
- `cargo check -p carina-core` PASS

5-round self-review (+ a follow-up round after the Round 5 fix that restored the sentinel name) all clean.