### PR TITLE
feat(executor): apply-time deferred-for re-expansion with typed witness

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -719,12 +719,19 @@ async fn run_apply_with_observer_factory(
                     ctx.schemas(),
                 )
                 .await;
+                let resolved_bucket =
+                    carina_core::executor::resolve_normalized_for_provider(normalized_bucket)
+                        .map_err(|err| {
+                            AppError::Config(format!(
+                                "Failed to resolve state bucket before create: {err}"
+                            ))
+                        })?;
 
                 match bucket_provider
                     .create(
                         &bucket_resource.id,
                         carina_core::provider::CreateRequest {
-                            resource: normalized_bucket,
+                            resource: resolved_bucket,
                         },
                     )
                     .await

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1247,6 +1247,7 @@ async fn run_apply_locked(
     let crate::wiring::ExpandedRefreshState {
         sorted_resources: resorted,
         residual_deferred_for,
+        apply_time_reexpansion_targets,
         new_child_ids: _,
         refreshable_child_ids: _,
         // `printed_warnings` drives the plan path's spinner-bar-region
@@ -1401,6 +1402,7 @@ async fn run_apply_locked(
         &bindings,
         &no_unresolved_upstreams,
     );
+    crate::wiring::add_apply_time_reexpansion_effects(&mut plan, &apply_time_reexpansion_targets);
 
     // Check for prevent_destroy violations
     if plan.has_errors() {

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -353,6 +353,7 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
     let mut state = build_state_after_apply(ApplyStateSave {
         state_file: input.state_file,
         sorted_resources: input.sorted_resources,
+        runtime_synthesized_resources: &input.result.runtime_synthesized_resources,
         current_states: input.current_states,
         applied_states: &input.result.applied_states,
         permanent_name_overrides: &input.result.permanent_name_overrides,

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -2217,8 +2217,8 @@ mod apply_deferred_for_parity {
         );
     }
 
-    /// No refreshed cert state ⇒ the loop stays deferred on the apply
-    /// path too (no mis-expansion), matching the plan path's
+    /// No refreshed cert state ⇒ the loop is carried as an apply-time
+    /// re-expansion target (no mis-expansion), matching the plan path's
     /// unresolvable-iterable behavior.
     #[test]
     fn apply_unresolvable_iterable_stays_deferred() {
@@ -2253,7 +2253,8 @@ mod apply_deferred_for_parity {
                 .all(|r| !r.id.resource_type.contains("RecordSet")),
             "no RecordSet materializes without a resolvable iterable on apply"
         );
-        assert_eq!(out.residual_deferred_for.len(), 1);
+        assert_eq!(out.apply_time_reexpansion_targets.len(), 1);
+        assert!(out.residual_deferred_for.is_empty());
         assert!(out.new_child_ids.is_empty());
     }
 

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -381,6 +381,7 @@ fn build_state_after_apply_finds_write_only_with_provider_prefix() {
     let result = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &current_states,
         applied_states: &applied_states,
         permanent_name_overrides: &permanent_name_overrides,
@@ -496,6 +497,7 @@ fn build_state_after_apply_preserves_block_name_attribute() {
     let state = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &current_states,
         applied_states: &applied_states,
         permanent_name_overrides: &permanent_name_overrides,
@@ -726,6 +728,7 @@ fn block_name_attribute_state_roundtrip() {
     let state = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied_states,
         permanent_name_overrides: &HashMap::new(),
@@ -932,6 +935,7 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(state_file),
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied_states,
         permanent_name_overrides: &HashMap::new(),
@@ -1048,6 +1052,7 @@ fn move_plus_update_keeps_post_update_attributes() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(state_file),
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied_states,
         permanent_name_overrides: &HashMap::new(),
@@ -1125,6 +1130,7 @@ fn move_alone_carries_attributes_via_current_states() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(state_file),
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &current_states,
         applied_states: &HashMap::new(),
         permanent_name_overrides: &HashMap::new(),
@@ -1177,6 +1183,7 @@ fn move_with_absent_from_is_no_op() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(StateFile::default()),
         sorted_resources: &[],
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &HashMap::new(),
         permanent_name_overrides: &HashMap::new(),
@@ -1223,6 +1230,7 @@ fn failed_refresh_preserves_existing_row() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(state_file),
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &HashMap::new(),
         permanent_name_overrides: &HashMap::new(),
@@ -1280,6 +1288,7 @@ fn move_from_overlapping_desired_resource_errors() {
     let result = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied,
         permanent_name_overrides: &HashMap::new(),
@@ -1333,6 +1342,7 @@ fn remove_overlapping_desired_resource_errors() {
     let result = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied,
         permanent_name_overrides: &HashMap::new(),
@@ -1387,6 +1397,7 @@ fn self_move_overlapping_desired_resource_errors() {
     let result = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &sorted_resources,
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied,
         permanent_name_overrides: &HashMap::new(),

--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -275,7 +275,7 @@ pub(crate) fn collect_required_actions(
     let mut required = Vec::new();
     for effect in plan.effects() {
         for (id, op) in effect_required_ops(effect) {
-            let actions = provider.required_permissions(id, op);
+            let actions = provider.required_permissions(&id, op);
             for action in actions {
                 required.push(RequiredAction {
                     effect: EffectAddress {
@@ -290,18 +290,23 @@ pub(crate) fn collect_required_actions(
     required
 }
 
-fn effect_required_ops(effect: &Effect) -> Vec<(&ResourceId, PlanOp)> {
+fn effect_required_ops(effect: &Effect) -> Vec<(ResourceId, PlanOp)> {
     match effect {
-        Effect::Read { resource } => vec![(&resource.id, PlanOp::Read)],
-        Effect::Create(resource) => vec![(&resource.id, PlanOp::Create)],
-        Effect::Update { id, .. } => vec![(id, PlanOp::Update)],
-        Effect::Replace { id, to, .. } => vec![(id, PlanOp::Delete), (&to.id, PlanOp::Create)],
-        Effect::Delete { id, .. } => vec![(id, PlanOp::Delete)],
-        Effect::Import { id, .. } => vec![(id, PlanOp::Read)],
-        Effect::Remove { .. }
-        | Effect::Move { .. }
-        | Effect::Wait { .. }
-        | Effect::ExpandDeferredFor { .. } => Vec::new(),
+        Effect::Read { resource } => vec![(resource.id.clone(), PlanOp::Read)],
+        Effect::Create(resource) => vec![(resource.id.clone(), PlanOp::Create)],
+        Effect::Update { id, .. } => vec![(id.clone(), PlanOp::Update)],
+        Effect::Replace { id, to, .. } => {
+            vec![
+                (id.clone(), PlanOp::Delete),
+                (to.id.clone(), PlanOp::Create),
+            ]
+        }
+        Effect::Delete { id, .. } => vec![(id.clone(), PlanOp::Delete)],
+        Effect::Import { id, .. } => vec![(id.clone(), PlanOp::Read)],
+        Effect::ExpandDeferredFor { template, .. } => {
+            effect_required_ops(&Effect::Create(template.template_resource.clone()))
+        }
+        Effect::Remove { .. } | Effect::Move { .. } | Effect::Wait { .. } => Vec::new(),
     }
 }
 
@@ -736,6 +741,7 @@ mod tests {
     use super::*;
     use aws_sdk_iam::error::ErrorMetadata;
     use carina_core::effect::ChangedCreateOnly;
+    use carina_core::parser::{DeferredForExpression, ForBinding};
     use carina_core::provider::{
         BoxFuture, CreateRequest, DeleteRequest, ProviderError, ProviderResult, ReadRequest,
         UpdateRequest,
@@ -859,6 +865,34 @@ mod tests {
                 "test:read:logs.Group",
             ]
         );
+    }
+
+    #[test]
+    fn collect_required_actions_includes_expand_deferred_for_template_create() {
+        let template_resource =
+            Resource::with_provider("aws", "route53.RecordSet", "validation_records", None);
+        let mut plan = Plan::new();
+        plan.add(Effect::ExpandDeferredFor {
+            id: ResourceId::new("__deferred_for", "validation_records"),
+            upstream_binding: "cert".to_string(),
+            template: Box::new(DeferredForExpression {
+                file: None,
+                line: 1,
+                header: "for opt in cert.domain_validation_options".to_string(),
+                resource_type: "aws.route53.RecordSet".to_string(),
+                attributes: Default::default(),
+                binding_name: "validation_records".to_string(),
+                iterable_binding: "cert".to_string(),
+                iterable_attr: "domain_validation_options".to_string(),
+                binding: ForBinding::Simple("opt".to_string()),
+                template_resource,
+            }),
+        });
+
+        let entries = collect_required_actions(&plan, &PermissionProvider);
+        let actions: Vec<_> = entries.into_iter().map(|entry| entry.action).collect();
+
+        assert_eq!(actions, vec!["test:create:route53.RecordSet"]);
     }
 
     #[test]

--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -298,7 +298,10 @@ fn effect_required_ops(effect: &Effect) -> Vec<(&ResourceId, PlanOp)> {
         Effect::Replace { id, to, .. } => vec![(id, PlanOp::Delete), (&to.id, PlanOp::Create)],
         Effect::Delete { id, .. } => vec![(id, PlanOp::Delete)],
         Effect::Import { id, .. } => vec![(id, PlanOp::Read)],
-        Effect::Remove { .. } | Effect::Move { .. } | Effect::Wait { .. } => Vec::new(),
+        Effect::Remove { .. }
+        | Effect::Move { .. }
+        | Effect::Wait { .. }
+        | Effect::ExpandDeferredFor { .. } => Vec::new(),
     }
 }
 
@@ -313,6 +316,7 @@ fn effect_resource_ids(effect: &Effect) -> Vec<&ResourceId> {
         Effect::Remove { id, .. } => vec![id],
         Effect::Move { from, to } => vec![from, to],
         Effect::Wait { .. } => Vec::new(),
+        Effect::ExpandDeferredFor { id, .. } => vec![id],
     }
 }
 

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -119,6 +119,7 @@ mod tests {
             failure_count: 0,
             skip_count: 0,
             applied_states: HashMap::new(),
+            runtime_synthesized_resources: Vec::new(),
             successfully_deleted: HashSet::new(),
             permanent_name_overrides: HashMap::new(),
             current_states: HashMap::new(),

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -528,6 +528,7 @@ pub(crate) fn dsl_value_to_json(
 pub(crate) struct ApplyStateSave<'a> {
     pub state_file: Option<StateFile>,
     pub sorted_resources: &'a [Resource],
+    pub runtime_synthesized_resources: &'a [Resource],
     pub current_states: &'a HashMap<ResourceId, State>,
     pub applied_states: &'a HashMap<ResourceId, State>,
     pub permanent_name_overrides: &'a HashMap<ResourceId, HashMap<String, String>>,
@@ -645,6 +646,7 @@ impl<'a> WritebackPlan<'a> {
 /// is Phase 1's job.
 fn decompose<'a>(
     sorted_resources: &'a [Resource],
+    runtime_synthesized_resources: &'a [Resource],
     current_states: &'a HashMap<ResourceId, State>,
     applied_states: &'a HashMap<ResourceId, State>,
     plan: &Plan,
@@ -666,6 +668,12 @@ fn decompose<'a>(
             } else {
                 wb.add_cleanup(resource.id.clone())?;
             }
+        }
+    }
+
+    for resource in runtime_synthesized_resources {
+        if let Some(applied) = applied_states.get(&resource.id) {
+            wb.add_upsert(resource, UpsertSource::Applied(applied))?;
         }
     }
 
@@ -697,6 +705,7 @@ pub(crate) fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateF
     let ApplyStateSave {
         state_file,
         sorted_resources,
+        runtime_synthesized_resources,
         current_states,
         applied_states,
         permanent_name_overrides,
@@ -709,6 +718,7 @@ pub(crate) fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateF
 
     let writeback = decompose(
         sorted_resources,
+        runtime_synthesized_resources,
         current_states,
         applied_states,
         plan,
@@ -872,6 +882,55 @@ mod post_apply_states_tests {
             Some(Value::Concrete(ConcreteValue::String(s))) => assert_eq!(s, "Enabled"),
             other => panic!("expected post-apply 'Enabled', got: {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod apply_state_save_tests {
+    use super::*;
+    use carina_core::plan::Plan;
+    use carina_core::resource::{ConcreteValue, Resource, State, Value};
+
+    #[test]
+    fn build_state_after_apply_persists_runtime_synthesized_resources() {
+        let runtime_child = Resource::new("route53.Record", "validation_records[0]")
+            .with_attribute(
+                "name",
+                Value::Concrete(ConcreteValue::String("_dns_record_name_".to_string())),
+            );
+        let child_id = runtime_child.id.clone();
+        let child_state = State::existing(
+            child_id.clone(),
+            HashMap::from([(
+                "name".to_string(),
+                Value::Concrete(ConcreteValue::String("_dns_record_name_".to_string())),
+            )]),
+        )
+        .with_identifier("record-id");
+
+        let state = build_state_after_apply(ApplyStateSave {
+            state_file: Some(StateFile::new()),
+            sorted_resources: &[],
+            current_states: &HashMap::new(),
+            applied_states: &HashMap::from([(child_id.clone(), child_state)]),
+            runtime_synthesized_resources: std::slice::from_ref(&runtime_child),
+            permanent_name_overrides: &HashMap::new(),
+            plan: &Plan::new(),
+            successfully_deleted: &HashSet::new(),
+            failed_refreshes: &HashSet::new(),
+            schemas: &carina_core::schema::SchemaRegistry::new(),
+        })
+        .expect("state writeback should accept runtime-synthesized child");
+
+        assert!(
+            state
+                .resources
+                .iter()
+                .any(|row| row.provider == child_id.provider
+                    && row.resource_type == child_id.resource_type
+                    && row.name == "validation_records[0]"),
+            "runtime-synthesized child must be persisted in state"
+        );
     }
 }
 

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -1008,6 +1008,7 @@ pub(crate) async fn run_state_refresh_locked(
         new_child_ids: _,
         refreshable_child_ids: _,
         residual_deferred_for: _,
+        apply_time_reexpansion_targets: _,
         printed_warnings: _,
     } = crate::wiring::expand_refresh_and_lift_states(crate::wiring::ExpandRefreshAndLiftInputs {
         parsed,

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -724,21 +724,41 @@ impl<'a> TreeRenderContext<'a> {
                 .unwrap();
             }
             Effect::ExpandDeferredFor {
-                id,
                 upstream_binding,
+                template,
                 ..
             } => {
                 writeln!(
                     self.out,
-                    "{}{}{} {} {} {}",
+                    "{}{}{} {}",
                     base_indent,
                     connector,
                     colored_symbol,
-                    id.display_type().cyan().bold(),
-                    id.name_str().yellow().bold(),
-                    format!("(deferred for: waits on {})", upstream_binding).dimmed()
+                    template.header.yellow().bold()
                 )
                 .unwrap();
+                let attr_prefix = if indent == 0 {
+                    format!("{}{}", base_indent, attr_base)
+                } else {
+                    let continuation = if is_last {
+                        format!("{}   ", prefix)
+                    } else {
+                        format!("{}│  ", prefix)
+                    };
+                    format!("{}{}   ", base_indent, continuation)
+                };
+                writeln!(
+                    self.out,
+                    "{}{}",
+                    attr_prefix,
+                    format!(
+                        "(deferred until apply: one {} per element after {} applies)",
+                        template.resource_type, upstream_binding
+                    )
+                    .dimmed()
+                )
+                .unwrap();
+                has_displayed_attrs = true;
             }
         }
 

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -473,6 +473,7 @@ impl<'a> TreeRenderContext<'a> {
             Effect::Remove { .. } => "~".yellow().bold(),
             Effect::Move { .. } => "->".yellow().bold(),
             Effect::Wait { .. } => ">".magenta().bold(),
+            Effect::ExpandDeferredFor { .. } => "~".yellow().bold(),
         };
 
         // Build the tree connector (shown before child resources)
@@ -719,6 +720,23 @@ impl<'a> TreeRenderContext<'a> {
                     colored_symbol,
                     binding.magenta().bold(),
                     format!("(until {})", until_surface).dimmed()
+                )
+                .unwrap();
+            }
+            Effect::ExpandDeferredFor {
+                id,
+                upstream_binding,
+                ..
+            } => {
+                writeln!(
+                    self.out,
+                    "{}{}{} {} {} {}",
+                    base_indent,
+                    connector,
+                    colored_symbol,
+                    id.display_type().cyan().bold(),
+                    id.name_str().yellow().bold(),
+                    format!("(deferred for: waits on {})", upstream_binding).dimmed()
                 )
                 .unwrap();
             }
@@ -2010,6 +2028,17 @@ pub fn format_effect(effect: &Effect) -> String {
             ..
         } => {
             format!("Wait {} (until {})", binding, until_surface)
+        }
+        Effect::ExpandDeferredFor {
+            id,
+            upstream_binding,
+            ..
+        } => {
+            format!(
+                "Expand deferred for {} (waits on {})",
+                id.human(),
+                upstream_binding
+            )
         }
     }
 }

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -2,7 +2,10 @@ use super::*;
 
 use carina_core::effect::{CascadingUpdate, Effect};
 use carina_core::plan::Plan;
-use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{
+    AccessPath, ConcreteValue, DeferredValue, Directives, Resource, ResourceId, State,
+    UnknownReason, Value,
+};
 
 fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) -> Resource {
     let mut r = Resource::new(resource_type, name);
@@ -1031,6 +1034,64 @@ fn test_replace_cascade_ref_hints_show_binding() {
         "Expected 'forces replacement, known after apply' in output, got: {}",
         output
     );
+}
+
+#[test]
+fn test_expand_deferred_for_renders_deferred_until_apply_marker() {
+    let mut template_resource = Resource::new("route53.Record", "validation_records");
+    template_resource.binding = Some("validation_records".to_string());
+    template_resource.set_attr(
+        "name",
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath {
+            path: AccessPath::with_fields("opt", "resource_record", vec!["name".to_string()]),
+        })),
+    );
+
+    let deferred = carina_core::parser::DeferredForExpression {
+        file: None,
+        line: 1,
+        header: "for opt in cert.domain_validation_options".to_string(),
+        resource_type: "aws.route53.Record".to_string(),
+        attributes: template_resource
+            .attributes
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+        binding_name: "validation_records".to_string(),
+        iterable_binding: "cert".to_string(),
+        iterable_attr: "domain_validation_options".to_string(),
+        binding: carina_core::parser::ForBinding::Simple("opt".to_string()),
+        template_resource,
+    };
+
+    let mut plan = Plan::new();
+    plan.add(Effect::ExpandDeferredFor {
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "cert".to_string(),
+        template: Box::new(deferred),
+    });
+
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        None,
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        None,
+    ));
+
+    insta::assert_snapshot!(output, @r###"
+Execution Plan:
+
+  ~ for opt in cert.domain_validation_options
+      (deferred until apply: one aws.route53.Record per element after cert applies)
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+
+"###);
 }
 
 /// Test that cascading update diff only shows attributes referencing the replaced binding,

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -158,6 +158,7 @@ async fn refresh_pending_states_updates_saved_state_from_provider_read() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(existing_state),
         sorted_resources: &[resource],
+        runtime_synthesized_resources: &[],
         current_states: &current_states,
         applied_states: &HashMap::new(),
         permanent_name_overrides: &HashMap::new(),
@@ -209,6 +210,7 @@ async fn refresh_pending_states_removes_not_found_resource_from_saved_state() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(existing_state),
         sorted_resources: &[resource],
+        runtime_synthesized_resources: &[],
         current_states: &current_states,
         applied_states: &HashMap::new(),
         permanent_name_overrides: &HashMap::new(),
@@ -256,6 +258,7 @@ async fn refresh_pending_states_does_not_overwrite_with_stale_snapshot_when_refr
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(existing_state),
         sorted_resources: &[resource],
+        runtime_synthesized_resources: &[],
         current_states: &current_states,
         applied_states: &HashMap::new(),
         permanent_name_overrides: &HashMap::new(),
@@ -1435,6 +1438,7 @@ async fn lock_released_on_write_state_failure() {
         failure_count: 0,
         skip_count: 0,
         applied_states: HashMap::new(),
+        runtime_synthesized_resources: Vec::new(),
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
@@ -1574,6 +1578,7 @@ async fn finalize_apply_uses_write_state_locked() {
         failure_count: 0,
         skip_count: 0,
         applied_states: HashMap::new(),
+        runtime_synthesized_resources: Vec::new(),
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
@@ -2222,6 +2227,7 @@ async fn finalize_apply_without_lock_uses_write_state() {
         failure_count: 0,
         skip_count: 0,
         applied_states: HashMap::new(),
+        runtime_synthesized_resources: Vec::new(),
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
@@ -2588,6 +2594,7 @@ fn import_effect_preserves_resource_metadata_in_state() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &[resource],
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied_states,
         permanent_name_overrides: &HashMap::new(),
@@ -2682,6 +2689,7 @@ fn build_state_after_apply_persists_write_only_attributes() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &[resource],
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied_states,
         permanent_name_overrides: &HashMap::new(),
@@ -2759,6 +2767,7 @@ fn write_only_canonical_enum_state_roundtrip_converges_without_diff() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: None,
         sorted_resources: &[resource.clone()],
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied_states,
         permanent_name_overrides: &HashMap::new(),
@@ -2843,6 +2852,7 @@ fn build_state_after_apply_write_only_detects_value_change() {
     let saved = build_state_after_apply(ApplyStateSave {
         state_file: Some(existing_state),
         sorted_resources: &[resource],
+        runtime_synthesized_resources: &[],
         current_states: &HashMap::new(),
         applied_states: &applied_states,
         permanent_name_overrides: &HashMap::new(),
@@ -3105,6 +3115,7 @@ async fn finalize_apply_clears_state_exports_when_params_empty() {
         failure_count: 0,
         skip_count: 0,
         applied_states: HashMap::new(),
+        runtime_synthesized_resources: Vec::new(),
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
@@ -3164,6 +3175,7 @@ async fn finalize_apply_preserves_state_exports_when_params_none() {
         failure_count: 0,
         skip_count: 0,
         applied_states: HashMap::new(),
+        runtime_synthesized_resources: Vec::new(),
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::new(),
@@ -3229,6 +3241,7 @@ async fn finalize_apply_persists_successful_state_when_one_export_is_unresolved(
         failure_count: 1,
         skip_count: 0,
         applied_states: HashMap::from([(a_id.clone(), a_state.clone())]),
+        runtime_synthesized_resources: Vec::new(),
         permanent_name_overrides: HashMap::new(),
         successfully_deleted: HashSet::new(),
         current_states: HashMap::from([(a_id, a_state)]),

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -16,8 +16,8 @@ use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
 use carina_core::executor::normalized::{
-    restore_stripped_attributes, run_desired_normalization_stages, states_contain_unknown,
-    strip_provider_boundary_attributes,
+    is_value_fully_concrete_for_expansion, restore_stripped_attributes,
+    run_desired_normalization_stages, states_contain_unknown, strip_provider_boundary_attributes,
 };
 use carina_core::identifier::{
     self, AnonymousIdBindingStateInfo, AnonymousIdStateInfo, PrefixStateInfo, StateBlockClaims,
@@ -1273,6 +1273,35 @@ impl RefreshableChildIds {
     }
 }
 
+/// A deferred-for expression whose iterable is not plan-time concrete,
+/// but has enough upstream identity for the apply executor to re-expand it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApplyTimeReexpansionTarget {
+    pub id: ResourceId,
+    pub upstream_binding: String,
+    pub template: carina_core::parser::DeferredForExpression,
+}
+
+impl ApplyTimeReexpansionTarget {
+    fn from_deferred(deferred: &carina_core::parser::DeferredForExpression) -> Self {
+        let mut id = deferred.template_resource.id.clone();
+        id.set_name(deferred.binding_name.clone());
+        Self {
+            id,
+            upstream_binding: deferred.iterable_binding.clone(),
+            template: deferred.clone(),
+        }
+    }
+
+    fn to_effect(&self) -> Effect {
+        Effect::ExpandDeferredFor {
+            id: self.id.clone(),
+            upstream_binding: self.upstream_binding.clone(),
+            template: Box::new(self.template.clone()),
+        }
+    }
+}
+
 /// Outcome of the carina#3132 post-refresh deferred-for expansion.
 pub struct DeferredForExpansion {
     /// The augmented, re-sorted resource set: every original resource
@@ -1282,6 +1311,9 @@ pub struct DeferredForExpansion {
     /// Loops still unresolved (iterable genuinely unknowable at plan
     /// time) — rendered as the carina#3128 validate/plan placeholder.
     pub residual_deferred_for: Vec<carina_core::parser::DeferredForExpression>,
+    /// Loops whose iterable is deferred until apply and should become
+    /// state-only `Effect::ExpandDeferredFor` entries in the plan.
+    pub apply_time_reexpansion_targets: Vec<ApplyTimeReexpansionTarget>,
     /// Ids of the resources materialized by this expansion (empty when
     /// no loop resolved).
     pub new_child_ids: HashSet<ResourceId>,
@@ -1353,6 +1385,7 @@ pub fn expand_same_config_deferred_for<E: Clone>(
         return Ok(DeferredForExpansion {
             sorted_resources: sorted_resources.to_vec(),
             residual_deferred_for: Vec::new(),
+            apply_time_reexpansion_targets: Vec::new(),
             new_child_ids: HashSet::new(),
             refreshable_child_ids: RefreshableChildIds::default(),
             printed_warnings,
@@ -1369,11 +1402,39 @@ pub fn expand_same_config_deferred_for<E: Clone>(
     })
     .project_iterable_bindings();
 
+    let mut apply_time_reexpansion_targets = Vec::new();
+    let pre_expandable_deferred_for: Vec<_> = parsed
+        .deferred_for_expressions
+        .iter()
+        .filter_map(|deferred| {
+            let iterable = iterable_bindings
+                .get(&deferred.iterable_binding)
+                .and_then(|attrs| attrs.get(&deferred.iterable_attr));
+
+            match iterable {
+                Some(value) if is_value_fully_concrete_for_expansion(value) => {
+                    Some(deferred.clone())
+                }
+                Some(_) | None => {
+                    apply_time_reexpansion_targets
+                        .push(ApplyTimeReexpansionTarget::from_deferred(deferred));
+                    None
+                }
+            }
+        })
+        .collect();
+
     // `expand_deferred_for_expressions` is a `&mut self` method that
     // appends generated resources and drops resolved entries. `parsed`
     // is borrowed immutably here, so expand on a local clone and read
     // the augmented resource set / residual deferred list back out.
     let mut expanded: carina_core::parser::File<E> = (*parsed).clone();
+    for target in &apply_time_reexpansion_targets {
+        expanded
+            .warnings
+            .retain(|w| w.line != target.template.line || w.file != target.template.file);
+    }
+    expanded.deferred_for_expressions = pre_expandable_deferred_for;
     expanded.expand_deferred_for_expressions(&iterable_bindings);
     let printed_warnings = expanded.print_warnings();
     let residual_deferred_for = expanded.deferred_for_expressions.clone();
@@ -1424,6 +1485,7 @@ pub fn expand_same_config_deferred_for<E: Clone>(
     Ok(DeferredForExpansion {
         sorted_resources: resorted,
         residual_deferred_for,
+        apply_time_reexpansion_targets,
         new_child_ids,
         refreshable_child_ids,
         printed_warnings,
@@ -1462,6 +1524,7 @@ pub fn expand_same_config_deferred_for<E: Clone>(
 pub struct ExpandedRefreshState {
     pub sorted_resources: Vec<Resource>,
     pub residual_deferred_for: Vec<carina_core::parser::DeferredForExpression>,
+    pub apply_time_reexpansion_targets: Vec<ApplyTimeReexpansionTarget>,
     pub new_child_ids: HashSet<ResourceId>,
     pub refreshable_child_ids: RefreshableChildIds,
     pub printed_warnings: bool,
@@ -1504,6 +1567,7 @@ pub async fn expand_refresh_and_lift_states<E: Clone, P: Provider + ProviderNorm
     let DeferredForExpansion {
         sorted_resources,
         residual_deferred_for,
+        apply_time_reexpansion_targets,
         new_child_ids,
         refreshable_child_ids,
         printed_warnings,
@@ -1556,6 +1620,7 @@ pub async fn expand_refresh_and_lift_states<E: Clone, P: Provider + ProviderNorm
     Ok(ExpandedRefreshState {
         sorted_resources,
         residual_deferred_for,
+        apply_time_reexpansion_targets,
         new_child_ids,
         refreshable_child_ids,
         printed_warnings,
@@ -1892,6 +1957,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     let DeferredForExpansion {
         sorted_resources: resorted,
         residual_deferred_for,
+        apply_time_reexpansion_targets,
         new_child_ids,
         refreshable_child_ids,
         printed_warnings,
@@ -2098,6 +2164,7 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         &plan_bindings,
         &upstream_binding_names,
     );
+    add_apply_time_reexpansion_effects(&mut plan, &apply_time_reexpansion_targets);
 
     let moved_origins: HashMap<ResourceId, ResourceId> = moved_pairs
         .iter()
@@ -2597,6 +2664,13 @@ pub fn add_state_block_effects(
     // Add the new state block effects
     for effect in new_effects {
         plan.add(effect);
+    }
+}
+
+/// Add apply-time deferred-for re-expansion effects to the plan.
+pub fn add_apply_time_reexpansion_effects(plan: &mut Plan, targets: &[ApplyTimeReexpansionTarget]) {
+    for target in targets {
+        plan.add(target.to_effect());
     }
 }
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -2371,7 +2371,7 @@ mod expand_same_config_deferred_for_tests {
     use super::*;
     use carina_core::binding_index::WaitAliasSpec;
     use carina_core::parser::{ProviderContext, parse};
-    use carina_core::resource::{ConcreteValue, State, Value};
+    use carina_core::resource::{ConcreteValue, DeferredValue, State, UnknownReason, Value};
     use std::collections::HashMap;
 
     /// `let cert` (same-config) + a `for` over its provider-read
@@ -2428,6 +2428,10 @@ mod expand_same_config_deferred_for_tests {
             Value::Concrete(ConcreteValue::String("111111111111".into())),
             Value::Concrete(ConcreteValue::String("222222222222".into())),
         ]))
+    }
+
+    fn unknown_account_ids() -> Value {
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue))
     }
 
     /// Direct unit test of `RefreshableChildIds::select` — the sole
@@ -2541,6 +2545,104 @@ mod expand_same_config_deferred_for_tests {
     }
 
     #[test]
+    fn expand_same_config_emits_expand_deferred_for_when_iterable_is_unresolved() {
+        let parsed = parse(SRC, &ProviderContext::default()).expect("parse");
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+        let states = states_with_cert(&parsed, "account_ids", unknown_account_ids());
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+        )
+        .expect("expand");
+
+        assert_eq!(
+            out.apply_time_reexpansion_targets.len(),
+            1,
+            "one deferred-for expression should be carried for apply-time re-expansion"
+        );
+        assert_eq!(
+            out.apply_time_reexpansion_targets[0].upstream_binding,
+            "cert"
+        );
+        assert!(
+            out.sorted_resources
+                .iter()
+                .all(|r| !r.id.resource_type.contains("Assignment")),
+            "no Assignment may be pre-expanded from an unresolved iterable"
+        );
+        assert!(
+            out.new_child_ids.is_empty(),
+            "unresolved iterable must not report materialized children"
+        );
+    }
+
+    #[test]
+    fn expand_same_config_pre_expands_when_iterable_is_concrete() {
+        let parsed = parse(SRC, &ProviderContext::default()).expect("parse");
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+        let states = states_with_cert(&parsed, "account_ids", account_ids());
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+        )
+        .expect("expand");
+
+        let assignments: Vec<_> = out
+            .sorted_resources
+            .iter()
+            .filter(|r| r.id.resource_type.contains("Assignment"))
+            .collect();
+        assert_eq!(assignments.len(), 2);
+        assert!(
+            out.apply_time_reexpansion_targets.is_empty(),
+            "fully concrete iterable must pre-expand instead of emitting ExpandDeferredFor"
+        );
+    }
+
+    #[test]
+    fn expand_same_config_passes_through_pr3558_dependency_bindings_on_pre_expanded_children() {
+        let parsed = parse(SRC, &ProviderContext::default()).expect("parse");
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+        let states = states_with_cert(&parsed, "account_ids", account_ids());
+
+        let out = expand_same_config_deferred_for(
+            &parsed,
+            &sorted,
+            &states,
+            &HashMap::new(),
+            &[] as &[WaitAliasSpec],
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+        )
+        .expect("expand");
+
+        let assignments: Vec<_> = out
+            .sorted_resources
+            .iter()
+            .filter(|r| r.id.resource_type.contains("Assignment"))
+            .collect();
+        assert_eq!(assignments.len(), 2);
+        for assignment in assignments {
+            assert!(
+                assignment.dependency_bindings.contains("cert"),
+                "pre-expanded child must retain the iterable binding dependency"
+            );
+        }
+    }
+
+    #[test]
     fn resort_preserves_pre_expansion_relative_order() {
         // carina#3132 highest-risk requirement: appending loop children
         // and re-sorting must not reorder already-planned resources
@@ -2612,10 +2714,13 @@ mod expand_same_config_deferred_for_tests {
             "no Assignment may materialize without a resolvable iterable"
         );
         assert_eq!(
-            out.residual_deferred_for.len(),
+            out.apply_time_reexpansion_targets.len(),
             1,
-            "the unresolvable loop must remain deferred so the validate/\
-             plan placeholder still renders"
+            "the unresolvable loop must become an apply-time re-expansion target"
+        );
+        assert!(
+            out.residual_deferred_for.is_empty(),
+            "apply-time re-expansion targets must not be mixed into residual deferred-for warnings"
         );
         assert_eq!(
             out.sorted_resources.len(),

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -465,7 +465,10 @@ pub fn build_detail_rows(
                 annotation: None,
             }]
         }
-        Effect::Remove { .. } | Effect::Move { .. } | Effect::Wait { .. } => Vec::new(),
+        Effect::Remove { .. }
+        | Effect::Move { .. }
+        | Effect::Wait { .. }
+        | Effect::ExpandDeferredFor { .. } => Vec::new(),
     }
 }
 

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -11,6 +11,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::non_empty::NonEmptyVec;
+use crate::parser::DeferredForExpression;
 use crate::resource::{DataSource, Directives, Resource, ResourceId, State};
 use crate::wait::predicate::WaitPredicate;
 
@@ -243,6 +244,21 @@ pub enum Effect {
         #[serde(default)]
         explicit_dependencies: HashSet<String>,
     },
+
+    /// Re-expand a `for opt in <upstream>.<collection> { ... }`
+    /// expression against the post-apply upstream state, emitting
+    /// fresh `Create` effects for the synthesised children.
+    ///
+    /// Emitted by the planner when the iterable's plan-time value is
+    /// unresolved. State-only: does not call the provider.
+    ExpandDeferredFor {
+        /// Synthetic id used for plan-tree display and progress.
+        id: ResourceId,
+        /// The iterable's binding name (e.g. "cert").
+        upstream_binding: String,
+        /// The for-expression body, replayed against the upstream state.
+        template: Box<DeferredForExpression>,
+    },
 }
 
 /// A type-level narrowing of [`Effect`] to the variants the basic
@@ -363,7 +379,8 @@ impl Effect {
             | Effect::Import { .. }
             | Effect::Remove { .. }
             | Effect::Move { .. }
-            | Effect::Wait { .. } => None,
+            | Effect::Wait { .. }
+            | Effect::ExpandDeferredFor { .. } => None,
         }
     }
 
@@ -387,20 +404,40 @@ impl Effect {
             Effect::Remove { .. } => "remove",
             Effect::Move { .. } => "move",
             Effect::Wait { .. } => "wait",
+            Effect::ExpandDeferredFor { .. } => "expand_deferred_for",
         }
     }
 
     /// Returns whether this Effect causes a mutation
     pub fn is_mutating(&self) -> bool {
-        !matches!(self, Effect::Read { .. }) && !self.is_wait()
+        match self {
+            Effect::Read { .. } => false,
+            Effect::Create(_) => true,
+            Effect::Update { .. } => true,
+            Effect::Replace { .. } => true,
+            Effect::Delete { .. } => true,
+            Effect::Import { .. } => true,
+            Effect::Remove { .. } => true,
+            Effect::Move { .. } => true,
+            Effect::Wait { .. } => false,
+            Effect::ExpandDeferredFor { .. } => true,
+        }
     }
 
-    /// Returns whether this is a state-only operation (import/remove/move)
+    /// Returns whether this is a state-only operation.
     pub fn is_state_operation(&self) -> bool {
-        matches!(
-            self,
-            Effect::Import { .. } | Effect::Remove { .. } | Effect::Move { .. }
-        )
+        match self {
+            Effect::Read { .. } => false,
+            Effect::Create(_) => false,
+            Effect::Update { .. } => false,
+            Effect::Replace { .. } => false,
+            Effect::Delete { .. } => false,
+            Effect::Import { .. } => true,
+            Effect::Remove { .. } => true,
+            Effect::Move { .. } => true,
+            Effect::Wait { .. } => false,
+            Effect::ExpandDeferredFor { .. } => true,
+        }
     }
 
     /// Returns the resource ID for this effect
@@ -415,6 +452,7 @@ impl Effect {
             Effect::Remove { id, .. } => id,
             Effect::Move { to, .. } => to,
             Effect::Wait { target_id, .. } => target_id,
+            Effect::ExpandDeferredFor { id, .. } => id,
         }
     }
 
@@ -438,37 +476,25 @@ impl Effect {
             | Effect::Import { .. }
             | Effect::Remove { .. }
             | Effect::Move { .. }
-            | Effect::Wait { .. } => None,
-        }
-    }
-
-    /// Returns the `directives` block of this effect's resource, if it
-    /// has one. `Read` (data source) and the managed variants both carry
-    /// directives; state-only and `Wait` effects do not.
-    fn resource_directives(&self) -> Option<&Directives> {
-        match self {
-            Effect::Create(resource) => Some(&resource.directives),
-            Effect::Update { to, .. } => Some(&to.directives),
-            Effect::Replace { to, .. } => Some(&to.directives),
-            Effect::Read { resource } => Some(&resource.directives),
-            Effect::Delete { .. }
-            | Effect::Import { .. }
-            | Effect::Remove { .. }
-            | Effect::Move { .. }
-            | Effect::Wait { .. } => None,
+            | Effect::Wait { .. }
+            | Effect::ExpandDeferredFor { .. } => None,
         }
     }
 
     /// Returns the binding name for this effect's resource, if it has one.
     pub fn binding_name(&self) -> Option<String> {
-        if let Effect::Delete { binding, .. } = self {
-            return binding.clone();
+        match self {
+            Effect::Read { resource } => resource.binding.clone(),
+            Effect::Create(resource) => resource.binding.clone(),
+            Effect::Update { to, .. } => to.binding.clone(),
+            Effect::Replace { to, .. } => to.binding.clone(),
+            Effect::Delete { binding, .. } => binding.clone(),
+            Effect::Import { .. } => None,
+            Effect::Remove { .. } => None,
+            Effect::Move { .. } => None,
+            Effect::Wait { binding, .. } => Some(binding.clone()),
+            Effect::ExpandDeferredFor { .. } => None,
         }
-        if let Effect::Wait { binding, .. } = self {
-            return Some(binding.clone());
-        }
-        self.as_resource_ref()
-            .and_then(|r| r.binding().map(str::to_string))
     }
 
     /// Returns the binding names this effect depends on **via explicit
@@ -485,24 +511,24 @@ impl Effect {
     /// State-only effects (Import, Remove, Move) return an empty set —
     /// they are scheduling primitives, not resource-state operations.
     pub fn explicit_dependencies(&self) -> HashSet<String> {
-        if let Some(directives) = self.resource_directives() {
-            return directives.depends_on.iter().cloned().collect();
+        match self {
+            Effect::Read { resource } => resource.directives.depends_on.iter().cloned().collect(),
+            Effect::Create(resource) => resource.directives.depends_on.iter().cloned().collect(),
+            Effect::Update { to, .. } => to.directives.depends_on.iter().cloned().collect(),
+            Effect::Replace { to, .. } => to.directives.depends_on.iter().cloned().collect(),
+            Effect::Delete {
+                explicit_dependencies,
+                ..
+            } => explicit_dependencies.clone(),
+            Effect::Import { .. } => HashSet::new(),
+            Effect::Remove { .. } => HashSet::new(),
+            Effect::Move { .. } => HashSet::new(),
+            Effect::Wait {
+                explicit_dependencies,
+                ..
+            } => explicit_dependencies.clone(),
+            Effect::ExpandDeferredFor { .. } => HashSet::new(),
         }
-        if let Effect::Delete {
-            explicit_dependencies,
-            ..
-        } = self
-        {
-            return explicit_dependencies.clone();
-        }
-        if let Effect::Wait {
-            explicit_dependencies,
-            ..
-        } = self
-        {
-            return explicit_dependencies.clone();
-        }
-        HashSet::new()
     }
 
     /// Bindings whose failure must prevent this effect from being dispatched.
@@ -534,7 +560,14 @@ impl Effect {
                 );
                 out
             }
-            _ => {
+            Effect::Read { .. }
+            | Effect::Create(_)
+            | Effect::Update { .. }
+            | Effect::Replace { .. }
+            | Effect::Delete { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Move { .. } => {
                 let mut deps = BTreeSet::new();
                 if let Some(resource) = self.as_resource_ref() {
                     deps.extend(crate::deps::get_resource_value_ref_dependencies(resource));
@@ -542,6 +575,9 @@ impl Effect {
                 deps.extend(self.explicit_dependencies());
                 deps.into_iter().collect()
             }
+            Effect::ExpandDeferredFor {
+                upstream_binding, ..
+            } => vec![upstream_binding.clone()],
         }
     }
 }
@@ -621,6 +657,29 @@ pub fn resolve_import_identifier(identifier: &crate::resource::Value) -> Result<
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    fn deferred_for_template() -> crate::parser::DeferredForExpression {
+        crate::parser::DeferredForExpression {
+            file: Some("main.crn".to_string()),
+            line: 12,
+            header: "for opt in cert.domain_validation_options".to_string(),
+            resource_type: "route53.Record".to_string(),
+            attributes: vec![],
+            binding_name: "validation_records".to_string(),
+            iterable_binding: "cert".to_string(),
+            iterable_attr: "domain_validation_options".to_string(),
+            binding: crate::parser::ForBinding::Simple("opt".to_string()),
+            template_resource: Resource::new("route53.Record", "validation_records"),
+        }
+    }
+
+    fn expand_deferred_for_effect() -> Effect {
+        Effect::ExpandDeferredFor {
+            id: ResourceId::new("route53.Record", "validation_records"),
+            upstream_binding: "cert".to_string(),
+            template: Box::new(deferred_for_template()),
+        }
+    }
 
     #[test]
     fn plan_op_supports_debug_eq_and_hash() {
@@ -706,6 +765,35 @@ mod tests {
         // Sanity: still passes for a concrete String/EnumIdentifier.
         let s = Value::Concrete(ConcreteValue::enum_identifier("ENUM_X"));
         assert_eq!(resolve_import_identifier(&s).unwrap(), "ENUM_X");
+    }
+
+    #[test]
+    fn expand_deferred_for_blocking_bindings_is_upstream_only() {
+        let effect = expand_deferred_for_effect();
+        assert_eq!(effect.blocking_bindings(), vec!["cert".to_string()]);
+    }
+
+    #[test]
+    fn expand_deferred_for_as_basic_returns_none() {
+        let effect = expand_deferred_for_effect();
+        assert!(effect.as_basic().is_none());
+    }
+
+    #[test]
+    fn expand_deferred_for_resource_id_returns_synthetic_id() {
+        let effect = expand_deferred_for_effect();
+        assert_eq!(
+            effect.resource_id(),
+            &ResourceId::new("route53.Record", "validation_records")
+        );
+    }
+
+    #[test]
+    fn expand_deferred_for_serde_roundtrip() {
+        let original = expand_deferred_for_effect();
+        let json = serde_json::to_string(&original).expect("serialize");
+        let decoded: Effect = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(decoded, original);
     }
 
     #[test]

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -436,6 +436,23 @@ impl Effect {
             Effect::Remove { .. } => true,
             Effect::Move { .. } => true,
             Effect::Wait { .. } => false,
+            Effect::ExpandDeferredFor { .. } => false,
+        }
+    }
+
+    /// Effects that do not call the provider and do not directly mutate state,
+    /// but produce new effects for the scheduler to dispatch.
+    pub fn is_scheduler_meta(&self) -> bool {
+        match self {
+            Effect::Read { .. } => false,
+            Effect::Create(_) => false,
+            Effect::Update { .. } => false,
+            Effect::Replace { .. } => false,
+            Effect::Delete { .. } => false,
+            Effect::Import { .. } => false,
+            Effect::Remove { .. } => false,
+            Effect::Move { .. } => false,
+            Effect::Wait { .. } => false,
             Effect::ExpandDeferredFor { .. } => true,
         }
     }
@@ -681,6 +698,87 @@ mod tests {
         }
     }
 
+    fn every_effect_variant() -> Vec<(&'static str, Effect)> {
+        use crate::resource::{ConcreteValue, State, Value};
+        use crate::wait::predicate::{AttrPath, WaitPredicate};
+        use std::time::Duration;
+
+        let rid = ResourceId::new("test", "x");
+        vec![
+            (
+                "Read",
+                Effect::Read {
+                    resource: DataSource::new("test", "x"),
+                },
+            ),
+            ("Create", Effect::Create(Resource::new("test", "x"))),
+            (
+                "Update",
+                Effect::Update {
+                    id: rid.clone(),
+                    from: Box::new(State::not_found(rid.clone())),
+                    to: Resource::new("test", "x"),
+                    changed_attributes: vec![],
+                },
+            ),
+            (
+                "Replace",
+                Effect::Replace {
+                    id: rid.clone(),
+                    from: Box::new(State::not_found(rid.clone())),
+                    to: Resource::new("test", "x"),
+                    directives: Directives::default(),
+                    changed_create_only: ChangedCreateOnly::new(vec!["attr".to_string()]).unwrap(),
+                    cascading_updates: vec![],
+                    temporary_name: None,
+                    cascade_ref_hints: vec![],
+                },
+            ),
+            (
+                "Delete",
+                Effect::Delete {
+                    id: rid.clone(),
+                    identifier: "x-1".to_string(),
+                    directives: Directives::default(),
+                    binding: None,
+                    dependencies: HashSet::new(),
+                    explicit_dependencies: HashSet::new(),
+                },
+            ),
+            (
+                "Import",
+                Effect::Import {
+                    id: rid.clone(),
+                    identifier: Value::Concrete(ConcreteValue::String("x-1".to_string())),
+                },
+            ),
+            ("Remove", Effect::Remove { id: rid.clone() }),
+            (
+                "Move",
+                Effect::Move {
+                    from: rid.clone(),
+                    to: ResourceId::new("test", "y"),
+                },
+            ),
+            (
+                "Wait",
+                Effect::Wait {
+                    binding: "w".to_string(),
+                    target_id: rid,
+                    until: WaitPredicate::Equals {
+                        attr: AttrPath::single("status"),
+                        value: Value::Concrete(ConcreteValue::String("ready".to_string())),
+                    },
+                    until_surface: "status == 'ready'".to_string(),
+                    timeout: Duration::from_secs(60),
+                    interval: Duration::from_secs(1),
+                    explicit_dependencies: HashSet::new(),
+                },
+            ),
+            ("ExpandDeferredFor", expand_deferred_for_effect()),
+        ]
+    }
+
     #[test]
     fn plan_op_supports_debug_eq_and_hash() {
         let op = PlanOp::Create;
@@ -794,6 +892,28 @@ mod tests {
         let json = serde_json::to_string(&original).expect("serialize");
         let decoded: Effect = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn is_scheduler_meta_only_true_for_expand_deferred_for() {
+        for (label, effect) in every_effect_variant() {
+            assert_eq!(
+                effect.is_scheduler_meta(),
+                label == "ExpandDeferredFor",
+                "{label} scheduler-meta classification mismatch",
+            );
+        }
+    }
+
+    #[test]
+    fn is_state_operation_excludes_expand_deferred_for() {
+        for (label, effect) in every_effect_variant() {
+            assert_eq!(
+                effect.is_state_operation(),
+                matches!(label, "Import" | "Remove" | "Move"),
+                "{label} state-operation classification mismatch",
+            );
+        }
     }
 
     #[test]

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -891,7 +891,18 @@ mod tests {
         let original = expand_deferred_for_effect();
         let json = serde_json::to_string(&original).expect("serialize");
         let decoded: Effect = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(decoded, original);
+        match decoded {
+            Effect::ExpandDeferredFor { template, .. } => {
+                assert_eq!(template.file, None);
+                assert_eq!(template.line, 0);
+                assert_eq!(template.header, "for opt in cert.domain_validation_options");
+                assert_eq!(template.resource_type, "route53.Record");
+                assert_eq!(template.binding_name, "validation_records");
+                assert_eq!(template.iterable_binding, "cert");
+                assert_eq!(template.iterable_attr, "domain_validation_options");
+            }
+            other => panic!("expected ExpandDeferredFor, got {other:?}"),
+        }
     }
 
     #[test]

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -18,11 +18,19 @@ use crate::provider::{
     build_update_patch,
 };
 use crate::resolver::resolve_ref_value;
-use crate::resource::{ConcreteValue, DeferredValue, Resource, ResourceId, State, Value};
-use crate::value::SecretHashContext;
+use crate::resource::{
+    ConcreteValue, DeferredValue, ResolvedResource, Resource, ResourceId, State, Value,
+};
+use crate::value::{SecretHashContext, SerializationContext, SerializationError};
 
 use super::wait::AppliedStates;
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
+
+/// Private capability token for constructing [`ResolvedResource`].
+/// Only this module can create a value, so the checked constructor in
+/// `resource` cannot be used by sibling modules as a convention-only
+/// escape hatch.
+pub(crate) struct ResolvedResourceToken(());
 
 /// Result of executing a basic effect (Create, Update, or Delete).
 ///
@@ -134,21 +142,22 @@ pub(super) async fn resolve_resource(
     resource: &Resource,
     bindings: &ResolvedBindings,
     pipeline: &RenormalizePipeline<'_>,
-) -> Result<NormalizedResource, String> {
+) -> Result<ResolvedResource, String> {
     let mut resolved = resource.clone();
     for (key, expr) in &resource.attributes {
         let resolved_value = unwrap_secret(resolve_ref_value(expr, bindings)?);
         assert_fully_resolved(&resolved_value, key, bindings)?;
         resolved.attributes.insert(key.clone(), resolved_value);
     }
-    Ok(apply_desired_normalization(
+    let normalized = apply_desired_normalization(
         resolved,
         pipeline.provider_configs,
         pipeline.normalizer,
         pipeline.factories,
         pipeline.schemas,
     )
-    .await)
+    .await;
+    resolved_normalized_resource(normalized).map_err(|err| err.to_string())
 }
 
 /// Resolve a resource, preferring unresolved source for re-resolution.
@@ -161,21 +170,35 @@ pub(super) async fn resolve_resource_with_source(
     source: &Resource,
     bindings: &ResolvedBindings,
     pipeline: &RenormalizePipeline<'_>,
-) -> Result<NormalizedResource, String> {
+) -> Result<ResolvedResource, String> {
     let mut resolved = target.clone();
     for (key, expr) in &source.attributes {
         let resolved_value = unwrap_secret(resolve_ref_value(expr, bindings)?);
         assert_fully_resolved(&resolved_value, key, bindings)?;
         resolved.attributes.insert(key.clone(), resolved_value);
     }
-    Ok(apply_desired_normalization(
+    let normalized = apply_desired_normalization(
         resolved,
         pipeline.provider_configs,
         pipeline.normalizer,
         pipeline.factories,
         pipeline.schemas,
     )
-    .await)
+    .await;
+    resolved_normalized_resource(normalized).map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+pub(super) fn resolved_resource(
+    resource: Resource,
+) -> Result<ResolvedResource, SerializationError> {
+    ResolvedResource::new(resource, ResolvedResourceToken(()))
+}
+
+pub(super) fn resolved_normalized_resource(
+    resource: NormalizedResource,
+) -> Result<ResolvedResource, SerializationError> {
+    resource.into_resolved_resource(ResolvedResourceToken(()))
 }
 
 /// The full plan-time normalization pipeline, threaded into the apply
@@ -199,34 +222,6 @@ pub(super) struct RenormalizePipeline<'a> {
 /// be resolved before reaching the provider (the executor unwraps
 /// secrets just downstream of this check).
 ///
-/// `Unknown` is *not* rejected: it is the deliberately-modeled
-/// "known after upstream apply" placeholder used by plan rendering
-/// (`UnknownReason::UpstreamRef`) and never reaches the apply path
-/// for local refs. Treating it as unresolved here would regress
-/// `resolve_refs_for_plan`'s contract.
-///
-/// # Kind-aware diagnostic (carina#3334)
-///
-/// When the unresolved value names a binding, the binding's
-/// [`BindingValueSource`] selects the remediation text:
-///
-/// - [`BindingValueSource::Upstream`] — the binding is an
-///   `upstream_state` read. `wait` blocks attach to managed-resource
-///   lifecycles in *this* configuration and cannot wake on an
-///   upstream stack's exports; the only fix is to apply the upstream
-///   stack first. The message says so verbatim.
-/// - [`BindingValueSource::Local`] / [`BindingValueSource::WaitAlias`]
-///   / unknown — the existing "add a `wait` block" hint applies (or
-///   is at least not actively misleading).
-///
-/// Sibling case carina#3252 was a data-source binding whose read
-/// state was missing from the binding view; that bug was fixed
-/// upstream (see [`crate::binding_index::ResolvedBindings`]
-/// `layer_data_source_bindings`) so the apply path no longer reaches
-/// this function for a resolved data source. If a data-source binding
-/// *does* still reach this function (e.g. a read returned 0 rows for
-/// the queried key), it falls through to the generic message — same
-/// behavior as before.
 fn assert_fully_resolved(
     value: &Value,
     attribute_key: &str,
@@ -282,27 +277,30 @@ fn assert_fully_resolved(
                 bindings,
             ))
         }
-        _ => Ok(()),
+        Value::Deferred(DeferredValue::Unknown(reason)) => {
+            Err(SerializationError::UnknownNotAllowed {
+                reason: reason.clone(),
+                context: SerializationContext::WasmBoundary,
+            }
+            .to_string())
+        }
+        Value::Concrete(ConcreteValue::String(_))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+        | Value::Concrete(ConcreteValue::CanonicalEnum(_))
+        | Value::Concrete(ConcreteValue::Int(_))
+        | Value::Concrete(ConcreteValue::Float(_))
+        | Value::Concrete(ConcreteValue::Bool(_))
+        | Value::Concrete(ConcreteValue::Duration(_))
+        | Value::Concrete(ConcreteValue::StringList(_)) => Ok(()),
     }
 }
 
-/// Shape of the unresolved value at the leaf of the rejected
-/// attribute. Drives the per-shape opening of the error message while
-/// the remediation text is selected by binding kind.
 enum UnresolvedSite {
     Ref { path: String },
     Interpolation,
     FunctionCall { name: String },
 }
 
-/// Build the kind-aware unresolved-binding error message.
-///
-/// `referenced_binding` is the name of the binding whose missing
-/// publish is the proximate cause of the failure. For container
-/// shapes (`Interpolation`, `FunctionCall`), the caller passes the
-/// first unresolved binding found by walking the value; an empty
-/// string means "no binding could be identified", which falls back to
-/// the generic remediation.
 fn unresolved_binding_message(
     attribute_key: &str,
     site: UnresolvedSite,
@@ -333,9 +331,6 @@ fn unresolved_binding_message(
     format!("{opener} {remediation}")
 }
 
-/// Walk a value tree and return the first binding name found inside
-/// any unresolved [`DeferredValue`] (`ResourceRef`, `BindingRef`,
-/// nested `Interpolation`, nested `FunctionCall`).
 fn collect_unresolved_bindings<'a>(value: &'a Value, out: &mut Vec<&'a str>) {
     use crate::resource::InterpolationPart;
     match value {
@@ -354,6 +349,7 @@ fn collect_unresolved_bindings<'a>(value: &'a Value, out: &mut Vec<&'a str>) {
                 collect_unresolved_bindings(a, out);
             }
         }
+        Value::Deferred(DeferredValue::Unknown(_)) => {}
         Value::Concrete(ConcreteValue::List(items)) => {
             for v in items {
                 collect_unresolved_bindings(v, out);
@@ -364,21 +360,17 @@ fn collect_unresolved_bindings<'a>(value: &'a Value, out: &mut Vec<&'a str>) {
                 collect_unresolved_bindings(v, out);
             }
         }
-        _ => {}
+        Value::Concrete(ConcreteValue::String(_))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+        | Value::Concrete(ConcreteValue::CanonicalEnum(_))
+        | Value::Concrete(ConcreteValue::Int(_))
+        | Value::Concrete(ConcreteValue::Float(_))
+        | Value::Concrete(ConcreteValue::Bool(_))
+        | Value::Concrete(ConcreteValue::Duration(_))
+        | Value::Concrete(ConcreteValue::StringList(_)) => {}
     }
 }
 
-/// Pick the most actionable binding name to feature in the
-/// diagnostic when a container value (`Interpolation`, `FunctionCall`)
-/// holds multiple unresolved references.
-///
-/// Selection rule: an `upstream_state` binding (whose remediation is
-/// "apply the upstream stack first") takes priority over a local /
-/// wait-alias binding (whose remediation is `wait`). Mixing the two
-/// in a single interpolation is unusual but legal — preferring
-/// Upstream means the message points at the binding the operator
-/// must act on outside the current configuration, not the one
-/// `wait` could (in principle) address.
 fn pick_unresolved_binding_for_diagnostic<'a>(
     value: &'a Value,
     bindings: &ResolvedBindings,
@@ -764,13 +756,11 @@ mod assert_fully_resolved_tests {
     }
 
     #[test]
-    fn unknown_is_intentionally_allowed() {
-        // `Unknown` is the plan-rendering placeholder for upstream
-        // refs (#2371). It legitimately reaches the apply path during
-        // re-resolution sweeps and must not be rejected by the local
-        // fail-fast.
+    fn unknown_is_rejected_at_apply_seam() {
         let v = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue));
-        assert!(assert_fully_resolved(&v, "name", &empty_bindings()).is_ok());
+        let err = assert_fully_resolved(&v, "name", &empty_bindings())
+            .expect_err("Unknown must be rejected at apply seam");
+        assert!(err.contains("value is not yet known"), "got: {err}");
     }
 
     #[test]

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -448,7 +448,9 @@ pub(super) fn process_basic_result(result: BasicEffectResult, exec: &mut Executi
 pub(super) fn count_actionable_effects(effects: &[Effect]) -> usize {
     effects
         .iter()
-        .filter(|e| !matches!(e, Effect::Read { .. }) && !e.is_state_operation())
+        .filter(|e| {
+            !matches!(e, Effect::Read { .. }) && !e.is_state_operation() && !e.is_scheduler_meta()
+        })
         .count()
 }
 

--- a/carina-core/src/executor/expand.rs
+++ b/carina-core/src/executor/expand.rs
@@ -1,29 +1,79 @@
 use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
-use crate::parser::{DeferredForExpression, expand_deferred_children};
+use crate::parser::{DeferredForExpression, ShapeMismatch, expand_deferred_children};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ExpansionFailure {
+    UpstreamBindingMissing {
+        upstream_binding: String,
+    },
+    IterableAttrMissing {
+        upstream_binding: String,
+        attr: String,
+    },
+    ShapeMismatch {
+        upstream_binding: String,
+        attr: String,
+        mismatch: ShapeMismatch,
+    },
+}
+
+impl ExpansionFailure {
+    pub(super) fn message(&self) -> String {
+        match self {
+            ExpansionFailure::UpstreamBindingMissing { upstream_binding } => {
+                format!(
+                    "deferred-for expansion upstream binding `{upstream_binding}` was not published before dispatch"
+                )
+            }
+            ExpansionFailure::IterableAttrMissing {
+                upstream_binding,
+                attr,
+            } => {
+                format!(
+                    "deferred-for expansion upstream binding `{upstream_binding}` does not contain iterable attribute `{attr}`"
+                )
+            }
+            ExpansionFailure::ShapeMismatch {
+                upstream_binding,
+                attr,
+                mismatch,
+            } => {
+                format!(
+                    "deferred-for expansion expected {} for `{upstream_binding}.{attr}` but got {}",
+                    mismatch.expected_kind(),
+                    mismatch.got_kind()
+                )
+            }
+        }
+    }
+}
 
 pub(super) fn expand_deferred_for_effects(
     upstream_binding: &str,
     template: &DeferredForExpression,
     bindings: &ResolvedBindings,
-) -> Vec<Effect> {
-    let upstream_attrs = bindings.get(upstream_binding).unwrap_or_else(|| {
-        panic!(
-            "ExpandDeferredFor upstream binding `{}` was not published before dispatch",
-            upstream_binding
-        )
-    });
-    let iterable = upstream_attrs
-        .get(&template.iterable_attr)
-        .unwrap_or_else(|| {
-            panic!(
-                "ExpandDeferredFor upstream binding `{}` does not contain iterable attribute `{}`",
-                upstream_binding, template.iterable_attr
-            )
-        });
+) -> Result<Vec<Effect>, ExpansionFailure> {
+    let upstream_attrs =
+        bindings
+            .get(upstream_binding)
+            .ok_or_else(|| ExpansionFailure::UpstreamBindingMissing {
+                upstream_binding: upstream_binding.to_string(),
+            })?;
+    let iterable = upstream_attrs.get(&template.iterable_attr).ok_or_else(|| {
+        ExpansionFailure::IterableAttrMissing {
+            upstream_binding: upstream_binding.to_string(),
+            attr: template.iterable_attr.clone(),
+        }
+    })?;
 
-    expand_deferred_children(template, iterable)
+    Ok(expand_deferred_children(template, iterable)
+        .map_err(|mismatch| ExpansionFailure::ShapeMismatch {
+            upstream_binding: upstream_binding.to_string(),
+            attr: template.iterable_attr.clone(),
+            mismatch,
+        })?
         .into_iter()
         .map(Effect::Create)
-        .collect()
+        .collect())
 }

--- a/carina-core/src/executor/expand.rs
+++ b/carina-core/src/executor/expand.rs
@@ -1,0 +1,29 @@
+use crate::binding_index::ResolvedBindings;
+use crate::effect::Effect;
+use crate::parser::{DeferredForExpression, expand_deferred_children};
+
+pub(super) fn expand_deferred_for_effects(
+    upstream_binding: &str,
+    template: &DeferredForExpression,
+    bindings: &ResolvedBindings,
+) -> Vec<Effect> {
+    let upstream_attrs = bindings.get(upstream_binding).unwrap_or_else(|| {
+        panic!(
+            "ExpandDeferredFor upstream binding `{}` was not published before dispatch",
+            upstream_binding
+        )
+    });
+    let iterable = upstream_attrs
+        .get(&template.iterable_attr)
+        .unwrap_or_else(|| {
+            panic!(
+                "ExpandDeferredFor upstream binding `{}` does not contain iterable attribute `{}`",
+                upstream_binding, template.iterable_attr
+            )
+        });
+
+    expand_deferred_children(template, iterable)
+        .into_iter()
+        .map(Effect::Create)
+        .collect()
+}

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -32,7 +32,7 @@ use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
 use crate::parser::ProviderConfig;
 use crate::provider::{Provider, ProviderNormalizer};
-use crate::resource::{ResolvedResource, ResourceId, State};
+use crate::resource::{ResolvedResource, Resource, ResourceId, State};
 use crate::value::SerializationError;
 use crate::wait::WaitObservation;
 
@@ -88,6 +88,7 @@ pub struct ExecutionResult {
     pub failure_count: usize,
     pub skip_count: usize,
     pub applied_states: std::collections::HashMap<ResourceId, State>,
+    pub runtime_synthesized_resources: Vec<Resource>,
     pub successfully_deleted: HashSet<ResourceId>,
     pub permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>>,
     pub current_states: HashMap<ResourceId, State>,

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -11,7 +11,7 @@
 //! - `replace`: Replace effect orchestration (CBD and DBD)
 //! - `phased`: Interdependent Replace ordering (4-phase execution)
 
-mod basic;
+pub(crate) mod basic;
 pub mod normalized;
 #[cfg(test)]
 mod normalized_tests;
@@ -31,7 +31,8 @@ use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
 use crate::parser::ProviderConfig;
 use crate::provider::{Provider, ProviderNormalizer};
-use crate::resource::{ResourceId, State};
+use crate::resource::{ResolvedResource, ResourceId, State};
+use crate::value::SerializationError;
 use crate::wait::WaitObservation;
 
 use parallel::execute_effects_sequential;
@@ -229,6 +230,14 @@ pub async fn execute_plan(
     } else {
         ExecutionOutcome::Completed(result)
     }
+}
+
+/// Prove an already-normalized desired resource is fully resolved before
+/// direct provider dispatch outside the normal plan executor.
+pub fn resolve_normalized_for_provider(
+    resource: normalized::NormalizedResource,
+) -> Result<ResolvedResource, SerializationError> {
+    basic::resolved_normalized_resource(resource)
 }
 
 #[cfg(test)]

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -12,6 +12,7 @@
 //! - `phased`: Interdependent Replace ordering (4-phase execution)
 
 pub(crate) mod basic;
+mod expand;
 pub mod normalized;
 #[cfg(test)]
 mod normalized_tests;

--- a/carina-core/src/executor/normalized.rs
+++ b/carina-core/src/executor/normalized.rs
@@ -28,8 +28,8 @@ use std::collections::HashMap;
 use crate::parser::ProviderConfig;
 use crate::provider::{ProviderFactory, ProviderNormalizer};
 use crate::resource::{
-    ConcreteValue, DeferredValue, InterpolationPart, Resource, ResourceId, State, Value,
-    contains_resource_ref,
+    ConcreteValue, DeferredValue, InterpolationPart, ResolvedResource, Resource, ResourceId, State,
+    Value, contains_resource_ref,
 };
 use crate::schema::SchemaRegistry;
 
@@ -42,6 +42,15 @@ impl NormalizedResource {
     /// Borrow the normalized resource for read-only consumers.
     pub fn as_resource(&self) -> &Resource {
         &self.0
+    }
+
+    /// Consume this normalized desired resource and prove it is free
+    /// of deferred placeholders before provider dispatch.
+    pub(crate) fn into_resolved_resource(
+        self,
+        token: crate::executor::basic::ResolvedResourceToken,
+    ) -> Result<ResolvedResource, crate::value::SerializationError> {
+        ResolvedResource::new(self.0, token)
     }
 }
 

--- a/carina-core/src/executor/normalized.rs
+++ b/carina-core/src/executor/normalized.rs
@@ -260,3 +260,34 @@ pub(crate) fn value_contains_unknown(value: &Value) -> bool {
         _ => false,
     }
 }
+
+/// Return whether `value` can drive plan-time deferred-for expansion.
+///
+/// Expansion needs a fully known iterable. Any reference-bearing or
+/// unevaluated deferred shape means substitution must wait until apply
+/// time, while concrete containers are walked recursively so deferred
+/// leaves nested inside lists/maps are rejected by the same predicate.
+pub fn is_value_fully_concrete_for_expansion(value: &Value) -> bool {
+    match value {
+        Value::Concrete(concrete) => match concrete {
+            ConcreteValue::String(_) => true,
+            ConcreteValue::EnumIdentifier(_) => true,
+            ConcreteValue::CanonicalEnum(_) => true,
+            ConcreteValue::Int(_) => true,
+            ConcreteValue::Float(_) => true,
+            ConcreteValue::Bool(_) => true,
+            ConcreteValue::Duration(_) => true,
+            ConcreteValue::List(items) => items.iter().all(is_value_fully_concrete_for_expansion),
+            ConcreteValue::StringList(_) => true,
+            ConcreteValue::Map(map) => map.values().all(is_value_fully_concrete_for_expansion),
+        },
+        Value::Deferred(deferred) => match deferred {
+            DeferredValue::ResourceRef { .. } => false,
+            DeferredValue::BindingRef { .. } => false,
+            DeferredValue::Interpolation(_) => false,
+            DeferredValue::FunctionCall { .. } => false,
+            DeferredValue::Secret(inner) => is_value_fully_concrete_for_expansion(inner),
+            DeferredValue::Unknown(_) => false,
+        },
+    }
+}

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -27,12 +27,12 @@ use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, 
 
 pub(super) fn is_runtime_dispatchable(effect: &Effect) -> bool {
     !matches!(effect, Effect::Read { .. })
-        && (!effect.is_state_operation() || matches!(effect, Effect::ExpandDeferredFor { .. }))
+        && (!effect.is_state_operation() || effect.is_scheduler_meta())
 }
 
 pub(super) fn is_runtime_noop(effect: &Effect) -> bool {
     matches!(effect, Effect::Read { .. })
-        || (effect.is_state_operation() && !matches!(effect, Effect::ExpandDeferredFor { .. }))
+        || (effect.is_state_operation() && !effect.is_scheduler_meta())
 }
 
 #[derive(Debug, Clone)]
@@ -395,7 +395,7 @@ pub(super) fn build_dependency_analysis(
 
     let mut analysis = DependencyAnalysis::new(effects.len());
     for (idx, effect) in effects.iter().enumerate() {
-        if matches!(effect, Effect::ExpandDeferredFor { .. }) {
+        if effect.is_scheduler_meta() {
             analyzer.collect_from_effect(effect, &mut analysis, idx);
         } else if effect.as_resource_ref().is_some() {
             if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
@@ -660,7 +660,7 @@ pub(super) async fn execute_effects_sequential(
             let effect = effects[idx].clone();
 
             if let Some(failed_dep) = find_failed_dependency(&effect, &failed_bindings) {
-                let c = if matches!(effect, Effect::ExpandDeferredFor { .. }) {
+                let c = if effect.is_scheduler_meta() {
                     completed.load(Ordering::Relaxed)
                 } else {
                     completed.fetch_add(1, Ordering::Relaxed) + 1

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tokio_util::sync::CancellationToken;
 
@@ -559,9 +559,10 @@ pub(super) async fn execute_effects_sequential(
     let mut successfully_deleted: HashSet<ResourceId> = HashSet::new();
     let mut permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>> = HashMap::new();
     let mut pending_refreshes: HashMap<ResourceId, String> = HashMap::new();
+    let mut runtime_synthesized_resources: Vec<Resource> = Vec::new();
 
     let mut effects = input.plan.effects().to_vec();
-    let total = count_actionable_effects(input.plan.effects());
+    let mut total = count_actionable_effects(input.plan.effects());
     let completed = AtomicUsize::new(0);
 
     let mut analysis =
@@ -695,11 +696,37 @@ pub(super) async fn execute_effects_sequential(
                 ..
             } = &effect
             {
-                let children =
-                    expand_deferred_for_effects(upstream_binding, template, &input.bindings);
+                let children = match expand_deferred_for_effects(
+                    upstream_binding,
+                    template,
+                    &input.bindings,
+                ) {
+                    Ok(children) => children,
+                    Err(err) => {
+                        let message = err.message();
+                        observer.on_event(&ExecutionEvent::EffectFailed {
+                            effect: &effect,
+                            error: &message,
+                            duration: Duration::ZERO,
+                            progress: ProgressInfo {
+                                completed: completed.load(Ordering::Relaxed),
+                                total,
+                            },
+                        });
+                        failure_count += 1;
+                        failed_bindings.insert(template.binding_name.clone());
+                        completed_indices.insert(idx);
+                        completed_synchronous_dispatch = true;
+                        break;
+                    }
+                };
                 if !children.is_empty() {
+                    total += count_actionable_effects(&children);
                     for child in children {
                         let child_idx = effects.len();
+                        if let Effect::Create(resource) = &child {
+                            runtime_synthesized_resources.push(resource.clone());
+                        }
                         if let Some(binding) = child.binding_name() {
                             idx_to_binding.insert(child_idx, binding);
                         }
@@ -1080,6 +1107,7 @@ pub(super) async fn execute_effects_sequential(
         failure_count,
         skip_count,
         applied_states: applied_states.into_inner(),
+        runtime_synthesized_resources,
         successfully_deleted,
         permanent_name_overrides,
         current_states: input.current_states.clone(),

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -16,6 +16,7 @@ use super::basic::{
     BasicEffectCtx, ExecutionState, RenormalizePipeline, count_actionable_effects,
     execute_basic_effect, process_basic_result, refresh_pending_states,
 };
+use super::expand::expand_deferred_for_effects;
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
 use super::wait::{
     AppliedStates, SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
@@ -23,6 +24,16 @@ use super::wait::{
     unsatisfiable_reason_message, wait_failure_message,
 };
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
+
+pub(super) fn is_runtime_dispatchable(effect: &Effect) -> bool {
+    !matches!(effect, Effect::Read { .. })
+        && (!effect.is_state_operation() || matches!(effect, Effect::ExpandDeferredFor { .. }))
+}
+
+pub(super) fn is_runtime_noop(effect: &Effect) -> bool {
+    matches!(effect, Effect::Read { .. })
+        || (effect.is_state_operation() && !matches!(effect, Effect::ExpandDeferredFor { .. }))
+}
 
 #[derive(Debug, Clone)]
 pub struct UnresolvedResource(Resource);
@@ -384,7 +395,9 @@ pub(super) fn build_dependency_analysis(
 
     let mut analysis = DependencyAnalysis::new(effects.len());
     for (idx, effect) in effects.iter().enumerate() {
-        if effect.as_resource_ref().is_some() {
+        if matches!(effect, Effect::ExpandDeferredFor { .. }) {
+            analyzer.collect_from_effect(effect, &mut analysis, idx);
+        } else if effect.as_resource_ref().is_some() {
             if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
                 analyzer.collect_from_resource(unresolved.as_resource(), &mut analysis, idx);
             } else {
@@ -547,17 +560,17 @@ pub(super) async fn execute_effects_sequential(
     let mut permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>> = HashMap::new();
     let mut pending_refreshes: HashMap<ResourceId, String> = HashMap::new();
 
-    let effects = input.plan.effects();
-    let total = count_actionable_effects(effects);
+    let mut effects = input.plan.effects().to_vec();
+    let total = count_actionable_effects(input.plan.effects());
     let completed = AtomicUsize::new(0);
 
     let mut analysis =
-        build_dependency_analysis(effects, input.unresolved_resources, input.compositions);
-    relax_update_update_edges(effects, &mut analysis);
-    let deps_of = analysis.into_deps_of();
+        build_dependency_analysis(&effects, input.unresolved_resources, input.compositions);
+    relax_update_update_edges(&effects, &mut analysis);
+    let mut deps_of = analysis.into_deps_of();
 
     // Build effect index -> binding name mapping for resolving dependency names
-    let idx_to_binding: HashMap<usize, String> = effects
+    let mut idx_to_binding: HashMap<usize, String> = effects
         .iter()
         .enumerate()
         .filter_map(|(idx, effect)| effect.binding_name().map(|b| (idx, b)))
@@ -568,15 +581,15 @@ pub(super) async fn execute_effects_sequential(
     // Track which effect indices have been dispatched (spawned or skipped)
     let mut dispatched: HashSet<usize> = HashSet::new();
     // All actionable effect indices (excluding Read and state operations)
-    let actionable_indices: Vec<usize> = (0..effects.len())
-        .filter(|&idx| {
-            !matches!(&effects[idx], Effect::Read { .. }) && !effects[idx].is_state_operation()
-        })
+    let mut actionable_indices: Vec<usize> = (0..effects.len())
+        .filter(|&idx| is_runtime_dispatchable(&effects[idx]))
         .collect();
 
-    // Mark Read and state operation effects as completed (they are no-ops in the executor)
+    // Mark Read and plain state operation effects as completed (they are no-ops in the executor).
+    // ExpandDeferredFor is state-only for progress/provider purposes, but it is a scheduler
+    // dispatch point that materializes dynamic Create effects.
     for (idx, effect) in effects.iter().enumerate() {
-        if matches!(effect, Effect::Read { .. }) || effect.is_state_operation() {
+        if is_runtime_noop(effect) {
             completed_indices.insert(idx);
             dispatched.insert(idx);
         }
@@ -640,12 +653,17 @@ pub(super) async fn execute_effects_sequential(
         newly_ready.truncate(available);
 
         // Process newly ready effects: skip those with failed deps, spawn the rest
+        let mut completed_synchronous_dispatch = false;
         for idx in newly_ready {
             dispatched.insert(idx);
-            let effect = &effects[idx];
+            let effect = effects[idx].clone();
 
-            if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
-                let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
+            if let Some(failed_dep) = find_failed_dependency(&effect, &failed_bindings) {
+                let c = if matches!(effect, Effect::ExpandDeferredFor { .. }) {
+                    completed.load(Ordering::Relaxed)
+                } else {
+                    completed.fetch_add(1, Ordering::Relaxed) + 1
+                };
                 let reason = if effect.is_wait() {
                     let detail =
                         unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
@@ -656,7 +674,7 @@ pub(super) async fn execute_effects_sequential(
                     format!("dependency '{}' failed", failed_dep)
                 };
                 observer.on_event(&ExecutionEvent::EffectSkipped {
-                    effect,
+                    effect: &effect,
                     reason: &reason,
                     progress: ProgressInfo {
                         completed: c,
@@ -671,6 +689,36 @@ pub(super) async fn execute_effects_sequential(
                 continue;
             }
 
+            if let Effect::ExpandDeferredFor {
+                upstream_binding,
+                template,
+                ..
+            } = &effect
+            {
+                let children =
+                    expand_deferred_for_effects(upstream_binding, template, &input.bindings);
+                if !children.is_empty() {
+                    for child in children {
+                        let child_idx = effects.len();
+                        if let Some(binding) = child.binding_name() {
+                            idx_to_binding.insert(child_idx, binding);
+                        }
+                        effects.push(child);
+                        actionable_indices.push(child_idx);
+                    }
+                    let mut analysis = build_dependency_analysis(
+                        &effects,
+                        input.unresolved_resources,
+                        input.compositions,
+                    );
+                    relax_update_update_edges(&effects, &mut analysis);
+                    deps_of = analysis.into_deps_of();
+                }
+                completed_indices.insert(idx);
+                completed_synchronous_dispatch = true;
+                break;
+            }
+
             // Snapshot bindings for this effect's resolution.
             let binding_snapshot = input.bindings.clone();
             let wait_identifiers = wait_identifiers.clone();
@@ -682,10 +730,11 @@ pub(super) async fn execute_effects_sequential(
                 schemas: input.schemas,
             };
             let completed_ref = &completed;
+            let effect_for_future = effect.clone();
             let make_future = move |wait_cancel_rx: Option<
                 tokio::sync::watch::Receiver<WaitSignal>,
             >| async move {
-                let result = match effect.as_basic() {
+                let result = match effect_for_future.as_basic() {
                     // `BasicEffect` is the type-level contract for
                     // `execute_basic_effect`: any Create/Update/Delete
                     // narrows here, and any non-basic variant falls
@@ -708,7 +757,7 @@ pub(super) async fn execute_effects_sequential(
                         )
                         .await,
                     ),
-                    None => match effect {
+                    None => match &effect_for_future {
                         Effect::Create(_) | Effect::Update { .. } | Effect::Delete { .. } => {
                             // `as_basic()` returns `Some` for exactly these
                             // three variants; they're handled by the `Some`
@@ -730,12 +779,14 @@ pub(super) async fn execute_effects_sequential(
                                 completed: c,
                                 total,
                             };
-                            observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                            observer.on_event(&ExecutionEvent::EffectStarted {
+                                effect: &effect_for_future,
+                            });
 
                             execute_replace_parallel(
                                 provider,
                                 &ReplaceContext {
-                                    effect,
+                                    effect: &effect_for_future,
                                     id,
                                     from,
                                     to,
@@ -757,9 +808,9 @@ pub(super) async fn execute_effects_sequential(
                         Effect::Import { .. } | Effect::Remove { .. } | Effect::Move { .. } => {
                             SingleEffectResult::ReadNoOp
                         }
-                        Effect::ExpandDeferredFor { .. } => {
-                            unreachable!("ExpandDeferredFor dispatch lands in Round 4")
-                        }
+                        Effect::ExpandDeferredFor { .. } => unreachable!(
+                            "ExpandDeferredFor is handled synchronously before provider dispatch"
+                        ),
                         Effect::Wait {
                             binding,
                             target_id,
@@ -770,7 +821,9 @@ pub(super) async fn execute_effects_sequential(
                         } => {
                             let c = completed_ref.fetch_add(1, Ordering::Relaxed) + 1;
                             let started = Instant::now();
-                            observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                            observer.on_event(&ExecutionEvent::EffectStarted {
+                                effect: &effect_for_future,
+                            });
                             let progress = ProgressInfo {
                                 completed: c,
                                 total,
@@ -808,12 +861,16 @@ pub(super) async fn execute_effects_sequential(
             }
         }
 
+        if completed_synchronous_dispatch {
+            continue;
+        }
+
         let count_undispatched =
             |dispatched: &HashSet<usize>, failed_bindings: &HashSet<String>| {
                 count_effectively_undispatched(
                     &actionable_indices,
                     dispatched,
-                    effects,
+                    &effects,
                     failed_bindings,
                 )
             };
@@ -832,7 +889,7 @@ pub(super) async fn execute_effects_sequential(
             if cancelled {
                 emit_cancelled_skips(
                     &CancelSkipCtx {
-                        effects,
+                        effects: &effects,
                         completed: &completed,
                         total,
                         observer,

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -757,6 +757,9 @@ pub(super) async fn execute_effects_sequential(
                         Effect::Import { .. } | Effect::Remove { .. } | Effect::Move { .. } => {
                             SingleEffectResult::ReadNoOp
                         }
+                        Effect::ExpandDeferredFor { .. } => {
+                            unreachable!("ExpandDeferredFor dispatch lands in Round 4")
+                        }
                         Effect::Wait {
                             binding,
                             target_id,

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -402,8 +402,9 @@ pub(super) async fn execute_effects_phased(
     let mut successfully_deleted: HashSet<ResourceId> = HashSet::new();
     let mut permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>> = HashMap::new();
     let mut pending_refreshes: HashMap<ResourceId, String> = HashMap::new();
+    let mut runtime_synthesized_resources: Vec<Resource> = Vec::new();
 
-    let total = count_actionable_effects(input.plan.effects());
+    let mut total = count_actionable_effects(input.plan.effects());
     let completed = AtomicUsize::new(0);
 
     let mut effects = input.plan.effects().to_vec();
@@ -526,11 +527,37 @@ pub(super) async fn execute_effects_phased(
                     ..
                 } = &effect
                 {
-                    let children =
-                        expand_deferred_for_effects(upstream_binding, template, &input.bindings);
+                    let children = match expand_deferred_for_effects(
+                        upstream_binding,
+                        template,
+                        &input.bindings,
+                    ) {
+                        Ok(children) => children,
+                        Err(err) => {
+                            let message = err.message();
+                            observer.on_event(&ExecutionEvent::EffectFailed {
+                                effect: &effect,
+                                error: &message,
+                                duration: Duration::ZERO,
+                                progress: ProgressInfo {
+                                    completed: completed.load(Ordering::Relaxed),
+                                    total,
+                                },
+                            });
+                            failure_count += 1;
+                            failed_bindings.insert(template.binding_name.clone());
+                            completed_indices.insert(idx);
+                            completed_synchronous_dispatch = true;
+                            break;
+                        }
+                    };
                     if !children.is_empty() {
+                        total += count_actionable_effects(&children);
                         for child in children {
                             let child_idx = effects.len();
+                            if let Effect::Create(resource) = &child {
+                                runtime_synthesized_resources.push(resource.clone());
+                            }
                             effects.push(child);
                             phase1_indices.push(child_idx);
                         }
@@ -1491,12 +1518,36 @@ pub(super) async fn execute_effects_phased(
                     ..
                 } = &effect
                 {
-                    let children =
-                        expand_deferred_for_effects(upstream_binding, template, &input.bindings);
+                    let children = match expand_deferred_for_effects(
+                        upstream_binding,
+                        template,
+                        &input.bindings,
+                    ) {
+                        Ok(children) => children,
+                        Err(err) => {
+                            let message = err.message();
+                            observer.on_event(&ExecutionEvent::EffectFailed {
+                                effect: &effect,
+                                error: &message,
+                                duration: Duration::ZERO,
+                                progress: ProgressInfo {
+                                    completed: completed.load(Ordering::Relaxed),
+                                    total,
+                                },
+                            });
+                            failure_count += 1;
+                            failed_bindings.insert(template.binding_name.clone());
+                            completed_indices.insert(idx);
+                            completed_synchronous_dispatch = true;
+                            break;
+                        }
+                    };
                     if !children.is_empty() {
+                        total += count_actionable_effects(&children);
                         for child in children {
                             let child_idx = effects.len();
                             if let Effect::Create(resource) = &child {
+                                runtime_synthesized_resources.push(resource.clone());
                                 debug_assert!(
                                     resource.dependency_bindings.contains(upstream_binding),
                                     "apply-time deferred-for child must retain iterable dependency"
@@ -2136,6 +2187,7 @@ pub(super) async fn execute_effects_phased(
         failure_count,
         skip_count,
         applied_states: applied_states.into_inner(),
+        runtime_synthesized_resources,
         successfully_deleted,
         permanent_name_overrides,
         current_states: input.current_states.clone(),

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -491,7 +491,7 @@ pub(super) async fn execute_effects_phased(
                 let effect = effects[idx].clone();
 
                 if let Some(failed_dep) = find_failed_dependency(&effect, &failed_bindings) {
-                    let c = if matches!(effect, Effect::ExpandDeferredFor { .. }) {
+                    let c = if effect.is_scheduler_meta() {
                         completed.load(Ordering::Relaxed)
                     } else {
                         completed.fetch_add(1, Ordering::Relaxed) + 1

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -17,6 +17,8 @@ use super::basic::{
     count_actionable_effects, execute_basic_effect, process_basic_result, queue_state_refresh,
     refresh_pending_states, resolve_resource, resolve_resource_with_source,
 };
+use super::expand::expand_deferred_for_effects;
+use super::parallel::is_runtime_dispatchable;
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::wait::{
     AppliedStates, SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
@@ -198,7 +200,7 @@ pub(super) fn build_phase_dependency_map(
         let mut dep_indices = HashSet::new();
         let effect = &effects[idx];
         match effect {
-            Effect::Wait { .. } => {
+            Effect::Wait { .. } | Effect::ExpandDeferredFor { .. } => {
                 resolver.collect_from_effect(effect, &mut dep_indices);
             }
             _ if effect.as_resource_ref().is_some() => {
@@ -404,9 +406,9 @@ pub(super) async fn execute_effects_phased(
     let total = count_actionable_effects(input.plan.effects());
     let completed = AtomicUsize::new(0);
 
-    let effects = input.plan.effects();
-    let replace_bindings = collect_replace_bindings(effects);
-    let sorted_indices = topological_sort_replaces(effects, &replace_bindings);
+    let mut effects = input.plan.effects().to_vec();
+    let replace_bindings = collect_replace_bindings(&effects);
+    let sorted_indices = topological_sort_replaces(&effects, &replace_bindings);
     let replaced_ids: HashSet<ResourceId> = effects
         .iter()
         .filter_map(|effect| match effect {
@@ -432,12 +434,21 @@ pub(super) async fn execute_effects_phased(
         let phase1_indices: Vec<usize> = (0..effects.len())
             .filter(|&idx| {
                 !matches!(&effects[idx], Effect::Replace { .. } | Effect::Read { .. })
+                    && is_runtime_dispatchable(&effects[idx])
+                    && !matches!(
+                        &effects[idx],
+                        Effect::ExpandDeferredFor {
+                            upstream_binding,
+                            ..
+                        } if replace_bindings.contains(upstream_binding)
+                    )
                     && !post_replace_wait_set.contains(&idx)
             })
             .collect();
 
-        let deps_of = build_phase_dependency_map(
-            effects,
+        let mut phase1_indices = phase1_indices;
+        let mut deps_of = build_phase_dependency_map(
+            &effects,
             &phase1_indices,
             input.unresolved_resources,
             input.compositions,
@@ -473,12 +484,17 @@ pub(super) async fn execute_effects_phased(
                 newly_ready.sort();
             }
 
+            let mut completed_synchronous_dispatch = false;
             for idx in newly_ready {
                 dispatched.insert(idx);
-                let effect = &effects[idx];
+                let effect = effects[idx].clone();
 
-                if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
-                    let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                if let Some(failed_dep) = find_failed_dependency(&effect, &failed_bindings) {
+                    let c = if matches!(effect, Effect::ExpandDeferredFor { .. }) {
+                        completed.load(Ordering::Relaxed)
+                    } else {
+                        completed.fetch_add(1, Ordering::Relaxed) + 1
+                    };
                     let reason = if effect.is_wait() {
                         let detail =
                             unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
@@ -489,7 +505,7 @@ pub(super) async fn execute_effects_phased(
                         format!("dependency '{}' failed", failed_dep)
                     };
                     observer.on_event(&ExecutionEvent::EffectSkipped {
-                        effect,
+                        effect: &effect,
                         reason: &reason,
                         progress: ProgressInfo {
                             completed: c,
@@ -504,6 +520,32 @@ pub(super) async fn execute_effects_phased(
                     continue;
                 }
 
+                if let Effect::ExpandDeferredFor {
+                    upstream_binding,
+                    template,
+                    ..
+                } = &effect
+                {
+                    let children =
+                        expand_deferred_for_effects(upstream_binding, template, &input.bindings);
+                    if !children.is_empty() {
+                        for child in children {
+                            let child_idx = effects.len();
+                            effects.push(child);
+                            phase1_indices.push(child_idx);
+                        }
+                        deps_of = build_phase_dependency_map(
+                            &effects,
+                            &phase1_indices,
+                            input.unresolved_resources,
+                            input.compositions,
+                        );
+                    }
+                    completed_indices.insert(idx);
+                    completed_synchronous_dispatch = true;
+                    break;
+                }
+
                 if let Effect::Wait {
                     binding,
                     target_id,
@@ -511,8 +553,13 @@ pub(super) async fn execute_effects_phased(
                     timeout,
                     interval,
                     ..
-                } = effect
+                } = &effect
                 {
+                    let binding = binding.clone();
+                    let target_id = target_id.clone();
+                    let until = until.clone();
+                    let timeout = *timeout;
+                    let interval = *interval;
                     let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
                     let progress = ProgressInfo {
                         completed: c,
@@ -520,19 +567,20 @@ pub(super) async fn execute_effects_phased(
                     };
                     let wait_identifiers = wait_identifiers.clone();
                     in_flight.push_wait(idx, |cancel_rx| {
+                        let effect = effect.clone();
                         Box::pin(async move {
                             let started = Instant::now();
-                            observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                            observer.on_event(&ExecutionEvent::EffectStarted { effect: &effect });
                             let identifier_resolver = |target_id: &ResourceId| {
                                 resolve_wait_identifier(&wait_identifiers, target_id)
                             };
                             let outcome = super::wait::execute_wait_effect(
                                 provider,
-                                target_id,
+                                &target_id,
                                 &identifier_resolver,
-                                until,
-                                *timeout,
-                                *interval,
+                                &until,
+                                timeout,
+                                interval,
                                 cancel_rx,
                                 observer,
                             )
@@ -540,7 +588,7 @@ pub(super) async fn execute_effects_phased(
                             (
                                 idx,
                                 PhaseEffectResult::Wait {
-                                    binding: binding.clone(),
+                                    binding,
                                     outcome,
                                     duration: started.elapsed(),
                                     progress,
@@ -563,10 +611,10 @@ pub(super) async fn execute_effects_phased(
                 // phases; everything else that isn't basic ends up
                 // here and is silently skipped from the basic
                 // executor's point of view.
-                let Some(basic_effect) = effect.as_basic() else {
+                if effect.as_basic().is_none() {
                     completed_indices.insert(idx);
                     continue;
-                };
+                }
 
                 let binding_snapshot = input.bindings.clone();
                 let unresolved = &input.unresolved_resources;
@@ -577,8 +625,12 @@ pub(super) async fn execute_effects_phased(
                     schemas: input.schemas,
                 };
                 let completed_ref = &completed;
+                let effect_for_future = effect.clone();
 
                 in_flight.push_non_wait(idx, async move {
+                    let basic_effect = effect_for_future
+                        .as_basic()
+                        .expect("phase 1 basic dispatch must receive a basic effect");
                     let basic = execute_basic_effect(
                         basic_effect,
                         &BasicEffectCtx {
@@ -596,12 +648,16 @@ pub(super) async fn execute_effects_phased(
                 });
             }
 
+            if completed_synchronous_dispatch {
+                continue;
+            }
+
             let count_undispatched =
                 |dispatched: &HashSet<usize>, failed_bindings: &HashSet<String>| {
                     count_effectively_undispatched(
                         &phase1_indices,
                         dispatched,
-                        effects,
+                        &effects,
                         failed_bindings,
                     )
                 };
@@ -613,7 +669,7 @@ pub(super) async fn execute_effects_phased(
             if in_flight.is_empty() {
                 if cancelled {
                     emit_cancelled_skips_with_progress(
-                        effects,
+                        &effects,
                         &phase1_indices,
                         &mut dispatched,
                         &mut completed_indices,
@@ -778,7 +834,7 @@ pub(super) async fn execute_effects_phased(
             .collect();
 
         let deps_of = build_phase_dependency_map(
-            effects,
+            &effects,
             &cbd_indices,
             input.unresolved_resources,
             input.compositions,
@@ -1030,7 +1086,7 @@ pub(super) async fn execute_effects_phased(
             if in_flight.is_empty() {
                 if cancelled {
                     emit_cancelled_skips_with_progress(
-                        effects,
+                        &effects,
                         &cbd_indices,
                         &mut dispatched,
                         &mut completed_indices,
@@ -1094,11 +1150,19 @@ pub(super) async fn execute_effects_phased(
                         queue_state_refresh(&mut pending_refreshes, &id, Some(&identifier));
                     }
                 }
-                PhaseEffectResult::Basic(BasicEffectResult::Failure { binding, .. }) => {
-                    failure_count += 1;
-                    if let Some(binding) = binding {
-                        failed_bindings.insert(binding);
-                    }
+                PhaseEffectResult::Basic(basic) => {
+                    process_basic_result(
+                        basic,
+                        &mut ExecutionState {
+                            success_count: &mut success_count,
+                            failure_count: &mut failure_count,
+                            applied_states: &mut applied_states,
+                            failed_bindings: &mut failed_bindings,
+                            successfully_deleted: &mut successfully_deleted,
+                            pending_refreshes: &mut pending_refreshes,
+                            bindings: &mut input.bindings,
+                        },
+                    );
                 }
                 _ => unreachable!(),
             }
@@ -1277,7 +1341,7 @@ pub(super) async fn execute_effects_phased(
             if in_flight.is_empty() {
                 if cancelled {
                     emit_cancelled_skips_with_progress(
-                        effects,
+                        &effects,
                         &delete_indices,
                         &mut dispatched,
                         &mut completed_indices,
@@ -1333,10 +1397,28 @@ pub(super) async fn execute_effects_phased(
     // Phase 4: Non-CBD creates and CBD finalization with parallel execution
     // -----------------------------------------------------------------------
     if !cancelled {
-        let phase4_indices: Vec<usize> = sorted_indices.clone();
+        let mut phase4_indices: Vec<usize> = sorted_indices.clone();
+        phase4_indices.extend(effects.iter().enumerate().filter_map(
+            |(idx, effect)| match effect {
+                Effect::ExpandDeferredFor {
+                    upstream_binding, ..
+                } if replace_bindings.contains(upstream_binding) => Some(idx),
+                Effect::Create(_)
+                | Effect::Update { .. }
+                | Effect::Replace { .. }
+                | Effect::Delete { .. }
+                | Effect::Read { .. }
+                | Effect::Import { .. }
+                | Effect::Remove { .. }
+                | Effect::Move { .. }
+                | Effect::Wait { .. }
+                | Effect::ExpandDeferredFor { .. } => None,
+            },
+        ));
+        phase4_indices.sort();
 
-        let deps_of = build_phase_dependency_map(
-            effects,
+        let mut deps_of = build_phase_dependency_map(
+            &effects,
             &phase4_indices,
             input.unresolved_resources,
             input.compositions,
@@ -1376,15 +1458,23 @@ pub(super) async fn execute_effects_phased(
                 newly_ready.sort();
             }
 
+            let mut completed_synchronous_dispatch = false;
             for idx in newly_ready {
                 dispatched.insert(idx);
-                let effect = &effects[idx];
-                let progress = replace_progress[&idx];
+                let effect = effects[idx].clone();
 
-                if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
+                if let Some(failed_dep) = find_failed_dependency(&effect, &failed_bindings) {
                     let reason = format!("dependency '{}' failed", failed_dep);
+                    let progress =
+                        replace_progress
+                            .get(&idx)
+                            .copied()
+                            .unwrap_or_else(|| ProgressInfo {
+                                completed: completed.load(Ordering::Relaxed),
+                                total,
+                            });
                     observer.on_event(&ExecutionEvent::EffectSkipped {
-                        effect,
+                        effect: &effect,
                         reason: &reason,
                         progress,
                     });
@@ -1392,6 +1482,71 @@ pub(super) async fn execute_effects_phased(
                         failed_bindings.insert(binding);
                     }
                     completed_indices.insert(idx);
+                    continue;
+                }
+
+                if let Effect::ExpandDeferredFor {
+                    upstream_binding,
+                    template,
+                    ..
+                } = &effect
+                {
+                    let children =
+                        expand_deferred_for_effects(upstream_binding, template, &input.bindings);
+                    if !children.is_empty() {
+                        for child in children {
+                            let child_idx = effects.len();
+                            if let Effect::Create(resource) = &child {
+                                debug_assert!(
+                                    resource.dependency_bindings.contains(upstream_binding),
+                                    "apply-time deferred-for child must retain iterable dependency"
+                                );
+                            }
+                            effects.push(child);
+                            phase4_indices.push(child_idx);
+                        }
+                        deps_of = build_phase_dependency_map(
+                            &effects,
+                            &phase4_indices,
+                            input.unresolved_resources,
+                            input.compositions,
+                        );
+                    }
+                    completed_indices.insert(idx);
+                    completed_synchronous_dispatch = true;
+                    break;
+                }
+
+                if effect.as_basic().is_some() {
+                    let binding_snapshot = input.bindings.clone();
+                    let unresolved = &input.unresolved_resources;
+                    let pipeline = RenormalizePipeline {
+                        normalizer: input.normalizer,
+                        provider_configs: input.provider_configs,
+                        factories: input.factories,
+                        schemas: input.schemas,
+                    };
+                    let completed_ref = &completed;
+                    let effect_for_future = effect.clone();
+                    in_flight.push(Box::pin(async move {
+                        let basic_effect = effect_for_future
+                            .as_basic()
+                            .expect("dynamic phase 4 create must be a basic effect");
+                        let basic = execute_basic_effect(
+                            basic_effect,
+                            &BasicEffectCtx {
+                                provider,
+                                bindings: &binding_snapshot,
+                                unresolved,
+                                pipeline: &pipeline,
+                                completed: completed_ref,
+                                total,
+                            },
+                            observer,
+                        )
+                        .await;
+                        (idx, PhaseEffectResult::Basic(basic))
+                    }));
                     continue;
                 }
 
@@ -1410,8 +1565,9 @@ pub(super) async fn execute_effects_phased(
                     directives,
                     temporary_name,
                     ..
-                } = effect
+                } = &effect
                 {
+                    let progress = replace_progress[&idx];
                     let effect_started = replace_start_times
                         .get(&idx)
                         .copied()
@@ -1426,6 +1582,7 @@ pub(super) async fn execute_effects_phased(
                         let id = id.clone();
                         let to = to.clone();
                         let temporary_name = temporary_name.clone();
+                        let effect_for_future = effect.clone();
 
                         in_flight.push(Box::pin(async move {
                             let started = effect_started;
@@ -1452,7 +1609,7 @@ pub(super) async fn execute_effects_phased(
                                             to: &temp.original_value,
                                         });
                                         observer.on_event(&ExecutionEvent::EffectSucceeded {
-                                            effect,
+                                            effect: &effect_for_future,
                                             state: None,
                                             duration: started.elapsed(),
                                             progress,
@@ -1473,7 +1630,7 @@ pub(super) async fn execute_effects_phased(
                                             error: &error_str,
                                         });
                                         observer.on_event(&ExecutionEvent::EffectFailed {
-                                            effect,
+                                            effect: &effect_for_future,
                                             error: "rename failed",
                                             duration: started.elapsed(),
                                             progress,
@@ -1483,7 +1640,7 @@ pub(super) async fn execute_effects_phased(
                                             PhaseEffectResult::CbdFinalizeFailed {
                                                 state,
                                                 resource_id: to.id.clone(),
-                                                binding: effect.binding_name(),
+                                                binding: effect_for_future.binding_name(),
                                             },
                                         )
                                     }
@@ -1504,7 +1661,7 @@ pub(super) async fn execute_effects_phased(
                                         }
                                     });
                                 observer.on_event(&ExecutionEvent::EffectSucceeded {
-                                    effect,
+                                    effect: &effect_for_future,
                                     state: None,
                                     duration: started.elapsed(),
                                     progress,
@@ -1529,8 +1686,9 @@ pub(super) async fn execute_effects_phased(
                         }
 
                         // Non-CBD: create new resource
+                        let effect_for_future = effect.clone();
                         in_flight.push(Box::pin(async move {
-                            if let Effect::Replace { to, .. } = effect {
+                            if let Effect::Replace { to, .. } = &effect_for_future {
                                 let started = effect_started;
                                 let resolve_source = unresolved
                                     .get(&to.id)
@@ -1546,7 +1704,7 @@ pub(super) async fn execute_effects_phased(
                                     Ok(r) => r,
                                     Err(e) => {
                                         observer.on_event(&ExecutionEvent::EffectFailed {
-                                            effect,
+                                            effect: &effect_for_future,
                                             error: &e,
                                             duration: started.elapsed(),
                                             progress,
@@ -1554,7 +1712,7 @@ pub(super) async fn execute_effects_phased(
                                         return (
                                             idx,
                                             PhaseEffectResult::Basic(BasicEffectResult::Failure {
-                                                binding: effect.binding_name(),
+                                                binding: effect_for_future.binding_name(),
                                                 refresh: None,
                                             }),
                                         );
@@ -1568,7 +1726,7 @@ pub(super) async fn execute_effects_phased(
                                 {
                                     Ok(state) => {
                                         observer.on_event(&ExecutionEvent::EffectSucceeded {
-                                            effect,
+                                            effect: &effect_for_future,
                                             state: Some(&state),
                                             duration: started.elapsed(),
                                             progress,
@@ -1586,7 +1744,7 @@ pub(super) async fn execute_effects_phased(
                                     Err(e) => {
                                         let error_str = e.to_string();
                                         observer.on_event(&ExecutionEvent::EffectFailed {
-                                            effect,
+                                            effect: &effect_for_future,
                                             error: &error_str,
                                             duration: started.elapsed(),
                                             progress,
@@ -1594,7 +1752,7 @@ pub(super) async fn execute_effects_phased(
                                         (
                                             idx,
                                             PhaseEffectResult::NonCbdCreateFailure {
-                                                binding: effect.binding_name(),
+                                                binding: effect_for_future.binding_name(),
                                             },
                                         )
                                     }
@@ -1607,16 +1765,28 @@ pub(super) async fn execute_effects_phased(
                 }
             }
 
+            if completed_synchronous_dispatch {
+                continue;
+            }
+
             if in_flight.is_empty() {
                 if cancelled {
                     emit_cancelled_skips_with_progress(
-                        effects,
+                        &effects,
                         &phase4_indices,
                         &mut dispatched,
                         &mut completed_indices,
                         &mut skip_count,
                         observer,
-                        |idx| replace_progress[&idx],
+                        |idx| {
+                            replace_progress
+                                .get(&idx)
+                                .copied()
+                                .unwrap_or_else(|| ProgressInfo {
+                                    completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
+                                    total,
+                                })
+                        },
                     );
                 }
                 break;
@@ -1679,11 +1849,19 @@ pub(super) async fn execute_effects_phased(
                         failed_bindings.insert(binding);
                     }
                 }
-                PhaseEffectResult::Basic(BasicEffectResult::Failure { binding, .. }) => {
-                    failure_count += 1;
-                    if let Some(binding) = binding {
-                        failed_bindings.insert(binding);
-                    }
+                PhaseEffectResult::Basic(basic) => {
+                    process_basic_result(
+                        basic,
+                        &mut ExecutionState {
+                            success_count: &mut success_count,
+                            failure_count: &mut failure_count,
+                            applied_states: &mut applied_states,
+                            failed_bindings: &mut failed_bindings,
+                            successfully_deleted: &mut successfully_deleted,
+                            pending_refreshes: &mut pending_refreshes,
+                            bindings: &mut input.bindings,
+                        },
+                    );
                 }
                 _ => unreachable!(),
             }
@@ -1695,7 +1873,7 @@ pub(super) async fn execute_effects_phased(
     // -----------------------------------------------------------------------
     if !cancelled && !post_replace_wait_indices.is_empty() {
         let deps_of = build_phase_dependency_map(
-            effects,
+            &effects,
             &post_replace_wait_indices,
             input.unresolved_resources,
             input.compositions,
@@ -1808,7 +1986,7 @@ pub(super) async fn execute_effects_phased(
                     count_effectively_undispatched(
                         &post_replace_wait_indices,
                         dispatched,
-                        effects,
+                        &effects,
                         failed_bindings,
                     )
                 };
@@ -1820,7 +1998,7 @@ pub(super) async fn execute_effects_phased(
             if in_flight.is_empty() {
                 if cancelled {
                     emit_cancelled_skips_with_progress(
-                        effects,
+                        &effects,
                         &post_replace_wait_indices,
                         &mut dispatched,
                         &mut completed_indices,

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -9,12 +9,11 @@ use crate::differ::{
 };
 use crate::effect::Effect;
 use crate::executor::UnresolvedResource;
-use crate::executor::normalized::NormalizedResource;
 use crate::provider::{
     CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, UpdatePatch, UpdateRequest,
     build_update_patch,
 };
-use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use crate::resource::{ConcreteValue, ResolvedResource, Resource, ResourceId, State, Value};
 use crate::schema::SchemaRegistry;
 use crate::value::SecretHashContext;
 
@@ -31,7 +30,7 @@ use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 /// from/to comparison directly).
 pub fn compute_full_diff_patch(
     from: &State,
-    to: &NormalizedResource,
+    to: &ResolvedResource,
     to_source: &Resource,
     schemas: &SchemaRegistry,
     resource_id: &ResourceId,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -4,7 +4,11 @@ use crate::provider::{
     BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
     ReadRequest, UpdateRequest,
 };
-use crate::resource::{ConcreteValue, DataSource, DeferredValue, Directives, Resource, Value};
+use crate::resource::{
+    AccessPath, ConcreteValue, DataSource, DeferredValue, Directives, Resource, UnknownReason,
+    Value,
+};
+use crate::value::SerializationError;
 use parallel::{build_dependency_analysis, build_dependency_levels};
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -242,6 +246,64 @@ fn completed_result(outcome: ExecutionOutcome) -> ExecutionResult {
             result.success_count, result.failure_count, result.skip_count
         ),
     }
+}
+
+fn resource_with_attr(value: Value) -> Resource {
+    let mut resource = Resource::new("test", "resolved-resource-test");
+    resource.set_attr("attr", value);
+    resource
+}
+
+fn for_value_path_unknown() -> Value {
+    Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath {
+        path: AccessPath::with_fields("opt", "resource_record", vec!["name".to_string()]),
+    }))
+}
+
+#[test]
+fn resolved_resource_constructor_rejects_value_unknown() {
+    let err = basic::resolved_resource(resource_with_attr(for_value_path_unknown()))
+        .expect_err("deferred unknown must not construct a ResolvedResource");
+
+    assert!(
+        matches!(err, SerializationError::UnknownNotAllowed { .. }),
+        "expected UnknownNotAllowed, got {err:?}"
+    );
+}
+
+#[test]
+fn resolved_resource_constructor_rejects_resource_ref() {
+    let value = Value::Deferred(DeferredValue::ResourceRef {
+        path: AccessPath::new("cert", "domain_validation_options"),
+    });
+
+    let err = basic::resolved_resource(resource_with_attr(value))
+        .expect_err("resource refs must not construct a ResolvedResource");
+
+    assert!(
+        matches!(err, SerializationError::UnresolvedResourceRef { .. }),
+        "expected UnresolvedResourceRef, got {err:?}"
+    );
+}
+
+#[test]
+fn resolved_resource_constructor_rejects_nested_deferred() {
+    let mut map = indexmap::IndexMap::new();
+    map.insert(
+        "secret".to_string(),
+        Value::Deferred(DeferredValue::Secret(Box::new(for_value_path_unknown()))),
+    );
+    let nested = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+        ConcreteValue::Map(map),
+    )]));
+
+    let err = basic::resolved_resource(resource_with_attr(nested))
+        .expect_err("nested deferred values must not construct a ResolvedResource");
+
+    assert!(
+        matches!(err, SerializationError::UnknownNotAllowed { .. }),
+        "expected UnknownNotAllowed, got {err:?}"
+    );
 }
 
 // -----------------------------------------------------------------------

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -16,6 +16,43 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+fn validation_deferred_for_expression() -> crate::parser::DeferredForExpression {
+    let mut template_resource = Resource::new("test", "validation_records");
+    template_resource.binding = Some("validation_records".to_string());
+    template_resource
+        .dependency_bindings
+        .insert("cert".to_string());
+    template_resource.set_attr(
+        "name",
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath {
+            path: AccessPath::with_fields("opt", "resource_record", vec!["name".to_string()]),
+        })),
+    );
+    template_resource.set_attr(
+        "value",
+        Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath {
+            path: AccessPath::with_fields("opt", "resource_record", vec!["value".to_string()]),
+        })),
+    );
+
+    crate::parser::DeferredForExpression {
+        file: None,
+        line: 1,
+        header: "for opt in cert.domain_validation_options".to_string(),
+        resource_type: "test.ValidationRecord".to_string(),
+        attributes: template_resource
+            .attributes
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+        binding_name: "validation_records".to_string(),
+        iterable_binding: "cert".to_string(),
+        iterable_attr: "domain_validation_options".to_string(),
+        binding: crate::parser::ForBinding::Simple("opt".to_string()),
+        template_resource,
+    }
+}
+
 // -----------------------------------------------------------------------
 // Mock Provider
 // -----------------------------------------------------------------------
@@ -5340,6 +5377,400 @@ async fn wait_resolves_target_identifier_from_just_replaced_state_phased() {
             .iter()
             .any(|identifier| identifier.as_deref() == Some("new-arn")),
         "phased wait read must use the replacement identifier from applied_states; got: {read_identifiers:?}"
+    );
+}
+
+#[tokio::test]
+async fn expand_deferred_for_dispatches_after_upstream_replace_before_wait_phased() {
+    use crate::effect::ChangedCreateOnly;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let mut cert = Resource::new("test", "cert");
+    cert.binding = Some("cert".to_string());
+    cert.set_attr(
+        "domain_name",
+        Value::Concrete(ConcreteValue::String("example.com".to_string())),
+    );
+    let cert_id = cert.id.clone();
+
+    let mut dep = Resource::new("test", "dep");
+    dep.binding = Some("dep".to_string());
+    dep.dependency_bindings.insert("cert".to_string());
+    let dep_id = dep.id.clone();
+
+    let old_cert_state = State::existing(cert_id.clone(), HashMap::new()).with_identifier("old");
+    let old_dep_state = State::existing(dep_id.clone(), HashMap::new()).with_identifier("dep-old");
+
+    let cert_state = State::existing(
+        cert_id.clone(),
+        HashMap::from([
+            (
+                "domain_validation_options".to_string(),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(indexmap::IndexMap::from([(
+                        "resource_record".to_string(),
+                        Value::Concrete(ConcreteValue::Map(indexmap::IndexMap::from([
+                            (
+                                "name".to_string(),
+                                Value::Concrete(ConcreteValue::String(
+                                    "_dns_record_name_".to_string(),
+                                )),
+                            ),
+                            (
+                                "value".to_string(),
+                                Value::Concrete(ConcreteValue::String(
+                                    "_dns_record_value_".to_string(),
+                                )),
+                            ),
+                        ]))),
+                    )])),
+                )])),
+            ),
+            (
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("issued".to_string())),
+            ),
+        ]),
+    )
+    .with_identifier("new");
+    let dep_state = State::existing(dep_id.clone(), HashMap::new()).with_identifier("dep-new");
+    let validation_id = ResourceId::new("test", "validation_records[0]");
+    let validation_state =
+        State::existing(validation_id.clone(), HashMap::new()).with_identifier("validation");
+
+    let provider = MockProvider::new();
+    provider.push_delete(Ok(()));
+    provider.push_delete(Ok(()));
+    provider.push_create(Ok(cert_state.clone()));
+    provider.push_create(Ok(dep_state));
+    provider.push_create(Ok(validation_state));
+    provider.push_read(Ok(cert_state));
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: cert_id.clone(),
+        from: Box::new(old_cert_state.clone()),
+        to: cert,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Replace {
+        id: dep_id.clone(),
+        from: Box::new(old_dep_state.clone()),
+        to: dep,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::ExpandDeferredFor {
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "cert".to_string(),
+        template: Box::new(validation_deferred_for_expression()),
+    });
+    plan.add(Effect::Wait {
+        binding: "cert_issued".to_string(),
+        target_id: cert_id.clone(),
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        until_surface: "cert.status == \"issued\"".to_string(),
+        timeout: std::time::Duration::from_secs(5),
+        interval: std::time::Duration::from_millis(10),
+        explicit_dependencies: HashSet::from(["validation_records[0]".to_string()]),
+    });
+    assert!(
+        has_interdependent_replaces(plan.effects()),
+        "test must exercise phased execution"
+    );
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([
+            (cert_id.clone(), old_cert_state),
+            (dep_id.clone(), old_dep_state),
+        ]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    assert_eq!(result.failure_count, 0);
+    assert_eq!(result.skip_count, 0);
+    let events = observer.events();
+    let cert_success = events
+        .iter()
+        .position(|event| event == "succeeded:test.cert")
+        .expect("cert replace must succeed");
+    let validation_success = events
+        .iter()
+        .position(|event| event == "succeeded:test.validation_records[0]")
+        .expect("validation record create must succeed");
+    let wait_success = events
+        .iter()
+        .enumerate()
+        .skip(validation_success + 1)
+        .find_map(|(idx, event)| (event == "succeeded:test.cert").then_some(idx))
+        .expect("wait must succeed");
+    assert!(cert_success < validation_success);
+    assert!(validation_success < wait_success);
+
+    let created = provider.captured_create_resources();
+    let validation = created
+        .iter()
+        .find(|resource| resource.id == validation_id)
+        .expect("validation child must be passed through provider create");
+    assert_eq!(
+        validation.attributes.get("name"),
+        Some(&Value::Concrete(ConcreteValue::String(
+            "_dns_record_name_".to_string()
+        )))
+    );
+}
+
+#[tokio::test]
+async fn expand_deferred_for_emits_zero_children_when_collection_is_empty() {
+    use crate::effect::ChangedCreateOnly;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let mut cert = Resource::new("test", "cert_empty");
+    cert.binding = Some("cert".to_string());
+    cert.set_attr(
+        "domain_name",
+        Value::Concrete(ConcreteValue::String("example.com".to_string())),
+    );
+    let cert_id = cert.id.clone();
+    let old_cert_state = State::existing(cert_id.clone(), HashMap::new()).with_identifier("old");
+    let cert_state = State::existing(
+        cert_id.clone(),
+        HashMap::from([
+            (
+                "domain_validation_options".to_string(),
+                Value::Concrete(ConcreteValue::List(Vec::new())),
+            ),
+            (
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("issued".to_string())),
+            ),
+        ]),
+    )
+    .with_identifier("new");
+
+    let provider = MockProvider::new();
+    provider.push_delete(Ok(()));
+    provider.push_create(Ok(cert_state.clone()));
+    provider.push_read(Ok(cert_state));
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: cert_id.clone(),
+        from: Box::new(old_cert_state.clone()),
+        to: cert,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::ExpandDeferredFor {
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "cert".to_string(),
+        template: Box::new(validation_deferred_for_expression()),
+    });
+    plan.add(Effect::Wait {
+        binding: "cert_issued".to_string(),
+        target_id: cert_id.clone(),
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        until_surface: "cert.status == \"issued\"".to_string(),
+        timeout: std::time::Duration::from_secs(5),
+        interval: std::time::Duration::from_millis(10),
+        explicit_dependencies: HashSet::new(),
+    });
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([(cert_id.clone(), old_cert_state)]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    assert_eq!(result.failure_count, 0);
+    assert_eq!(result.skip_count, 0);
+    assert!(
+        provider
+            .calls()
+            .iter()
+            .all(|(op, id)| op != "create" || id != "test.validation_records[0]"),
+        "empty collection must not synthesize children"
+    );
+    let events = observer.events();
+    assert!(
+        events.contains(&"succeeded:test.cert_empty".to_string()),
+        "events: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn expand_deferred_for_cancelled_after_upstream_create_reports_skipped() {
+    use crate::effect::ChangedCreateOnly;
+
+    struct CancelAfterCertProvider {
+        cancel: CancellationToken,
+        calls: Mutex<Vec<(String, String)>>,
+    }
+
+    impl Provider for CancelAfterCertProvider {
+        fn name(&self) -> &str {
+            "cancel-after-cert"
+        }
+
+        fn read(
+            &self,
+            id: &ResourceId,
+            _identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        }
+
+        fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+            self.read(&resource.id, None, ReadRequest)
+        }
+
+        fn create(
+            &self,
+            id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(("create".to_string(), id.to_string()));
+            let cancel = self.cancel.clone();
+            let id = id.clone();
+            Box::pin(async move {
+                cancel.cancel();
+                Ok(State::existing(
+                    id,
+                    HashMap::from([(
+                        "domain_validation_options".to_string(),
+                        Value::Concrete(ConcreteValue::List(Vec::new())),
+                    )]),
+                ))
+            })
+        }
+
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            unreachable!("test does not update")
+        }
+
+        fn delete(
+            &self,
+            id: &ResourceId,
+            _identifier: &str,
+            _request: DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(("delete".to_string(), id.to_string()));
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: crate::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    let mut cert = Resource::new("test", "cert_cancel");
+    cert.binding = Some("cert".to_string());
+    cert.set_attr(
+        "domain_name",
+        Value::Concrete(ConcreteValue::String("example.com".to_string())),
+    );
+    let cert_id = cert.id.clone();
+    let old_cert_state = State::existing(cert_id.clone(), HashMap::new()).with_identifier("old");
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: cert_id.clone(),
+        from: Box::new(old_cert_state.clone()),
+        to: cert,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::ExpandDeferredFor {
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "cert".to_string(),
+        template: Box::new(validation_deferred_for_expression()),
+    });
+
+    let cancel = CancellationToken::new();
+    let provider = CancelAfterCertProvider {
+        cancel: cancel.clone(),
+        calls: Mutex::new(Vec::new()),
+    };
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([(cert_id.clone(), old_cert_state)]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(1).unwrap(),
+    };
+    let observer = MockObserver::new();
+    let outcome = execute_plan(&provider, input, &observer, cancel).await;
+
+    assert!(matches!(outcome, ExecutionOutcome::Cancelled(_)));
+    assert!(
+        observer
+            .events()
+            .iter()
+            .any(|event| { event == "skipped:__deferred_for.validation_records:cancelled" })
     );
 }
 

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -201,6 +201,11 @@ struct MockObserver {
     events: Mutex<Vec<String>>,
 }
 
+struct ProgressObserver {
+    events: MockObserver,
+    progress: Mutex<Vec<ProgressInfo>>,
+}
+
 fn format_execution_event(event: &ExecutionEvent<'_>) -> String {
     match event {
         ExecutionEvent::Waiting {
@@ -272,6 +277,46 @@ impl ExecutionObserver for MockObserver {
             .lock()
             .unwrap()
             .push(format_execution_event(event));
+    }
+}
+
+impl ProgressObserver {
+    fn new() -> Self {
+        Self {
+            events: MockObserver::new(),
+            progress: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn events(&self) -> Vec<String> {
+        self.events.events()
+    }
+
+    fn progress(&self) -> Vec<ProgressInfo> {
+        self.progress.lock().unwrap().clone()
+    }
+}
+
+impl ExecutionObserver for ProgressObserver {
+    fn on_event(&self, event: &ExecutionEvent) {
+        self.events.on_event(event);
+        match event {
+            ExecutionEvent::EffectSucceeded { progress, .. }
+            | ExecutionEvent::EffectFailed { progress, .. }
+            | ExecutionEvent::EffectSkipped { progress, .. } => {
+                self.progress.lock().unwrap().push(*progress);
+            }
+            ExecutionEvent::Waiting { .. }
+            | ExecutionEvent::EffectStarted { .. }
+            | ExecutionEvent::WaitPolling { .. }
+            | ExecutionEvent::CascadeUpdateSucceeded { .. }
+            | ExecutionEvent::CascadeUpdateFailed { .. }
+            | ExecutionEvent::RenameSucceeded { .. }
+            | ExecutionEvent::RenameFailed { .. }
+            | ExecutionEvent::RefreshStarted
+            | ExecutionEvent::RefreshSucceeded { .. }
+            | ExecutionEvent::RefreshFailed { .. } => {}
+        }
     }
 }
 
@@ -686,6 +731,7 @@ fn empty_execution_result() -> ExecutionResult {
         failure_count: 0,
         skip_count: 0,
         applied_states: Default::default(),
+        runtime_synthesized_resources: Vec::new(),
         successfully_deleted: HashSet::new(),
         permanent_name_overrides: HashMap::new(),
         current_states: HashMap::new(),
@@ -5505,7 +5551,7 @@ async fn expand_deferred_for_dispatches_after_upstream_replace_before_wait_phase
         parallelism: crate::executor::TEST_UNCAPPED,
     };
 
-    let observer = MockObserver::new();
+    let observer = ProgressObserver::new();
     let result =
         completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
 
@@ -5528,6 +5574,13 @@ async fn expand_deferred_for_dispatches_after_upstream_replace_before_wait_phase
         .expect("wait must succeed");
     assert!(cert_success < validation_success);
     assert!(validation_success < wait_success);
+    assert!(
+        observer
+            .progress()
+            .iter()
+            .all(|progress| progress.completed <= progress.total),
+        "dynamic creates must increase total before progress is emitted"
+    );
 
     let created = provider.captured_create_resources();
     let validation = created
@@ -5772,6 +5825,126 @@ async fn expand_deferred_for_cancelled_after_upstream_create_reports_skipped() {
             .iter()
             .any(|event| { event == "skipped:__deferred_for.validation_records:cancelled" })
     );
+}
+
+#[tokio::test]
+async fn expand_deferred_for_returns_error_when_upstream_binding_missing() {
+    let provider = MockProvider::new();
+    let mut plan = Plan::new();
+    plan.add(Effect::ExpandDeferredFor {
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "missing_cert".to_string(),
+        template: Box::new(validation_deferred_for_expression()),
+    });
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    assert_eq!(result.failure_count, 1);
+    assert!(observer.events().iter().any(|event| {
+        event.contains("failed:__deferred_for.validation_records") && event.contains("missing_cert")
+    }));
+}
+
+#[tokio::test]
+async fn expand_deferred_for_returns_error_when_iterable_attr_missing() {
+    let mut cert = Resource::new("test", "cert_missing_attr");
+    cert.binding = Some("cert".to_string());
+    let cert_id = cert.id.clone();
+
+    let provider = MockProvider::new();
+    provider.push_create(Ok(State::existing(cert_id.clone(), HashMap::new())));
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::ExpandDeferredFor {
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "cert".to_string(),
+        template: Box::new(validation_deferred_for_expression()),
+    });
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(1).unwrap(),
+    };
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    assert_eq!(result.failure_count, 1);
+    assert!(observer.events().iter().any(|event| {
+        event.contains("failed:__deferred_for.validation_records")
+            && event.contains("domain_validation_options")
+    }));
+}
+
+#[tokio::test]
+async fn apply_time_expand_deferred_for_emits_failed_on_shape_mismatch() {
+    let mut cert = Resource::new("test", "cert_shape_mismatch");
+    cert.binding = Some("cert".to_string());
+    let cert_id = cert.id.clone();
+    let cert_state = State::existing(
+        cert_id.clone(),
+        HashMap::from([(
+            "domain_validation_options".to_string(),
+            Value::Concrete(ConcreteValue::Map(indexmap::IndexMap::new())),
+        )]),
+    );
+
+    let provider = MockProvider::new();
+    provider.push_create(Ok(cert_state));
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::ExpandDeferredFor {
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "cert".to_string(),
+        template: Box::new(validation_deferred_for_expression()),
+    });
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(1).unwrap(),
+    };
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    assert_eq!(result.failure_count, 1);
+    assert!(observer.events().iter().any(|event| {
+        event.contains("failed:__deferred_for.validation_records")
+            && event.contains("expected list")
+            && event.contains("got map")
+    }));
 }
 
 /// Regression for carina#3164: a plan that mixes `Effect::Move` with

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -1313,43 +1313,18 @@ impl<E> File<E> {
 
             match (&deferred.binding, iterable_value) {
                 // Simple binding: only the value var is bound
-                (ForBinding::Simple(_), Value::Concrete(ConcreteValue::List(items))) => {
-                    for (i, item) in items.iter().enumerate() {
-                        let address = format!("{}[{}]", deferred.binding_name, i);
-                        expanded_resources
-                            .push(build_expanded_child(deferred, address, None, None, item));
-                    }
+                (ForBinding::Simple(_), Value::Concrete(ConcreteValue::List(_))) => {
+                    expanded_resources.extend(expand_deferred_children(deferred, iterable_value));
                     resolved_indices.push(idx);
                 }
                 // Indexed binding: both index and value vars are bound
-                (ForBinding::Indexed(_, _), Value::Concrete(ConcreteValue::List(items))) => {
-                    for (i, item) in items.iter().enumerate() {
-                        let address = format!("{}[{}]", deferred.binding_name, i);
-                        expanded_resources.push(build_expanded_child(
-                            deferred,
-                            address,
-                            Some(i as i64),
-                            None,
-                            item,
-                        ));
-                    }
+                (ForBinding::Indexed(_, _), Value::Concrete(ConcreteValue::List(_))) => {
+                    expanded_resources.extend(expand_deferred_children(deferred, iterable_value));
                     resolved_indices.push(idx);
                 }
                 // Map binding expands over maps, substituting both key and value vars
-                (ForBinding::Map(_, _), Value::Concrete(ConcreteValue::Map(map))) => {
-                    let mut keys: Vec<&String> = map.keys().collect();
-                    keys.sort();
-                    for key in keys {
-                        let val = &map[key];
-                        let address = crate::utils::map_key_address(&deferred.binding_name, key);
-                        expanded_resources.push(build_expanded_child(
-                            deferred,
-                            address,
-                            None,
-                            Some(key),
-                            val,
-                        ));
-                    }
+                (ForBinding::Map(_, _), Value::Concrete(ConcreteValue::Map(_))) => {
+                    expanded_resources.extend(expand_deferred_children(deferred, iterable_value));
                     resolved_indices.push(idx);
                 }
                 // Shape mismatch: replace the original "not yet available" warning
@@ -1408,6 +1383,92 @@ impl<E> File<E> {
         // composition for-body never reaches the deferred path.)
         self.resources.extend(expanded_resources);
         self.warnings.extend(new_warnings);
+    }
+}
+
+pub fn expand_deferred_children(
+    deferred: &DeferredForExpression,
+    iterable_value: &Value,
+) -> Vec<Resource> {
+    match &deferred.binding {
+        ForBinding::Simple(_) => match iterable_value {
+            Value::Concrete(ConcreteValue::List(items)) => items
+                .iter()
+                .enumerate()
+                .map(|(i, item)| {
+                    let address = format!("{}[{}]", deferred.binding_name, i);
+                    build_expanded_child(deferred, address, None, None, item)
+                })
+                .collect(),
+            Value::Concrete(ConcreteValue::Map(_))
+            | Value::Concrete(ConcreteValue::String(_))
+            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
+            | Value::Concrete(ConcreteValue::Int(_))
+            | Value::Concrete(ConcreteValue::Float(_))
+            | Value::Concrete(ConcreteValue::Bool(_))
+            | Value::Concrete(ConcreteValue::Duration(_))
+            | Value::Concrete(ConcreteValue::StringList(_))
+            | Value::Deferred(DeferredValue::ResourceRef { .. })
+            | Value::Deferred(DeferredValue::BindingRef { .. })
+            | Value::Deferred(DeferredValue::Interpolation(_))
+            | Value::Deferred(DeferredValue::FunctionCall { .. })
+            | Value::Deferred(DeferredValue::Secret(_))
+            | Value::Deferred(DeferredValue::Unknown(_)) => Vec::new(),
+        },
+        ForBinding::Indexed(_, _) => match iterable_value {
+            Value::Concrete(ConcreteValue::List(items)) => items
+                .iter()
+                .enumerate()
+                .map(|(i, item)| {
+                    let address = format!("{}[{}]", deferred.binding_name, i);
+                    build_expanded_child(deferred, address, Some(i as i64), None, item)
+                })
+                .collect(),
+            Value::Concrete(ConcreteValue::Map(_))
+            | Value::Concrete(ConcreteValue::String(_))
+            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
+            | Value::Concrete(ConcreteValue::Int(_))
+            | Value::Concrete(ConcreteValue::Float(_))
+            | Value::Concrete(ConcreteValue::Bool(_))
+            | Value::Concrete(ConcreteValue::Duration(_))
+            | Value::Concrete(ConcreteValue::StringList(_))
+            | Value::Deferred(DeferredValue::ResourceRef { .. })
+            | Value::Deferred(DeferredValue::BindingRef { .. })
+            | Value::Deferred(DeferredValue::Interpolation(_))
+            | Value::Deferred(DeferredValue::FunctionCall { .. })
+            | Value::Deferred(DeferredValue::Secret(_))
+            | Value::Deferred(DeferredValue::Unknown(_)) => Vec::new(),
+        },
+        ForBinding::Map(_, _) => match iterable_value {
+            Value::Concrete(ConcreteValue::Map(map)) => {
+                let mut keys: Vec<&String> = map.keys().collect();
+                keys.sort();
+                keys.into_iter()
+                    .map(|key| {
+                        let val = &map[key];
+                        let address = crate::utils::map_key_address(&deferred.binding_name, key);
+                        build_expanded_child(deferred, address, None, Some(key), val)
+                    })
+                    .collect()
+            }
+            Value::Concrete(ConcreteValue::List(_))
+            | Value::Concrete(ConcreteValue::String(_))
+            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
+            | Value::Concrete(ConcreteValue::Int(_))
+            | Value::Concrete(ConcreteValue::Float(_))
+            | Value::Concrete(ConcreteValue::Bool(_))
+            | Value::Concrete(ConcreteValue::Duration(_))
+            | Value::Concrete(ConcreteValue::StringList(_))
+            | Value::Deferred(DeferredValue::ResourceRef { .. })
+            | Value::Deferred(DeferredValue::BindingRef { .. })
+            | Value::Deferred(DeferredValue::Interpolation(_))
+            | Value::Deferred(DeferredValue::FunctionCall { .. })
+            | Value::Deferred(DeferredValue::Secret(_))
+            | Value::Deferred(DeferredValue::Unknown(_)) => Vec::new(),
+        },
     }
 }
 

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 /// resources *would* be created once the iterable becomes available.
 /// Also stores enough information to expand the loop later when the iterable
 /// is loaded from upstream_state.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DeferredForExpression {
     /// Full source path of the file this deferred expression originated
     /// from (stamped by `config_loader` after parsing).

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -24,8 +24,10 @@ use std::collections::{HashMap, HashSet};
 pub struct DeferredForExpression {
     /// Full source path of the file this deferred expression originated
     /// from (stamped by `config_loader` after parsing).
+    #[serde(skip)]
     pub file: Option<String>,
     /// Source line number of the `for` keyword.
+    #[serde(skip)]
     pub line: usize,
     /// The for-expression header, e.g., `for account_id in orgs.accounts`.
     pub header: String,
@@ -1822,6 +1824,33 @@ mod substitute_placeholder_tests {
 
         assert_eq!(err.expected_kind(), "list");
         assert_eq!(err.got_kind(), "map");
+    }
+
+    #[test]
+    fn deferred_for_expression_serde_skips_diagnostic_location() {
+        let deferred = DeferredForExpression {
+            file: Some("/abs/path.crn".to_string()),
+            line: 42,
+            header: "for opt in cert.options".to_string(),
+            resource_type: "mock.Target".to_string(),
+            attributes: Vec::new(),
+            binding_name: "children".to_string(),
+            iterable_binding: "cert".to_string(),
+            iterable_attr: "options".to_string(),
+            binding: ForBinding::Simple("opt".to_string()),
+            template_resource: Resource::new("mock.Target", "children"),
+        };
+
+        let json = serde_json::to_string(&deferred).expect("serialize deferred for expression");
+        assert!(
+            !json.contains("/abs/path.crn"),
+            "saved-plan JSON must not contain machine-local source paths: {json}"
+        );
+
+        let decoded: DeferredForExpression =
+            serde_json::from_str(&json).expect("deserialize deferred for expression");
+        assert_eq!(decoded.file, None);
+        assert_eq!(decoded.line, 0);
     }
 
     #[test]

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -47,6 +47,29 @@ pub struct DeferredForExpression {
     pub template_resource: Resource,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShapeMismatch {
+    expected_kind: &'static str,
+    got_kind: &'static str,
+}
+
+impl ShapeMismatch {
+    fn new(expected_kind: &'static str, got_kind: &'static str) -> Self {
+        Self {
+            expected_kind,
+            got_kind,
+        }
+    }
+
+    pub fn expected_kind(&self) -> &'static str {
+        self.expected_kind
+    }
+
+    pub fn got_kind(&self) -> &'static str {
+        self.got_kind
+    }
+}
+
 /// Origin of a resource yielded by [`ParsedFile::iter_all_resources`].
 ///
 /// `Direct` means the resource was declared at top-level and its iterable
@@ -1314,17 +1337,26 @@ impl<E> File<E> {
             match (&deferred.binding, iterable_value) {
                 // Simple binding: only the value var is bound
                 (ForBinding::Simple(_), Value::Concrete(ConcreteValue::List(_))) => {
-                    expanded_resources.extend(expand_deferred_children(deferred, iterable_value));
+                    expanded_resources.extend(
+                        expand_deferred_children(deferred, iterable_value)
+                            .expect("matched simple deferred-for list iterable"),
+                    );
                     resolved_indices.push(idx);
                 }
                 // Indexed binding: both index and value vars are bound
                 (ForBinding::Indexed(_, _), Value::Concrete(ConcreteValue::List(_))) => {
-                    expanded_resources.extend(expand_deferred_children(deferred, iterable_value));
+                    expanded_resources.extend(
+                        expand_deferred_children(deferred, iterable_value)
+                            .expect("matched indexed deferred-for list iterable"),
+                    );
                     resolved_indices.push(idx);
                 }
                 // Map binding expands over maps, substituting both key and value vars
                 (ForBinding::Map(_, _), Value::Concrete(ConcreteValue::Map(_))) => {
-                    expanded_resources.extend(expand_deferred_children(deferred, iterable_value));
+                    expanded_resources.extend(
+                        expand_deferred_children(deferred, iterable_value)
+                            .expect("matched map deferred-for map iterable"),
+                    );
                     resolved_indices.push(idx);
                 }
                 // Shape mismatch: replace the original "not yet available" warning
@@ -1389,85 +1421,138 @@ impl<E> File<E> {
 pub fn expand_deferred_children(
     deferred: &DeferredForExpression,
     iterable_value: &Value,
-) -> Vec<Resource> {
+) -> Result<Vec<Resource>, ShapeMismatch> {
     match &deferred.binding {
         ForBinding::Simple(_) => match iterable_value {
-            Value::Concrete(ConcreteValue::List(items)) => items
+            Value::Concrete(ConcreteValue::List(items)) => Ok(items
                 .iter()
                 .enumerate()
                 .map(|(i, item)| {
                     let address = format!("{}[{}]", deferred.binding_name, i);
                     build_expanded_child(deferred, address, None, None, item)
                 })
-                .collect(),
-            Value::Concrete(ConcreteValue::Map(_))
-            | Value::Concrete(ConcreteValue::String(_))
-            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
-            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
-            | Value::Concrete(ConcreteValue::Int(_))
-            | Value::Concrete(ConcreteValue::Float(_))
-            | Value::Concrete(ConcreteValue::Bool(_))
-            | Value::Concrete(ConcreteValue::Duration(_))
-            | Value::Concrete(ConcreteValue::StringList(_))
-            | Value::Deferred(DeferredValue::ResourceRef { .. })
-            | Value::Deferred(DeferredValue::BindingRef { .. })
-            | Value::Deferred(DeferredValue::Interpolation(_))
-            | Value::Deferred(DeferredValue::FunctionCall { .. })
-            | Value::Deferred(DeferredValue::Secret(_))
-            | Value::Deferred(DeferredValue::Unknown(_)) => Vec::new(),
+                .collect()),
+            Value::Concrete(ConcreteValue::Map(_)) => Err(ShapeMismatch::new("list", "map")),
+            Value::Concrete(ConcreteValue::String(_)) => Err(ShapeMismatch::new("list", "string")),
+            Value::Concrete(ConcreteValue::EnumIdentifier(_)) => {
+                Err(ShapeMismatch::new("list", "enum identifier"))
+            }
+            Value::Concrete(ConcreteValue::CanonicalEnum(_)) => {
+                Err(ShapeMismatch::new("list", "enum"))
+            }
+            Value::Concrete(ConcreteValue::Int(_)) => Err(ShapeMismatch::new("list", "int")),
+            Value::Concrete(ConcreteValue::Float(_)) => Err(ShapeMismatch::new("list", "float")),
+            Value::Concrete(ConcreteValue::Bool(_)) => Err(ShapeMismatch::new("list", "bool")),
+            Value::Concrete(ConcreteValue::Duration(_)) => {
+                Err(ShapeMismatch::new("list", "duration"))
+            }
+            Value::Concrete(ConcreteValue::StringList(_)) => {
+                Err(ShapeMismatch::new("list", "string list"))
+            }
+            Value::Deferred(DeferredValue::ResourceRef { .. }) => {
+                Err(ShapeMismatch::new("list", "deferred resource reference"))
+            }
+            Value::Deferred(DeferredValue::BindingRef { .. }) => {
+                Err(ShapeMismatch::new("list", "deferred binding reference"))
+            }
+            Value::Deferred(DeferredValue::Interpolation(_)) => {
+                Err(ShapeMismatch::new("list", "deferred interpolation"))
+            }
+            Value::Deferred(DeferredValue::FunctionCall { .. }) => {
+                Err(ShapeMismatch::new("list", "deferred function call"))
+            }
+            Value::Deferred(DeferredValue::Secret(_)) => Err(ShapeMismatch::new("list", "secret")),
+            Value::Deferred(DeferredValue::Unknown(_)) => {
+                Err(ShapeMismatch::new("list", "unknown"))
+            }
         },
         ForBinding::Indexed(_, _) => match iterable_value {
-            Value::Concrete(ConcreteValue::List(items)) => items
+            Value::Concrete(ConcreteValue::List(items)) => Ok(items
                 .iter()
                 .enumerate()
                 .map(|(i, item)| {
                     let address = format!("{}[{}]", deferred.binding_name, i);
                     build_expanded_child(deferred, address, Some(i as i64), None, item)
                 })
-                .collect(),
-            Value::Concrete(ConcreteValue::Map(_))
-            | Value::Concrete(ConcreteValue::String(_))
-            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
-            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
-            | Value::Concrete(ConcreteValue::Int(_))
-            | Value::Concrete(ConcreteValue::Float(_))
-            | Value::Concrete(ConcreteValue::Bool(_))
-            | Value::Concrete(ConcreteValue::Duration(_))
-            | Value::Concrete(ConcreteValue::StringList(_))
-            | Value::Deferred(DeferredValue::ResourceRef { .. })
-            | Value::Deferred(DeferredValue::BindingRef { .. })
-            | Value::Deferred(DeferredValue::Interpolation(_))
-            | Value::Deferred(DeferredValue::FunctionCall { .. })
-            | Value::Deferred(DeferredValue::Secret(_))
-            | Value::Deferred(DeferredValue::Unknown(_)) => Vec::new(),
+                .collect()),
+            Value::Concrete(ConcreteValue::Map(_)) => Err(ShapeMismatch::new("list", "map")),
+            Value::Concrete(ConcreteValue::String(_)) => Err(ShapeMismatch::new("list", "string")),
+            Value::Concrete(ConcreteValue::EnumIdentifier(_)) => {
+                Err(ShapeMismatch::new("list", "enum identifier"))
+            }
+            Value::Concrete(ConcreteValue::CanonicalEnum(_)) => {
+                Err(ShapeMismatch::new("list", "enum"))
+            }
+            Value::Concrete(ConcreteValue::Int(_)) => Err(ShapeMismatch::new("list", "int")),
+            Value::Concrete(ConcreteValue::Float(_)) => Err(ShapeMismatch::new("list", "float")),
+            Value::Concrete(ConcreteValue::Bool(_)) => Err(ShapeMismatch::new("list", "bool")),
+            Value::Concrete(ConcreteValue::Duration(_)) => {
+                Err(ShapeMismatch::new("list", "duration"))
+            }
+            Value::Concrete(ConcreteValue::StringList(_)) => {
+                Err(ShapeMismatch::new("list", "string list"))
+            }
+            Value::Deferred(DeferredValue::ResourceRef { .. }) => {
+                Err(ShapeMismatch::new("list", "deferred resource reference"))
+            }
+            Value::Deferred(DeferredValue::BindingRef { .. }) => {
+                Err(ShapeMismatch::new("list", "deferred binding reference"))
+            }
+            Value::Deferred(DeferredValue::Interpolation(_)) => {
+                Err(ShapeMismatch::new("list", "deferred interpolation"))
+            }
+            Value::Deferred(DeferredValue::FunctionCall { .. }) => {
+                Err(ShapeMismatch::new("list", "deferred function call"))
+            }
+            Value::Deferred(DeferredValue::Secret(_)) => Err(ShapeMismatch::new("list", "secret")),
+            Value::Deferred(DeferredValue::Unknown(_)) => {
+                Err(ShapeMismatch::new("list", "unknown"))
+            }
         },
         ForBinding::Map(_, _) => match iterable_value {
             Value::Concrete(ConcreteValue::Map(map)) => {
                 let mut keys: Vec<&String> = map.keys().collect();
                 keys.sort();
-                keys.into_iter()
+                Ok(keys
+                    .into_iter()
                     .map(|key| {
                         let val = &map[key];
                         let address = crate::utils::map_key_address(&deferred.binding_name, key);
                         build_expanded_child(deferred, address, None, Some(key), val)
                     })
-                    .collect()
+                    .collect())
             }
-            Value::Concrete(ConcreteValue::List(_))
-            | Value::Concrete(ConcreteValue::String(_))
-            | Value::Concrete(ConcreteValue::EnumIdentifier(_))
-            | Value::Concrete(ConcreteValue::CanonicalEnum(_))
-            | Value::Concrete(ConcreteValue::Int(_))
-            | Value::Concrete(ConcreteValue::Float(_))
-            | Value::Concrete(ConcreteValue::Bool(_))
-            | Value::Concrete(ConcreteValue::Duration(_))
-            | Value::Concrete(ConcreteValue::StringList(_))
-            | Value::Deferred(DeferredValue::ResourceRef { .. })
-            | Value::Deferred(DeferredValue::BindingRef { .. })
-            | Value::Deferred(DeferredValue::Interpolation(_))
-            | Value::Deferred(DeferredValue::FunctionCall { .. })
-            | Value::Deferred(DeferredValue::Secret(_))
-            | Value::Deferred(DeferredValue::Unknown(_)) => Vec::new(),
+            Value::Concrete(ConcreteValue::List(_)) => Err(ShapeMismatch::new("map", "list")),
+            Value::Concrete(ConcreteValue::String(_)) => Err(ShapeMismatch::new("map", "string")),
+            Value::Concrete(ConcreteValue::EnumIdentifier(_)) => {
+                Err(ShapeMismatch::new("map", "enum identifier"))
+            }
+            Value::Concrete(ConcreteValue::CanonicalEnum(_)) => {
+                Err(ShapeMismatch::new("map", "enum"))
+            }
+            Value::Concrete(ConcreteValue::Int(_)) => Err(ShapeMismatch::new("map", "int")),
+            Value::Concrete(ConcreteValue::Float(_)) => Err(ShapeMismatch::new("map", "float")),
+            Value::Concrete(ConcreteValue::Bool(_)) => Err(ShapeMismatch::new("map", "bool")),
+            Value::Concrete(ConcreteValue::Duration(_)) => {
+                Err(ShapeMismatch::new("map", "duration"))
+            }
+            Value::Concrete(ConcreteValue::StringList(_)) => {
+                Err(ShapeMismatch::new("map", "string list"))
+            }
+            Value::Deferred(DeferredValue::ResourceRef { .. }) => {
+                Err(ShapeMismatch::new("map", "deferred resource reference"))
+            }
+            Value::Deferred(DeferredValue::BindingRef { .. }) => {
+                Err(ShapeMismatch::new("map", "deferred binding reference"))
+            }
+            Value::Deferred(DeferredValue::Interpolation(_)) => {
+                Err(ShapeMismatch::new("map", "deferred interpolation"))
+            }
+            Value::Deferred(DeferredValue::FunctionCall { .. }) => {
+                Err(ShapeMismatch::new("map", "deferred function call"))
+            }
+            Value::Deferred(DeferredValue::Secret(_)) => Err(ShapeMismatch::new("map", "secret")),
+            Value::Deferred(DeferredValue::Unknown(_)) => Err(ShapeMismatch::new("map", "unknown")),
         },
     }
 }
@@ -1706,6 +1791,37 @@ mod substitute_placeholder_tests {
             !names.contains("plain_value_name"),
             "plain value lets must be excluded from structural binding names"
         );
+    }
+
+    #[test]
+    fn expand_deferred_children_returns_shape_mismatch_for_simple_binding_with_map_iterable() {
+        let mut template_resource = Resource::new("mock.Target", "children");
+        template_resource.binding = Some("children".to_string());
+        template_resource.set_attr(
+            "name",
+            Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),
+        );
+        let deferred = DeferredForExpression {
+            file: None,
+            line: 1,
+            header: "for opt in cert.options".to_string(),
+            resource_type: "mock.Target".to_string(),
+            attributes: Vec::new(),
+            binding_name: "children".to_string(),
+            iterable_binding: "cert".to_string(),
+            iterable_attr: "options".to_string(),
+            binding: ForBinding::Simple("opt".to_string()),
+            template_resource,
+        };
+
+        let err = expand_deferred_children(
+            &deferred,
+            &Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+        )
+        .expect_err("simple for-binding over a map must be a shape mismatch");
+
+        assert_eq!(err.expected_kind(), "list");
+        assert_eq!(err.got_kind(), "map");
     }
 
     #[test]

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -16,7 +16,7 @@ use crate::parser::{
 use crate::resource::{ConcreteValue, DataSource, DeferredValue, Resource, UnknownReason, Value};
 
 /// Binding pattern for a for expression
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ForBinding {
     /// Simple: `for x in ...`
     Simple(String),

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -22,6 +22,7 @@ pub use ast::{
     ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock, ResourceContext, ResourceRef,
     ResourceTypePath, StateBlock, StateBlockAddress, TypeExpr, UntilPredicateAst, UpstreamState,
     UseStatement, UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock, WaitBinding,
+    expand_deferred_children,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub(crate) use entry::{BindingSeed, parse_with_seeded_bindings};

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -20,9 +20,9 @@ pub use ast::{
     ArgumentParameter, AttributeParameter, BackendConfig, BindingName, DeferredForExpression,
     ExportParamLike, ExportParameter, File, FnParam, InferredExportParam, InferredFile, ModuleCall,
     ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock, ResourceContext, ResourceRef,
-    ResourceTypePath, StateBlock, StateBlockAddress, TypeExpr, UntilPredicateAst, UpstreamState,
-    UseStatement, UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock, WaitBinding,
-    expand_deferred_children,
+    ResourceTypePath, ShapeMismatch, StateBlock, StateBlockAddress, TypeExpr, UntilPredicateAst,
+    UpstreamState, UseStatement, UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock,
+    WaitBinding, expand_deferred_children,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub(crate) use entry::{BindingSeed, parse_with_seeded_bindings};

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -218,6 +218,7 @@ impl Plan {
                 Effect::Remove { .. } => summary.remove += 1,
                 Effect::Move { .. } => summary.moved += 1,
                 Effect::Wait { .. } => summary.wait += 1,
+                Effect::ExpandDeferredFor { .. } => {}
             }
         }
         summary
@@ -301,7 +302,8 @@ impl ModularPlan {
                 | Effect::Import { .. }
                 | Effect::Remove { .. }
                 | Effect::Move { .. }
-                | Effect::Wait { .. } => ModuleSource::Root,
+                | Effect::Wait { .. }
+                | Effect::ExpandDeferredFor { .. } => ModuleSource::Root,
             };
             modular.effect_sources.insert(idx, source);
         }
@@ -431,6 +433,11 @@ fn format_effect_brief(effect: &Effect) -> String {
             until_surface,
             ..
         } => format!("> {} (until {})", binding, until_surface),
+        Effect::ExpandDeferredFor {
+            id,
+            upstream_binding,
+            ..
+        } => format!("~ {} (deferred for: waits on {})", id, upstream_binding),
     }
 }
 

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -98,6 +98,18 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
                     effect_deps.insert(idx, deps);
                     continue;
                 }
+                Effect::ExpandDeferredFor {
+                    id,
+                    upstream_binding,
+                    ..
+                } => {
+                    let fallback = id.to_string();
+                    binding_to_effect.insert(fallback.clone(), idx);
+                    effect_bindings.insert(idx, fallback);
+                    effect_types.insert(idx, "deferred_for".to_string());
+                    effect_deps.insert(idx, HashSet::from([upstream_binding.clone()]));
+                    continue;
+                }
             };
 
         if let Some(r) = resource {

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -10,8 +10,9 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::effect::PlanOp;
-use crate::executor::normalized::NormalizedResource;
-use crate::resource::{ConcreteValue, DataSource, Directives, Resource, ResourceId, State, Value};
+use crate::resource::{
+    ConcreteValue, DataSource, Directives, ResolvedResource, Resource, ResourceId, State, Value,
+};
 use crate::schema::{SchemaRegistry, TypeIdentity};
 use crate::wait::BindingPattern;
 use crate::wait::predicate::AttrPath;
@@ -351,7 +352,7 @@ pub type ProviderResult<T> = Result<T, ProviderError>;
 #[derive(Debug, Clone)]
 pub struct CreateRequest {
     /// Full desired state for the new resource.
-    pub resource: NormalizedResource,
+    pub resource: ResolvedResource,
 }
 
 /// Per-operation request record for [`Provider::read`].
@@ -443,7 +444,7 @@ pub enum PatchOpKind {
 /// value from `to`.
 pub fn build_update_patch(
     changed_attributes: &[String],
-    to: &NormalizedResource,
+    to: &ResolvedResource,
     from: &State,
 ) -> UpdatePatch {
     let to = to.as_resource();
@@ -1353,14 +1354,17 @@ impl Provider for Box<dyn Provider> {
 mod tests {
     use super::*;
 
-    fn normalized_for_test(resource: Resource) -> NormalizedResource {
-        futures::executor::block_on(crate::executor::normalized::apply_desired_normalization(
-            resource,
-            &[],
-            &NoopNormalizer,
-            &[],
-            &crate::schema::SchemaRegistry::new(),
-        ))
+    fn resolved_for_test(resource: Resource) -> ResolvedResource {
+        let normalized =
+            futures::executor::block_on(crate::executor::normalized::apply_desired_normalization(
+                resource,
+                &[],
+                &NoopNormalizer,
+                &[],
+                &crate::schema::SchemaRegistry::new(),
+            ));
+        crate::executor::resolve_normalized_for_provider(normalized)
+            .expect("test resource should be fully resolved")
     }
 
     // Mock Provider for testing
@@ -1620,7 +1624,7 @@ mod tests {
             .create(
                 &id,
                 CreateRequest {
-                    resource: normalized_for_test(resource),
+                    resource: resolved_for_test(resource),
                 },
             )
             .await
@@ -1650,7 +1654,7 @@ mod tests {
             .create(
                 &id,
                 CreateRequest {
-                    resource: normalized_for_test(resource),
+                    resource: resolved_for_test(resource),
                 },
             )
             .await
@@ -2072,14 +2076,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("added".into())),
         );
 
-        let to =
-            futures::executor::block_on(crate::executor::normalized::apply_desired_normalization(
-                to,
-                &[],
-                &NoopNormalizer,
-                &[],
-                &crate::schema::SchemaRegistry::new(),
-            ));
+        let to = resolved_for_test(to);
         let changed = vec!["a".to_string(), "b".to_string(), "c".to_string()];
         let patch = build_update_patch(&changed, &to, &from);
         assert_eq!(patch.ops.len(), 3);

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -1830,6 +1830,116 @@ impl Resource {
     }
 }
 
+/// A managed resource whose attribute tree has been checked and found
+/// free of any `Value::Deferred` placeholder before provider dispatch.
+///
+/// The constructor requires a private token from
+/// `carina_core::executor::basic`, so callers outside the basic
+/// executor's resolve helpers cannot manufacture this witness.
+///
+/// ```compile_fail
+/// use carina_core::resource::{ResolvedResource, Resource};
+///
+/// let resource = Resource::new("test", "example");
+/// let _: ResolvedResource = resource.into();
+/// ```
+///
+/// ```compile_fail
+/// use carina_core::resource::{ResolvedResource, Resource};
+///
+/// let resource = Resource::new("test", "example");
+/// let _ = ResolvedResource::new(resource);
+/// ```
+///
+/// ```compile_fail
+/// use carina_core::resource::{ResolvedResource, Resource};
+///
+/// let resource = Resource::new("test", "example");
+/// let _ = ResolvedResource::try_new(resource);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedResource(Resource);
+
+impl ResolvedResource {
+    pub(crate) fn new(
+        resource: Resource,
+        _token: crate::executor::basic::ResolvedResourceToken,
+    ) -> Result<Self, crate::value::SerializationError> {
+        assert_resource_fully_resolved(&resource)?;
+        Ok(Self(resource))
+    }
+
+    /// Borrow the underlying resource for provider-boundary consumers.
+    pub fn as_resource(&self) -> &Resource {
+        &self.0
+    }
+}
+
+pub(crate) fn assert_resource_fully_resolved(
+    resource: &Resource,
+) -> Result<(), crate::value::SerializationError> {
+    for value in resource.attributes.values() {
+        assert_value_fully_resolved(value)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn assert_value_fully_resolved(
+    value: &Value,
+) -> Result<(), crate::value::SerializationError> {
+    let context = crate::value::SerializationContext::WasmBoundary;
+    match value {
+        Value::Concrete(ConcreteValue::List(items)) => {
+            for item in items {
+                assert_value_fully_resolved(item)?;
+            }
+            Ok(())
+        }
+        Value::Concrete(ConcreteValue::Map(map)) => {
+            for v in map.values() {
+                assert_value_fully_resolved(v)?;
+            }
+            Ok(())
+        }
+        Value::Deferred(DeferredValue::Secret(inner)) => assert_value_fully_resolved(inner),
+        Value::Deferred(DeferredValue::ResourceRef { path }) => {
+            Err(crate::value::SerializationError::UnresolvedResourceRef {
+                path: path.to_dot_string(),
+                context,
+            })
+        }
+        Value::Deferred(DeferredValue::BindingRef { binding }) => {
+            Err(crate::value::SerializationError::UnresolvedResourceRef {
+                path: binding.clone(),
+                context,
+            })
+        }
+        Value::Deferred(DeferredValue::Interpolation(_)) => {
+            Err(crate::value::SerializationError::UnresolvedInterpolation { context })
+        }
+        Value::Deferred(DeferredValue::FunctionCall { name, .. }) => {
+            Err(crate::value::SerializationError::UnresolvedFunctionCall {
+                name: name.clone(),
+                context,
+            })
+        }
+        Value::Deferred(DeferredValue::Unknown(reason)) => {
+            Err(crate::value::SerializationError::UnknownNotAllowed {
+                reason: reason.clone(),
+                context,
+            })
+        }
+        Value::Concrete(ConcreteValue::String(_))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(_))
+        | Value::Concrete(ConcreteValue::CanonicalEnum(_))
+        | Value::Concrete(ConcreteValue::Int(_))
+        | Value::Concrete(ConcreteValue::Float(_))
+        | Value::Concrete(ConcreteValue::Bool(_))
+        | Value::Concrete(ConcreteValue::Duration(_))
+        | Value::Concrete(ConcreteValue::StringList(_)) => Ok(()),
+    }
+}
+
 /// Current state fetched from actual infrastructure
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct State {

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -908,6 +908,26 @@ pub fn redact_secrets_in_managed(
     })
 }
 
+/// Redact secrets in a managed resource while preserving deferred placeholders.
+///
+/// Deferred-for templates intentionally contain `Unknown(ForValue*)`
+/// placeholders until apply-time expansion substitutes the iterable
+/// values. They still need secret redaction for saved plans, but they
+/// must not use the strict provider-bound redactor.
+fn redact_secrets_in_managed_only(
+    resource: &crate::resource::Resource,
+) -> Result<crate::resource::Resource, SerializationError> {
+    let attributes: Result<_, _> = resource
+        .attributes
+        .iter()
+        .map(|(k, e)| redact_secrets_only(e).map(|rv| (k.clone(), rv)))
+        .collect();
+    Ok(crate::resource::Resource {
+        attributes: attributes?,
+        ..resource.clone()
+    })
+}
+
 /// Redact all secrets in a [`DataSource`](crate::resource::DataSource).
 pub fn redact_secrets_in_data_source(
     resource: &crate::resource::DataSource,
@@ -1067,10 +1087,10 @@ pub fn redact_secrets_in_effect(
             redacted_template.attributes = redacted_template
                 .attributes
                 .iter()
-                .map(|(key, value)| Ok((key.clone(), redact_secrets_in_value(value)?)))
+                .map(|(key, value)| Ok((key.clone(), redact_secrets_only(value)?)))
                 .collect::<Result<Vec<_>, SerializationError>>()?;
             redacted_template.template_resource =
-                redact_secrets_in_managed(&redacted_template.template_resource)?;
+                redact_secrets_in_managed_only(&redacted_template.template_resource)?;
             Effect::ExpandDeferredFor {
                 id: id.clone(),
                 upstream_binding: upstream_binding.clone(),
@@ -5004,6 +5024,88 @@ mod tests {
                 );
             }
             other => panic!("expected Effect::Import, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn redact_secrets_in_expand_deferred_for_preserves_for_unknowns() {
+        use crate::effect::Effect;
+        use crate::parser::{DeferredForExpression, ForBinding};
+        use crate::plan::Plan;
+        use crate::resource::{
+            AccessPath, DeferredValue, Resource, ResourceId, UnknownReason, Value,
+        };
+
+        let placeholder = Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath {
+            path: AccessPath::with_fields("opt", "resource_record", vec!["name".to_string()]),
+        }));
+        let mut template_resource = Resource::new("aws.route53.RecordSet", "validation_records");
+        template_resource.set_attr("name", placeholder.clone());
+        let effect = Effect::ExpandDeferredFor {
+            id: ResourceId::new("__deferred_for", "validation_records"),
+            upstream_binding: "cert".to_string(),
+            template: Box::new(DeferredForExpression {
+                file: None,
+                line: 1,
+                header: "for opt in cert.domain_validation_options".to_string(),
+                resource_type: "aws.route53.RecordSet".to_string(),
+                attributes: vec![("name".to_string(), placeholder.clone())],
+                binding_name: "validation_records".to_string(),
+                iterable_binding: "cert".to_string(),
+                iterable_attr: "domain_validation_options".to_string(),
+                binding: ForBinding::Simple("opt".to_string()),
+                template_resource,
+            }),
+        };
+
+        let redacted = redact_secrets_in_effect(&effect)
+            .expect("deferred-for template placeholders must survive effect redaction");
+        assert_expand_deferred_for_placeholder_survives(&redacted, &placeholder);
+
+        let mut plan = Plan::new();
+        plan.add(effect);
+        let redacted_plan = redact_secrets_in_plan(&plan)
+            .expect("deferred-for template placeholders must survive plan redaction");
+        assert_expand_deferred_for_placeholder_survives(&redacted_plan.effects()[0], &placeholder);
+    }
+
+    fn assert_expand_deferred_for_placeholder_survives(
+        effect: &crate::effect::Effect,
+        expected: &Value,
+    ) {
+        fn assert_for_value_path(value: Option<&Value>, expected: &Value) {
+            match (value, expected) {
+                (
+                    Some(Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath {
+                        path,
+                    }))),
+                    Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValuePath {
+                        path: expected_path,
+                    })),
+                ) => {
+                    assert_eq!(path.binding(), expected_path.binding());
+                    assert_eq!(path.attribute(), expected_path.attribute());
+                    assert_eq!(path.segments(), expected_path.segments());
+                }
+                (actual, expected) => {
+                    panic!("expected preserved ForValuePath {expected:?}, got {actual:?}")
+                }
+            }
+        }
+
+        match effect {
+            crate::effect::Effect::ExpandDeferredFor { template, .. } => {
+                assert_for_value_path(
+                    template
+                        .attributes
+                        .iter()
+                        .find(|(key, _)| key == "name")
+                        .map(|(_, value)| value),
+                    expected,
+                );
+                assert_for_value_path(template.template_resource.attributes.get("name"), expected);
+            }
+            other => panic!("expected Effect::ExpandDeferredFor, got {other:?}"),
         }
     }
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1058,6 +1058,25 @@ pub fn redact_secrets_in_effect(
         // typed predicate over scalar values, surface form is the
         // user-authored source. Clone through unchanged.
         Effect::Wait { .. } => effect.clone(),
+        Effect::ExpandDeferredFor {
+            id,
+            upstream_binding,
+            template,
+        } => {
+            let mut redacted_template = (**template).clone();
+            redacted_template.attributes = redacted_template
+                .attributes
+                .iter()
+                .map(|(key, value)| Ok((key.clone(), redact_secrets_in_value(value)?)))
+                .collect::<Result<Vec<_>, SerializationError>>()?;
+            redacted_template.template_resource =
+                redact_secrets_in_managed(&redacted_template.template_resource)?;
+            Effect::ExpandDeferredFor {
+                id: id.clone(),
+                upstream_binding: upstream_binding.clone(),
+                template: Box::new(redacted_template),
+            }
+        }
     })
 }
 

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -8,20 +8,22 @@ use carina_core::provider::{
     CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, ProviderFactory, ReadRequest,
     UpdatePatch, UpdateRequest,
 };
-use carina_core::resource::{ConcreteValue, DataSource, Resource, ResourceId, Value};
+use carina_core::resource::{
+    ConcreteValue, DataSource, ResolvedResource, Resource, ResourceId, Value,
+};
 use carina_plugin_host::WasmProviderFactory;
 
-async fn normalized_for_test(
-    resource: Resource,
-) -> carina_core::executor::normalized::NormalizedResource {
-    carina_core::executor::normalized::apply_desired_normalization(
+async fn normalized_for_test(resource: Resource) -> ResolvedResource {
+    let normalized = carina_core::executor::normalized::apply_desired_normalization(
         resource,
         &[],
         &carina_core::provider::NoopNormalizer,
         &[],
         &carina_core::schema::SchemaRegistry::new(),
     )
-    .await
+    .await;
+    carina_core::executor::resolve_normalized_for_provider(normalized)
+        .expect("test resource should be fully resolved")
 }
 
 fn wasm_path() -> Option<PathBuf> {

--- a/carina-tui/src/app/mod.rs
+++ b/carina-tui/src/app/mod.rs
@@ -806,6 +806,25 @@ fn effect_to_node(effect: &Effect, schemas: Option<&SchemaRegistry>) -> TreeNode
             depth: 0,
             parent: None,
         },
+        Effect::ExpandDeferredFor {
+            id,
+            upstream_binding,
+            ..
+        } => TreeNode {
+            effect_label: format!(
+                "{} (deferred for: waits on {})",
+                id.human(),
+                upstream_binding
+            ),
+            resource_type: id.display_type(),
+            name_part: id.name_str().to_string(),
+            symbol: "~".to_string(),
+            kind: EffectKind::Update,
+            detail_rows,
+            children: Vec::new(),
+            depth: 0,
+            parent: None,
+        },
     }
 }
 

--- a/notes/specs/2026-06-15-apply-time-deferred-for-reexpansion-plan.md
+++ b/notes/specs/2026-06-15-apply-time-deferred-for-reexpansion-plan.md
@@ -1,0 +1,372 @@
+# Apply-time deferred-for re-expansion: Implementation plan
+
+<!-- derived-from ./2026-06-15-apply-time-deferred-for-reexpansion-design.md -->
+
+Closes carina-rs/carina#3561.
+
+This plan decomposes the design into concrete TDD tasks, each scoped
+to a single file or a tight cluster of files. Every task ships with
+its failing test first; no production code lands without a failing
+test in the same change.
+
+## Sequencing
+
+The work splits into four cohesive cargo-rounds. Each round is
+self-contained: it leaves the build green, the test suite green, and
+the public API in a coherent (if incomplete) state. The four rounds
+land in a single PR.
+
+```
+Round 1   ResolvedResource witness in carina-core
+Round 2   Effect::ExpandDeferredFor variant + constructor + accessors
+Round 3   Plan-time emission rule (expansion → ExpandDeferredFor when
+          iterable is unresolved at plan time)
+Round 4   Apply-time scheduler integration: re-expansion runs, emits
+          ResolvedResource children, downstream waits/depends_on see
+          them complete
+```
+
+The design's Open Questions are resolved before implementation begins
+(see §Resolutions below). Plan display for `ExpandDeferredFor` lands
+as part of Round 4 — silent meta-effect, the children are what the
+user sees.
+
+## Resolutions to design open questions
+
+1. **State-only vs synthetic-generator variant.** The effect is
+   *state-only*: it does not call the provider; it consults
+   `applied_states`, derives a fresh expansion, and emits new effects
+   into the in-flight scheduler. It rides the existing `Move` /
+   `Import` / `Remove` shape — state-only, executor-internal, no
+   provider involvement — so the executor seam already has a place
+   to dispatch it (`Effect::as_basic()` returns `None` for it, the
+   phased executor's `_ => state-only` arm picks it up). The
+   "synthetic generator" framing would have implied a new executor
+   subsystem; the state-only framing reuses what is there.
+
+2. **Plan display.** `ExpandDeferredFor` does not get its own row in
+   the plan tree. The children it produces at apply time are what the
+   user sees. At plan time, the tree continues to display whatever
+   `expand_same_config_deferred_for` produced — either pre-expanded
+   children (when the iterable resolved at plan time, unchanged from
+   today) or a single "deferred until apply" marker under the for-loop
+   header (new — replaces the silently-stamped `Unknown(ForValuePath)`
+   children). The latter case is a known-after-apply display, similar
+   to how `wait` blocks render.
+
+3. **Shrinking re-expansion.** When the apply-time re-expansion
+   produces fewer children than the plan-time prediction (e.g. the
+   plan predicted 2 children but the post-apply upstream has 1), the
+   missing children are *not* emitted. They never reach the
+   scheduler; no `Create` runs for them; nothing is in state for
+   them, so no orphan reconciliation is needed in this PR. The plan
+   display already labels these as "deferred until apply" in
+   resolution (2), so the user is not promised a fixed count. The
+   plan-time pre-expanded path (iterable knowable at plan time) keeps
+   today's contract.
+
+## Round 1 — `ResolvedResource` witness
+
+**Goal**: a type that wraps a `Resource` whose attribute tree has
+been walked and found free of any `Value::Deferred(*)` arm. Only the
+basic executor's `resolve_*` helpers can construct one.
+
+**File targets**:
+
+- `carina-core/src/resource.rs` — new `pub struct ResolvedResource`
+  with private inner field and a `pub(crate)` constructor visible to
+  `executor::basic` (place the type in `resource.rs` next to
+  `Resource`; the constructor lives in a small `mod resolved` whose
+  `pub(crate) fn new` is the only path to the witness).
+- `carina-core/src/executor/basic.rs` — `resolve_resource` and
+  `resolve_resource_with_source` return
+  `Result<NormalizedResource, …>` today; both grow a `resolved:
+  ResolvedResource` field on `NormalizedResource` (or change
+  `NormalizedResource` to wrap `ResolvedResource` directly — choose
+  whichever produces the smaller diff at write time; either works).
+- `carina-core/src/executor/parallel.rs`,
+  `carina-core/src/executor/phased.rs`,
+  `carina-core/src/executor/replace.rs` — the call sites that
+  currently take `&NormalizedResource` or feed the resolved
+  `Resource` to `Provider::create` / `update` switch to
+  `&ResolvedResource`. The provider trait itself stays on `Resource`
+  at the WIT boundary; the typestate enforces the host-side
+  guarantee that we hand `provider.create` only a fully-resolved
+  resource.
+
+**Tests (red first)**:
+
+- `resolved_resource_constructor_rejects_value_unknown`: build a
+  `Resource` with one `Value::Deferred(DeferredValue::Unknown { …
+  ForValuePath … })` attribute; assert the constructor returns
+  `Err(SerializationError::UnknownNotAllowed { … })`. Add this test
+  to the resolve helper's existing test module
+  (`carina-core/src/executor/tests.rs` already covers
+  `resolve_resource`; co-locate).
+- `resolved_resource_constructor_rejects_resource_ref`: same shape
+  with `DeferredValue::ResourceRef`, expects
+  `UnresolvedResourceRef`.
+- `resolved_resource_constructor_rejects_nested_deferred`: place the
+  `Unknown` value inside a `List` / `Map` / `Secret` — the same
+  containers `assert_fully_resolved` already walks — assert it is
+  still rejected.
+- `compile_fail` doctest in `carina-core/src/resource.rs`: a plain
+  `Resource` cannot be coerced into `ResolvedResource`; constructing
+  one outside `carina-core::executor::basic` does not compile.
+  Mirror the pattern carina#3164 used for `BasicEffect`.
+
+**Round-1 verify**: `cargo nextest run -p carina-core` + the
+`compile_fail` doctest hits via `cargo test -p carina-core --doc`.
+
+## Round 2 — `Effect::ExpandDeferredFor` variant
+
+**Goal**: a new state-only effect variant that carries the
+information needed for apply-time re-expansion.
+
+**File targets**:
+
+- `carina-core/src/effect.rs` — add the variant:
+
+  ```rust
+  /// Re-expand a `for opt in <upstream>.<collection> { ... }`
+  /// expression against the post-apply upstream state, emitting
+  /// fresh `Create` effects for the synthesised children.
+  ///
+  /// Emitted by the planner when the iterable's plan-time value is
+  /// unresolved (upstream is a Create / Replace whose collection
+  /// attribute is not yet known). The executor dispatches the
+  /// effect after `upstream_binding`'s `applied_states` entry has
+  /// been written by an upstream Create/Update/Replace future.
+  /// State-only: does not call the provider.
+  ExpandDeferredFor {
+      /// Synthetic id used for plan-tree display and progress.
+      id: ResourceId,
+      /// The iterable's binding name (e.g. "cert").
+      upstream_binding: String,
+      /// The for-expression body, replayed against
+      /// `applied_states[upstream_binding].attributes`.
+      template: Box<DeferredForExpression>,
+  },
+  ```
+
+  Update the exhaustive match arms in:
+
+  - `Effect::as_basic()` → returns `None` (state-only, like `Move`).
+  - `Effect::resource_id()` → returns `&id`.
+  - `Effect::as_resource_ref()` → returns `None`.
+  - `Effect::binding_name()` → returns `None` (no single binding
+    name; the children carry their own bindings).
+  - `Effect::explicit_dependencies()` → returns `HashSet::new()`.
+  - `Effect::blocking_bindings()` → returns
+    `vec![upstream_binding.clone()]`. This single line is what
+    crosses the phase boundary by construction: any phase that
+    contains an `ExpandDeferredFor` will look up `upstream_binding`
+    in its `binding_to_idx` and find it (because we place the
+    effect in the same phase as the upstream's finalization — see
+    Round 4).
+  - `Effect::type_str()` → `"expand_deferred_for"`.
+  - Pattern matches in `state_only_or_blocking_only_effect`,
+    `count_actionable_effects`, `Effect::is_wait`,
+    `Effect::is_state_only` (if such a method exists; otherwise
+    add it now and use it consistently — exhaustive match is the
+    enforcement mechanism).
+
+**Tests (red first)**:
+
+- `expand_deferred_for_blocking_bindings_is_upstream_only`:
+  construct an `Effect::ExpandDeferredFor { upstream_binding:
+  "cert".into(), … }`; assert `blocking_bindings()` returns
+  `["cert"]`.
+- `expand_deferred_for_as_basic_returns_none`: assert state-only
+  classification.
+- `expand_deferred_for_resource_id_returns_synthetic_id`: assert
+  `resource_id()` returns the synthetic id passed at construction.
+- `expand_deferred_for_serde_roundtrip`: bincode / serde_json
+  round-trip a plan that contains one of these — `DeferredForExpression`
+  already derives the requisite traits per existing tests; the new
+  variant follows the same shape. (Saved-plan path coverage; the
+  variant is part of the plan file.)
+
+**Round-2 verify**: `cargo nextest run -p carina-core`.
+
+## Round 3 — Plan-time emission rule
+
+**Goal**: switch
+`carina-cli/src/wiring/mod.rs::expand_same_config_deferred_for` from
+"always pre-expand against `current_states`" to "pre-expand when the
+iterable is fully known at plan time, otherwise emit a single
+`Effect::ExpandDeferredFor` deferring expansion to apply".
+
+**File targets**:
+
+- `carina-cli/src/wiring/mod.rs` — `expand_same_config_deferred_for`
+  inspects the resolved iterable value. If the value is a
+  `ConcreteValue::List` / `ConcreteValue::Map` with no `Value::Deferred`
+  leaves, pre-expand as today. Otherwise:
+  - Skip pre-expansion of the deferred resource's children.
+  - Record the deferred expression in the output's
+    `residual_deferred_for` (the existing field) the same way
+    today's "iterable not found in `bindings`" branch does, *plus*
+    emit one `Effect::ExpandDeferredFor` into the plan via the
+    plan-construction path that consumes `residual_deferred_for`.
+- `carina-cli/src/commands/plan.rs` and
+  `carina-cli/src/commands/apply/mod.rs` — the sites that currently
+  read `ctx.residual_deferred_for` to print "deferred until apply"
+  warnings also feed the new effects into the `Plan` when
+  appropriate. Today they live next to `add_state_block_effects`;
+  the new emission is a sibling step.
+- `carina-core/src/plan.rs` — no change required; `Plan` stores
+  `Vec<Effect>` and accepts the new variant transparently.
+
+**Tests (red first)**:
+
+- `expand_same_config_emits_expand_deferred_for_when_iterable_is_unresolved`
+  in `carina-cli/src/wiring/tests.rs`: fixture is a Replace cert +
+  a `for opt in cert.domain_validation_options` block; the cert's
+  current_states value is empty / does not contain a usable DVO.
+  Assert the output's effect list contains exactly one
+  `Effect::ExpandDeferredFor { upstream_binding: "cert", … }` and
+  no pre-expanded `Effect::Create` for the children.
+- `expand_same_config_pre_expands_when_iterable_is_concrete`: the
+  same fixture but with the cert present in `current_states` and
+  its DVO populated; assert the children are pre-expanded as today
+  and **no** `Effect::ExpandDeferredFor` is emitted. This is the
+  regression boundary that confirms we did not break the
+  plan-time-knowable path.
+- `expand_same_config_passes_through_pr3558_dependency_bindings_on_pre_expanded_children`:
+  cover that the pre-expanded path still carries
+  `dependency_bindings.insert(iterable_binding)` (PR #3558's
+  invariant) for the same-phase race protection.
+
+**Round-3 verify**: `cargo nextest run -p carina-cli wiring`.
+
+## Round 4 — Apply-time scheduler integration
+
+**Goal**: the phased executor recognises `Effect::ExpandDeferredFor`,
+runs it after the upstream's `applied_states` entry is written, and
+appends the synthesised children to the in-flight effect list so they
+schedule as ordinary `Create`s.
+
+**File targets**:
+
+- `carina-core/src/executor/phased.rs` —
+  - The Phase 4 dispatch loop (`Effect::Replace` finalization +
+    `Effect::Create` for non-CBD replaces) gets a sibling
+    `if let Effect::ExpandDeferredFor { … } = effect { … }` arm.
+    Dispatch is synchronous: look up
+    `applied_states[upstream_binding]`, run the re-expansion
+    against the resolved attributes, build a fresh `Resource` per
+    collection element (mirroring `parser::ast::build_expanded_child`
+    but with `substitute_attrs` consuming the *resolved* iterable
+    value), wrap each in `ResolvedResource` via
+    `resolve_resource(…)`, append as `Effect::Create` to the
+    in-flight phase indices, and mark the `ExpandDeferredFor`
+    effect complete.
+  - The same arm lives in Phase 1 for first-time `Create` upstreams
+    (no Replace, just a fresh Create whose collection becomes
+    known once its `applied_states` entry exists). One helper
+    (`fn dispatch_expand_deferred_for(...)`) is called from both
+    phases; the helper is the single seam where re-expansion
+    runs.
+- `carina-core/src/executor/parallel.rs` — the non-phased executor
+  (used by the simpler test paths) gets the same arm so the
+  contract is uniform. If `parallel.rs` is reserved for paths that
+  cannot reach `ExpandDeferredFor`, document why and leave the
+  dispatch out; otherwise mirror the helper.
+- `carina-core/src/executor/wait.rs` — no change needed.
+  `Effect::Wait`'s `blocking_bindings` includes its
+  `explicit_dependencies`; once the re-expansion has emitted and
+  the children's `Effect::Create` completes, the wait fires
+  because its dependency entry (`validation_records`) is now in
+  `binding_to_idx` and `completed_indices`.
+- `carina-core/src/parser/ast.rs::build_expanded_child` — extract
+  the loop-variable substitution into a free function callable
+  from the executor's re-expansion helper (today it is a private
+  helper). The free function takes `(deferred:
+  &DeferredForExpression, iterable_value: &Value)` and returns
+  `Vec<Resource>`; the parser's existing call site re-uses it.
+
+**Tests (red first)**:
+
+- Repro test, `carina-core/src/executor/tests.rs`: build a plan
+  with `[Replace cert, ExpandDeferredFor cert→validation_records,
+  Wait cert_issued{depends_on=[validation_records]}]`. Run through
+  the phased executor with a mock provider whose `cert` create
+  returns a `State` whose `domain_validation_options` is a list of
+  one element with `resource_record.name = "_dns_record_name_"` and
+  `resource_record.value = "_dns_record_value_"`. Assert the event
+  trace is:
+  ```
+  Replace cert  → SUCCESS
+  ExpandDeferredFor → emits Effect::Create validation_records[0]
+  Create validation_records[0] → SUCCESS (uses the resolved
+    "_dns_record_name_" value)
+  Wait cert_issued → SUCCESS (sees validation_records satisfied)
+  ```
+  No `Create validation_records[0]` may appear before `Replace cert`
+  completes.
+- Negative test:
+  `expand_deferred_for_emits_zero_children_when_collection_is_empty`.
+  Mock provider returns an empty `domain_validation_options`; the
+  effect completes, emits zero children, and the wait either fires
+  (if `validation_records`'s dependency is vacuous) or hits its
+  timeout cleanly.
+- Cancellation test: the apply is cancelled mid-flight after
+  `cert` create completes but before `ExpandDeferredFor`
+  dispatches. Assert the effect is reported as skipped, not
+  failed.
+- Plan-tree display test: `carina-cli/src/commands/plan.rs`
+  snapshot fixture for the new "deferred until apply" rendering of
+  the for-loop body. Snapshot updates via `cargo insta accept`
+  belong in this PR.
+
+**Round-4 verify**: `cargo nextest run -p carina-core -p carina-cli`,
+`cargo test --workspace --doc`,
+`cargo clippy --workspace --all-targets -- -D warnings`,
+`bash scripts/check-*.sh`.
+
+## Cross-cutting concerns
+
+- **Saved plan compatibility.** `Effect::ExpandDeferredFor` is part
+  of the `Plan` serialization. The "no backwards compatibility"
+  rule applies — saved plans from older binaries that did not have
+  this variant are not portable across the change. No migration
+  shim.
+- **Provider boundary.** The variant never crosses the WIT
+  boundary; it is dispatched host-side. No `carina-provider-aws` /
+  `carina-provider-awscc` work is in scope. After this PR merges,
+  no provider rev bump is needed unless an unrelated reason calls
+  for one.
+- **PR #3558's `dependency_bindings.insert(iterable_binding)`
+  remains** for the plan-time-knowable path. The new variant
+  handles the plan-time-unknowable path. Together they cover both
+  branches of the design.
+- **`feedback_codegen_verification`** does not apply — this PR
+  touches no schema codegen. The `scripts/check-*.sh` invariants
+  still run.
+
+## Out of scope
+
+- `for_each` over arbitrary maps that are not derived from a
+  managed resource attribute.
+- Datasource-deferred attributes (`for opt in
+  datasource.collection`). The fix shape is similar in spirit
+  (re-expand after the datasource refresh), but the `applied_states`
+  hook is not the right seam — datasources go through `Effect::Read`
+  with its own state seam. A follow-up issue can pick this up if it
+  surfaces.
+- Upstream-stack-deferred attributes (`for opt in
+  upstream.collection`). These already have a resolution model via
+  `upstream_state` reads and `wait` blocks against the upstream
+  stack's apply.
+
+## Test-plan summary
+
+By the time Round 4 lands, the regression coverage is:
+
+- 4 typestate tests in `carina-core` (Round 1).
+- 4 effect-shape tests in `carina-core` (Round 2).
+- 3 plan-time emission tests in `carina-cli/wiring` (Round 3).
+- 3 apply-time dispatch tests in `carina-core/executor` (Round 4).
+- 1 plan-tree snapshot in `carina-cli` (Round 4).
+- PR #3558's existing tests stay green untouched.


### PR DESCRIPTION
Closes #3561.

## Summary

Implements the design merged in #3562 to close the deferred-for apply-time deadlock described in #3561. Two pieces land together (per CLAUDE.md "broken state unrepresentable" — neither half is enough on its own):

1. **`ResolvedResource` witness** — a `pub struct` whose only constructor lives behind a `pub(crate)` token in `executor::basic`. The basic executor's resolve helpers mint the token and run `assert_resource_fully_resolved` before returning the witness. `provider.create` / `provider.update` / `compute_full_diff_patch` now take `&ResolvedResource`, so a `Resource` whose attribute tree still contains a `Value::Deferred(*)` placeholder cannot reach the provider boundary by construction. Compile-fail doctests pin the invariant: raw coercion, direct `new` outside the basic executor, and any `try_new`-style sibling all fail to compile.

2. **`Effect::ExpandDeferredFor` apply-time re-expansion** — a state-only meta-effect (`is_scheduler_meta()`) that carries the original `DeferredForExpression` template plus the upstream binding name. The planner emits it when the iterable's plan-time value is not fully concrete (any `Value::Deferred(*)` at any depth); the scheduler dispatches it once the upstream's `applied_states` entry has been written by an upstream Create/Update/Replace. The dispatch helper re-runs `expand_deferred_children` against the now-resolved iterable, builds `Effect::Create(Resource)` children whose attributes are fully concrete, and appends them to the in-flight phase's effect list. The synthesised children flow through the basic executor's `resolve_resource` → `ResolvedResource` → `provider.create` path.

Phase placement keys on the upstream's effect kind: Phase 1 for first-time-Create upstreams, Phase 4 for Replace upstreams. The parallel (non-phased) executor mirrors the same dynamic-queue shape. Plan stays immutable — the dynamic effect list is a per-phase scheduler buffer.

The downstream `wait cert { until = ... depends_on = [validation_records] }` pattern now fires correctly because the wait's `explicit_dependencies` entry is satisfied when every synthesised child completes — no scheduling-vs-value-resolution mismatch remains.

## End-to-end coverage

`expand_deferred_for_dispatches_after_upstream_replace_before_wait_phased` in `carina-core/src/executor/tests.rs` builds the exact issue #3561 fixture (Replace cert + ExpandDeferredFor + Wait with `depends_on=[validation_records]`), runs it through the phased executor with a mock provider whose cert Create publishes a concrete DVO list, and asserts:

- Event order: `Replace cert → Create validation_records[0] → Wait cert_issued`. No Create before Replace, no Wait before Create.
- The synthesised child's `name` attribute reaches `provider.create` as a concrete `String("_dns_record_name_")`, never as `Value::Deferred(Unknown(ForValuePath(_)))`.

The plan-time classification side is pinned by `expand_same_config_emits_expand_deferred_for_when_iterable_is_unresolved` in `carina-cli/src/wiring/tests.rs`, with a sibling test confirming the fully-concrete iterable still pre-expands as before (no regression on the plan-time-knowable branch).

## Review

This PR went through `/code-review medium` (5 findings, all CONFIRMED) and 5 rounds of self-review. The findings and follow-ups:

| Round | Finding | Resolution |
| --- | --- | --- |
| code-review | state writeback dropped runtime-synthesised children → infinite re-create loop | Fixed: `ExecutionResult.runtime_synthesized_resources` typed channel; `state_writeback::decompose` walks them as a second pass |
| code-review | `expand_deferred_for_effects` panicked on missing binding / iterable_attr | Fixed: typed `ExpansionFailure` enum; dispatch sites emit `EffectFailed` and continue |
| code-review | `expand_deferred_children` silently produced zero children on shape mismatch | Fixed: returns `Result<Vec<Resource>, ShapeMismatch>`; plan-time and apply-time consumers handle Err uniformly |
| code-review | progress total drift (`completed > total` for dynamic children) | Fixed: `total` bumped at each dynamic-child append |
| code-review | IAM preflight under-reported permissions for apply-time children | Fixed: `ExpandDeferredFor` arm recurses through a hypothetical `Effect::Create(template_resource)` |
| self-review 1 | `redact_secrets_in_value` rejected `Unknown` placeholders in `ExpandDeferredFor.template` → saved-plan write failed | Fixed: Unknown-tolerant `redact_secrets_only` walker (matches the existing Interpolation/FunctionCall treatment) |
| self-review 2 | `is_state_operation()` lumped `ExpandDeferredFor` in, forcing `matches!(ExpandDeferredFor)` carve-outs at every site | Fixed: split into `is_state_operation` (Import/Remove/Move) and `is_scheduler_meta` (ExpandDeferredFor); typed predicates with exhaustive arms |
| self-review 3 | `DeferredForExpression.file` / `line` leaked absolute paths into saved plans (machine-local, CI-non-deterministic) | Fixed: `#[serde(skip)]` on both diagnostic-only fields |

Three follow-up issues filed for separate concerns:
- #3563 — end-to-end re-plan no-op integration test
- #3564 — `ExpansionFailure::message()` uses scheduler-internal vocabulary
- #3565 — `ShapeMismatch` carries stringly-typed `&'static str` kind names; typed `ValueKind` is the right shape

## Out of scope

- `for_each` over arbitrary maps not derived from a managed resource attribute
- Datasource-deferred attributes (`for opt in datasource.collection { ... }`)
- Upstream-stack-deferred attributes (`for opt in upstream.collection { ... }`)

These are named explicitly in the design doc's non-goals.

## Test plan

- [x] `cargo nextest run --workspace` — 4255 tests passed, 72 skipped.
- [x] `cargo test --workspace --doc` — passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all green.
- [x] `cargo fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
