### PR TITLE
destroy: cancel-aware loop and finalize_destroy helper (T6, #3506)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -35,6 +35,7 @@ use crate::commands::plan::PlanFile;
 use crate::commands::shared::effect_execution::{
     execute_import_effects, execute_state_only_effects,
 };
+use crate::commands::shared::finalize::handle_finalize_after_execute;
 use crate::commands::shared::observer::CliObserver;
 use crate::commands::shared::progress::{
     RefreshProgress, emit_newline_on_interrupt, format_duration, refresh_multi_progress,
@@ -65,33 +66,6 @@ fn cli_observer_factory(plan: &Plan) -> Box<dyn ExecutionObserver> {
 
 fn format_total_apply_line(elapsed: Duration) -> String {
     format!("Done in {}.", format_duration(elapsed))
-}
-
-/// Handle the finalize_apply call after execute_effects returns.
-///
-/// Four cases:
-/// 1. not cancelled + finalize Ok    -> Ok(())  (normal completion)
-/// 2. not cancelled + finalize Err   -> Err(finalize_err)  (state save failed mid-run)
-/// 3. cancelled     + finalize Ok    -> Err(Interrupted)  (state saved despite cancel)
-/// 4. cancelled     + finalize Err   -> Err(Interrupted) after logging warning  (cancel + save failed)
-///
-/// On cancellation, the Interrupted error takes precedence so the user sees
-/// "the apply was interrupted" rather than a backend error that happened to
-/// occur during cleanup. The finalize error is still logged to stderr.
-/// Production signal-driven cancellation is wired in T7/T8; T5 only preserves
-/// partial state after the executor observes a cancellation token.
-fn handle_finalize_after_execute(
-    finalize_result: Result<(), AppError>,
-    cancelled: bool,
-) -> Result<(), AppError> {
-    if cancelled {
-        if let Err(err) = finalize_result {
-            eprintln!("warning: state save during cancellation also failed: {err}");
-        }
-        return Err(AppError::Interrupted);
-    }
-
-    finalize_result
 }
 
 fn split_execution_outcome(outcome: ExecutionOutcome) -> (ExecutionResult, bool) {

--- a/carina-cli/src/commands/apply/tests/cancellation_fixture.rs
+++ b/carina-cli/src/commands/apply/tests/cancellation_fixture.rs
@@ -1,14 +1,13 @@
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use carina_core::executor::{ExecutionEvent, ExecutionObserver};
 use carina_core::parser::ProviderContext;
 use carina_core::plan::Plan;
-use carina_state::{LocalBackend, StateBackend};
-use tempfile::TempDir;
+use carina_state::LocalBackend;
 use tokio_util::sync::CancellationToken;
 
+use crate::commands::shared::cancellation_test_support::CancellationFixtureBase;
 use crate::commands::shared::observer::CliObserver;
 
 struct CancellingObserver {
@@ -31,43 +30,24 @@ impl ExecutionObserver for CancellingObserver {
 }
 
 pub(super) struct ApplyCancellationFixture {
-    _dir: TempDir,
-    config_path: PathBuf,
-    crn_path: PathBuf,
-    state_path: PathBuf,
-    lock_path: PathBuf,
-    backend: LocalBackend,
+    base: CancellationFixtureBase,
     provider_context: ProviderContext,
-    cancel: CancellationToken,
     cancel_after_successes: Option<usize>,
     success_count: Arc<AtomicUsize>,
 }
 
 impl ApplyCancellationFixture {
     pub(super) fn new() -> Self {
-        let dir = TempDir::new().expect("tempdir");
-        let config_path = dir.path().to_path_buf();
-        let crn_path = dir.path().join("main.crn");
-        let state_path = dir.path().join("carina.state.json");
-        let lock_path = state_path.with_extension("lock");
-        let backend = LocalBackend::with_path(state_path.clone());
-
         Self {
-            _dir: dir,
-            config_path,
-            crn_path,
-            state_path,
-            lock_path,
-            backend,
+            base: CancellationFixtureBase::new(),
             provider_context: ProviderContext::default(),
-            cancel: CancellationToken::new(),
             cancel_after_successes: None,
             success_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
     pub(super) fn with_resources<const N: usize>(self, names: [&str; N]) -> Self {
-        let state_path = self.state_path.display();
+        let state_path = self.base.state_path().display();
         let mut crn = format!(
             "backend local {{ path = \"{state_path}\" }}\n\
              provider mock {{}}\n"
@@ -77,18 +57,8 @@ impl ApplyCancellationFixture {
                 "let {name} = mock.test.resource {{ name = \"{name}\" }}\n"
             ));
         }
-        std::fs::write(&self.crn_path, crn).expect("write fixture config");
-        let backend_lock = serde_json::json!({
-            "backend_type": "local",
-            "attributes": {
-                "path": self.state_path.display().to_string(),
-            },
-        });
-        std::fs::write(
-            self.config_path.join("carina-backend.lock"),
-            format!("{}\n", serde_json::to_string_pretty(&backend_lock).unwrap()),
-        )
-        .expect("write backend lock");
+        self.base.write_crn(crn);
+        self.base.write_backend_lock();
         self
     }
 
@@ -98,32 +68,27 @@ impl ApplyCancellationFixture {
     }
 
     pub(super) fn cancel_token(&self) -> CancellationToken {
-        self.cancel.clone()
+        self.base.cancel_token()
     }
 
     pub(super) async fn read_state(&self) -> carina_state::StateFile {
-        self.backend
-            .read_state()
-            .await
-            .expect("read state")
-            .expect("state exists")
-            .into_state()
+        self.base.read_state().await
     }
 
-    pub(super) fn lock_path(&self) -> &Path {
-        &self.lock_path
+    pub(super) fn lock_path(&self) -> &std::path::Path {
+        self.base.lock_path()
     }
 
     pub(super) fn provider_context(&self) -> &ProviderContext {
         &self.provider_context
     }
 
-    pub(super) fn config_path(&self) -> &Path {
-        &self.config_path
+    pub(super) fn config_path(&self) -> &std::path::Path {
+        self.base.config_path()
     }
 
     pub(super) fn backend(&self) -> &LocalBackend {
-        &self.backend
+        self.base.backend()
     }
 
     pub(super) fn observer_factory(&self) -> impl Fn(&Plan) -> Box<dyn ExecutionObserver> + '_ {
@@ -133,7 +98,7 @@ impl ApplyCancellationFixture {
                     inner: CliObserver::new(plan),
                     success_count: Arc::clone(&self.success_count),
                     threshold,
-                    cancel: self.cancel.clone(),
+                    cancel: self.base.cancel_token(),
                 })
             } else {
                 Box::new(CliObserver::new(plan))

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use colored::Colorize;
-use futures::stream::{self, FuturesUnordered, StreamExt};
+use futures::stream::{FuturesUnordered, StreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
@@ -18,12 +18,14 @@ use carina_core::effect::Effect;
 use carina_core::plan::Plan;
 use carina_core::provider::Provider;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
-use carina_state::{LockInfo, StateBackend};
+use carina_state::{LockInfo, StateBackend, StateFile};
+use tokio_util::sync::CancellationToken;
 
 use carina_core::parser::ProviderContext;
 
 use super::{DriftCommand, validate_and_resolve_with_config, verify_for_mutation};
 use crate::DetailLevel;
+use crate::commands::shared::finalize::handle_finalize_after_execute;
 use crate::commands::shared::progress::{
     RefreshProgress, format_duration, refresh_multi_progress, spinner_style,
 };
@@ -49,6 +51,7 @@ pub async fn run_destroy(
     force: bool,
     parallelism: NonZeroUsize,
     provider_context: &ProviderContext,
+    cancel: CancellationToken,
 ) -> Result<(), AppError> {
     let mut parsed = load_configuration_with_config(
         path,
@@ -106,6 +109,7 @@ pub async fn run_destroy(
         force,
         base_dir,
         parallelism,
+        cancel,
     ))
     .await;
 
@@ -139,6 +143,7 @@ async fn run_destroy_locked(
     force: bool,
     base_dir: &std::path::Path,
     parallelism: NonZeroUsize,
+    cancel: CancellationToken,
 ) -> Result<(), AppError> {
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let ctx = WiringContext::new(factories);
@@ -206,26 +211,56 @@ async fn run_destroy_locked(
         // composition resources are not destroyed and never enter this list.
         let resources: Vec<&Resource> = all_resources.iter().collect();
         let provider_ref = &provider;
-        let results: Vec<Result<(ResourceId, State), AppError>> = stream::iter(&resources)
-            .map(|resource| {
+        let mut refresh_cancelled = false;
+        let mut resource_iter = resources.into_iter();
+        let mut refresh_in_flight = FuturesUnordered::new();
+        loop {
+            while !refresh_cancelled && refresh_in_flight.len() < 5 {
+                let Some(resource) = resource_iter.next() else {
+                    break;
+                };
                 let progress = RefreshProgress::begin_multi(&multi, &resource.id);
                 let identifier = state_file
                     .as_ref()
                     .and_then(|sf| sf.get_identifier_for_resource(resource));
-                async move {
+                refresh_in_flight.push(async move {
                     let state = read_with_retry(provider_ref, &resource.id, identifier.as_deref())
                         .await
                         .map_err(AppError::Provider)?;
                     progress.finish();
                     Ok((resource.id.clone(), state))
+                });
+            }
+
+            if refresh_in_flight.is_empty() {
+                break;
+            }
+
+            let result: Result<(ResourceId, State), AppError> = if refresh_cancelled {
+                refresh_in_flight.next().await.unwrap()
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        refresh_cancelled = true;
+                        continue;
+                    }
+                    result = refresh_in_flight.next() => {
+                        result.unwrap()
+                    }
                 }
-            })
-            .buffer_unordered(5)
-            .collect()
-            .await;
-        for result in results {
+            };
+
+            if refresh_cancelled {
+                continue;
+            }
             let (id, state) = result?;
             current_states.insert(id, state);
+        }
+        drop(refresh_in_flight);
+        drop(resource_iter);
+        if refresh_cancelled {
+            return Err(AppError::Interrupted);
         }
 
         // Include orphaned resources (in state but not in .crn).
@@ -235,29 +270,56 @@ async fn run_destroy_locked(
                 all_resources.iter().map(|r| r.id.clone()).collect();
             let orphan_states: Vec<(ResourceId, State)> =
                 sf.build_orphan_states(&desired_ids).into_iter().collect();
-            let orphan_results: Vec<Result<(ResourceId, State), AppError>> =
-                stream::iter(orphan_states)
-                    .map(|(id, state)| {
-                        let progress = RefreshProgress::begin_multi(&multi, &id);
-                        async move {
-                            let refreshed =
-                                read_with_retry(provider_ref, &id, state.identifier.as_deref())
-                                    .await
-                                    .map_err(AppError::Provider)?;
-                            progress.finish();
-                            Ok((id, refreshed))
+            let mut refresh_cancelled = false;
+            let mut orphan_iter = orphan_states.into_iter();
+            let mut orphan_in_flight = FuturesUnordered::new();
+            loop {
+                while !refresh_cancelled && orphan_in_flight.len() < 5 {
+                    let Some((id, state)) = orphan_iter.next() else {
+                        break;
+                    };
+                    let progress = RefreshProgress::begin_multi(&multi, &id);
+                    orphan_in_flight.push(async move {
+                        let refreshed =
+                            read_with_retry(provider_ref, &id, state.identifier.as_deref())
+                                .await
+                                .map_err(AppError::Provider)?;
+                        progress.finish();
+                        Ok((id, refreshed))
+                    });
+                }
+
+                if orphan_in_flight.is_empty() {
+                    break;
+                }
+
+                let result: Result<(ResourceId, State), AppError> = if refresh_cancelled {
+                    orphan_in_flight.next().await.unwrap()
+                } else {
+                    tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => {
+                            refresh_cancelled = true;
+                            continue;
                         }
-                    })
-                    .buffer_unordered(5)
-                    .collect()
-                    .await;
-            for result in orphan_results {
+                        result = orphan_in_flight.next() => {
+                            result.unwrap()
+                        }
+                    }
+                };
+
+                if refresh_cancelled {
+                    continue;
+                }
                 let (id, refreshed) = result?;
                 if refreshed.exists {
                     current_states.insert(id.clone(), refreshed);
                     let orphan_resource = build_orphan_resource(sf, &id);
                     all_resources.push(orphan_resource);
                 }
+            }
+            if refresh_cancelled {
+                return Err(AppError::Interrupted);
             }
         }
     } else if let Some(sf) = state_file.as_ref() {
@@ -476,6 +538,7 @@ async fn run_destroy_locked(
     let mut skip_count = 0;
     let mut destroyed_ids: Vec<ResourceId> = Vec::new();
     let mut failed_bindings: HashSet<String> = HashSet::new();
+    let mut cancelled = false;
     // timed_out_resources: binding -> (ResourceId, identifier)
     let mut timed_out_resources: HashMap<String, (ResourceId, String)> = HashMap::new();
 
@@ -544,190 +607,221 @@ async fn run_destroy_locked(
     let mut in_flight = FuturesUnordered::new();
 
     loop {
-        // Find newly ready resources: all deletion deps completed, not yet
-        // dispatched, and not waiting for a retry gate.
-        let mut newly_ready: Vec<usize> = Vec::new();
-        for &idx in &all_indices {
-            if dispatched.contains(&idx) || retry_pending.contains(&idx) {
-                continue;
-            }
-            let deps = &deletion_deps[&idx];
-            if deps.iter().all(|d| completed_indices.contains(d)) {
-                newly_ready.push(idx);
-            }
+        let undispatched_at_loop_start = all_indices
+            .iter()
+            .filter(|&&idx| !dispatched.contains(&idx))
+            .count();
+        if cancel.is_cancelled()
+            && !cancelled
+            && (undispatched_at_loop_start > 0 || !in_flight.is_empty())
+        {
+            cancelled = true;
         }
-        newly_ready.sort();
-        newly_ready.truncate(parallelism.get().saturating_sub(in_flight.len()));
 
-        // Process newly ready resources
-        for idx in newly_ready {
-            dispatched.insert(idx);
-
-            let (binding, identifier, effect) = &resource_info[idx];
-            let resource = resources_to_destroy[idx];
-
-            // Check if any dependent has actually failed (non-timeout)
-            if let Some(failed_dep) =
-                find_failed_dependent(binding, &dependents_map, &failed_bindings)
-            {
-                let c = completed_counter.fetch_add(1, Ordering::Relaxed) + 1;
-                let counter = format!("{}/{}", c, destroy_total).dimmed();
-                let msg = format!(
-                    "{} {} - skipped (dependent {} failed) {}",
-                    "⊘".yellow(),
-                    format_effect(effect),
-                    failed_dep,
-                    counter
-                );
-                if let Some(pb) = spinners.remove(&idx) {
-                    pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
-                    pb.finish_with_message(msg);
-                } else {
-                    eprintln!("  {}", msg);
+        if !cancelled {
+            // Find newly ready resources: all deletion deps completed, not yet
+            // dispatched, and not waiting for a retry gate.
+            let mut newly_ready: Vec<usize> = Vec::new();
+            for &idx in &all_indices {
+                if dispatched.contains(&idx) || retry_pending.contains(&idx) {
+                    continue;
                 }
-                skip_count += 1;
-                failed_bindings.insert(binding.clone());
-                completed_indices.insert(idx);
-                continue;
+                let deps = &deletion_deps[&idx];
+                if deps.iter().all(|d| completed_indices.contains(d)) {
+                    newly_ready.push(idx);
+                }
             }
+            newly_ready.sort();
+            newly_ready.truncate(parallelism.get().saturating_sub(in_flight.len()));
 
-            // Check if any dependent timed out -- wait for it to complete
-            let timed_out_deps: Vec<String> = dependents_map
-                .get(binding)
-                .map(|deps| {
-                    deps.iter()
-                        .filter(|d| timed_out_resources.contains_key(d.as_str()))
-                        .cloned()
-                        .collect()
-                })
-                .unwrap_or_default();
+            // Process newly ready resources
+            for idx in newly_ready {
+                if cancel.is_cancelled() {
+                    cancelled = true;
+                    break;
+                }
 
-            let mut wait_failed = false;
-            for dep_binding in &timed_out_deps {
-                if let Some((dep_id, dep_identifier)) =
-                    timed_out_resources.remove(dep_binding.as_str())
+                dispatched.insert(idx);
+
+                let (binding, identifier, effect) = &resource_info[idx];
+                let resource = resources_to_destroy[idx];
+
+                // Check if any dependent has actually failed (non-timeout)
+                if let Some(failed_dep) =
+                    find_failed_dependent(binding, &dependents_map, &failed_bindings)
                 {
-                    multi
-                        .println(format!(
-                            "  {} Waiting for {} to be deleted...",
-                            "⏳".yellow(),
-                            dep_id
-                        ))
-                        .ok();
+                    let c = completed_counter.fetch_add(1, Ordering::Relaxed) + 1;
+                    let counter = format!("{}/{}", c, destroy_total).dimmed();
+                    let msg = format!(
+                        "{} {} - skipped (dependent {} failed) {}",
+                        "⊘".yellow(),
+                        format_effect(effect),
+                        failed_dep,
+                        counter
+                    );
+                    if let Some(pb) = spinners.remove(&idx) {
+                        pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+                        pb.finish_with_message(msg);
+                    } else {
+                        eprintln!("  {}", msg);
+                    }
+                    skip_count += 1;
+                    failed_bindings.insert(binding.clone());
+                    completed_indices.insert(idx);
+                    continue;
+                }
 
-                    match wait_for_deletion(
-                        &provider,
-                        &dep_id,
-                        &dep_identifier,
-                        180,
-                        std::time::Duration::from_secs(10),
-                    )
-                    .await
+                // Check if any dependent timed out -- wait for it to complete
+                let timed_out_deps: Vec<String> = dependents_map
+                    .get(binding)
+                    .map(|deps| {
+                        deps.iter()
+                            .filter(|d| timed_out_resources.contains_key(d.as_str()))
+                            .cloned()
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let mut wait_failed = false;
+                for dep_binding in &timed_out_deps {
+                    if let Some((dep_id, dep_identifier)) =
+                        timed_out_resources.remove(dep_binding.as_str())
                     {
-                        WaitResult::Deleted => {
-                            multi
-                                .println(format!(
-                                    "  {} Delete {} (completed after extended wait)",
-                                    "✓".green(),
-                                    dep_id
-                                ))
-                                .ok();
-                            destroyed_ids.push(dep_id.clone());
-                            success_count += 1;
-                        }
-                        WaitResult::ReadError(msg) => {
-                            multi
-                                .println(format!("  {} Delete {}", "✗".red(), dep_id))
-                                .ok();
-                            multi
-                                .println(format!(
-                                    "      {} {}",
-                                    "→".red(),
-                                    format!("read error during wait: {}", msg).red()
-                                ))
-                                .ok();
-                            failed_bindings.insert(dep_binding.clone());
-                            failure_count += 1;
-                            wait_failed = true;
-                        }
-                        WaitResult::TimedOut => {
-                            multi
-                                .println(format!("  {} Delete {}", "✗".red(), dep_id))
-                                .ok();
-                            multi
-                                .println(format!(
-                                    "      {} {}",
-                                    "→".red(),
-                                    "still exists after extended wait".red()
-                                ))
-                                .ok();
-                            failed_bindings.insert(dep_binding.clone());
-                            failure_count += 1;
-                            wait_failed = true;
+                        multi
+                            .println(format!(
+                                "  {} Waiting for {} to be deleted...",
+                                "⏳".yellow(),
+                                dep_id
+                            ))
+                            .ok();
+
+                        match wait_for_deletion(
+                            &provider,
+                            &dep_id,
+                            &dep_identifier,
+                            180,
+                            std::time::Duration::from_secs(10),
+                        )
+                        .await
+                        {
+                            WaitResult::Deleted => {
+                                multi
+                                    .println(format!(
+                                        "  {} Delete {} (completed after extended wait)",
+                                        "✓".green(),
+                                        dep_id
+                                    ))
+                                    .ok();
+                                destroyed_ids.push(dep_id.clone());
+                                success_count += 1;
+                            }
+                            WaitResult::ReadError(msg) => {
+                                multi
+                                    .println(format!("  {} Delete {}", "✗".red(), dep_id))
+                                    .ok();
+                                multi
+                                    .println(format!(
+                                        "      {} {}",
+                                        "→".red(),
+                                        format!("read error during wait: {}", msg).red()
+                                    ))
+                                    .ok();
+                                failed_bindings.insert(dep_binding.clone());
+                                failure_count += 1;
+                                wait_failed = true;
+                            }
+                            WaitResult::TimedOut => {
+                                multi
+                                    .println(format!("  {} Delete {}", "✗".red(), dep_id))
+                                    .ok();
+                                multi
+                                    .println(format!(
+                                        "      {} {}",
+                                        "→".red(),
+                                        "still exists after extended wait".red()
+                                    ))
+                                    .ok();
+                                failed_bindings.insert(dep_binding.clone());
+                                failure_count += 1;
+                                wait_failed = true;
+                            }
                         }
                     }
                 }
-            }
 
-            if wait_failed {
-                let c = completed_counter.fetch_add(1, Ordering::Relaxed) + 1;
-                let counter = format!("{}/{}", c, destroy_total).dimmed();
-                let msg = format!(
-                    "{} {} - skipped (dependent deletion did not complete) {}",
-                    "⊘".yellow(),
-                    format_effect(effect),
-                    counter
-                );
-                if let Some(pb) = spinners.remove(&idx) {
-                    pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
-                    pb.finish_with_message(msg);
-                } else {
-                    eprintln!("  {}", msg);
+                if wait_failed {
+                    let c = completed_counter.fetch_add(1, Ordering::Relaxed) + 1;
+                    let counter = format!("{}/{}", c, destroy_total).dimmed();
+                    let msg = format!(
+                        "{} {} - skipped (dependent deletion did not complete) {}",
+                        "⊘".yellow(),
+                        format_effect(effect),
+                        counter
+                    );
+                    if let Some(pb) = spinners.remove(&idx) {
+                        pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+                        pb.finish_with_message(msg);
+                    } else {
+                        eprintln!("  {}", msg);
+                    }
+                    skip_count += 1;
+                    failed_bindings.insert(binding.clone());
+                    completed_indices.insert(idx);
+                    continue;
                 }
-                skip_count += 1;
-                failed_bindings.insert(binding.clone());
-                completed_indices.insert(idx);
-                continue;
-            }
 
-            // Create a spinner for the in-flight deletion
-            let pb = multi.add(ProgressBar::new_spinner());
-            pb.set_style(spinner_style());
-            pb.set_message(format_effect(effect));
-            pb.enable_steady_tick(Duration::from_millis(80));
-            spinners.insert(idx, pb);
+                // Create a spinner for the in-flight deletion
+                let pb = multi.add(ProgressBar::new_spinner());
+                pb.set_style(spinner_style());
+                pb.set_message(format_effect(effect));
+                pb.enable_steady_tick(Duration::from_millis(80));
+                spinners.insert(idx, pb);
 
-            // Spawn the deletion as a concurrent future
-            let resource_id = resource.id.clone();
-            let identifier = identifier.clone();
-            let directives = resource.directives.clone();
-            let binding = binding.clone();
+                // Spawn the deletion as a concurrent future
+                let resource_id = resource.id.clone();
+                let identifier = identifier.clone();
+                let directives = resource.directives.clone();
+                let binding = binding.clone();
 
-            let provider_ref = &provider;
-            in_flight.push(async move {
-                let started = Instant::now();
-                let delete_result = provider_ref
-                    .delete(
-                        &resource_id,
-                        &identifier,
-                        carina_core::provider::DeleteRequest {
-                            directives: directives.clone(),
-                        },
+                let provider_ref = &provider;
+                in_flight.push(async move {
+                    let started = Instant::now();
+                    let delete_result = provider_ref
+                        .delete(
+                            &resource_id,
+                            &identifier,
+                            carina_core::provider::DeleteRequest {
+                                directives: directives.clone(),
+                            },
+                        )
+                        .await;
+                    (
+                        idx,
+                        binding,
+                        resource_id,
+                        identifier,
+                        started,
+                        delete_result,
                     )
-                    .await;
-                (
-                    idx,
-                    binding,
-                    resource_id,
-                    identifier,
-                    started,
-                    delete_result,
-                )
-            });
+                });
+            }
         }
 
         // If nothing is in flight, we're done (or stuck)
         if in_flight.is_empty() {
+            if cancelled {
+                let remaining: Vec<usize> = all_indices
+                    .iter()
+                    .filter(|idx| !dispatched.contains(idx) && !completed_indices.contains(idx))
+                    .copied()
+                    .collect();
+                for idx in remaining {
+                    dispatched.insert(idx);
+                    completed_indices.insert(idx);
+                    skip_count += 1;
+                }
+                break;
+            }
             let remaining: Vec<usize> = all_indices
                 .iter()
                 .filter(|idx| !dispatched.contains(idx) && !completed_indices.contains(idx))
@@ -775,8 +869,21 @@ async fn run_destroy_locked(
         }
 
         // Wait for the next deletion to complete
-        let (finished_idx, binding, resource_id, identifier, started, delete_result) =
-            in_flight.next().await.unwrap();
+        let (finished_idx, binding, resource_id, identifier, started, delete_result) = if cancelled
+        {
+            in_flight.next().await.unwrap()
+        } else {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    cancelled = true;
+                    continue;
+                }
+                finished = in_flight.next() => {
+                    finished.unwrap()
+                }
+            }
+        };
         completed_indices.insert(finished_idx);
 
         // An effect completed — release all retry-pending indices so they
@@ -816,6 +923,7 @@ async fn run_destroy_locked(
                 );
                 finish_spinner(&mut spinners, finished_idx, msg);
                 success_count += 1;
+                observe_destroy_success_for_tests(success_count, &resource_id, &cancel);
                 destroyed_ids.push(resource_id);
             }
             Err(carina_core::provider::ProviderError::Timeout(_)) => {
@@ -870,71 +978,84 @@ async fn run_destroy_locked(
         }
     }
 
-    // Handle any remaining timed-out resources that no parent waited on
-    for (dep_binding, (dep_id, dep_identifier)) in &timed_out_resources {
-        eprintln!(
-            "  {} Waiting for {} to be deleted...",
-            "⏳".yellow(),
-            dep_id
-        );
+    // Handle any remaining timed-out resources that no parent waited on.
+    if !cancelled {
+        for (dep_binding, (dep_id, dep_identifier)) in &timed_out_resources {
+            if cancel.is_cancelled() {
+                cancelled = true;
+                break;
+            }
 
-        match wait_for_deletion(
-            &provider,
-            dep_id,
-            dep_identifier,
-            180,
-            std::time::Duration::from_secs(10),
-        )
-        .await
-        {
-            WaitResult::Deleted => {
-                eprintln!(
-                    "  {} Delete {} (completed after extended wait)",
-                    "✓".green(),
-                    dep_id
-                );
-                destroyed_ids.push(dep_id.clone());
-                success_count += 1;
-            }
-            WaitResult::ReadError(msg) => {
-                eprintln!("  {} Delete {}", "✗".red(), dep_id);
-                eprintln!(
-                    "      {} {}",
-                    "→".red(),
-                    format!("read error during wait: {}", msg).red()
-                );
-                failed_bindings.insert(dep_binding.clone());
-                failure_count += 1;
-            }
-            WaitResult::TimedOut => {
-                eprintln!("  {} Delete {}", "✗".red(), dep_id);
-                eprintln!(
-                    "      {} {}",
-                    "→".red(),
-                    "still exists after extended wait".red()
-                );
-                failed_bindings.insert(dep_binding.clone());
-                failure_count += 1;
+            eprintln!(
+                "  {} Waiting for {} to be deleted...",
+                "⏳".yellow(),
+                dep_id
+            );
+
+            let outcome = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    cancelled = true;
+                    break;
+                }
+                result = wait_for_deletion(
+                    &provider,
+                    dep_id,
+                    dep_identifier,
+                    180,
+                    std::time::Duration::from_secs(10),
+                ) => result,
+            };
+
+            match outcome {
+                WaitResult::Deleted => {
+                    eprintln!(
+                        "  {} Delete {} (completed after extended wait)",
+                        "✓".green(),
+                        dep_id
+                    );
+                    destroyed_ids.push(dep_id.clone());
+                    success_count += 1;
+                }
+                WaitResult::ReadError(msg) => {
+                    eprintln!("  {} Delete {}", "✗".red(), dep_id);
+                    eprintln!(
+                        "      {} {}",
+                        "→".red(),
+                        format!("read error during wait: {}", msg).red()
+                    );
+                    failed_bindings.insert(dep_binding.clone());
+                    failure_count += 1;
+                }
+                WaitResult::TimedOut => {
+                    eprintln!("  {} Delete {}", "✗".red(), dep_id);
+                    eprintln!(
+                        "      {} {}",
+                        "→".red(),
+                        "still exists after extended wait".red()
+                    );
+                    failed_bindings.insert(dep_binding.clone());
+                    failure_count += 1;
+                }
             }
         }
     }
 
-    // Save state
+    if cancelled && destroyed_ids.is_empty() {
+        return Err(AppError::Interrupted);
+    }
+
     println!();
     println!("{}", "Saving state...".cyan());
 
-    // Get or create state file
-    let mut state = state_file.unwrap_or_default();
-
-    apply_destroy_to_state(&mut state, &destroyed_ids);
-
-    // Save state (with or without lock validation)
-    if let Some(lock) = lock {
-        crate::commands::apply::save_state_locked(backend, lock, &mut state).await?;
-    } else {
-        crate::commands::apply::save_state_unlocked(backend, &mut state).await?;
-    }
-    println!("  {} State saved (serial: {})", "✓".green(), state.serial);
+    let finalize_result = finalize_destroy(FinalizeDestroyInput {
+        backend,
+        lock,
+        state_file,
+        destroyed_ids: &destroyed_ids,
+    })
+    .await;
+    handle_finalize_after_execute(finalize_result, cancelled)?;
 
     println!();
     if failure_count == 0 && skip_count == 0 {
@@ -954,15 +1075,141 @@ async fn run_destroy_locked(
 }
 
 #[cfg(test)]
+static DESTROY_SUCCESS_CANCEL_AFTER: std::sync::Mutex<Option<DestroySuccessCancelHook>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(test)]
+struct DestroySuccessCancelHook {
+    threshold: usize,
+    cancel: CancellationToken,
+}
+
+#[cfg(test)]
+pub(crate) fn set_destroy_success_cancel_after(threshold: usize, cancel: CancellationToken) {
+    *DESTROY_SUCCESS_CANCEL_AFTER
+        .lock()
+        .expect("destroy success cancel hook lock") =
+        Some(DestroySuccessCancelHook { threshold, cancel });
+}
+
+#[cfg(test)]
+pub(crate) fn clear_destroy_success_cancel_after() {
+    *DESTROY_SUCCESS_CANCEL_AFTER
+        .lock()
+        .expect("destroy success cancel hook lock") = None;
+}
+
+#[cfg(test)]
+fn observe_destroy_success_for_tests(
+    success_count: usize,
+    _resource_id: &ResourceId,
+    _cancel: &CancellationToken,
+) {
+    if let Some(hook) = DESTROY_SUCCESS_CANCEL_AFTER
+        .lock()
+        .expect("destroy success cancel hook lock")
+        .as_ref()
+        && success_count == hook.threshold
+    {
+        hook.cancel.cancel();
+    }
+}
+
+#[cfg(not(test))]
+fn observe_destroy_success_for_tests(
+    _success_count: usize,
+    _resource_id: &ResourceId,
+    _cancel: &CancellationToken,
+) {
+}
+
+pub(crate) struct FinalizeDestroyInput<'a> {
+    pub backend: &'a dyn StateBackend,
+    pub lock: Option<&'a LockInfo>,
+    pub state_file: Option<StateFile>,
+    pub destroyed_ids: &'a [ResourceId],
+}
+
+pub(crate) async fn finalize_destroy(input: FinalizeDestroyInput<'_>) -> Result<(), AppError> {
+    let mut state = input.state_file.unwrap_or_default();
+
+    // NOTE: apply_destroy_to_state currently clears state.exports unconditionally.
+    // On a cancelled partial destroy, exports for resources that survived are
+    // also wiped. This is pre-existing behavior; downstream consumers should
+    // re-derive exports from a fresh plan. See carina-cli/src/commands/shared/state_writeback.rs.
+    apply_destroy_to_state(&mut state, input.destroyed_ids);
+
+    if let Some(lock) = input.lock {
+        crate::commands::apply::save_state_locked(input.backend, lock, &mut state).await?;
+    } else {
+        crate::commands::apply::save_state_unlocked(input.backend, &mut state).await?;
+    }
+    println!("  {} State saved (serial: {})", "✓".green(), state.serial);
+    Ok(())
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use carina_core::provider::{BoxFuture, Provider, ProviderError, ProviderResult};
     use carina_core::resource::DataSource;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    #[path = "cancellation_fixture.rs"]
+    mod cancellation_fixture;
+
+    use cancellation_fixture::DestroyCancellationFixture;
+
     #[test]
     fn destroy_parallelism_default_is_eight() {
         assert_eq!(crate::DEFAULT_PARALLELISM.get(), 8);
+    }
+
+    #[tokio::test]
+    async fn run_destroy_cancelled_after_partial_execution_persists_deletions_and_releases_lock() {
+        let fixture = DestroyCancellationFixture::new()
+            .with_existing_resources(["first", "second"])
+            .cancel_after_successes(1);
+        let token = fixture.cancel_token();
+
+        let err = run_destroy(
+            fixture.config_path(),
+            true,
+            true,
+            false,
+            false,
+            NonZeroUsize::new(1).unwrap(),
+            fixture.provider_context(),
+            token,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AppError::Interrupted),
+            "expected Interrupted, got {err:?}"
+        );
+        let state = fixture.read_state().await;
+        assert!(fixture.backend().state_path().exists());
+        assert!(
+            state
+                .find_resource("mock", "test.resource", "first")
+                .is_none(),
+            "first must be deleted from state"
+        );
+        assert!(
+            state
+                .find_resource("mock", "test.resource", "second")
+                .is_some(),
+            "second must remain in state"
+        );
+        assert!(!fixture.lock_path().exists(), "lock file must be released");
+        assert_eq!(state.resources.len(), 1);
+        assert!(state.serial >= 1, "state must be written");
+        assert!(
+            state.exports.is_empty(),
+            "exports must be cleared on partial destroy"
+        );
     }
 
     /// A mock provider whose `read()` returns a sequence of results.

--- a/carina-cli/src/commands/destroy/tests/cancellation_fixture.rs
+++ b/carina-cli/src/commands/destroy/tests/cancellation_fixture.rs
@@ -1,0 +1,96 @@
+use carina_core::parser::ProviderContext;
+use carina_state::{LocalBackend, ResourceState, StateFile};
+use tokio_util::sync::CancellationToken;
+
+use crate::commands::shared::cancellation_test_support::CancellationFixtureBase;
+
+pub(super) struct DestroyCancellationFixture {
+    base: CancellationFixtureBase,
+    provider_context: ProviderContext,
+}
+
+impl DestroyCancellationFixture {
+    pub(super) fn new() -> Self {
+        crate::commands::destroy::clear_destroy_success_cancel_after();
+
+        Self {
+            base: CancellationFixtureBase::new(),
+            provider_context: ProviderContext::default(),
+        }
+    }
+
+    pub(super) fn with_existing_resources<const N: usize>(self, names: [&str; N]) -> Self {
+        let state_path = self.base.state_path().display();
+        let mut crn = format!(
+            "backend local {{ path = \"{state_path}\" }}\n\
+             provider mock {{}}\n"
+        );
+        let mut state = StateFile::new();
+        state
+            .exports
+            .insert("surviving_export".to_string(), serde_json::json!("value"));
+
+        for name in names.iter().rev() {
+            crn.push_str(&format!(
+                "let {name} = mock.test.resource {{ name = \"{name}\" }}\n"
+            ));
+        }
+
+        for name in names {
+            let mut resource =
+                ResourceState::new("test.resource", name, "mock").with_identifier("mock-id");
+            resource.binding = Some(name.to_string());
+            resource
+                .attributes
+                .insert("name".to_string(), serde_json::json!(name));
+            state.upsert_resource(resource);
+        }
+
+        self.base.write_crn(crn);
+        self.base.write_backend_lock();
+        self.base.write_state(&state);
+
+        self
+    }
+
+    /// Cancel the token after `count` successful deletions.
+    ///
+    /// IMPORTANT: this hook fires from inside the in-flight completion handler.
+    /// With parallelism > 1, multiple completions can happen between the threshold
+    /// being reached and the next dispatch site observing cancel; the test must
+    /// therefore use `NonZeroUsize::new(1).unwrap()` parallelism to be deterministic.
+    pub(super) fn cancel_after_successes(self, count: usize) -> Self {
+        crate::commands::destroy::set_destroy_success_cancel_after(count, self.base.cancel_token());
+        self
+    }
+
+    pub(super) fn cancel_token(&self) -> CancellationToken {
+        self.base.cancel_token()
+    }
+
+    pub(super) async fn read_state(&self) -> StateFile {
+        self.base.read_state().await
+    }
+
+    pub(super) fn lock_path(&self) -> &std::path::Path {
+        self.base.lock_path()
+    }
+
+    pub(super) fn provider_context(&self) -> &ProviderContext {
+        &self.provider_context
+    }
+
+    pub(super) fn config_path(&self) -> &std::path::Path {
+        self.base.config_path()
+    }
+
+    pub(super) fn backend(&self) -> &LocalBackend {
+        self.base.backend()
+    }
+}
+
+impl Drop for DestroyCancellationFixture {
+    fn drop(&mut self) {
+        crate::commands::destroy::clear_destroy_success_cancel_after();
+    }
+}

--- a/carina-cli/src/commands/shared/cancellation_test_support.rs
+++ b/carina-cli/src/commands/shared/cancellation_test_support.rs
@@ -1,0 +1,88 @@
+use std::path::{Path, PathBuf};
+
+use carina_state::{LocalBackend, StateBackend, StateFile};
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+pub(crate) struct CancellationFixtureBase {
+    _dir: TempDir,
+    config_path: PathBuf,
+    crn_path: PathBuf,
+    state_path: PathBuf,
+    lock_path: PathBuf,
+    backend: LocalBackend,
+    cancel: CancellationToken,
+}
+
+impl CancellationFixtureBase {
+    pub(crate) fn new() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let config_path = dir.path().to_path_buf();
+        let crn_path = dir.path().join("main.crn");
+        let state_path = dir.path().join("carina.state.json");
+        let lock_path = state_path.with_extension("lock");
+        let backend = LocalBackend::with_path(state_path.clone());
+
+        Self {
+            _dir: dir,
+            config_path,
+            crn_path,
+            state_path,
+            lock_path,
+            backend,
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    pub(crate) fn write_crn(&self, content: impl AsRef<str>) {
+        std::fs::write(&self.crn_path, content.as_ref()).expect("write fixture config");
+    }
+
+    pub(crate) fn write_backend_lock(&self) {
+        let backend_lock = serde_json::json!({
+            "backend_type": "local",
+            "attributes": {
+                "path": self.state_path.display().to_string(),
+            },
+        });
+        std::fs::write(
+            self.config_path.join("carina-backend.lock"),
+            format!("{}\n", serde_json::to_string_pretty(&backend_lock).unwrap()),
+        )
+        .expect("write backend lock");
+    }
+
+    pub(crate) fn write_state(&self, state: &StateFile) {
+        let state_json = carina_core::utils::pretty_with_newline(state).expect("state json");
+        std::fs::write(&self.state_path, state_json).expect("write initial state");
+    }
+
+    pub(crate) async fn read_state(&self) -> StateFile {
+        self.backend
+            .read_state()
+            .await
+            .expect("read state")
+            .expect("state exists")
+            .into_state()
+    }
+
+    pub(crate) fn config_path(&self) -> &Path {
+        &self.config_path
+    }
+
+    pub(crate) fn state_path(&self) -> &Path {
+        &self.state_path
+    }
+
+    pub(crate) fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+
+    pub(crate) fn backend(&self) -> &LocalBackend {
+        &self.backend
+    }
+
+    pub(crate) fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+}

--- a/carina-cli/src/commands/shared/finalize.rs
+++ b/carina-cli/src/commands/shared/finalize.rs
@@ -1,0 +1,25 @@
+use crate::error::AppError;
+
+/// Handle state finalization after a mutating command has observed execution.
+///
+/// Four cases:
+/// 1. not cancelled + finalize Ok    -> Ok(())
+/// 2. not cancelled + finalize Err   -> Err(finalize_err)
+/// 3. cancelled     + finalize Ok    -> Err(Interrupted)
+/// 4. cancelled     + finalize Err   -> Err(Interrupted) after logging warning
+///
+/// On cancellation, `Interrupted` takes precedence so the user sees the
+/// interruption instead of a cleanup error. The finalize error is still logged.
+pub(crate) fn handle_finalize_after_execute(
+    finalize_result: Result<(), AppError>,
+    cancelled: bool,
+) -> Result<(), AppError> {
+    if cancelled {
+        if let Err(err) = finalize_result {
+            eprintln!("warning: state save during cancellation also failed: {err}");
+        }
+        return Err(AppError::Interrupted);
+    }
+
+    finalize_result
+}

--- a/carina-cli/src/commands/shared/mod.rs
+++ b/carina-cli/src/commands/shared/mod.rs
@@ -6,7 +6,10 @@
 //! out lets the command files focus on top-level flow and tightens the
 //! cohesion of the shared utilities.
 
+#[cfg(test)]
+pub(crate) mod cancellation_test_support;
 pub(crate) mod effect_execution;
+pub(crate) mod finalize;
 pub(crate) mod observer;
 pub(crate) mod progress;
 pub(crate) mod retry;

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -400,6 +400,9 @@ async fn main() {
             force,
             parallelism,
         } => {
+            // TODO(T7/T8): replace this fresh token with one fed by the signal listener.
+            // Until then, real SIGINT/SIGTERM still drops the future via signal::run_with_ctrl_c.
+            let cancel_token = tokio_util::sync::CancellationToken::new();
             run_destroy(
                 &path,
                 auto_approve,
@@ -408,6 +411,7 @@ async fn main() {
                 force,
                 parallelism,
                 &provider_context,
+                cancel_token,
             )
             .await
         }


### PR DESCRIPTION
Closes #3506. Refs #3498.

T6 of the apply interruption resilience series. `destroy.rs` now observes the cancel token across its three execution phases (refresh, main delete loop, post-loop `wait_for_deletion` cleanup) using the same shape T4 adopted for the executor (top-of-loop flip + biased `tokio::select!` around each await point). A cancelled run still persists whatever was deleted and releases the lock before returning `AppError::Interrupted`.

## Cancel observation seams

- **Refresh phase** (managed + orphan): manual `FuturesUnordered` + biased `select!` so a cancel mid-refresh drains in-flight reads and returns `Interrupted` without touching anything else.
- **Main delete loop**: top-of-loop flip with the same "actually-unfinished work" guard the executor uses; biased `select!` around `in_flight.next()`; cancelled iterations break without marking undispatched resources as failures.
- **Post-loop `wait_for_deletion` cleanup**: each per-resource wait wrapped in a biased `select!` so a long extended wait drains immediately on cancel instead of blocking up to 30 minutes.

## State persistence

- `finalize_destroy(FinalizeDestroyInput { backend, lock, state_file, destroyed_ids })` extracted from the inline state-save block so apply and destroy share the same "finalize after execute, prefer `Interrupted` on cancel" `handle_finalize_after_execute` helper. The helper now lives in `carina-cli/src/commands/shared/finalize.rs`.
- **Empty-deletions short-circuit**: a cancel observed before any delete completes returns `Err(Interrupted)` without bumping `state.serial`, so a no-op cancel does not advance the state file.

## Pre-existing apply_destroy_to_state behaviour pinned

`apply_destroy_to_state` currently clears `state.exports` unconditionally; that behaviour now becomes user-visible under partial cancel. The `finalize_destroy` site documents it inline and the new test pins the behaviour (initial state seeded with an export, asserted empty after partial cancel) so a future change cannot silently regress it.

## Tests

- `DestroyCancellationFixture` composes the new `shared/cancellation_test_support.rs` base, mirroring T5's `ApplyCancellationFixture` composition (no fixture duplication).
- `run_destroy_cancelled_after_partial_execution_persists_deletions_and_releases_lock` asserts: `err matches Interrupted`, exactly the cancelled-after-1-success resource is removed from state, the survivor is kept, the lock file is gone, and exports are cleared.

## Verify

- `cargo nextest run -p carina-cli` PASS (639 tests)
- `cargo nextest run -p carina-core` PASS (2498 tests)
- `cargo clippy --workspace --all-targets -- -D warnings` PASS
- `cargo test --workspace --doc` PASS (T2's `ExecutionOutcomeCannotBeQuestionMarked` compile_fail guard intact)
- `cargo fmt --check` PASS
- All `scripts/check-*.sh` PASS (pre-existing env-only `check-example-warnings.sh` issue is not a T6 regression)

5-round self-review: code-review medium (5 findings), Round 1 (1 wait_for_deletion granularity fix), Round 2 (CLEAN), Round 3 (refresh phase cancel-aware fix), Round 4 (transient compile observation during in-flight fix), Round 5 (CLEAN, ready for PR).

T5 is wholly preserved; T6 only generalises shared helpers and adds the destroy-side seam.