### PR TITLE
executor: thread CancellationToken through execute_plan signature (T3, #3503)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -14,7 +14,9 @@ use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
 use carina_core::executor::normalized::apply_desired_normalization;
-use carina_core::executor::{ExecutionInput, ExecutionResult, UnresolvedResource};
+use carina_core::executor::{
+    ExecutionInput, ExecutionOutcome, ExecutionResult, UnresolvedResource,
+};
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer, ReadRequest};
 use carina_core::resolver::resolve_refs_with_state_and_remote;
@@ -23,6 +25,7 @@ use carina_core::resource::ConcreteValue;
 use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::value::format_value;
 use carina_state::{BackendLock, LockInfo, StateBackend, StateFile};
+use tokio_util::sync::CancellationToken;
 
 use carina_core::parser::{ProviderConfig, ProviderContext};
 
@@ -74,6 +77,7 @@ pub async fn execute_effects(
     current_states: &mut HashMap<ResourceId, State>,
     unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
     compositions: &[carina_core::resource::Composition],
+    cancel: CancellationToken,
     parallelism: NonZeroUsize,
 ) -> ApplyResult {
     let input = ExecutionInput {
@@ -90,7 +94,14 @@ pub async fn execute_effects(
     };
 
     let observer = CliObserver::new(plan);
-    let result = carina_core::executor::execute_plan(provider, input, &observer).await;
+    let outcome = carina_core::executor::execute_plan(provider, input, &observer, cancel).await;
+    // T3: both arms surface the same ExecutionResult so callers see consistent
+    // intermediate state regardless of whether cancellation has been observed yet.
+    // T5 (carina#3505) will rewrap this into the finalize_apply pipeline so the
+    // caller can distinguish Completed from Cancelled at the apply boundary.
+    let result = match outcome {
+        ExecutionOutcome::Completed(result) | ExecutionOutcome::Cancelled(result) => result,
+    };
 
     // Write back the updated current_states so callers see refreshes
     *current_states = result.current_states.clone();
@@ -1486,6 +1497,7 @@ async fn run_apply_locked(
         &mut current_states,
         &unresolved_resources,
         &parsed.compositions,
+        CancellationToken::new(),
         parallelism,
     )
     .await;
@@ -1940,6 +1952,7 @@ async fn run_apply_from_plan_locked(
         &mut current_states,
         &unresolved_resources,
         plan_compositions,
+        CancellationToken::new(),
         parallelism,
     )
     .await;

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1843,6 +1843,7 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
         &mut current_states,
         &unresolved_resources,
         &[],
+        tokio_util::sync::CancellationToken::new(),
         carina_core::executor::TEST_UNCAPPED,
     )
     .await;
@@ -2020,6 +2021,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
         &mut current_states,
         &unresolved_resources,
         &[],
+        tokio_util::sync::CancellationToken::new(),
         carina_core::executor::TEST_UNCAPPED,
     )
     .await;

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -32,7 +32,10 @@ use carina_core::binding_index::ResolvedBindings;
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::create_plan;
-use carina_core::executor::{ExecutionInput, ExecutionObserver, UnresolvedResource, execute_plan};
+use carina_core::executor::{
+    ExecutionInput, ExecutionObserver, ExecutionOutcome, ExecutionResult, UnresolvedResource,
+    execute_plan,
+};
 use carina_core::parser::ProviderContext;
 use carina_core::provider::{
     BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
@@ -41,6 +44,17 @@ use carina_core::resource::{DataSource, ResourceId, State, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 use indexmap::IndexMap;
 use std::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+fn completed_result(outcome: ExecutionOutcome) -> ExecutionResult {
+    match outcome {
+        ExecutionOutcome::Completed(result) => result,
+        ExecutionOutcome::Cancelled(result) => panic!(
+            "uncancelled execution returned Cancelled: success={}, failure={}, skip={}",
+            result.success_count, result.failure_count, result.skip_count
+        ),
+    }
+}
 
 // --- Minimal aws provider stub: just enough schema for the fixture's
 // aws.acm.Certificate + aws.cloudfront.Distribution to resolve. ---
@@ -468,7 +482,8 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
         schemas: ctx.schemas(),
         parallelism: carina_core::executor::TEST_UNCAPPED,
     };
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     let failures = observer.failures.lock().unwrap().clone();
     (result.failure_count, result.skip_count, failures)
 }

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -35,6 +35,7 @@ use crate::resource::{ResourceId, State, Value};
 
 use parallel::execute_effects_sequential;
 use phased::{execute_effects_phased, has_interdependent_replaces};
+use tokio_util::sync::CancellationToken;
 
 pub const TEST_UNCAPPED: NonZeroUsize = NonZeroUsize::new(usize::MAX).unwrap();
 
@@ -216,12 +217,14 @@ pub async fn execute_plan(
     provider: &dyn Provider,
     mut input: ExecutionInput<'_>,
     observer: &dyn ExecutionObserver,
-) -> ExecutionResult {
-    if has_interdependent_replaces(input.plan.effects()) {
+    _cancel: CancellationToken,
+) -> ExecutionOutcome {
+    let result = if has_interdependent_replaces(input.plan.effects()) {
         execute_effects_phased(provider, &mut input, observer).await
     } else {
         execute_effects_sequential(provider, &mut input, observer).await
-    }
+    };
+    ExecutionOutcome::Completed(result)
 }
 
 #[cfg(test)]

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -9,6 +9,7 @@ use parallel::{build_dependency_analysis, build_dependency_levels};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use tokio_util::sync::CancellationToken;
 
 // -----------------------------------------------------------------------
 // Mock Provider
@@ -221,6 +222,16 @@ impl ExecutionObserver for MockObserver {
             }
         };
         self.events.lock().unwrap().push(msg);
+    }
+}
+
+fn completed_result(outcome: ExecutionOutcome) -> ExecutionResult {
+    match outcome {
+        ExecutionOutcome::Completed(result) => result,
+        ExecutionOutcome::Cancelled(result) => panic!(
+            "uncancelled execution returned Cancelled: success={}, failure={}, skip={}",
+            result.success_count, result.failure_count, result.skip_count
+        ),
     }
 }
 
@@ -617,6 +628,87 @@ fn execution_outcome_completed_and_cancelled_are_matchable() {
 }
 
 #[tokio::test]
+async fn execute_plan_returns_completed_when_not_cancelled() {
+    let provider = MockProvider::new();
+    let resource = make_resource("one", &[]);
+    let rid = resource.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(resource));
+
+    provider.push_create(Ok(ok_state(&rid)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+
+    let observer = MockObserver::new();
+    let cancel = CancellationToken::new();
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    match outcome {
+        ExecutionOutcome::Completed(result) => {
+            assert_eq!(result.failure_count, 0);
+            assert_eq!(result.success_count, 1);
+        }
+        ExecutionOutcome::Cancelled(_) => panic!("uncancelled execution returned Cancelled"),
+    }
+}
+
+#[tokio::test]
+async fn execute_plan_with_pre_cancelled_token_still_returns_completed_at_t3() {
+    // T3 contract: execute_plan receives a CancellationToken but does not
+    // observe it. A pre-cancelled token must therefore still yield Completed.
+    // T4 (carina#3504) will flip this expectation to Cancelled and rename the test.
+    let provider = MockProvider::new();
+    let resource = make_resource("one", &[]);
+    let rid = resource.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(resource));
+
+    provider.push_create(Ok(ok_state(&rid)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+
+    let observer = MockObserver::new();
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    match outcome {
+        ExecutionOutcome::Completed(result) => {
+            assert_eq!(result.success_count, 1, "T3 must not observe cancellation");
+        }
+        ExecutionOutcome::Cancelled(_) => panic!(
+            "T3 must not observe cancellation; if this fires, T4 may have leaked into this PR"
+        ),
+    }
+}
+
+#[tokio::test]
 async fn test_simple_create() {
     let provider = MockProvider::new();
     let resource = make_resource("a", &[]);
@@ -641,7 +733,8 @@ async fn test_simple_create() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 1);
     assert_eq!(result.failure_count, 0);
@@ -693,7 +786,8 @@ async fn test_apply_renormalizes_after_resolution() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let captured = provider.captured_create_resources();
@@ -750,7 +844,8 @@ async fn test_apply_reapplies_enum_alias_stage() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let captured = provider.captured_create_resources();
@@ -812,7 +907,8 @@ async fn test_apply_reapplies_enum_alias_stage_update_path() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let reqs = provider.captured_update_requests();
@@ -866,7 +962,8 @@ async fn test_apply_reapplies_canonicalize_stage() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let captured = provider.captured_create_resources();
@@ -926,7 +1023,8 @@ async fn test_apply_renormalizes_update_path() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let reqs = provider.captured_update_requests();
@@ -1012,7 +1110,8 @@ async fn test_apply_update_patch_preserves_provider_default_tags() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let reqs = provider.captured_update_requests();
@@ -1121,7 +1220,8 @@ async fn test_apply_effective_changed_uses_plan_time_comparison_semantics() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let reqs = provider.captured_update_requests();
@@ -1180,7 +1280,8 @@ async fn test_apply_effective_changed_skips_internal_and_write_only_attributes()
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let reqs = provider.captured_update_requests();
@@ -1240,7 +1341,8 @@ async fn test_apply_effective_changed_skips_matching_unwrapped_secret_hash() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let reqs = provider.captured_update_requests();
@@ -1305,7 +1407,8 @@ async fn test_apply_effective_changed_skips_secret_shape_divergence() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let reqs = provider.captured_update_requests();
@@ -1361,7 +1464,8 @@ async fn test_apply_renormalizes_nested_value_under_ref_bearing_resource() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 2, "both creates should succeed");
 
     let captured = provider.captured_create_resources();
@@ -1507,7 +1611,8 @@ async fn test_async_normalizer_does_not_self_deadlock_on_apply_path() {
     // be reproduced with a real WASM guest (the issue's user-driven
     // real-infra smoke); this test cannot even express the old shape
     // because the trait is now async — that is the point.
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(
         result.success_count, 2,
         "both creates must complete — no self-deadlock acquiring the \
@@ -1563,7 +1668,8 @@ async fn test_simple_delete() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 1);
     assert!(result.successfully_deleted.contains(&rid));
@@ -1597,7 +1703,8 @@ async fn test_failed_effect_propagates_to_dependent() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.failure_count, 1);
     assert_eq!(result.skip_count, 1);
@@ -1651,7 +1758,8 @@ async fn test_cbd_creates_before_deletes() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 1);
     assert_eq!(result.failure_count, 0);
@@ -1726,7 +1834,8 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 1);
 
     let reqs = provider.captured_update_requests();
@@ -1773,7 +1882,8 @@ async fn test_dbd_deletes_before_creates() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 1);
     assert_eq!(result.failure_count, 0);
@@ -1855,7 +1965,8 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 2);
     assert_eq!(result.failure_count, 0);
@@ -1936,7 +2047,8 @@ async fn test_phased_noncbd_creates_after_deletes() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 2);
     assert_eq!(result.failure_count, 0);
@@ -1975,7 +2087,8 @@ async fn test_observer_events_emitted_correctly() {
     };
 
     let observer = MockObserver::new();
-    execute_plan(&provider, input, &observer).await;
+    let _ =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     let events = observer.events();
     assert_eq!(events.len(), 2);
@@ -2005,7 +2118,8 @@ async fn test_read_effect_is_no_op() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 0);
     assert_eq!(result.failure_count, 0);
@@ -2048,7 +2162,8 @@ async fn test_independent_effects_run_in_parallel() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 3);
     assert_eq!(result.failure_count, 0);
@@ -2101,7 +2216,8 @@ async fn test_parallel_failure_skips_dependents() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     // vpc + subnet_b succeed, subnet_a fails, subnet_c skipped
     assert_eq!(result.success_count, 2);
@@ -2151,7 +2267,8 @@ async fn test_dependency_levels_sequential_chain() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 3);
 
@@ -2388,7 +2505,8 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 3);
     assert_eq!(result.failure_count, 0);
@@ -2601,7 +2719,8 @@ async fn run_tag_sweep(parallelism: NonZeroUsize) -> (std::time::Duration, usize
 
     let observer = MockObserver::new();
     let started = Instant::now();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     let elapsed = started.elapsed();
 
     assert_eq!(result.success_count, 13);
@@ -2669,7 +2788,8 @@ async fn run_provider_contract_case(unknown_read: bool) -> usize {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 2);
     assert_eq!(result.failure_count, 0);
     provider.max_active()
@@ -2763,7 +2883,8 @@ async fn test_waiting_events_emitted_for_dependent_effects() {
     provider.push_create(Ok(
         State::existing(c_id, id_attr("id-c")).with_identifier("id-c")
     ));
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 2);
 
@@ -2919,7 +3040,8 @@ async fn test_update_effect_binding_map_propagation() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 1);
     assert_eq!(result.failure_count, 0);
@@ -3040,7 +3162,8 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 2, "Both resources should succeed");
     assert_eq!(result.failure_count, 0, "No failures expected");
@@ -3233,7 +3356,8 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 3);
     assert_eq!(result.failure_count, 0);
@@ -3328,7 +3452,8 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(result.success_count, 3);
     assert_eq!(result.failure_count, 0);
@@ -3421,7 +3546,8 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(
         result.success_count,
@@ -3571,7 +3697,8 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(
         result.failure_count,
@@ -3652,7 +3779,8 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     assert_eq!(result.success_count, 2);
     // The wait's captured State is keyed under a synthetic `__wait`
     // ResourceId. This is what guarantees state writeback never sees
@@ -3771,7 +3899,8 @@ async fn test_chained_index_then_field_unresolved_at_apply_fails_with_clear_erro
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     // Cert succeeds; the record fails at apply-time resolution
     // *before* reaching the provider — no `create` call for the
@@ -3953,7 +4082,8 @@ async fn test_chained_index_then_nested_field_resolves_from_post_create_state() 
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(
         result.failure_count,
@@ -4164,7 +4294,8 @@ async fn wait_resolves_target_identifier_from_just_created_state() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(
         result.failure_count,
@@ -4257,7 +4388,8 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(
         result.failure_count, 0,
@@ -4390,7 +4522,8 @@ async fn test_data_source_read_state_resolves_for_downstream_resource() {
     };
 
     let observer = MockObserver::new();
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     assert_eq!(
         result.failure_count,

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -30,7 +30,10 @@ use std::sync::Mutex;
 use carina_core::config_loader::parse_directory;
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::create_plan;
-use carina_core::executor::{ExecutionInput, ExecutionObserver, UnresolvedResource, execute_plan};
+use carina_core::executor::{
+    ExecutionInput, ExecutionObserver, ExecutionOutcome, ExecutionResult, UnresolvedResource,
+    execute_plan,
+};
 use carina_core::module_resolver::resolve_modules;
 use carina_core::parser::ProviderContext;
 use carina_core::provider::{
@@ -40,6 +43,17 @@ use carina_core::provider::{
 use carina_core::resolver::resolve_refs_with_state_and_remote;
 use carina_core::resource::{ConcreteValue, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
+use tokio_util::sync::CancellationToken;
+
+fn completed_result(outcome: ExecutionOutcome) -> ExecutionResult {
+    match outcome {
+        ExecutionOutcome::Completed(result) => result,
+        ExecutionOutcome::Cancelled(result) => panic!(
+            "uncancelled execution returned Cancelled: success={}, failure={}, skip={}",
+            result.success_count, result.failure_count, result.skip_count
+        ),
+    }
+}
 
 /// cert read returns ISSUED (+ certificate_arn) immediately; other
 /// resources create/read trivially. Keeps a correct wait fast.
@@ -289,7 +303,8 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
         parallelism: carina_core::executor::TEST_UNCAPPED,
     };
 
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
     let failures = observer.failures.lock().unwrap().clone();
     assert_eq!(
@@ -436,7 +451,8 @@ async fn nested_module_wait_binding_survives_two_expansions() {
         parallelism: carina_core::executor::TEST_UNCAPPED,
     };
 
-    let result = execute_plan(&provider, input, &observer).await;
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
     let failures = observer.failures.lock().unwrap().clone();
     assert_eq!(
         result.failure_count, 0,


### PR DESCRIPTION
Closes #3503. Refs #3498.

T3 of the apply interruption resilience series. Changes `execute_plan` to accept a `CancellationToken` and return `ExecutionOutcome` (introduced in T2). T4 will wire the cancel observation.

## What changes

- `execute_plan(provider, input, observer, _cancel: CancellationToken) -> ExecutionOutcome`. At T3 the cancel argument is intentionally unobserved (`_cancel`); the function still always returns `ExecutionOutcome::Completed(result)`.
- The `execute_effects` wrapper in `carina-cli/src/commands/apply/mod.rs` plumbs the cancel token through and uses an or-pattern to extract the inner `ExecutionResult` from either arm. This keeps the production code path panic-free even if T4 lands before T5 — the meaningful Completed/Cancelled distinction is T5's responsibility.
- All 45+ direct call sites in tests and integration tests are updated. A small private `completed_result(outcome) -> ExecutionResult` helper sits in each test crate to dedupe the destructure (3 byte-identical copies; consolidation deferred to T13 or a later cleanup).

## Two new contract tests

- `execute_plan_returns_completed_when_not_cancelled`: happy path with a fresh token.
- `execute_plan_with_pre_cancelled_token_still_returns_completed_at_t3`: cancels the token before calling `execute_plan`, asserts the result is still `Completed` because T3 does not observe cancel. T4 will rename and flip this test.

## Verify

- `cargo check --workspace` PASS
- `cargo nextest run -p carina-core` 2482 passed
- `cargo nextest run -p carina-cli` 626 passed
- `cargo test --workspace --doc` PASS (compile_fail doctest for `ExecutionOutcomeCannotBeQuestionMarked` still PASS)
- `cargo clippy --workspace --all-targets -- -D warnings` PASS

5-round self-review: Round 2 caught a stale rebase (folded in), Round 4 caught a missing T5-cleanup instruction (added to issue #3505 body), Round 5 caught a WIP commit message (reworded). All clean post-fix.

## Why an or-pattern instead of `unreachable!` on Cancelled

A code-review pass flagged that an initial `Cancelled(_) => unreachable!()` would have meant T4 landing before T5 makes the production wrapper panic. The or-pattern collapse keeps production safe and lets T5 introduce the meaningful distinction at the right seam (the apply boundary, not the wrapper).