### PR TITLE
fix(parser): record iterable binding as dep on deferred-for children

### DIFF
--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -1316,11 +1316,8 @@ impl<E> File<E> {
                 (ForBinding::Simple(_), Value::Concrete(ConcreteValue::List(items))) => {
                     for (i, item) in items.iter().enumerate() {
                         let address = format!("{}[{}]", deferred.binding_name, i);
-                        let mut resource = deferred.template_resource.clone();
-                        resource.id.set_name(address.clone());
-                        resource.binding = Some(address);
-                        substitute_attrs(&mut resource, None, None, item);
-                        expanded_resources.push(resource);
+                        expanded_resources
+                            .push(build_expanded_child(deferred, address, None, None, item));
                     }
                     resolved_indices.push(idx);
                 }
@@ -1328,11 +1325,13 @@ impl<E> File<E> {
                 (ForBinding::Indexed(_, _), Value::Concrete(ConcreteValue::List(items))) => {
                     for (i, item) in items.iter().enumerate() {
                         let address = format!("{}[{}]", deferred.binding_name, i);
-                        let mut resource = deferred.template_resource.clone();
-                        resource.id.set_name(address.clone());
-                        resource.binding = Some(address);
-                        substitute_attrs(&mut resource, Some(i as i64), None, item);
-                        expanded_resources.push(resource);
+                        expanded_resources.push(build_expanded_child(
+                            deferred,
+                            address,
+                            Some(i as i64),
+                            None,
+                            item,
+                        ));
                     }
                     resolved_indices.push(idx);
                 }
@@ -1343,11 +1342,13 @@ impl<E> File<E> {
                     for key in keys {
                         let val = &map[key];
                         let address = crate::utils::map_key_address(&deferred.binding_name, key);
-                        let mut resource = deferred.template_resource.clone();
-                        resource.id.set_name(address.clone());
-                        resource.binding = Some(address);
-                        substitute_attrs(&mut resource, None, Some(key), val);
-                        expanded_resources.push(resource);
+                        expanded_resources.push(build_expanded_child(
+                            deferred,
+                            address,
+                            None,
+                            Some(key),
+                            val,
+                        ));
                     }
                     resolved_indices.push(idx);
                 }
@@ -1408,6 +1409,23 @@ impl<E> File<E> {
         self.resources.extend(expanded_resources);
         self.warnings.extend(new_warnings);
     }
+}
+
+fn build_expanded_child(
+    deferred: &DeferredForExpression,
+    address: String,
+    index: Option<i64>,
+    key: Option<&str>,
+    item: &Value,
+) -> Resource {
+    let mut resource = deferred.template_resource.clone();
+    resource.id.set_name(address.clone());
+    resource.binding = Some(address);
+    resource
+        .dependency_bindings
+        .insert(deferred.iterable_binding.clone());
+    substitute_attrs(&mut resource, index, key, item);
+    resource
 }
 
 /// Run `substitute_placeholder` over every attribute of `resource`, then

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
-use crate::binding_index::IterableBindings;
+use crate::binding_index::{IterableBindings, PreApplyInputs, ResolvedBindings};
+use crate::resolver::resolve_refs_for_plan;
 use crate::resource::{ConcreteValue, DeferredValue, InterpolationPart, Resource, Value};
 use crate::schema::TypeIdentity;
 use indexmap::IndexMap;
@@ -8026,6 +8027,132 @@ fn expand_deferred_for_indexed_binding_substitutes_index_and_value() {
     assert_eq!(
         parsed.resources[1].get_attr("position"),
         Some(&Value::Concrete(ConcreteValue::Int(1)))
+    );
+}
+
+#[test]
+fn expand_deferred_for_children_depend_on_iterable_binding_for_all_binding_shapes() {
+    let input = r#"
+        let orgs = upstream_state {
+            source = "../organizations"
+        }
+
+        for account_id in orgs.accounts {
+            awscc.sso.Assignment {
+                target_id = account_id
+            }
+        }
+
+        for (i, account_id) in orgs.accounts {
+            awscc.sso.Assignment {
+                target_id = account_id
+                position = i
+            }
+        }
+
+        for name, account_id in orgs.named_accounts {
+            awscc.sso.Assignment {
+                target_id = account_id
+                target_name = name
+            }
+        }
+    "#;
+
+    let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(parsed.deferred_for_expressions.len(), 3);
+
+    let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+    let mut orgs_attrs = HashMap::new();
+    orgs_attrs.insert(
+        "accounts".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("111111111111".to_string()),
+        )])),
+    );
+    let mut named_accounts: IndexMap<String, Value> = IndexMap::new();
+    named_accounts.insert(
+        "prod".to_string(),
+        Value::Concrete(ConcreteValue::String("222222222222".to_string())),
+    );
+    orgs_attrs.insert(
+        "named_accounts".to_string(),
+        Value::Concrete(ConcreteValue::Map(named_accounts)),
+    );
+    remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(remote_bindings));
+
+    assert_eq!(parsed.deferred_for_expressions.len(), 0);
+    assert_eq!(parsed.resources.len(), 3); // allow: direct — fixture test inspection
+    for resource in &parsed.resources {
+        assert!(
+            resource.dependency_bindings.contains("orgs"),
+            "expanded deferred-for child {} should depend on iterable binding `orgs`, got {:?}",
+            resource.id,
+            resource.dependency_bindings
+        );
+    }
+}
+
+/// Guards carina#3554 against a future refactor of
+/// `get_resource_value_ref_dependencies` that drops the union with existing
+/// `dependency_bindings`.
+#[test]
+fn expand_deferred_for_dependency_binding_survives_resolve() {
+    let input = r#"
+        let orgs = upstream_state {
+            source = "../organizations"
+        }
+
+        for account_id in orgs.accounts {
+            awscc.sso.Assignment {
+                target_id = account_id
+                anchor_id = anchor.target_id
+            }
+        }
+    "#;
+
+    let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(parsed.deferred_for_expressions.len(), 1);
+
+    let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+    let mut orgs_attrs = HashMap::new();
+    orgs_attrs.insert(
+        "accounts".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("111111111111".to_string()),
+        )])),
+    );
+    remote_bindings.insert("orgs".to_string(), orgs_attrs);
+    let mut anchor_attrs = HashMap::new();
+    anchor_attrs.insert(
+        "target_id".to_string(),
+        Value::Concrete(ConcreteValue::String("anchor".to_string())),
+    );
+    remote_bindings.insert("anchor".to_string(), anchor_attrs);
+
+    parsed.expand_deferred_for_expressions(&IterableBindings::from_upstream_only(
+        remote_bindings.clone(),
+    ));
+    assert_eq!(parsed.deferred_for_expressions.len(), 0);
+    assert_eq!(parsed.resources.len(), 1); // allow: direct — fixture test inspection
+
+    let bindings = ResolvedBindings::pre_apply(PreApplyInputs {
+        managed: &parsed.resources,
+        compositions: &parsed.compositions,
+        data_sources: &parsed.data_sources,
+        current_states: &HashMap::new(),
+        remote_bindings: &remote_bindings,
+        wait_aliases: &[],
+    });
+    let upstream_keys: HashSet<&str> = remote_bindings.keys().map(String::as_str).collect();
+    resolve_refs_for_plan(&mut parsed.resources, &bindings, &upstream_keys).unwrap();
+
+    let child = &parsed.resources[0];
+    assert!(
+        child.dependency_bindings.contains("orgs"),
+        "resolve_refs_for_plan must preserve deferred-for iterable dependency binding, got {:?}",
+        child.dependency_bindings
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #3554.

A `for opt in cert.collection { Resource{...} }` block expanded its loop body into children whose `dependency_bindings` were empty. The apply scheduler therefore had no edge from `validation_records[0]` to `cert`, and the child Create dispatched concurrently with the upstream Replace — losing the race against `cert.collection` being populated.

## Root cause

- At parse time `for_expr.rs` parses the body once with placeholder values for the loop variable; the resulting `template_resource.dependency_bindings` is empty.
- `expand_deferred_for_expressions` clones the template and rewrites `opt.X` placeholders to concrete values via `substitute_attrs`, but never touches `dependency_bindings`.
- Downstream `deps::get_resource_dependencies` reads that empty set, so the apply scheduler has no edge from the child to its iterable's producer.

## Fix — single expansion seam

The 3 ForBinding arms (Simple/Indexed/Map) of `expand_deferred_for_expressions` now route through a new `build_expanded_child` helper. The helper inserts `deferred.iterable_binding` into the cloned child's `dependency_bindings` before `substitute_attrs` runs. A new arm cannot expand without going through the helper, so the dep edge is carried by construction rather than by convention.

Three lenses (long-term / type-safety / root-cause) all pointed at this seam uniquely, so per the pick-issue rule I proceeded without asking.

## Test coverage

`carina-core/src/parser/tests.rs` gets two regressions:

- `expand_deferred_for_children_depend_on_iterable_binding_for_all_binding_shapes` (line 8033). Three deferred loops over `orgs.*` (Simple / Indexed / Map). For every expanded child, the test asserts `dependency_bindings.contains("orgs")`.
- `expand_deferred_for_dependency_binding_survives_resolve` (line 8114). End-to-end through `parse → expand → resolve_refs_for_plan`. The fixture body sets `anchor_id = anchor.target_id` so attribute-only deps land as `{anchor}`. If a future refactor of `get_resource_value_ref_dependencies` drops the union with the existing `dependency_bindings`, the resolver's overwrite would yield `{anchor}` — without `orgs` — and this test fails. Today it stays green because the union loop in `deps.rs` lines 114-116 keeps `orgs`.

## Test plan

- [x] `cargo nextest run --workspace` — 4229 passed, 72 skipped.
- [x] `cargo test --workspace --doc` — passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all green.
- [x] `cargo fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)