### PR TITLE
feat(plan): IAM permission preflight check (closes #3496)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -155,7 +155,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -205,8 +205,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.11"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -259,27 +259,55 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.18"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959dab27ce613e6c9658eb3621064d0e2027e5f2acb65bc526a43577facea557"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "fastrand",
  "http 0.2.12",
+ "http 1.4.0",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-iam"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb72c86b8b7aeb3967a3a9cebcb773d88350c04b9d0770ad75bea8f76c89bfa"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -291,8 +319,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -317,8 +345,8 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -328,14 +356,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "lru 0.16.3",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -349,8 +377,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -372,8 +400,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -395,8 +423,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -412,26 +440,25 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.7"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e523e1c4e8e7e8ff219d732988e22bfeae8a1cafdbe6d9eca1546fa080be7c"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
- "ring",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -440,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.7"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee19095c7c4dda59f1697d028ce704c24b2d33c6718790c7f1d5a3015b4107c"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -455,7 +482,7 @@ version = "0.63.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23374b9170cbbcc6f5df8dc5ebb9b6c5c28a3c8f599f0e8b8b10eb6f4a5c6e74"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.62.6",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -465,15 +492,15 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.14"
+version = "0.60.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc12f8b310e38cad85cf3bef45ad236f470717393c613266ce0a89512286b650"
+checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -503,10 +530,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http-client"
-version = "1.1.5"
+name = "aws-smithy-http"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -542,19 +590,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-observability"
-version = "0.2.0"
+name = "aws-smithy-json"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1fcbefc7ece1d70dcce29e490f269695dfca2d2bacdeaf9e5c3f799e4e6a42"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.9"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5d689cf437eae90460e944a58b5668530d433b4ff85789e69d2f2a556e057d"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -562,15 +621,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.8"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5b6167fcdf47399024e81ac08e795180c576a20e4d4ce67949f9a88ae37dc1"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -578,6 +638,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -586,11 +647,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.10.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efce7aaaf59ad53c5412f14fc19b2d5c6ab2c3ec688d272fd31f76ec12f44fb0"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -602,10 +664,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.3.6"
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f172bcb02424eb94425db8aed1b6d583b5104d4d5ddddf22402c661a320048"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -629,22 +713,23 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.13"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b2f670422ff42bf7065031e72b45bc52a3508bd089f743ea90731ca2b6ea57"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.11"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -652,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -705,7 +790,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -715,6 +800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -851,8 +945,10 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "aws-config",
+ "aws-sdk-iam",
  "aws-sdk-kms",
  "aws-sdk-s3",
+ "aws-sdk-sts",
  "base64",
  "carina-core",
  "carina-lsp",
@@ -945,7 +1041,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -1001,7 +1097,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "time",
@@ -1097,7 +1193,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1163,6 +1259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1363,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1423,7 +1540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin",
 ]
@@ -1489,24 +1606,14 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1521,12 +1628,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1607,11 +1732,12 @@ checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1641,9 +1767,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1713,14 +1852,16 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1731,17 +1872,17 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der",
- "digest",
+ "crypto-bigint",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1834,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -2041,6 +2182,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2092,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -2187,7 +2329,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2267,6 +2418,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2874,7 +3034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3017,13 +3177,14 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3072,8 +3233,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3084,6 +3245,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3132,7 +3302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3179,9 +3349,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -3206,7 +3376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3291,6 +3461,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3563,13 +3742,12 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -3788,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -3967,8 +4145,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3978,8 +4156,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4037,11 +4226,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4110,9 +4299,9 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -4597,9 +4786,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -4654,7 +4843,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -5033,7 +5222,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasm-encoder 0.245.1",
@@ -5056,7 +5245,7 @@ dependencies = [
  "rustix 1.1.3",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "toml 0.9.12+spec-1.1.0",
  "wasmtime-environ",
  "windows-sys 0.61.2",
@@ -5709,13 +5898,13 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "hmac",
+ "hmac 0.12.1",
  "http 1.4.0",
  "rand 0.9.4",
  "rcgen",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6117,7 +6306,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "getrandom 0.3.4",
- "hmac",
+ "hmac 0.12.1",
  "indexmap",
  "lzma-rs",
  "memchr",

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -23,8 +23,10 @@ carina-provider-resolver = { path = "../carina-provider-resolver" }
 carina-state = { path = "../carina-state" }
 carina-tui = { path = "../carina-tui" }
 aws-config = "1"
+aws-sdk-iam = "1"
 aws-sdk-kms = "1"
 aws-sdk-s3 = "1"
+aws-sdk-sts = "1"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }

--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -1,0 +1,802 @@
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use aws_config::BehaviorVersion;
+use aws_sdk_iam::types::PolicyEvaluationDecisionType;
+use carina_core::effect::{Effect, PlanOp};
+use carina_core::plan::Plan;
+use carina_core::provider::Provider;
+use carina_core::resource::ResourceId;
+use colored::Colorize;
+use serde_json::Value as JsonValue;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IamPreflightResult {
+    Skipped(IamPreflightSkipped),
+    Checked(IamPreflightReport),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IamPreflightSkipped {
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IamPreflightReport {
+    pub actor_arn: String,
+    pub method: IamCheckMethod,
+    pub missing_by_effect: Vec<MissingEffectActions>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IamCheckMethod {
+    SimulatePrincipalPolicy,
+    DocumentFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MissingEffectActions {
+    pub effect: EffectAddress,
+    pub missing_actions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EffectAddress {
+    pub resource: String,
+    pub op: PlanOp,
+}
+
+impl PartialOrd for EffectAddress {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for EffectAddress {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.resource
+            .cmp(&other.resource)
+            .then_with(|| plan_op_rank(self.op).cmp(&plan_op_rank(other.op)))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RequiredAction {
+    pub effect: EffectAddress,
+    pub action: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SimulationResult {
+    denied_actions: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DocumentFallbackResult {
+    allowed_actions: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SimulateError {
+    NeedsFallback(String),
+    Other(String),
+}
+
+pub(crate) async fn run_iam_preflight(
+    plan: &Plan,
+    provider: &dyn Provider,
+    strict: bool,
+) -> IamPreflightResult {
+    let required = collect_required_actions(plan, provider);
+    if required.is_empty() {
+        return IamPreflightResult::Checked(IamPreflightReport {
+            actor_arn: String::new(),
+            method: IamCheckMethod::SimulatePrincipalPolicy,
+            missing_by_effect: Vec::new(),
+        });
+    }
+
+    let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
+    let sts_client = aws_sdk_sts::Client::new(&config);
+    let actor_arn = match resolve_actor_arn(&sts_client).await {
+        Ok(actor) => actor,
+        Err(e) => {
+            return IamPreflightResult::Skipped(IamPreflightSkipped {
+                reason: format!(
+                    "Warning: IAM preflight check skipped because AWS caller identity could not be resolved ({e})."
+                ),
+            });
+        }
+    };
+
+    let action_set = unique_actions(&required);
+    let iam_client = aws_sdk_iam::Client::new(&config);
+    let (method, missing_actions) = match simulate(&actor_arn, &action_set, &iam_client).await {
+        Ok(simulated) => (
+            IamCheckMethod::SimulatePrincipalPolicy,
+            simulated.denied_actions,
+        ),
+        Err(SimulateError::NeedsFallback(_)) => {
+            match document_fallback(&actor_arn, &action_set, &iam_client).await {
+                Ok(fallback) => {
+                    let missing = action_set
+                        .iter()
+                        .filter(|action| {
+                            !action_allowed_by_documents(action, &fallback.allowed_actions)
+                        })
+                        .cloned()
+                        .collect();
+                    (IamCheckMethod::DocumentFallback, missing)
+                }
+                Err(e) => {
+                    return IamPreflightResult::Skipped(IamPreflightSkipped {
+                        reason: format!(
+                            "Warning: IAM preflight check skipped because IAM policies could not be read ({e})."
+                        ),
+                    });
+                }
+            }
+        }
+        Err(SimulateError::Other(e)) => {
+            return IamPreflightResult::Skipped(IamPreflightSkipped {
+                reason: format!(
+                    "Warning: IAM preflight check skipped because IAM policy simulation failed ({e})."
+                ),
+            });
+        }
+    };
+
+    let report = IamPreflightReport {
+        actor_arn,
+        method,
+        missing_by_effect: group_missing_by_effect(&required, &missing_actions),
+    };
+
+    if strict && !report.missing_by_effect.is_empty() {
+        return IamPreflightResult::Checked(report);
+    }
+
+    IamPreflightResult::Checked(report)
+}
+
+pub(crate) fn collect_required_actions(
+    plan: &Plan,
+    provider: &dyn Provider,
+) -> Vec<RequiredAction> {
+    let mut required = Vec::new();
+    for effect in plan.effects() {
+        for (id, op) in effect_required_ops(effect) {
+            let actions = provider.required_permissions(id, op);
+            for action in actions {
+                required.push(RequiredAction {
+                    effect: EffectAddress {
+                        resource: id.human().to_string(),
+                        op,
+                    },
+                    action,
+                });
+            }
+        }
+    }
+    required
+}
+
+fn effect_required_ops(effect: &Effect) -> Vec<(&ResourceId, PlanOp)> {
+    match effect {
+        Effect::Read { resource } => vec![(&resource.id, PlanOp::Read)],
+        Effect::Create(resource) => vec![(&resource.id, PlanOp::Create)],
+        Effect::Update { id, .. } => vec![(id, PlanOp::Update)],
+        Effect::Replace { id, to, .. } => vec![(id, PlanOp::Delete), (&to.id, PlanOp::Create)],
+        Effect::Delete { id, .. } => vec![(id, PlanOp::Delete)],
+        Effect::Import { id, .. } => vec![(id, PlanOp::Read)],
+        Effect::Remove { .. } | Effect::Move { .. } | Effect::Wait { .. } => Vec::new(),
+    }
+}
+
+pub(crate) fn format_warnings(result: &IamPreflightResult) -> Option<String> {
+    match result {
+        IamPreflightResult::Skipped(skipped) => Some(skipped.reason.clone()),
+        IamPreflightResult::Checked(report) if report.missing_by_effect.is_empty() => None,
+        IamPreflightResult::Checked(report) => {
+            let mut out = String::new();
+            match report.method {
+                IamCheckMethod::SimulatePrincipalPolicy => {
+                    out.push_str(&format!(
+                        "Warning: IAM preflight check found missing permissions for {} using iam:SimulatePrincipalPolicy.\n",
+                        report.actor_arn
+                    ));
+                    out.push_str(
+                        "  Note: SCPs, condition keys, and exact resource ARN scopes may still affect apply.\n",
+                    );
+                }
+                IamCheckMethod::DocumentFallback => {
+                    out.push_str(&format!(
+                        "Warning: IAM preflight check found missing permissions for {} using policy document fallback.\n",
+                        report.actor_arn
+                    ));
+                    out.push_str(
+                        "  Weaker check: fallback only matches identity-policy action names; it does not evaluate SCPs, permission boundaries, condition keys, or resource scopes.\n",
+                    );
+                }
+            }
+            for effect in &report.missing_by_effect {
+                out.push_str(&format!(
+                    "  {} ({})\n",
+                    effect.effect.resource,
+                    plan_op_label(effect.effect.op)
+                ));
+                for action in &effect.missing_actions {
+                    out.push_str(&format!("    -> missing {action}\n"));
+                }
+            }
+            Some(out.trim_end().to_string())
+        }
+    }
+}
+
+pub(crate) fn emit_warnings(result: &IamPreflightResult) {
+    if let Some(warning) = format_warnings(result) {
+        eprintln!("{}", warning.yellow());
+    }
+}
+
+pub(crate) fn should_fail_strict(result: &IamPreflightResult) -> bool {
+    matches!(
+        result,
+        IamPreflightResult::Checked(IamPreflightReport {
+            missing_by_effect,
+            ..
+        }) if !missing_by_effect.is_empty()
+    )
+}
+
+async fn resolve_actor_arn(sts_client: &aws_sdk_sts::Client) -> Result<String, String> {
+    let output = sts_client
+        .get_caller_identity()
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    output
+        .arn()
+        .map(str::to_string)
+        .ok_or_else(|| "GetCallerIdentity returned no ARN".to_string())
+}
+
+fn unique_actions(required: &[RequiredAction]) -> BTreeSet<String> {
+    required.iter().map(|entry| entry.action.clone()).collect()
+}
+
+async fn simulate(
+    actor_arn: &str,
+    actions: &BTreeSet<String>,
+    iam_client: &aws_sdk_iam::Client,
+) -> Result<SimulationResult, SimulateError> {
+    let mut denied_actions = BTreeSet::new();
+    let mut marker: Option<String> = None;
+    loop {
+        let mut request = iam_client
+            .simulate_principal_policy()
+            .policy_source_arn(actor_arn)
+            .resource_arns("*")
+            .set_marker(marker.clone());
+        for action in actions {
+            request = request.action_names(action);
+        }
+
+        let output = request.send().await.map_err(|e| {
+            let msg = e.to_string();
+            if is_access_denied(&msg) {
+                SimulateError::NeedsFallback(msg)
+            } else {
+                SimulateError::Other(msg)
+            }
+        })?;
+
+        denied_actions.extend(
+            output
+                .evaluation_results()
+                .iter()
+                .filter(|result| result.eval_decision() != &PolicyEvaluationDecisionType::Allowed)
+                .map(|result| result.eval_action_name().to_string()),
+        );
+
+        if !output.is_truncated() {
+            break;
+        }
+        marker = output.marker().map(str::to_string);
+        if marker.is_none() {
+            break;
+        }
+    }
+    Ok(SimulationResult { denied_actions })
+}
+
+async fn document_fallback(
+    actor_arn: &str,
+    actions: &BTreeSet<String>,
+    iam_client: &aws_sdk_iam::Client,
+) -> Result<DocumentFallbackResult, String> {
+    let role_name = role_name_from_actor_arn(actor_arn)
+        .ok_or_else(|| format!("actor ARN is not an IAM role or assumed role: {actor_arn}"))?;
+    let mut allowed_actions = BTreeSet::new();
+
+    let inline_policy_names = iam_client
+        .list_role_policies()
+        .role_name(&role_name)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .policy_names()
+        .to_vec();
+    for policy_name in inline_policy_names {
+        let output = iam_client
+            .get_role_policy()
+            .role_name(&role_name)
+            .policy_name(policy_name)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        collect_allowed_actions_from_policy(
+            output.policy_document(),
+            actions,
+            &mut allowed_actions,
+        );
+    }
+
+    let attached = iam_client
+        .list_attached_role_policies()
+        .role_name(&role_name)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .attached_policies()
+        .to_vec();
+    for policy in attached {
+        let Some(policy_arn) = policy.policy_arn() else {
+            continue;
+        };
+        let policy_output = iam_client
+            .get_policy()
+            .policy_arn(policy_arn)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        let Some(default_version_id) = policy_output
+            .policy()
+            .and_then(|policy| policy.default_version_id())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let version_output = iam_client
+            .get_policy_version()
+            .policy_arn(policy_arn)
+            .version_id(default_version_id)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        if let Some(document) = version_output
+            .policy_version()
+            .and_then(|version| version.document())
+        {
+            collect_allowed_actions_from_policy(document, actions, &mut allowed_actions);
+        }
+    }
+
+    Ok(DocumentFallbackResult { allowed_actions })
+}
+
+fn collect_allowed_actions_from_policy(
+    policy_document: &str,
+    required_actions: &BTreeSet<String>,
+    allowed_actions: &mut BTreeSet<String>,
+) {
+    let document = serde_json::from_str::<JsonValue>(policy_document)
+        .or_else(|_| {
+            percent_decode(policy_document).and_then(|decoded| serde_json::from_str(&decoded))
+        })
+        .ok();
+    let Some(document) = document else {
+        return;
+    };
+    let Some(statements) = document.get("Statement") else {
+        return;
+    };
+
+    let statement_values: Vec<&JsonValue> = match statements {
+        JsonValue::Array(items) => items.iter().collect(),
+        value => vec![value],
+    };
+
+    for statement in statement_values {
+        if statement
+            .get("Effect")
+            .and_then(JsonValue::as_str)
+            .is_none_or(|effect| !effect.eq_ignore_ascii_case("Allow"))
+        {
+            continue;
+        }
+        let patterns = action_patterns(statement.get("Action"));
+        for required in required_actions {
+            if patterns
+                .iter()
+                .any(|pattern| action_matches(pattern, required))
+            {
+                allowed_actions.insert(required.clone());
+            }
+        }
+    }
+}
+
+fn action_patterns(value: Option<&JsonValue>) -> Vec<String> {
+    match value {
+        Some(JsonValue::String(action)) => vec![action.clone()],
+        Some(JsonValue::Array(actions)) => actions
+            .iter()
+            .filter_map(JsonValue::as_str)
+            .map(str::to_string)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn action_matches(pattern: &str, action: &str) -> bool {
+    let pattern = pattern.to_ascii_lowercase();
+    let action = action.to_ascii_lowercase();
+    if pattern == "*" || pattern == action {
+        return true;
+    }
+    let Some(prefix) = pattern.strip_suffix('*') else {
+        return false;
+    };
+    action.starts_with(prefix)
+}
+
+fn action_allowed_by_documents(action: &str, allowed_actions: &BTreeSet<String>) -> bool {
+    allowed_actions.contains(action)
+}
+
+fn percent_decode(input: &str) -> Result<String, serde_json::Error> {
+    let mut bytes = Vec::with_capacity(input.len());
+    let input = input.as_bytes();
+    let mut index = 0;
+    while index < input.len() {
+        match input[index] {
+            b'%' if index + 2 < input.len() => {
+                let hex = std::str::from_utf8(&input[index + 1..index + 3]).unwrap_or("");
+                if let Ok(value) = u8::from_str_radix(hex, 16) {
+                    bytes.push(value);
+                    index += 3;
+                    continue;
+                }
+                bytes.push(input[index]);
+                index += 1;
+            }
+            b'+' => {
+                bytes.push(b' ');
+                index += 1;
+            }
+            byte => {
+                bytes.push(byte);
+                index += 1;
+            }
+        }
+    }
+    let decoded = String::from_utf8_lossy(&bytes).into_owned();
+    serde_json::from_str::<JsonValue>(&decoded).map(|_| decoded)
+}
+
+fn group_missing_by_effect(
+    required: &[RequiredAction],
+    missing_actions: &BTreeSet<String>,
+) -> Vec<MissingEffectActions> {
+    let mut grouped: BTreeMap<EffectAddress, BTreeSet<String>> = BTreeMap::new();
+    for entry in required {
+        if missing_actions.contains(&entry.action) {
+            grouped
+                .entry(entry.effect.clone())
+                .or_default()
+                .insert(entry.action.clone());
+        }
+    }
+    grouped
+        .into_iter()
+        .map(|(effect, actions)| MissingEffectActions {
+            effect,
+            missing_actions: actions.into_iter().collect(),
+        })
+        .collect()
+}
+
+fn role_name_from_actor_arn(actor_arn: &str) -> Option<String> {
+    if let Some(rest) = actor_arn.split(":assumed-role/").nth(1) {
+        return rest.split('/').next().map(str::to_string);
+    }
+    if let Some(rest) = actor_arn.split(":role/").nth(1) {
+        return rest.rsplit('/').next().map(str::to_string);
+    }
+    None
+}
+
+fn is_access_denied(message: &str) -> bool {
+    message.contains("AccessDenied")
+        || message.contains("Access Denied")
+        || message.contains("not authorized")
+}
+
+#[cfg(test)]
+fn build_simulate_input_for_test(
+    actor_arn: &str,
+    actions: &BTreeSet<String>,
+    marker: Option<String>,
+) -> aws_sdk_iam::operation::simulate_principal_policy::SimulatePrincipalPolicyInput {
+    let mut builder =
+        aws_sdk_iam::operation::simulate_principal_policy::SimulatePrincipalPolicyInput::builder()
+            .policy_source_arn(actor_arn)
+            .resource_arns("*")
+            .set_marker(marker);
+    for action in actions {
+        builder = builder.action_names(action);
+    }
+    builder.build().expect("simulate input should be valid")
+}
+
+fn plan_op_label(op: PlanOp) -> &'static str {
+    match op {
+        PlanOp::Create => "create",
+        PlanOp::Read => "read",
+        PlanOp::Update => "update",
+        PlanOp::Delete => "delete",
+    }
+}
+
+fn plan_op_rank(op: PlanOp) -> u8 {
+    match op {
+        PlanOp::Read => 0,
+        PlanOp::Create => 1,
+        PlanOp::Update => 2,
+        PlanOp::Delete => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_core::effect::ChangedCreateOnly;
+    use carina_core::provider::{
+        BoxFuture, CreateRequest, DeleteRequest, ProviderError, ProviderResult, ReadRequest,
+        UpdateRequest,
+    };
+    use carina_core::resource::{ConcreteValue, DataSource, Resource, State, Value};
+
+    struct PermissionProvider;
+
+    impl Provider for PermissionProvider {
+        fn name(&self) -> &str {
+            "permission-test"
+        }
+
+        fn read(
+            &self,
+            _id: &ResourceId,
+            _identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("unused")) })
+        }
+
+        fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = resource.id.clone();
+            Box::pin(async move { Err(ProviderError::not_found(id.to_string())) })
+        }
+
+        fn create(
+            &self,
+            _id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("unused")) })
+        }
+
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("unused")) })
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async { Err(ProviderError::internal("unused")) })
+        }
+
+        fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String> {
+            vec![format!("test:{}:{}", plan_op_label(op), id.resource_type)]
+        }
+    }
+
+    #[test]
+    fn collect_required_actions_maps_effect_variants() {
+        let mut plan = Plan::new();
+        let read = DataSource::with_provider("awscc", "identity.User", "me", None);
+        let create = Resource::with_provider("awscc", "ec2.Vpc", "new", None);
+        let update_id = ResourceId::with_provider("awscc", "ec2.Subnet", "old", None);
+        let update_to = Resource::with_provider("awscc", "ec2.Subnet", "old", None);
+        let replace_id = ResourceId::with_provider("awscc", "s3.Bucket", "old", None);
+        let replace_to = Resource::with_provider("awscc", "s3.Bucket", "new", None);
+        let delete_id = ResourceId::with_provider("awscc", "iam.Role", "old", None);
+        let import_id = ResourceId::with_provider("awscc", "logs.Group", "existing", None);
+
+        plan.add(Effect::Read { resource: read });
+        plan.add(Effect::Create(create));
+        plan.add(Effect::Update {
+            id: update_id.clone(),
+            from: Box::new(State::not_found(update_id.clone())),
+            to: update_to,
+            changed_attributes: vec!["cidr".to_string()],
+        });
+        plan.add(Effect::Replace {
+            id: replace_id.clone(),
+            from: Box::new(State::not_found(replace_id.clone())),
+            to: replace_to,
+            directives: Default::default(),
+            changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+            cascading_updates: vec![],
+            temporary_name: None,
+            cascade_ref_hints: vec![],
+        });
+        plan.add(Effect::Delete {
+            id: delete_id.clone(),
+            identifier: "role-id".to_string(),
+            directives: Default::default(),
+            binding: None,
+            dependencies: Default::default(),
+            explicit_dependencies: Default::default(),
+        });
+        plan.add(Effect::Import {
+            id: import_id,
+            identifier: Value::Concrete(ConcreteValue::String("group".to_string())),
+        });
+        plan.add(Effect::Remove {
+            id: ResourceId::with_provider("awscc", "skip.Remove", "x", None),
+        });
+        plan.add(Effect::Move {
+            from: ResourceId::with_provider("awscc", "skip.Move", "x", None),
+            to: ResourceId::with_provider("awscc", "skip.Move", "y", None),
+        });
+
+        let entries = collect_required_actions(&plan, &PermissionProvider);
+        let actions: Vec<_> = entries.into_iter().map(|entry| entry.action).collect();
+
+        assert_eq!(
+            actions,
+            vec![
+                "test:read:identity.User",
+                "test:create:ec2.Vpc",
+                "test:update:ec2.Subnet",
+                "test:delete:s3.Bucket",
+                "test:create:s3.Bucket",
+                "test:delete:iam.Role",
+                "test:read:logs.Group",
+            ]
+        );
+    }
+
+    #[test]
+    fn format_warnings_groups_by_effect_and_marks_fallback_limits() {
+        let result = IamPreflightResult::Checked(IamPreflightReport {
+            actor_arn: "arn:aws:sts::123456789012:assumed-role/deploy/session".to_string(),
+            method: IamCheckMethod::DocumentFallback,
+            missing_by_effect: vec![MissingEffectActions {
+                effect: EffectAddress {
+                    resource: "awscc.elasticloadbalancingv2.LoadBalancer alb".to_string(),
+                    op: PlanOp::Create,
+                },
+                missing_actions: vec![
+                    "iam:CreateServiceLinkedRole".to_string(),
+                    "ec2:DescribeInternetGateways".to_string(),
+                ],
+            }],
+        });
+
+        insta::assert_snapshot!(format_warnings(&result).unwrap(), @r###"
+Warning: IAM preflight check found missing permissions for arn:aws:sts::123456789012:assumed-role/deploy/session using policy document fallback.
+  Weaker check: fallback only matches identity-policy action names; it does not evaluate SCPs, permission boundaries, condition keys, or resource scopes.
+  awscc.elasticloadbalancingv2.LoadBalancer alb (create)
+    -> missing iam:CreateServiceLinkedRole
+    -> missing ec2:DescribeInternetGateways
+"###);
+    }
+
+    #[test]
+    fn policy_document_action_matching_supports_literal_and_prefix_wildcard() {
+        let required = BTreeSet::from([
+            "ec2:DescribeInternetGateways".to_string(),
+            "iam:CreateServiceLinkedRole".to_string(),
+            "s3:CreateBucket".to_string(),
+        ]);
+        let document = r#"{
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "ec2:Describe*", "Resource": "*"},
+                {"Effect": "Allow", "Action": ["iam:CreateServiceLinkedRole"], "Resource": "*"},
+                {"Effect": "Deny", "Action": "s3:*", "Resource": "*"}
+            ]
+        }"#;
+        let mut allowed = BTreeSet::new();
+
+        collect_allowed_actions_from_policy(document, &required, &mut allowed);
+
+        assert_eq!(
+            allowed,
+            BTreeSet::from([
+                "ec2:DescribeInternetGateways".to_string(),
+                "iam:CreateServiceLinkedRole".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn policy_document_action_matching_accepts_url_encoded_iam_documents() {
+        let required = BTreeSet::from(["iam:CreateServiceLinkedRole".to_string()]);
+        let encoded = "%7B%22Statement%22%3A%7B%22Effect%22%3A%22Allow%22%2C%22Action%22%3A%22iam%3ACreateServiceLinkedRole%22%7D%7D";
+        let mut allowed = BTreeSet::new();
+
+        collect_allowed_actions_from_policy(encoded, &required, &mut allowed);
+
+        assert_eq!(
+            allowed,
+            BTreeSet::from(["iam:CreateServiceLinkedRole".to_string()])
+        );
+    }
+
+    #[test]
+    fn role_name_parses_iam_role_and_assumed_role_arns() {
+        assert_eq!(
+            role_name_from_actor_arn("arn:aws:sts::123456789012:assumed-role/deploy/session"),
+            Some("deploy".to_string())
+        );
+        assert_eq!(
+            role_name_from_actor_arn("arn:aws:iam::123456789012:role/path/deploy"),
+            Some("deploy".to_string())
+        );
+        assert_eq!(
+            role_name_from_actor_arn("arn:aws:iam::123456789012:user/alice"),
+            None
+        );
+    }
+
+    #[test]
+    fn simulate_request_input_uses_actor_actions_resource_star_and_marker() {
+        let actions = BTreeSet::from([
+            "ec2:DescribeInternetGateways".to_string(),
+            "iam:CreateServiceLinkedRole".to_string(),
+        ]);
+
+        let input = build_simulate_input_for_test(
+            "arn:aws:sts::123456789012:assumed-role/deploy/session",
+            &actions,
+            Some("next-page".to_string()),
+        );
+
+        assert_eq!(
+            input.policy_source_arn(),
+            Some("arn:aws:sts::123456789012:assumed-role/deploy/session")
+        );
+        assert_eq!(
+            input.action_names(),
+            &[
+                "ec2:DescribeInternetGateways".to_string(),
+                "iam:CreateServiceLinkedRole".to_string()
+            ]
+        );
+        assert_eq!(input.resource_arns(), &["*".to_string()]);
+        assert_eq!(input.marker(), Some("next-page"));
+    }
+}

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod destroy;
 pub mod docs;
 pub mod export;
 pub mod fmt;
+pub(crate) mod iam_preflight;
 pub mod init;
 pub mod lint;
 pub mod migrate_state;

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -411,8 +411,8 @@ pub async fn run_plan(
     tui: bool,
     refresh: bool,
     json: bool,
-    _check_iam: bool,
-    _strict_iam: bool,
+    check_iam: bool,
+    strict_iam: bool,
     provider_context: &ProviderContext,
 ) -> Result<bool, AppError> {
     let loaded = load_configuration_with_config(
@@ -717,6 +717,26 @@ pub async fn run_plan(
             "{} resource(s) have prevent_destroy set and cannot be deleted or replaced",
             ctx.plan.errors().len()
         )));
+    }
+
+    let iam_preflight_result = if check_iam {
+        let result =
+            crate::commands::iam_preflight::run_iam_preflight(&ctx.plan, &ctx.provider, strict_iam)
+                .await;
+        crate::commands::iam_preflight::emit_warnings(&result);
+        Some(result)
+    } else {
+        None
+    };
+    let iam_strict_failed = strict_iam
+        && iam_preflight_result
+            .as_ref()
+            .is_some_and(crate::commands::iam_preflight::should_fail_strict);
+
+    if iam_strict_failed {
+        return Err(AppError::Validation(
+            "IAM preflight check failed in strict mode".to_string(),
+        ));
     }
 
     // Build delete attributes map from current states for display

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -42,6 +42,7 @@ use crate::error::AppError;
 /// Result of creating a plan, with context needed for saving
 pub struct PlanContext {
     pub plan: Plan,
+    pub provider: ProviderRouter,
     pub sorted_resources: Vec<Resource>,
     pub current_states: HashMap<ResourceId, State>,
     /// Maps moved-to resource IDs to their original (moved-from) IDs.
@@ -2104,6 +2105,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
 
     Ok(PlanContext {
         plan,
+        provider,
         sorted_resources,
         current_states,
         moved_origins,


### PR DESCRIPTION
## Summary

- Implements the final `iam_preflight` body from `notes/specs/2026-06-14-iam-preflight-design.md`.
- Runs plan-time IAM permission collection through `Provider::required_permissions` for provider-touching effects, including `Replace` as delete + create and `Import` as read.
- Adds STS caller resolution, IAM `SimulatePrincipalPolicy`, role-policy document fallback, grouped stderr warnings, and strict-mode failure before plan display / `--out` write.

Closes #3496

## Context

This is PR#4 in the IAM preflight chain. It builds on:

- carina#3517: PR#1, core `PlanOp`, provider trait, WIT boundary, CLI flags.
- awscc#367: PR#2, awscc handler permission extraction.
- aws#438: PR#3, aws provider empty implementation.

## IAM Check Behavior

`--check-iam` resolves the current actor with `sts:GetCallerIdentity`, deduplicates required IAM actions across plan effects, and checks them with `iam:SimulatePrincipalPolicy` using `ResourceArns = ["*"]`.

If simulation is denied because the actor lacks `iam:SimulatePrincipalPolicy`, the fallback reads role inline and attached managed policy documents and matches action names. The warning output names this as a weaker check and explicitly states that fallback does not evaluate SCPs, permission boundaries, condition keys, or resource scopes. The Simulate path also notes the design-doc limits around SCPs, condition keys, and exact resource ARN scope.

`--strict-iam` fails with exit code 1 when any missing action is found, before plan display and before `--out` writes the saved plan. Non-strict mode warns and continues, including `--out`, matching the drift-warning style.

## Tests

- `RUSTC_WRAPPER= cargo check -p carina-cli --offline`
- `RUSTC_WRAPPER= cargo nextest run -p carina-cli --offline`
- `RUSTC_WRAPPER= cargo test --workspace --doc --offline`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --offline -- -D warnings`
- `RUSTC_WRAPPER= bash -lc 'for script in scripts/check-*.sh; do bash "$script" || exit $?; done'`

The first script sweep without `RUSTC_WRAPPER=` failed because the sandbox blocked the configured local `sccache-wrapper`; rerunning with plain rustc passed. A full AWS-backed E2E was not added because stubbing the CLI's provider plugin plus STS/IAM SDK clients end-to-end would be heavier than this PR's local seams; coverage instead includes unit tests for effect collection, warning formatting, fallback action matching, URL-encoded IAM documents, role ARN parsing, and Simulate request construction without sending a network request.
