### PR TITLE
fix(executor): exclude pre-failed effects from terminal undispatched count

### DIFF
--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -19,7 +19,7 @@ use super::basic::{
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
 use super::wait::{
     SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome, WaitSignal,
-    unsatisfiable_reason_message, wait_failure_message,
+    count_effectively_undispatched, unsatisfiable_reason_message, wait_failure_message,
 };
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
 
@@ -829,14 +829,17 @@ pub(super) async fn execute_effects_sequential(
             }
         }
 
-        let undispatched_count = || {
-            actionable_indices
-                .iter()
-                .filter(|&&idx| !dispatched.contains(&idx))
-                .count()
-        };
+        let count_undispatched =
+            |dispatched: &HashSet<usize>, failed_bindings: &HashSet<String>| {
+                count_effectively_undispatched(
+                    &actionable_indices,
+                    dispatched,
+                    effects,
+                    failed_bindings,
+                )
+            };
         in_flight
-            .check_terminal(undispatched_count())
+            .check_terminal(count_undispatched(&dispatched, &failed_bindings))
             .cancel_if_terminal()
             .drop_without_awaiting();
 
@@ -876,7 +879,7 @@ pub(super) async fn execute_effects_sequential(
         // Wait for the next effect to complete
         let (finished_idx, result) = if cancelled {
             let Some(finished) = in_flight
-                .check_terminal(undispatched_count())
+                .check_terminal(count_undispatched(&dispatched, &failed_bindings))
                 .cancel_if_terminal()
                 .next_completed()
                 .await
@@ -893,7 +896,7 @@ pub(super) async fn execute_effects_sequential(
                     continue;
                 }
                 finished = in_flight
-                    .check_terminal(undispatched_count())
+                    .check_terminal(count_undispatched(&dispatched, &failed_bindings))
                     .cancel_if_terminal()
                     .next_completed() => {
                     let Some(finished) = finished else {
@@ -1024,7 +1027,7 @@ pub(super) async fn execute_effects_sequential(
         }
 
         in_flight
-            .check_terminal(undispatched_count())
+            .check_terminal(count_undispatched(&dispatched, &failed_bindings))
             .cancel_if_terminal()
             .drop_without_awaiting();
     }
@@ -1342,6 +1345,111 @@ mod tests {
                 .any(|event| event.contains("alb")),
             "test setup should fail alb create; failures: {:?}",
             observer.failures()
+        );
+        assert!(
+            observer.skipped().iter().any(|event| {
+                event.contains("cert") && event.to_ascii_lowercase().contains("unsatisfiable")
+            }),
+            "wait skip reason should contain unsatisfiable, skipped: {:?}",
+            observer.skipped()
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_marked_unsatisfiable_when_failing_sibling_blocks_consumer_inside_wait_subtree() {
+        let provider = TerminalWaitProvider::new();
+
+        let mut cert = Resource::new("test", "cert");
+        cert.binding = Some("cert".to_string());
+        let cert_id = cert.id.clone();
+
+        let mut alb = Resource::new("test", "alb");
+        alb.binding = Some("alb".to_string());
+
+        let mut listener = Resource::new("test", "listener");
+        listener.binding = Some("listener".to_string());
+        listener.set_attr(
+            "load_balancer_arn",
+            Value::resource_ref("alb", "load_balancer_arn", vec![]),
+        );
+        listener.set_attr(
+            "certificate_arn",
+            Value::resource_ref("cert_issued", "arn", vec![]),
+        );
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(cert.clone()));
+        plan.add(Effect::Wait {
+            binding: "cert_issued".to_string(),
+            target_id: cert_id.clone(),
+            target: WaitTarget::ResolvedAtApply,
+            until: WaitPredicate::Equals {
+                attr: AttrPath::single("status"),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+            },
+            until_surface: "cert.status == ISSUED".to_string(),
+            timeout: std::time::Duration::from_secs(60),
+            interval: std::time::Duration::from_millis(1),
+            explicit_dependencies: std::collections::HashSet::new(),
+        });
+        plan.add(Effect::Create(alb.clone()));
+        plan.add(Effect::Create(listener.clone()));
+
+        let unresolved = HashMap::from([
+            (
+                cert.id.clone(),
+                UnresolvedResource::from_pre_resolve(cert.clone()),
+            ),
+            (
+                alb.id.clone(),
+                UnresolvedResource::from_pre_resolve(alb.clone()),
+            ),
+            (
+                listener.id.clone(),
+                UnresolvedResource::from_pre_resolve(listener.clone()),
+            ),
+        ]);
+        let deps = build_dependency_analysis(plan.effects(), &unresolved, &[]).into_deps_of();
+        assert!(
+            deps.get(&3).is_some_and(|listener_deps| {
+                listener_deps.contains(&1) && listener_deps.contains(&2)
+            }),
+            "listener should depend on both alb and cert_issued; deps: {deps:?}"
+        );
+
+        let schemas = SchemaRegistry::new();
+        let mut input = ExecutionInput {
+            plan: &plan,
+            unresolved_resources: &unresolved,
+            compositions: &[],
+            bindings: Default::default(),
+            current_states: HashMap::new(),
+            normalizer: &NoopNormalizer,
+            provider_configs: &[],
+            factories: &[],
+            schemas: &schemas,
+            parallelism: std::num::NonZeroUsize::new(2).unwrap(),
+        };
+        let observer = RecordingSkipObserver::new();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            execute_effects_sequential(&provider, &mut input, &observer, &CancellationToken::new()),
+        )
+        .await
+        .expect("wait should be skipped as unsatisfiable instead of polling until timeout");
+        let (result, was_cancelled) = result;
+        assert!(!was_cancelled);
+
+        assert!(
+            result.failure_count >= 1,
+            "alb create should fail; failure_count: {}",
+            result.failure_count
+        );
+        assert!(
+            result.skip_count >= 1,
+            "listener and cert_issued should be skipped; skip_count: {}",
+            result.skip_count
         );
         assert!(
             observer.skipped().iter().any(|event| {

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -20,7 +20,7 @@ use super::basic::{
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::wait::{
     SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
-    unsatisfiable_reason_message, wait_failure_message,
+    count_effectively_undispatched, unsatisfiable_reason_message, wait_failure_message,
 };
 use super::{
     ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo,
@@ -582,14 +582,17 @@ pub(super) async fn execute_effects_phased(
                 });
             }
 
-            let undispatched_count = || {
-                phase1_indices
-                    .iter()
-                    .filter(|&&idx| !dispatched.contains(&idx))
-                    .count()
-            };
+            let count_undispatched =
+                |dispatched: &HashSet<usize>, failed_bindings: &HashSet<String>| {
+                    count_effectively_undispatched(
+                        &phase1_indices,
+                        dispatched,
+                        effects,
+                        failed_bindings,
+                    )
+                };
             in_flight
-                .check_terminal(undispatched_count())
+                .check_terminal(count_undispatched(&dispatched, &failed_bindings))
                 .cancel_if_terminal()
                 .drop_without_awaiting();
 
@@ -613,7 +616,7 @@ pub(super) async fn execute_effects_phased(
 
             let (finished_idx, result) = if cancelled {
                 let Some(finished) = in_flight
-                    .check_terminal(undispatched_count())
+                    .check_terminal(count_undispatched(&dispatched, &failed_bindings))
                     .cancel_if_terminal()
                     .next_completed()
                     .await
@@ -630,7 +633,7 @@ pub(super) async fn execute_effects_phased(
                         continue;
                     }
                     finished = in_flight
-                        .check_terminal(undispatched_count())
+                        .check_terminal(count_undispatched(&dispatched, &failed_bindings))
                         .cancel_if_terminal()
                         .next_completed() => {
                         let Some(finished) = finished else {
@@ -720,7 +723,7 @@ pub(super) async fn execute_effects_phased(
             }
 
             in_flight
-                .check_terminal(undispatched_count())
+                .check_terminal(count_undispatched(&dispatched, &failed_bindings))
                 .cancel_if_terminal()
                 .drop_without_awaiting();
         }
@@ -1972,6 +1975,113 @@ mod tests {
                 .any(|event| event.contains("alb")),
             "test setup should fail alb create; failures: {:?}",
             observer.failures()
+        );
+        assert!(
+            observer.skipped().iter().any(|event| {
+                event.contains("cert") && event.to_ascii_lowercase().contains("unsatisfiable")
+            }),
+            "wait skip reason should contain unsatisfiable, skipped: {:?}",
+            observer.skipped()
+        );
+    }
+
+    #[tokio::test]
+    async fn phased_wait_marked_unsatisfiable_when_failing_sibling_blocks_consumer_inside_wait_subtree()
+     {
+        let provider = TerminalWaitProvider::new();
+
+        let mut cert = Resource::new("test", "cert");
+        cert.binding = Some("cert".to_string());
+        let cert_id = cert.id.clone();
+
+        let mut alb = Resource::new("test", "alb");
+        alb.binding = Some("alb".to_string());
+
+        let mut listener = Resource::new("test", "listener");
+        listener.binding = Some("listener".to_string());
+        listener.set_attr(
+            "load_balancer_arn",
+            Value::resource_ref("alb", "load_balancer_arn", vec![]),
+        );
+        listener.set_attr(
+            "certificate_arn",
+            Value::resource_ref("cert_issued", "arn", vec![]),
+        );
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(cert.clone()));
+        plan.add(Effect::Wait {
+            binding: "cert_issued".to_string(),
+            target_id: cert_id.clone(),
+            target: WaitTarget::ResolvedAtApply,
+            until: WaitPredicate::Equals {
+                attr: AttrPath::single("status"),
+                value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+            },
+            until_surface: "cert.status == ISSUED".to_string(),
+            timeout: std::time::Duration::from_secs(60),
+            interval: std::time::Duration::from_millis(1),
+            explicit_dependencies: std::collections::HashSet::new(),
+        });
+        plan.add(Effect::Create(alb.clone()));
+        plan.add(Effect::Create(listener.clone()));
+
+        let unresolved = HashMap::from([
+            (
+                cert.id.clone(),
+                UnresolvedResource::from_pre_resolve(cert.clone()),
+            ),
+            (
+                alb.id.clone(),
+                UnresolvedResource::from_pre_resolve(alb.clone()),
+            ),
+            (
+                listener.id.clone(),
+                UnresolvedResource::from_pre_resolve(listener.clone()),
+            ),
+        ]);
+        let phase1_indices: Vec<usize> = (0..plan.effects().len()).collect();
+        let deps = build_phase_dependency_map(plan.effects(), &phase1_indices, &unresolved, &[]);
+        assert!(
+            deps.get(&3).is_some_and(|listener_deps| {
+                listener_deps.contains(&1) && listener_deps.contains(&2)
+            }),
+            "listener should depend on both alb and cert_issued; deps: {deps:?}"
+        );
+
+        let schemas = SchemaRegistry::new();
+        let mut input = ExecutionInput {
+            plan: &plan,
+            unresolved_resources: &unresolved,
+            compositions: &[],
+            bindings: Default::default(),
+            current_states: HashMap::new(),
+            normalizer: &NoopNormalizer,
+            provider_configs: &[],
+            factories: &[],
+            schemas: &schemas,
+            parallelism: std::num::NonZeroUsize::new(2).unwrap(),
+        };
+        let observer = RecordingSkipObserver::new();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            execute_effects_phased(&provider, &mut input, &observer, &CancellationToken::new()),
+        )
+        .await
+        .expect("wait should be skipped as unsatisfiable instead of polling until timeout");
+        let (result, was_cancelled) = result;
+        assert!(!was_cancelled);
+
+        assert!(
+            result.failure_count >= 1,
+            "alb create should fail; failure_count: {}",
+            result.failure_count
+        );
+        assert!(
+            result.skip_count >= 1,
+            "listener and cert_issued should be skipped; skip_count: {}",
+            result.skip_count
         );
         assert!(
             observer.skipped().iter().any(|event| {

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -7,13 +7,15 @@
 //!
 //! See `notes/specs/2026-05-09-wait-construct-design.md` §Executor logic.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 use futures::stream::{FuturesUnordered, StreamExt};
 
+use crate::deps::find_failed_dependency;
+use crate::effect::Effect;
 use crate::executor::{ExecutionEvent, ExecutionObserver};
 use crate::provider::{Provider, ProviderError, ReadRequest};
 use crate::resource::{ResourceId, State, Value};
@@ -152,6 +154,25 @@ pub(super) fn cancel_waits_if_terminal(
             let _ = cancel.send(WaitSignal::NoMutatorRemaining);
         }
     }
+}
+
+/// Count effects that are not yet dispatched and not effectively
+/// pre-skipped by a failed dependency. An effect whose direct dependency is
+/// already in `failed_bindings` will be skipped on its next dispatch attempt
+/// without producing work; treating it as still "undispatched" for the
+/// terminal-with-pending-waits check would keep waits polling forever when
+/// their consumer downstream is blocked on a failing sibling. (carina#3544)
+pub(super) fn count_effectively_undispatched(
+    actionable_indices: &[usize],
+    dispatched: &HashSet<usize>,
+    effects: &[Effect],
+    failed_bindings: &HashSet<String>,
+) -> usize {
+    actionable_indices
+        .iter()
+        .filter(|&&idx| !dispatched.contains(&idx))
+        .filter(|&&idx| find_failed_dependency(&effects[idx], failed_bindings).is_none())
+        .count()
 }
 
 /// Wait-aware in-flight future set with typestate-guarded terminal checks.


### PR DESCRIPTION
## Summary

#3544 の修正。`wait` ブロックの上流リソースが失敗したとき、その影響が wait の subtree 内の consumer 経由で伝わるケースで、依然として wait が fail-fast せず 75 分間 silent hang してしまう問題を直す。

#3497 のときは「terminal-with-pending-waits 検出」が「他に動ける effect がいない」を見て発火していたが、Issue #3544 のシナリオではその条件が「**dispatch されたら確実に skip されるが、まだ dispatch されていない effect**」を「未 dispatch」とカウントしてしまうために偽陽性で成立しなかった。

## 何が起きていたか

```
+ aws.acm.Certificate cert
    └─ > cert_issued  (wait until cert.status == issued)
          └─ + Listener (load_balancer_arn = alb..., certificate_arn = cert_issued.arn)
+ LoadBalancer alb   ← FAILS
```

1. `alb` が失敗 → `failed_bindings.insert("alb")`
2. Listener は deps `[alb, cert_issued]` のうち `cert_issued` が completed_indices に無いので `newly_ready` にならない
3. Listener は dispatch されないが `dispatched` にも入っていない → naive な undispatched_count に勘定される
4. terminal check は `undispatched_count > 0` を理由に cancel 信号を送らない
5. `cert_issued` は永遠に poll、75 分後に user-set timeout

## 根本原因

executor の terminal 判定で使う「undispatched effect 数」の計算が naive で、`dispatched.contains(&idx)` だけを基準にしていた。**「dispatch されたら絶対 skip される」 = `find_failed_dependency` がすでに hit する effect** を「未 dispatch」と区別なく扱ってしまうことが seam。

## 修正

`carina-core/src/executor/wait.rs` に新ヘルパー `count_effectively_undispatched` を追加し、両 executor (parallel + phased) の terminal-check 呼び出しすべてをそこ経由に変える。

```rust
pub(super) fn count_effectively_undispatched(
    actionable_indices: &[usize],
    dispatched: &HashSet<usize>,
    effects: &[Effect],
    failed_bindings: &HashSet<String>,
) -> usize {
    actionable_indices
        .iter()
        .filter(|&&idx| !dispatched.contains(&idx))
        .filter(|&&idx| find_failed_dependency(&effects[idx], failed_bindings).is_none())
        .count()
}
```

呼び出しサイトは parallel.rs に 4、phased.rs に 4、計 8 箇所。各 executor 内で 2 引数の closure を作って簡潔に。

## 動作

1. `alb` 失敗 → `failed_bindings += "alb"`
2. 次の loop で count を計算。Listener は `find_failed_dependency` ヒットなので **除外** → undispatched_count == 0
3. in-flight が wait のみ + count 0 → terminal 成立、cancel 信号送信
4. `cert_issued` は cancel を観測して `WaitOutcome::Cancelled` で抜ける
5. Listener が `newly_ready` になり pre-skip path で `unsatisfiable: dependency 'alb' failed`
6. apply が即終了

cascade-skip propagation はループの iterative な進行に任せていて、間接依存も次の loop で順次解消される。

## Test plan

- 新規 reproducing test を両 executor で追加: `wait_marked_unsatisfiable_when_failing_sibling_blocks_consumer_inside_wait_subtree` (parallel) と `phased_wait_marked_unsatisfiable_when_failing_sibling_blocks_consumer_inside_wait_subtree` (phased)
- いずれも `tokio::time::timeout(Duration::from_secs(2), execute_effects_*(...))` で wrap してあるので、修正前は 60 秒 wait timeout まで hang して必ず test も timeout 失敗する。修正後は 2 秒以内に cancel 経由で skip → test pass
- 既存の #3497 系テスト (`wait_marked_unsatisfiable_when_only_waits_in_flight`) は無修正で pass

検証:
- `cargo nextest run --workspace --all-features` — 4200 passed
- `cargo test --workspace --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bash scripts/check-*.sh`

5 round self-review 完了、real issue ゼロ。Round 1 で「`check_terminal` が `usize` を受けるので将来 caller が naive count を渡せる」と type-safety 上の弱さの指摘があったが、blast radius が小さく helper の doc で意図を明示しているため acceptable と判断(別途 typestate 化はもし第三の executor が現れた時の課題)。

Closes #3544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
