### PR TITLE
refactor(effect): name the wait-kind seam with Effect::is_wait()

### DIFF
--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -3530,10 +3530,7 @@ mod wait_until_enum_alias {
             &raw_waits,
         );
         assert!(
-            plan_raw
-                .effects()
-                .iter()
-                .any(|e| matches!(e, Effect::Wait { .. })),
+            plan_raw.effects().iter().any(|e| e.is_wait()),
             "precondition: with the raw enum RHS the differ emits the no-op \
              wait (the carina#3358 bug); effects were {:?}",
             plan_raw.effects()
@@ -3554,10 +3551,7 @@ mod wait_until_enum_alias {
             &waits,
         );
         assert!(
-            !plan_fixed
-                .effects()
-                .iter()
-                .any(|e| matches!(e, Effect::Wait { .. })),
+            !plan_fixed.effects().iter().any(|e| e.is_wait()),
             "carina#3358: after enum-alias resolution the already-satisfied \
              wait must be elided; effects were {:?}",
             plan_fixed.effects()

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1225,7 +1225,7 @@ fn wait_binding_lowers_to_wait_effect() {
     let wait_effect = plan
         .effects()
         .iter()
-        .find(|e| matches!(e, Effect::Wait { .. }))
+        .find(|e| e.is_wait())
         .expect("expected Wait effect");
     let Effect::Wait {
         binding,
@@ -1312,7 +1312,7 @@ fn wait_uses_schema_default_timeout_when_omitted() {
     } = plan
         .effects()
         .iter()
-        .find(|e| matches!(e, Effect::Wait { .. }))
+        .find(|e| e.is_wait())
         .expect("expected Wait effect")
     else {
         unreachable!();
@@ -1369,7 +1369,6 @@ fn wait_with_unknown_target_emits_plan_error() {
 /// distribution (unchanged) referencing `cert_issued`.
 #[test]
 fn wait_omitted_when_all_consumers_unchanged() {
-    use crate::effect::Effect;
     use crate::parser::{UntilPredicateAst, WaitBinding};
 
     let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
@@ -1418,10 +1417,7 @@ fn wait_omitted_when_all_consumers_unchanged() {
     );
 
     assert!(
-        !plan
-            .effects()
-            .iter()
-            .any(|e| matches!(e, Effect::Wait { .. })),
+        !plan.effects().iter().any(|e| e.is_wait()),
         "carina#3101: no Effect::Wait when every consumer is unchanged; \
          effects were {:?}",
         plan.effects()
@@ -1488,7 +1484,6 @@ fn wait_emitted_when_a_consumer_has_a_pending_change() {
 /// in `web_acl_id` while still referencing `cert_issued`.
 #[test]
 fn wait_omitted_when_already_satisfied_and_target_unchanged() {
-    use crate::effect::Effect;
     use crate::parser::{UntilPredicateAst, WaitBinding};
 
     // cert: exists with status == ISSUED and is unchanged (desired
@@ -1543,10 +1538,7 @@ fn wait_omitted_when_already_satisfied_and_target_unchanged() {
     );
 
     assert!(
-        !plan
-            .effects()
-            .iter()
-            .any(|e| matches!(e, Effect::Wait { .. })),
+        !plan.effects().iter().any(|e| e.is_wait()),
         "carina#3358: an already-satisfied wait whose target is unchanged \
          must be elided even when a consumer has a pending change that \
          merely references it; effects were {:?}",

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -405,6 +405,14 @@ impl Effect {
         }
     }
 
+    /// Returns true iff this effect polls an external state and
+    /// could in principle hang forever — meaning that if it is the
+    /// only kind left in flight while no other effect can dispatch,
+    /// the executor must intervene rather than wait.
+    pub fn is_wait(&self) -> bool {
+        matches!(self, Effect::Wait { .. })
+    }
+
     /// Returns the kind of Effect as a string (for display)
     pub fn kind(&self) -> &'static str {
         match self {
@@ -422,7 +430,7 @@ impl Effect {
 
     /// Returns whether this Effect causes a mutation
     pub fn is_mutating(&self) -> bool {
-        !matches!(self, Effect::Read { .. } | Effect::Wait { .. })
+        !matches!(self, Effect::Read { .. }) && !self.is_wait()
     }
 
     /// Returns whether this is a state-only operation (import/remove/move)

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -604,7 +604,7 @@ pub(super) async fn execute_effects_sequential(
 
             if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
                 let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
-                let reason = if matches!(effect, Effect::Wait { .. }) {
+                let reason = if effect.is_wait() {
                     let detail =
                         unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
                             binding: failed_dep,
@@ -660,7 +660,7 @@ pub(super) async fn execute_effects_sequential(
                 schemas: input.schemas,
             };
             let completed_ref = &completed;
-            let wait_cancel_rx = if matches!(effect, Effect::Wait { .. }) {
+            let wait_cancel_rx = if effect.is_wait() {
                 let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
                 wait_cancellers.insert(idx, cancel_tx);
                 in_flight_kinds.insert(idx, InFlightKind::Wait);

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -1087,6 +1087,14 @@ mod tests {
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Err(ProviderError::internal("delete not used")) })
         }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: crate::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     struct RecordingSkipObserver {

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1585,6 +1585,14 @@ mod tests {
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Err(ProviderError::internal("delete not used")) })
         }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: crate::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
     }
 
     struct RecordingSkipObserver {

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -418,7 +418,7 @@ pub(super) async fn execute_effects_phased(
 
                 if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
                     let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
-                    let reason = if matches!(effect, Effect::Wait { .. }) {
+                    let reason = if effect.is_wait() {
                         let detail =
                             unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
                                 binding: failed_dep,

--- a/notes/plans/2026-05-09-wait-construct-plan.md
+++ b/notes/plans/2026-05-09-wait-construct-plan.md
@@ -520,7 +520,7 @@ Each task is one TDD cycle. Goal: write failing test → run → see fail → mi
           &HashMap::new(),
           &HashMap::new(),
       );
-      let wait_effect = plan.effects().iter().find(|e| matches!(e, Effect::Wait { .. })).expect("expected Wait effect");
+      let wait_effect = plan.effects().iter().find(|e| e.is_wait()).expect("expected Wait effect");
       let Effect::Wait { binding, target_id, until, .. } = wait_effect else { unreachable!() };
       assert_eq!(binding, "cert_issued");
       assert_eq!(target_id.name, "cert");
@@ -870,7 +870,7 @@ Each task is one TDD cycle. Goal: write failing test → run → see fail → mi
       assert!(resource_types.iter().any(|t| t == &"cloudfront.Distribution"));
   }
   ```
-- **Implementation:** in the executor's "after this effect succeeded, update state file" path, skip when `matches!(effect, Effect::Wait { .. })`. (The synthetic `__wait` ResourceId from Task 4.8 is for in-memory binding resolution only; never persist it.)
+- **Implementation:** in the executor's "after this effect succeeded, update state file" path, skip when `effect.is_wait()`. (The synthetic `__wait` ResourceId from Task 4.8 is for in-memory binding resolution only; never persist it.)
 - **Verification:** `cargo nextest run -p carina-core executor::tests::state_file_has_no_wait_entries_after_apply`.
 
 **Task 5.3: Plan display fixture and snapshot test.**


### PR DESCRIPTION
## Summary

#3497 / #3515 で入った wait fail-fast の terminal-check は、Effect が wait かどうかを `matches!(effect, Effect::Wait { .. })` で判定する箇所が executor 内に複数できた。同じ判定を複数の dispatch サイトで書くと、将来 wait と同じ意味論を持つ effect variant が増えたときに silently 食い違う可能性がある。

`Effect::is_wait()` を 1 つ追加して、そういう「Wait variant を destructure せず、kind だけ知りたい」サイトをすべてそれ経由にする。pure mechanical refactor で挙動変更なし。

意図を doc comment に書いた:

> Returns true iff this effect polls an external state and could in principle hang forever — meaning that if it is the only kind left in flight while no other effect can dispatch, the executor must intervene rather than wait.

これは次の type-level 強化(#3516 step (b)/(c): in_flight push の typestate 化、plan-time mutator inference)の hook になる。

## 変更点

- `carina-core/src/effect.rs`: `Effect::is_wait()` を追加。既存の `Effect::is_mutating()` も内部で使うようにした。
- `carina-core/src/executor/parallel.rs`: 2 サイト置換。
- `carina-core/src/executor/phased.rs`: 1 サイト置換。
- `carina-core/src/differ/plan_tests.rs` / `carina-cli/src/wiring/tests.rs`: 既存の `matches!` をそろえる。
- `notes/plans/2026-05-09-wait-construct-plan.md`: 旧計画書中のコード例を新しい綴りに合わせて更新。

destructured field を実際に読む `if let Effect::Wait { binding, ... }` は対象外、純粋な kind チェックのみ。

## Out of scope

- #3516 step (b): `in_flight.push` の typestate 化(terminal-check を忘れることを compile error にする)
- #3516 step (c): plan-time mutator inference(Issue #3497 option #1 の精密版)

それぞれ別 PR で。

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 4141 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

Refs #3516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
