### PR TITLE
fix(wait): resolve target identifier per-poll instead of plan-time snapshot

### DIFF
--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -360,7 +360,6 @@ pub fn find_failed_dependent<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::effect::WaitTarget;
     use crate::resource::{DeferredValue, Directives, Resource, ResourceId, Value};
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
@@ -368,7 +367,6 @@ mod tests {
         Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target: WaitTarget::Known("cert-id".to_string()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(crate::resource::ConcreteValue::String(

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::deps::get_resource_dependencies;
-use crate::effect::{CascadingUpdate, ChangedCreateOnly, Effect, TemporaryName, WaitTarget};
+use crate::effect::{CascadingUpdate, ChangedCreateOnly, Effect, TemporaryName};
 use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
@@ -538,18 +538,6 @@ pub fn create_plan(
             value: wb.until_predicate.rhs.clone(),
         };
         let target_id = target_id_resolved;
-        // The target's identifier is only known at plan time if it
-        // already exists in state. When the target is created/updated
-        // in this same run it has no prior state, so the executor must
-        // resolve the real identifier from the just-applied state — see
-        // [`WaitTarget`] and carina#3119.
-        let target = match current_states
-            .get(&target_id)
-            .and_then(|s| s.identifier.clone())
-        {
-            Some(id) => WaitTarget::Known(id),
-            None => WaitTarget::ResolvedAtApply,
-        };
         let schema = registry.get(
             &target_id.provider,
             &target_id.resource_type,
@@ -572,28 +560,24 @@ pub fn create_plan(
         // would poll-and-return immediately. Dragging such a wait into
         // the plan is pure noise (a `> <binding> (until …)` node with no
         // pending work), so suppress it. The wait *does* have work when:
-        //   1. the target has no resolved identifier at plan time
-        //      (`ResolvedAtApply`; typically created this run) — its
-        //      post-apply attributes are unknown, must poll;
+        //   1. the target has no state entry (typically created this
+        //      run) — its post-apply attributes are unknown, must poll;
         //   2. the target has a mutating effect in this plan — cached
         //      attributes are stale, must re-poll; or
         //   3. the target is unchanged but its cached state does not yet
         //      satisfy the predicate (missing state ⇒ treat as work).
-        let wait_has_work = match &target {
-            WaitTarget::ResolvedAtApply => true,
-            WaitTarget::Known(_) => {
+        let wait_has_work = current_states
+            .get(&target_id)
+            .map(|state| {
                 let target_is_mutating = plan
                     .effects()
                     .iter()
                     .any(|e| e.resource_id() == &target_id && e.is_mutating());
-                let target_needs_wait = current_states
-                    .get(&target_id)
-                    .map(|s| !until.evaluate(&s.attributes))
-                    .unwrap_or(true);
+                let target_needs_wait = !until.evaluate(&state.attributes);
 
                 target_is_mutating || target_needs_wait
-            }
-        };
+            })
+            .unwrap_or(true);
         if !wait_has_work {
             continue;
         }
@@ -618,7 +602,6 @@ pub fn create_plan(
             // type tracked for its own newtype migration (carina#3066).
             binding: wb.binding.as_str().to_string(),
             target_id,
-            target,
             until,
             until_surface: wb.until_raw.clone(),
             timeout,

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1803,7 +1803,7 @@ fn wait_omitted_when_already_satisfied_and_target_unchanged() {
 /// carina#3358 counterpart: when the wait's target *is* changing in the
 /// same plan, the cached state is stale — its post-apply attributes are
 /// unknown, so the wait must still be emitted to re-poll on `apply`.
-/// Here the target is new (`WaitTarget::ResolvedAtApply`).
+/// Here the target is new and has no current state entry.
 #[test]
 fn wait_emitted_when_target_is_changing_even_if_cached_state_satisfies() {
     use crate::effect::Effect;
@@ -1853,22 +1853,20 @@ fn wait_emitted_when_target_is_changing_even_if_cached_state_satisfies() {
     );
 }
 
-/// carina#3358: pins the `WaitTarget::Known` + `target_is_mutating`
-/// branch of `wait_has_work`. An *existing* target (resolved identifier
-/// in state → `Known`) whose cached state already satisfies the
-/// predicate, but which has a pending `Update` in this plan, must still
-/// emit the wait: the cached `ISSUED` is stale relative to the
-/// about-to-apply change, so the executor must re-poll. Without this
-/// test the `target_is_mutating ||` half of the gate is dead under the
-/// suite and could be silently dropped, re-introducing the bug for
-/// changing-but-Known targets.
+/// carina#3358: pins the existing-target + `target_is_mutating`
+/// branch of `wait_has_work`. An existing target whose cached state
+/// already satisfies the predicate, but which has a pending `Update` in
+/// this plan, must still emit the wait: the cached `ISSUED` is stale
+/// relative to the about-to-apply change, so the executor must re-poll.
+/// Without this test the `target_is_mutating ||` half of the gate is
+/// dead under the suite and could be silently dropped.
 #[test]
 fn wait_emitted_when_known_target_has_pending_update_even_if_cached_state_satisfies() {
     use crate::effect::Effect;
     use crate::parser::{UntilPredicateAst, WaitBinding};
 
-    // cert EXISTS in state with an identifier (→ WaitTarget::Known) and
-    // its cached `status` already satisfies the predicate, BUT it has a
+    // cert EXISTS in state and its cached `status` already satisfies
+    // the predicate, BUT it has a
     // pending Update (desired `domain_name` differs from state).
     let cert = Resource::new("acm.Certificate", "cert")
         .with_binding("cert")
@@ -1922,9 +1920,9 @@ fn wait_emitted_when_known_target_has_pending_update_even_if_cached_state_satisf
         &[wait],
     );
 
-    // Precondition: cert really has a pending Update (Known + mutating),
-    // so this hits the `target_is_mutating` arm — not `ResolvedAtApply`
-    // and not the `target_needs_wait` arm.
+    // Precondition: cert really has a pending Update, so this hits the
+    // `target_is_mutating` arm for an existing state row and not the
+    // `target_needs_wait` arm.
     assert!(
         plan.effects()
             .iter()

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -107,44 +107,6 @@ impl From<ChangedCreateOnly> for Vec<String> {
     }
 }
 
-/// How an [`Effect::Wait`] obtains the cloud provider identifier its
-/// polling `read()` needs.
-///
-/// The differ cannot always know the target's identifier at plan time:
-/// when the target is *created in the same apply run* it has no prior
-/// state, so its real identifier (e.g. an ACM certificate ARN) only
-/// exists after the `Create` effect completes. Splitting "known now"
-/// from "resolve at apply" into the type — instead of overloading
-/// `Option<String>`'s `None` — forces the executor to handle the
-/// apply-time case explicitly via an exhaustive `match`, so future code
-/// cannot silently pass a stale plan-time `None` to `provider.read`
-/// (carina#3119).
-///
-/// Guard: the old `Option<String>`-shaped pattern — treating the
-/// plan-time value as something you can `.as_deref()` straight into the
-/// poll loop — no longer type-checks. `WaitTarget` has no `Option`-like
-/// API, so there is no `None` to forward:
-///
-/// ```compile_fail
-/// use carina_core::effect::WaitTarget;
-/// let t = WaitTarget::ResolvedAtApply;
-/// // Was: `target_identifier.as_deref()` — `WaitTarget` has no
-/// // `as_deref`, forcing callers through an exhaustive match that
-/// // handles the apply-time resolution explicitly.
-/// let _ = t.as_deref();
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum WaitTarget {
-    /// The target already exists; its identifier was resolved from
-    /// `current_states` at plan time.
-    Known(String),
-    /// The target is created or updated in this same run. The executor
-    /// resolves the real identifier from the just-applied state
-    /// (`applied_states`) before polling; falls back to no identifier
-    /// only when the target was never produced in this plan.
-    ResolvedAtApply,
-}
-
 /// Effect representing an operation on a resource
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Effect {
@@ -255,9 +217,6 @@ pub enum Effect {
         /// Resolved id of the target resource (`wait cert { ... }` →
         /// `cert`'s `ResourceId`).
         target_id: ResourceId,
-        /// How the executor obtains the target's cloud provider
-        /// identifier for its polling `read()`. See [`WaitTarget`].
-        target: WaitTarget,
         /// Typed predicate evaluated against each `read()` snapshot.
         until: WaitPredicate,
         /// Surface form of the `until` expression as the user wrote it
@@ -1001,7 +960,6 @@ mod tests {
         let _ = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1022,7 +980,6 @@ mod tests {
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1044,7 +1001,6 @@ mod tests {
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1067,7 +1023,6 @@ mod tests {
         let original = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1162,7 +1117,6 @@ mod tests {
         let wait = Effect::Wait {
             binding: "w".to_string(),
             target_id: rid.clone(),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: crate::wait::predicate::AttrPath::single("status"),
                 value: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -21,6 +21,7 @@ use crate::resolver::resolve_ref_value;
 use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};
 use crate::value::SecretHashContext;
 
+use super::wait::AppliedStates;
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 
 /// Result of executing a basic effect (Create, Update, or Delete).
@@ -56,7 +57,7 @@ pub(super) enum BasicEffectResult {
 pub(super) struct ExecutionState<'a> {
     pub(super) success_count: &'a mut usize,
     pub(super) failure_count: &'a mut usize,
-    pub(super) applied_states: &'a mut HashMap<ResourceId, State>,
+    pub(super) applied_states: &'a mut AppliedStates,
     pub(super) failed_bindings: &'a mut std::collections::HashSet<String>,
     pub(super) successfully_deleted: &'a mut std::collections::HashSet<ResourceId>,
     pub(super) pending_refreshes: &'a mut HashMap<ResourceId, String>,

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -85,7 +85,7 @@ pub struct ExecutionResult {
     pub success_count: usize,
     pub failure_count: usize,
     pub skip_count: usize,
-    pub applied_states: HashMap<ResourceId, State>,
+    pub applied_states: std::collections::HashMap<ResourceId, State>,
     pub successfully_deleted: HashSet<ResourceId>,
     pub permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>>,
     pub current_states: HashMap<ResourceId, State>,

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -7,10 +7,10 @@ use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use crate::deps::find_failed_dependency;
-use crate::effect::{Effect, WaitTarget};
+use crate::effect::Effect;
 use crate::parser::ResourceRef;
 use crate::provider::Provider;
-use crate::resource::{Resource, ResourceId, State, Value};
+use crate::resource::{Resource, ResourceId, Value};
 
 use super::basic::{
     BasicEffectCtx, ExecutionState, RenormalizePipeline, count_actionable_effects,
@@ -18,8 +18,9 @@ use super::basic::{
 };
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
 use super::wait::{
-    SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome, WaitSignal,
-    count_effectively_undispatched, unsatisfiable_reason_message, wait_failure_message,
+    AppliedStates, SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
+    WaitSignal, count_effectively_undispatched, resolve_wait_identifier,
+    unsatisfiable_reason_message, wait_failure_message,
 };
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
 
@@ -548,7 +549,7 @@ pub(super) async fn execute_effects_sequential(
     let mut success_count = 0;
     let mut failure_count = 0;
     let mut skip_count = 0;
-    let mut applied_states: HashMap<ResourceId, State> = HashMap::new();
+    let (mut applied_states, wait_identifiers) = AppliedStates::with_initial(&input.current_states);
     let mut failed_bindings: HashSet<String> = HashSet::new();
     let mut successfully_deleted: HashSet<ResourceId> = HashSet::new();
     let mut permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>> = HashMap::new();
@@ -678,29 +679,9 @@ pub(super) async fn execute_effects_sequential(
                 continue;
             }
 
-            // Snapshot bindings for this effect's resolution
+            // Snapshot bindings for this effect's resolution.
             let binding_snapshot = input.bindings.clone();
-            // Resolve the wait target's identifier *now*, before the
-            // dispatch closure: a target created in this same run has no
-            // plan-time identifier (`WaitTarget::ResolvedAtApply`), so
-            // we read it from the just-completed effect's state held in
-            // `applied_states`. The scheduler guarantees the producing
-            // Create/Update/Replace ran before this Wait is dispatched
-            // (see the Wait-dependency edges above), so the entry is
-            // present. Falls back to no identifier only when the target
-            // was never produced in this plan (refresh-only apply).
-            // carina#3119.
-            let wait_identifier: Option<String> = match effect {
-                Effect::Wait {
-                    target_id, target, ..
-                } => match target {
-                    WaitTarget::Known(id) => Some(id.clone()),
-                    WaitTarget::ResolvedAtApply => applied_states
-                        .get(target_id)
-                        .and_then(|s| s.identifier.clone()),
-                },
-                _ => None,
-            };
+            let wait_identifiers = wait_identifiers.clone();
             let unresolved = &input.unresolved_resources;
             let pipeline = RenormalizePipeline {
                 normalizer: input.normalizer,
@@ -799,10 +780,13 @@ pub(super) async fn execute_effects_sequential(
                                 completed: c,
                                 total,
                             };
+                            let identifier_resolver = |target_id: &ResourceId| {
+                                resolve_wait_identifier(&wait_identifiers, target_id)
+                            };
                             let outcome = super::wait::execute_wait_effect(
                                 provider,
                                 target_id,
-                                wait_identifier.as_deref(),
+                                &identifier_resolver,
                                 until,
                                 *timeout,
                                 *interval,
@@ -1025,7 +1009,6 @@ pub(super) async fn execute_effects_sequential(
                 }
             },
         }
-
         in_flight
             .check_terminal(count_undispatched(&dispatched, &failed_bindings))
             .cancel_if_terminal()
@@ -1044,7 +1027,7 @@ pub(super) async fn execute_effects_sequential(
         success_count,
         failure_count,
         skip_count,
-        applied_states,
+        applied_states: applied_states.into_inner(),
         successfully_deleted,
         permanent_name_overrides,
         current_states: input.current_states.clone(),
@@ -1063,7 +1046,7 @@ mod tests {
         BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
         ReadRequest, UpdateRequest,
     };
-    use crate::resource::{Composition, ConcreteValue, DataSource, Value};
+    use crate::resource::{Composition, ConcreteValue, DataSource, State, Value};
     use crate::schema::SchemaRegistry;
     use crate::wait::predicate::{AttrPath, WaitPredicate};
     use std::collections::BTreeSet;
@@ -1287,7 +1270,6 @@ mod tests {
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: cert_id.clone(),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1382,7 +1364,6 @@ mod tests {
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: cert_id.clone(),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -8,7 +8,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use tokio_util::sync::CancellationToken;
 
 use crate::deps::{find_failed_dependency, get_resource_dependencies};
-use crate::effect::{Effect, WaitTarget};
+use crate::effect::Effect;
 use crate::provider::{CreateRequest, DeleteRequest, Provider, UpdateRequest};
 use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
@@ -19,8 +19,9 @@ use super::basic::{
 };
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::wait::{
-    SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
-    count_effectively_undispatched, unsatisfiable_reason_message, wait_failure_message,
+    AppliedStates, SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
+    count_effectively_undispatched, resolve_wait_identifier, unsatisfiable_reason_message,
+    wait_failure_message,
 };
 use super::{
     ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo,
@@ -165,6 +166,10 @@ pub(super) fn topological_sort_replaces(
 ///
 /// Only considers dependencies between effects in the given subset. Dependencies
 /// on effects outside the subset are ignored (assumed already completed).
+/// When `include_wait_target_edges` is true, Wait effects also depend on the
+/// same-phase effect that produces their target. Phase 5 passes false because
+/// its waits target Replace effects that have already completed by strict phase
+/// ordering; there is intentionally no fictional cross-phase dep edge.
 ///
 /// `Virtual` resources (the synthetic bindings module calls expose for their
 /// `attributes { }` block) have no Effect and would be invisible to a direct
@@ -177,6 +182,7 @@ pub(super) fn build_phase_dependency_map(
     phase_indices: &[usize],
     unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
     compositions: &[crate::resource::Composition],
+    include_wait_target_edges: bool,
 ) -> HashMap<usize, HashSet<usize>> {
     // Build binding -> effect index mapping for effects in this phase
     let phase_set: HashSet<usize> = phase_indices.iter().copied().collect();
@@ -193,11 +199,22 @@ pub(super) fn build_phase_dependency_map(
     for &idx in phase_indices {
         let mut dep_indices = HashSet::new();
         let effect = &effects[idx];
-        if effect.as_resource_ref().is_some() {
-            resolver.collect_from_effect(effect, &mut dep_indices);
-            if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
-                resolver.collect_from_resource(unresolved.as_resource(), &mut dep_indices);
+        match effect {
+            Effect::Wait { target_id, .. } => {
+                resolver.collect_from_effect(effect, &mut dep_indices);
+                if include_wait_target_edges
+                    && let Some(target_idx) = binding_to_idx.get(target_id.name_str())
+                {
+                    dep_indices.insert(*target_idx);
+                }
             }
+            _ if effect.as_resource_ref().is_some() => {
+                resolver.collect_from_effect(effect, &mut dep_indices);
+                if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
+                    resolver.collect_from_resource(unresolved.as_resource(), &mut dep_indices);
+                }
+            }
+            _ => {}
         }
         deps_of.insert(idx, dep_indices);
     }
@@ -262,9 +279,21 @@ impl<'a> DepResolver<'a> {
     /// the `ResourceLike` value-ref + `dependency_bindings` view and the
     /// effect's explicit `depends_on` edges — the same set
     /// `get_resource_dependencies` computes for a managed resource.
-    /// State-only / `Wait` effects have no resource and contribute
-    /// nothing.
+    /// State-only effects have no resource and contribute nothing. Wait
+    /// effects contribute their explicit `depends_on` edges here; any
+    /// same-phase target-producer edge is owned by `build_phase_dependency_map`.
+    /// Phase 5 waits do not need such an edge because their Replace targets
+    /// completed in an earlier phase by construction.
     pub(super) fn collect_from_effect(&self, effect: &Effect, out: &mut HashSet<usize>) {
+        if let Effect::Wait { .. } = effect {
+            let dep_bindings = effect.explicit_dependencies();
+            let mut visited: HashSet<&str> = HashSet::new();
+            for binding in &dep_bindings {
+                self.expand(binding.as_str(), out, &mut visited);
+            }
+            return;
+        }
+
         let Some(resource) = effect.as_resource_ref() else {
             return;
         };
@@ -392,7 +421,7 @@ pub(super) async fn execute_effects_phased(
     let mut success_count = 0;
     let mut failure_count = 0;
     let mut skip_count = 0;
-    let mut applied_states: HashMap<ResourceId, State> = HashMap::new();
+    let (mut applied_states, wait_identifiers) = AppliedStates::with_initial(&input.current_states);
     let mut failed_bindings: HashSet<String> = HashSet::new();
     let mut successfully_deleted: HashSet<ResourceId> = HashSet::new();
     let mut permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>> = HashMap::new();
@@ -404,6 +433,22 @@ pub(super) async fn execute_effects_phased(
     let effects = input.plan.effects();
     let replace_bindings = collect_replace_bindings(effects);
     let sorted_indices = topological_sort_replaces(effects, &replace_bindings);
+    let replaced_ids: HashSet<ResourceId> = effects
+        .iter()
+        .filter_map(|effect| match effect {
+            Effect::Replace { id, .. } => Some(id.clone()),
+            _ => None,
+        })
+        .collect();
+    let post_replace_wait_indices: Vec<usize> = effects
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, effect)| match effect {
+            Effect::Wait { target_id, .. } if replaced_ids.contains(target_id) => Some(idx),
+            _ => None,
+        })
+        .collect();
+    let post_replace_wait_set: HashSet<usize> = post_replace_wait_indices.iter().copied().collect();
     let mut cancelled = false;
 
     // -----------------------------------------------------------------------
@@ -411,7 +456,10 @@ pub(super) async fn execute_effects_phased(
     // -----------------------------------------------------------------------
     {
         let phase1_indices: Vec<usize> = (0..effects.len())
-            .filter(|&idx| !matches!(&effects[idx], Effect::Replace { .. } | Effect::Read { .. }))
+            .filter(|&idx| {
+                !matches!(&effects[idx], Effect::Replace { .. } | Effect::Read { .. })
+                    && !post_replace_wait_set.contains(&idx)
+            })
             .collect();
 
         let deps_of = build_phase_dependency_map(
@@ -419,6 +467,7 @@ pub(super) async fn execute_effects_phased(
             &phase1_indices,
             input.unresolved_resources,
             input.compositions,
+            true,
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
@@ -482,18 +531,6 @@ pub(super) async fn execute_effects_phased(
                     continue;
                 }
 
-                let wait_identifier: Option<String> = match effect {
-                    Effect::Wait {
-                        target_id, target, ..
-                    } => match target {
-                        WaitTarget::Known(id) => Some(id.clone()),
-                        WaitTarget::ResolvedAtApply => applied_states
-                            .get(target_id)
-                            .and_then(|state| state.identifier.clone()),
-                    },
-                    _ => None,
-                };
-
                 if let Effect::Wait {
                     binding,
                     target_id,
@@ -508,14 +545,18 @@ pub(super) async fn execute_effects_phased(
                         completed: c,
                         total,
                     };
+                    let wait_identifiers = wait_identifiers.clone();
                     in_flight.push_wait(idx, |cancel_rx| {
                         Box::pin(async move {
                             let started = Instant::now();
                             observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                            let identifier_resolver = |target_id: &ResourceId| {
+                                resolve_wait_identifier(&wait_identifiers, target_id)
+                            };
                             let outcome = super::wait::execute_wait_effect(
                                 provider,
                                 target_id,
-                                wait_identifier.as_deref(),
+                                &identifier_resolver,
                                 until,
                                 *timeout,
                                 *interval,
@@ -721,7 +762,6 @@ pub(super) async fn execute_effects_phased(
                 },
                 _ => unreachable!(),
             }
-
             in_flight
                 .check_terminal(count_undispatched(&dispatched, &failed_bindings))
                 .cancel_if_terminal()
@@ -769,6 +809,7 @@ pub(super) async fn execute_effects_phased(
             &cbd_indices,
             input.unresolved_resources,
             input.compositions,
+            true,
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
@@ -1327,6 +1368,7 @@ pub(super) async fn execute_effects_phased(
             &phase4_indices,
             input.unresolved_resources,
             input.compositions,
+            true,
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
@@ -1677,6 +1719,248 @@ pub(super) async fn execute_effects_phased(
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Phase 5: Waits whose targets were replaced in this phased run
+    // -----------------------------------------------------------------------
+    if !cancelled && !post_replace_wait_indices.is_empty() {
+        let deps_of = build_phase_dependency_map(
+            effects,
+            &post_replace_wait_indices,
+            input.unresolved_resources,
+            input.compositions,
+            false,
+        );
+        let mut completed_indices: HashSet<usize> = HashSet::new();
+        let mut dispatched: HashSet<usize> = HashSet::new();
+        let mut in_flight: WaitAwareInFlight<'_, PhaseEffectResult> = WaitAwareInFlight::new();
+
+        loop {
+            let mut newly_ready: Vec<usize> = Vec::new();
+            if !cancelled {
+                for &idx in &post_replace_wait_indices {
+                    if dispatched.contains(&idx) {
+                        continue;
+                    }
+                    let deps = deps_of.get(&idx).cloned().unwrap_or_default();
+                    if deps.iter().all(|d| completed_indices.contains(d)) {
+                        newly_ready.push(idx);
+                    } else {
+                        let pending: Vec<String> = deps
+                            .iter()
+                            .filter(|d| !completed_indices.contains(d))
+                            .map(|d| effects[*d].resource_id().to_string())
+                            .collect();
+                        observer.on_event(&ExecutionEvent::Waiting {
+                            effect: &effects[idx],
+                            pending_dependencies: pending,
+                        });
+                    }
+                }
+                newly_ready.sort();
+            }
+
+            for idx in newly_ready {
+                dispatched.insert(idx);
+                let effect = &effects[idx];
+
+                if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
+                    let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                    let detail =
+                        unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
+                            binding: failed_dep,
+                        });
+                    let reason = format!("unsatisfiable: {detail}");
+                    observer.on_event(&ExecutionEvent::EffectSkipped {
+                        effect,
+                        reason: &reason,
+                        progress: ProgressInfo {
+                            completed: c,
+                            total,
+                        },
+                    });
+                    skip_count += 1;
+                    if let Some(binding) = effect.binding_name() {
+                        failed_bindings.insert(binding);
+                    }
+                    completed_indices.insert(idx);
+                    continue;
+                }
+
+                if let Effect::Wait {
+                    binding,
+                    target_id,
+                    until,
+                    timeout,
+                    interval,
+                    ..
+                } = effect
+                {
+                    let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                    let progress = ProgressInfo {
+                        completed: c,
+                        total,
+                    };
+                    let wait_identifiers = wait_identifiers.clone();
+                    in_flight.push_wait(idx, |cancel_rx| {
+                        Box::pin(async move {
+                            let started = Instant::now();
+                            observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                            let identifier_resolver = |target_id: &ResourceId| {
+                                resolve_wait_identifier(&wait_identifiers, target_id)
+                            };
+                            let outcome = super::wait::execute_wait_effect(
+                                provider,
+                                target_id,
+                                &identifier_resolver,
+                                until,
+                                *timeout,
+                                *interval,
+                                cancel_rx,
+                                observer,
+                            )
+                            .await;
+                            (
+                                idx,
+                                PhaseEffectResult::Wait {
+                                    binding: binding.clone(),
+                                    outcome,
+                                    duration: started.elapsed(),
+                                    progress,
+                                },
+                            )
+                        })
+                    });
+                }
+            }
+
+            let count_undispatched =
+                |dispatched: &HashSet<usize>, failed_bindings: &HashSet<String>| {
+                    count_effectively_undispatched(
+                        &post_replace_wait_indices,
+                        dispatched,
+                        effects,
+                        failed_bindings,
+                    )
+                };
+            in_flight
+                .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                .cancel_if_terminal()
+                .drop_without_awaiting();
+
+            if in_flight.is_empty() {
+                if cancelled {
+                    emit_cancelled_skips_with_progress(
+                        effects,
+                        &post_replace_wait_indices,
+                        &mut dispatched,
+                        &mut completed_indices,
+                        &mut skip_count,
+                        observer,
+                        |_| ProgressInfo {
+                            completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
+                            total,
+                        },
+                    );
+                }
+                break;
+            }
+
+            let (finished_idx, result) = if cancelled {
+                let Some(finished) = in_flight
+                    .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                    .cancel_if_terminal()
+                    .next_completed()
+                    .await
+                else {
+                    break;
+                };
+                finished
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        cancelled = true;
+                        in_flight.signal_in_flight_waits();
+                        continue;
+                    }
+                    finished = in_flight
+                        .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                        .cancel_if_terminal()
+                        .next_completed() => {
+                        let Some(finished) = finished else {
+                            break;
+                        };
+                        finished
+                    }
+                }
+            };
+            completed_indices.insert(finished_idx);
+
+            match result {
+                PhaseEffectResult::Wait {
+                    binding,
+                    outcome,
+                    duration,
+                    progress,
+                } => match outcome {
+                    WaitOutcome::Satisfied { state } => {
+                        observer.on_event(&ExecutionEvent::EffectSucceeded {
+                            effect: &effects[finished_idx],
+                            state: Some(&state),
+                            duration,
+                            progress,
+                        });
+                        success_count += 1;
+                        let synthetic = ResourceId::new("__wait", &binding);
+                        let attrs: HashMap<String, Value> = state
+                            .attributes
+                            .iter()
+                            .map(|(key, value)| (key.clone(), value.clone()))
+                            .collect();
+                        input
+                            .bindings
+                            .record_applied(Some(&binding), &attrs, &state);
+                        applied_states.insert(synthetic, state);
+                    }
+                    WaitOutcome::Unsatisfiable(reason) => {
+                        let detail = unsatisfiable_reason_message(&reason);
+                        let reason = format!("unsatisfiable: {detail}");
+                        observer.on_event(&ExecutionEvent::EffectSkipped {
+                            effect: &effects[finished_idx],
+                            reason: &reason,
+                            progress,
+                        });
+                        skip_count += 1;
+                        failed_bindings.insert(binding);
+                    }
+                    WaitOutcome::Cancelled => {
+                        observer.on_event(&ExecutionEvent::EffectSkipped {
+                            effect: &effects[finished_idx],
+                            reason: SKIP_REASON_CANCELLED,
+                            progress,
+                        });
+                        skip_count += 1;
+                    }
+                    outcome @ (WaitOutcome::Timeout { .. }
+                    | WaitOutcome::NotFound(_)
+                    | WaitOutcome::ReadFailed(_)) => {
+                        let error =
+                            wait_failure_message(&outcome, effects[finished_idx].resource_id());
+                        observer.on_event(&ExecutionEvent::EffectFailed {
+                            effect: &effects[finished_idx],
+                            error: &error,
+                            duration,
+                            progress,
+                        });
+                        failure_count += 1;
+                        failed_bindings.insert(binding);
+                    }
+                },
+                _ => unreachable!(),
+            }
+        }
+    }
+
     // Preserve CBD create states for any temporary that was created in Phase 2
     // but did not complete finalize. Phase 4 removes finalized indices from
     // cbd_create_states, so anything remaining here is genuinely unprocessed.
@@ -1703,7 +1987,7 @@ pub(super) async fn execute_effects_phased(
         success_count,
         failure_count,
         skip_count,
-        applied_states,
+        applied_states: applied_states.into_inner(),
         successfully_deleted,
         permanent_name_overrides,
         current_states: input.current_states.clone(),
@@ -1914,7 +2198,6 @@ mod tests {
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: cert_id.clone(),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -2013,7 +2296,6 @@ mod tests {
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: cert_id.clone(),
-            target: WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -2041,7 +2323,8 @@ mod tests {
             ),
         ]);
         let phase1_indices: Vec<usize> = (0..plan.effects().len()).collect();
-        let deps = build_phase_dependency_map(plan.effects(), &phase1_indices, &unresolved, &[]);
+        let deps =
+            build_phase_dependency_map(plan.effects(), &phase1_indices, &unresolved, &[], true);
         assert!(
             deps.get(&3).is_some_and(|listener_deps| {
                 listener_deps.contains(&1) && listener_deps.contains(&2)
@@ -2129,7 +2412,8 @@ mod tests {
             UnresolvedResource::from_pre_resolve(role_policy.clone()),
         );
 
-        let deps_of = build_phase_dependency_map(&effects, &phase_indices, &unresolved, &[virt]);
+        let deps_of =
+            build_phase_dependency_map(&effects, &phase_indices, &unresolved, &[virt], true);
 
         assert!(
             deps_of[&1].contains(&0),
@@ -2176,6 +2460,7 @@ mod tests {
             &phase_indices,
             &unresolved,
             &[inner_virt, outer_virt],
+            true,
         );
 
         assert!(

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -586,7 +586,7 @@ fn empty_execution_result() -> ExecutionResult {
         success_count: 0,
         failure_count: 0,
         skip_count: 0,
-        applied_states: HashMap::new(),
+        applied_states: Default::default(),
         successfully_deleted: HashSet::new(),
         permanent_name_overrides: HashMap::new(),
         current_states: HashMap::new(),
@@ -1210,7 +1210,6 @@ async fn execute_plan_cancels_in_flight_wait_effect_promptly() {
     plan.add(Effect::Wait {
         binding: "cert_ready".to_string(),
         target_id: cert_id,
-        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("READY".to_string())),
@@ -1279,7 +1278,6 @@ async fn execute_plan_cancelled_wait_emits_cancelled_skip_not_unsatisfiable() {
     plan.add(Effect::Wait {
         binding: "cert_ready".to_string(),
         target_id: cert_id,
-        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("READY".to_string())),
@@ -4248,7 +4246,6 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
         target_id: cert_id.clone(),
-        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -4401,7 +4398,6 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
         target_id: cert_id.clone(),
-        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -4503,7 +4499,6 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
         target_id: cert_id.clone(),
-        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -4983,7 +4978,7 @@ impl Provider for IdentifierAwareProvider {
         _identifier: &str,
         _request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
-        Box::pin(async move { Err(ProviderError::api_error("delete not expected")) })
+        Box::pin(async move { Ok(()) })
     }
 
     fn required_permissions(&self, _id: &ResourceId, _op: crate::effect::PlanOp) -> Vec<String> {
@@ -4992,9 +4987,7 @@ impl Provider for IdentifierAwareProvider {
 }
 
 /// Regression for carina#3119: a resource created *in the same apply run*
-/// has no plan-time identifier, so the differ emits
-/// `WaitTarget::ResolvedAtApply` on `Effect::Wait`. The executor must
-/// resolve the real identifier from the just-completed Create's state
+/// must be polled with the identifier from the just-completed Create's state
 /// (held in `applied_states`), not poll `provider.read` with no
 /// identifier.
 ///
@@ -5026,9 +5019,6 @@ async fn wait_resolves_target_identifier_from_just_created_state() {
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
         target_id: cert_id.clone(),
-        // The differ emits `ResolvedAtApply` because the cert does not
-        // exist at plan time (created in this same run).
-        target: crate::effect::WaitTarget::ResolvedAtApply,
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("issued".to_string())),
@@ -5072,6 +5062,222 @@ async fn wait_resolves_target_identifier_from_just_created_state() {
         "the wait read must be called with the created identifier \
          resolved from applied_states, not the plan-time None; got: {:?}",
         provider.read_identifiers()
+    );
+}
+
+/// Regression for carina#3553: when a wait target is replaced in the same
+/// apply run, the wait must poll the post-replace identifier from the
+/// replacement state, not the pre-replace identifier snapshotted in the plan.
+#[tokio::test]
+async fn wait_resolves_target_identifier_from_just_replaced_state() {
+    use crate::effect::ChangedCreateOnly;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let mut cert = Resource::new("test", "cert");
+    cert.binding = Some("cert".to_string());
+    let cert_id = cert.id.clone();
+    cert.set_attr(
+        "domain_name",
+        Value::Concrete(ConcreteValue::String("new.example.com".to_string())),
+    );
+
+    let old_state = State::existing(
+        cert_id.clone(),
+        HashMap::from([(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        )]),
+    )
+    .with_identifier("old-arn");
+
+    let new_state = State::existing(
+        cert_id.clone(),
+        HashMap::from([(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("issued".to_string())),
+        )]),
+    )
+    .with_identifier("new-arn");
+
+    let provider = IdentifierAwareProvider::new("new-arn", new_state);
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: cert_id.clone(),
+        from: Box::new(old_state.clone()),
+        to: cert,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Wait {
+        binding: "cert_issued".to_string(),
+        target_id: cert_id.clone(),
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        until_surface: "cert.status == \"issued\"".to_string(),
+        timeout: std::time::Duration::from_secs(5),
+        interval: std::time::Duration::from_millis(10),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([(cert_id.clone(), old_state)]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+    let read_identifiers = provider.read_identifiers();
+
+    assert!(
+        !read_identifiers
+            .iter()
+            .any(|identifier| identifier.as_deref() == Some("old-arn")),
+        "wait polled stale pre-replace identifier old-arn; read identifiers seen: {read_identifiers:?}"
+    );
+    assert_eq!(
+        result.failure_count, 0,
+        "wait must use the replacement identifier; read identifiers seen: {read_identifiers:?}"
+    );
+    assert_eq!(result.success_count, 2, "Replace and Wait must succeed");
+    assert!(
+        read_identifiers
+            .iter()
+            .any(|identifier| identifier.as_deref() == Some("new-arn")),
+        "wait read must use the replacement identifier from applied_states; got: {read_identifiers:?}"
+    );
+}
+
+/// Regression for carina#3553 in the phased executor: interdependent
+/// replacements force phased execution, and a wait targeting one of
+/// those replacements must not run before the replacement publishes its
+/// new identifier.
+#[tokio::test]
+async fn wait_resolves_target_identifier_from_just_replaced_state_phased() {
+    use crate::effect::ChangedCreateOnly;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let mut cert = Resource::new("test", "cert");
+    cert.binding = Some("cert".to_string());
+    let cert_id = cert.id.clone();
+    cert.set_attr(
+        "domain_name",
+        Value::Concrete(ConcreteValue::String("new.example.com".to_string())),
+    );
+
+    let mut dep = Resource::new("test", "dep");
+    dep.binding = Some("dep".to_string());
+    dep.dependency_bindings.insert("cert".to_string());
+    let dep_id = dep.id.clone();
+
+    let old_cert_state = State::existing(
+        cert_id.clone(),
+        HashMap::from([(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        )]),
+    )
+    .with_identifier("old-arn");
+    let new_cert_state = State::existing(
+        cert_id.clone(),
+        HashMap::from([(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("issued".to_string())),
+        )]),
+    )
+    .with_identifier("new-arn");
+    let old_dep_state = State::existing(dep_id.clone(), HashMap::new()).with_identifier("dep-old");
+
+    let provider = IdentifierAwareProvider::new("new-arn", new_cert_state);
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: cert_id.clone(),
+        from: Box::new(old_cert_state.clone()),
+        to: cert,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Replace {
+        id: dep_id.clone(),
+        from: Box::new(old_dep_state.clone()),
+        to: dep,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Wait {
+        binding: "cert_issued".to_string(),
+        target_id: cert_id.clone(),
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        until_surface: "cert.status == \"issued\"".to_string(),
+        timeout: std::time::Duration::from_secs(5),
+        interval: std::time::Duration::from_millis(10),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+    assert!(
+        has_interdependent_replaces(plan.effects()),
+        "test must exercise phased execution"
+    );
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([
+            (cert_id.clone(), old_cert_state),
+            (dep_id.clone(), old_dep_state),
+        ]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+    let read_identifiers = provider.read_identifiers();
+
+    assert!(
+        !read_identifiers
+            .iter()
+            .any(|identifier| identifier.as_deref() == Some("old-arn")),
+        "phased wait polled stale pre-replace identifier old-arn; read identifiers seen: {read_identifiers:?}"
+    );
+    assert_eq!(
+        result.failure_count, 0,
+        "phased wait must use the replacement identifier; read identifiers seen: {read_identifiers:?}"
+    );
+    assert!(
+        read_identifiers
+            .iter()
+            .any(|identifier| identifier.as_deref() == Some("new-arn")),
+        "phased wait read must use the replacement identifier from applied_states; got: {read_identifiers:?}"
     );
 }
 

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -10,6 +10,7 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -22,6 +23,61 @@ use crate::resource::{ResourceId, State, Value};
 use crate::value::format_value_user_facing;
 use crate::wait::WaitObservation;
 use crate::wait::predicate::WaitPredicate;
+
+pub(crate) type WaitIdentifierResolver<'a> =
+    dyn Fn(&ResourceId) -> Option<String> + Send + Sync + 'a;
+pub(crate) type SharedWaitIdentifiers = Arc<Mutex<HashMap<ResourceId, Option<String>>>>;
+
+fn initial_wait_identifiers(current_states: &HashMap<ResourceId, State>) -> SharedWaitIdentifiers {
+    Arc::new(Mutex::new(
+        current_states
+            .iter()
+            .map(|(id, state)| (id.clone(), state.identifier.clone()))
+            .collect(),
+    ))
+}
+
+pub(crate) fn resolve_wait_identifier(
+    shared: &SharedWaitIdentifiers,
+    target_id: &ResourceId,
+) -> Option<String> {
+    shared
+        .lock()
+        .expect("wait identifier map poisoned")
+        .get(target_id)
+        .cloned()
+        .flatten()
+}
+
+pub(crate) struct AppliedStates {
+    states: HashMap<ResourceId, State>,
+    wait_identifiers: SharedWaitIdentifiers,
+}
+
+impl AppliedStates {
+    pub(crate) fn with_initial(
+        current_states: &HashMap<ResourceId, State>,
+    ) -> (Self, SharedWaitIdentifiers) {
+        let shared = initial_wait_identifiers(current_states);
+        let applied_states = Self {
+            states: HashMap::new(),
+            wait_identifiers: shared.clone(),
+        };
+        (applied_states, shared)
+    }
+
+    pub(crate) fn insert(&mut self, id: ResourceId, state: State) {
+        self.wait_identifiers
+            .lock()
+            .expect("wait identifier map poisoned")
+            .insert(id.clone(), state.identifier.clone());
+        self.states.insert(id, state);
+    }
+
+    pub(crate) fn into_inner(self) -> HashMap<ResourceId, State> {
+        self.states
+    }
+}
 
 /// Outcome of polling a Wait effect. The variants distinguish:
 /// - `Satisfied`: the wait condition was met; carries the resource state.
@@ -306,7 +362,7 @@ impl<'a, 'fut, R> NextReady<'a, 'fut, R> {
 pub async fn execute_wait_effect(
     provider: &dyn Provider,
     target_id: &ResourceId,
-    target_identifier: Option<&str>,
+    identifier_resolver: &WaitIdentifierResolver<'_>,
     until: &WaitPredicate,
     timeout: Duration,
     interval: Duration,
@@ -317,7 +373,7 @@ pub async fn execute_wait_effect(
         provider,
         target_id.name_str(),
         target_id,
-        target_identifier,
+        identifier_resolver,
         until,
         timeout,
         interval,
@@ -333,7 +389,7 @@ pub(crate) async fn execute_wait_effect_with_heartbeat_gap(
     provider: &dyn Provider,
     binding: &str,
     target_id: &ResourceId,
-    target_identifier: Option<&str>,
+    identifier_resolver: &WaitIdentifierResolver<'_>,
     until: &WaitPredicate,
     timeout: Duration,
     interval: Duration,
@@ -344,8 +400,9 @@ pub(crate) async fn execute_wait_effect_with_heartbeat_gap(
     let start = Instant::now();
     let mut last_heartbeat_at: Option<Instant> = None;
     loop {
+        let target_identifier = identifier_resolver(target_id);
         let state = match provider
-            .read(target_id, target_identifier, ReadRequest)
+            .read(target_id, target_identifier.as_deref(), ReadRequest)
             .await
         {
             Ok(state) => state,
@@ -418,6 +475,10 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::watch;
+
+    fn no_identifier(_: &ResourceId) -> Option<String> {
+        None
+    }
 
     /// Minimal test provider: returns a queue of pre-canned read
     /// responses in order, then repeats the last one. Counts every
@@ -583,7 +644,7 @@ mod tests {
         let result = execute_wait_effect(
             &provider,
             &target,
-            None,
+            &no_identifier,
             &pred,
             Duration::from_secs(60),
             Duration::from_millis(10),
@@ -617,7 +678,7 @@ mod tests {
         let result = execute_wait_effect(
             &provider,
             &target,
-            None,
+            &no_identifier,
             &pred,
             Duration::from_secs(60),
             Duration::from_millis(1),
@@ -642,7 +703,7 @@ mod tests {
         let result = execute_wait_effect(
             &provider,
             &target,
-            None,
+            &no_identifier,
             &pred,
             Duration::from_millis(10),
             Duration::from_millis(2),
@@ -753,7 +814,7 @@ mod tests {
         let result = execute_wait_effect(
             &provider,
             &target,
-            None,
+            &no_identifier,
             &pred,
             Duration::from_secs(60),
             Duration::from_millis(1),
@@ -790,7 +851,7 @@ mod tests {
             execute_wait_effect(
                 &provider,
                 &target,
-                None,
+                &no_identifier,
                 &pred,
                 Duration::from_secs(60),
                 Duration::from_millis(1),
@@ -825,7 +886,7 @@ mod tests {
             &provider,
             "cert_issued",
             &target,
-            None,
+            &no_identifier,
             &pred,
             Duration::from_millis(100),
             Duration::from_millis(1),

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -508,7 +508,6 @@ mod tests {
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target: crate::effect::WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -535,7 +534,6 @@ mod tests {
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
-            target: crate::effect::WaitTarget::ResolvedAtApply,
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),


### PR DESCRIPTION
## Summary

Closes #3553.

`Effect::Wait` baked its target's identifier into the plan via `WaitTarget::Known(String)`. When the target was Replaced in the same apply run, the wait kept polling the pre-Replace identifier and failed with `Could not find <old-arn>` — the new resource was never observed.

This PR removes the snapshot mechanism from the type system rather than patching it at the consumer sites. The wait poller now resolves the target identifier on every iteration, so a Replace landing mid-run is seen by the next poll. The two schedulers (parallel/sequential and phased) both go through the same seam.

## Approach — both root-cause and type-safety lenses

Per the project's "make the broken state unrepresentable" rule, the same upstream change satisfies both lenses uniquely; I did not consult the user because the three lenses (long-term / type-safety / root-cause) all selected the same option.

- **Delete `WaitTarget` enum entirely.** `Effect::Wait` carries only `target_id: ResourceId`. Nothing in the plan can freeze an identifier.
- **Resolve per-poll.** The wait poller takes a resolver closure backed by `Arc<Mutex<HashMap<ResourceId, Option<String>>>>`. Every iteration reads the freshest identifier the executor has observed.
- **`AppliedStates` newtype with write-through `insert`.** Wrapping `applied_states` so every `insert` updates the shared `wait_identifiers` map in lockstep removes the previous draft's six separate ``sync_wait_identifiers`` call sites — a new caller adding an insertion site cannot forget to sync because there is no separate ``sync`` to forget.
- **`AppliedStates::with_initial(current_states) -> (Self, SharedWaitIdentifiers)`** mints the wrapper and the resolver handle together. A future executor cannot route inserts to one Arc while the resolver reads from another.

## Phased scheduler — same fix, extra wiring

The phased executor was dispatching ``Effect::Wait`` in Phase 1 with no edge to the target's mutator. When the target was a Replace (Phase 2–4), the wait drained to NotFound/Timeout before the Replace ran. Two additions:

- **Wait→target-producer dep edge** in `build_phase_dependency_map` so the wait waits for its Create/Update/Replace.
- **Phase 5 carve-out**: a Wait whose ``target_id`` is in ``Effect::Replace`` is deferred to a new post-Phase-4 phase, so Phase 4's ``AppliedStates::insert`` has already published the new identifier when the wait first polls.

`build_phase_dependency_map` now takes `include_wait_target_edges: bool` so the Phase 5 invocation explicitly opts out of the same-phase edge (the producing Replace is in a prior phase, not in Phase 5's index set).

## Test coverage

Three executor tests using ``IdentifierAwareProvider`` (a mock provider that fails read when called with the wrong identifier and records every identifier it sees):

- ``wait_resolves_target_identifier_from_just_replaced_state`` — sequential path, the exact shape of the issue's reproduction (one Replace + one Wait).
- ``wait_resolves_target_identifier_from_just_replaced_state_phased`` — asserts ``has_interdependent_replaces`` at runtime so the test is pinned to the phased path; covers two interdependent Replaces + Wait.
- ``wait_resolves_target_identifier_from_just_created_state`` (pre-existing) still passes via the new ``AppliedStates`` write-through.

## Out of scope — follow-up filed

``find_failed_dependency`` for ``Effect::Wait`` inspects only ``explicit_dependencies``; it does not check the wait's implicit ``target_id`` binding. When a Replace fails, the dependent Wait is dispatched anyway and surfaces ``NotFound`` instead of ``unsatisfiable: dependency 'cert' failed``. This is a different broken invariant (failure propagation vs identifier resolution), exists today in both schedulers on ``main``, and is tracked as #3556.

## Test plan

- [x] `cargo nextest run --workspace` — 4227 passed, 72 skipped.
- [x] `cargo test --workspace --doc` — passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all green.
- [x] `cargo fmt --all --check` — clean.
- [x] `rg WaitTarget` across workspace — 0 matches.
- [x] `rg "sync_wait_identifiers"` — 0 matches (helper deleted, write-through took its place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)