### PR TITLE
feat(wait): show predicate-referenced attribute in heartbeat output

### DIFF
--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 
 use carina_core::executor::{ExecutionEvent, ExecutionObserver};
 use carina_core::plan::Plan;
-use carina_core::resource::Value;
 use carina_core::value::format_value_user_facing;
+use carina_core::wait::WaitObservation;
 use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
@@ -164,19 +164,11 @@ fn handle_tty(
             }
         }
         ExecutionEvent::WaitPolling {
-            binding,
+            observation,
             elapsed,
-            last_attrs,
-            ..
         } => {
-            let observed = format_wait_observed_attr(last_attrs);
             multi
-                .println(format!(
-                    "  ~ {}: waited {}, {}",
-                    binding,
-                    format_duration(*elapsed),
-                    observed
-                ))
+                .println(format_wait_polling_line(observation, *elapsed))
                 .ok();
         }
         ExecutionEvent::CascadeUpdateSucceeded { id } => {
@@ -287,19 +279,9 @@ fn format_plain(event: &ExecutionEvent) -> Vec<String> {
             )]
         }
         ExecutionEvent::WaitPolling {
-            binding,
+            observation,
             elapsed,
-            last_attrs,
-            ..
-        } => {
-            let observed = format_wait_observed_attr(last_attrs);
-            vec![format!(
-                "  ~ {}: waited {}, {}",
-                binding,
-                format_duration(*elapsed),
-                observed
-            )]
-        }
+        } => vec![format_wait_polling_line(observation, *elapsed)],
         ExecutionEvent::CascadeUpdateSucceeded { id } => {
             vec![format!("  ✓ Update {} (cascade)", id)]
         }
@@ -324,8 +306,23 @@ fn format_plain(event: &ExecutionEvent) -> Vec<String> {
     }
 }
 
-fn format_wait_observed_attr(last_attrs: &HashMap<String, Value>) -> String {
-    let mut observed: Vec<_> = last_attrs.iter().collect();
+fn format_wait_polling_line(observation: &WaitObservation, elapsed: Duration) -> String {
+    let observed = format_wait_observed_attr(observation);
+    format!(
+        "  ~ {}: waited {}, {}",
+        observation.binding(),
+        format_duration(elapsed),
+        observed
+    )
+}
+
+fn format_wait_observed_attr(observation: &WaitObservation) -> String {
+    if let Some((attr, value)) = observation.primary() {
+        let key = attr.segments.join(".");
+        return format!("{key}={}", format_value_user_facing(value));
+    }
+
+    let mut observed: Vec<_> = observation.last_attrs().iter().collect();
     observed.sort_by_key(|(key, _)| *key);
     let Some((key, value)) = observed.first() else {
         return "no observed attributes".to_string();
@@ -338,14 +335,34 @@ mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::executor::ProgressInfo;
-    use carina_core::resource::{ConcreteValue, DeferredValue, Resource, UnknownReason};
+    use carina_core::resource::{
+        ConcreteValue, DeferredValue, Resource, ResourceId, UnknownReason, Value,
+    };
+    use carina_core::wait::predicate::{AttrPath, WaitPredicate};
+    use indexmap::IndexMap;
 
     fn dummy_create_effect() -> Effect {
         Effect::Create(Resource::new("aws.s3.Bucket", "demo"))
     }
 
+    fn wait_observation<'a>(
+        target_id: &'a ResourceId,
+        predicate: &'a WaitPredicate,
+        last_attrs: &'a HashMap<String, Value>,
+    ) -> WaitObservation<'a> {
+        WaitObservation::new("demo_ready", target_id, predicate, last_attrs)
+    }
+
+    fn equals_predicate(attr: AttrPath, value: &str) -> WaitPredicate {
+        WaitPredicate::Equals {
+            attr,
+            value: Value::Concrete(ConcreteValue::String(value.to_string())),
+        }
+    }
+
     #[test]
     fn wait_observed_attr_is_deterministic() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
         let attrs = HashMap::from([
             (
                 "status".to_string(),
@@ -356,34 +373,104 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("arn:demo".to_string())),
             ),
         ]);
+        let predicate = equals_predicate(AttrPath::single("missing"), "present");
+        let observation = wait_observation(&target_id, &predicate, &attrs);
 
-        assert_eq!(format_wait_observed_attr(&attrs), "arn=arn:demo");
+        assert_eq!(format_wait_observed_attr(&observation), "arn=arn:demo");
+    }
+
+    #[test]
+    fn wait_observed_attr_uses_predicate_attr_when_present() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let status = AttrPath::single("status");
+        let predicate = equals_predicate(status, "pending");
+        let attrs = HashMap::from([
+            (
+                "arn".to_string(),
+                Value::Concrete(ConcreteValue::String("arn:demo".to_string())),
+            ),
+            (
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("pending".to_string())),
+            ),
+        ]);
+        let observation = wait_observation(&target_id, &predicate, &attrs);
+
+        assert_eq!(format_wait_observed_attr(&observation), "status=pending");
+    }
+
+    #[test]
+    fn wait_observed_attr_formats_multi_segment_predicate_attr() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let renewal_status = AttrPath {
+            segments: vec!["renewal_summary".to_string(), "renewal_status".to_string()],
+        };
+        let predicate = equals_predicate(renewal_status, "PENDING");
+        let attrs = HashMap::from([(
+            "renewal_summary".to_string(),
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+                "renewal_status".to_string(),
+                Value::Concrete(ConcreteValue::String("PENDING".to_string())),
+            )]))),
+        )]);
+        let observation = wait_observation(&target_id, &predicate, &attrs);
+
+        assert_eq!(
+            format_wait_observed_attr(&observation),
+            "renewal_summary.renewal_status=PENDING"
+        );
+    }
+
+    #[test]
+    fn wait_observed_attr_falls_back_to_sort_first_when_predicate_attr_missing() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let xyz = AttrPath::single("xyz");
+        let predicate = equals_predicate(xyz, "present");
+        let attrs = HashMap::from([
+            (
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("pending".to_string())),
+            ),
+            (
+                "arn".to_string(),
+                Value::Concrete(ConcreteValue::String("arn:demo".to_string())),
+            ),
+        ]);
+        let observation = wait_observation(&target_id, &predicate, &attrs);
+
+        assert_eq!(format_wait_observed_attr(&observation), "arn=arn:demo");
     }
 
     #[test]
     fn wait_observed_attr_uses_display_formatting() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
         let attrs = HashMap::from([(
             "arn".to_string(),
             Value::Concrete(ConcreteValue::String(
                 "arn:aws:acm:1:certificate/abc".to_string(),
             )),
         )]);
+        let predicate = equals_predicate(AttrPath::single("missing"), "present");
+        let observation = wait_observation(&target_id, &predicate, &attrs);
 
         assert_eq!(
-            format_wait_observed_attr(&attrs),
+            format_wait_observed_attr(&observation),
             "arn=arn:aws:acm:1:certificate/abc"
         );
     }
 
     #[test]
     fn wait_observed_attr_handles_unknown_value() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
         let attrs = HashMap::from([(
             "status".to_string(),
             Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
         )]);
+        let predicate = equals_predicate(AttrPath::single("missing"), "present");
+        let observation = wait_observation(&target_id, &predicate, &attrs);
 
         assert_eq!(
-            format_wait_observed_attr(&attrs),
+            format_wait_observed_attr(&observation),
             "status=(known after upstream apply)"
         );
     }

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -31,7 +31,8 @@ use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
 use crate::parser::ProviderConfig;
 use crate::provider::{Provider, ProviderNormalizer};
-use crate::resource::{ResourceId, State, Value};
+use crate::resource::{ResourceId, State};
+use crate::wait::WaitObservation;
 
 use parallel::execute_effects_sequential;
 use phased::{execute_effects_phased, has_interdependent_replaces};
@@ -166,10 +167,8 @@ pub enum ExecutionEvent<'a> {
     /// Emitted at `max(30s, interval * 5)` cadence with the elapsed time and
     /// last observed attributes so operators can see what the wait is reading.
     WaitPolling {
-        binding: &'a str,
-        target_id: &'a ResourceId,
+        observation: WaitObservation<'a>,
         elapsed: Duration,
-        last_attrs: &'a HashMap<String, Value>,
     },
     CascadeUpdateSucceeded {
         id: &'a ResourceId,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -184,10 +184,12 @@ fn format_execution_event(event: &ExecutionEvent<'_>) -> String {
         ExecutionEvent::EffectSkipped { effect, reason, .. } => {
             format!("skipped:{}:{}", effect.resource_id(), reason)
         }
-        ExecutionEvent::WaitPolling {
-            binding, target_id, ..
-        } => {
-            format!("wait_polling:{}:{}", binding, target_id)
+        ExecutionEvent::WaitPolling { observation, .. } => {
+            format!(
+                "wait_polling:{}:{}",
+                observation.binding(),
+                observation.target_id()
+            )
         }
         ExecutionEvent::CascadeUpdateSucceeded { id } => {
             format!("cascade_ok:{}", id)

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -20,6 +20,7 @@ use crate::executor::{ExecutionEvent, ExecutionObserver};
 use crate::provider::{Provider, ProviderError, ReadRequest};
 use crate::resource::{ResourceId, State, Value};
 use crate::value::format_value_user_facing;
+use crate::wait::WaitObservation;
 use crate::wait::predicate::WaitPredicate;
 
 /// Outcome of polling a Wait effect. The variants distinguish:
@@ -366,11 +367,10 @@ pub(crate) async fn execute_wait_effect_with_heartbeat_gap(
             .map(|last| now.duration_since(last) >= heartbeat_gap)
             .unwrap_or(true);
         if should_emit_heartbeat {
+            let observation = WaitObservation::new(binding, target_id, until, &state.attributes);
             observer.on_event(&ExecutionEvent::WaitPolling {
-                binding,
-                target_id,
+                observation,
                 elapsed: start.elapsed(),
-                last_attrs: &state.attributes,
             });
             last_heartbeat_at = Some(now);
         }
@@ -530,7 +530,7 @@ mod tests {
     }
 
     struct HeartbeatObserver {
-        heartbeats: Mutex<Vec<Instant>>,
+        heartbeats: Mutex<Vec<(Instant, Vec<AttrPath>)>>,
     }
 
     impl HeartbeatObserver {
@@ -540,15 +540,23 @@ mod tests {
             }
         }
 
-        fn heartbeats(&self) -> Vec<Instant> {
+        fn heartbeats(&self) -> Vec<(Instant, Vec<AttrPath>)> {
             self.heartbeats.lock().unwrap().clone()
         }
     }
 
     impl ExecutionObserver for HeartbeatObserver {
         fn on_event(&self, event: &ExecutionEvent) {
-            if let ExecutionEvent::WaitPolling { .. } = event {
-                self.heartbeats.lock().unwrap().push(Instant::now());
+            if let ExecutionEvent::WaitPolling { observation, .. } = event {
+                let watched_attrs = observation
+                    .watched_attrs()
+                    .iter()
+                    .map(|attr| (*attr).clone())
+                    .collect();
+                self.heartbeats
+                    .lock()
+                    .unwrap()
+                    .push((Instant::now(), watched_attrs));
             }
         }
     }
@@ -836,8 +844,9 @@ mod tests {
             !heartbeats.is_empty(),
             "wait should emit at least one WaitPolling heartbeat"
         );
+        assert_eq!(heartbeats[0].1, vec![AttrPath::single("status")]);
         for pair in heartbeats.windows(2) {
-            let gap = pair[1].duration_since(pair[0]);
+            let gap = pair[1].0.duration_since(pair[0].0);
             assert!(
                 gap >= Duration::from_millis(5),
                 "heartbeat gap should respect max(30s, interval * 5) with test seam, got {gap:?}"

--- a/carina-core/src/wait/mod.rs
+++ b/carina-core/src/wait/mod.rs
@@ -3,7 +3,9 @@
 //! See `notes/specs/2026-05-09-wait-construct-design.md`.
 
 pub mod augment;
+mod observation;
 pub mod predicate;
+pub use observation::WaitObservation;
 
 use predicate::AttrPath;
 

--- a/carina-core/src/wait/observation.rs
+++ b/carina-core/src/wait/observation.rs
@@ -1,0 +1,159 @@
+use std::collections::HashMap;
+
+use crate::resource::{ResourceId, Value};
+use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+/// Snapshot of what a Wait effect is observing during a single poll
+/// iteration. The CLI heartbeat formatter consumes this to render the
+/// attribute the wait is actually polling (instead of an arbitrary
+/// HashMap entry).
+///
+/// `watched_attrs` is the set of attributes referenced by the wait's
+/// predicate, in evaluation order. Today's predicate AST only contains
+/// `Equals { attr, value }` so this is always a single-element list,
+/// but the field exists so future predicate variants (`And`, `Or`,
+/// `NotEquals`, ...) can grow without breaking consumers.
+///
+/// `last_attrs` is the raw provider read result; `primary()` projects
+/// it through `watched_attrs` for the common heartbeat case.
+///
+/// Construct via [`WaitObservation::new`] so `watched_attrs` is
+/// derived from the predicate. The fields are private to make
+/// "watched_attrs that doesn't match any predicate" unrepresentable -
+/// see [`WaitObservation::new`].
+#[derive(Debug)]
+pub struct WaitObservation<'a> {
+    binding: &'a str,
+    target_id: &'a ResourceId,
+    watched_attrs: Vec<&'a AttrPath>,
+    last_attrs: &'a HashMap<String, Value>,
+}
+
+impl<'a> WaitObservation<'a> {
+    /// Build an observation snapshot. `watched_attrs` is derived from
+    /// `predicate.watched_attrs()` so consumers cannot pass a set that
+    /// disagrees with the predicate. This is the only way to construct
+    /// a `WaitObservation` outside the wait module's own tests.
+    pub fn new(
+        binding: &'a str,
+        target_id: &'a ResourceId,
+        predicate: &'a WaitPredicate,
+        last_attrs: &'a HashMap<String, Value>,
+    ) -> Self {
+        Self {
+            binding,
+            target_id,
+            watched_attrs: predicate.watched_attrs(),
+            last_attrs,
+        }
+    }
+
+    // Follow-up: fully closing this typestate would also make
+    // `AttrPath::segments` private and add a fallible constructor that
+    // rejects empty paths. That is wider because AttrPath is serialized.
+
+    pub fn binding(&self) -> &str {
+        self.binding
+    }
+
+    pub fn target_id(&self) -> &ResourceId {
+        self.target_id
+    }
+
+    pub fn watched_attrs(&self) -> &[&AttrPath] {
+        &self.watched_attrs
+    }
+
+    pub fn last_attrs(&self) -> &HashMap<String, Value> {
+        self.last_attrs
+    }
+
+    /// First (path, value) pair where `path` is a watched attribute that
+    /// actually appears in the provider's last read result. Returns
+    /// `None` when the watched set is empty or none of its keys are
+    /// present in `last_attrs` - heartbeat consumers should fall back
+    /// to a deterministic display in that case.
+    pub fn primary(&self) -> Option<(&AttrPath, &Value)> {
+        self.watched_attrs
+            .iter()
+            .find_map(|&attr| attr.resolve(self.last_attrs).map(|value| (attr, value)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use indexmap::IndexMap;
+
+    use super::WaitObservation;
+    use crate::resource::{ConcreteValue, ResourceId, Value};
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    fn string_value(value: &str) -> Value {
+        Value::Concrete(ConcreteValue::String(value.to_string()))
+    }
+
+    fn equals_predicate(attr: AttrPath, value: &str) -> WaitPredicate {
+        WaitPredicate::Equals {
+            attr,
+            value: string_value(value),
+        }
+    }
+
+    #[test]
+    fn primary_returns_first_watched_attr_present_in_last_attrs() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let status = AttrPath::single("status");
+        let predicate = equals_predicate(status.clone(), "pending");
+        let last_attrs = HashMap::from([
+            ("arn".to_string(), string_value("arn:demo")),
+            ("status".to_string(), string_value("pending")),
+        ]);
+
+        let observation = WaitObservation::new("demo_ready", &target_id, &predicate, &last_attrs);
+
+        let Some((attr, value)) = observation.primary() else {
+            panic!("expected primary watched attr");
+        };
+        assert_eq!(attr, &status);
+        assert_eq!(value, last_attrs.get("status").unwrap());
+    }
+
+    #[test]
+    fn primary_walks_multi_segment_path() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let renewal_status = AttrPath {
+            segments: vec!["renewal_summary".to_string(), "renewal_status".to_string()],
+        };
+        let predicate = equals_predicate(renewal_status.clone(), "PENDING");
+        let leaf = string_value("PENDING");
+        let last_attrs = HashMap::from([(
+            "renewal_summary".to_string(),
+            Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+                "renewal_status".to_string(),
+                leaf.clone(),
+            )]))),
+        )]);
+
+        let observation = WaitObservation::new("demo_ready", &target_id, &predicate, &last_attrs);
+
+        let Some((attr, value)) = observation.primary() else {
+            panic!("expected nested watched attr");
+        };
+        assert_eq!(attr, &renewal_status);
+        assert_eq!(value, &leaf);
+    }
+
+    #[test]
+    fn primary_returns_none_when_no_watched_attr_present() {
+        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let xyz = AttrPath::single("xyz");
+        let predicate = equals_predicate(xyz, "present");
+        let last_attrs = HashMap::from([("arn".to_string(), string_value("arn:demo"))]);
+
+        let observation = WaitObservation::new("demo_ready", &target_id, &predicate, &last_attrs);
+
+        assert!(observation.primary().is_none());
+    }
+}

--- a/carina-core/src/wait/predicate.rs
+++ b/carina-core/src/wait/predicate.rs
@@ -9,13 +9,14 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::resource::Value;
+use crate::resource::{ConcreteValue, Value};
 
 /// Dotted path into a target's attribute tree.
 ///
-/// MVP only resolves a single top-level segment; nested-field traversal
-/// (`renewal_summary.renewal_status`) is reserved for a follow-up that
-/// teaches the evaluator to descend into `Value::Concrete(ConcreteValue::Map)`.
+/// Resolution walks the path one segment at a time, descending into
+/// nested `ConcreteValue::Map` values. For example, an `AttrPath`
+/// with `segments = ["renewal_summary", "renewal_status"]` resolves
+/// to `attrs["renewal_summary"]["renewal_status"]`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AttrPath {
     pub segments: Vec<String>,
@@ -27,6 +28,23 @@ impl AttrPath {
             segments: vec![name.into()],
         }
     }
+
+    /// Walk this path into `attrs`, descending through nested
+    /// `ConcreteValue::Map` values as needed. Returns the leaf `Value`
+    /// or `None` if any segment is missing or not a map at a non-leaf.
+    pub(crate) fn resolve<'a>(&self, attrs: &'a HashMap<String, Value>) -> Option<&'a Value> {
+        let (first, rest) = self.segments.split_first()?;
+        let mut current = attrs.get(first)?;
+        for segment in rest {
+            match current {
+                Value::Concrete(ConcreteValue::Map(map)) => {
+                    current = map.get(segment)?;
+                }
+                _ => return None,
+            }
+        }
+        Some(current)
+    }
 }
 
 /// Typed predicate AST evaluated against a target's attribute snapshot.
@@ -37,22 +55,55 @@ pub enum WaitPredicate {
 }
 
 impl WaitPredicate {
+    /// Attribute paths referenced by this predicate, in evaluation
+    /// order. Heartbeat consumers use this to show the operator the
+    /// value the wait is actually polling. Future predicate variants
+    /// (And, Or, NotEquals, comparisons) extend this list.
+    pub fn watched_attrs(&self) -> Vec<&AttrPath> {
+        match self {
+            WaitPredicate::Equals { attr, .. } => vec![attr],
+        }
+    }
+
     /// Evaluate against the target's `read()` attribute map. Returns
     /// `true` when the predicate is satisfied; missing attributes and
     /// type mismatches both yield `false` (the wait keeps polling).
     pub fn evaluate(&self, attrs: &HashMap<String, Value>) -> bool {
         match self {
             WaitPredicate::Equals { attr, value } => {
-                resolve(attrs, &attr.segments).is_some_and(|v| v == value)
+                attr.resolve(attrs).is_some_and(|v| v == value)
             }
         }
     }
 }
 
-fn resolve<'a>(attrs: &'a HashMap<String, Value>, path: &[String]) -> Option<&'a Value> {
-    let first = attrs.get(path.first()?)?;
-    if path.len() == 1 {
-        return Some(first);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::ConcreteValue;
+    use std::collections::HashMap;
+
+    #[test]
+    fn equals_watched_attrs_returns_the_predicate_attr() {
+        let attr = AttrPath::single("status");
+        let predicate = WaitPredicate::Equals {
+            attr: attr.clone(),
+            value: Value::Concrete(ConcreteValue::String("ready".to_string())),
+        };
+
+        assert_eq!(predicate.watched_attrs(), vec![&attr]);
     }
-    None
+
+    #[test]
+    fn resolve_returns_none_for_empty_path() {
+        let attrs = HashMap::from([(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        )]);
+        let path = AttrPath {
+            segments: Vec::new(),
+        };
+
+        assert!(path.resolve(&attrs).is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Issue #3545 の修正。wait の heartbeat が「HashMap の alphabetically-first attribute」を毎回出していて、operator が見たい predicate の attribute (例: ACM Certificate の `status`) が見えなかった問題を、`WaitObservation` という型を導入して根本対応する。

複数の選択肢があった中で、**Option 6 (`WaitObservation` 中間型で predicate 拡張を吸収)** を採用しました。Issue 本文の Option 1/2 に加えて 5 つの候補を出して 3 lens で評価した結果、Option 6 が長期/型安全/根本の 3 つ全部で最も整合します。

## 何が変わるか

- 新型 `WaitObservation<'a>` を `carina-core/src/wait/observation.rs` に追加
- `WaitPredicate::watched_attrs(&self) -> Vec<&AttrPath>` メソッドを追加(今は `Equals { attr, .. }` だけなので 1 要素返却)
- `ExecutionEvent::WaitPolling` の payload を `{ observation: WaitObservation<'a>, elapsed: Duration }` に変える
- heartbeat formatter (`observer.rs::format_wait_observed_attr`) が `observation.primary()` を呼んで `status=pending` のように predicate-referenced attribute を表示

## Typestate hardening

`WaitObservation` のフィールドはすべて private。唯一の public constructor `WaitObservation::new(binding, target_id, predicate, last_attrs)` が `watched_attrs` を `predicate.watched_attrs()` から導出するので、「watched_attrs が predicate と食い違う」状態は型レベルで unrepresentable。

`WaitPredicate::watched_attrs()` は `_ =>` 無しの exhaustive match なので、将来 `And` / `Or` / `NotEquals` 等の variant を足したら compile error で気付ける。

## 副次的改善

`AttrPath::resolve` が full-path walker(`ConcreteValue::Map` を辿る)に拡張された結果、`WaitPredicate::evaluate` も nested predicate を扱えるようになる。これまで `wait cert { until = cert.renewal_summary.renewal_status == SUCCESS }` のような nested 表現は **常に false** で wait が永遠に成立しない silent bug があったが、本 PR で動くようになる。

## 出力例

修正前:
```
~ registry_publish.cert: waited 33.0s, certificate_arn=arn:aws:acm:...
```

修正後:
```
~ registry_publish.cert: waited 33.0s, status=PENDING_VALIDATION
```

## 設計の経緯

Issue 本文は Option 1 (`predicate_attr: &AttrPath` を直接 payload に追加) と Option 2 (executor 側で `observed: (String, Value)` を確定) の 2 案を提示していました。これに加えて 5 つの候補を 3 lens で評価:

- Option 1 は predicate が `And`/`Or` に拡張されたとき「単一 attr」前提が崩れる
- Option 2 は表示判断が executor に固定され、consumer が柔軟性ゼロ
- Option 3 (`predicate: &WaitPredicate` 全体を渡す) は consumer が predicate の variant に追従する負担
- Option 6 (`WaitObservation` 中間型) は predicate 拡張を中間型で吸収するので consumer 側コードは不変

3 lens (長期 / 型安全 / 根本) すべてで Option 6 が優位だったため、user 同意を得て採用しました。

## Out of scope (別 issue)

- **#3548**: `AttrPath::segments` が public `Vec<String>` のまま、empty を構築可能。本 PR の typestate hardening は WaitObservation 止まりで、AttrPath まで広げると serde 影響など別射程
- **`wait_failure_message` (Timeout arm) も watched_attrs 優先表示すべき**: heartbeat と同じ問題が timeout error message でも起きる。本 PR の射程外、別途 issue を立てる

## 5 round self-review 結果

| Round | Findings | 状態 |
|---|---|---|
| 1 | follow-up: wait_failure_message も対応すべき / 副次的改善あり | 別 issue + PR body 記載 |
| 2 | HIGH: WaitObservation の pub fields が typestate を漏らす | in-PR fix(private + constructor) |
| 3 | from_parts test escape hatch が seam を漏らす + AttrPath segments が public | in-PR fix(escape hatch 削除) + #3548 起票 |
| 4 | clean | - |
| 5 | clean, ship | - |

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 4208 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] 新規 test:
  - `WaitObservation::primary` の single-segment / multi-segment / missing-attr ケース
  - `AttrPath::resolve` の empty path / nested map traversal
  - `format_wait_observed_attr` の predicate-attr 優先表示 + fallback
  - `WaitPredicate::evaluate` の nested path 評価(副次的に追加可能)

Closes #3545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
