### PR TITLE
fix(apply): tolerate per-export resolution failures in state writeback

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -370,7 +370,7 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
     if let Some(params) = input.export_params {
         let post_apply_states =
             PostApplyStates::from_current_and_state(input.current_states, &state);
-        state.exports = resolve_exports(
+        let resolution = resolve_exports(
             params,
             input.sorted_resources,
             input.data_sources,
@@ -378,6 +378,7 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
             &post_apply_states,
             input.wait_aliases,
         )?;
+        resolution.write_into(&mut state);
     }
 
     if let Some(lock) = input.lock {
@@ -478,7 +479,7 @@ pub(crate) async fn persist_exports_only(
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
     let post_apply_states = PostApplyStates::from_current_and_state(current_states, &state);
-    let exports = resolve_exports(
+    let resolution = resolve_exports(
         export_params,
         sorted_resources,
         data_sources,
@@ -486,7 +487,7 @@ pub(crate) async fn persist_exports_only(
         &post_apply_states,
         wait_aliases,
     )?;
-    state.exports = exports;
+    resolution.write_into(&mut state);
     if let Some(lk) = lock {
         save_state_locked(backend, lk, &mut state).await?;
     } else {

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1,11 +1,131 @@
 use super::*;
+use carina_core::provider::{
+    BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, Provider, ProviderError,
+    ProviderFactory, ProviderNormalizer, ProviderResult, ReadRequest, UpdateRequest,
+};
+use carina_core::resource::{DataSource, ResourceId};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
+use indexmap::IndexMap;
+use std::collections::HashMap;
 use std::time::Duration;
 
 #[path = "tests/cancellation_fixture.rs"]
 mod cancellation_fixture;
 
 use cancellation_fixture::ApplyCancellationFixture;
+
+struct FailBCreateFactory;
+
+impl ProviderFactory for FailBCreateFactory {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn display_name(&self) -> &str {
+        "Mock provider with B create failure"
+    }
+
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "test-region".to_string()
+    }
+
+    fn create_provider(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(FailBCreateProvider) as Box<dyn Provider>) })
+    }
+
+    fn create_normalizer(
+        &self,
+        _binding: Option<&str>,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+        Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+    }
+
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![
+            ResourceSchema::new("test.resource")
+                .attribute(AttributeSchema::new("name", AttributeType::string())),
+        ]
+    }
+}
+
+struct FailBCreateProvider;
+
+impl Provider for FailBCreateProvider {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn read(
+        &self,
+        id: &ResourceId,
+        _identifier: Option<&str>,
+        _request: ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(State::not_found(id)) })
+    }
+
+    fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(State::not_found(id)) })
+    }
+
+    fn create(
+        &self,
+        id: &ResourceId,
+        request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        Box::pin(async move {
+            if id.name_str() == "b" {
+                return Err(ProviderError::api_error("create failed").for_resource(id));
+            }
+            let resource = request.resource.as_resource().clone();
+            Ok(State::existing(id, resource.resolved_attributes()).with_identifier("mock-id"))
+        })
+    }
+
+    fn update(
+        &self,
+        id: &ResourceId,
+        _identifier: &str,
+        _request: UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        Box::pin(async move { Err(ProviderError::internal("unexpected update").for_resource(id)) })
+    }
+
+    fn delete(
+        &self,
+        id: &ResourceId,
+        _identifier: &str,
+        _request: DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        let id = id.clone();
+        Box::pin(async move { Err(ProviderError::internal("unexpected delete").for_resource(id)) })
+    }
+
+    fn required_permissions(
+        &self,
+        _id: &ResourceId,
+        _op: carina_core::effect::PlanOp,
+    ) -> Vec<String> {
+        Vec::new()
+    }
+}
 
 #[test]
 fn total_apply_line_formats_duration() {
@@ -115,6 +235,68 @@ async fn apply_cancel_token_integration_persists_completed_state_releases_lock_a
         "target_group must not be in state (cancelled before completion)"
     );
     assert!(!fixture.lock_path().exists(), "lock file must be released");
+}
+
+#[tokio::test]
+async fn run_apply_locked_with_create_failure_persists_resolved_export_only() {
+    let fixture = ApplyCancellationFixture::new()
+        .with_resources_and_exports(["a", "b"], &[("ax", "a.name"), ("bx", "b.id")]);
+    let loaded = load_configuration_with_config(
+        fixture.config_path(),
+        fixture.provider_context(),
+        &SchemaRegistry::new(),
+    )
+    .expect("fixture must load");
+    let mut parsed = loaded.parsed;
+    let mut unresolved_parsed = loaded.unresolved_parsed;
+    let base_dir = get_base_dir(fixture.config_path());
+    let validation_errors = crate::commands::validate_and_resolve_errors_with_factories(
+        &mut parsed,
+        base_dir,
+        false,
+        vec![Box::new(FailBCreateFactory)],
+        HashMap::new(),
+    );
+    assert!(
+        validation_errors.is_empty(),
+        "fixture must validate, got: {validation_errors:?}"
+    );
+    let ctx = WiringContext::new(vec![Box::new(FailBCreateFactory)]);
+    let observer_factory = fixture.observer_factory();
+    let err = run_apply_locked(
+        &ctx,
+        &mut parsed,
+        &mut unresolved_parsed,
+        true,
+        fixture.backend(),
+        None,
+        base_dir,
+        fixture.provider_context(),
+        fixture.cancel_token(),
+        &observer_factory,
+        NonZeroUsize::new(1).unwrap(),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("Apply failed. 1 succeeded, 1 failed."),
+        "partial apply must still surface a non-success result, got {err:?}"
+    );
+
+    let state = fixture.read_state().await;
+    assert!(
+        state.find_resource("mock", "test.resource", "a").is_some(),
+        "successful resource A must be persisted"
+    );
+    assert!(
+        state.find_resource("mock", "test.resource", "b").is_none(),
+        "resource B must not be persisted"
+    );
+    assert_eq!(state.exports.get("ax"), Some(&serde_json::json!("a")));
+    assert!(!state.exports.contains_key("bx"));
+    assert_eq!(state.serial, 1);
 }
 
 fn s3_backend_config_with_encrypt(encrypt: bool) -> carina_core::parser::BackendConfig {
@@ -1308,7 +1490,9 @@ fn resolve_exports_resolves_cross_file_resource_refs() {
         &post_apply_states,
         &[],
     )
-    .unwrap();
+    .unwrap()
+    .into_parts()
+    .0;
 
     assert_eq!(
         exports.get("account_id"),
@@ -1405,7 +1589,9 @@ fn resolve_exports_resolves_module_call_attribute_via_composition() {
         &post_apply_states,
         &[],
     )
-    .unwrap();
+    .unwrap()
+    .into_parts()
+    .0;
 
     assert_eq!(
         exports.get("role_arn"),
@@ -1522,7 +1708,9 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_compositions()
         &post_apply_states,
         &[],
     )
-    .unwrap();
+    .unwrap()
+    .into_parts()
+    .0;
 
     assert_eq!(
         exports.get("role_arn"),
@@ -1702,7 +1890,9 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
         &post_apply_states,
         &[],
     )
-    .unwrap();
+    .unwrap()
+    .into_parts()
+    .0;
 
     assert_eq!(
         exports.get("role_arn"),
@@ -1810,7 +2000,9 @@ fn resolve_exports_resolves_data_source_attribute_after_apply_3266() {
         &post_apply_states,
         &[],
     )
-    .unwrap();
+    .unwrap()
+    .into_parts()
+    .0;
 
     let expected_json = serde_json::json!([new_arn]);
     assert_eq!(

--- a/carina-cli/src/commands/apply/tests/cancellation_fixture.rs
+++ b/carina-cli/src/commands/apply/tests/cancellation_fixture.rs
@@ -47,6 +47,14 @@ impl ApplyCancellationFixture {
     }
 
     pub(super) fn with_resources<const N: usize>(self, names: [&str; N]) -> Self {
+        self.with_resources_and_exports(names, &[])
+    }
+
+    pub(super) fn with_resources_and_exports<const N: usize>(
+        self,
+        names: [&str; N],
+        exports: &[(&str, &str)],
+    ) -> Self {
         let state_path = self.base.state_path().display();
         let mut crn = format!(
             "backend local {{ path = \"{state_path}\" }}\n\
@@ -56,6 +64,13 @@ impl ApplyCancellationFixture {
             crn.push_str(&format!(
                 "let {name} = mock.test.resource {{ name = \"{name}\" }}\n"
             ));
+        }
+        if !exports.is_empty() {
+            crn.push_str("exports {\n");
+            for (name, expr) in exports {
+                crn.push_str(&format!("  {name}: String = {expr}\n"));
+            }
+            crn.push_str("}\n");
         }
         self.base.write_crn(crn);
         self.base.write_backend_lock();

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -12,6 +12,7 @@ use carina_core::plan::Plan;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 use carina_state::{LockInfo, ResourceState, StateBackend, StateFile};
+use colored::Colorize;
 
 use crate::error::AppError;
 
@@ -195,6 +196,80 @@ pub(crate) struct FinalizeApplyInput<'a> {
     pub pre_resolve_compositions: &'a [carina_core::resource::Composition],
 }
 
+/// Export writeback result split by per-export outcome.
+///
+/// This deliberately avoids the all-or-nothing `HashMap` shape that
+/// caused carina#3551: a partially failed apply can leave exports that
+/// depend on the failed resource unresolved, but carina#3498 requires
+/// successfully completed resources from the same run to still be
+/// persisted. Resolved exports are written to `state.exports`; skipped
+/// exports are omitted and surfaced to the operator by the caller.
+pub(crate) struct ExportResolution {
+    /// Exports that resolved to concrete JSON and are safe to persist.
+    resolved: HashMap<String, serde_json::Value>,
+    /// Exports omitted because their value still depends on unresolved
+    /// apply-time data.
+    skipped: Vec<SkippedExport>,
+}
+
+impl ExportResolution {
+    /// Persist export resolution into `state.exports` and emit one
+    /// operator-visible stdout line per omitted export.
+    ///
+    /// This is a three-way merge: resolved exports win with their new
+    /// values, skipped exports preserve any prior persisted value, and
+    /// names absent from both sets are dropped so source-side export
+    /// removals still converge (carina#3551, carina#2932).
+    ///
+    /// Consumes `self` so the skipped diagnostics cannot be silently
+    /// dropped by a caller that reads only the resolved half
+    /// (carina#3551 / CLAUDE.md "Long-term view alongside root-cause").
+    pub(crate) fn write_into(self, state: &mut StateFile) {
+        let mut next = HashMap::new();
+        for skipped in &self.skipped {
+            println!("{}", render_skipped(skipped));
+            if let Some(prior) = state.exports.get(&skipped.name) {
+                next.insert(skipped.name.clone(), prior.clone());
+            }
+        }
+        for (name, value) in self.resolved {
+            next.insert(name, value);
+        }
+        state.exports = next;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_parts(self) -> (HashMap<String, serde_json::Value>, Vec<SkippedExport>) {
+        (self.resolved, self.skipped)
+    }
+}
+
+fn render_skipped(skipped: &SkippedExport) -> String {
+    format!(
+        "  {} export {} not written: {}",
+        "!".yellow(),
+        skipped.name,
+        skipped.reason
+    )
+}
+
+/// Diagnostic for an export omitted during state writeback.
+///
+/// carina#3551 showed that unresolved sibling-resource references must
+/// not abort the whole writeback after carina#3498 made partial apply
+/// persistence meaningful. The reason is pre-formatted diagnostic text
+/// for the operator-visible progress log on stdout, not data intended
+/// for programmatic matching.
+#[derive(Debug)]
+pub(crate) struct SkippedExport {
+    /// Export name from the source `exports {}` block.
+    name: String,
+    /// Pre-formatted human reason for the omission. This is
+    /// diagnostic data for the progress log on stdout, not a stable
+    /// machine contract.
+    reason: String,
+}
+
 /// Resolve export expressions using bindings built from applied state.
 ///
 /// `sorted_resources` carries the in-memory resource graph including any
@@ -236,6 +311,16 @@ pub(crate) struct FinalizeApplyInput<'a> {
 /// 5. Layer the re-resolved compositions onto the bindings view via
 ///    `layer_compositions_post_apply` (#3176).
 /// 6. Resolve export expressions against the combined view.
+///
+/// # Partial-apply tolerance (carina#3551 / carina#3498)
+///
+/// Export expressions can reference a resource attribute that remains
+/// unresolved because that resource's Create or Update failed while
+/// earlier resources in the same apply succeeded. Those per-export
+/// resolution failures are reported in [`ExportResolution::skipped`]
+/// and omitted from `state.exports` so the writeback still persists
+/// completed resources. Genuine serialization corruption, such as a
+/// non-finite float, remains an error and aborts writeback.
 pub(crate) fn resolve_exports(
     export_params: &[carina_core::parser::InferredExportParam],
     sorted_resources: &[Resource],
@@ -243,9 +328,10 @@ pub(crate) fn resolve_exports(
     pre_resolve_compositions: &[carina_core::resource::Composition],
     post_apply_states: &PostApplyStates,
     wait_aliases: &[carina_core::binding_index::WaitAliasSpec],
-) -> Result<HashMap<String, serde_json::Value>, AppError> {
+) -> Result<ExportResolution, AppError> {
     use carina_core::binding_index::ResolvedBindings;
     use carina_core::resolver::resolve_virtual_refs_post_apply;
+    use carina_core::value::SerializationError;
 
     // Step 1: the post-apply state view was assembled by
     // [`PostApplyStates::from_current_and_state`] before this call.
@@ -292,16 +378,48 @@ pub(crate) fn resolve_exports(
 
     // Step 6: resolve the export expressions against the combined
     // view.
-    let mut exports = HashMap::new();
+    let mut resolved_exports = HashMap::new();
+    let mut skipped = Vec::new();
     for param in export_params {
         if let Some(ref value) = param.value {
             let resolved = crate::commands::plan::resolve_export_value(value, &bindings);
-            if let Some(json) = dsl_value_to_json(&resolved)? {
-                exports.insert(param.name.clone(), json);
+            match dsl_value_to_json(&resolved) {
+                Ok(Some(json)) => {
+                    resolved_exports.insert(param.name.clone(), json);
+                }
+                Ok(None) => {}
+                Err(SerializationError::UnresolvedResourceRef { path, .. }) => {
+                    skipped.push(SkippedExport {
+                        name: param.name.clone(),
+                        reason: format!("unresolved reference {path}"),
+                    });
+                }
+                Err(SerializationError::UnknownNotAllowed { reason, .. }) => {
+                    skipped.push(SkippedExport {
+                        name: param.name.clone(),
+                        reason: format!("value not yet known ({reason})"),
+                    });
+                }
+                Err(SerializationError::UnresolvedInterpolation { .. }) => {
+                    skipped.push(SkippedExport {
+                        name: param.name.clone(),
+                        reason: "unresolved interpolation".into(),
+                    });
+                }
+                Err(SerializationError::UnresolvedFunctionCall { name, .. }) => {
+                    skipped.push(SkippedExport {
+                        name: param.name.clone(),
+                        reason: format!("unresolved function call {name}(...)"),
+                    });
+                }
+                Err(e @ SerializationError::NonFiniteFloat { .. }) => return Err(e.into()),
             }
         }
     }
-    Ok(exports)
+    Ok(ExportResolution {
+        resolved: resolved_exports,
+        skipped,
+    })
 }
 
 /// Convert a DSL Value to a serde_json::Value for state persistence.
@@ -754,6 +872,168 @@ mod post_apply_states_tests {
             Some(Value::Concrete(ConcreteValue::String(s))) => assert_eq!(s, "Enabled"),
             other => panic!("expected post-apply 'Enabled', got: {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod resolve_exports_tests {
+    use super::*;
+    use carina_core::parser::{InferredExportParam, TypeExpr};
+    use carina_core::resource::{
+        AccessPath, ConcreteValue, DeferredValue, InterpolationPart, Value,
+    };
+    use carina_state::StateFile;
+
+    fn export_param(name: &str, value: Value) -> InferredExportParam {
+        InferredExportParam {
+            name: name.to_string(),
+            type_expr: TypeExpr::Unknown,
+            value: Some(value),
+        }
+    }
+
+    fn resolve_export_parts(
+        export_params: &[InferredExportParam],
+    ) -> (HashMap<String, serde_json::Value>, Vec<SkippedExport>) {
+        let state = StateFile::new();
+        let post_apply_states = PostApplyStates::from_current_and_state(&HashMap::new(), &state);
+        resolve_exports(export_params, &[], &[], &[], &post_apply_states, &[])
+            .expect("unresolved exports should be skipped, not abort writeback")
+            .into_parts()
+    }
+
+    #[test]
+    fn unresolved_export_is_skipped_without_dropping_resolved_exports() {
+        let export_params = vec![
+            export_param(
+                "target_group_arn",
+                Value::Deferred(DeferredValue::ResourceRef {
+                    path: AccessPath::with_fields(
+                        "registry_publish",
+                        "target_group",
+                        vec!["arn".into()],
+                    ),
+                }),
+            ),
+            export_param(
+                "ok_export",
+                Value::Concrete(ConcreteValue::String("ok".into())),
+            ),
+        ];
+
+        let (resolved, skipped) = resolve_export_parts(&export_params);
+
+        assert_eq!(resolved.get("ok_export"), Some(&serde_json::json!("ok")));
+        assert!(
+            !resolved.contains_key("target_group_arn"),
+            "unresolved export must be omitted from resolved map"
+        );
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].name, "target_group_arn");
+        assert!(
+            skipped[0]
+                .reason
+                .contains("registry_publish.target_group.arn"),
+            "skip reason should name unresolved path, got: {:?}",
+            skipped[0]
+        );
+        assert_eq!(
+            render_skipped(&skipped[0]),
+            "  ! export target_group_arn not written: unresolved reference registry_publish.target_group.arn"
+        );
+    }
+
+    #[test]
+    fn multiple_unresolved_exports_are_skipped_in_export_order() {
+        let export_params = vec![
+            export_param(
+                "first_missing",
+                Value::Deferred(DeferredValue::ResourceRef {
+                    path: AccessPath::new("first", "id"),
+                }),
+            ),
+            export_param(
+                "ok_export",
+                Value::Concrete(ConcreteValue::String("ok".into())),
+            ),
+            export_param(
+                "second_missing",
+                Value::Deferred(DeferredValue::ResourceRef {
+                    path: AccessPath::new("second", "id"),
+                }),
+            ),
+        ];
+
+        let (resolved, skipped) = resolve_export_parts(&export_params);
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved.get("ok_export"), Some(&serde_json::json!("ok")));
+        assert_eq!(skipped.len(), 2);
+        assert_eq!(skipped[0].name, "first_missing");
+        assert_eq!(skipped[1].name, "second_missing");
+    }
+
+    #[test]
+    fn unresolved_interpolation_export_is_skipped() {
+        let export_params = vec![export_param(
+            "template",
+            Value::Deferred(DeferredValue::Interpolation(vec![
+                InterpolationPart::Literal("x".into()),
+            ])),
+        )];
+
+        let (resolved, skipped) = resolve_export_parts(&export_params);
+
+        assert!(resolved.is_empty());
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].name, "template");
+        assert_eq!(skipped[0].reason, "unresolved interpolation");
+    }
+
+    #[test]
+    fn unresolved_function_call_export_is_skipped() {
+        let export_params = vec![export_param(
+            "joined",
+            Value::Deferred(DeferredValue::FunctionCall {
+                name: "join".into(),
+                args: vec![],
+            }),
+        )];
+
+        let (resolved, skipped) = resolve_export_parts(&export_params);
+
+        assert!(resolved.is_empty());
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].name, "joined");
+        assert_eq!(skipped[0].reason, "unresolved function call join(...)");
+    }
+
+    #[test]
+    fn write_into_preserves_prior_skipped_exports_and_drops_orphans() {
+        let mut state = StateFile::new();
+        state
+            .exports
+            .insert("ax".to_string(), serde_json::json!("old-a"));
+        state
+            .exports
+            .insert("bx".to_string(), serde_json::json!("old-b"));
+        state
+            .exports
+            .insert("orphan".to_string(), serde_json::json!("old-orphan"));
+
+        ExportResolution {
+            resolved: HashMap::from([("ax".to_string(), serde_json::json!("new-a"))]),
+            skipped: vec![SkippedExport {
+                name: "bx".to_string(),
+                reason: "unresolved reference b.name".to_string(),
+            }],
+        }
+        .write_into(&mut state);
+
+        assert_eq!(state.exports.len(), 2);
+        assert_eq!(state.exports.get("ax"), Some(&serde_json::json!("new-a")));
+        assert_eq!(state.exports.get("bx"), Some(&serde_json::json!("old-b")));
+        assert!(!state.exports.contains_key("orphan"));
     }
 }
 

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -1188,7 +1188,7 @@ pub(crate) async fn run_state_refresh_locked(
                 &current_states,
                 &state,
             );
-        state.exports = crate::commands::shared::state_writeback::resolve_exports(
+        let resolution = crate::commands::shared::state_writeback::resolve_exports(
             &parsed.export_params,
             &sorted_resources,
             &parsed.data_sources,
@@ -1196,6 +1196,7 @@ pub(crate) async fn run_state_refresh_locked(
             &post_apply_states,
             &wait_aliases,
         )?;
+        resolution.write_into(&mut state);
     }
 
     // Save state (with or without lock validation)

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -3198,3 +3198,103 @@ async fn finalize_apply_preserves_state_exports_when_params_none() {
         state.exports
     );
 }
+
+#[tokio::test]
+async fn finalize_apply_persists_successful_state_when_one_export_is_unresolved() {
+    use carina_core::parser::{InferredExportParam, TypeExpr};
+    use carina_core::resource::AccessPath;
+
+    let captured = Arc::new(Mutex::new(None));
+    let backend = CapturingBackend {
+        captured: captured.clone(),
+    };
+    let lock = LockInfo::new("apply");
+
+    let mut resource_a = Resource::with_provider("mock", "test.resource", "a", None);
+    resource_a.binding = Some("a".to_string());
+    let mut resource_b = Resource::with_provider("mock", "test.resource", "b", None);
+    resource_b.binding = Some("b".to_string());
+    let sorted_resources = vec![resource_a.clone(), resource_b];
+
+    let a_id = resource_a.id.clone();
+    let mut a_attrs = HashMap::new();
+    a_attrs.insert(
+        "id".to_string(),
+        Value::Concrete(ConcreteValue::String("a-id".to_string())),
+    );
+    let a_state = State::existing(a_id.clone(), a_attrs).with_identifier("a-id");
+
+    let result = ApplyResult {
+        success_count: 1,
+        failure_count: 1,
+        skip_count: 0,
+        applied_states: HashMap::from([(a_id.clone(), a_state.clone())]),
+        permanent_name_overrides: HashMap::new(),
+        successfully_deleted: HashSet::new(),
+        current_states: HashMap::from([(a_id, a_state)]),
+        bindings: carina_core::binding_index::ResolvedBindings::default(),
+        failed_refreshes: HashSet::new(),
+    };
+
+    let export_params = vec![
+        InferredExportParam {
+            name: "ax".to_string(),
+            type_expr: TypeExpr::Unknown,
+            value: Some(Value::Deferred(DeferredValue::ResourceRef {
+                path: AccessPath::new("a", "id"),
+            })),
+        },
+        InferredExportParam {
+            name: "bx".to_string(),
+            type_expr: TypeExpr::Unknown,
+            value: Some(Value::Deferred(DeferredValue::ResourceRef {
+                path: AccessPath::new("b", "id"),
+            })),
+        },
+    ];
+
+    let op_result = finalize_apply(FinalizeApplyInput {
+        result: &result,
+        state_file: Some(StateFile::new()),
+        sorted_resources: &sorted_resources,
+        data_sources: &[],
+        current_states: &result.current_states,
+        plan: &Plan::new(),
+        backend: &backend,
+        lock: Some(&lock),
+        schemas: &SchemaRegistry::new(),
+        export_params: Some(&export_params),
+        wait_aliases: &[],
+        pre_resolve_compositions: &[],
+    })
+    .await;
+
+    assert!(
+        op_result.is_ok(),
+        "unresolved export from failed resource must not abort writeback: {op_result:?}"
+    );
+    assert!(
+        result.failure_count > 0,
+        "the modeled apply result must still represent a partial failure"
+    );
+
+    let written = captured.lock().unwrap();
+    let state = written.as_ref().expect("state should be written");
+    assert!(
+        state.find_resource("mock", "test.resource", "a").is_some(),
+        "successful resource A must be persisted"
+    );
+    assert!(
+        state.find_resource("mock", "test.resource", "b").is_none(),
+        "failed resource B must not be persisted"
+    );
+    assert_eq!(state.exports.get("ax"), Some(&serde_json::json!("a-id")));
+    assert!(
+        !state.exports.contains_key("bx"),
+        "unresolved export bx must be omitted"
+    );
+    assert_eq!(
+        state.serial, 1,
+        "writeback should advance serial after persisting partial apply state"
+    );
+}


### PR DESCRIPTION
## Summary

- Partial `apply` failures used to abort `state writeback` wholesale when an `exports {}` value referenced an attribute of a resource whose Create / Update had failed. The successful resources from the same run were then never persisted to state, leaving AWS orphans that the next `plan` could not see.
- The root cause is the all-or-nothing shape of `resolve_exports`: a single per-export `SerializationError::UnresolvedResourceRef` Err propagated to `finalize_apply` and dropped the entire state object on the floor.
- The fix reshapes the API so the broken state cannot be reintroduced. `resolve_exports` now returns `ExportResolution { resolved, skipped }` with module-private fields; the single by-value consuming method `ExportResolution::write_into` is the only seam, and the match on `SerializationError` is exhaustive so a new variant added in `carina-core` will force the maintainer to classify it.
- `write_into` performs a 3-way merge: resolved entries overwrite, skipped entries preserve the previously-persisted value (so a previously-good export ARN survives a later-failed re-apply), and names absent from both sets are dropped to preserve the existing carina#2932 semantic that source-side `exports {}` removals clear stale persisted values.
- Skipped exports surface on stdout alongside the existing apply progress output as `"  ! export <name> not written: <reason>"`.

## Test plan

- [x] `cargo nextest run -p carina-cli` — 663 passed (6 new tests: single skip, multi-skip ordering, interpolation arm, function-call arm, 3-way merge prior-preservation, real-apply-path partial failure)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [ ] Real-infra rerun of the original carina-rs/infra publish dispatch on a deploy role still missing the two IAM actions, to confirm the successful-resource set (service-SG, ALB-SG, SG-ingress, ACM cert) is now persisted to `s3://.../publish/carina.state.json` despite the LoadBalancer / TargetGroup 403s.

Closes #3551

🤖 Generated with [Claude Code](https://claude.com/claude-code)