### PR TITLE
fix(plan): include AWS Message in IAM preflight error (closes #3532)

### DIFF
--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -577,16 +577,14 @@ fn classify_simulate_error(err: SimulatePrincipalPolicyError) -> SimulateError {
     // The generated enum is #[non_exhaustive], and IAM may return operation-level
     // errors such as AccessDenied through generic metadata instead of a named
     // variant. Match every known variant, then classify future/generic variants
-    // by their service error code.
+    // through the same metadata formatter.
     match err {
         SimulatePrincipalPolicyError::InvalidInputException(_)
         | SimulatePrincipalPolicyError::NoSuchEntityException(_)
-        | SimulatePrincipalPolicyError::PolicyEvaluationException(_) => SimulateError::Other(
-            format!("AWS IAM SimulatePrincipalPolicy failed with code {code}"),
-        ),
-        _ => SimulateError::Other(format!(
-            "AWS IAM SimulatePrincipalPolicy failed with code {code}"
-        )),
+        | SimulatePrincipalPolicyError::PolicyEvaluationException(_) => {
+            SimulateError::Other(format_simulate_error(&err))
+        }
+        _ => SimulateError::Other(format_simulate_error(&err)),
     }
 }
 
@@ -834,7 +832,7 @@ IAM preflight findings (1 warning):
     }
 
     #[test]
-    fn classify_simulate_non_access_denied_reports_service_code() {
+    fn classify_simulate_non_access_denied_reports_service_code_and_message() {
         let err = SimulatePrincipalPolicyError::generic(
             ErrorMetadata::builder()
                 .code("ThrottlingException")
@@ -846,6 +844,30 @@ IAM preflight findings (1 warning):
             classify_simulate_error(err),
             SimulateError::Other(message)
                 if message.contains("code ThrottlingException")
+                    && message.contains("rate exceeded")
+                    && !message.contains("service error")
+        ));
+    }
+
+    #[test]
+    fn classify_simulate_named_error_reports_service_message() {
+        let err = SimulatePrincipalPolicyError::InvalidInputException(
+            aws_sdk_iam::types::error::InvalidInputException::builder()
+                .message("ResourceArns cannot be used with ec2:DescribeInternetGateways")
+                .meta(
+                    ErrorMetadata::builder()
+                        .code("InvalidInput")
+                        .message("ResourceArns cannot be used with ec2:DescribeInternetGateways")
+                        .build(),
+                )
+                .build(),
+        );
+
+        assert!(matches!(
+            classify_simulate_error(err),
+            SimulateError::Other(message)
+                if message.contains("code InvalidInput")
+                    && message.contains("ResourceArns cannot be used with ec2:DescribeInternetGateways")
                     && !message.contains("service error")
         ));
     }


### PR DESCRIPTION
Closes #3532

## Root cause

`carina-cli/src/commands/iam_preflight.rs` `classify_simulate_error` had two paths formatting non-AccessDenied errors. The AccessDenied → `NeedsFallback` branch correctly delegated to `format_simulate_error`, which extracts both `code` AND `message` from the SDK error meta. But both `Other` arms (named-variant and catch-all `_`) hand-built a code-only string and dropped the AWS API's `Message` field.

The Message is where AWS names the specific request-parameter problem (`"The ResourceArns list cannot contain entries for actions that do not support resource-level permissions: ec2:DescribeInternetGateways"` and similar). Without it, the operator sees only `AWS IAM SimulatePrincipalPolicy failed with code InvalidInput` and has no signal for what to fix.

## Fix

Route both `Other` arms through `format_simulate_error(&err)` so all error paths share the same formatter. With this change there is no longer a way to format a Simulate error without the Message — a future SDK variant or wording change is handled in a single place.

Kept the explicit named-variant arm as a "we considered these variants" marker. It's structurally identical to the catch-all now, but the two arms together still document which variants the SDK exposes today.

## Tests

- `classify_simulate_non_access_denied_reports_service_code_and_message` (renamed; strengthened to require the `message` text and reject the historical `"service error"` flattening)
- `classify_simulate_named_error_reports_service_message` (new; locks the named-variant arm to the same shape)

## Verify

- `cargo check -p carina-cli`
- `cargo nextest run -p carina-cli`
- `cargo test --workspace --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- all `scripts/check-*.sh`

The issue author's `InvalidInput` repro will now show the specific parameter problem inline in the existing skip warning (no other output changes).
