### PR TITLE
refactor(executor): typestate-guard the wait-aware in-flight set

### DIFF
--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -4,8 +4,6 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
-use futures::stream::{FuturesUnordered, StreamExt};
-
 use crate::deps::find_failed_dependency;
 use crate::effect::{Effect, WaitTarget};
 use crate::parser::ResourceRef;
@@ -18,8 +16,8 @@ use super::basic::{
 };
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
 use super::wait::{
-    InFlightKind, UnsatisfiableReason, WaitOutcome, cancel_waits_if_terminal,
-    unsatisfiable_reason_message, wait_failure_message,
+    UnsatisfiableReason, WaitAwareInFlight, WaitOutcome, unsatisfiable_reason_message,
+    wait_failure_message,
 };
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
 
@@ -555,9 +553,7 @@ pub(super) async fn execute_effects_sequential(
         }
     }
 
-    let mut in_flight = FuturesUnordered::new();
-    let mut in_flight_kinds: HashMap<usize, InFlightKind> = HashMap::new();
-    let mut wait_cancellers: HashMap<usize, tokio::sync::watch::Sender<bool>> = HashMap::new();
+    let mut in_flight: WaitAwareInFlight<'_, SingleEffectResult> = WaitAwareInFlight::new();
 
     loop {
         // Find newly ready effects: all deps completed and not yet dispatched
@@ -660,17 +656,7 @@ pub(super) async fn execute_effects_sequential(
                 schemas: input.schemas,
             };
             let completed_ref = &completed;
-            let wait_cancel_rx = if effect.is_wait() {
-                let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
-                wait_cancellers.insert(idx, cancel_tx);
-                in_flight_kinds.insert(idx, InFlightKind::Wait);
-                Some(cancel_rx)
-            } else {
-                in_flight_kinds.insert(idx, InFlightKind::NonWait);
-                None
-            };
-
-            in_flight.push(async move {
+            let make_future = move |wait_cancel_rx: Option<tokio::sync::watch::Receiver<bool>>| async move {
                 let result = match effect.as_basic() {
                     // `BasicEffect` is the type-level contract for
                     // `execute_basic_effect`: any Create/Update/Delete
@@ -779,14 +765,25 @@ pub(super) async fn execute_effects_sequential(
                     },
                 };
                 (idx, result)
-            });
+            };
+
+            if effect.is_wait() {
+                in_flight.push_wait(idx, |cancel_rx| Box::pin(make_future(Some(cancel_rx))));
+            } else {
+                in_flight.push_non_wait(idx, make_future(None));
+            }
         }
 
-        let undispatched_count = actionable_indices
-            .iter()
-            .filter(|&&idx| !dispatched.contains(&idx))
-            .count();
-        cancel_waits_if_terminal(&in_flight_kinds, undispatched_count, &wait_cancellers);
+        let undispatched_count = || {
+            actionable_indices
+                .iter()
+                .filter(|&&idx| !dispatched.contains(&idx))
+                .count()
+        };
+        in_flight
+            .check_terminal(undispatched_count())
+            .cancel_if_terminal()
+            .drop_without_awaiting();
 
         // If nothing is in flight, we're done (or stuck in a cycle)
         if in_flight.is_empty() {
@@ -809,10 +806,15 @@ pub(super) async fn execute_effects_sequential(
         }
 
         // Wait for the next effect to complete
-        let (finished_idx, result) = in_flight.next().await.unwrap();
+        let Some((finished_idx, result)) = in_flight
+            .check_terminal(undispatched_count())
+            .cancel_if_terminal()
+            .next_completed()
+            .await
+        else {
+            break;
+        };
         completed_indices.insert(finished_idx);
-        in_flight_kinds.remove(&finished_idx);
-        wait_cancellers.remove(&finished_idx);
 
         // Process the result and update shared state immediately
         match result {
@@ -924,11 +926,10 @@ pub(super) async fn execute_effects_sequential(
             },
         }
 
-        let undispatched_count = actionable_indices
-            .iter()
-            .filter(|&&idx| !dispatched.contains(&idx))
-            .count();
-        cancel_waits_if_terminal(&in_flight_kinds, undispatched_count, &wait_cancellers);
+        in_flight
+            .check_terminal(undispatched_count())
+            .cancel_if_terminal()
+            .drop_without_awaiting();
     }
 
     let failed_refreshes = refresh_pending_states(

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -18,8 +18,8 @@ use super::basic::{
 };
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::wait::{
-    InFlightKind, UnsatisfiableReason, WaitOutcome, cancel_waits_if_terminal,
-    unsatisfiable_reason_message, wait_failure_message,
+    UnsatisfiableReason, WaitAwareInFlight, WaitOutcome, unsatisfiable_reason_message,
+    wait_failure_message,
 };
 use super::{
     ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo,
@@ -393,11 +393,7 @@ pub(super) async fn execute_effects_phased(
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
-        type PhaseFuture<'a> =
-            std::pin::Pin<Box<dyn std::future::Future<Output = (usize, PhaseEffectResult)> + 'a>>;
-        let mut in_flight: FuturesUnordered<PhaseFuture<'_>> = FuturesUnordered::new();
-        let mut in_flight_kinds: HashMap<usize, InFlightKind> = HashMap::new();
-        let mut wait_cancellers: HashMap<usize, tokio::sync::watch::Sender<bool>> = HashMap::new();
+        let mut in_flight: WaitAwareInFlight<'_, PhaseEffectResult> = WaitAwareInFlight::new();
 
         loop {
             let mut newly_ready: Vec<usize> = Vec::new();
@@ -469,34 +465,32 @@ pub(super) async fn execute_effects_phased(
                         completed: c,
                         total,
                     };
-                    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
-                    wait_cancellers.insert(idx, cancel_tx);
-                    in_flight_kinds.insert(idx, InFlightKind::Wait);
-
-                    in_flight.push(Box::pin(async move {
-                        let started = Instant::now();
-                        observer.on_event(&ExecutionEvent::EffectStarted { effect });
-                        let outcome = super::wait::execute_wait_effect(
-                            provider,
-                            target_id,
-                            wait_identifier.as_deref(),
-                            until,
-                            *timeout,
-                            *interval,
-                            cancel_rx,
-                            observer,
-                        )
-                        .await;
-                        (
-                            idx,
-                            PhaseEffectResult::Wait {
-                                binding: binding.clone(),
-                                outcome,
-                                duration: started.elapsed(),
-                                progress,
-                            },
-                        )
-                    }));
+                    in_flight.push_wait(idx, |cancel_rx| {
+                        Box::pin(async move {
+                            let started = Instant::now();
+                            observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                            let outcome = super::wait::execute_wait_effect(
+                                provider,
+                                target_id,
+                                wait_identifier.as_deref(),
+                                until,
+                                *timeout,
+                                *interval,
+                                cancel_rx,
+                                observer,
+                            )
+                            .await;
+                            (
+                                idx,
+                                PhaseEffectResult::Wait {
+                                    binding: binding.clone(),
+                                    outcome,
+                                    duration: started.elapsed(),
+                                    progress,
+                                },
+                            )
+                        })
+                    });
                     continue;
                 }
 
@@ -526,9 +520,8 @@ pub(super) async fn execute_effects_phased(
                     schemas: input.schemas,
                 };
                 let completed_ref = &completed;
-                in_flight_kinds.insert(idx, InFlightKind::NonWait);
 
-                in_flight.push(Box::pin(async move {
+                in_flight.push_non_wait(idx, async move {
                     let basic = execute_basic_effect(
                         basic_effect,
                         &BasicEffectCtx {
@@ -543,23 +536,33 @@ pub(super) async fn execute_effects_phased(
                     )
                     .await;
                     (idx, PhaseEffectResult::Basic(basic))
-                }));
+                });
             }
 
-            let undispatched_count = phase1_indices
-                .iter()
-                .filter(|&&idx| !dispatched.contains(&idx))
-                .count();
-            cancel_waits_if_terminal(&in_flight_kinds, undispatched_count, &wait_cancellers);
+            let undispatched_count = || {
+                phase1_indices
+                    .iter()
+                    .filter(|&&idx| !dispatched.contains(&idx))
+                    .count()
+            };
+            in_flight
+                .check_terminal(undispatched_count())
+                .cancel_if_terminal()
+                .drop_without_awaiting();
 
             if in_flight.is_empty() {
                 break;
             }
 
-            let (finished_idx, result) = in_flight.next().await.unwrap();
+            let Some((finished_idx, result)) = in_flight
+                .check_terminal(undispatched_count())
+                .cancel_if_terminal()
+                .next_completed()
+                .await
+            else {
+                break;
+            };
             completed_indices.insert(finished_idx);
-            in_flight_kinds.remove(&finished_idx);
-            wait_cancellers.remove(&finished_idx);
 
             match result {
                 PhaseEffectResult::Basic(basic) => {
@@ -630,11 +633,10 @@ pub(super) async fn execute_effects_phased(
                 _ => unreachable!(),
             }
 
-            let undispatched_count = phase1_indices
-                .iter()
-                .filter(|&&idx| !dispatched.contains(&idx))
-                .count();
-            cancel_waits_if_terminal(&in_flight_kinds, undispatched_count, &wait_cancellers);
+            in_flight
+                .check_terminal(undispatched_count())
+                .cancel_if_terminal()
+                .drop_without_awaiting();
         }
     }
 

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -8,7 +8,11 @@
 //! See `notes/specs/2026-05-09-wait-construct-design.md` §Executor logic.
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
+
+use futures::stream::{FuturesUnordered, StreamExt};
 
 use crate::executor::{ExecutionEvent, ExecutionObserver};
 use crate::provider::{Provider, ProviderError, ReadRequest};
@@ -94,6 +98,114 @@ pub(super) fn cancel_waits_if_terminal(
             let _ = cancel.send(true);
         }
     }
+}
+
+/// Wait-aware in-flight future set with typestate-guarded terminal checks.
+///
+/// You cannot push while a [`TerminalCheck`] or [`NextReady`] is alive because
+/// both hold a mutable borrow of this set. The only way to await the next
+/// completed future is through `cancel_if_terminal().next_completed()`, so the
+/// terminal wait cancellation check cannot be skipped.
+#[allow(clippy::type_complexity)]
+pub(super) struct WaitAwareInFlight<'fut, R> {
+    inner: FuturesUnordered<Pin<Box<dyn Future<Output = (usize, R)> + 'fut>>>,
+    kinds: HashMap<usize, InFlightKind>,
+    cancellers: HashMap<usize, tokio::sync::watch::Sender<bool>>,
+}
+
+impl<'fut, R> WaitAwareInFlight<'fut, R> {
+    /// Create an empty wait-aware in-flight set.
+    pub(super) fn new() -> Self {
+        Self {
+            inner: FuturesUnordered::new(),
+            kinds: HashMap::new(),
+            cancellers: HashMap::new(),
+        }
+    }
+
+    /// Return `true` when no futures are currently in flight.
+    pub(super) fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Return the number of futures currently in flight.
+    pub(super) fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Dispatch a non-wait future and record its in-flight kind.
+    pub(super) fn push_non_wait<F>(&mut self, idx: usize, fut: F)
+    where
+        F: Future<Output = (usize, R)> + 'fut,
+    {
+        self.inner.push(Box::pin(fut));
+        self.kinds.insert(idx, InFlightKind::NonWait);
+    }
+
+    /// Dispatch a wait future and register its cancellation sender.
+    pub(super) fn push_wait<MkFut>(&mut self, idx: usize, mk_fut: MkFut)
+    where
+        MkFut: FnOnce(
+            tokio::sync::watch::Receiver<bool>,
+        ) -> Pin<Box<dyn Future<Output = (usize, R)> + 'fut>>,
+    {
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        self.cancellers.insert(idx, cancel_tx);
+        self.kinds.insert(idx, InFlightKind::Wait);
+        self.inner.push(mk_fut(cancel_rx));
+    }
+
+    /// Begin the required terminal wait cancellation check before awaiting.
+    #[must_use = "TerminalCheck must be consumed via cancel_if_terminal() to advance the loop"]
+    pub(super) fn check_terminal(
+        &mut self,
+        undispatched_count: usize,
+    ) -> TerminalCheck<'_, 'fut, R> {
+        TerminalCheck {
+            parent: self,
+            undispatched_count,
+        }
+    }
+}
+
+/// Terminal-check typestate handle that blocks further pushes while alive.
+#[must_use = "TerminalCheck must be consumed via cancel_if_terminal()"]
+pub(super) struct TerminalCheck<'a, 'fut, R> {
+    parent: &'a mut WaitAwareInFlight<'fut, R>,
+    undispatched_count: usize,
+}
+
+impl<'a, 'fut, R> TerminalCheck<'a, 'fut, R> {
+    /// Cancel waits if only waits remain and no undispatched effects exist.
+    pub(super) fn cancel_if_terminal(self) -> NextReady<'a, 'fut, R> {
+        cancel_waits_if_terminal(
+            &self.parent.kinds,
+            self.undispatched_count,
+            &self.parent.cancellers,
+        );
+        NextReady {
+            parent: self.parent,
+        }
+    }
+}
+
+/// Ready-to-await typestate handle produced after terminal checking.
+#[must_use = "NextReady must be awaited or explicitly dropped"]
+pub(super) struct NextReady<'a, 'fut, R> {
+    parent: &'a mut WaitAwareInFlight<'fut, R>,
+}
+
+impl<'a, 'fut, R> NextReady<'a, 'fut, R> {
+    /// Await the next completion and clean up its wait-aware bookkeeping.
+    pub(super) async fn next_completed(self) -> Option<(usize, R)> {
+        let (idx, result) = self.parent.inner.next().await?;
+        self.parent.kinds.remove(&idx);
+        self.parent.cancellers.remove(&idx);
+        Some((idx, result))
+    }
+
+    /// Explicitly drop this ready handle without awaiting a completion.
+    pub(super) fn drop_without_awaiting(self) {}
 }
 
 /// Run the wait polling loop:

--- a/notes/specs/2026-06-14-wait-typestate-in-flight-design.md
+++ b/notes/specs/2026-06-14-wait-typestate-in-flight-design.md
@@ -1,0 +1,165 @@
+# wait-aware in-flight typestate — 設計
+
+Issue: carina#3516 step (b)  
+親 issue: #3497 / #3515
+
+## 解こうとしている問題
+
+#3515 で入れた fail-fast 機構は次の 4 ステップを **全 executor loop で順番どおりに** 実行する前提で成り立っている。
+
+1. dispatch するときに、wait なら `tokio::sync::watch` channel を作って `wait_cancellers.insert(idx, sender)` し、`in_flight_kinds.insert(idx, InFlightKind::Wait)` する。non-wait は `NonWait` を入れる。
+2. dispatch 直後と 結果処理直後の 2 ヶ所で `cancel_waits_if_terminal(in_flight_kinds, undispatched, wait_cancellers)` を呼ぶ。
+3. `in_flight.next().await` から返ってきたら `in_flight_kinds.remove(&idx)` と `wait_cancellers.remove(&idx)` をする。
+4. wait の `SingleEffectResult` を `match` するときに、`Satisfied / Unsatisfiable / Timeout / NotFound / ReadFailed` を漏れなく扱う(これは `WaitOutcome` の型で保証されている)。
+
+このうち 1〜3 は **生 `HashMap` と `FuturesUnordered` の直叩き**で書かれていて、新しい executor loop を足すときに「うっかり cancel 呼び忘れる」「`wait_cancellers` の insert を忘れる」「remove を忘れる」が全部 compile error にならない。#3515 の review round 1 で指摘されたとおり、これは convention level の保護。
+
+`InFlightKind::Wait` ⇄ `wait_cancellers` の 2 つを別々のマップに散らかしているのもエラーを誘発する形。同じ idx に対して片方だけ insert / 片方だけ remove する書き間違いがしうる。
+
+## ねらい
+
+- **型レベル**で「wait future の push」と「cancel sender の registration」を 1 アクションにまとめる。
+- **型レベル**で「`in_flight.next().await` の前に terminal check を必ず通る」ことを強制する。
+- 既存の 2 ヶ所 (`parallel.rs::execute_effects_sequential` と `phased.rs::execute_effects_phased` Phase 1) の loop を、新型を使う形に書き直す。挙動と test は何も変えない。
+- `unsatisfiable_reason_message` / `wait_failure_message` / `InFlightKind` は既に wait.rs に集約済み。これらは触らない。
+
+## 型シェイプ
+
+`carina-core/src/executor/wait.rs` に追加する `WaitAwareInFlight` 構造体。
+
+```rust
+pub(super) struct WaitAwareInFlight<'a, R> {
+    inner: FuturesUnordered<Pin<Box<dyn Future<Output = (usize, R)> + 'a>>>,
+    kinds: HashMap<usize, InFlightKind>,
+    cancellers: HashMap<usize, watch::Sender<bool>>,
+}
+
+impl<'a, R> WaitAwareInFlight<'a, R> {
+    pub fn new() -> Self { ... }
+
+    /// dispatch a non-wait future. Caller hands over a future producing
+    /// `(idx, R)`. Tracking is automatic.
+    pub fn push_non_wait(
+        &mut self,
+        idx: usize,
+        fut: impl Future<Output = (usize, R)> + 'a,
+    ) { ... }
+
+    /// dispatch a wait future. Returns the cancel `watch::Receiver` so the
+    /// caller threads it into `execute_wait_effect`. The sender is owned
+    /// internally — caller cannot forget to register it.
+    pub fn push_wait(
+        &mut self,
+        idx: usize,
+        fut_with_cancel: impl FnOnce(watch::Receiver<bool>) -> Pin<Box<dyn Future<Output = (usize, R)> + 'a>>,
+    ) { ... }
+
+    /// Returns the typestate-guarded ready handle.
+    /// Caller MUST consume it before the next dispatch tick.
+    /// Holds the loop progress fact ("we just observed terminal-or-not").
+    #[must_use = "TerminalCheck must be consumed via inspect_terminal() to advance the loop"]
+    pub fn check_terminal(
+        &mut self,
+        undispatched_count: usize,
+    ) -> TerminalCheck<'_, 'a, R> { ... }
+
+    pub fn is_empty(&self) -> bool { self.inner.is_empty() }
+
+    pub fn len(&self) -> usize { self.inner.len() }
+}
+
+/// One-shot RAII handle: created by `check_terminal()`, consumed by
+/// `next_completed()`. While alive, no further push is allowed
+/// (compile-enforced by &mut borrow of `WaitAwareInFlight`).
+#[must_use]
+pub(super) struct TerminalCheck<'a, 'fut, R> {
+    parent: &'a mut WaitAwareInFlight<'fut, R>,
+}
+
+impl<'a, 'fut, R> TerminalCheck<'a, 'fut, R> {
+    /// If the in-flight set is exactly "only waits, nothing else to
+    /// dispatch", send cancel to every wait. Idempotent.
+    pub fn cancel_if_terminal(self) -> NextReady<'a, 'fut, R> {
+        if cancel_waits_if_terminal(&self.parent.kinds, /* undispatched */ 0, &self.parent.cancellers) {
+            // signal sent
+        }
+        NextReady { parent: self.parent }
+    }
+}
+
+#[must_use]
+pub(super) struct NextReady<'a, 'fut, R> {
+    parent: &'a mut WaitAwareInFlight<'fut, R>,
+}
+
+impl<'a, 'fut, R> NextReady<'a, 'fut, R> {
+    /// Await the next completion. On completion, cleans up `kinds` and
+    /// `cancellers` for that idx — caller cannot forget.
+    pub async fn next_completed(self) -> Option<(usize, R)> {
+        let (idx, r) = self.parent.inner.next().await?;
+        self.parent.kinds.remove(&idx);
+        self.parent.cancellers.remove(&idx);
+        Some((idx, r))
+    }
+}
+```
+
+### この型で禁止される書き方
+
+- `in_flight.push(...)` を直接呼ぶ → 型上できない(`inner` は `pub` でない)。
+- wait future を push して cancel sender の登録を忘れる → `push_wait` の引数が `FnOnce(Receiver) -> Future` なので、cancel channel を作って sender を登録した上で receiver を渡す経路しか書けない。
+- `check_terminal()` を呼ばずに `next().await` する → `next_completed` は `NextReady` の method、`NextReady` は `TerminalCheck::cancel_if_terminal()` 経由でしか作れない。`#[must_use]` も付くので drop で warning。
+- `next().await` 後の `remove` 忘れ → `NextReady::next_completed` の中で必ず行うので呼び忘れ不能。
+
+両方の loop が `check_terminal().cancel_if_terminal().next_completed()` のチェーンを通る形になる。新しい loop を将来追加する人は、push しただけでは next を await できず、自然に terminal check 経由のチェーンを書く。
+
+### `cancel_waits_if_terminal` の引数の取り回し
+
+現状の helper は `undispatched_count: usize` を引数で取る。`TerminalCheck` から呼ぶときも `undispatched_count` が必要なので、`check_terminal(undispatched_count)` が引数を受け取り `TerminalCheck` がそれを保持して `cancel_if_terminal` 内で使う。
+
+### dispatch loop での 2 回チェック
+
+#3515 では「dispatch loop の後」と「結果処理の後」の 2 ヶ所で `cancel_waits_if_terminal` を呼んでいた。新型でも同じ 2 ヶ所で `check_terminal(...).cancel_if_terminal()` を呼べばよい(2 回目の戻り値 `NextReady` を `next_completed` で消費)。1 回目の戻り値 `NextReady` は使わずに drop しても `#[must_use]` の warning が出るので分かる。
+
+1 回目の呼び出しが「過渡的(まだ next_completed の前)」、2 回目が「実際に進む」という形にする。両方とも `cancel_if_terminal` までは呼んで、1 回目だけ `NextReady::next_completed` を呼ばずに済む API にしたい。具体的には:
+
+```rust
+// 1 回目: dispatch 直後。状態だけ更新したい。
+in_flight.check_terminal(undispatched()).cancel_if_terminal().drop_without_awaiting();
+
+// 2 回目: 実際に next 取り出す。
+let (idx, r) = in_flight
+    .check_terminal(undispatched())
+    .cancel_if_terminal()
+    .next_completed()
+    .await
+    .expect("in_flight non-empty in loop body");
+```
+
+`drop_without_awaiting()` は `NextReady` を消費して `()` を返すだけのメソッド。`#[must_use]` を満たす逃げ道。
+
+## 範囲
+
+- `carina-core/src/executor/wait.rs` に typestate 型 (`WaitAwareInFlight`, `TerminalCheck`, `NextReady`) を追加。既存 helper (`cancel_waits_if_terminal` 等) は内部で再利用。
+- `carina-core/src/executor/parallel.rs::execute_effects_sequential` を新型に書き換え。生 `in_flight: FuturesUnordered`、`in_flight_kinds: HashMap`、`wait_cancellers: HashMap` を削除し、`WaitAwareInFlight` に置換。
+- `carina-core/src/executor/phased.rs::execute_effects_phased` Phase 1 で同じ置換。Phase 2/3/4 は wait を扱わないので非対象。
+- 既存 test は全部素通り(挙動変更なし)。新規 test は不要 — 既存の `wait_marked_unsatisfiable_when_only_waits_in_flight` 系が依然として通れば、挙動互換は証明された。
+
+## 1 PR でやり、やらないこと
+
+やる: 上記 4 つ。  
+やらない: step (c) の plan-time mutator inference。
+
+## 検証戦略
+
+- 既存 test 一式 (parallel/phased の `wait_marked_unsatisfiable_*` を含む) が変更なしで全部 pass。
+- `cargo nextest run --workspace --all-features` / clippy / doc-tests / scripts/check-*.sh が全部 green。
+- 静的に意図された compile error が起きることを確かめる "trybuild" 風テストは入れない(workspace に trybuild が無いため範囲外)。代わりに、新しい API doc に「これらを直接 push したり remove したりできない」旨を書いて signal にする。
+
+## 段階
+
+1. 設計レビュー(この doc)
+2. 型を追加(wait.rs)
+3. parallel.rs 置換
+4. phased.rs 置換
+5. verify → 5-round review → PR


### PR DESCRIPTION
## Summary

PR #3515 (carina#3497) は wait fail-fast の runtime check を入れたが、それは "executor の全 loop で `cancel_waits_if_terminal` を順番通り呼ぶ" という **convention に依存**していた。新しい executor loop を将来追加するときに呼び忘れると silent regress するので、型レベルで強制する。

#3516 で予告した step (b)。step (a) は #3519 で済み。

## 何を強制したいか

#3515 では次の 4 ステップを 3 つの生コンテナ (`FuturesUnordered`, `HashMap<idx, InFlightKind>`, `HashMap<idx, watch::Sender<bool>>`) を直接触って書いていた:

1. dispatch のとき、wait なら watch channel を作って sender を `wait_cancellers` に登録し、`in_flight_kinds` に `Wait` を入れる。non-wait は `NonWait` を入れる。
2. dispatch 直後と結果処理直後の 2 ヶ所で `cancel_waits_if_terminal(...)` を呼ぶ。
3. `in_flight.next().await` の戻り idx に対して 2 つのマップから `remove` する。
4. wait の `WaitOutcome` を網羅的に match する(これは元から型で保証)。

1〜3 が convention-level で、loop を新規に書く人が片方のマップだけ insert したり、`cancel_waits_if_terminal` を呼び忘れたりしても compile error にならない。

## どう型にしたか

新しい `WaitAwareInFlight` 構造体に 3 コンテナを集約し、次のチェーンでしか await できないようにする:

```rust
in_flight
    .check_terminal(undispatched_count())
    .cancel_if_terminal()
    .next_completed()
    .await
```

中間の `TerminalCheck` と `NextReady` は `&mut WaitAwareInFlight` を保持する short-lived ハンドル。それぞれ `#[must_use]` 付き。

成立する不変条件:

- **wait future を push して cancel sender 登録を忘れる**: `push_wait(idx, FnOnce(Receiver) -> Future)` の引数が「receiver を渡すと future を返すクロージャ」なので、watch channel を作って sender を登録した上で receiver を渡す経路しか型上書けない。
- **`check_terminal` を呼ばずに await する**: `next_completed()` は `NextReady` の method で、`NextReady` は `TerminalCheck::cancel_if_terminal()` 経由でしか作れない。
- **await 後の cleanup 忘れ**: `next_completed()` が完了 idx を内部で `kinds` / `cancellers` から remove する。caller は触らない。
- **terminal check 中の push**: `TerminalCheck` が `&mut WaitAwareInFlight` を保持しているので、生存中の push は borrow check で落ちる。

dispatch loop の "状態だけ更新したい" 場面用に `NextReady::drop_without_awaiting()` を用意してあるので、`#[must_use]` の縛りはちゃんと使い切れる。

## 変更

- `carina-core/src/executor/wait.rs`: `WaitAwareInFlight`, `TerminalCheck`, `NextReady` を追加 (+112 行)。既存の `cancel_waits_if_terminal` 関数はそのまま、`TerminalCheck::cancel_if_terminal` 内部で再利用。
- `carina-core/src/executor/parallel.rs::execute_effects_sequential`: 生 `FuturesUnordered` + 2 つの map の宣言を削除、`WaitAwareInFlight::new()` に置換。dispatch / await を typestate チェーン経由に書き直し。-29 行。
- `carina-core/src/executor/phased.rs::execute_effects_phased` Phase 1: 同じ置換。-53 行。
- `notes/specs/2026-06-14-wait-typestate-in-flight-design.md`: 設計書。

## 挙動は変えない

- terminal check の呼び出しポイントは元と同じ (dispatch 後 + await 直前 + 結果処理後) で、`cancel_if_terminal` が同じ helper を呼ぶ。
- 既存テスト (`wait_marked_unsatisfiable_when_only_waits_in_flight` を parallel と phased の両方で含む) を **無修正で** 通している。
- ユーザに見える surface は変わらない。

## Out of scope

- step (c) "plan-time mutator inference" — Issue #3516 のコメントに書いた通り、これは provider-domain 知識への依存があるので別途設計判断 (`satisfied_by` field 案 vs `Provider::satisfier_hint` API 案) が必要。

## Test plan

- [x] `cargo nextest run --workspace --all-features`
- [x] `cargo nextest run -p carina-core --all-features wait_marked_unsatisfiable` — parallel + phased 両方 pass
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

Refs #3516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
