### PR TITLE
test(apply): add #3498 regression test for cancel-aware partial apply (T11, #3511)

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -69,6 +69,54 @@ async fn run_apply_cancelled_after_partial_execution_persists_state_and_releases
     assert!(!fixture.lock_path().exists());
 }
 
+#[tokio::test]
+async fn apply_cancel_token_integration_persists_completed_state_releases_lock_and_returns_interrupted()
+ {
+    // Regression test for #3498: a cancelled apply must persist completed
+    // resources to state, release the lock, and return AppError::Interrupted.
+    // The resource names mirror the publish-ALB scenario that surfaced this
+    // bug in production.
+    let fixture = ApplyCancellationFixture::new()
+        .with_resources(["alb", "listener", "target_group"])
+        .cancel_after_successes(1);
+    let token = fixture.cancel_token();
+
+    let observer_factory = fixture.observer_factory();
+    let err = run_apply_with_observer_factory(
+        fixture.config_path(),
+        true,
+        true,
+        NonZeroUsize::new(1).unwrap(),
+        fixture.provider_context(),
+        token,
+        &observer_factory,
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, AppError::Interrupted));
+    let state = fixture.read_state().await;
+    assert!(
+        state
+            .find_resource("mock", "test.resource", "alb")
+            .is_some(),
+        "alb must be persisted to state (it completed before cancel)"
+    );
+    assert!(
+        state
+            .find_resource("mock", "test.resource", "listener")
+            .is_none(),
+        "listener must not be in state (cancelled before completion)"
+    );
+    assert!(
+        state
+            .find_resource("mock", "test.resource", "target_group")
+            .is_none(),
+        "target_group must not be in state (cancelled before completion)"
+    );
+    assert!(!fixture.lock_path().exists(), "lock file must be released");
+}
+
 fn s3_backend_config_with_encrypt(encrypt: bool) -> carina_core::parser::BackendConfig {
     let mut attributes = HashMap::new();
     attributes.insert(


### PR DESCRIPTION
Closes #3511. Refs #3498.

T11 of the apply interruption resilience series. Adds a dedicated regression test named after the #3498 publish-ALB scenario so a future change that re-introduces the bug (cancelled apply does not persist completed resources, lock leaks, or wrong error type) trips a test with the scenario in its name.

## What the test asserts

`apply_cancel_token_integration_persists_completed_state_releases_lock_and_returns_interrupted` runs `run_apply` against three resources (`alb`, `listener`, `target_group`) with parallelism 1, cancels the token after the first success, and asserts:

- `Err(AppError::Interrupted)` surfaces from `run_apply`
- the completed resource (`alb`) is in state
- the cancelled resources (`listener`, `target_group`) are NOT in state
- the lock file is gone

## Coexistence with T5 test

The pre-existing T5 contract test `run_apply_cancelled_after_partial_execution_persists_state_and_releases_lock` (with names first/second/third) pins the general partial-apply behavior. T11 keeps that test and adds the new one as the named #3498 regression marker — both fixtures share `ApplyCancellationFixture` so duplication is minimal.

## Verify

- `cargo nextest run -p carina-cli apply_cancel_token_integration_*` PASS (1/1)
- `cargo nextest run -p carina-cli` PASS (647 tests; T5 test still passes too)
- `cargo test --workspace --doc` PASS (T2's `ExecutionOutcomeCannotBeQuestionMarked` compile_fail guard intact)
- `cargo check --workspace` PASS
- `cargo clippy --workspace --all-targets -- -D warnings` PASS
- `cargo fmt --check` PASS

Pure test-code addition, no production change. Review confirms scope discipline (only `apply/tests.rs` touched, +48 lines).