### PR TITLE
fix(deps): include wait target binding in blocker check, via typed accessor

### DIFF
--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -313,26 +313,10 @@ pub fn find_failed_dependency(
     effect: &Effect,
     failed_bindings: &HashSet<String>,
 ) -> Option<String> {
-    if let Effect::Wait {
-        explicit_dependencies,
-        ..
-    } = effect
-    {
-        return explicit_dependencies
-            .iter()
-            .find(|dep| failed_bindings.contains(*dep))
-            .cloned();
-    }
-
-    // carina#3181 PR D: `Effect` payloads are typestate structs, so the
-    // dependency set is assembled from the `ResourceLike` view (value
-    // refs + `dependency_bindings`) plus the effect's explicit
-    // `depends_on` edges — the same union `get_resource_dependencies`
-    // computes for a legacy `Resource`.
-    let resource = effect.as_resource_ref()?;
-    let mut deps = get_resource_value_ref_dependencies(resource);
-    deps.extend(effect.explicit_dependencies());
-    deps.into_iter().find(|dep| failed_bindings.contains(dep))
+    effect
+        .blocking_bindings()
+        .into_iter()
+        .find(|dep| failed_bindings.contains(dep))
 }
 
 /// Check if any dependent of the given binding has failed (is in failed_bindings).
@@ -363,7 +347,7 @@ mod tests {
     use crate::resource::{DeferredValue, Directives, Resource, ResourceId, Value};
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
-    fn wait_effect_with_explicit_dependency(binding: &str) -> Effect {
+    fn wait_effect_with_explicit_dependency(binding: Option<&str>) -> Effect {
         Effect::Wait {
             binding: "cert_issued".to_string(),
             target_id: ResourceId::new("acm.Certificate", "cert"),
@@ -376,7 +360,7 @@ mod tests {
             until_surface: "cert.status == ISSUED".to_string(),
             timeout: std::time::Duration::from_secs(60),
             interval: std::time::Duration::from_millis(1),
-            explicit_dependencies: HashSet::from([binding.to_string()]),
+            explicit_dependencies: binding.into_iter().map(String::from).collect(),
         }
     }
 
@@ -609,7 +593,7 @@ mod tests {
 
     #[test]
     fn find_failed_dependency_returns_wait_explicit_dependency_when_failed() {
-        let effect = wait_effect_with_explicit_dependency("failed_binding");
+        let effect = wait_effect_with_explicit_dependency(Some("failed_binding"));
         let failed_bindings: HashSet<String> =
             ["failed_binding"].into_iter().map(String::from).collect();
 
@@ -620,8 +604,46 @@ mod tests {
     }
 
     #[test]
+    fn find_failed_dependency_returns_wait_target_binding_when_failed() {
+        let effect = wait_effect_with_explicit_dependency(None);
+        let failed_bindings: HashSet<String> = ["cert"].into_iter().map(String::from).collect();
+
+        assert_eq!(
+            find_failed_dependency(&effect, &failed_bindings),
+            Some("cert".to_string())
+        );
+    }
+
+    #[test]
+    fn find_failed_dependency_returns_wait_target_binding_in_preference_to_explicit_when_both_fail()
+    {
+        let effect = wait_effect_with_explicit_dependency(Some("other_failed"));
+        let failed_bindings: HashSet<String> = ["cert", "other_failed"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+
+        assert_eq!(
+            find_failed_dependency(&effect, &failed_bindings),
+            Some("cert".to_string())
+        );
+    }
+
+    #[test]
+    fn wait_blocking_bindings_include_target_before_explicit_dependencies() {
+        let effect = wait_effect_with_explicit_dependency(Some("other_failed"));
+        let blocking_bindings = effect.blocking_bindings();
+
+        assert_eq!(blocking_bindings.first(), Some(&"cert".to_string()));
+        assert_eq!(
+            blocking_bindings.into_iter().collect::<HashSet<_>>(),
+            HashSet::from(["cert".to_string(), "other_failed".to_string()])
+        );
+    }
+
+    #[test]
     fn find_failed_dependency_returns_none_when_wait_explicit_dependency_did_not_fail() {
-        let effect = wait_effect_with_explicit_dependency("failed_binding");
+        let effect = wait_effect_with_explicit_dependency(Some("failed_binding"));
         let failed_bindings: HashSet<String> = HashSet::new();
 
         assert_eq!(find_failed_dependency(&effect, &failed_bindings), None);

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -3,7 +3,10 @@
 //! An Effect describes "what to do" without actually performing the side effect.
 //! Side effects only occur when they are executed via a Provider.
 
-use std::{collections::HashSet, ops::Deref};
+use std::{
+    collections::{BTreeSet, HashSet},
+    ops::Deref,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -500,6 +503,46 @@ impl Effect {
             return explicit_dependencies.clone();
         }
         HashSet::new()
+    }
+
+    /// Bindings whose failure must prevent this effect from being dispatched.
+    ///
+    /// For [`Effect::Wait`] this is `target_id.name_str()` plus the wait's
+    /// explicit dependencies, with the target binding first. For other
+    /// resource-carrying variants this is value-reference bindings plus
+    /// explicit dependencies. State-only effects that do not carry dependency
+    /// metadata return an empty list.
+    ///
+    /// This concentrates the "what blocks me?" rule in one place so callers
+    /// cannot forget Wait's implicit target binding.
+    pub fn blocking_bindings(&self) -> Vec<String> {
+        match self {
+            Effect::Wait {
+                target_id,
+                explicit_dependencies,
+                ..
+            } => {
+                let target_binding = target_id.name_str();
+                let mut out = Vec::with_capacity(1 + explicit_dependencies.len());
+                out.push(target_binding.to_string());
+                out.extend(
+                    explicit_dependencies
+                        .iter()
+                        .filter(|dep| dep.as_str() != target_binding)
+                        .cloned()
+                        .collect::<BTreeSet<_>>(),
+                );
+                out
+            }
+            _ => {
+                let mut deps = BTreeSet::new();
+                if let Some(resource) = self.as_resource_ref() {
+                    deps.extend(crate::deps::get_resource_value_ref_dependencies(resource));
+                }
+                deps.extend(self.explicit_dependencies());
+                deps.into_iter().collect()
+            }
+        }
     }
 }
 

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -261,8 +261,10 @@ impl DependencyAnalyzer {
     ) {
         if let Some(resource) = effect.as_resource_ref() {
             self.collect_from_resource_ref(resource, analysis, child);
+            return;
         }
-        for binding in effect.explicit_dependencies() {
+
+        for binding in effect.blocking_bindings() {
             self.record_binding_edge(&binding, ReadsSet::unknown(), analysis, child);
         }
     }
@@ -429,23 +431,13 @@ pub(super) fn build_dependency_analysis(
         analysis.add_edge(parent_idx, child_idx, ReadsSet::unknown());
     }
 
-    // Wait dependencies: each `Effect::Wait` depends on the effect that
-    // produces its target (Create / Update / Replace on `target_id`) so
-    // the wait does not start polling before the target has been
-    // created. Explicit `depends_on = [...]` entries from the wait
-    // block layer on top.
+    // Wait dependencies: each `Effect::Wait` depends on its blocking
+    // bindings, with the target binding first. This keeps the polling
+    // wait behind the effect that produces its target, plus any explicit
+    // `depends_on = [...]` entries from the wait block.
     for (idx, effect) in effects.iter().enumerate() {
-        if let Effect::Wait { target_id, .. } = effect {
-            // Edge from the wait to its target's binding-effect (if
-            // present in the plan). The target may already exist (no
-            // Create effect in this plan) — then the wait is free to
-            // start immediately, which is what we want for refresh-only
-            // applies.
-            if let Some(target_binding) = lookup_idx(target_id.name_str()) {
-                analysis.add_edge(idx, target_binding, ReadsSet::unknown());
-            }
-            // Honour `depends_on = [...]` declared in the wait block.
-            for dep_binding in effect.explicit_dependencies() {
+        if let Effect::Wait { .. } = effect {
+            for dep_binding in effect.blocking_bindings() {
                 if let Some(dep_idx) = lookup_idx(&dep_binding) {
                     analysis.add_edge(idx, dep_idx, ReadsSet::unknown());
                 }

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -165,11 +165,10 @@ pub(super) fn topological_sort_replaces(
 /// Build a dependency map for a subset of effects identified by their indices.
 ///
 /// Only considers dependencies between effects in the given subset. Dependencies
-/// on effects outside the subset are ignored (assumed already completed).
-/// When `include_wait_target_edges` is true, Wait effects also depend on the
-/// same-phase effect that produces their target. Phase 5 passes false because
-/// its waits target Replace effects that have already completed by strict phase
-/// ordering; there is intentionally no fictional cross-phase dep edge.
+/// on effects outside the subset are ignored (assumed already completed). Wait
+/// blockers, including both target and explicit wait-block dependencies, are
+/// handled uniformly by `DepResolver::collect_from_effect` via
+/// `Effect::blocking_bindings()`.
 ///
 /// `Virtual` resources (the synthetic bindings module calls expose for their
 /// `attributes { }` block) have no Effect and would be invisible to a direct
@@ -182,7 +181,6 @@ pub(super) fn build_phase_dependency_map(
     phase_indices: &[usize],
     unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
     compositions: &[crate::resource::Composition],
-    include_wait_target_edges: bool,
 ) -> HashMap<usize, HashSet<usize>> {
     // Build binding -> effect index mapping for effects in this phase
     let phase_set: HashSet<usize> = phase_indices.iter().copied().collect();
@@ -200,13 +198,8 @@ pub(super) fn build_phase_dependency_map(
         let mut dep_indices = HashSet::new();
         let effect = &effects[idx];
         match effect {
-            Effect::Wait { target_id, .. } => {
+            Effect::Wait { .. } => {
                 resolver.collect_from_effect(effect, &mut dep_indices);
-                if include_wait_target_edges
-                    && let Some(target_idx) = binding_to_idx.get(target_id.name_str())
-                {
-                    dep_indices.insert(*target_idx);
-                }
             }
             _ if effect.as_resource_ref().is_some() => {
                 resolver.collect_from_effect(effect, &mut dep_indices);
@@ -274,31 +267,12 @@ impl<'a> DepResolver<'a> {
     /// Walk an effect's dependencies and merge the reached effect indices
     /// into `out`.
     ///
-    /// carina#3181: `Effect` payloads are typestate structs (managed
-    /// resources / data sources), so the dependency set is the union of
-    /// the `ResourceLike` value-ref + `dependency_bindings` view and the
-    /// effect's explicit `depends_on` edges — the same set
-    /// `get_resource_dependencies` computes for a managed resource.
-    /// State-only effects have no resource and contribute nothing. Wait
-    /// effects contribute their explicit `depends_on` edges here; any
-    /// same-phase target-producer edge is owned by `build_phase_dependency_map`.
-    /// Phase 5 waits do not need such an edge because their Replace targets
-    /// completed in an earlier phase by construction.
+    /// `Effect::blocking_bindings` concentrates the blocker set: managed
+    /// resources/data sources contribute value refs plus explicit
+    /// `depends_on`, and waits contribute their target plus explicit
+    /// wait-block dependencies.
     pub(super) fn collect_from_effect(&self, effect: &Effect, out: &mut HashSet<usize>) {
-        if let Effect::Wait { .. } = effect {
-            let dep_bindings = effect.explicit_dependencies();
-            let mut visited: HashSet<&str> = HashSet::new();
-            for binding in &dep_bindings {
-                self.expand(binding.as_str(), out, &mut visited);
-            }
-            return;
-        }
-
-        let Some(resource) = effect.as_resource_ref() else {
-            return;
-        };
-        let mut dep_bindings = crate::deps::get_resource_value_ref_dependencies(resource);
-        dep_bindings.extend(effect.explicit_dependencies());
+        let dep_bindings = effect.blocking_bindings();
         let mut visited: HashSet<&str> = HashSet::new();
         for binding in &dep_bindings {
             self.expand(binding.as_str(), out, &mut visited);
@@ -467,7 +441,6 @@ pub(super) async fn execute_effects_phased(
             &phase1_indices,
             input.unresolved_resources,
             input.compositions,
-            true,
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
@@ -809,7 +782,6 @@ pub(super) async fn execute_effects_phased(
             &cbd_indices,
             input.unresolved_resources,
             input.compositions,
-            true,
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
@@ -1368,7 +1340,6 @@ pub(super) async fn execute_effects_phased(
             &phase4_indices,
             input.unresolved_resources,
             input.compositions,
-            true,
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
@@ -1728,7 +1699,6 @@ pub(super) async fn execute_effects_phased(
             &post_replace_wait_indices,
             input.unresolved_resources,
             input.compositions,
-            false,
         );
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
@@ -2323,8 +2293,7 @@ mod tests {
             ),
         ]);
         let phase1_indices: Vec<usize> = (0..plan.effects().len()).collect();
-        let deps =
-            build_phase_dependency_map(plan.effects(), &phase1_indices, &unresolved, &[], true);
+        let deps = build_phase_dependency_map(plan.effects(), &phase1_indices, &unresolved, &[]);
         assert!(
             deps.get(&3).is_some_and(|listener_deps| {
                 listener_deps.contains(&1) && listener_deps.contains(&2)
@@ -2412,8 +2381,7 @@ mod tests {
             UnresolvedResource::from_pre_resolve(role_policy.clone()),
         );
 
-        let deps_of =
-            build_phase_dependency_map(&effects, &phase_indices, &unresolved, &[virt], true);
+        let deps_of = build_phase_dependency_map(&effects, &phase_indices, &unresolved, &[virt]);
 
         assert!(
             deps_of[&1].contains(&0),
@@ -2460,7 +2428,6 @@ mod tests {
             &phase_indices,
             &unresolved,
             &[inner_virt, outer_virt],
-            true,
         );
 
         assert!(

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -9,7 +9,6 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use crate::deps::get_resource_value_ref_dependencies;
 use crate::effect::Effect;
 use crate::plan::Plan;
 use crate::resource::{ConcreteValue, DeferredValue, Value};
@@ -45,8 +44,7 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
                     let rl = effect
                         .as_resource_ref()
                         .expect("variant carries a resource");
-                    let mut deps = get_resource_value_ref_dependencies(rl);
-                    deps.extend(effect.explicit_dependencies());
+                    let deps = effect.blocking_bindings().into_iter().collect();
                     (Some(rl), deps)
                 }
                 Effect::Delete {
@@ -87,8 +85,11 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
                 Effect::Wait {
                     binding, target_id, ..
                 } => {
-                    // The wait depends on its target binding so the tree
-                    // shows the wait as a child of the resource it gates.
+                    // Scheduling uses `Effect::blocking_bindings()` so
+                    // wait targets and explicit wait-block dependencies
+                    // both block dispatch. The display tree intentionally
+                    // uses only the target edge because it visualizes the
+                    // structural "wait gates this resource" relationship.
                     let mut deps = HashSet::new();
                     deps.insert(target_id.name_str().to_string());
                     binding_to_effect.insert(binding.clone(), idx);


### PR DESCRIPTION
## Summary

Closes #3556.

`find_failed_dependency` skipped a `Effect::Wait` when its `target_id` binding was in `failed_bindings` because the function only inspected `explicit_dependencies`. A failed Replace on `cert` therefore did not skip a `wait cert_issued` block; the wait dispatched and returned NotFound / Timeout, masking the real cause.

## Approach — typed accessor, not a per-caller patch

Patching only `find_failed_dependency` would leave `Effect::explicit_dependencies()` returning a misleading subset for `Wait`. The next caller asking "what blocks this effect?" — a future cycle detector, blast-radius computation, plan-display revision — would silently re-introduce the bug. Per CLAUDE.md "new caller tomorrow" rule, the right shape is a typed accessor that concentrates the rule.

- `Effect::blocking_bindings(&self) -> Vec<String>` returns the full blocker set per variant: Wait → target binding first then dedup-sorted explicit dependencies; resource-carrying variants → value-ref bindings plus explicit dependencies; state-only variants → empty.
- `find_failed_dependency`, `build_dependency_analysis`'s Wait edge loop, and `DepResolver::collect_from_effect` all funnel through it. No site now has to remember the Wait special case.
- `build_phase_dependency_map`'s `include_wait_target_edges` boolean is gone — the target edge is contributed by `collect_from_effect` via `blocking_bindings`, and Phase 5 (added in #3557) still skips it naturally because the target is not in Phase 5's `binding_to_idx`.

## Display intentionally narrower than scheduling

The plan-tree's Wait node keeps the older, target-only shape. Display visualises the structural "wait gates this resource" relation; scheduling needs the full blocker set. The comment in `plan_tree.rs` makes the split explicit so a later contributor does not "fix" the narrower view by reflex.

## Test coverage

Three new tests next to the existing `deps.rs` deps fixtures:

- `find_failed_dependency_returns_wait_target_binding_when_failed` — the bug's headline scenario.
- `find_failed_dependency_returns_wait_target_binding_in_preference_to_explicit_when_both_fail` — pins the ordering contract.
- `wait_blocking_bindings_include_target_before_explicit_dependencies` — pins the accessor's contract independently of `find_failed_dependency`.

The existing helper `wait_effect_with_explicit_dependency` was refactored to take `Option<&str>`, removing post-construction mutation.

## Test plan

- [x] `cargo nextest run --workspace` — 4232 passed, 72 skipped.
- [x] `cargo test --workspace --doc` — passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all green.
- [x] `cargo fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)