### PR TITLE
fix(observer,wait): use format_value for wait heartbeat / timeout messages

### DIFF
--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 
 use carina_core::executor::{ExecutionEvent, ExecutionObserver};
 use carina_core::plan::Plan;
+use carina_core::resource::Value;
+use carina_core::value::format_value_user_facing;
 use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
@@ -322,13 +324,13 @@ fn format_plain(event: &ExecutionEvent) -> Vec<String> {
     }
 }
 
-fn format_wait_observed_attr(last_attrs: &HashMap<String, carina_core::resource::Value>) -> String {
+fn format_wait_observed_attr(last_attrs: &HashMap<String, Value>) -> String {
     let mut observed: Vec<_> = last_attrs.iter().collect();
     observed.sort_by_key(|(key, _)| *key);
     let Some((key, value)) = observed.first() else {
         return "no observed attributes".to_string();
     };
-    format!("{key}={value:?}")
+    format!("{key}={}", format_value_user_facing(value))
 }
 
 #[cfg(test)]
@@ -336,7 +338,7 @@ mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::executor::ProgressInfo;
-    use carina_core::resource::{ConcreteValue, Resource, Value};
+    use carina_core::resource::{ConcreteValue, DeferredValue, Resource, UnknownReason};
 
     fn dummy_create_effect() -> Effect {
         Effect::Create(Resource::new("aws.s3.Bucket", "demo"))
@@ -355,9 +357,34 @@ mod tests {
             ),
         ]);
 
+        assert_eq!(format_wait_observed_attr(&attrs), "arn=arn:demo");
+    }
+
+    #[test]
+    fn wait_observed_attr_uses_display_formatting() {
+        let attrs = HashMap::from([(
+            "arn".to_string(),
+            Value::Concrete(ConcreteValue::String(
+                "arn:aws:acm:1:certificate/abc".to_string(),
+            )),
+        )]);
+
         assert_eq!(
             format_wait_observed_attr(&attrs),
-            "arn=Concrete(String(\"arn:demo\"))"
+            "arn=arn:aws:acm:1:certificate/abc"
+        );
+    }
+
+    #[test]
+    fn wait_observed_attr_handles_unknown_value() {
+        let attrs = HashMap::from([(
+            "status".to_string(),
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
+        )]);
+
+        assert_eq!(
+            format_wait_observed_attr(&attrs),
+            "status=(known after upstream apply)"
         );
     }
 

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -17,6 +17,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use crate::executor::{ExecutionEvent, ExecutionObserver};
 use crate::provider::{Provider, ProviderError, ReadRequest};
 use crate::resource::{ResourceId, State, Value};
+use crate::value::format_value_user_facing;
 use crate::wait::predicate::WaitPredicate;
 
 /// Outcome of polling a Wait effect. The variants distinguish:
@@ -90,15 +91,30 @@ pub(super) fn wait_failure_message(outcome: &WaitOutcome, target_id: &ResourceId
         WaitOutcome::Timeout {
             last_attrs,
             elapsed,
-        } => format!(
-            "wait on {} timed out after {:?} (last observed attributes: {:?})",
-            target_id, elapsed, last_attrs
-        ),
+        } => {
+            let observed = format_wait_last_attrs(last_attrs);
+            format!(
+                "wait on {} timed out after {:?} (last observed attributes: {})",
+                target_id, elapsed, observed
+            )
+        }
         WaitOutcome::NotFound(err) | WaitOutcome::ReadFailed(err) => err.to_string(),
         WaitOutcome::Satisfied { .. } | WaitOutcome::Cancelled | WaitOutcome::Unsatisfiable(_) => {
             unreachable!("satisfied, cancelled, and unsatisfiable waits are not failures")
         }
     }
+}
+
+fn format_wait_last_attrs(last_attrs: &HashMap<String, Value>) -> String {
+    let mut keys: Vec<_> = last_attrs.keys().collect();
+    keys.sort();
+    if keys.is_empty() {
+        return "no observed attributes".to_string();
+    }
+    keys.into_iter()
+        .map(|key| format!("{key}={}", format_value_user_facing(&last_attrs[key])))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Skip reason emitted on `EffectSkipped` when an effect is dropped or
@@ -375,7 +391,7 @@ mod tests {
     use crate::provider::{
         BoxFuture, CreateRequest, DeleteRequest, ProviderResult, ReadRequest, UpdateRequest,
     };
-    use crate::resource::{ConcreteValue, DataSource, Value};
+    use crate::resource::{ConcreteValue, DataSource, DeferredValue, UnknownReason, Value};
     use crate::wait::predicate::{AttrPath, WaitPredicate};
     use std::collections::HashMap;
     use std::sync::Mutex;
@@ -622,6 +638,77 @@ mod tests {
                 "PENDING_VALIDATION".to_string()
             )))
         );
+    }
+
+    #[test]
+    fn wait_timeout_failure_message_uses_display_formatting_for_last_attrs() {
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let outcome = WaitOutcome::Timeout {
+            last_attrs: HashMap::from([
+                (
+                    "status".to_string(),
+                    Value::Concrete(ConcreteValue::String("pending".to_string())),
+                ),
+                (
+                    "arn".to_string(),
+                    Value::Concrete(ConcreteValue::String(
+                        "arn:aws:acm:1:certificate/abc".to_string(),
+                    )),
+                ),
+            ]),
+            elapsed: Duration::from_secs(1),
+        };
+
+        let message = wait_failure_message(&outcome, &target);
+
+        assert!(message.contains(
+            "last observed attributes: arn=arn:aws:acm:1:certificate/abc, status=pending"
+        ));
+        assert!(!message.contains("Concrete"));
+        assert!(!message.contains("String("));
+    }
+
+    #[test]
+    fn wait_timeout_failure_message_handles_empty_last_attrs() {
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let outcome = WaitOutcome::Timeout {
+            last_attrs: HashMap::new(),
+            elapsed: Duration::from_secs(1),
+        };
+
+        let message = wait_failure_message(&outcome, &target);
+
+        assert!(message.contains("last observed attributes: no observed attributes"));
+    }
+
+    #[test]
+    fn wait_timeout_failure_message_handles_unknown_and_deferred_attrs() {
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let outcome = WaitOutcome::Timeout {
+            last_attrs: HashMap::from([
+                (
+                    "status".to_string(),
+                    Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
+                ),
+                (
+                    "target".to_string(),
+                    Value::resource_ref("vpc", "id", vec![]),
+                ),
+            ]),
+            elapsed: Duration::from_secs(1),
+        };
+
+        let message = wait_failure_message(&outcome, &target);
+
+        assert!(
+            message.contains(
+                "last observed attributes: status=(known after upstream apply), target=vpc.id"
+            ),
+            "{message}"
+        );
+        assert!(!message.contains("Deferred"));
+        assert!(!message.contains("Unknown("));
+        assert!(!message.contains("ResourceRef"));
     }
 
     #[tokio::test]

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -409,6 +409,21 @@ pub fn format_value(value: &Value) -> String {
     format_value_with_key(value, None)
 }
 
+/// Format a `Value` for user-visible messages where DSL literal quotes
+/// around bare strings get in the way.
+pub fn format_value_user_facing(value: &Value) -> String {
+    let formatted = format_value(value);
+    if matches!(value, Value::Concrete(ConcreteValue::String(_))) {
+        formatted
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .unwrap_or(&formatted)
+            .to_string()
+    } else {
+        formatted
+    }
+}
+
 /// Format a `Value` for display, with an optional key for context
 pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
     let mut sink = StringSink::default();
@@ -2614,6 +2629,23 @@ mod tests {
     fn test_format_value_string() {
         let v = Value::Concrete(ConcreteValue::String("hello".to_string()));
         assert_eq!(format_value(&v), "\"hello\"");
+    }
+
+    #[test]
+    fn test_format_value_user_facing_string_is_unquoted() {
+        let v = Value::Concrete(ConcreteValue::String("hello".to_string()));
+        assert_eq!(format_value_user_facing(&v), "hello");
+    }
+
+    #[test]
+    fn test_format_value_user_facing_non_string_matches_format_value() {
+        for value in [
+            Value::Concrete(ConcreteValue::Bool(true)),
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
+            Value::resource_ref("vpc", "id", vec![]),
+        ] {
+            assert_eq!(format_value_user_facing(&value), format_value(&value));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

#3543 の修正。`wait` ブロックの heartbeat と timeout エラーメッセージで `Concrete(String("..."))` のような Rust 内部型表記が user-visible 出力にリークしていた件を直す。

## 根本原因

`Value` enum に `Display` 実装が無い設計の中で、user 向け文字列を生成する 2 サイトが `{:?}` (Debug) を使ってしまっていた:

- `carina-cli/src/commands/shared/observer.rs::format_wait_observed_attr` — heartbeat の `key={value:?}` 出力
- `carina-core/src/executor/wait.rs::wait_failure_message` — Timeout 時のエラーメッセージ `(last observed attributes: {:?})`

両者は同じ class のバグ。既存の `carina_core::value::format_value` は DSL リテラル形式の表示を提供していますが、bare string を `"..."` のクォート付きで返す。heartbeat やエラーメッセージの context ではクォートが邪魔なので、新公開関数 `format_value_user_facing` を追加してそこに統一しました。

```rust
pub fn format_value_user_facing(value: &Value) -> String {
    let formatted = format_value(value);
    if matches!(value, Value::Concrete(ConcreteValue::String(_))) {
        formatted
            .strip_prefix('"')
            .and_then(|s| s.strip_suffix('"'))
            .unwrap_or(&formatted)
            .to_string()
    } else {
        formatted
    }
}
```

bare string のときだけクォートを剥がし、それ以外の variant (`Unknown` / `Deferred` / list / struct …) は `format_value` の出力をそのまま通します。

## 期待する出力

```
~ registry_publish.cert: waited 33.0s,
  certificate_arn=arn:aws:acm:ap-northeast-1:151116838382:certificate/c202187b-d7a1-40fc-a0aa-39c4b10ba323
```

(従来は `certificate_arn=Concrete(String("arn:..."))`)

Timeout エラーメッセージも同様に `(last observed attributes: status=pending_validation)` のように出るようになります。

## Out of scope

Round 4 review で **「heartbeat が常に alphabetically-first の属性しか出さない、predicate が見ている属性を出すべき」** という別の問題も発見しました。これは `ExecutionEvent::WaitPolling` payload に `AttrPath` を threading する必要がある、本 PR の射程を超える変更なので別 issue として記録: **#3545**。

## Test plan

- [x] `format_value_user_facing` のユニットテスト(bare string クォート剥がし、`Unknown` / `Deferred(ResourceRef)` 等の non-string variant が `format_value` と byte-identical なこと)
- [x] `format_wait_observed_attr` のテスト(複数属性での deterministic ordering、`Unknown` value の取り扱い)
- [x] `wait_failure_message` Timeout arm のテスト(複数属性 + `Unknown` / `ResourceRef` 混在で Debug 漏れがないこと)
- [x] `cargo nextest run --workspace --all-features` — 4198 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

5 round self-review 完了。round 4 で 1 件 finding(Unknown/Deferred 変種のテストカバレッジ不足) → 対応済み + 別 issue (#3545) を起票。

Closes #3543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
