### PR TITLE
feat(wait): make AttrPath empty-segments state unrepresentable

### DIFF
--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -318,7 +318,7 @@ fn format_wait_polling_line(observation: &WaitObservation, elapsed: Duration) ->
 
 fn format_wait_observed_attr(observation: &WaitObservation) -> String {
     if let Some((attr, value)) = observation.primary() {
-        let key = attr.segments.join(".");
+        let key = attr.segments().join(".");
         return format!("{key}={}", format_value_user_facing(value));
     }
 
@@ -402,9 +402,8 @@ mod tests {
     #[test]
     fn wait_observed_attr_formats_multi_segment_predicate_attr() {
         let target_id = ResourceId::new("aws.test.Resource", "demo");
-        let renewal_status = AttrPath {
-            segments: vec!["renewal_summary".to_string(), "renewal_status".to_string()],
-        };
+        let renewal_status =
+            AttrPath::try_new(vec!["renewal_summary".into(), "renewal_status".into()]).unwrap();
         let predicate = equals_predicate(renewal_status, "PENDING");
         let attrs = HashMap::from([(
             "renewal_summary".to_string(),

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -516,8 +516,22 @@ pub fn create_plan(
         // `lhs_segments` is guaranteed non-empty and the first segment
         // equals `wb.target` (enforced by `parse_wait_expr`). The
         // predicate attribute path is therefore `lhs_segments[1..]`.
-        let attr = AttrPath {
-            segments: wb.until_predicate.lhs_segments[1..].to_vec(),
+        // This `try_new` branch is defense in depth: the parser rejects
+        // bare-target LHS values like `until = cert == ...`, but keep a
+        // plan-level error here in case a future parser path relaxes
+        // that rule or constructs `WaitBinding` directly.
+        let attr = match AttrPath::try_new(wb.until_predicate.lhs_segments[1..].to_vec()) {
+            Ok(attr) => attr,
+            Err(err) => {
+                plan.add_error(PlanError {
+                    resource_id: target_id_resolved.clone(),
+                    message: format!(
+                        "wait `{}`: invalid predicate attribute path: {err}",
+                        wb.binding
+                    ),
+                });
+                continue;
+            }
         };
         let until = WaitPredicate::Equals {
             attr: attr.clone(),

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1324,9 +1324,7 @@ fn wait_binding_lowers_to_wait_effect() {
     assert_eq!(
         until,
         &WaitPredicate::Equals {
-            attr: AttrPath {
-                segments: vec!["status".to_string()],
-            },
+            attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String(
                 "aws.acm.Certificate.Status.Issued".to_string()
             )),
@@ -1336,6 +1334,56 @@ fn wait_binding_lowers_to_wait_effect() {
     assert_eq!(
         until_surface,
         "cert.status == aws.acm.Certificate.Status.Issued"
+    );
+}
+
+#[test]
+fn create_plan_records_error_for_empty_predicate_attr_path() {
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
+    // The wait must gate a pending downstream change, otherwise
+    // create_plan legitimately skips emitting or lowering the wait.
+    let mut consumer = Resource::new("cloudfront.Distribution", "dist").with_binding("dist");
+    consumer
+        .dependency_bindings
+        .insert("cert_issued".to_string());
+    let resources = vec![cert, consumer];
+
+    let wait = WaitBinding {
+        binding: "cert_issued".into(),
+        target: "cert".into(),
+        until_raw: "cert == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
+        },
+        timeout_secs: None,
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &[],
+        &crate::provider::ProviderRouter::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+
+    assert!(
+        plan.errors().iter().any(|err| {
+            err.message.contains("cert_issued")
+                && err.message.contains("invalid predicate attribute path")
+                && err.message.contains("empty")
+        }),
+        "expected invalid empty predicate attr path error, got {:?}",
+        plan.errors()
     );
 }
 

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -1164,9 +1164,7 @@ mod tests {
             target_id: rid.clone(),
             target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
-                attr: crate::wait::predicate::AttrPath {
-                    segments: vec!["status".to_string()],
-                },
+                attr: crate::wait::predicate::AttrPath::single("status"),
                 value: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(
                     "ready".to_string(),
                 )),

--- a/carina-core/src/wait/mod.rs
+++ b/carina-core/src/wait/mod.rs
@@ -6,8 +6,7 @@ pub mod augment;
 mod observation;
 pub mod predicate;
 pub use observation::WaitObservation;
-
-use predicate::AttrPath;
+pub use predicate::{AttrPath, AttrPathError, WaitPredicate};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BindingPattern {

--- a/carina-core/src/wait/observation.rs
+++ b/carina-core/src/wait/observation.rs
@@ -48,10 +48,6 @@ impl<'a> WaitObservation<'a> {
         }
     }
 
-    // Follow-up: fully closing this typestate would also make
-    // `AttrPath::segments` private and add a fallible constructor that
-    // rejects empty paths. That is wider because AttrPath is serialized.
-
     pub fn binding(&self) -> &str {
         self.binding
     }
@@ -123,9 +119,8 @@ mod tests {
     #[test]
     fn primary_walks_multi_segment_path() {
         let target_id = ResourceId::new("aws.test.Resource", "demo");
-        let renewal_status = AttrPath {
-            segments: vec!["renewal_summary".to_string(), "renewal_status".to_string()],
-        };
+        let renewal_status =
+            AttrPath::try_new(vec!["renewal_summary".into(), "renewal_status".into()]).unwrap();
         let predicate = equals_predicate(renewal_status.clone(), "PENDING");
         let leaf = string_value("PENDING");
         let last_attrs = HashMap::from([(

--- a/carina-core/src/wait/predicate.rs
+++ b/carina-core/src/wait/predicate.rs
@@ -8,8 +8,15 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::resource::{ConcreteValue, Value};
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AttrPathError {
+    #[error("AttrPath segments cannot be empty")]
+    Empty,
+}
 
 /// Dotted path into a target's attribute tree.
 ///
@@ -17,9 +24,15 @@ use crate::resource::{ConcreteValue, Value};
 /// nested `ConcreteValue::Map` values. For example, an `AttrPath`
 /// with `segments = ["renewal_summary", "renewal_status"]` resolves
 /// to `attrs["renewal_summary"]["renewal_status"]`.
+///
+/// The `segments` field is private to make the empty-path state
+/// unrepresentable: construct via `AttrPath::single` for a single
+/// top-level attribute or `AttrPath::try_new` for a multi-segment
+/// path. Serde deserialization also rejects empty segments.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(into = "AttrPathSerde", try_from = "AttrPathSerde")]
 pub struct AttrPath {
-    pub segments: Vec<String>,
+    segments: Vec<String>,
 }
 
 impl AttrPath {
@@ -29,11 +42,22 @@ impl AttrPath {
         }
     }
 
+    pub fn try_new(segments: Vec<String>) -> Result<Self, AttrPathError> {
+        if segments.is_empty() {
+            return Err(AttrPathError::Empty);
+        }
+        Ok(Self { segments })
+    }
+
+    pub fn segments(&self) -> &[String] {
+        &self.segments
+    }
+
     /// Walk this path into `attrs`, descending through nested
     /// `ConcreteValue::Map` values as needed. Returns the leaf `Value`
     /// or `None` if any segment is missing or not a map at a non-leaf.
     pub(crate) fn resolve<'a>(&self, attrs: &'a HashMap<String, Value>) -> Option<&'a Value> {
-        let (first, rest) = self.segments.split_first()?;
+        let (first, rest) = self.segments().split_first()?;
         let mut current = attrs.get(first)?;
         for segment in rest {
             match current {
@@ -44,6 +68,27 @@ impl AttrPath {
             }
         }
         Some(current)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AttrPathSerde {
+    segments: Vec<String>,
+}
+
+impl From<AttrPath> for AttrPathSerde {
+    fn from(p: AttrPath) -> Self {
+        Self {
+            segments: p.segments,
+        }
+    }
+}
+
+impl TryFrom<AttrPathSerde> for AttrPath {
+    type Error = AttrPathError;
+
+    fn try_from(p: AttrPathSerde) -> Result<Self, Self::Error> {
+        AttrPath::try_new(p.segments)
     }
 }
 
@@ -95,14 +140,55 @@ mod tests {
     }
 
     #[test]
-    fn resolve_returns_none_for_empty_path() {
+    fn attr_path_try_new_rejects_empty_segments() {
+        assert!(matches!(
+            AttrPath::try_new(vec![]),
+            Err(AttrPathError::Empty)
+        ));
+    }
+
+    #[test]
+    fn attr_path_try_new_accepts_non_empty_segments() {
+        let path =
+            AttrPath::try_new(vec!["renewal_summary".into(), "renewal_status".into()]).unwrap();
+
+        assert_eq!(path.segments(), &["renewal_summary", "renewal_status"]);
+    }
+
+    #[test]
+    fn attr_path_segments_field_is_not_publicly_accessible() {
+        let path = AttrPath::single("status");
+        let segments: &[String] = path.segments();
+
+        assert_eq!(segments, &["status"]);
+    }
+
+    #[test]
+    fn attr_path_serde_roundtrip_preserves_wire_format() {
+        let path =
+            AttrPath::try_new(vec!["renewal_summary".into(), "renewal_status".into()]).unwrap();
+
+        let json = serde_json::to_string(&path).unwrap();
+        assert_eq!(json, r#"{"segments":["renewal_summary","renewal_status"]}"#);
+        let parsed: AttrPath = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.segments(), &["renewal_summary", "renewal_status"]);
+    }
+
+    #[test]
+    fn attr_path_serde_rejects_empty_segments() {
+        let json = r#"{"segments":[]}"#;
+        let result: Result<AttrPath, _> = serde_json::from_str(json);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_returns_none_for_missing_attr() {
         let attrs = HashMap::from([(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String("pending".to_string())),
         )]);
-        let path = AttrPath {
-            segments: Vec::new(),
-        };
+        let path = AttrPath::single("missing");
 
         assert!(path.resolve(&attrs).is_none());
     }

--- a/carina-core/src/wait/tests.rs
+++ b/carina-core/src/wait/tests.rs
@@ -58,16 +58,13 @@ fn binding_pattern_variants_construct_and_debug_print() {
 
     let attribute_match = BindingPattern::AttributeMatch {
         resource_type: "route53.RecordSet".to_string(),
-        attr: AttrPath {
-            segments: vec!["name".to_string()],
-        },
-        from: AttrPath {
-            segments: vec![
-                "domain_validation_options".to_string(),
-                "resource_record".to_string(),
-                "name".to_string(),
-            ],
-        },
+        attr: AttrPath::single("name"),
+        from: AttrPath::try_new(vec![
+            "domain_validation_options".to_string(),
+            "resource_record".to_string(),
+            "name".to_string(),
+        ])
+        .unwrap(),
     };
     assert!(format!("{attribute_match:?}").contains("AttributeMatch"));
 }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -20,7 +20,7 @@ use carina_core::schema::{
 };
 use carina_core::value::{SerializationContext, SerializationError};
 use carina_core::wait::BindingPattern as CoreBindingPattern;
-use carina_core::wait::predicate::AttrPath as CoreAttrPath;
+use carina_core::wait::predicate::{AttrPath as CoreAttrPath, AttrPathError};
 
 use carina_provider_protocol::types as proto;
 
@@ -237,26 +237,25 @@ pub fn core_to_wit_binding_pattern(p: &CoreBindingPattern) -> wit::BindingPatter
             from,
         } => wit::BindingPattern::AttributeMatch(wit::AttributeMatchPattern {
             resource_type: resource_type.clone(),
-            attr: attr.segments.clone(),
-            from: from.segments.clone(),
+            attr: attr.segments().to_vec(),
+            from: from.segments().to_vec(),
         }),
     }
 }
 
-pub fn wit_to_core_binding_pattern(p: wit::BindingPattern) -> CoreBindingPattern {
-    match p {
+pub fn wit_to_core_binding_pattern(
+    p: wit::BindingPattern,
+) -> Result<CoreBindingPattern, AttrPathError> {
+    let pattern = match p {
         wit::BindingPattern::Exact(name) => CoreBindingPattern::Exact(name),
         wit::BindingPattern::ForLoopChildren(base) => CoreBindingPattern::ForLoopChildren { base },
         wit::BindingPattern::AttributeMatch(pattern) => CoreBindingPattern::AttributeMatch {
             resource_type: pattern.resource_type,
-            attr: CoreAttrPath {
-                segments: pattern.attr,
-            },
-            from: CoreAttrPath {
-                segments: pattern.from,
-            },
+            attr: CoreAttrPath::try_new(pattern.attr)?,
+            from: CoreAttrPath::try_new(pattern.from)?,
         },
-    }
+    };
+    Ok(pattern)
 }
 
 /// Helper: convert a core Value to a serde_json::Value for JSON
@@ -1074,20 +1073,75 @@ mod tests {
             CoreBindingPattern::AttributeMatch {
                 resource_type: "route53.RecordSet".to_string(),
                 attr: CoreAttrPath::single("name"),
-                from: CoreAttrPath {
-                    segments: vec![
-                        "domain_validation_options".to_string(),
-                        "resource_record".to_string(),
-                        "name".to_string(),
-                    ],
-                },
+                from: CoreAttrPath::try_new(vec![
+                    "domain_validation_options".to_string(),
+                    "resource_record".to_string(),
+                    "name".to_string(),
+                ])
+                .unwrap(),
             },
         ];
 
         for pattern in patterns {
             let wit = core_to_wit_binding_pattern(&pattern);
-            assert_eq!(wit_to_core_binding_pattern(wit), pattern);
+            assert_eq!(wit_to_core_binding_pattern(wit).unwrap(), pattern);
         }
+    }
+
+    #[test]
+    fn wit_to_core_binding_pattern_returns_err_for_empty_attr_path() {
+        let wit = wit::BindingPattern::AttributeMatch(wit::AttributeMatchPattern {
+            resource_type: "route53.RecordSet".to_string(),
+            attr: vec![],
+            from: vec!["resource_record_name".to_string()],
+        });
+
+        assert!(matches!(
+            wit_to_core_binding_pattern(wit),
+            Err(AttrPathError::Empty)
+        ));
+    }
+
+    #[test]
+    fn wit_to_core_binding_pattern_returns_err_for_empty_from_path() {
+        let wit = wit::BindingPattern::AttributeMatch(wit::AttributeMatchPattern {
+            resource_type: "route53.RecordSet".to_string(),
+            attr: vec!["name".to_string()],
+            from: vec![],
+        });
+
+        assert!(matches!(
+            wit_to_core_binding_pattern(wit),
+            Err(AttrPathError::Empty)
+        ));
+    }
+
+    #[test]
+    fn wit_to_core_binding_pattern_ok_for_non_empty_paths() {
+        let wit = wit::BindingPattern::AttributeMatch(wit::AttributeMatchPattern {
+            resource_type: "route53.RecordSet".to_string(),
+            attr: vec!["name".to_string()],
+            from: vec!["resource_record_name".to_string()],
+        });
+
+        assert_eq!(
+            wit_to_core_binding_pattern(wit).unwrap(),
+            CoreBindingPattern::AttributeMatch {
+                resource_type: "route53.RecordSet".to_string(),
+                attr: CoreAttrPath::single("name"),
+                from: CoreAttrPath::single("resource_record_name"),
+            }
+        );
+    }
+
+    #[test]
+    fn wit_to_core_binding_pattern_ok_for_exact() {
+        let wit = wit::BindingPattern::Exact("validation_record".to_string());
+
+        assert_eq!(
+            wit_to_core_binding_pattern(wit).unwrap(),
+            CoreBindingPattern::Exact("validation_record".to_string())
+        );
     }
 
     /// RFC #2371 stage 4 contract pin: `Value::Deferred(DeferredValue::Unknown)` reaching either

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -2153,7 +2153,7 @@ impl Provider for WasmProvider {
 
     fn satisfier_hint(&self, target_id: &ResourceId, attr_path: &AttrPath) -> Vec<BindingPattern> {
         let wit_id = wasm_convert::core_to_wit_resource_id(target_id);
-        let attr_path = attr_path.segments.clone();
+        let wit_attr_path = attr_path.segments().to_vec();
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let mut locked = match LockedStore::acquire(&self.instance, "satisfier_hint").await
@@ -2167,13 +2167,26 @@ impl Provider for WasmProvider {
                 let call = self
                     .instance
                     .bindings
-                    .call_satisfier_hint(locked.store(), &wit_id, &attr_path)
+                    .call_satisfier_hint(locked.store(), &wit_id, &wit_attr_path)
                     .await;
                 locked.disarm();
                 match call {
                     Ok(patterns) => patterns
                         .into_iter()
-                        .map(wasm_convert::wit_to_core_binding_pattern)
+                        .filter_map(|p| match wasm_convert::wit_to_core_binding_pattern(p) {
+                            Ok(pattern) => Some(pattern),
+                            Err(err) => {
+                                log::warn!(
+                                    target: "carina_plugin_host::wasm_factory",
+                                    "provider '{}' returned invalid satisfier-hint pattern for {} (attr: {}); skipping: {}",
+                                    self.name,
+                                    target_id,
+                                    attr_path.segments().join("."),
+                                    err
+                                );
+                                None
+                            }
+                        })
                         .collect(),
                     Err(e) => {
                         log::error!("WASM trap in satisfier_hint: {e}");


### PR DESCRIPTION
## Summary

Issue #3548 の修正。`AttrPath` の `segments: Vec<String>` フィールドが public で、空ベクタの AttrPath を構築できる「broken state」を型レベルで unrepresentable にする。

#3545 PR の round 3-4 review で発見した typestate hole の follow-up です。`WaitObservation` の hardening を AttrPath にまで届かせる形。

## 何が変わるか

### `AttrPath` の typestate

```rust
pub struct AttrPath {
    segments: Vec<String>,  // private
}

impl AttrPath {
    pub fn single(name: impl Into<String>) -> Self { ... }
    pub fn try_new(segments: Vec<String>) -> Result<Self, AttrPathError> {
        if segments.is_empty() { return Err(AttrPathError::Empty); }
        Ok(Self { segments })
    }
    pub fn segments(&self) -> &[String] { &self.segments }
}

#[derive(Debug, Error)]
pub enum AttrPathError {
    #[error("AttrPath segments cannot be empty")]
    Empty,
}
```

### serde wire format 保持

```rust
#[serde(into = "AttrPathSerde", try_from = "AttrPathSerde")]
pub struct AttrPath { ... }

// AttrPathSerde は private 中間型。JSON 形式は `{"segments": [...]}` のまま。
// deserialize 時は try_from 経由で empty を reject。
```

既存の saved plan / state file の JSON は byte-identical に round-trip します。round-trip test で固定。

### WIT 境界の panic 排除

`wit_to_core_binding_pattern` が `.expect("…must not be empty")` で panic していたところを `Result<_, AttrPathError>` 化。buggy / malicious WASM provider が `satisfier_hint` で `attr: []` を返しても **host を kill しない**。`wasm_factory::satisfier_hint` で invalid pattern を `log::warn!` (provider 名 + target_id + attr_path + error) と共に skip、他の valid pattern はそのまま返す degraded-mode 動作。

### 防御層 (defense in depth)

`differ/plan.rs::create_plan` も `AttrPath::try_new` 失敗を `plan.add_error` に routing。parser (`lower_until_lhs`) が bare-target LHS を既に reject していますが、将来の parser relax や `WaitBinding` 直接構築のケースに備えて planner レベルでも防御 + regression test を追加。

## Provider repo への影響

ゼロ。`carina-provider-aws` と `carina-provider-awscc` は `AttrPath` を一切参照していません(host-only type で WIT は `list<string>`)。**Provider repo の rev bump は不要**。

## API tidiness

`AttrPath`, `AttrPathError`, `WaitPredicate` を `carina_core::wait` で re-export(`WaitObservation` と同じ convention)。

## 5 round self-review 結果

| Round | Findings | 対応 |
|---|---|---|
| 1 | WIT 境界の `.expect` が host panic 起こす | in-PR fix: `Result` 化 + warn-and-skip |
| 2 | log::warn の context が薄い | in-PR fix: target_id + attr_path を log に追加 |
| 3 | planner error path がテスト未カバー | in-PR fix: regression test 追加 |
| 4 | observation.rs に obsolete follow-up comment、re-export 未整理 | in-PR fix: 削除 + re-export |
| 5 | clean, ship | - |

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 4218 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] 新規 test:
  - `AttrPath::try_new` empty reject / non-empty ok
  - serde round-trip preserves `{"segments":[...]}`
  - serde rejects `{"segments":[]}` on deserialize
  - WIT boundary returns Err for empty attr/from paths
  - WIT boundary returns Ok for Exact and non-empty AttributeMatch
  - `differ::create_plan` records error for empty predicate attr path (defense-in-depth)

Closes #3548

🤖 Generated with [Claude Code](https://claude.com/claude-code)
