### PR TITLE
apply: route through ExecutionOutcome and persist state on cancel (T5, #3505)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -15,7 +15,7 @@ use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
 use carina_core::executor::normalized::apply_desired_normalization;
 use carina_core::executor::{
-    ExecutionInput, ExecutionOutcome, ExecutionResult, UnresolvedResource,
+    ExecutionInput, ExecutionObserver, ExecutionOutcome, ExecutionResult, UnresolvedResource,
 };
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer, ReadRequest};
@@ -57,8 +57,48 @@ use crate::wiring::{
 /// Re-export ExecutionResult as the public API for apply results.
 pub type ApplyResult = ExecutionResult;
 
+type ObserverFactory<'a> = dyn Fn(&Plan) -> Box<dyn ExecutionObserver> + 'a;
+
+fn cli_observer_factory(plan: &Plan) -> Box<dyn ExecutionObserver> {
+    Box::new(CliObserver::new(plan))
+}
+
 fn format_total_apply_line(elapsed: Duration) -> String {
     format!("Done in {}.", format_duration(elapsed))
+}
+
+/// Handle the finalize_apply call after execute_effects returns.
+///
+/// Four cases:
+/// 1. not cancelled + finalize Ok    -> Ok(())  (normal completion)
+/// 2. not cancelled + finalize Err   -> Err(finalize_err)  (state save failed mid-run)
+/// 3. cancelled     + finalize Ok    -> Err(Interrupted)  (state saved despite cancel)
+/// 4. cancelled     + finalize Err   -> Err(Interrupted) after logging warning  (cancel + save failed)
+///
+/// On cancellation, the Interrupted error takes precedence so the user sees
+/// "the apply was interrupted" rather than a backend error that happened to
+/// occur during cleanup. The finalize error is still logged to stderr.
+/// Production signal-driven cancellation is wired in T7/T8; T5 only preserves
+/// partial state after the executor observes a cancellation token.
+fn handle_finalize_after_execute(
+    finalize_result: Result<(), AppError>,
+    cancelled: bool,
+) -> Result<(), AppError> {
+    if cancelled {
+        if let Err(err) = finalize_result {
+            eprintln!("warning: state save during cancellation also failed: {err}");
+        }
+        return Err(AppError::Interrupted);
+    }
+
+    finalize_result
+}
+
+fn split_execution_outcome(outcome: ExecutionOutcome) -> (ExecutionResult, bool) {
+    match outcome {
+        ExecutionOutcome::Completed(result) => (result, false),
+        ExecutionOutcome::Cancelled(result) => (result, true),
+    }
 }
 
 /// Execute all effects in a plan, resolving references dynamically.
@@ -79,12 +119,47 @@ pub async fn execute_effects(
     compositions: &[carina_core::resource::Composition],
     cancel: CancellationToken,
     parallelism: NonZeroUsize,
-) -> ApplyResult {
+) -> ExecutionOutcome {
+    let observer = cli_observer_factory(plan);
+    execute_effects_with_observer(
+        plan,
+        provider,
+        normalizer,
+        provider_configs,
+        factories,
+        schemas,
+        bindings,
+        current_states,
+        unresolved_resources,
+        compositions,
+        cancel,
+        parallelism,
+        observer,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_effects_with_observer(
+    plan: &Plan,
+    provider: &dyn Provider,
+    normalizer: &dyn ProviderNormalizer,
+    provider_configs: &[ProviderConfig],
+    factories: &[Box<dyn carina_core::provider::ProviderFactory>],
+    schemas: &carina_core::schema::SchemaRegistry,
+    bindings: &mut ResolvedBindings,
+    current_states: &mut HashMap<ResourceId, State>,
+    unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
+    compositions: &[carina_core::resource::Composition],
+    cancel: CancellationToken,
+    parallelism: NonZeroUsize,
+    observer: Box<dyn ExecutionObserver>,
+) -> ExecutionOutcome {
     let input = ExecutionInput {
         plan,
         unresolved_resources,
         compositions,
-        bindings: std::mem::take(bindings),
+        bindings: bindings.clone(),
         current_states: std::mem::take(current_states),
         normalizer,
         provider_configs,
@@ -93,20 +168,16 @@ pub async fn execute_effects(
         parallelism,
     };
 
-    let observer = CliObserver::new(plan);
-    let outcome = carina_core::executor::execute_plan(provider, input, &observer, cancel).await;
-    // T3: both arms surface the same ExecutionResult so callers see consistent
-    // intermediate state regardless of whether cancellation has been observed yet.
-    // T5 (carina#3505) will rewrap this into the finalize_apply pipeline so the
-    // caller can distinguish Completed from Cancelled at the apply boundary.
-    let result = match outcome {
-        ExecutionOutcome::Completed(result) | ExecutionOutcome::Cancelled(result) => result,
-    };
+    let outcome = carina_core::executor::execute_plan(provider, input, &*observer, cancel).await;
 
     // Write back the updated current_states so callers see refreshes
+    let result = match &outcome {
+        ExecutionOutcome::Completed(result) | ExecutionOutcome::Cancelled(result) => result,
+    };
     *current_states = result.current_states.clone();
+    *bindings = result.bindings.clone();
 
-    result
+    outcome
 }
 
 /// Re-load each upstream declared in the saved plan and verify its
@@ -562,6 +633,30 @@ pub async fn run_apply(
     lock: bool,
     parallelism: NonZeroUsize,
     provider_context: &ProviderContext,
+    cancel: CancellationToken,
+) -> Result<(), AppError> {
+    run_apply_with_observer_factory(
+        path,
+        auto_approve,
+        lock,
+        parallelism,
+        provider_context,
+        cancel,
+        &cli_observer_factory,
+    )
+    .await
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[allow(clippy::too_many_arguments)]
+async fn run_apply_with_observer_factory(
+    path: &Path,
+    auto_approve: bool,
+    lock: bool,
+    parallelism: NonZeroUsize,
+    provider_context: &ProviderContext,
+    cancel: CancellationToken,
+    observer_factory: &ObserverFactory<'_>,
 ) -> Result<(), AppError> {
     let loaded = load_configuration_with_config(
         path,
@@ -809,6 +904,8 @@ pub async fn run_apply(
         lock_info.as_ref(),
         base_dir,
         provider_context,
+        cancel,
+        observer_factory,
         parallelism,
     ))
     .await;
@@ -847,6 +944,8 @@ async fn run_apply_locked(
     lock: Option<&LockInfo>,
     base_dir: &std::path::Path,
     provider_context: &ProviderContext,
+    cancel: CancellationToken,
+    observer_factory: &ObserverFactory<'_>,
     parallelism: NonZeroUsize,
 ) -> Result<Option<Duration>, AppError> {
     // Read current state from backend. carina#3315: if `check_and_migrate`
@@ -1487,7 +1586,8 @@ async fn run_apply_locked(
     // `ProviderNormalizer`; the same object is passed in both positions
     // so apply re-normalizes with exactly the plan-time normalizer
     // (carina#3060). They must stay the same object.
-    let mut result = execute_effects(
+    let observer = observer_factory(&plan);
+    let outcome = execute_effects_with_observer(
         &plan,
         &provider,
         &provider,
@@ -1498,10 +1598,12 @@ async fn run_apply_locked(
         &mut current_states,
         &unresolved_resources,
         &parsed.compositions,
-        CancellationToken::new(),
+        cancel,
         parallelism,
+        observer,
     )
     .await;
+    let (mut result, cancelled) = split_execution_outcome(outcome);
 
     // Execute import effects: read imported resources from the provider
     execute_import_effects(&plan, &provider, &mut result).await;
@@ -1515,7 +1617,7 @@ async fn run_apply_locked(
     // provider-level default tags. Otherwise the next plan projects the
     // tags out of `current` and surfaces a spurious `tags: (none) → ...`
     // diff (refs awscc#206).
-    finalize_apply(FinalizeApplyInput {
+    let finalize_result = finalize_apply(FinalizeApplyInput {
         result: &result,
         state_file,
         sorted_resources: &resources_for_plan,
@@ -1529,7 +1631,8 @@ async fn run_apply_locked(
         wait_aliases: &wait_aliases,
         pre_resolve_compositions: &pre_resolve_compositions,
     })
-    .await?;
+    .await;
+    handle_finalize_after_execute(finalize_result, cancelled)?;
 
     println!();
     if result.failure_count == 0 && result.skip_count == 0 {
@@ -1582,6 +1685,30 @@ pub async fn run_apply_from_plan(
     lock: bool,
     parallelism: NonZeroUsize,
     provider_context: &ProviderContext,
+    cancel: CancellationToken,
+) -> Result<(), AppError> {
+    run_apply_from_plan_with_observer_factory(
+        plan_path,
+        auto_approve,
+        lock,
+        parallelism,
+        provider_context,
+        cancel,
+        &cli_observer_factory,
+    )
+    .await
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[allow(clippy::too_many_arguments)]
+async fn run_apply_from_plan_with_observer_factory(
+    plan_path: &PathBuf,
+    auto_approve: bool,
+    lock: bool,
+    parallelism: NonZeroUsize,
+    provider_context: &ProviderContext,
+    cancel: CancellationToken,
+    observer_factory: &ObserverFactory<'_>,
 ) -> Result<(), AppError> {
     // Read and deserialize the plan file
     let content =
@@ -1685,6 +1812,8 @@ pub async fn run_apply_from_plan(
         backend.as_ref(),
         lock_info.as_ref(),
         base_dir,
+        cancel,
+        observer_factory,
         parallelism,
     ))
     .await;
@@ -1713,12 +1842,15 @@ pub async fn run_apply_from_plan(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_apply_from_plan_locked(
     plan_file: PlanFile,
     auto_approve: bool,
     backend: &dyn StateBackend,
     lock: Option<&LockInfo>,
     base_dir: &std::path::Path,
+    cancel: CancellationToken,
+    observer_factory: &ObserverFactory<'_>,
     parallelism: NonZeroUsize,
 ) -> Result<Option<Duration>, AppError> {
     // Read current state and validate lineage. carina#3315: a
@@ -1942,7 +2074,8 @@ async fn run_apply_from_plan_locked(
     // Same object in both positions: `ProviderRouter` is both the
     // `Provider` and the `ProviderNormalizer`, so apply re-normalizes
     // with the plan-time normalizer (carina#3060).
-    let mut result = execute_effects(
+    let observer = observer_factory(plan);
+    let outcome = execute_effects_with_observer(
         plan,
         &provider,
         &provider,
@@ -1953,10 +2086,12 @@ async fn run_apply_from_plan_locked(
         &mut current_states,
         &unresolved_resources,
         plan_compositions,
-        CancellationToken::new(),
+        cancel,
         parallelism,
+        observer,
     )
     .await;
+    let (mut result, cancelled) = split_execution_outcome(outcome);
 
     // Execute import effects: read imported resources from the provider
     execute_import_effects(plan, &provider, &mut result).await;
@@ -1969,7 +2104,7 @@ async fn run_apply_from_plan_locked(
     let (factories, _) = build_factories_from_providers(&plan_file.provider_configs, base_dir);
     let ctx = WiringContext::new(factories);
 
-    finalize_apply(FinalizeApplyInput {
+    let finalize_result = finalize_apply(FinalizeApplyInput {
         result: &result,
         state_file,
         sorted_resources,
@@ -1993,7 +2128,8 @@ async fn run_apply_from_plan_locked(
         // pre-resolve composition snapshot is needed.
         pre_resolve_compositions: &[],
     })
-    .await?;
+    .await;
+    handle_finalize_after_execute(finalize_result, cancelled)?;
 
     println!();
     if result.failure_count == 0 && result.skip_count == 0 {

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -2,6 +2,11 @@ use super::*;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
 use std::time::Duration;
 
+#[path = "tests/cancellation_fixture.rs"]
+mod cancellation_fixture;
+
+use cancellation_fixture::ApplyCancellationFixture;
+
 #[test]
 fn total_apply_line_formats_duration() {
     assert_eq!(
@@ -13,6 +18,55 @@ fn total_apply_line_formats_duration() {
 #[test]
 fn apply_parallelism_default_is_eight() {
     assert_eq!(crate::DEFAULT_PARALLELISM.get(), 8);
+}
+
+#[tokio::test]
+async fn run_apply_cancelled_after_partial_execution_persists_state_and_releases_lock() {
+    let fixture = ApplyCancellationFixture::new()
+        .with_resources(["first", "second", "third"])
+        .cancel_after_successes(1);
+    let token = fixture.cancel_token();
+
+    let observer_factory = fixture.observer_factory();
+    let err = run_apply_with_observer_factory(
+        fixture.config_path(),
+        true,
+        true,
+        NonZeroUsize::new(1).unwrap(),
+        fixture.provider_context(),
+        token,
+        &observer_factory,
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        matches!(err, AppError::Interrupted),
+        "expected Interrupted, got {err:?}"
+    );
+
+    let state = fixture.read_state().await;
+    assert!(fixture.backend().state_path().exists());
+    assert_eq!(
+        state.resources.len(),
+        1,
+        "state must contain exactly the completed resource"
+    );
+    assert_eq!(
+        state.serial, 1,
+        "state serial should advance once from the initial empty state"
+    );
+    assert!(
+        state
+            .find_resource("mock", "test.resource", "first")
+            .is_some()
+    );
+    assert!(
+        state
+            .find_resource("mock", "test.resource", "second")
+            .is_none()
+    );
+    assert!(!fixture.lock_path().exists());
 }
 
 fn s3_backend_config_with_encrypt(encrypt: bool) -> carina_core::parser::BackendConfig {
@@ -2078,6 +2132,7 @@ mod saved_plan_version_tests {
             false,
             std::num::NonZeroUsize::new(8).unwrap(),
             &carina_core::parser::ProviderContext::default(),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
 

--- a/carina-cli/src/commands/apply/tests/cancellation_fixture.rs
+++ b/carina-cli/src/commands/apply/tests/cancellation_fixture.rs
@@ -1,0 +1,143 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use carina_core::executor::{ExecutionEvent, ExecutionObserver};
+use carina_core::parser::ProviderContext;
+use carina_core::plan::Plan;
+use carina_state::{LocalBackend, StateBackend};
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+use crate::commands::shared::observer::CliObserver;
+
+struct CancellingObserver {
+    inner: CliObserver,
+    success_count: Arc<AtomicUsize>,
+    threshold: usize,
+    cancel: CancellationToken,
+}
+
+impl ExecutionObserver for CancellingObserver {
+    fn on_event(&self, event: &ExecutionEvent) {
+        self.inner.on_event(event);
+        if matches!(event, ExecutionEvent::EffectSucceeded { .. }) {
+            let successes = self.success_count.fetch_add(1, Ordering::SeqCst) + 1;
+            if successes == self.threshold {
+                self.cancel.cancel();
+            }
+        }
+    }
+}
+
+pub(super) struct ApplyCancellationFixture {
+    _dir: TempDir,
+    config_path: PathBuf,
+    crn_path: PathBuf,
+    state_path: PathBuf,
+    lock_path: PathBuf,
+    backend: LocalBackend,
+    provider_context: ProviderContext,
+    cancel: CancellationToken,
+    cancel_after_successes: Option<usize>,
+    success_count: Arc<AtomicUsize>,
+}
+
+impl ApplyCancellationFixture {
+    pub(super) fn new() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let config_path = dir.path().to_path_buf();
+        let crn_path = dir.path().join("main.crn");
+        let state_path = dir.path().join("carina.state.json");
+        let lock_path = state_path.with_extension("lock");
+        let backend = LocalBackend::with_path(state_path.clone());
+
+        Self {
+            _dir: dir,
+            config_path,
+            crn_path,
+            state_path,
+            lock_path,
+            backend,
+            provider_context: ProviderContext::default(),
+            cancel: CancellationToken::new(),
+            cancel_after_successes: None,
+            success_count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub(super) fn with_resources<const N: usize>(self, names: [&str; N]) -> Self {
+        let state_path = self.state_path.display();
+        let mut crn = format!(
+            "backend local {{ path = \"{state_path}\" }}\n\
+             provider mock {{}}\n"
+        );
+        for name in names {
+            crn.push_str(&format!(
+                "let {name} = mock.test.resource {{ name = \"{name}\" }}\n"
+            ));
+        }
+        std::fs::write(&self.crn_path, crn).expect("write fixture config");
+        let backend_lock = serde_json::json!({
+            "backend_type": "local",
+            "attributes": {
+                "path": self.state_path.display().to_string(),
+            },
+        });
+        std::fs::write(
+            self.config_path.join("carina-backend.lock"),
+            format!("{}\n", serde_json::to_string_pretty(&backend_lock).unwrap()),
+        )
+        .expect("write backend lock");
+        self
+    }
+
+    pub(super) fn cancel_after_successes(mut self, count: usize) -> Self {
+        self.cancel_after_successes = Some(count);
+        self
+    }
+
+    pub(super) fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    pub(super) async fn read_state(&self) -> carina_state::StateFile {
+        self.backend
+            .read_state()
+            .await
+            .expect("read state")
+            .expect("state exists")
+            .into_state()
+    }
+
+    pub(super) fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+
+    pub(super) fn provider_context(&self) -> &ProviderContext {
+        &self.provider_context
+    }
+
+    pub(super) fn config_path(&self) -> &Path {
+        &self.config_path
+    }
+
+    pub(super) fn backend(&self) -> &LocalBackend {
+        &self.backend
+    }
+
+    pub(super) fn observer_factory(&self) -> impl Fn(&Plan) -> Box<dyn ExecutionObserver> + '_ {
+        move |plan| {
+            if let Some(threshold) = self.cancel_after_successes {
+                Box::new(CancellingObserver {
+                    inner: CliObserver::new(plan),
+                    success_count: Arc::clone(&self.success_count),
+                    threshold,
+                    cancel: self.cancel.clone(),
+                })
+            } else {
+                Box::new(CliObserver::new(plan))
+            }
+        }
+    }
+}

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -122,6 +122,7 @@ mod tests {
             successfully_deleted: HashSet::new(),
             permanent_name_overrides: HashMap::new(),
             current_states: HashMap::new(),
+            bindings: carina_core::binding_index::ResolvedBindings::default(),
             failed_refreshes: HashSet::new(),
         }
     }

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -367,10 +367,29 @@ async fn main() {
             lock,
             parallelism,
         } => {
+            // TODO(T7/T8): replace this fresh token with one fed by the signal listener.
+            // Until then, real SIGINT/SIGTERM still drops the future via signal::run_with_ctrl_c.
+            let cancel_token = tokio_util::sync::CancellationToken::new();
             if path.extension().is_some_and(|ext| ext == "json") {
-                run_apply_from_plan(&path, auto_approve, lock, parallelism, &provider_context).await
+                run_apply_from_plan(
+                    &path,
+                    auto_approve,
+                    lock,
+                    parallelism,
+                    &provider_context,
+                    cancel_token,
+                )
+                .await
             } else {
-                run_apply(&path, auto_approve, lock, parallelism, &provider_context).await
+                run_apply(
+                    &path,
+                    auto_approve,
+                    lock,
+                    parallelism,
+                    &provider_context,
+                    cancel_token,
+                )
+                .await
             }
         }
         Commands::Destroy {

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1438,6 +1438,7 @@ async fn lock_released_on_write_state_failure() {
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
+        bindings: carina_core::binding_index::ResolvedBindings::default(),
         failed_refreshes: HashSet::new(),
     };
 
@@ -1576,6 +1577,7 @@ async fn finalize_apply_uses_write_state_locked() {
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
+        bindings: carina_core::binding_index::ResolvedBindings::default(),
         failed_refreshes: HashSet::new(),
     };
 
@@ -1833,7 +1835,7 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
         carina_core::executor::UnresolvedResource::from_pre_resolve(new_resource),
     )]);
 
-    let result = execute_effects(
+    let outcome = execute_effects(
         &plan,
         &provider,
         &carina_core::provider::NoopNormalizer,
@@ -1848,6 +1850,12 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
         carina_core::executor::TEST_UNCAPPED,
     )
     .await;
+    let result = match outcome {
+        carina_core::executor::ExecutionOutcome::Completed(result) => result,
+        carina_core::executor::ExecutionOutcome::Cancelled(_) => {
+            panic!("uncancelled execute_effects returned Cancelled")
+        }
+    };
 
     // The rename failed, so the effect should be counted as a failure
     assert_eq!(
@@ -2011,7 +2019,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
 
     // --- Execute ---
     let provider = RecordingProvider::new();
-    let result = execute_effects(
+    let outcome = execute_effects(
         &plan,
         &provider,
         &carina_core::provider::NoopNormalizer,
@@ -2026,6 +2034,12 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
         carina_core::executor::TEST_UNCAPPED,
     )
     .await;
+    let result = match outcome {
+        carina_core::executor::ExecutionOutcome::Completed(result) => result,
+        carina_core::executor::ExecutionOutcome::Cancelled(_) => {
+            panic!("uncancelled execute_effects returned Cancelled")
+        }
+    };
 
     assert_eq!(result.success_count, 2, "Both effects should succeed");
     assert_eq!(result.failure_count, 0, "No effects should fail");
@@ -2210,6 +2224,7 @@ async fn finalize_apply_without_lock_uses_write_state() {
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
+        bindings: carina_core::binding_index::ResolvedBindings::default(),
         failed_refreshes: HashSet::new(),
     };
 
@@ -3092,6 +3107,7 @@ async fn finalize_apply_clears_state_exports_when_params_empty() {
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
+        bindings: carina_core::binding_index::ResolvedBindings::default(),
         failed_refreshes: HashSet::new(),
     };
 
@@ -3150,6 +3166,7 @@ async fn finalize_apply_preserves_state_exports_when_params_none() {
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
+        bindings: carina_core::binding_index::ResolvedBindings::default(),
         failed_refreshes: HashSet::new(),
     };
 

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -88,6 +88,7 @@ pub struct ExecutionResult {
     pub successfully_deleted: HashSet<ResourceId>,
     pub permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>>,
     pub current_states: HashMap<ResourceId, State>,
+    pub bindings: ResolvedBindings,
     pub failed_refreshes: HashSet<ResourceId>,
 }
 

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -1045,6 +1045,7 @@ pub(super) async fn execute_effects_sequential(
         successfully_deleted,
         permanent_name_overrides,
         current_states: input.current_states.clone(),
+        bindings: input.bindings.clone(),
         failed_refreshes,
     };
     (result, cancelled)

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1704,6 +1704,7 @@ pub(super) async fn execute_effects_phased(
         successfully_deleted,
         permanent_name_overrides,
         current_states: input.current_states.clone(),
+        bindings: input.bindings.clone(),
         failed_refreshes,
     };
     (result, cancelled)

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -588,6 +588,7 @@ fn empty_execution_result() -> ExecutionResult {
         successfully_deleted: HashSet::new(),
         permanent_name_overrides: HashMap::new(),
         current_states: HashMap::new(),
+        bindings: ResolvedBindings::default(),
         failed_refreshes: HashSet::new(),
     }
 }


### PR DESCRIPTION
Closes #3505. Refs #3498.

T5 of the apply interruption resilience series. `apply.rs` now matches on the executor's `ExecutionOutcome` and runs `finalize_apply` (state save + lock release) on both `Completed` and `Cancelled` before returning. A cancelled run returns `Err(AppError::Interrupted)` only after state has been flushed and the lock released, so the next plan sees the resources the run actually created.

## What changes

- `execute_effects` returns `ExecutionOutcome` (no longer collapses both arms with the T3 placeholder or-pattern).
- Two small helpers keep the partial-apply contract enforced in one place:
  - `split_execution_outcome(outcome) -> (ExecutionResult, cancelled)`: destructures both arms uniformly so callers can never silently drop the Cancelled case — this is the type guarantee from T2 reaching apply.rs.
  - `handle_finalize_after_execute(...)`: runs `finalize_apply` and chooses the right error to surface across the four (cancelled × finalize-ok/err) cases. When cancelled and finalize fails, the finalize error is logged to stderr and `Interrupted` is returned, so the user sees the cancel as the primary outcome rather than a backend error masking it.
- Same flow lands in both `run_apply_locked` and `run_apply_from_plan_locked`. T6 will lift the helpers to a shared location when destroy.rs takes the third caller.
- `ExecutionResult` gained `pub bindings: ResolvedBindings`, written back to the caller of `execute_effects`. This closes the asymmetry where `current_states` was written back but `bindings` was silently dropped — a hidden contract that T6 (destroy) would have tripped on.
- T3 placeholder comments in `apply/mod.rs` are removed.

## Test

`ApplyCancellationFixture` drives the integration test `run_apply_cancelled_after_partial_execution_persists_state_and_releases_lock`. After 1 successful Create, the observer cancels the token; the test then asserts:

- `err matches AppError::Interrupted`
- `state.resources.len() == 1` and the first resource is present, the others absent
- `state.serial == 1` (state was actually saved, not skipped)
- lock file is absent

The cancel trigger is a `CancellingObserver` carrying `Arc<AtomicUsize>` and the token directly — no process-global env vars — so the test is safe under `cargo test` thread parallelism as well as nextest's process-per-test.

## Production scope note

`CancellationToken` in `main.rs` is still produced as `CancellationToken::new()` with a `TODO(T7/T8)` note; the seam is dormant against real SIGINT/SIGTERM until T7/T8 plug in a signal-driven listener. The seam exists, the tests exercise it, but a real Ctrl+C today still drops the future via `signal::run_with_ctrl_c` (T7 will replace that).

## Verify

- `cargo nextest run -p carina-cli`: PASS
- `cargo nextest run -p carina-core`: PASS
- `cargo check --workspace`: PASS
- `cargo clippy --workspace --all-targets -- -D warnings`: PASS
- `cargo test --workspace --doc`: PASS (T2's `ExecutionOutcomeCannotBeQuestionMarked` compile_fail guard intact)

5-round self-review: code-review medium (5 findings), Round 1 (2 readability), Round 2 (3 fixes incl. rebase), Round 3 (CLEAN), Round 4 (commit hygiene), Round 5 (CLEAN, ready for PR).