### PR TITLE
fix(plan): typed IAM Simulate error classify + warning placement + --help text (closes #3524)

### DIFF
--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 
 use aws_config::BehaviorVersion;
+use aws_sdk_iam::operation::simulate_principal_policy::SimulatePrincipalPolicyError;
 use aws_sdk_iam::types::PolicyEvaluationDecisionType;
 use carina_core::effect::{Effect, PlanOp};
 use carina_core::plan::Plan;
@@ -25,6 +26,7 @@ pub(crate) struct IamPreflightSkipped {
 pub(crate) struct IamPreflightReport {
     pub actor_arn: String,
     pub method: IamCheckMethod,
+    pub source_providers: Vec<String>,
     pub missing_by_effect: Vec<MissingEffectActions>,
 }
 
@@ -92,6 +94,7 @@ pub(crate) async fn run_iam_preflight(
         return IamPreflightResult::Checked(IamPreflightReport {
             actor_arn: String::new(),
             method: IamCheckMethod::SimulatePrincipalPolicy,
+            source_providers: plan_provider_names(plan),
             missing_by_effect: Vec::new(),
         });
     }
@@ -129,9 +132,13 @@ pub(crate) async fn run_iam_preflight(
                     (IamCheckMethod::DocumentFallback, missing)
                 }
                 Err(e) => {
+                    let actor_role_arn =
+                        role_arn_from_actor_arn(&actor_arn).unwrap_or_else(|| actor_arn.clone());
                     return IamPreflightResult::Skipped(IamPreflightSkipped {
                         reason: format!(
-                            "Warning: IAM preflight check skipped because IAM policies could not be read ({e})."
+                            "Warning: IAM preflight check skipped for actor {actor_arn} because IAM policy simulation was denied and IAM policies could not be read for fallback ({e}). \
+                             The actor needs `iam:SimulatePrincipalPolicy` (with `Resource = {actor_role_arn}`) OR `iam:GetRolePolicy` + `iam:ListAttachedRolePolicies` for the fallback path. \
+                             Add the grant to enable --check-iam."
                         ),
                     });
                 }
@@ -149,6 +156,7 @@ pub(crate) async fn run_iam_preflight(
     let report = IamPreflightReport {
         actor_arn,
         method,
+        source_providers: plan_provider_names(plan),
         missing_by_effect: group_missing_by_effect(&required, &missing_actions),
     };
 
@@ -193,32 +201,59 @@ fn effect_required_ops(effect: &Effect) -> Vec<(&ResourceId, PlanOp)> {
     }
 }
 
+fn effect_resource_ids(effect: &Effect) -> Vec<&ResourceId> {
+    match effect {
+        Effect::Read { resource } => vec![&resource.id],
+        Effect::Create(resource) => vec![&resource.id],
+        Effect::Update { id, .. } => vec![id],
+        Effect::Replace { id, to, .. } => vec![id, &to.id],
+        Effect::Delete { id, .. } => vec![id],
+        Effect::Import { id, .. } => vec![id],
+        Effect::Remove { id, .. } => vec![id],
+        Effect::Move { from, to } => vec![from, to],
+        Effect::Wait { .. } => Vec::new(),
+    }
+}
+
+fn plan_provider_names(plan: &Plan) -> Vec<String> {
+    plan.effects()
+        .iter()
+        .flat_map(effect_resource_ids)
+        .filter_map(|id| (!id.provider.is_empty()).then_some(id.provider.clone()))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
 pub(crate) fn format_warnings(result: &IamPreflightResult) -> Option<String> {
     match result {
-        IamPreflightResult::Skipped(skipped) => Some(skipped.reason.clone()),
+        IamPreflightResult::Skipped(skipped) => Some(format!(
+            "IAM preflight findings (1 warning):\n  {}",
+            skipped.reason
+        )),
         IamPreflightResult::Checked(report) if report.missing_by_effect.is_empty() => None,
         IamPreflightResult::Checked(report) => {
             let mut out = String::new();
+            out.push_str("IAM preflight findings (1 warning):\n");
+            out.push_str("  Required permissions sourced from each provider:\n");
+            for line in permission_source_lines(report) {
+                out.push_str(&format!("    - {line}\n"));
+            }
             match report.method {
                 IamCheckMethod::SimulatePrincipalPolicy => {
                     out.push_str(&format!(
-                        "Warning: IAM preflight check found missing permissions for {} using iam:SimulatePrincipalPolicy.\n",
+                        "  Check method: iam:SimulatePrincipalPolicy (SCPs, condition keys, exact resource ARN scopes may still affect apply)\n  Actor: {}\n",
                         report.actor_arn
                     ));
-                    out.push_str(
-                        "  Note: SCPs, condition keys, and exact resource ARN scopes may still affect apply.\n",
-                    );
                 }
                 IamCheckMethod::DocumentFallback => {
                     out.push_str(&format!(
-                        "Warning: IAM preflight check found missing permissions for {} using policy document fallback.\n",
+                        "  Check method: policy document fallback (weaker check: identity-policy action names only; does not evaluate SCPs, permission boundaries, condition keys, or resource scopes)\n  Actor: {}\n",
                         report.actor_arn
                     ));
-                    out.push_str(
-                        "  Weaker check: fallback only matches identity-policy action names; it does not evaluate SCPs, permission boundaries, condition keys, or resource scopes.\n",
-                    );
                 }
             }
+            out.push('\n');
             for effect in &report.missing_by_effect {
                 out.push_str(&format!(
                     "  {} ({})\n",
@@ -237,6 +272,12 @@ pub(crate) fn format_warnings(result: &IamPreflightResult) -> Option<String> {
 pub(crate) fn emit_warnings(result: &IamPreflightResult) {
     if let Some(warning) = format_warnings(result) {
         eprintln!("{}", warning.yellow());
+    }
+}
+
+pub(crate) fn print_warnings(result: &IamPreflightResult) {
+    if let Some(warning) = format_warnings(result) {
+        println!("{}", warning.yellow());
     }
 }
 
@@ -283,14 +324,10 @@ async fn simulate(
             request = request.action_names(action);
         }
 
-        let output = request.send().await.map_err(|e| {
-            let msg = e.to_string();
-            if is_access_denied(&msg) {
-                SimulateError::NeedsFallback(msg)
-            } else {
-                SimulateError::Other(msg)
-            }
-        })?;
+        let output = request
+            .send()
+            .await
+            .map_err(|e| classify_simulate_error(e.into_service_error()))?;
 
         denied_actions.extend(
             output
@@ -518,10 +555,69 @@ fn role_name_from_actor_arn(actor_arn: &str) -> Option<String> {
     None
 }
 
-fn is_access_denied(message: &str) -> bool {
-    message.contains("AccessDenied")
-        || message.contains("Access Denied")
-        || message.contains("not authorized")
+fn role_arn_from_actor_arn(actor_arn: &str) -> Option<String> {
+    if actor_arn.contains(":role/") {
+        return Some(actor_arn.to_string());
+    }
+    let account = actor_arn.split(":sts::").nth(1)?.split(':').next()?;
+    let role_name = role_name_from_actor_arn(actor_arn)?;
+    Some(format!("arn:aws:iam::{account}:role/{role_name}"))
+}
+
+fn classify_simulate_error(err: SimulatePrincipalPolicyError) -> SimulateError {
+    let code = err
+        .meta()
+        .code()
+        .map(str::to_string)
+        .unwrap_or_else(|| "unknown".to_string());
+    if code == "AccessDenied" {
+        return SimulateError::NeedsFallback(format_simulate_error(&err));
+    }
+
+    // The generated enum is #[non_exhaustive], and IAM may return operation-level
+    // errors such as AccessDenied through generic metadata instead of a named
+    // variant. Match every known variant, then classify future/generic variants
+    // by their service error code.
+    match err {
+        SimulatePrincipalPolicyError::InvalidInputException(_)
+        | SimulatePrincipalPolicyError::NoSuchEntityException(_)
+        | SimulatePrincipalPolicyError::PolicyEvaluationException(_) => SimulateError::Other(
+            format!("AWS IAM SimulatePrincipalPolicy failed with code {code}"),
+        ),
+        _ => SimulateError::Other(format!(
+            "AWS IAM SimulatePrincipalPolicy failed with code {code}"
+        )),
+    }
+}
+
+fn format_simulate_error(err: &SimulatePrincipalPolicyError) -> String {
+    let code = err.meta().code().unwrap_or("unknown");
+    let message = err.meta().message().unwrap_or("no message");
+    format!("AWS IAM SimulatePrincipalPolicy failed with code {code}: {message}")
+}
+
+fn permission_source_lines(report: &IamPreflightReport) -> Vec<String> {
+    let mut providers: BTreeSet<&str> =
+        report.source_providers.iter().map(String::as_str).collect();
+    if providers.is_empty() {
+        providers = report
+            .missing_by_effect
+            .iter()
+            .filter_map(|effect| effect.effect.resource.split('.').next())
+            .collect();
+    }
+    providers
+        .into_iter()
+        .map(|provider| {
+            // Kept CLI-local for carina#3524 to avoid a provider/WIT contract change;
+            // follow-up issue will move this onto Provider as permission_source().
+            match provider {
+                "awscc" => "awscc -> CloudFormation registry schema `handlers.<op>.permissions` (AWS does not guarantee completeness)".to_string(),
+                "aws" => "aws -> none declared (provider does not currently report required permissions)".to_string(),
+                other => format!("{other} -> provider-declared required permissions"),
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -562,6 +658,7 @@ fn plan_op_rank(op: PlanOp) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_sdk_iam::error::ErrorMetadata;
     use carina_core::effect::ChangedCreateOnly;
     use carina_core::provider::{
         BoxFuture, CreateRequest, DeleteRequest, ProviderError, ProviderResult, ReadRequest,
@@ -693,6 +790,7 @@ mod tests {
         let result = IamPreflightResult::Checked(IamPreflightReport {
             actor_arn: "arn:aws:sts::123456789012:assumed-role/deploy/session".to_string(),
             method: IamCheckMethod::DocumentFallback,
+            source_providers: vec!["awscc".to_string()],
             missing_by_effect: vec![MissingEffectActions {
                 effect: EffectAddress {
                     resource: "awscc.elasticloadbalancingv2.LoadBalancer alb".to_string(),
@@ -706,12 +804,50 @@ mod tests {
         });
 
         insta::assert_snapshot!(format_warnings(&result).unwrap(), @r###"
-Warning: IAM preflight check found missing permissions for arn:aws:sts::123456789012:assumed-role/deploy/session using policy document fallback.
-  Weaker check: fallback only matches identity-policy action names; it does not evaluate SCPs, permission boundaries, condition keys, or resource scopes.
+IAM preflight findings (1 warning):
+  Required permissions sourced from each provider:
+    - awscc -> CloudFormation registry schema `handlers.<op>.permissions` (AWS does not guarantee completeness)
+  Check method: policy document fallback (weaker check: identity-policy action names only; does not evaluate SCPs, permission boundaries, condition keys, or resource scopes)
+  Actor: arn:aws:sts::123456789012:assumed-role/deploy/session
+
   awscc.elasticloadbalancingv2.LoadBalancer alb (create)
     -> missing iam:CreateServiceLinkedRole
     -> missing ec2:DescribeInternetGateways
 "###);
+    }
+
+    #[test]
+    fn classify_simulate_access_denied_uses_fallback() {
+        let err = SimulatePrincipalPolicyError::generic(
+            ErrorMetadata::builder()
+                .code("AccessDenied")
+                .message("not authorized to call SimulatePrincipalPolicy")
+                .build(),
+        );
+
+        assert!(matches!(
+            classify_simulate_error(err),
+            SimulateError::NeedsFallback(message)
+                if message.contains("code AccessDenied")
+                    && !message.contains("service error")
+        ));
+    }
+
+    #[test]
+    fn classify_simulate_non_access_denied_reports_service_code() {
+        let err = SimulatePrincipalPolicyError::generic(
+            ErrorMetadata::builder()
+                .code("ThrottlingException")
+                .message("rate exceeded")
+                .build(),
+        );
+
+        assert!(matches!(
+            classify_simulate_error(err),
+            SimulateError::Other(message)
+                if message.contains("code ThrottlingException")
+                    && !message.contains("service error")
+        ));
     }
 
     #[test]
@@ -769,6 +905,14 @@ Warning: IAM preflight check found missing permissions for arn:aws:sts::12345678
         assert_eq!(
             role_name_from_actor_arn("arn:aws:iam::123456789012:user/alice"),
             None
+        );
+    }
+
+    #[test]
+    fn role_arn_parses_assumed_role_for_simulate_resource_hint() {
+        assert_eq!(
+            role_arn_from_actor_arn("arn:aws:sts::123456789012:assumed-role/deploy/session"),
+            Some("arn:aws:iam::123456789012:role/deploy".to_string())
         );
     }
 

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -723,7 +723,6 @@ pub async fn run_plan(
         let result =
             crate::commands::iam_preflight::run_iam_preflight(&ctx.plan, &ctx.provider, strict_iam)
                 .await;
-        crate::commands::iam_preflight::emit_warnings(&result);
         Some(result)
     } else {
         None
@@ -732,12 +731,6 @@ pub async fn run_plan(
         && iam_preflight_result
             .as_ref()
             .is_some_and(crate::commands::iam_preflight::should_fail_strict);
-
-    if iam_strict_failed {
-        return Err(AppError::Validation(
-            "IAM preflight check failed in strict mode".to_string(),
-        ));
-    }
 
     // Build delete attributes map from current states for display
     let delete_attributes: HashMap<ResourceId, HashMap<String, Value>> = ctx
@@ -774,9 +767,15 @@ pub async fn run_plan(
         let json_str = serde_json::to_string_pretty(&plan_file)
             .map_err(|e| format!("Failed to serialize plan: {}", e))?;
         println!("{}", json_str);
+        if let Some(result) = iam_preflight_result.as_ref() {
+            crate::commands::iam_preflight::emit_warnings(result);
+        }
     } else if tui {
         carina_tui::run(&ctx.plan, wiring.schemas())
             .map_err(|e| AppError::Config(format!("TUI error: {}", e)))?;
+        if let Some(result) = iam_preflight_result.as_ref() {
+            crate::commands::iam_preflight::emit_warnings(result);
+        }
     } else {
         // Resolve export values for display
         let export_wait_aliases: Vec<carina_core::binding_index::WaitAliasSpec> = parsed
@@ -816,6 +815,21 @@ pub async fn run_plan(
             println!();
             println!("{}", note.yellow());
         }
+        if let Some(result) = iam_preflight_result.as_ref() {
+            crate::commands::iam_preflight::print_warnings(result);
+        }
+    }
+
+    if iam_strict_failed {
+        eprintln!(
+            "{}",
+            "Error: IAM preflight check failed in strict mode"
+                .red()
+                .bold()
+        );
+        return Err(AppError::Validation(
+            "IAM preflight check failed in strict mode".to_string(),
+        ));
     }
 
     // Save plan to file if --out was specified

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -76,9 +76,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
 
+        /// Pre-check apply role's IAM permissions against the actions providers declare. Emits warnings; does not fail the plan.
         #[arg(long)]
         check_iam: bool,
 
+        /// With --check-iam, fail (exit 1) instead of warning when permissions are missing. Requires --check-iam.
         #[arg(long, requires = "check_iam")]
         strict_iam: bool,
     },
@@ -674,6 +676,23 @@ mod error_format_tests {
     #[test]
     fn plan_check_iam_flag_parses() {
         assert!(Cli::try_parse_from(["carina", "plan", "--check-iam"]).is_ok());
+    }
+
+    #[test]
+    fn plan_iam_flags_have_help_text() {
+        let command = Cli::command();
+        let plan = command
+            .get_subcommands()
+            .find(|cmd| cmd.get_name() == "plan")
+            .expect("plan subcommand exists");
+
+        for id in ["check_iam", "strict_iam"] {
+            let arg = plan
+                .get_arguments()
+                .find(|arg| arg.get_id() == id)
+                .unwrap_or_else(|| panic!("{id} argument exists"));
+            assert!(arg.get_help().is_some(), "{id} should have help text");
+        }
     }
 
     #[test]

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -66,6 +66,55 @@ fn snapshot_depends_on() {
     insta::assert_snapshot!(output);
 }
 
+#[test]
+fn snapshot_iam_preflight_warning_appears_after_plan_summary() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("depends_on");
+    let mut output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::None,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        None,
+    ));
+    let warning = crate::commands::iam_preflight::format_warnings(
+        &crate::commands::iam_preflight::IamPreflightResult::Checked(
+            crate::commands::iam_preflight::IamPreflightReport {
+                actor_arn: "arn:aws:sts::123456789012:assumed-role/deploy/session".to_string(),
+                method: crate::commands::iam_preflight::IamCheckMethod::SimulatePrincipalPolicy,
+                source_providers: vec!["aws".to_string(), "awscc".to_string()],
+                missing_by_effect: vec![crate::commands::iam_preflight::MissingEffectActions {
+                    effect: crate::commands::iam_preflight::EffectAddress {
+                        resource: "awscc.elasticloadbalancingv2.LoadBalancer registry_publish.alb"
+                            .to_string(),
+                        op: carina_core::effect::PlanOp::Create,
+                    },
+                    missing_actions: vec!["ec2:DescribeInternetGateways".to_string()],
+                }],
+            },
+        ),
+    )
+    .expect("warning should render");
+    output.push_str(&strip_ansi(&warning));
+    output.push('\n');
+
+    let execution_plan = output.find("Execution Plan:").expect("plan header");
+    let summary = output.find("Plan: ").expect("plan summary");
+    let iam = output
+        .find("IAM preflight findings")
+        .expect("iam warning block");
+
+    assert!(
+        execution_plan < summary,
+        "plan summary should follow header"
+    );
+    assert!(summary < iam, "IAM warning should follow plan summary");
+    insta::assert_snapshot!(output);
+}
+
 /// Plan-display gate for the `wait` construct (carina#2825). The
 /// fixture wires ACM Certificate → Route53 validation record → wait
 /// (blocking on `cert.status == ISSUED`). The snapshot pins:

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_iam_preflight_warning_appears_after_plan_summary.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_iam_preflight_warning_appears_after_plan_summary.snap
@@ -1,0 +1,21 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+assertion_line: 115
+expression: output
+---
+Execution Plan:
+
+  + aws.iam.Role role
+        └─ + aws.s3.Bucket (bucket: my-bucket)
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+
+IAM preflight findings (1 warning):
+  Required permissions sourced from each provider:
+    - aws -> none declared (provider does not currently report required permissions)
+    - awscc -> CloudFormation registry schema `handlers.<op>.permissions` (AWS does not guarantee completeness)
+  Check method: iam:SimulatePrincipalPolicy (SCPs, condition keys, exact resource ARN scopes may still affect apply)
+  Actor: arn:aws:sts::123456789012:assumed-role/deploy/session
+
+  awscc.elasticloadbalancingv2.LoadBalancer registry_publish.alb (create)
+    -> missing ec2:DescribeInternetGateways


### PR DESCRIPTION
Closes #3524

Further diagnosis: https://github.com/carina-rs/carina/issues/3524#issuecomment-4701219793

## Three bugs, one PR

### Bug 1 — SDK error classify was string-match on the wrong string

`iam_preflight.rs:521` (pre-fix) routed `iam:SimulatePrincipalPolicy` errors to the policy-document fallback when `e.to_string()` contained the substring `"AccessDenied"`. The AWS SDK's `SdkError::ServiceError` `Display` impl flattens to `"service error"` for many shapes — `AccessDenied` never appears in the string we matched. The actual dominant deployment case (the actor role itself lacks `iam:SimulatePrincipalPolicy`) was therefore misclassified as `SimulateError::Other`, the fallback never ran, and the user saw `IAM policy simulation failed (service error)`.

Fix: classify on the SDK's typed `SimulatePrincipalPolicyError` via `e.into_service_error()` + `.meta().code()`. AccessDenied (from any variant — generic or named — and the `#[non_exhaustive]` future variants) routes to fallback; other variants render their AWS error code in the skip message instead of the generic `(service error)`.

### Bug 2 — warnings appeared above the plan body

The previous code emitted IAM preflight warnings BEFORE `Execution Plan:`, so on a multi-hundred-line plan the warning was off-screen by the time the operator reached the `Plan: N to add, …` summary. Issue author and reviewer both missed it on first read.

Fix: emit warnings at the bottom of the plan output, immediately after the `Plan: …` summary line, mirroring `terraform plan` / `cargo` / `make` summary-at-end conventions. Strict mode still fails with exit 1 but only after printing the plan + warning so the user sees what failed.

### Bug 3 — `--help` text was empty

`--check-iam` and `--strict-iam` had no `#[arg(help = …)]`. Added concise descriptions.

## Source-of-truth attribution (also from the issue conversation)

The warning block now names where each provider's required-permission list comes from:

```
IAM preflight findings (N):
  Required permissions sourced from each provider:
    - awscc → CloudFormation registry schema handlers block (may be incomplete)
    - aws   → none declared (provider does not currently report required permissions)
  Check method: iam:SimulatePrincipalPolicy (SCPs, condition keys, exact resource ARN scopes may still affect apply)
  Actor: arn:aws:iam::...
  …
```

This attribution is **hardcoded in `iam_preflight.rs`** for now (provider name → source description map). A cleaner long-term shape — extending the `Provider` trait with `permission_source()` so each provider declares its own attribution — would cross the WIT boundary and require a multi-repo PR chain. Filed as #3528.

## Tests

- `classify_simulate_error` unit tests for AccessDenied → NeedsFallback and non-AccessDenied → service code in message
- Snapshot test asserting the IAM warning block appears **after** the `Plan: …` summary line
- clap test asserting `--check-iam` and `--strict-iam` each have non-empty help text

## Verify

- `cargo check -p carina-cli`
- `cargo nextest run $(scripts/touched-crates.sh)` — 4161 passed
- `cargo test --workspace --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- all `scripts/check-*.sh`
