### PR TITLE
cli: drive confirm prompt with cancel token (T10, #3510)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1449,10 +1449,8 @@ async fn run_apply_locked(
         );
 
         let stdin = tokio::io::BufReader::new(tokio::io::stdin());
-        let interrupt = async {
-            let _ = tokio::signal::ctrl_c().await;
-        };
-        if confirm_apply(stdin, interrupt, auto_approve).await? == ApplyConfirmation::Cancelled {
+        if confirm_apply(stdin, cancel.clone(), auto_approve).await? == ApplyConfirmation::Cancelled
+        {
             return Ok(None);
         }
 
@@ -1533,10 +1531,7 @@ async fn run_apply_locked(
     );
 
     let stdin = tokio::io::BufReader::new(tokio::io::stdin());
-    let interrupt = async {
-        let _ = tokio::signal::ctrl_c().await;
-    };
-    if confirm_apply(stdin, interrupt, auto_approve).await? == ApplyConfirmation::Cancelled {
+    if confirm_apply(stdin, cancel.clone(), auto_approve).await? == ApplyConfirmation::Cancelled {
         return Ok(None);
     }
 
@@ -1978,10 +1973,7 @@ async fn run_apply_from_plan_locked(
     );
 
     let stdin = tokio::io::BufReader::new(tokio::io::stdin());
-    let interrupt = async {
-        let _ = tokio::signal::ctrl_c().await;
-    };
-    if confirm_apply(stdin, interrupt, auto_approve).await? == ApplyConfirmation::Cancelled {
+    if confirm_apply(stdin, cancel.clone(), auto_approve).await? == ApplyConfirmation::Cancelled {
         return Ok(None);
     }
 
@@ -2137,14 +2129,13 @@ pub(crate) enum ApplyConfirmation {
 
 /// Prompt the user to confirm an apply. Shared between the resource-change and
 /// export-only paths so both use identical wording and behavior.
-pub(crate) async fn confirm_apply<R, F>(
+pub(crate) async fn confirm_apply<R>(
     reader: R,
-    interrupt: F,
+    cancel: CancellationToken,
     auto_approve: bool,
 ) -> Result<ApplyConfirmation, AppError>
 where
     R: tokio::io::AsyncBufRead + Unpin,
-    F: std::future::Future<Output = ()>,
 {
     if auto_approve {
         return Ok(ApplyConfirmation::Confirmed);
@@ -2165,7 +2156,7 @@ where
         print!("\n  Enter a value: ");
         std::io::Write::flush(&mut std::io::stdout()).map_err(|e| e.to_string())?;
 
-        let read_result = crate::signal::read_line_with_interrupt(reader, interrupt).await;
+        let read_result = crate::signal::read_line_until_cancelled(reader, cancel).await;
         emit_newline_on_interrupt(&mut std::io::stdout(), &read_result);
         read_result?
     };

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1796,27 +1796,39 @@ fn emit_newline_on_interrupt_writes_nothing_on_other_error() {
     assert!(buf.is_empty());
 }
 
+struct NeverReady;
+
+impl tokio::io::AsyncRead for NeverReady {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+        _: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Pending
+    }
+}
+
 #[tokio::test]
 async fn confirm_apply_returns_confirmed_on_yes() {
     let input = &b"yes\n"[..];
-    let interrupt = std::future::pending::<()>();
-    let outcome = confirm_apply(input, interrupt, false).await.unwrap();
+    let cancel = CancellationToken::new();
+    let outcome = confirm_apply(input, cancel, false).await.unwrap();
     assert_eq!(outcome, ApplyConfirmation::Confirmed);
 }
 
 #[tokio::test]
 async fn confirm_apply_returns_cancelled_on_no() {
     let input = &b"no\n"[..];
-    let interrupt = std::future::pending::<()>();
-    let outcome = confirm_apply(input, interrupt, false).await.unwrap();
+    let cancel = CancellationToken::new();
+    let outcome = confirm_apply(input, cancel, false).await.unwrap();
     assert_eq!(outcome, ApplyConfirmation::Cancelled);
 }
 
 #[tokio::test]
 async fn confirm_apply_returns_cancelled_on_empty_input() {
     let input = &b"\n"[..];
-    let interrupt = std::future::pending::<()>();
-    let outcome = confirm_apply(input, interrupt, false).await.unwrap();
+    let cancel = CancellationToken::new();
+    let outcome = confirm_apply(input, cancel, false).await.unwrap();
     assert_eq!(outcome, ApplyConfirmation::Cancelled);
 }
 
@@ -1824,27 +1836,28 @@ async fn confirm_apply_returns_cancelled_on_empty_input() {
 async fn confirm_apply_auto_approve_skips_read() {
     // Reader would hang forever; auto_approve must short-circuit without reading.
     let input = tokio::io::BufReader::new(tokio::io::empty());
-    let interrupt = std::future::pending::<()>();
-    let outcome = confirm_apply(input, interrupt, true).await.unwrap();
+    let cancel = CancellationToken::new();
+    let outcome = confirm_apply(input, cancel, true).await.unwrap();
     assert_eq!(outcome, ApplyConfirmation::Confirmed);
 }
 
 #[tokio::test]
-async fn confirm_apply_propagates_interrupt() {
-    // A reader that never resolves, to force the interrupt path.
-    struct NeverReady;
-    impl tokio::io::AsyncRead for NeverReady {
-        fn poll_read(
-            self: std::pin::Pin<&mut Self>,
-            _: &mut std::task::Context<'_>,
-            _: &mut tokio::io::ReadBuf<'_>,
-        ) -> std::task::Poll<std::io::Result<()>> {
-            std::task::Poll::Pending
-        }
-    }
+async fn confirm_apply_returns_interrupted_when_cancel_fires_after_subscription() {
     let reader = tokio::io::BufReader::new(NeverReady);
-    let interrupt = async {};
-    let err = confirm_apply(reader, interrupt, false).await.unwrap_err();
+    let cancel = CancellationToken::new();
+    let waiting = tokio::spawn(confirm_apply(reader, cancel.clone(), false));
+    tokio::task::yield_now().await;
+    cancel.cancel();
+    let err = waiting.await.unwrap().unwrap_err();
+    assert!(matches!(err, AppError::Interrupted));
+}
+
+#[tokio::test]
+async fn confirm_apply_returns_interrupted_when_cancel_token_fires() {
+    let token = CancellationToken::new();
+    token.cancel();
+    let reader = tokio::io::BufReader::new(NeverReady);
+    let err = confirm_apply(reader, token, false).await.unwrap_err();
     assert!(matches!(err, AppError::Interrupted));
 }
 

--- a/carina-cli/src/signal.rs
+++ b/carina-cli/src/signal.rs
@@ -111,18 +111,22 @@ where
     exit.exit(130);
 }
 
-/// Read a single line from `reader`, cancellable by `interrupt`.
+/// Read a single line from `reader`, cancellable by `cancel`.
 ///
 /// Returns the line with any trailing `\n` or `\r\n` stripped, or
-/// `Err(AppError::Interrupted)` if `interrupt` fires first.
-pub async fn read_line_with_interrupt<R, F>(reader: R, interrupt: F) -> Result<String, AppError>
+/// `Err(AppError::Interrupted)` if `cancel` fires first.
+pub async fn read_line_until_cancelled<R>(
+    reader: R,
+    cancel: CancellationToken,
+) -> Result<String, AppError>
 where
     R: AsyncBufRead + Unpin,
-    F: Future<Output = ()>,
 {
     tokio::pin!(reader);
     let mut buf = String::new();
     tokio::select! {
+        biased;
+        _ = cancel.cancelled() => Err(AppError::Interrupted),
         result = reader.read_line(&mut buf) => {
             result.map_err(|e| AppError::Config(e.to_string()))?;
             if buf.ends_with('\n') {
@@ -133,7 +137,6 @@ where
             }
             Ok(buf)
         }
-        _ = interrupt => Err(AppError::Interrupted),
     }
 }
 
@@ -143,29 +146,39 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     #[tokio::test]
-    async fn read_line_returns_input_before_interrupt() {
+    async fn read_line_until_cancelled_returns_input_when_token_not_cancelled() {
         let input = &b"yes\n"[..];
-        let interrupt = std::future::pending::<()>();
-        let line = read_line_with_interrupt(input, interrupt).await.unwrap();
+        let token = CancellationToken::new();
+        let line = read_line_until_cancelled(input, token).await.unwrap();
         assert_eq!(line, "yes");
     }
 
     #[tokio::test]
-    async fn read_line_strips_crlf() {
+    async fn read_line_until_cancelled_strips_crlf() {
         let input = &b"no\r\n"[..];
-        let interrupt = std::future::pending::<()>();
-        let line = read_line_with_interrupt(input, interrupt).await.unwrap();
+        let token = CancellationToken::new();
+        let line = read_line_until_cancelled(input, token).await.unwrap();
         assert_eq!(line, "no");
     }
 
     #[tokio::test]
-    async fn read_line_returns_interrupted_when_signal_fires_first() {
+    async fn read_line_until_cancelled_returns_interrupted_when_token_is_cancelled() {
         // Simulates a user who hasn't pressed Enter at the confirmation prompt.
+        let token = CancellationToken::new();
+        token.cancel();
         let reader = tokio::io::BufReader::new(NeverReady);
-        let interrupt = async {};
-        let err = read_line_with_interrupt(reader, interrupt)
-            .await
-            .unwrap_err();
+        let err = read_line_until_cancelled(reader, token).await.unwrap_err();
+        assert!(matches!(err, AppError::Interrupted));
+    }
+
+    #[tokio::test]
+    async fn read_line_until_cancelled_returns_interrupted_when_cancel_fires_after_subscription() {
+        let token = CancellationToken::new();
+        let reader = tokio::io::BufReader::new(NeverReady);
+        let waiting = tokio::spawn(read_line_until_cancelled(reader, token.clone()));
+        tokio::task::yield_now().await;
+        token.cancel();
+        let err = waiting.await.unwrap().unwrap_err();
         assert!(matches!(err, AppError::Interrupted));
     }
 


### PR DESCRIPTION
Closes #3510. Refs #3498.

T10 of the apply interruption resilience series. Replaces the generic `interrupt: F` parameter on the confirm prompt with a `CancellationToken` so that the prompt participates in the same cancel pipeline as the rest of apply / destroy / state refresh (wired in T5-T9).

## What changes

- `signal::read_line_with_interrupt<R, F>` is removed; `signal::read_line_until_cancelled<R>(reader, cancel: CancellationToken)` replaces it. No compatibility wrapper.
- `confirm_apply<R, F>` → `confirm_apply<R>(reader, cancel: CancellationToken, auto_approve)`. All three production call sites in `apply.rs` pass `cancel.clone()` from the surrounding `run_apply_locked` / `run_apply_from_plan_locked` scope.
- The `tokio::select!` in `read_line_until_cancelled` is `biased;` with the cancel arm first. Without this, a Ctrl+C that lands at the same instant as the user pressing Enter would non-deterministically pick "read wins" half the time — meaning Ctrl+C silently failed to cancel. With `biased;`, cancel always wins.

## Tests

- Existing `read_line_with_interrupt` tests are renamed and rewritten against the new token API.
- New `read_line_until_cancelled_returns_interrupted_when_cancel_fires_after_subscription` covers the post-poll race (future spawned, `yield_now`, then `cancel`).
- New `confirm_apply_returns_interrupted_when_cancel_token_fires` exercises the prompt end-to-end with a pre-cancelled token.
- The pre-existing `confirm_apply_propagates_interrupt` was removed because the rewrite made it functionally identical to the new pre-cancel test.
- `NeverReady` is now a single shared helper in `apply/tests.rs` to avoid per-test redeclaration.

## Verify

- `cargo nextest run -p carina-cli` PASS (646 tests)
- `cargo nextest run -p carina-core` PASS (T1-T6 cancel observation behaviour unchanged)
- `cargo test --workspace --doc` PASS (T2's `ExecutionOutcomeCannotBeQuestionMarked` compile_fail guard intact)
- `cargo clippy -p carina-cli --all-targets -- -D warnings` PASS
- `cargo fmt --check` PASS
- Repo-invariant `scripts/check-*.sh` PASS (workspace clippy hits a pre-existing `carina_provider_protocol` WASM-target gap on `origin/main` HEAD too — unrelated)

5-round self-review history:
- code-review medium: false alarm from a stale-rebase diff; rebased onto current `origin/main`
- Round 1: test duplication after rewrite → propagates_interrupt removed, `NeverReady` hoisted
- Round 2: CLEAN integration with T5/T6/T7+T8+T9
- Round 3: missing `biased;` on the new select — fixed (cancel-wins is the correct prompt UX)
- Round 4: WIP commit message → reworded
- Round 5: CLEAN, ready for PR