### PR TITLE
executor: observe cancellation in sequential and phased executors (T4, #3504)

### DIFF
--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -217,14 +217,18 @@ pub async fn execute_plan(
     provider: &dyn Provider,
     mut input: ExecutionInput<'_>,
     observer: &dyn ExecutionObserver,
-    _cancel: CancellationToken,
+    cancel: CancellationToken,
 ) -> ExecutionOutcome {
-    let result = if has_interdependent_replaces(input.plan.effects()) {
-        execute_effects_phased(provider, &mut input, observer).await
+    let (result, was_cancelled) = if has_interdependent_replaces(input.plan.effects()) {
+        execute_effects_phased(provider, &mut input, observer, &cancel).await
     } else {
-        execute_effects_sequential(provider, &mut input, observer).await
+        execute_effects_sequential(provider, &mut input, observer, &cancel).await
     };
-    ExecutionOutcome::Completed(result)
+    if was_cancelled {
+        ExecutionOutcome::Cancelled(result)
+    } else {
+        ExecutionOutcome::Completed(result)
+    }
 }
 
 #[cfg(test)]

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -4,6 +4,8 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
+use tokio_util::sync::CancellationToken;
+
 use crate::deps::find_failed_dependency;
 use crate::effect::{Effect, WaitTarget};
 use crate::parser::ResourceRef;
@@ -16,8 +18,8 @@ use super::basic::{
 };
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
 use super::wait::{
-    UnsatisfiableReason, WaitAwareInFlight, WaitOutcome, unsatisfiable_reason_message,
-    wait_failure_message,
+    SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome, WaitSignal,
+    unsatisfiable_reason_message, wait_failure_message,
 };
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
 
@@ -143,6 +145,39 @@ mod reads {
 }
 
 use reads::{KnownReads, ReadsSet};
+
+struct CancelSkipCtx<'a> {
+    effects: &'a [Effect],
+    completed: &'a AtomicUsize,
+    total: usize,
+    observer: &'a dyn ExecutionObserver,
+}
+
+fn emit_cancelled_skips(
+    ctx: &CancelSkipCtx<'_>,
+    indices: &[usize],
+    dispatched: &mut HashSet<usize>,
+    completed_indices: &mut HashSet<usize>,
+    skip_count: &mut usize,
+) {
+    for &idx in indices {
+        if dispatched.contains(&idx) {
+            continue;
+        }
+        dispatched.insert(idx);
+        completed_indices.insert(idx);
+        let c = ctx.completed.fetch_add(1, Ordering::Relaxed) + 1;
+        ctx.observer.on_event(&ExecutionEvent::EffectSkipped {
+            effect: &ctx.effects[idx],
+            reason: SKIP_REASON_CANCELLED,
+            progress: ProgressInfo {
+                completed: c,
+                total: ctx.total,
+            },
+        });
+        *skip_count += 1;
+    }
+}
 
 pub(super) struct DependencyAnalysis {
     deps_of: HashMap<usize, HashSet<usize>>,
@@ -508,7 +543,8 @@ pub(super) async fn execute_effects_sequential(
     provider: &dyn Provider,
     input: &mut ExecutionInput<'_>,
     observer: &dyn ExecutionObserver,
-) -> ExecutionResult {
+    cancel: &CancellationToken,
+) -> (ExecutionResult, bool) {
     let mut success_count = 0;
     let mut failure_count = 0;
     let mut skip_count = 0;
@@ -554,39 +590,56 @@ pub(super) async fn execute_effects_sequential(
     }
 
     let mut in_flight: WaitAwareInFlight<'_, SingleEffectResult> = WaitAwareInFlight::new();
+    let mut cancelled = false;
 
     loop {
+        let undispatched_at_loop_start = actionable_indices
+            .iter()
+            .filter(|&&idx| !dispatched.contains(&idx))
+            .count();
+        if cancel.is_cancelled()
+            && !cancelled
+            && (undispatched_at_loop_start > 0 || !in_flight.is_empty())
+        {
+            cancelled = true;
+            in_flight.signal_in_flight_waits();
+        }
+
         // Find newly ready effects: all deps completed and not yet dispatched
         let mut newly_ready: Vec<usize> = Vec::new();
-        for &idx in &actionable_indices {
-            if dispatched.contains(&idx) {
-                continue;
+        if !cancelled {
+            for &idx in &actionable_indices {
+                if dispatched.contains(&idx) {
+                    continue;
+                }
+                let deps = &deps_of[&idx];
+                if deps.iter().all(|d| completed_indices.contains(d)) {
+                    newly_ready.push(idx);
+                }
             }
-            let deps = &deps_of[&idx];
-            if deps.iter().all(|d| completed_indices.contains(d)) {
-                newly_ready.push(idx);
-            }
+            // Sort for deterministic ordering
+            newly_ready.sort();
         }
-        // Sort for deterministic ordering
-        newly_ready.sort();
 
         // Emit Waiting events for effects that have unmet dependencies
-        for &idx in &actionable_indices {
-            if dispatched.contains(&idx) || newly_ready.contains(&idx) {
-                continue;
-            }
-            let deps = &deps_of[&idx];
-            let pending: Vec<String> = deps
-                .iter()
-                .filter(|d| !completed_indices.contains(d))
-                .filter_map(|d| idx_to_binding.get(d).cloned())
-                .collect();
-            if !pending.is_empty() {
-                // Emit on every iteration to update the pending dependency list
-                observer.on_event(&ExecutionEvent::Waiting {
-                    effect: &effects[idx],
-                    pending_dependencies: pending,
-                });
+        if !cancelled {
+            for &idx in &actionable_indices {
+                if dispatched.contains(&idx) || newly_ready.contains(&idx) {
+                    continue;
+                }
+                let deps = &deps_of[&idx];
+                let pending: Vec<String> = deps
+                    .iter()
+                    .filter(|d| !completed_indices.contains(d))
+                    .filter_map(|d| idx_to_binding.get(d).cloned())
+                    .collect();
+                if !pending.is_empty() {
+                    // Emit on every iteration to update the pending dependency list
+                    observer.on_event(&ExecutionEvent::Waiting {
+                        effect: &effects[idx],
+                        pending_dependencies: pending,
+                    });
+                }
             }
         }
 
@@ -656,7 +709,9 @@ pub(super) async fn execute_effects_sequential(
                 schemas: input.schemas,
             };
             let completed_ref = &completed;
-            let make_future = move |wait_cancel_rx: Option<tokio::sync::watch::Receiver<bool>>| async move {
+            let make_future = move |wait_cancel_rx: Option<
+                tokio::sync::watch::Receiver<WaitSignal>,
+            >| async move {
                 let result = match effect.as_basic() {
                     // `BasicEffect` is the type-level contract for
                     // `execute_basic_effect`: any Create/Update/Delete
@@ -792,7 +847,20 @@ pub(super) async fn execute_effects_sequential(
                 .iter()
                 .filter(|idx| !dispatched.contains(idx))
                 .count();
-            if remaining > 0 {
+            if cancelled {
+                emit_cancelled_skips(
+                    &CancelSkipCtx {
+                        effects,
+                        completed: &completed,
+                        total,
+                        observer,
+                    },
+                    &actionable_indices,
+                    &mut dispatched,
+                    &mut completed_indices,
+                    &mut skip_count,
+                );
+            } else if remaining > 0 {
                 // Cycle detected: skip remaining effects as failures
                 for &idx in &actionable_indices {
                     if !dispatched.contains(&idx) {
@@ -806,13 +874,34 @@ pub(super) async fn execute_effects_sequential(
         }
 
         // Wait for the next effect to complete
-        let Some((finished_idx, result)) = in_flight
-            .check_terminal(undispatched_count())
-            .cancel_if_terminal()
-            .next_completed()
-            .await
-        else {
-            break;
+        let (finished_idx, result) = if cancelled {
+            let Some(finished) = in_flight
+                .check_terminal(undispatched_count())
+                .cancel_if_terminal()
+                .next_completed()
+                .await
+            else {
+                break;
+            };
+            finished
+        } else {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    cancelled = true;
+                    in_flight.signal_in_flight_waits();
+                    continue;
+                }
+                finished = in_flight
+                    .check_terminal(undispatched_count())
+                    .cancel_if_terminal()
+                    .next_completed() => {
+                    let Some(finished) = finished else {
+                        break;
+                    };
+                    finished
+                }
+            }
         };
         completed_indices.insert(finished_idx);
 
@@ -910,6 +999,14 @@ pub(super) async fn execute_effects_sequential(
                     skip_count += 1;
                     failed_bindings.insert(binding);
                 }
+                WaitOutcome::Cancelled => {
+                    observer.on_event(&ExecutionEvent::EffectSkipped {
+                        effect: &effects[finished_idx],
+                        reason: SKIP_REASON_CANCELLED,
+                        progress,
+                    });
+                    skip_count += 1;
+                }
                 outcome @ (WaitOutcome::Timeout { .. }
                 | WaitOutcome::NotFound(_)
                 | WaitOutcome::ReadFailed(_)) => {
@@ -940,7 +1037,7 @@ pub(super) async fn execute_effects_sequential(
     )
     .await;
 
-    ExecutionResult {
+    let result = ExecutionResult {
         success_count,
         failure_count,
         skip_count,
@@ -949,7 +1046,8 @@ pub(super) async fn execute_effects_sequential(
         permanent_name_overrides,
         current_states: input.current_states.clone(),
         failed_refreshes,
-    }
+    };
+    (result, cancelled)
 }
 
 #[cfg(test)]
@@ -1224,10 +1322,12 @@ mod tests {
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(1),
-            execute_effects_sequential(&provider, &mut input, &observer),
+            execute_effects_sequential(&provider, &mut input, &observer, &CancellationToken::new()),
         )
         .await
         .expect("wait should be skipped as unsatisfiable instead of timing out");
+        let (result, was_cancelled) = result;
+        assert!(!was_cancelled);
 
         assert_eq!(result.failure_count, 1, "alb create should fail");
         assert_eq!(

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use futures::stream::{FuturesUnordered, StreamExt};
+use tokio_util::sync::CancellationToken;
 
 use crate::deps::{find_failed_dependency, get_resource_dependencies};
 use crate::effect::{Effect, WaitTarget};
@@ -18,13 +19,39 @@ use super::basic::{
 };
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::wait::{
-    UnsatisfiableReason, WaitAwareInFlight, WaitOutcome, unsatisfiable_reason_message,
-    wait_failure_message,
+    SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
+    unsatisfiable_reason_message, wait_failure_message,
 };
 use super::{
     ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo,
     UnresolvedResource,
 };
+
+fn emit_cancelled_skips_with_progress<F>(
+    effects: &[Effect],
+    indices: &[usize],
+    dispatched: &mut HashSet<usize>,
+    completed_indices: &mut HashSet<usize>,
+    skip_count: &mut usize,
+    observer: &dyn ExecutionObserver,
+    mut progress_for: F,
+) where
+    F: FnMut(usize) -> ProgressInfo,
+{
+    for &idx in indices {
+        if dispatched.contains(&idx) {
+            continue;
+        }
+        dispatched.insert(idx);
+        completed_indices.insert(idx);
+        observer.on_event(&ExecutionEvent::EffectSkipped {
+            effect: &effects[idx],
+            reason: SKIP_REASON_CANCELLED,
+            progress: progress_for(idx),
+        });
+        *skip_count += 1;
+    }
+}
 
 /// Check if the plan contains multiple Replace effects that depend on each other.
 pub(super) fn has_interdependent_replaces(effects: &[Effect]) -> bool {
@@ -360,7 +387,8 @@ pub(super) async fn execute_effects_phased(
     provider: &dyn Provider,
     input: &mut ExecutionInput<'_>,
     observer: &dyn ExecutionObserver,
-) -> ExecutionResult {
+    cancel: &CancellationToken,
+) -> (ExecutionResult, bool) {
     let mut success_count = 0;
     let mut failure_count = 0;
     let mut skip_count = 0;
@@ -376,6 +404,7 @@ pub(super) async fn execute_effects_phased(
     let effects = input.plan.effects();
     let replace_bindings = collect_replace_bindings(effects);
     let sorted_indices = topological_sort_replaces(effects, &replace_bindings);
+    let mut cancelled = false;
 
     // -----------------------------------------------------------------------
     // Phase 1: Non-Replace effects with parallel execution
@@ -396,17 +425,31 @@ pub(super) async fn execute_effects_phased(
         let mut in_flight: WaitAwareInFlight<'_, PhaseEffectResult> = WaitAwareInFlight::new();
 
         loop {
-            let mut newly_ready: Vec<usize> = Vec::new();
-            for &idx in &phase1_indices {
-                if dispatched.contains(&idx) {
-                    continue;
-                }
-                let deps = &deps_of[&idx];
-                if deps.iter().all(|d| completed_indices.contains(d)) {
-                    newly_ready.push(idx);
-                }
+            let undispatched_at_loop_start = phase1_indices
+                .iter()
+                .filter(|&&idx| !dispatched.contains(&idx))
+                .count();
+            if cancel.is_cancelled()
+                && !cancelled
+                && (undispatched_at_loop_start > 0 || !in_flight.is_empty())
+            {
+                cancelled = true;
+                in_flight.signal_in_flight_waits();
             }
-            newly_ready.sort();
+
+            let mut newly_ready: Vec<usize> = Vec::new();
+            if !cancelled {
+                for &idx in &phase1_indices {
+                    if dispatched.contains(&idx) {
+                        continue;
+                    }
+                    let deps = &deps_of[&idx];
+                    if deps.iter().all(|d| completed_indices.contains(d)) {
+                        newly_ready.push(idx);
+                    }
+                }
+                newly_ready.sort();
+            }
 
             for idx in newly_ready {
                 dispatched.insert(idx);
@@ -551,16 +594,51 @@ pub(super) async fn execute_effects_phased(
                 .drop_without_awaiting();
 
             if in_flight.is_empty() {
+                if cancelled {
+                    emit_cancelled_skips_with_progress(
+                        effects,
+                        &phase1_indices,
+                        &mut dispatched,
+                        &mut completed_indices,
+                        &mut skip_count,
+                        observer,
+                        |_| ProgressInfo {
+                            completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
+                            total,
+                        },
+                    );
+                }
                 break;
             }
 
-            let Some((finished_idx, result)) = in_flight
-                .check_terminal(undispatched_count())
-                .cancel_if_terminal()
-                .next_completed()
-                .await
-            else {
-                break;
+            let (finished_idx, result) = if cancelled {
+                let Some(finished) = in_flight
+                    .check_terminal(undispatched_count())
+                    .cancel_if_terminal()
+                    .next_completed()
+                    .await
+                else {
+                    break;
+                };
+                finished
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        cancelled = true;
+                        in_flight.signal_in_flight_waits();
+                        continue;
+                    }
+                    finished = in_flight
+                        .check_terminal(undispatched_count())
+                        .cancel_if_terminal()
+                        .next_completed() => {
+                        let Some(finished) = finished else {
+                            break;
+                        };
+                        finished
+                    }
+                }
             };
             completed_indices.insert(finished_idx);
 
@@ -615,6 +693,14 @@ pub(super) async fn execute_effects_phased(
                         skip_count += 1;
                         failed_bindings.insert(binding);
                     }
+                    WaitOutcome::Cancelled => {
+                        observer.on_event(&ExecutionEvent::EffectSkipped {
+                            effect: &effects[finished_idx],
+                            reason: SKIP_REASON_CANCELLED,
+                            progress,
+                        });
+                        skip_count += 1;
+                    }
                     outcome @ (WaitOutcome::Timeout { .. }
                     | WaitOutcome::NotFound(_)
                     | WaitOutcome::ReadFailed(_)) => {
@@ -639,7 +725,6 @@ pub(super) async fn execute_effects_phased(
                 .drop_without_awaiting();
         }
     }
-
     // -----------------------------------------------------------------------
     // Phase 2: CBD creates with parallel execution (forward dependency order)
     // -----------------------------------------------------------------------
@@ -687,17 +772,30 @@ pub(super) async fn execute_effects_phased(
         let mut in_flight = FuturesUnordered::new();
 
         loop {
-            let mut newly_ready: Vec<usize> = Vec::new();
-            for &idx in &cbd_indices {
-                if dispatched.contains(&idx) {
-                    continue;
-                }
-                let deps = &deps_of[&idx];
-                if deps.iter().all(|d| completed_indices.contains(d)) {
-                    newly_ready.push(idx);
-                }
+            let undispatched_at_loop_start = cbd_indices
+                .iter()
+                .filter(|&&idx| !dispatched.contains(&idx))
+                .count();
+            if cancel.is_cancelled()
+                && !cancelled
+                && (undispatched_at_loop_start > 0 || !in_flight.is_empty())
+            {
+                cancelled = true;
             }
-            newly_ready.sort();
+
+            let mut newly_ready: Vec<usize> = Vec::new();
+            if !cancelled {
+                for &idx in &cbd_indices {
+                    if dispatched.contains(&idx) {
+                        continue;
+                    }
+                    let deps = &deps_of[&idx];
+                    if deps.iter().all(|d| completed_indices.contains(d)) {
+                        newly_ready.push(idx);
+                    }
+                }
+                newly_ready.sort();
+            }
 
             for idx in newly_ready {
                 dispatched.insert(idx);
@@ -914,10 +1012,32 @@ pub(super) async fn execute_effects_phased(
             }
 
             if in_flight.is_empty() {
+                if cancelled {
+                    emit_cancelled_skips_with_progress(
+                        effects,
+                        &cbd_indices,
+                        &mut dispatched,
+                        &mut completed_indices,
+                        &mut skip_count,
+                        observer,
+                        |idx| replace_progress[&idx],
+                    );
+                }
                 break;
             }
 
-            let (finished_idx, started, result) = in_flight.next().await.unwrap();
+            let (finished_idx, started, result) = if cancelled {
+                in_flight.next().await.unwrap()
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        cancelled = true;
+                        continue;
+                    }
+                    finished = in_flight.next() => finished.unwrap(),
+                }
+            };
             completed_indices.insert(finished_idx);
 
             match result {
@@ -968,11 +1088,10 @@ pub(super) async fn execute_effects_phased(
             }
         }
     }
-
     // -----------------------------------------------------------------------
     // Phase 3: All deletes with parallel execution (reverse dependency order)
     // -----------------------------------------------------------------------
-    {
+    if !cancelled {
         // Collect indices for deletes that should execute: all Replace effects
         // that haven't been failed/skipped. For CBD, skip if create phase failed.
         let delete_indices: Vec<usize> = sorted_indices
@@ -1040,17 +1159,30 @@ pub(super) async fn execute_effects_phased(
         let mut in_flight = FuturesUnordered::new();
 
         loop {
-            let mut newly_ready: Vec<usize> = Vec::new();
-            for &idx in &delete_indices {
-                if dispatched.contains(&idx) {
-                    continue;
-                }
-                let deps = &reverse_deps[&idx];
-                if deps.iter().all(|d| completed_indices.contains(d)) {
-                    newly_ready.push(idx);
-                }
+            let undispatched_at_loop_start = delete_indices
+                .iter()
+                .filter(|&&idx| !dispatched.contains(&idx))
+                .count();
+            if cancel.is_cancelled()
+                && !cancelled
+                && (undispatched_at_loop_start > 0 || !in_flight.is_empty())
+            {
+                cancelled = true;
             }
-            newly_ready.sort();
+
+            let mut newly_ready: Vec<usize> = Vec::new();
+            if !cancelled {
+                for &idx in &delete_indices {
+                    if dispatched.contains(&idx) {
+                        continue;
+                    }
+                    let deps = &reverse_deps[&idx];
+                    if deps.iter().all(|d| completed_indices.contains(d)) {
+                        newly_ready.push(idx);
+                    }
+                }
+                newly_ready.sort();
+            }
 
             for idx in newly_ready {
                 dispatched.insert(idx);
@@ -1127,10 +1259,32 @@ pub(super) async fn execute_effects_phased(
             }
 
             if in_flight.is_empty() {
+                if cancelled {
+                    emit_cancelled_skips_with_progress(
+                        effects,
+                        &delete_indices,
+                        &mut dispatched,
+                        &mut completed_indices,
+                        &mut skip_count,
+                        observer,
+                        |idx| replace_progress[&idx],
+                    );
+                }
                 break;
             }
 
-            let (finished_idx, result) = in_flight.next().await.unwrap();
+            let (finished_idx, result) = if cancelled {
+                in_flight.next().await.unwrap()
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        cancelled = true;
+                        continue;
+                    }
+                    finished = in_flight.next() => finished.unwrap(),
+                }
+            };
             completed_indices.insert(finished_idx);
 
             match result {
@@ -1159,11 +1313,10 @@ pub(super) async fn execute_effects_phased(
             }
         }
     }
-
     // -----------------------------------------------------------------------
     // Phase 4: Non-CBD creates and CBD finalization with parallel execution
     // -----------------------------------------------------------------------
-    {
+    if !cancelled {
         let phase4_indices: Vec<usize> = sorted_indices.clone();
 
         let deps_of = build_phase_dependency_map(
@@ -1176,20 +1329,36 @@ pub(super) async fn execute_effects_phased(
         let mut dispatched: HashSet<usize> = HashSet::new();
         type PhaseFuture<'a> =
             std::pin::Pin<Box<dyn std::future::Future<Output = (usize, PhaseEffectResult)> + 'a>>;
+        // Phase 4 dispatches only Replace finalize/create work from sorted
+        // Replace indices; no Wait effects can appear here, so no wait_cancellers
+        // are needed for cancellation.
         let mut in_flight: FuturesUnordered<PhaseFuture<'_>> = FuturesUnordered::new();
 
         loop {
-            let mut newly_ready: Vec<usize> = Vec::new();
-            for &idx in &phase4_indices {
-                if dispatched.contains(&idx) {
-                    continue;
-                }
-                let deps = &deps_of[&idx];
-                if deps.iter().all(|d| completed_indices.contains(d)) {
-                    newly_ready.push(idx);
-                }
+            let undispatched_at_loop_start = phase4_indices
+                .iter()
+                .filter(|&&idx| !dispatched.contains(&idx))
+                .count();
+            if cancel.is_cancelled()
+                && !cancelled
+                && (undispatched_at_loop_start > 0 || !in_flight.is_empty())
+            {
+                cancelled = true;
             }
-            newly_ready.sort();
+
+            let mut newly_ready: Vec<usize> = Vec::new();
+            if !cancelled {
+                for &idx in &phase4_indices {
+                    if dispatched.contains(&idx) {
+                        continue;
+                    }
+                    let deps = &deps_of[&idx];
+                    if deps.iter().all(|d| completed_indices.contains(d)) {
+                        newly_ready.push(idx);
+                    }
+                }
+                newly_ready.sort();
+            }
 
             for idx in newly_ready {
                 dispatched.insert(idx);
@@ -1234,7 +1403,7 @@ pub(super) async fn execute_effects_phased(
 
                     if directives.create_before_destroy {
                         // CBD finalization: skip if create phase failed
-                        let Some(state) = cbd_create_states.remove(&idx) else {
+                        let Some(state) = cbd_create_states.get(&idx).cloned() else {
                             completed_indices.insert(idx);
                             continue;
                         };
@@ -1423,10 +1592,32 @@ pub(super) async fn execute_effects_phased(
             }
 
             if in_flight.is_empty() {
+                if cancelled {
+                    emit_cancelled_skips_with_progress(
+                        effects,
+                        &phase4_indices,
+                        &mut dispatched,
+                        &mut completed_indices,
+                        &mut skip_count,
+                        observer,
+                        |idx| replace_progress[&idx],
+                    );
+                }
                 break;
             }
 
-            let (finished_idx, result) = in_flight.next().await.unwrap();
+            let (finished_idx, result) = if cancelled {
+                in_flight.next().await.unwrap()
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        cancelled = true;
+                        continue;
+                    }
+                    finished = in_flight.next() => finished.unwrap(),
+                }
+            };
             completed_indices.insert(finished_idx);
 
             match result {
@@ -1435,6 +1626,7 @@ pub(super) async fn execute_effects_phased(
                     resource_id,
                     permanent_overrides,
                 } => {
+                    cbd_create_states.remove(&finished_idx);
                     success_count += 1;
                     applied_states.insert(resource_id, state);
                     if let Some((id, overrides)) = permanent_overrides {
@@ -1446,6 +1638,7 @@ pub(super) async fn execute_effects_phased(
                     resource_id,
                     binding,
                 } => {
+                    cbd_create_states.remove(&finished_idx);
                     failure_count += 1;
                     applied_states.insert(resource_id, state);
                     if let Some(binding) = binding {
@@ -1481,6 +1674,20 @@ pub(super) async fn execute_effects_phased(
         }
     }
 
+    // Preserve CBD create states for any temporary that was created in Phase 2
+    // but did not complete finalize. Phase 4 removes finalized indices from
+    // cbd_create_states, so anything remaining here is genuinely unprocessed.
+    // Do not re-call bindings.record_applied: Phase 2 already recorded the
+    // binding when the create succeeded, matching Phase 4's success path.
+    if cancelled {
+        for (idx, state) in cbd_create_states {
+            if let Effect::Replace { to, .. } = &effects[idx] {
+                success_count += 1;
+                applied_states.insert(to.id.clone(), state);
+            }
+        }
+    }
+
     let failed_refreshes = refresh_pending_states(
         provider,
         &mut input.current_states,
@@ -1489,7 +1696,7 @@ pub(super) async fn execute_effects_phased(
     )
     .await;
 
-    ExecutionResult {
+    let result = ExecutionResult {
         success_count,
         failure_count,
         skip_count,
@@ -1498,7 +1705,8 @@ pub(super) async fn execute_effects_phased(
         permanent_name_overrides,
         current_states: input.current_states.clone(),
         failed_refreshes,
-    }
+    };
+    (result, cancelled)
 }
 
 #[cfg(test)]
@@ -1741,10 +1949,12 @@ mod tests {
 
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(1),
-            execute_effects_phased(&provider, &mut input, &observer),
+            execute_effects_phased(&provider, &mut input, &observer, &CancellationToken::new()),
         )
         .await
         .expect("wait should be skipped as unsatisfiable instead of timing out");
+        let (result, was_cancelled) = result;
+        assert!(!was_cancelled);
 
         assert!(
             result.failure_count >= 1,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -7,6 +7,7 @@ use crate::provider::{
 use crate::resource::{ConcreteValue, DataSource, DeferredValue, Directives, Resource, Value};
 use parallel::{build_dependency_analysis, build_dependency_levels};
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -159,6 +160,57 @@ struct MockObserver {
     events: Mutex<Vec<String>>,
 }
 
+fn format_execution_event(event: &ExecutionEvent<'_>) -> String {
+    match event {
+        ExecutionEvent::Waiting {
+            effect,
+            pending_dependencies,
+        } => {
+            format!(
+                "waiting:{}:[{}]",
+                effect.resource_id(),
+                pending_dependencies.join(",")
+            )
+        }
+        ExecutionEvent::EffectStarted { effect } => {
+            format!("started:{}", effect.resource_id())
+        }
+        ExecutionEvent::EffectSucceeded { effect, .. } => {
+            format!("succeeded:{}", effect.resource_id())
+        }
+        ExecutionEvent::EffectFailed { effect, error, .. } => {
+            format!("failed:{}:{}", effect.resource_id(), error)
+        }
+        ExecutionEvent::EffectSkipped { effect, reason, .. } => {
+            format!("skipped:{}:{}", effect.resource_id(), reason)
+        }
+        ExecutionEvent::WaitPolling {
+            binding, target_id, ..
+        } => {
+            format!("wait_polling:{}:{}", binding, target_id)
+        }
+        ExecutionEvent::CascadeUpdateSucceeded { id } => {
+            format!("cascade_ok:{}", id)
+        }
+        ExecutionEvent::CascadeUpdateFailed { id, error } => {
+            format!("cascade_fail:{}:{}", id, error)
+        }
+        ExecutionEvent::RenameSucceeded { id, from, to } => {
+            format!("rename_ok:{}:{}:{}", id, from, to)
+        }
+        ExecutionEvent::RenameFailed { id, error } => {
+            format!("rename_fail:{}:{}", id, error)
+        }
+        ExecutionEvent::RefreshStarted => "refresh_started".to_string(),
+        ExecutionEvent::RefreshSucceeded { id } => {
+            format!("refresh_ok:{}", id)
+        }
+        ExecutionEvent::RefreshFailed { id, error } => {
+            format!("refresh_fail:{}:{}", id, error)
+        }
+    }
+}
+
 impl MockObserver {
     fn new() -> Self {
         Self {
@@ -173,55 +225,10 @@ impl MockObserver {
 
 impl ExecutionObserver for MockObserver {
     fn on_event(&self, event: &ExecutionEvent) {
-        let msg = match event {
-            ExecutionEvent::Waiting {
-                effect,
-                pending_dependencies,
-            } => {
-                format!(
-                    "waiting:{}:[{}]",
-                    effect.resource_id(),
-                    pending_dependencies.join(",")
-                )
-            }
-            ExecutionEvent::EffectStarted { effect } => {
-                format!("started:{}", effect.resource_id())
-            }
-            ExecutionEvent::EffectSucceeded { effect, .. } => {
-                format!("succeeded:{}", effect.resource_id())
-            }
-            ExecutionEvent::EffectFailed { effect, error, .. } => {
-                format!("failed:{}:{}", effect.resource_id(), error)
-            }
-            ExecutionEvent::EffectSkipped { effect, reason, .. } => {
-                format!("skipped:{}:{}", effect.resource_id(), reason)
-            }
-            ExecutionEvent::WaitPolling {
-                binding, target_id, ..
-            } => {
-                format!("wait_polling:{}:{}", binding, target_id)
-            }
-            ExecutionEvent::CascadeUpdateSucceeded { id } => {
-                format!("cascade_ok:{}", id)
-            }
-            ExecutionEvent::CascadeUpdateFailed { id, error } => {
-                format!("cascade_fail:{}:{}", id, error)
-            }
-            ExecutionEvent::RenameSucceeded { id, from, to } => {
-                format!("rename_ok:{}:{}:{}", id, from, to)
-            }
-            ExecutionEvent::RenameFailed { id, error } => {
-                format!("rename_fail:{}:{}", id, error)
-            }
-            ExecutionEvent::RefreshStarted => "refresh_started".to_string(),
-            ExecutionEvent::RefreshSucceeded { id } => {
-                format!("refresh_ok:{}", id)
-            }
-            ExecutionEvent::RefreshFailed { id, error } => {
-                format!("refresh_fail:{}:{}", id, error)
-            }
-        };
-        self.events.lock().unwrap().push(msg);
+        self.events
+            .lock()
+            .unwrap()
+            .push(format_execution_event(event));
     }
 }
 
@@ -601,6 +608,423 @@ fn provider_config_with_default_tags(
     }
 }
 
+fn create_independent_create_plan<const N: usize>(names: [&str; N]) -> Plan {
+    let mut plan = Plan::new();
+    for name in names {
+        plan.add(Effect::Create(make_resource(name, &[])));
+    }
+    plan
+}
+
+fn create_interdependent_replace_plan() -> Plan {
+    let a_id = ResourceId::new("test", "a");
+    let b_id = ResourceId::new("test", "b");
+
+    let a_from = State::existing(a_id.clone(), HashMap::new()).with_identifier("a-old");
+    let mut a_to = Resource::new("test", "a");
+    a_to.binding = Some("a".to_string());
+
+    let b_from = State::existing(b_id.clone(), HashMap::new()).with_identifier("b-old");
+    let mut b_to = Resource::new("test", "b");
+    b_to.binding = Some("b".to_string());
+    b_to.dependency_bindings = std::collections::BTreeSet::from(["a".to_string()]);
+
+    let directives = Directives {
+        create_before_destroy: true,
+        ..Default::default()
+    };
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: a_id,
+        from: Box::new(a_from),
+        to: a_to,
+        directives: directives.clone(),
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+    plan.add(Effect::Replace {
+        id: b_id,
+        from: Box::new(b_from),
+        to: b_to,
+        directives,
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+            .unwrap(),
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+    plan
+}
+
+fn create_interdependent_replace_plan_with_renames<const N: usize>(names: [&str; N]) -> Plan {
+    let directives = Directives {
+        create_before_destroy: true,
+        ..Default::default()
+    };
+    let mut plan = Plan::new();
+    for (idx, name) in names.iter().enumerate() {
+        let id = ResourceId::new("test", *name);
+        let from =
+            State::existing(id.clone(), HashMap::new()).with_identifier(format!("{name}-old"));
+        let mut to = Resource::new("test", *name);
+        to.binding = Some((*name).to_string());
+        if idx > 0 {
+            to.dependency_bindings = std::collections::BTreeSet::from([names[idx - 1].to_string()]);
+        }
+        plan.add(Effect::Replace {
+            id,
+            from: Box::new(from),
+            to,
+            directives: directives.clone(),
+            changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
+                .unwrap(),
+            cascading_updates: vec![],
+            temporary_name: Some(crate::effect::TemporaryName {
+                attribute: "name".to_string(),
+                original_value: format!("{name}-final"),
+                temporary_value: format!("{name}-temp"),
+                can_rename: true,
+            }),
+            cascade_ref_hints: vec![],
+        });
+    }
+    plan
+}
+
+struct DelayedCountingProvider {
+    default_delay: std::time::Duration,
+    delays: HashMap<String, std::time::Duration>,
+    cancel_after_create: Option<String>,
+    cancel: Option<CancellationToken>,
+    started: Arc<Mutex<Vec<String>>>,
+}
+
+impl DelayedCountingProvider {
+    fn new(default_delay: std::time::Duration) -> Self {
+        Self {
+            default_delay,
+            delays: HashMap::new(),
+            cancel_after_create: None,
+            cancel: None,
+            started: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn with_delay(mut self, name: &str, delay: std::time::Duration) -> Self {
+        self.delays.insert(name.to_string(), delay);
+        self
+    }
+
+    fn with_cancel_after_create(mut self, name: &str, cancel: CancellationToken) -> Self {
+        self.cancel_after_create = Some(name.to_string());
+        self.cancel = Some(cancel);
+        self
+    }
+
+    fn started_names(&self) -> Vec<String> {
+        self.started.lock().unwrap().clone()
+    }
+
+    fn delay_for(&self, id: &ResourceId) -> std::time::Duration {
+        self.delays
+            .get(id.name_str())
+            .copied()
+            .unwrap_or(self.default_delay)
+    }
+}
+
+impl Provider for DelayedCountingProvider {
+    fn name(&self) -> &str {
+        "delayed-counting"
+    }
+
+    fn read(
+        &self,
+        _id: &ResourceId,
+        _identifier: Option<&str>,
+        _request: ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        Box::pin(async { Err(ProviderError::internal("read not used")) })
+    }
+
+    fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+        self.read(&resource.id, None, ReadRequest)
+    }
+
+    fn create(
+        &self,
+        id: &ResourceId,
+        _request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        let delay = self.delay_for(&id);
+        let started = self.started.clone();
+        let cancel_after_create = self.cancel_after_create.clone();
+        let cancel = self.cancel.clone();
+        Box::pin(async move {
+            started.lock().unwrap().push(id.name_str().to_string());
+            tokio::time::sleep(delay).await;
+            if cancel_after_create.as_deref() == Some(id.name_str())
+                && let Some(cancel) = cancel
+            {
+                cancel.cancel();
+            }
+            Ok(ok_state(&id))
+        })
+    }
+
+    fn update(
+        &self,
+        id: &ResourceId,
+        _identifier: &str,
+        _request: UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        let started = self.started.clone();
+        Box::pin(async move {
+            started
+                .lock()
+                .unwrap()
+                .push(format!("update:{}", id.name_str()));
+            let mut attrs = HashMap::new();
+            attrs.insert(
+                "finalized".to_string(),
+                Value::Concrete(ConcreteValue::Bool(true)),
+            );
+            Ok(State::existing(id, attrs).with_identifier("finalized-id"))
+        })
+    }
+
+    fn delete(
+        &self,
+        id: &ResourceId,
+        _identifier: &str,
+        _request: DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        let id = id.clone();
+        let started = self.started.clone();
+        Box::pin(async move {
+            started
+                .lock()
+                .unwrap()
+                .push(format!("delete:{}", id.name_str()));
+            Ok(())
+        })
+    }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: crate::effect::PlanOp) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+struct PendingWaitProvider {
+    reads: AtomicUsize,
+}
+
+impl PendingWaitProvider {
+    fn new() -> Self {
+        Self {
+            reads: AtomicUsize::new(0),
+        }
+    }
+
+    fn read_count(&self) -> usize {
+        self.reads.load(Ordering::Relaxed)
+    }
+}
+
+impl Provider for PendingWaitProvider {
+    fn name(&self) -> &str {
+        "pending-wait"
+    }
+
+    fn read(
+        &self,
+        id: &ResourceId,
+        _identifier: Option<&str>,
+        _request: ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        let id = id.clone();
+        Box::pin(async move {
+            let mut attrs = HashMap::new();
+            attrs.insert(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("PENDING".to_string())),
+            );
+            Ok(State::existing(id, attrs).with_identifier("pending-id"))
+        })
+    }
+
+    fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+        self.read(&resource.id, None, ReadRequest)
+    }
+
+    fn create(
+        &self,
+        id: &ResourceId,
+        _request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(ok_state(&id)) })
+    }
+
+    fn update(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _request: UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        Box::pin(async { Err(ProviderError::internal("update not used")) })
+    }
+
+    fn delete(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _request: DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async { Err(ProviderError::internal("delete not used")) })
+    }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: crate::effect::PlanOp) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+struct CancelsAfterSuccesses {
+    successes: AtomicUsize,
+    threshold: usize,
+    token: CancellationToken,
+}
+
+impl CancelsAfterSuccesses {
+    fn new(threshold: usize) -> Self {
+        Self {
+            successes: AtomicUsize::new(0),
+            threshold,
+            token: CancellationToken::new(),
+        }
+    }
+
+    fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+}
+
+impl ExecutionObserver for CancelsAfterSuccesses {
+    fn on_event(&self, event: &ExecutionEvent) {
+        if matches!(event, ExecutionEvent::EffectSucceeded { .. }) {
+            let successes = self.successes.fetch_add(1, Ordering::Relaxed) + 1;
+            if successes >= self.threshold {
+                self.token.cancel();
+            }
+        }
+    }
+}
+
+struct CancelsWhenStarted {
+    name: String,
+    token: CancellationToken,
+}
+
+impl CancelsWhenStarted {
+    fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            token: CancellationToken::new(),
+        }
+    }
+
+    fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+}
+
+struct CancelsWhenWaitStarted {
+    binding: String,
+    token: CancellationToken,
+}
+
+impl CancelsWhenWaitStarted {
+    fn new(binding: &str) -> Self {
+        Self {
+            binding: binding.to_string(),
+            token: CancellationToken::new(),
+        }
+    }
+
+    fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+}
+
+impl ExecutionObserver for CancelsWhenWaitStarted {
+    fn on_event(&self, event: &ExecutionEvent) {
+        if let ExecutionEvent::EffectStarted {
+            effect: Effect::Wait { binding, .. },
+        } = event
+            && binding == &self.binding
+        {
+            self.token.cancel();
+        }
+    }
+}
+
+struct RecordingCancelsWhenWaitStarted {
+    binding: String,
+    token: CancellationToken,
+    events: Mutex<Vec<String>>,
+}
+
+impl RecordingCancelsWhenWaitStarted {
+    fn new(binding: &str) -> Self {
+        Self {
+            binding: binding.to_string(),
+            token: CancellationToken::new(),
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    fn events(&self) -> Vec<String> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl ExecutionObserver for RecordingCancelsWhenWaitStarted {
+    fn on_event(&self, event: &ExecutionEvent) {
+        self.events
+            .lock()
+            .unwrap()
+            .push(format_execution_event(event));
+        if let ExecutionEvent::EffectStarted {
+            effect: Effect::Wait { binding, .. },
+        } = event
+            && binding == &self.binding
+        {
+            self.token.cancel();
+        }
+    }
+}
+
+impl ExecutionObserver for CancelsWhenStarted {
+    fn on_event(&self, event: &ExecutionEvent) {
+        if let ExecutionEvent::EffectStarted { effect } = event
+            && effect.resource_id().name_str() == self.name
+        {
+            self.token.cancel();
+        }
+    }
+}
+
 // -----------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------
@@ -666,18 +1090,12 @@ async fn execute_plan_returns_completed_when_not_cancelled() {
 }
 
 #[tokio::test]
-async fn execute_plan_with_pre_cancelled_token_still_returns_completed_at_t3() {
-    // T3 contract: execute_plan receives a CancellationToken but does not
-    // observe it. A pre-cancelled token must therefore still yield Completed.
-    // T4 (carina#3504) will flip this expectation to Cancelled and rename the test.
+async fn execute_plan_with_pre_cancelled_token_returns_cancelled_at_t4_or_later() {
     let provider = MockProvider::new();
     let resource = make_resource("one", &[]);
-    let rid = resource.id.clone();
 
     let mut plan = Plan::new();
     plan.add(Effect::Create(resource));
-
-    provider.push_create(Ok(ok_state(&rid)));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -699,13 +1117,351 @@ async fn execute_plan_with_pre_cancelled_token_still_returns_completed_at_t3() {
     let outcome = execute_plan(&provider, input, &observer, cancel).await;
 
     match outcome {
-        ExecutionOutcome::Completed(result) => {
-            assert_eq!(result.success_count, 1, "T3 must not observe cancellation");
+        ExecutionOutcome::Cancelled(result) => {
+            assert_eq!(result.success_count, 0);
+            assert!(result.applied_states.is_empty());
+            assert!(provider.calls().is_empty());
         }
-        ExecutionOutcome::Cancelled(_) => panic!(
-            "T3 must not observe cancellation; if this fires, T4 may have leaked into this PR"
-        ),
+        ExecutionOutcome::Completed(_) => panic!("pre-cancelled execution returned Completed"),
     }
+}
+
+#[tokio::test]
+async fn execute_plan_with_empty_plan_and_pre_cancelled_token_returns_completed() {
+    let provider = MockProvider::new();
+    let plan = Plan::new();
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+    let observer = MockObserver::new();
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    match outcome {
+        ExecutionOutcome::Completed(result) => {
+            assert_eq!(result.success_count, 0);
+            assert_eq!(result.skip_count, 0);
+        }
+        ExecutionOutcome::Cancelled(_) => panic!("empty pre-cancelled plan returned Cancelled"),
+    }
+}
+
+#[tokio::test]
+async fn execute_plan_cancelled_after_three_completed_keeps_in_flight_and_drops_pending() {
+    let provider = DelayedCountingProvider::new(std::time::Duration::from_millis(1));
+    let observer = CancelsAfterSuccesses::new(3);
+    let cancel = observer.token();
+    let plan = create_independent_create_plan(["r1", "r2", "r3", "r4", "r5"]);
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(1).unwrap(),
+    };
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("cancelled run returned Completed"),
+    };
+    assert_eq!(result.applied_states.len(), 3);
+    assert_eq!(provider.started_names(), vec!["r1", "r2", "r3"]);
+}
+
+#[tokio::test]
+async fn execute_plan_cancels_in_flight_wait_effect_promptly() {
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let provider = PendingWaitProvider::new();
+    let observer = CancelsWhenWaitStarted::new("cert_ready");
+    let cancel = observer.token();
+
+    let cert = make_resource("cert", &[]);
+    let cert_id = cert.id.clone();
+    let mut dist = make_resource("dist", &[]);
+    dist.set_attr(
+        "ref_cert_ready".to_string(),
+        Value::resource_ref("cert_ready".to_string(), "id".to_string(), vec![]),
+    );
+    dist.dependency_bindings = ["cert_ready".to_string()].into_iter().collect();
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::Wait {
+        binding: "cert_ready".to_string(),
+        target_id: cert_id,
+        target: crate::effect::WaitTarget::ResolvedAtApply,
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("READY".to_string())),
+        },
+        until_surface: "cert.status == READY".to_string(),
+        timeout: std::time::Duration::from_secs(60),
+        interval: std::time::Duration::from_secs(60),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+    plan.add(Effect::Create(dist));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(1).unwrap(),
+    };
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_millis(200),
+        execute_plan(&provider, input, &observer, cancel),
+    )
+    .await
+    .expect("cancelled wait should not block until its natural timeout");
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("cancelled wait returned Completed"),
+    };
+    assert_eq!(result.success_count, 1, "the completed Create is preserved");
+    assert_eq!(
+        result.skip_count, 2,
+        "the in-flight Wait and suppressed downstream Create are skipped"
+    );
+    assert!(
+        provider.read_count() > 0,
+        "wait should have polled at least once"
+    );
+}
+
+#[tokio::test]
+async fn execute_plan_cancelled_wait_emits_cancelled_skip_not_unsatisfiable() {
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let provider = PendingWaitProvider::new();
+    let observer = RecordingCancelsWhenWaitStarted::new("cert_ready");
+    let cancel = observer.token();
+
+    let cert = make_resource("cert", &[]);
+    let cert_id = cert.id.clone();
+    let mut dist = make_resource("dist", &[]);
+    dist.set_attr(
+        "ref_cert_ready".to_string(),
+        Value::resource_ref("cert_ready".to_string(), "id".to_string(), vec![]),
+    );
+    dist.dependency_bindings = ["cert_ready".to_string()].into_iter().collect();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::Wait {
+        binding: "cert_ready".to_string(),
+        target_id: cert_id,
+        target: crate::effect::WaitTarget::ResolvedAtApply,
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("READY".to_string())),
+        },
+        until_surface: "cert.status == READY".to_string(),
+        timeout: std::time::Duration::from_secs(60),
+        interval: std::time::Duration::from_secs(60),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+    plan.add(Effect::Create(dist));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(1).unwrap(),
+    };
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("cancelled wait returned Completed"),
+    };
+    let events = observer.events();
+    assert!(
+        events.iter().any(|event| event == "succeeded:test.cert"),
+        "cert create should succeed before cancellation; events: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "skipped:test.cert:cancelled"),
+        "in-flight Wait should be skipped as cancelled; events: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "skipped:test.dist:cancelled"),
+        "downstream Create should be skipped as cancelled; events: {events:?}"
+    );
+    assert!(
+        events.iter().all(|event| !event.contains("unsatisfiable")),
+        "cancelled Wait must not be reported as unsatisfiable; events: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .all(|event| !event.contains("dependency 'cert_ready' failed")),
+        "cancelled Wait must not mark its binding failed; events: {events:?}"
+    );
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.failure_count, 0);
+    assert_eq!(result.skip_count, 2);
+}
+
+#[tokio::test]
+async fn execute_plan_cancelled_while_effect_in_flight_records_that_effect() {
+    let provider = DelayedCountingProvider::new(std::time::Duration::ZERO)
+        .with_delay("r2", std::time::Duration::from_millis(10));
+    let observer = CancelsWhenStarted::new("r2");
+    let cancel = observer.token();
+    let plan = create_independent_create_plan(["r1", "r2", "r3"]);
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(1).unwrap(),
+    };
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("cancelled run returned Completed"),
+    };
+    assert!(
+        result
+            .applied_states
+            .contains_key(&ResourceId::new("test", "r2"))
+    );
+    assert_eq!(provider.started_names(), vec!["r1", "r2"]);
+}
+
+#[tokio::test]
+async fn execute_plan_phased_cancel_during_phase4_preserves_unprocessed_cbd_creates() {
+    let provider = DelayedCountingProvider::new(std::time::Duration::ZERO);
+    let observer = CancelsAfterSuccesses::new(2);
+    let cancel = observer.token();
+    let plan = create_interdependent_replace_plan_with_renames(["a", "b", "c", "d"]);
+    assert!(has_interdependent_replaces(plan.effects()));
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(2).unwrap(),
+    };
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("phase-4 cancel returned Completed"),
+    };
+    assert_eq!(result.success_count, 4);
+    assert_eq!(result.applied_states.len(), 4);
+    for name in ["a", "b"] {
+        let state = result
+            .applied_states
+            .get(&ResourceId::new("test", name))
+            .expect("finalized resource should be recorded");
+        assert_eq!(
+            state.attributes.get("finalized"),
+            Some(&Value::Concrete(ConcreteValue::Bool(true)))
+        );
+    }
+    for name in ["c", "d"] {
+        let state = result
+            .applied_states
+            .get(&ResourceId::new("test", name))
+            .expect("unprocessed CBD create state should be preserved");
+        assert_eq!(
+            state.attributes.get("finalized"),
+            None,
+            "unprocessed resources must keep Phase-2 create state, not finalize state"
+        );
+    }
+}
+
+#[tokio::test]
+async fn execute_plan_phased_cancelled_between_phases_keeps_completed_resources_in_state() {
+    let cancel = CancellationToken::new();
+    let provider = DelayedCountingProvider::new(std::time::Duration::from_millis(1))
+        .with_cancel_after_create("a", cancel.clone());
+    let observer = MockObserver::new();
+    let plan = create_interdependent_replace_plan();
+    assert!(has_interdependent_replaces(plan.effects()));
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(2).unwrap(),
+    };
+
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    let result = match outcome {
+        ExecutionOutcome::Cancelled(result) => result,
+        ExecutionOutcome::Completed(_) => panic!("phased cancel returned Completed"),
+    };
+    assert!(
+        result
+            .applied_states
+            .contains_key(&ResourceId::new("test", "a"))
+    );
+    assert!(
+        !provider
+            .started_names()
+            .iter()
+            .any(|name| name.starts_with("delete:"))
+    );
 }
 
 #[tokio::test]

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -19,16 +19,20 @@ use crate::provider::{Provider, ProviderError, ReadRequest};
 use crate::resource::{ResourceId, State, Value};
 use crate::wait::predicate::WaitPredicate;
 
-/// Terminal result of a wait polling loop.
-///
-/// `Satisfied` carries the observed target snapshot, `Unsatisfiable`
-/// represents a static or dynamic skip reason, `Timeout` is real-time
-/// exhaustion, and read-side failures distinguish deletion from other errors.
+/// Outcome of polling a Wait effect. The variants distinguish:
+/// - `Satisfied`: the wait condition was met; carries the resource state.
+/// - `Cancelled`: external cancel observed mid-poll; abort early without failure.
+/// - `Unsatisfiable`: the wait can never be satisfied, such as when no
+///   remaining mutator can change the target.
+/// - `Timeout`: wait window elapsed without satisfying the condition.
+/// - `NotFound`: provider reported the resource missing during polling.
+/// - `ReadFailed`: provider read failed mid-poll.
 #[derive(Debug)]
 pub enum WaitOutcome {
     Satisfied {
         state: State,
     },
+    Cancelled,
     Unsatisfiable(UnsatisfiableReason),
     Timeout {
         last_attrs: HashMap<String, Value>,
@@ -59,6 +63,19 @@ pub(super) enum InFlightKind {
     NonWait,
 }
 
+/// Signal sent on the watch channel that controls an in-flight Wait future.
+/// - `Continue`: initial sentinel, polling proceeds normally.
+/// - `NoMutatorRemaining`: dispatching loop has no other effects that could
+///   resolve the dependency; the Wait should abort as Unsatisfiable.
+/// - `Cancelled`: external cancel observed; the Wait should abort and report
+///   `WaitOutcome::Cancelled`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WaitSignal {
+    Continue,
+    NoMutatorRemaining,
+    Cancelled,
+}
+
 pub(super) fn unsatisfiable_reason_message(reason: &UnsatisfiableReason) -> String {
     match reason {
         UnsatisfiableReason::DependencyFailed { binding } => {
@@ -78,16 +95,37 @@ pub(super) fn wait_failure_message(outcome: &WaitOutcome, target_id: &ResourceId
             target_id, elapsed, last_attrs
         ),
         WaitOutcome::NotFound(err) | WaitOutcome::ReadFailed(err) => err.to_string(),
-        WaitOutcome::Satisfied { .. } | WaitOutcome::Unsatisfiable(_) => {
-            unreachable!("satisfied and unsatisfiable waits are not failures")
+        WaitOutcome::Satisfied { .. } | WaitOutcome::Cancelled | WaitOutcome::Unsatisfiable(_) => {
+            unreachable!("satisfied, cancelled, and unsatisfiable waits are not failures")
         }
+    }
+}
+
+/// Skip reason emitted on `EffectSkipped` when an effect is dropped or
+/// aborted due to cancel observation. Consumers may match on this exact
+/// string to render cancelled effects distinctly from cascade failures.
+pub(super) const SKIP_REASON_CANCELLED: &str = "cancelled";
+
+/// Signal all in-flight Wait effect cancellers, causing their polling to
+/// abort early. Used when cancel observation needs to drain in-flight Wait
+/// effects without waiting for their natural timeout.
+///
+/// `send` errors are intentionally ignored: a dropped receiver means the
+/// Wait future has already completed and removed itself from
+/// `wait_cancellers`, so signaling that channel is a no-op.
+pub(super) fn signal_in_flight_waits(
+    wait_cancellers: &HashMap<usize, tokio::sync::watch::Sender<WaitSignal>>,
+) {
+    for (_idx, tx) in wait_cancellers.iter() {
+        // Receiver dropped == Wait future completed; nothing to cancel.
+        let _ = tx.send(WaitSignal::Cancelled);
     }
 }
 
 pub(super) fn cancel_waits_if_terminal(
     in_flight_kinds: &HashMap<usize, InFlightKind>,
     undispatched_count: usize,
-    wait_cancellers: &HashMap<usize, tokio::sync::watch::Sender<bool>>,
+    wait_cancellers: &HashMap<usize, tokio::sync::watch::Sender<WaitSignal>>,
 ) {
     let only_waits = !in_flight_kinds.is_empty()
         && in_flight_kinds
@@ -95,7 +133,7 @@ pub(super) fn cancel_waits_if_terminal(
             .all(|kind| matches!(kind, InFlightKind::Wait));
     if only_waits && undispatched_count == 0 {
         for cancel in wait_cancellers.values() {
-            let _ = cancel.send(true);
+            let _ = cancel.send(WaitSignal::NoMutatorRemaining);
         }
     }
 }
@@ -110,7 +148,7 @@ pub(super) fn cancel_waits_if_terminal(
 pub(super) struct WaitAwareInFlight<'fut, R> {
     inner: FuturesUnordered<Pin<Box<dyn Future<Output = (usize, R)> + 'fut>>>,
     kinds: HashMap<usize, InFlightKind>,
-    cancellers: HashMap<usize, tokio::sync::watch::Sender<bool>>,
+    cancellers: HashMap<usize, tokio::sync::watch::Sender<WaitSignal>>,
 }
 
 impl<'fut, R> WaitAwareInFlight<'fut, R> {
@@ -133,6 +171,11 @@ impl<'fut, R> WaitAwareInFlight<'fut, R> {
         self.inner.len()
     }
 
+    /// Signal every in-flight wait to stop because external cancellation was observed.
+    pub(super) fn signal_in_flight_waits(&self) {
+        signal_in_flight_waits(&self.cancellers);
+    }
+
     /// Dispatch a non-wait future and record its in-flight kind.
     pub(super) fn push_non_wait<F>(&mut self, idx: usize, fut: F)
     where
@@ -146,10 +189,10 @@ impl<'fut, R> WaitAwareInFlight<'fut, R> {
     pub(super) fn push_wait<MkFut>(&mut self, idx: usize, mk_fut: MkFut)
     where
         MkFut: FnOnce(
-            tokio::sync::watch::Receiver<bool>,
+            tokio::sync::watch::Receiver<WaitSignal>,
         ) -> Pin<Box<dyn Future<Output = (usize, R)> + 'fut>>,
     {
-        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(WaitSignal::Continue);
         self.cancellers.insert(idx, cancel_tx);
         self.kinds.insert(idx, InFlightKind::Wait);
         self.inner.push(mk_fut(cancel_rx));
@@ -229,7 +272,7 @@ pub async fn execute_wait_effect(
     until: &WaitPredicate,
     timeout: Duration,
     interval: Duration,
-    cancel: tokio::sync::watch::Receiver<bool>,
+    cancel: tokio::sync::watch::Receiver<WaitSignal>,
     observer: &dyn ExecutionObserver,
 ) -> WaitOutcome {
     execute_wait_effect_with_heartbeat_gap(
@@ -256,7 +299,7 @@ pub(crate) async fn execute_wait_effect_with_heartbeat_gap(
     until: &WaitPredicate,
     timeout: Duration,
     interval: Duration,
-    mut cancel: tokio::sync::watch::Receiver<bool>,
+    mut cancel: tokio::sync::watch::Receiver<WaitSignal>,
     observer: &dyn ExecutionObserver,
     heartbeat_gap: Duration,
 ) -> WaitOutcome {
@@ -306,9 +349,18 @@ pub(crate) async fn execute_wait_effect_with_heartbeat_gap(
             };
         }
         tokio::select! {
+            biased;
             changed = cancel.changed() => {
-                if changed.is_ok() && *cancel.borrow() {
-                    return WaitOutcome::Unsatisfiable(UnsatisfiableReason::NoMutatorRemaining);
+                if changed.is_ok() {
+                    match *cancel.borrow() {
+                        WaitSignal::Cancelled => return WaitOutcome::Cancelled,
+                        WaitSignal::NoMutatorRemaining => {
+                            return WaitOutcome::Unsatisfiable(
+                                UnsatisfiableReason::NoMutatorRemaining
+                            );
+                        }
+                        WaitSignal::Continue => {}
+                    }
                 }
             }
             () = tokio::time::sleep(interval) => {}
@@ -481,7 +533,7 @@ mod tests {
         let provider = ReadSequenceProvider::new(vec![state_with_status("ISSUED")]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
-        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let result = execute_wait_effect(
             &provider,
@@ -515,7 +567,7 @@ mod tests {
         ]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
-        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let result = execute_wait_effect(
             &provider,
@@ -540,7 +592,7 @@ mod tests {
         let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
-        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let result = execute_wait_effect(
             &provider,
@@ -580,7 +632,7 @@ mod tests {
         ]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
-        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let result = execute_wait_effect(
             &provider,
@@ -604,7 +656,7 @@ mod tests {
         let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
-        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let (cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let reads_seen = AtomicUsize::new(0);
 
@@ -613,7 +665,7 @@ mod tests {
                 loop {
                     if provider.read_count() >= 3 {
                         reads_seen.store(provider.read_count(), Ordering::SeqCst);
-                        let _ = cancel_tx.send(true);
+                        let _ = cancel_tx.send(WaitSignal::NoMutatorRemaining);
                         break;
                     }
                     tokio::time::sleep(Duration::from_millis(1)).await;
@@ -650,7 +702,7 @@ mod tests {
         let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
         let pred = equals_status("ISSUED");
         let target = ResourceId::new("acm.Certificate", "cert");
-        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = HeartbeatObserver::new();
 
         let result = execute_wait_effect_with_heartbeat_gap(


### PR DESCRIPTION
Closes #3504. Refs #3498.

T4 of the apply interruption resilience series. Adds cancel-token observation to the sequential and phased executors so that `execute_plan` returns `ExecutionOutcome::Cancelled(result)` when a cancel is observed mid-run, preserving the work that was actually completed.

## Semantics

- New effects stop dispatching once cancel is observed.
- In-flight effects are awaited to completion (drop would diverge state from the AWS side that was already mutated).
- In-flight Wait effects abort their polling immediately via a typed `WaitSignal::Cancelled` on the watch channel — no more 30-minute wait after Ctrl+C.
- A flip from observation only happens when at least one actionable effect would have been suppressed; pre-cancelling a token on an empty plan still returns `Completed`.
- Phase 4 CBD finalize is symmetric: finalized indices are removed from `cbd_create_states`, so a cancel after finalize completes does not double-count or overwrite the post-finalize state.

## Type safety

- New `WaitOutcome::Cancelled` variant distinguishes cancel-aborted Wait from cascade-failed Wait; cancelled Waits do NOT enter `failed_bindings`, so their dependents are skipped with `reason = SKIP_REASON_CANCELLED` instead of cascade-failure.
- New `WaitSignal` enum (`Continue` / `NoMutatorRemaining` / `Cancelled`) replaces the prior `bool` watch channel; cancel and no-mutator termination are no longer indistinguishable at the channel layer.
- Shared `signal_in_flight_waits` helper in `wait.rs` centralises the fan-out so sequential and phased cannot drift.
- All 5 `tokio::select!` sites that race cancel against `in_flight.next()` use `biased;` so cancel observation is deterministic.

Integrates with the typestate `WaitAwareInFlight` set introduced upstream in #3522 — cancel signals are routed through the typestate's own `signal_in_flight_waits` method so the API surface stays single-seam.

## Tests

- 3 original T4 contract tests (sequential cancel after N, in-flight retained, phased between-phase cancel).
- 4 fix-evidence tests added during review: prompt in-flight Wait cancel, Phase-4 finalize no-double-count, empty plan returns Completed, Phase 4 mid-cancel preserves unprocessed CBD creates.
- 1 type-safety test: Wait cancel emits `cancelled` skip, dependent effects also skipped with `cancelled` (never `unsatisfiable`).
- 1 inverted T3 contract test: pre-cancelled token now returns `Cancelled` at T4+.

## Verify

- `cargo nextest run -p carina-core` 2492 PASS
- `cargo clippy --workspace --all-targets -- -D warnings` PASS
- `cargo test -p carina-core --doc` 14 PASS including the T2 `ExecutionOutcomeCannotBeQuestionMarked` compile_fail guard

5-round self-review history: code-review medium (4 correctness fixes), Round 1 (3 correctness fixes), Round 2 (3 hygiene fixes), Round 3 (1 type-safety fix), Round 4 (3 doc-only fixes), Round 5 (caught the stale rebase and missing commit — both fixed). All gates green post-rebase onto `origin/main`.