### PR TITLE
feat(differ): augment wait explicit_dependencies via Provider::satisfier_hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tracing",
  "uuid",
 ]
 

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1285,6 +1285,7 @@ async fn run_apply_locked(
     let mut plan = create_plan(
         &resources_for_plan,
         &data_sources_for_plan,
+        &provider,
         &current_states,
         &directives_map,
         schemas,

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -324,6 +324,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
     let mut plan = create_plan(
         &resources,
         &data_sources_for_plan,
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         wiring.schemas(),

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1317,6 +1317,7 @@ fn orphaned_state_resource_produces_delete_effect() {
     let plan = create_plan(
         &desired,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -2322,6 +2323,7 @@ fn orphaned_resource_deleted_externally_should_not_produce_delete_effect() {
     let plan = create_plan(
         &desired,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -2408,6 +2410,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
     let plan = create_plan(
         &desired,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -2456,6 +2459,7 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
     let plan = create_plan(
         &desired,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -2502,6 +2506,7 @@ fn refresh_false_without_state_file_treats_resources_as_new() {
     let plan = create_plan(
         &desired,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -2752,6 +2757,7 @@ fn write_only_canonical_enum_state_roundtrip_converges_without_diff() {
     let plan = create_plan(
         &[resource],
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         reloaded.as_map(),
         &HashMap::new(),
         &schemas,

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -2067,6 +2067,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     let mut plan = create_plan(
         &resources,
         &data_sources_for_plan,
+        &provider,
         &current_states,
         &directives_map,
         ctx.schemas(),

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -195,6 +195,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
     let plan_without = create_plan(
         &resources_without,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &schemas,
@@ -214,6 +215,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
     let plan_with = create_plan(
         &resources_with,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &schemas,
@@ -306,6 +308,7 @@ fn test_merge_default_tags_prevents_false_diff() {
     let plan_without = create_plan(
         &resources_without,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &schemas,
@@ -336,6 +339,7 @@ fn test_merge_default_tags_prevents_false_diff() {
     let plan_with = create_plan(
         &resources_with,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &schemas,
@@ -3521,6 +3525,7 @@ mod wait_until_enum_alias {
         let plan_raw = create_plan(
             &resources,
             &[],
+            &carina_core::provider::ProviderRouter::new(),
             &states,
             &HashMap::new(),
             ctx.schemas(),
@@ -3542,6 +3547,7 @@ mod wait_until_enum_alias {
         let plan_fixed = create_plan(
             &resources,
             &[],
+            &carina_core::provider::ProviderRouter::new(),
             &states,
             &HashMap::new(),
             ctx.schemas(),

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -437,6 +437,7 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
     let plan = create_plan(
         &resources_for_plan,
         &parsed.data_sources,
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         ctx.schemas(),

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { version = "1", features = ["v4"] }
 indexmap = { version = "2", features = ["serde"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-util = "0.7"
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync"] }

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -77,6 +77,7 @@ fn create_plan_from_resources() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -107,6 +108,7 @@ fn create_plan_with_read_only_resource() {
     let plan = create_plan(
         &resources,
         &data_sources,
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -212,6 +214,7 @@ fn create_plan_detects_orphaned_resources_for_deletion() {
     let plan = create_plan(
         &desired,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -263,6 +266,7 @@ fn read_only_resource_always_generates_read_effect() {
     let plan = create_plan(
         &[],
         &data_sources,
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -335,6 +339,7 @@ fn replace_when_create_only_attr_changed() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -391,6 +396,7 @@ fn normal_update_when_non_create_only_attr_changed() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -453,6 +459,7 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -507,6 +514,7 @@ fn replace_carries_create_before_destroy_directives() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -629,6 +637,7 @@ fn replace_with_provider_prefixed_schema_key() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -899,6 +908,7 @@ fn orphan_delete_preserves_binding_and_dependencies() {
     let plan = create_plan(
         &desired,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -7,10 +7,12 @@ use crate::effect::{CascadingUpdate, ChangedCreateOnly, Effect, TemporaryName, W
 use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
+use crate::provider::Provider;
 use crate::resource::{ConcreteValue, DataSource, Directives, Resource, ResourceId, State, Value};
 use crate::schema::{
     ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
 };
+use crate::wait::augment::satisfier_augmentation;
 use crate::wait::predicate::{AttrPath, WaitPredicate};
 
 use super::{Diff, diff};
@@ -201,6 +203,7 @@ fn generate_temporary_name(
 /// let _ = create_plan(
 ///     &compositions,
 ///     &[],
+///     &carina_core::provider::ProviderRouter::new(),
 ///     &HashMap::new(),
 ///     &HashMap::new(),
 ///     &SchemaRegistry::default(),
@@ -214,6 +217,7 @@ fn generate_temporary_name(
 pub fn create_plan(
     managed: &[Resource],
     data_sources: &[DataSource],
+    provider: &dyn Provider,
     current_states: &HashMap<ResourceId, State>,
     directives_map: &HashMap<ResourceId, Directives>,
     registry: &SchemaRegistry,
@@ -223,6 +227,7 @@ pub fn create_plan(
     wait_bindings: &[WaitBinding],
 ) -> Plan {
     let mut plan = Plan::new();
+    let known_bindings = known_binding_names(managed, data_sources);
 
     let desired_ids: std::collections::HashSet<&ResourceId> = managed
         .iter()
@@ -515,7 +520,7 @@ pub fn create_plan(
             segments: wb.until_predicate.lhs_segments[1..].to_vec(),
         };
         let until = WaitPredicate::Equals {
-            attr,
+            attr: attr.clone(),
             value: wb.until_predicate.rhs.clone(),
         };
         let target_id = target_id_resolved;
@@ -578,6 +583,21 @@ pub fn create_plan(
         if !wait_has_work {
             continue;
         }
+        let mut explicit_dependencies: HashSet<String> = wb
+            .depends_on
+            .iter()
+            .map(|d| d.as_str().to_string())
+            .collect();
+        // Provider hints supplement user-authored ordering. They are additive
+        // because `depends_on` is the user's source of truth and must never be
+        // weakened by provider-derived knowledge.
+        explicit_dependencies.extend(satisfier_augmentation(
+            provider,
+            &target_id,
+            &attr,
+            &known_bindings,
+        ));
+
         plan.add(Effect::Wait {
             // Lower BindingName -> String at the AST→Effect seam: the
             // executor IR (Effect) is string-keyed and is the separate
@@ -589,15 +609,23 @@ pub fn create_plan(
             until_surface: wb.until_raw.clone(),
             timeout,
             interval,
-            explicit_dependencies: wb
-                .depends_on
-                .iter()
-                .map(|d| d.as_str().to_string())
-                .collect(),
+            explicit_dependencies,
         });
     }
 
     plan
+}
+
+fn known_binding_names(managed: &[Resource], data_sources: &[DataSource]) -> HashSet<String> {
+    managed
+        .iter()
+        .filter_map(|resource| resource.binding.clone())
+        .chain(
+            data_sources
+                .iter()
+                .filter_map(|resource| resource.binding.clone()),
+        )
+        .collect()
 }
 
 /// Populate cascading updates for Replace effects with create_before_destroy.

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use indexmap::IndexMap;
 
 use crate::explicit::ExplicitFields;
-use crate::resource::ConcreteValue;
+use crate::resource::{ConcreteValue, DataSource};
 
 /// Build an `ExplicitFields::Struct` whose children are all `Leaf` —
 /// the shape `state v5 → v6` reads produce, and a convenient way to
@@ -15,6 +15,70 @@ fn explicit_top_level(keys: &[&str]) -> ExplicitFields {
             .iter()
             .map(|k| ((*k).to_string(), ExplicitFields::Leaf))
             .collect(),
+    }
+}
+
+struct HintProvider {
+    hints: Vec<crate::wait::BindingPattern>,
+}
+
+impl crate::provider::Provider for HintProvider {
+    fn name(&self) -> &str {
+        "hint"
+    }
+
+    fn read(
+        &self,
+        _id: &ResourceId,
+        _identifier: Option<&str>,
+        _request: crate::provider::ReadRequest,
+    ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<State>> {
+        Box::pin(async { panic!("unexpected read") })
+    }
+
+    fn read_data_source(
+        &self,
+        _resource: &DataSource,
+    ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<State>> {
+        Box::pin(async { panic!("unexpected read_data_source") })
+    }
+
+    fn create(
+        &self,
+        _id: &ResourceId,
+        _request: crate::provider::CreateRequest,
+    ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<State>> {
+        Box::pin(async { panic!("unexpected create") })
+    }
+
+    fn update(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _request: crate::provider::UpdateRequest,
+    ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<State>> {
+        Box::pin(async { panic!("unexpected update") })
+    }
+
+    fn delete(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _request: crate::provider::DeleteRequest,
+    ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<()>> {
+        Box::pin(async { panic!("unexpected delete") })
+    }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: crate::effect::PlanOp) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn satisfier_hint(
+        &self,
+        _target_id: &ResourceId,
+        _attr_path: &crate::wait::predicate::AttrPath,
+    ) -> Vec<crate::wait::BindingPattern> {
+        self.hints.clone()
     }
 }
 
@@ -64,6 +128,7 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -150,6 +215,7 @@ fn create_before_destroy_generates_temporary_name_with_can_rename() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -218,6 +284,7 @@ fn no_temporary_name_without_create_before_destroy() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -289,6 +356,7 @@ fn no_temporary_name_when_name_prefix_is_used() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -344,6 +412,7 @@ fn no_temporary_name_without_name_attribute_in_schema() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -413,6 +482,7 @@ fn no_temporary_name_when_name_attribute_changes() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -681,6 +751,7 @@ fn create_plan_detects_attribute_removal() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -748,6 +819,7 @@ fn create_plan_filters_non_removable_attribute_removal() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -818,6 +890,7 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -893,6 +966,7 @@ fn prevent_destroy_blocks_delete_for_orphaned_resource() {
     let plan = create_plan(
         &[],
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -958,6 +1032,7 @@ fn prevent_destroy_blocks_replace() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &schemas,
@@ -1013,6 +1088,7 @@ fn prevent_destroy_does_not_block_update() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1052,6 +1128,7 @@ fn prevent_destroy_does_not_block_create() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &HashMap::new(), // no current states (resource doesn't exist)
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1093,6 +1170,7 @@ fn without_prevent_destroy_delete_works_normally() {
     let plan = create_plan(
         &[],
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(), // no directives (default = prevent_destroy: false)
         &SchemaRegistry::new(),
@@ -1156,6 +1234,7 @@ fn prevent_destroy_collects_multiple_errors() {
     let plan = create_plan(
         &[],
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &directives_map,
         &SchemaRegistry::new(),
@@ -1213,6 +1292,7 @@ fn wait_binding_lowers_to_wait_effect() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &HashMap::new(),
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1260,6 +1340,127 @@ fn wait_binding_lowers_to_wait_effect() {
 }
 
 #[test]
+fn wait_provider_satisfier_hint_augments_explicit_dependencies() {
+    use crate::effect::Effect;
+    use crate::wait::BindingPattern;
+
+    let parsed = crate::parser::parse_and_resolve(
+        r#"
+        provider aws {
+            region = "us-east-1"
+        }
+
+        let cert = aws.acm.Certificate {
+            domain_name       = "example.com"
+            validation_method = "DNS"
+        }
+
+        let validation_records = aws.route53.RecordSet {
+            name = "_acme.example.com"
+        }
+
+        let cert_issued = wait cert {
+            until = cert.status == "ISSUED"
+        }
+
+        let dist = aws.cloudfront.Distribution {
+            cert_status = cert_issued.status
+        }
+        "#,
+    )
+    .expect("parsed file should be valid");
+    let provider = HintProvider {
+        hints: vec![BindingPattern::Exact("validation_records".to_string())],
+    };
+
+    let plan = create_plan(
+        &parsed.resources,
+        &parsed.data_sources,
+        &provider,
+        &HashMap::new(),
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &parsed.wait_bindings,
+    );
+
+    let Effect::Wait {
+        explicit_dependencies,
+        ..
+    } = plan
+        .effects()
+        .iter()
+        .find(|effect| effect.is_wait())
+        .expect("wait should be emitted for changed downstream consumer")
+    else {
+        unreachable!();
+    };
+    assert!(
+        explicit_dependencies.contains("validation_records"),
+        "provider satisfier hint should add validation_records; got {explicit_dependencies:?}"
+    );
+}
+
+#[test]
+fn wait_user_depends_on_conflict_with_provider_hint_deduplicates() {
+    use crate::effect::Effect;
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+    use crate::wait::BindingPattern;
+
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
+    let dependency = Resource::new("route53.RecordSet", "record").with_binding("something");
+    let mut consumer = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    consumer
+        .dependency_bindings
+        .insert("cert_issued".to_string());
+    let resources = vec![cert, dependency, consumer];
+    let wait = WaitBinding {
+        binding: "cert_issued".into(),
+        target: "cert".into(),
+        until_raw: "cert.status == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        },
+        timeout_secs: None,
+        depends_on: vec!["something".into()],
+        line: 1,
+    };
+    let provider = HintProvider {
+        hints: vec![BindingPattern::Exact("something".to_string())],
+    };
+
+    let plan = create_plan(
+        &resources,
+        &[],
+        &provider,
+        &HashMap::new(),
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+
+    let Effect::Wait {
+        explicit_dependencies,
+        ..
+    } = plan
+        .effects()
+        .iter()
+        .find(|effect| effect.is_wait())
+        .expect("wait should be emitted")
+    else {
+        unreachable!();
+    };
+    assert_eq!(explicit_dependencies.len(), 1);
+    assert!(explicit_dependencies.contains("something"));
+}
+
+#[test]
 fn wait_uses_schema_default_timeout_when_omitted() {
     use crate::effect::Effect;
     use crate::parser::{UntilPredicateAst, WaitBinding};
@@ -1299,6 +1500,7 @@ fn wait_uses_schema_default_timeout_when_omitted() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &HashMap::new(),
         &HashMap::new(),
         &schemas,
@@ -1343,6 +1545,7 @@ fn wait_with_unknown_target_emits_plan_error() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &HashMap::new(),
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1407,6 +1610,7 @@ fn wait_omitted_when_all_consumers_unchanged() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1455,6 +1659,7 @@ fn wait_emitted_when_a_consumer_has_a_pending_change() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &HashMap::new(),
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1528,6 +1733,7 @@ fn wait_omitted_when_already_satisfied_and_target_unchanged() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1579,6 +1785,7 @@ fn wait_emitted_when_target_is_changing_even_if_cached_state_satisfies() {
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &HashMap::new(),
         &HashMap::new(),
         &SchemaRegistry::new(),
@@ -1657,6 +1864,7 @@ fn wait_emitted_when_known_target_has_pending_update_even_if_cached_state_satisf
     let plan = create_plan(
         &resources,
         &[],
+        &crate::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &SchemaRegistry::new(),

--- a/carina-core/src/wait/augment.rs
+++ b/carina-core/src/wait/augment.rs
@@ -1,0 +1,187 @@
+use std::collections::HashSet;
+
+use crate::provider::Provider;
+use crate::resource::ResourceId;
+use crate::wait::BindingPattern;
+use crate::wait::predicate::AttrPath;
+
+/// Resolve satisfier hints from the provider against the plan's known bindings,
+/// and return additional explicit dependencies for a wait on `target_id.attr_path`.
+pub fn satisfier_augmentation(
+    provider: &dyn Provider,
+    target_id: &ResourceId,
+    attr_path: &AttrPath,
+    known_bindings: &HashSet<String>,
+) -> HashSet<String> {
+    let mut additional = HashSet::new();
+
+    for hint in provider.satisfier_hint(target_id, attr_path) {
+        match hint {
+            BindingPattern::Exact(name) => {
+                if known_bindings.contains(&name) {
+                    additional.insert(name);
+                }
+            }
+            BindingPattern::ForLoopChildren { base } => {
+                let prefix = format!("{base}[");
+                additional.extend(
+                    known_bindings
+                        .iter()
+                        .filter(|name| name.starts_with(&prefix))
+                        .cloned(),
+                );
+            }
+            BindingPattern::AttributeMatch {
+                resource_type,
+                attr,
+                from,
+            } => {
+                tracing::debug!(
+                    target = "carina_core::wait::augment",
+                    %resource_type,
+                    attr = ?attr,
+                    from = ?from,
+                    "skipping state-dependent wait satisfier hint"
+                );
+            }
+        }
+    }
+
+    additional
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct HintProvider {
+        hints: Vec<BindingPattern>,
+    }
+
+    impl Provider for HintProvider {
+        fn name(&self) -> &str {
+            "hint"
+        }
+
+        fn read(
+            &self,
+            _id: &ResourceId,
+            _identifier: Option<&str>,
+            _request: crate::provider::ReadRequest,
+        ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<crate::resource::State>>
+        {
+            Box::pin(async { panic!("unexpected read") })
+        }
+
+        fn read_data_source(
+            &self,
+            _resource: &crate::resource::DataSource,
+        ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<crate::resource::State>>
+        {
+            Box::pin(async { panic!("unexpected read_data_source") })
+        }
+
+        fn create(
+            &self,
+            _id: &ResourceId,
+            _request: crate::provider::CreateRequest,
+        ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<crate::resource::State>>
+        {
+            Box::pin(async { panic!("unexpected create") })
+        }
+
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: crate::provider::UpdateRequest,
+        ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<crate::resource::State>>
+        {
+            Box::pin(async { panic!("unexpected update") })
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: crate::provider::DeleteRequest,
+        ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<()>> {
+            Box::pin(async { panic!("unexpected delete") })
+        }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: crate::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn satisfier_hint(
+            &self,
+            _target_id: &ResourceId,
+            _attr_path: &AttrPath,
+        ) -> Vec<BindingPattern> {
+            self.hints.clone()
+        }
+    }
+
+    fn augment(hints: Vec<BindingPattern>, known: &[&str]) -> HashSet<String> {
+        let provider = HintProvider { hints };
+        let known_bindings = known.iter().map(|name| (*name).to_string()).collect();
+        satisfier_augmentation(
+            &provider,
+            &ResourceId::new("acm.Certificate", "cert"),
+            &AttrPath::single("status"),
+            &known_bindings,
+        )
+    }
+
+    #[test]
+    fn exact_hint_included_when_known() {
+        assert_eq!(
+            augment(vec![BindingPattern::Exact("alb".to_string())], &["alb"]),
+            HashSet::from(["alb".to_string()])
+        );
+    }
+
+    #[test]
+    fn exact_hint_skipped_when_missing() {
+        assert!(augment(vec![BindingPattern::Exact("missing".to_string())], &["alb"]).is_empty());
+    }
+
+    #[test]
+    fn for_loop_children_includes_matching_children() {
+        assert_eq!(
+            augment(
+                vec![BindingPattern::ForLoopChildren {
+                    base: "validation_records".to_string(),
+                }],
+                &[
+                    "validation_records[0]",
+                    "validation_records[1]",
+                    "unrelated_binding",
+                ],
+            ),
+            HashSet::from([
+                "validation_records[0]".to_string(),
+                "validation_records[1]".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn attribute_match_is_deferred() {
+        assert!(
+            augment(
+                vec![BindingPattern::AttributeMatch {
+                    resource_type: "route53.Record".to_string(),
+                    attr: AttrPath::single("name"),
+                    from: AttrPath::single("validation_name"),
+                }],
+                &["route53_record"],
+            )
+            .is_empty()
+        );
+    }
+}

--- a/carina-core/src/wait/mod.rs
+++ b/carina-core/src/wait/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! See `notes/specs/2026-05-09-wait-construct-design.md`.
 
+pub mod augment;
 pub mod predicate;
 
 use predicate::AttrPath;

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -258,6 +258,7 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
     let plan = create_plan(
         &resources_for_plan,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &registry,
@@ -407,6 +408,7 @@ async fn nested_module_wait_binding_survives_two_expansions() {
     let plan = create_plan(
         &resources_for_plan,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &registry,
@@ -564,6 +566,7 @@ async fn carina3085_distribution_wait_ref_resolves_no_phantom_via_real_pipeline(
     let plan = create_plan(
         &resources_for_plan,
         &[],
+        &carina_core::provider::ProviderRouter::new(),
         &current_states,
         &HashMap::new(),
         &registry,


### PR DESCRIPTION
## Summary

Issue #3516 step (c) **Sub-C (PR 2)**。Sub-B (#3525) で導入した `Provider::satisfier_hint` を、plan ステージで **実際に呼んで wait の `explicit_dependencies` を補強する** logic を追加します。

これでようやく Issue #3497 の本来狙い「wait の satisfier が plan 時点で `failed_bindings` に入っていれば、ランタイム検出に頼らず dispatch 前に skip される」が成立します。runtime 側の terminal-with-pending-waits 検出 (#3515) は引き続き defense-in-depth として残ります。

設計: `notes/specs/2026-06-14-wait-satisfier-hint-design.md`

## 何を入れたか

- 新ヘルパー `carina_core::wait::augment::satisfier_augmentation(provider, target_id, attr_path, known_bindings) -> HashSet<String>`
- `BindingPattern` の解決:
  - `Exact(name)`: `known_bindings` に含まれていれば追加
  - `ForLoopChildren { base }`: `<base>[` で始まる binding 全部を追加
  - `AttributeMatch { .. }`: state 依存なので本 PR では skip。`tracing::debug!` で観測可能にしてあるので、follow-up PR でいつ実装するかも追えます
- differ の `Wait` 構築点で `satisfier_augmentation` を呼んで、ユーザの `depends_on` 集合に **union**(削らない、足すだけ)
- `differ::create_plan` シグネチャに `&dyn Provider` を追加。`carina-cli` の apply/plan/fixture_plan 等の呼び出し側を更新

## 副作用

- `provider.satisfier_hint` のデフォルト実装は `Vec::new()` なので、override しない既存 provider では plan 出力は変わりません
- ユーザの `depends_on` は尊重(消さない)。provider hint は supplement
- ランタイムの terminal check (#3515) はそのまま。 hint が漏れたとしても deep-defense で守られます

## Out of scope

- **`AttributeMatch` の plan-time マッチング**: state を見ないと evaluate できないので state 引数を取る別 API になる。別 follow-up
- **Sub-D (PR 3)**: 実際の provider impl(`carina-provider-aws` の ACM Certificate など)。別 repo 作業

## Test plan

- [x] `wait::augment` unit tests: Exact 一致 / Exact 不在 / ForLoopChildren / AttributeMatch skip / dedupe
- [x] differ integration test: parsed file が depends_on を持たない wait でも、provider が hint を返すと `explicit_dependencies` に補強された binding が現れる
- [x] `cargo nextest run --workspace --all-features` — passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

Refs #3516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
