### PR TITLE
test(signal): pin SIGTERM/SIGINT cancel-path equivalence contract (T12, #3512)

### DIFF
--- a/carina-cli/src/signal.rs
+++ b/carina-cli/src/signal.rs
@@ -227,6 +227,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn terminate_and_interrupt_events_share_the_same_cancel_path() {
+        // T12 contract: the listener treats Interrupt and Terminate identically.
+        // Both fire token.cancel() and neither call exit on the first signal.
+        // This pins the design so a future change cannot accidentally introduce
+        // signal-kind-specific behavior at the listener layer.
+        for signal in [ShutdownSignal::Interrupt, ShutdownSignal::Terminate] {
+            let token = CancellationToken::new();
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            let exit_calls = Arc::new(Mutex::new(Vec::<i32>::new()));
+            let exit = RecordingExit {
+                calls: Arc::clone(&exit_calls),
+            };
+
+            let task = tokio::spawn(listen_for_shutdown_events(
+                token.clone(),
+                SignalEvents::from_receiver(rx),
+                exit,
+            ));
+            tx.send(signal).unwrap();
+            token.cancelled().await;
+
+            assert!(token.is_cancelled(), "{signal:?} must cancel the token");
+            assert_eq!(
+                *exit_calls.lock().unwrap(),
+                Vec::<i32>::new(),
+                "{signal:?} must not exit on first signal"
+            );
+
+            drop(tx);
+            task.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
     async fn signal_listener_calls_exit_130_on_second_interrupt() {
         let token = CancellationToken::new();
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();


### PR DESCRIPTION
Closes #3512. Refs #3498.

T12 of the apply interruption resilience series. Adds a single loop-based contract test asserting that the unified shutdown listener treats `ShutdownSignal::Interrupt` and `ShutdownSignal::Terminate` identically on the first signal: both fire `token.cancel()` and neither call `exit`. A future divergence between the two signal kinds at the listener layer becomes a test failure with the signal kind in the assertion message.

## Coexistence with T7 tests

T7's `signal_listener_cancels_token_on_interrupt_event` and `signal_listener_cancels_token_on_terminate_event` pin each variant individually. T12 adds the explicit "share-the-same-cancel-path" invariant on top. Both are kept.

## Why not an OS-signal test

The plan calls this out: sending a real SIGTERM through `nix::sys::signal::kill` from the test harness introduces timing flakes that the channel-backed `SignalEvents::Receiver` fake does not. The production wiring (`SignalEvents::unix()` on `tokio::signal::unix::SignalKind::interrupt()` / `terminate()`) is reviewable by inspection.

## Verify

- `cargo nextest run -p carina-cli terminate_and_interrupt_events_share_the_same_cancel_path` PASS
- `cargo nextest run -p carina-cli` PASS (648 tests)
- `cargo check --workspace` PASS
- `cargo clippy --workspace --all-targets -- -D warnings` PASS
- `cargo fmt --check` PASS

Pure test-code addition, no production change (signal.rs +34 lines only).