### PR TITLE
feat(provider): add satisfier_hint trait method + WASM host wiring

### DIFF
--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -13,6 +13,8 @@ use crate::effect::PlanOp;
 use crate::executor::normalized::NormalizedResource;
 use crate::resource::{ConcreteValue, DataSource, Directives, Resource, ResourceId, State, Value};
 use crate::schema::{SchemaRegistry, TypeIdentity};
+use crate::wait::BindingPattern;
+use crate::wait::predicate::AttrPath;
 
 /// Contextual metadata attached to every [`ProviderError`] variant.
 ///
@@ -593,6 +595,16 @@ pub trait Provider: Send + Sync {
     /// Permissions this provider needs to perform `op` on `id`.
     /// Empty vec means the provider declares no permissions for this resource/op pair.
     fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String>;
+
+    /// Binding-name patterns for resources that can satisfy a wait on `target_id.attr_path`.
+    /// Empty vec means the provider declares no satisfier hint for this target attribute.
+    fn satisfier_hint(
+        &self,
+        _target_id: &ResourceId,
+        _attr_path: &AttrPath,
+    ) -> Vec<BindingPattern> {
+        Vec::new()
+    }
 }
 
 /// Convenience for a `ProviderNormalizer` method that does nothing.
@@ -911,6 +923,13 @@ impl Provider for ProviderRouter {
     fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String> {
         match self.get_provider_or_error(id) {
             Ok(provider) => provider.required_permissions(id, op),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn satisfier_hint(&self, target_id: &ResourceId, attr_path: &AttrPath) -> Vec<BindingPattern> {
+        match self.get_provider_or_error(target_id) {
+            Ok(provider) => provider.satisfier_hint(target_id, attr_path),
             Err(_) => Vec::new(),
         }
     }
@@ -1324,6 +1343,10 @@ impl Provider for Box<dyn Provider> {
     fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String> {
         (**self).required_permissions(id, op)
     }
+
+    fn satisfier_hint(&self, target_id: &ResourceId, attr_path: &AttrPath) -> Vec<BindingPattern> {
+        (**self).satisfier_hint(target_id, attr_path)
+    }
 }
 
 #[cfg(test)]
@@ -1423,6 +1446,16 @@ mod tests {
         let id = ResourceId::new("test", "example");
         let state = provider.read(&id, None, ReadRequest).await.unwrap();
         assert!(!state.exists);
+    }
+
+    #[test]
+    fn provider_default_satisfier_hint_is_empty() {
+        let provider = MockProvider;
+        let id = ResourceId::new("test", "example");
+        assert_eq!(
+            provider.satisfier_hint(&id, &AttrPath::single("status")),
+            Vec::new()
+        );
     }
 
     /// A provider that only accepts a data source when the full `Resource`

--- a/carina-core/src/wait/mod.rs
+++ b/carina-core/src/wait/mod.rs
@@ -4,5 +4,20 @@
 
 pub mod predicate;
 
+use predicate::AttrPath;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BindingPattern {
+    Exact(String),
+    ForLoopChildren {
+        base: String,
+    },
+    AttributeMatch {
+        resource_type: String,
+        attr: AttrPath,
+        from: AttrPath,
+    },
+}
+
 #[cfg(test)]
 mod tests;

--- a/carina-core/src/wait/predicate.rs
+++ b/carina-core/src/wait/predicate.rs
@@ -16,7 +16,7 @@ use crate::resource::Value;
 /// MVP only resolves a single top-level segment; nested-field traversal
 /// (`renewal_summary.renewal_status`) is reserved for a follow-up that
 /// teaches the evaluator to descend into `Value::Concrete(ConcreteValue::Map)`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AttrPath {
     pub segments: Vec<String>,
 }

--- a/carina-core/src/wait/tests.rs
+++ b/carina-core/src/wait/tests.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use crate::resource::{ConcreteValue, Value};
+use crate::wait::BindingPattern;
 use crate::wait::predicate::{AttrPath, WaitPredicate};
 
 #[test]
@@ -39,4 +41,57 @@ fn equals_returns_false_when_attribute_absent() {
     };
     let attrs: HashMap<String, Value> = HashMap::new();
     assert!(!pred.evaluate(&attrs));
+}
+
+#[test]
+fn binding_pattern_variants_construct_and_debug_print() {
+    let exact = BindingPattern::Exact("record".to_string());
+    assert_eq!(format!("{exact:?}"), r#"Exact("record")"#);
+
+    let children = BindingPattern::ForLoopChildren {
+        base: "records".to_string(),
+    };
+    assert_eq!(
+        format!("{children:?}"),
+        r#"ForLoopChildren { base: "records" }"#
+    );
+
+    let attribute_match = BindingPattern::AttributeMatch {
+        resource_type: "route53.RecordSet".to_string(),
+        attr: AttrPath {
+            segments: vec!["name".to_string()],
+        },
+        from: AttrPath {
+            segments: vec![
+                "domain_validation_options".to_string(),
+                "resource_record".to_string(),
+                "name".to_string(),
+            ],
+        },
+    };
+    assert!(format!("{attribute_match:?}").contains("AttributeMatch"));
+}
+
+#[test]
+fn binding_pattern_compares_and_hashes() {
+    let first = BindingPattern::AttributeMatch {
+        resource_type: "route53.RecordSet".to_string(),
+        attr: AttrPath::single("name"),
+        from: AttrPath::single("resource_record_name"),
+    };
+    let same = BindingPattern::AttributeMatch {
+        resource_type: "route53.RecordSet".to_string(),
+        attr: AttrPath::single("name"),
+        from: AttrPath::single("resource_record_name"),
+    };
+    let different = BindingPattern::Exact("record".to_string());
+
+    assert_eq!(first, same);
+    assert_ne!(first, different);
+
+    let mut set = HashSet::new();
+    set.insert(first);
+    set.insert(same);
+    set.insert(different);
+    assert_eq!(set.len(), 2);
 }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -19,6 +19,8 @@ use carina_core::schema::{
     ResourceSchema as CoreResourceSchema, StructField as CoreStructField, legacy_validator,
 };
 use carina_core::value::{SerializationContext, SerializationError};
+use carina_core::wait::BindingPattern as CoreBindingPattern;
+use carina_core::wait::predicate::AttrPath as CoreAttrPath;
 
 use carina_provider_protocol::types as proto;
 
@@ -220,6 +222,40 @@ pub fn core_to_wit_plan_op(op: CorePlanOp) -> wit_provider::PlanOp {
         CorePlanOp::Read => wit_provider::PlanOp::Read,
         CorePlanOp::Update => wit_provider::PlanOp::Update,
         CorePlanOp::Delete => wit_provider::PlanOp::Delete,
+    }
+}
+
+pub fn core_to_wit_binding_pattern(p: &CoreBindingPattern) -> wit::BindingPattern {
+    match p {
+        CoreBindingPattern::Exact(name) => wit::BindingPattern::Exact(name.clone()),
+        CoreBindingPattern::ForLoopChildren { base } => {
+            wit::BindingPattern::ForLoopChildren(base.clone())
+        }
+        CoreBindingPattern::AttributeMatch {
+            resource_type,
+            attr,
+            from,
+        } => wit::BindingPattern::AttributeMatch(wit::AttributeMatchPattern {
+            resource_type: resource_type.clone(),
+            attr: attr.segments.clone(),
+            from: from.segments.clone(),
+        }),
+    }
+}
+
+pub fn wit_to_core_binding_pattern(p: wit::BindingPattern) -> CoreBindingPattern {
+    match p {
+        wit::BindingPattern::Exact(name) => CoreBindingPattern::Exact(name),
+        wit::BindingPattern::ForLoopChildren(base) => CoreBindingPattern::ForLoopChildren { base },
+        wit::BindingPattern::AttributeMatch(pattern) => CoreBindingPattern::AttributeMatch {
+            resource_type: pattern.resource_type,
+            attr: CoreAttrPath {
+                segments: pattern.attr,
+            },
+            from: CoreAttrPath {
+                segments: pattern.from,
+            },
+        },
     }
 }
 
@@ -1025,6 +1061,32 @@ mod tests {
             length,
             validate: None,
             to_dsl: None,
+        }
+    }
+
+    #[test]
+    fn binding_pattern_round_trips_through_wit() {
+        let patterns = vec![
+            CoreBindingPattern::Exact("validation_record".to_string()),
+            CoreBindingPattern::ForLoopChildren {
+                base: "validation_records".to_string(),
+            },
+            CoreBindingPattern::AttributeMatch {
+                resource_type: "route53.RecordSet".to_string(),
+                attr: CoreAttrPath::single("name"),
+                from: CoreAttrPath {
+                    segments: vec![
+                        "domain_validation_options".to_string(),
+                        "resource_record".to_string(),
+                        "name".to_string(),
+                    ],
+                },
+            },
+        ];
+
+        for pattern in patterns {
+            let wit = core_to_wit_binding_pattern(&pattern);
+            assert_eq!(wit_to_core_binding_pattern(wit), pattern);
         }
     }
 

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -28,6 +28,8 @@ use carina_core::provider::{
 use carina_core::resource::{DataSource, Resource, ResourceId, State, Value};
 use carina_core::schema::{CompletionValue, ResourceSchema, TypeIdentity};
 use carina_core::value::SerializationError;
+use carina_core::wait::BindingPattern;
+use carina_core::wait::predicate::AttrPath;
 
 use crate::wasm_bindings::CarinaProvider;
 use crate::wasm_bindings_http::CarinaProviderWithHttp;
@@ -912,6 +914,26 @@ impl WasmBindings {
                 };
                 b.carina_provider_provider()
                     .call_required_permissions(store, id, operation)
+                    .await
+            }
+        }
+    }
+
+    async fn call_satisfier_hint(
+        &self,
+        store: &mut Store<HostState>,
+        target_id: &wit_types::ResourceId,
+        attr_path: &[String],
+    ) -> wasmtime::Result<Vec<wit_types::BindingPattern>> {
+        match self {
+            WasmBindings::Basic(b) => {
+                b.carina_provider_provider()
+                    .call_satisfier_hint(store, target_id, attr_path)
+                    .await
+            }
+            WasmBindings::Http(b) => {
+                b.carina_provider_provider()
+                    .call_satisfier_hint(store, target_id, attr_path)
                     .await
             }
         }
@@ -2122,6 +2144,39 @@ impl Provider for WasmProvider {
                     Ok(permissions) => permissions,
                     Err(e) => {
                         log::error!("WASM trap in required_permissions: {e}");
+                        Vec::new()
+                    }
+                }
+            })
+        })
+    }
+
+    fn satisfier_hint(&self, target_id: &ResourceId, attr_path: &AttrPath) -> Vec<BindingPattern> {
+        let wit_id = wasm_convert::core_to_wit_resource_id(target_id);
+        let attr_path = attr_path.segments.clone();
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                let mut locked = match LockedStore::acquire(&self.instance, "satisfier_hint").await
+                {
+                    Ok(locked) => locked,
+                    Err(e) => {
+                        log::error!("WASM satisfier_hint lock failed: {e}");
+                        return Vec::new();
+                    }
+                };
+                let call = self
+                    .instance
+                    .bindings
+                    .call_satisfier_hint(locked.store(), &wit_id, &attr_path)
+                    .await;
+                locked.disarm();
+                match call {
+                    Ok(patterns) => patterns
+                        .into_iter()
+                        .map(wasm_convert::wit_to_core_binding_pattern)
+                        .collect(),
+                    Err(e) => {
+                        log::error!("WASM trap in satisfier_hint: {e}");
                         Vec::new()
                     }
                 }

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -67,6 +67,19 @@ pub enum PlanOp {
     Delete,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BindingPattern {
+    Exact(String),
+    ForLoopChildren {
+        base: String,
+    },
+    AttributeMatch {
+        resource_type: String,
+        attr: Vec<String>,
+        from: Vec<String>,
+    },
+}
+
 /// Trait that provider authors implement.
 #[allow(clippy::result_large_err)]
 pub trait CarinaProvider {
@@ -155,6 +168,16 @@ pub trait CarinaProvider {
     /// Permissions this provider needs to perform `op` on `id`.
     /// Empty vec means the provider declares no permissions for this resource/op pair.
     fn required_permissions(&self, id: &ResourceId, op: PlanOp) -> Vec<String>;
+
+    /// Binding-name patterns for resources that can satisfy a wait on `target_id.attr_path`.
+    /// Empty vec means the provider declares no satisfier hint for this target attribute.
+    fn satisfier_hint(
+        &self,
+        _target_id: &ResourceId,
+        _attr_path: &[String],
+    ) -> Vec<BindingPattern> {
+        Vec::new()
+    }
 
     /// Return provider config attribute completions.
     /// Key is attribute name (e.g., "region"), value is list of completion candidates.

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -349,6 +349,30 @@ macro_rules! export_provider {
                 }
             }
 
+            fn sdk_to_wit_binding_pattern(
+                pattern: &$crate::BindingPattern,
+            ) -> wit_types::BindingPattern {
+                match pattern {
+                    $crate::BindingPattern::Exact(name) => {
+                        wit_types::BindingPattern::Exact(name.clone())
+                    }
+                    $crate::BindingPattern::ForLoopChildren { base } => {
+                        wit_types::BindingPattern::ForLoopChildren(base.clone())
+                    }
+                    $crate::BindingPattern::AttributeMatch {
+                        resource_type,
+                        attr,
+                        from,
+                    } => wit_types::BindingPattern::AttributeMatch(
+                        wit_types::AttributeMatchPattern {
+                            resource_type: resource_type.clone(),
+                            attr: attr.clone(),
+                            from: from.clone(),
+                        },
+                    ),
+                }
+            }
+
             struct WasmGuest;
 
             impl exports::carina::provider::provider::Guest for WasmGuest {
@@ -485,6 +509,18 @@ macro_rules! export_provider {
                         &proto_id,
                         wit_to_sdk_plan_op(operation),
                     )
+                }
+
+                fn satisfier_hint(
+                    target_id: wit_types::ResourceId,
+                    attr_path: Vec<String>,
+                ) -> Vec<wit_types::BindingPattern> {
+                    let provider = get_provider().lock().unwrap();
+                    let proto_id = wit_to_proto_resource_id(&target_id);
+                    $crate::CarinaProvider::satisfier_hint(&*provider, &proto_id, &attr_path)
+                        .iter()
+                        .map(sdk_to_wit_binding_pattern)
+                        .collect()
                 }
 
                 fn provider_config_completions() -> String {
@@ -868,6 +904,30 @@ macro_rules! export_provider {
                 }
             }
 
+            fn sdk_to_wit_binding_pattern(
+                pattern: &$crate::BindingPattern,
+            ) -> wit_types::BindingPattern {
+                match pattern {
+                    $crate::BindingPattern::Exact(name) => {
+                        wit_types::BindingPattern::Exact(name.clone())
+                    }
+                    $crate::BindingPattern::ForLoopChildren { base } => {
+                        wit_types::BindingPattern::ForLoopChildren(base.clone())
+                    }
+                    $crate::BindingPattern::AttributeMatch {
+                        resource_type,
+                        attr,
+                        from,
+                    } => wit_types::BindingPattern::AttributeMatch(
+                        wit_types::AttributeMatchPattern {
+                            resource_type: resource_type.clone(),
+                            attr: attr.clone(),
+                            from: from.clone(),
+                        },
+                    ),
+                }
+            }
+
             struct WasmGuest;
 
             impl exports::carina::provider::provider::Guest for WasmGuest {
@@ -1004,6 +1064,18 @@ macro_rules! export_provider {
                         &proto_id,
                         wit_to_sdk_plan_op(operation),
                     )
+                }
+
+                fn satisfier_hint(
+                    target_id: wit_types::ResourceId,
+                    attr_path: Vec<String>,
+                ) -> Vec<wit_types::BindingPattern> {
+                    let provider = get_provider().lock().unwrap();
+                    let proto_id = wit_to_proto_resource_id(&target_id);
+                    $crate::CarinaProvider::satisfier_hint(&*provider, &proto_id, &attr_path)
+                        .iter()
+                        .map(sdk_to_wit_binding_pattern)
+                        .collect()
                 }
 
                 fn provider_config_completions() -> String {


### PR DESCRIPTION
## Summary

Issue #3516 step (c) **Sub-B (PR 1)**. carina#3516 で予告した satisfier-hint 機構の 4 PR 連鎖の中の最初の実装 PR です。

このPRは plan ステージの挙動を変えません。foundational work で、後続の Sub-C (PR 2) が plan ステージで実 augmentation を行うために必要な型と trait method を用意します。

設計: `notes/specs/2026-06-14-wait-satisfier-hint-design.md`(PR #3523)

## 何を入れたか

新しい trait method:

```rust
fn satisfier_hint(
    &self,
    target_id: &ResourceId,
    attr_path: &AttrPath,
) -> Vec<BindingPattern> {
    Vec::new()
}
```

default は空配列。Provider 実装側が、自分が知っている mutator 関係を型で宣言する。

`BindingPattern` 型:

- `Exact(name)` — 名前完全一致
- `ForLoopChildren { base }` — for ループ展開された子バインディング全部にマッチ
- `AttributeMatch { resource_type, attr, from }` — 「resource_type 型のうち、属性 attr が、target の属性 from を参照しているもの」全部にマッチ。ACM Certificate の satisfier 表現が典型例

`carina-plugin-host` 側の `wasm_convert.rs` と `wasm_factory.rs` で WIT 経由の round-trip も実装。WASM provider plugin が satisfier-hint を実装できる。

## carina-plugin-wit submodule

`208082b` → `03e4997` に bump。中身は別 repo の PR 2 つ:

- carina-plugin-wit#23: `satisfier-hint` 関数と `binding-pattern` variant を追加
- carina-plugin-wit#24: wit-parser の予約語 `from` のエスケープ (`%from`)

## Out of scope

- **Sub-C (PR 2)**: plan ステージで `BindingPattern` をマッチさせて wait の `explicit_dependencies` を補強する logic。これが入ると本来狙っていた fail-fast 動作が実際に効くようになる。
- **Sub-D (PR 3)**: 実際の provider impl(`carina-provider-aws` の ACM など、別 repo の作業)。

## 挙動は変えない

このPRは:

- trait method の default が空を返すので、現状の Provider 実装は何も override せず動く
- plan ステージは `satisfier_hint` を呼んでいないので、plan 出力は変わらない
- 既存テストはすべて pass、無修正

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 4160 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

Refs #3516, #3523

🤖 Generated with [Claude Code](https://claude.com/claude-code)
