### PR TITLE
feat(provider): UpdateOutcome with shared PartialReadDiagnostic (#3571)

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -106,7 +106,7 @@ impl Provider for FailBCreateProvider {
         id: &ResourceId,
         _identifier: &str,
         _request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         let id = id.clone();
         Box::pin(async move { Err(ProviderError::internal("unexpected update").for_resource(id)) })
     }

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -1272,7 +1272,7 @@ mod tests {
             _id: &ResourceId,
             _identifier: &str,
             _request: carina_core::provider::UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
             Box::pin(async { unreachable!() })
         }
 

--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -782,7 +782,7 @@ mod tests {
             _id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
             Box::pin(async { Err(ProviderError::internal("unused")) })
         }
 

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -185,7 +185,7 @@ mod tests {
             _id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
             unreachable!("import path must not call update")
         }
 

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -91,7 +91,7 @@ impl Provider for TestProvider {
         _id: &ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         Box::pin(async { Err(ProviderError::internal("unexpected update")) })
     }
 
@@ -1679,7 +1679,7 @@ impl Provider for RecordingProvider {
         id: &ResourceId,
         _identifier: &str,
         request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         // Reconstruct a Resource view of the desired post-update state for
         // existing tests that introspect the recorded `to`.
         let mut attrs = request.from.attributes.clone();
@@ -1707,7 +1707,7 @@ impl Provider for RecordingProvider {
         }
         self.update_calls.lock().unwrap().push((id.to_string(), to));
         let state = State::existing(id.clone(), attrs).with_identifier("subnet-123");
-        Box::pin(async move { Ok(state) })
+        Box::pin(async move { Ok(carina_core::provider::UpdateOutcome::Success { state }) })
     }
 
     fn delete(
@@ -1768,7 +1768,7 @@ impl Provider for RenameFailProvider {
         _id: &ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         Box::pin(async { Err(ProviderError::api_error("rename failed: API error")) })
     }
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -2297,9 +2297,13 @@ mod read_with_retry_identifier_tests {
             id: &ResourceId,
             _identifier: &str,
             _request: carina_core::provider::UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
             let id = id.clone();
-            Box::pin(async move { Ok(State::not_found(id)) })
+            Box::pin(async move {
+                Ok(carina_core::provider::UpdateOutcome::Success {
+                    state: State::not_found(id),
+                })
+            })
         }
 
         fn delete(
@@ -3526,9 +3530,13 @@ mod wait_until_enum_alias {
             id: &ResourceId,
             _i: &str,
             _r: carina_core::provider::UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
             let id = id.clone();
-            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+            Box::pin(async move {
+                Ok(carina_core::provider::UpdateOutcome::Success {
+                    state: State::existing(id, HashMap::new()),
+                })
+            })
         }
         fn delete(
             &self,

--- a/carina-cli/tests/composition_binding_resolve_e2e.rs
+++ b/carina-cli/tests/composition_binding_resolve_e2e.rs
@@ -127,9 +127,13 @@ impl Provider for NoopProvider {
         id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         let id = id.clone();
-        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+        Box::pin(async move {
+            Ok(carina_core::provider::UpdateOutcome::Success {
+                state: carina_core::resource::State::existing(id, HashMap::new()),
+            })
+        })
     }
     fn delete(
         &self,

--- a/carina-cli/tests/deferred_populate_validate_e2e.rs
+++ b/carina-cli/tests/deferred_populate_validate_e2e.rs
@@ -163,9 +163,13 @@ impl Provider for NoopProvider {
         id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         let id = id.clone();
-        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+        Box::pin(async move {
+            Ok(carina_core::provider::UpdateOutcome::Success {
+                state: carina_core::resource::State::existing(id, HashMap::new()),
+            })
+        })
     }
     fn delete(
         &self,

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -239,7 +239,8 @@ impl Provider for NoopProvider {
         _id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
+    ) -> BoxFuture<'_, carina_core::provider::ProviderResult<carina_core::provider::UpdateOutcome>>
+    {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
     }
     fn delete(

--- a/carina-cli/tests/nested_module_call_ref_e2e.rs
+++ b/carina-cli/tests/nested_module_call_ref_e2e.rs
@@ -124,9 +124,13 @@ impl Provider for NoopProvider {
         id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         let id = id.clone();
-        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+        Box::pin(async move {
+            Ok(carina_core::provider::UpdateOutcome::Success {
+                state: carina_core::resource::State::existing(id, HashMap::new()),
+            })
+        })
     }
     fn delete(
         &self,

--- a/carina-cli/tests/partial_update_e2e.rs
+++ b/carina-cli/tests/partial_update_e2e.rs
@@ -1,0 +1,215 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+struct Scenario {
+    _tmp: TempDir,
+    project: PathBuf,
+    mock_state: PathBuf,
+}
+
+impl Scenario {
+    fn new() -> Self {
+        let tmp = TempDir::new().unwrap();
+        let project = tmp.path().to_path_buf();
+        Self {
+            mock_state: project.join("mock-state.json"),
+            project,
+            _tmp: tmp,
+        }
+    }
+
+    fn write_config(&self, version: &str) {
+        self.write_config_with_name_and_version("r1", version);
+    }
+
+    fn write_config_with_name_and_version(&self, name: &str, version: &str) {
+        fs::write(
+            self.project.join("main.crn"),
+            format!(
+                r#"backend local {{ path = "carina.state.json" }}
+provider mock {{}}
+
+let r1 = mock.test.resource {{
+  name = "{name}"
+  tags = {{ version = "{version}" }}
+}}
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    fn init(&self) {
+        let output = carina(&self.project)
+            .args(["init", "."])
+            .output()
+            .expect("failed to execute carina init");
+        assert_success("carina init", &output);
+    }
+
+    fn apply(&self) -> Output {
+        carina(&self.project)
+            .args(["apply", ".", "--auto-approve", "--lock=false"])
+            .env("CARINA_MOCK_STATE_FILE", &self.mock_state)
+            .output()
+            .expect("failed to execute carina apply")
+    }
+
+    fn apply_partial_create(&self) -> Output {
+        carina(&self.project)
+            .args(["apply", ".", "--auto-approve", "--lock=false"])
+            .env("CARINA_MOCK_STATE_FILE", &self.mock_state)
+            .env("CARINA_MOCK_PARTIAL_CREATE_FOR", "*")
+            .env("CARINA_MOCK_PARTIAL_CREATE_MISSING", "tags")
+            .output()
+            .expect("failed to execute carina apply")
+    }
+
+    fn apply_partial_update(&self) -> Output {
+        carina(&self.project)
+            .args(["apply", ".", "--auto-approve", "--lock=false"])
+            .env("CARINA_MOCK_STATE_FILE", &self.mock_state)
+            .env("CARINA_MOCK_PARTIAL_UPDATE_FOR", "*")
+            .env("CARINA_MOCK_PARTIAL_UPDATE_MISSING", "tags")
+            .output()
+            .expect("failed to execute carina apply")
+    }
+
+    fn plan(&self) -> Output {
+        carina(&self.project)
+            .args(["plan", "."])
+            .env("CARINA_MOCK_STATE_FILE", &self.mock_state)
+            .output()
+            .expect("failed to execute carina plan")
+    }
+}
+
+fn carina(project: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_carina"));
+    command
+        .current_dir(project)
+        .env("NO_COLOR", "1")
+        .env("CARINA_MOCK_ENABLE_TEST_RESOURCE_SCHEMA", "1")
+        .env_remove("CLICOLOR_FORCE");
+    command
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn partial_update_records_state_and_next_plan_surfaces_unknown_reason() {
+    let scenario = Scenario::new();
+    scenario.write_config("one");
+    scenario.init();
+
+    let create = scenario.apply();
+    assert_success("initial apply", &create);
+
+    scenario.write_config("two");
+    let update = scenario.apply_partial_update();
+    let update_text = output_text(&update);
+    assert_eq!(
+        update.status.code(),
+        Some(2),
+        "partial update apply must exit 2\nstdout/stderr:\n{update_text}"
+    );
+    assert!(
+        update_text.contains("(partial)"),
+        "apply output must render partial update\nstdout/stderr:\n{update_text}"
+    );
+
+    let state_text = fs::read_to_string(scenario.project.join("carina.state.json")).unwrap();
+    assert!(
+        !state_text.contains("__carina_unknown"),
+        "state file must not persist unknown sentinels:\n{state_text}"
+    );
+    assert!(
+        state_text.contains("\"partial_read\""),
+        "state file must persist the partial_read marker:\n{state_text}"
+    );
+    assert!(
+        state_text.contains("\"missing_attributes\""),
+        "state file must persist partial missing attributes:\n{state_text}"
+    );
+    assert!(
+        state_text.contains("mock partial update"),
+        "state file must persist partial update detail:\n{state_text}"
+    );
+
+    let plan = scenario.plan();
+    assert_success("carina plan", &plan);
+    let plan_text = output_text(&plan);
+    assert!(
+        plan_text.contains("~ mock.test.resource r1") && plan_text.contains("1 to change"),
+        "next plan must show the partially-updated resource as an update\nstdout/stderr:\n{plan_text}"
+    );
+    assert!(
+        plan_text
+            .contains("(known after next apply: post-create read failed — mock partial update)"),
+        "next plan must surface the partial-update unknown reason\nstdout/stderr:\n{plan_text}"
+    );
+}
+
+#[test]
+fn replace_partial_create_records_state_and_next_plan_surfaces_unknown_reason() {
+    let scenario = Scenario::new();
+    scenario.write_config_with_name_and_version("r1", "one");
+    scenario.init();
+
+    let create = scenario.apply();
+    assert_success("initial apply", &create);
+
+    scenario.write_config_with_name_and_version("r1-replacement", "one");
+    let replace = scenario.apply_partial_create();
+    let replace_text = output_text(&replace);
+    assert_eq!(
+        replace.status.code(),
+        Some(2),
+        "replace partial apply must exit 2\nstdout/stderr:\n{replace_text}"
+    );
+    assert!(
+        replace_text.contains("(partial)"),
+        "replace apply output must render partial replace\nstdout/stderr:\n{replace_text}"
+    );
+
+    let state_text = fs::read_to_string(scenario.project.join("carina.state.json")).unwrap();
+    assert!(
+        state_text.contains("\"partial_read\""),
+        "replace writeback must persist the partial_read marker:\n{state_text}"
+    );
+    assert!(
+        state_text.contains("mock partial create"),
+        "state file must persist replace partial detail:\n{state_text}"
+    );
+
+    let plan = scenario.plan();
+    assert_success("carina plan after replace partial", &plan);
+    let plan_text = output_text(&plan);
+    assert!(
+        plan_text.contains("~ mock.test.resource r1") && plan_text.contains("1 to change"),
+        "next plan must show the replace partial resource as an update\nstdout/stderr:\n{plan_text}"
+    );
+    assert!(
+        plan_text
+            .contains("(known after next apply: post-create read failed — mock partial create)"),
+        "next plan must surface the replace partial reason\nstdout/stderr:\n{plan_text}"
+    );
+}

--- a/carina-cli/tests/validate_deferred_for_enumeration_e2e.rs
+++ b/carina-cli/tests/validate_deferred_for_enumeration_e2e.rs
@@ -149,9 +149,13 @@ impl Provider for NoopProvider {
         id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         let id = id.clone();
-        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+        Box::pin(async move {
+            Ok(carina_core::provider::UpdateOutcome::Success {
+                state: carina_core::resource::State::existing(id, HashMap::new()),
+            })
+        })
     }
     fn delete(
         &self,

--- a/carina-cli/tests/validate_unknown_custom_type_e2e.rs
+++ b/carina-cli/tests/validate_unknown_custom_type_e2e.rs
@@ -146,9 +146,13 @@ impl Provider for NoopProvider {
         id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         let id = id.clone();
-        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+        Box::pin(async move {
+            Ok(carina_core::provider::UpdateOutcome::Success {
+                state: carina_core::resource::State::existing(id, HashMap::new()),
+            })
+        })
     }
     fn delete(
         &self,

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -201,9 +201,13 @@ impl Provider for NoopProvider {
         id: &carina_core::resource::ResourceId,
         _i: &str,
         _r: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         let id = id.clone();
-        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+        Box::pin(async move {
+            Ok(carina_core::provider::UpdateOutcome::Success {
+                state: carina_core::resource::State::existing(id, HashMap::new()),
+            })
+        })
     }
     fn delete(
         &self,

--- a/carina-cli/tests/wait_validate_e2e.rs
+++ b/carina-cli/tests/wait_validate_e2e.rs
@@ -119,9 +119,13 @@ impl Provider for NoopProvider {
         id: &carina_core::resource::ResourceId,
         _identifier: &str,
         _request: carina_core::provider::UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+    ) -> BoxFuture<'_, ProviderResult<carina_core::provider::UpdateOutcome>> {
         let id = id.clone();
-        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+        Box::pin(async move {
+            Ok(carina_core::provider::UpdateOutcome::Success {
+                state: carina_core::resource::State::existing(id, HashMap::new()),
+            })
+        })
     }
     fn delete(
         &self,

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -59,7 +59,10 @@ impl crate::provider::Provider for HintProvider {
         _id: &ResourceId,
         _identifier: &str,
         _request: crate::provider::UpdateRequest,
-    ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<State>> {
+    ) -> crate::provider::BoxFuture<
+        '_,
+        crate::provider::ProviderResult<crate::provider::UpdateOutcome>,
+    > {
         Box::pin(async { panic!("unexpected update") })
     }
 

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -14,8 +14,8 @@ use crate::executor::UnresolvedResource;
 use crate::executor::normalized::{NormalizedResource, apply_desired_normalization};
 use crate::parser::ProviderConfig;
 use crate::provider::{
-    CreateRequest, DeleteRequest, PartialCreateDiagnostic, Provider, ProviderNormalizer,
-    ReadRequest, UpdateRequest, build_update_patch,
+    CreateRequest, DeleteRequest, PartialReadDiagnostic, Provider, ProviderNormalizer, ReadRequest,
+    UpdateOutcome, UpdateRequest, build_update_patch,
 };
 use crate::resolver::resolve_ref_value;
 use crate::resource::{
@@ -52,7 +52,7 @@ pub(super) enum BasicEffectResult {
     PartialSuccess {
         state: State,
         resource_id: ResourceId,
-        diagnostic: PartialCreateDiagnostic,
+        diagnostic: PartialReadDiagnostic,
         resolved_attrs: Option<HashMap<String, Value>>,
         binding: Option<String>,
     },
@@ -73,7 +73,7 @@ pub(super) struct ExecutionState<'a> {
     pub(super) success_count: &'a mut usize,
     pub(super) failure_count: &'a mut usize,
     pub(super) partial_count: &'a mut usize,
-    pub(super) partial_diagnostics: &'a mut Vec<(ResourceId, PartialCreateDiagnostic)>,
+    pub(super) partial_diagnostics: &'a mut Vec<(ResourceId, PartialReadDiagnostic)>,
     pub(super) applied_states: &'a mut AppliedStates,
     pub(super) failed_bindings: &'a mut std::collections::HashSet<String>,
     pub(super) successfully_deleted: &'a mut std::collections::HashSet<ResourceId>,
@@ -673,18 +673,42 @@ pub(super) async fn execute_basic_effect<'a>(
                 patch,
             };
             match provider.update(id, identifier, request).await {
-                Ok(state) => {
-                    observer.on_event(&ExecutionEvent::EffectSucceeded {
-                        effect,
-                        state: Some(&state),
-                        duration: started.elapsed(),
-                        progress,
-                    });
-                    BasicEffectResult::Success {
-                        state: Some(state),
-                        resource_id: id.clone(),
-                        resolved_attrs: Some(resolved_to.as_resource().resolved_attributes()),
-                        binding: to.binding.clone(),
+                Ok(outcome) => {
+                    let diagnostic = match &outcome {
+                        UpdateOutcome::Success { .. } => None,
+                        UpdateOutcome::PartialSuccess { diagnostic, .. } => {
+                            Some(diagnostic.clone())
+                        }
+                    };
+                    let state = outcome.into_state_for_writeback();
+                    if let Some(diagnostic) = diagnostic {
+                        observer.on_event(&ExecutionEvent::EffectPartiallySucceeded {
+                            effect,
+                            state: &state,
+                            diagnostic: &diagnostic,
+                            duration: started.elapsed(),
+                            progress,
+                        });
+                        BasicEffectResult::PartialSuccess {
+                            state,
+                            resource_id: id.clone(),
+                            diagnostic,
+                            resolved_attrs: Some(resolved_to.as_resource().resolved_attributes()),
+                            binding: to.binding.clone(),
+                        }
+                    } else {
+                        observer.on_event(&ExecutionEvent::EffectSucceeded {
+                            effect,
+                            state: Some(&state),
+                            duration: started.elapsed(),
+                            progress,
+                        });
+                        BasicEffectResult::Success {
+                            state: Some(state),
+                            resource_id: id.clone(),
+                            resolved_attrs: Some(resolved_to.as_resource().resolved_attributes()),
+                            binding: to.binding.clone(),
+                        }
                     }
                 }
                 Err(e) => {
@@ -748,7 +772,7 @@ pub(super) async fn execute_basic_effect<'a>(
 #[cfg(test)]
 mod process_basic_result_tests {
     use super::*;
-    use crate::provider::PartialCreateDiagnostic;
+    use crate::provider::PartialReadDiagnostic;
     use crate::resource::{State, Value};
     use std::collections::HashSet;
 
@@ -756,7 +780,7 @@ mod process_basic_result_tests {
     fn partial_success_records_state_and_diagnostic() {
         let id = ResourceId::with_provider("mock", "test.resource", "r1", None);
         let state = State::existing(id.clone(), HashMap::new()).with_identifier("mock-id");
-        let diagnostic = PartialCreateDiagnostic::new(
+        let diagnostic = PartialReadDiagnostic::new(
             "mock partial create".to_string(),
             vec!["computed".to_string()],
         )

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
 use crate::parser::ProviderConfig;
-use crate::provider::{PartialCreateDiagnostic, Provider, ProviderNormalizer};
+use crate::provider::{PartialReadDiagnostic, Provider, ProviderNormalizer};
 use crate::resource::{ResolvedResource, Resource, ResourceId, State};
 use crate::value::SerializationError;
 use crate::wait::WaitObservation;
@@ -87,7 +87,7 @@ pub struct ExecutionResult {
     pub success_count: usize,
     pub failure_count: usize,
     pub partial_count: usize,
-    pub partial_diagnostics: Vec<(ResourceId, PartialCreateDiagnostic)>,
+    pub partial_diagnostics: Vec<(ResourceId, PartialReadDiagnostic)>,
     pub skip_count: usize,
     pub applied_states: std::collections::HashMap<ResourceId, State>,
     pub runtime_synthesized_resources: Vec<Resource>,
@@ -159,7 +159,7 @@ pub enum ExecutionEvent<'a> {
     EffectPartiallySucceeded {
         effect: &'a Effect,
         state: &'a State,
-        diagnostic: &'a PartialCreateDiagnostic,
+        diagnostic: &'a PartialReadDiagnostic,
         duration: Duration,
         progress: ProgressInfo,
     },

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -996,6 +996,7 @@ pub(super) async fn execute_effects_sequential(
                 state,
                 resource_id,
                 diagnostic,
+                cascade_diagnostics,
                 resolved_attrs,
                 binding,
                 refreshes,
@@ -1010,10 +1011,18 @@ pub(super) async fn execute_effects_sequential(
                     }
                 }
                 if success {
+                    let mut recorded_partial = false;
                     if let Some(diagnostic) = diagnostic {
                         partial_count += 1;
                         partial_diagnostics.push((resource_id.clone(), diagnostic));
-                    } else {
+                        recorded_partial = true;
+                    }
+                    for (id, diagnostic) in cascade_diagnostics {
+                        partial_count += 1;
+                        partial_diagnostics.push((id, diagnostic));
+                        recorded_partial = true;
+                    }
+                    if !recorded_partial {
                         success_count += 1;
                     }
                     if let Some((id, overrides)) = permanent_overrides {
@@ -1255,7 +1264,7 @@ mod tests {
             _id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
             Box::pin(async { Err(ProviderError::internal("update not used")) })
         }
 

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -10,7 +10,7 @@ use tokio_util::sync::CancellationToken;
 use crate::deps::{find_failed_dependency, get_resource_dependencies};
 use crate::effect::Effect;
 use crate::provider::{
-    CreateRequest, DeleteRequest, PartialCreateDiagnostic, Provider, UpdateRequest,
+    CreateRequest, DeleteRequest, PartialReadDiagnostic, Provider, UpdateOutcome, UpdateRequest,
 };
 use crate::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 
@@ -345,7 +345,8 @@ pub(super) enum PhaseEffectResult {
     CbdCreateSuccess {
         idx: usize,
         state: State,
-        diagnostic: Option<PartialCreateDiagnostic>,
+        diagnostic: Option<PartialReadDiagnostic>,
+        cascade_diagnostics: Vec<(ResourceId, PartialReadDiagnostic)>,
         cascade_states: Vec<(ResourceId, State, HashMap<String, Value>, Option<String>)>,
     },
     /// Phase 2: CBD create failed
@@ -365,7 +366,7 @@ pub(super) enum PhaseEffectResult {
     NonCbdCreateSuccess {
         state: State,
         resource_id: ResourceId,
-        diagnostic: Option<PartialCreateDiagnostic>,
+        diagnostic: Option<PartialReadDiagnostic>,
         resolved_attrs: HashMap<String, Value>,
         binding: Option<String>,
     },
@@ -375,6 +376,7 @@ pub(super) enum PhaseEffectResult {
     CbdFinalizeSuccess {
         state: State,
         resource_id: ResourceId,
+        diagnostic: Option<PartialReadDiagnostic>,
         permanent_overrides: Option<(ResourceId, HashMap<String, String>)>,
     },
     /// Phase 4: CBD finalization failed (rename failed)
@@ -836,7 +838,7 @@ pub(super) async fn execute_effects_phased(
     // Phase 2: CBD creates with parallel execution (forward dependency order)
     // -----------------------------------------------------------------------
     let mut cbd_create_states: HashMap<usize, State> = HashMap::new();
-    let mut cbd_create_diagnostics: HashMap<usize, PartialCreateDiagnostic> = HashMap::new();
+    let mut cbd_create_diagnostics: HashMap<usize, PartialReadDiagnostic> = HashMap::new();
     let mut replace_start_times: HashMap<usize, Instant> = HashMap::new();
 
     // Assign progress numbers to all Replace effects upfront.
@@ -989,6 +991,7 @@ pub(super) async fn execute_effects_phased(
                                 );
 
                                 let mut cascade_failed = false;
+                                let mut cascade_diagnostics = Vec::new();
                                 let mut refreshes = Vec::new();
                                 let mut cascade_states = Vec::new();
                                 for cascade in cascading_updates {
@@ -1034,12 +1037,25 @@ pub(super) async fn execute_effects_phased(
                                         .update(&cascade.id, cascade_identifier, cascade_request)
                                         .await
                                     {
-                                        Ok(cascade_state) => {
+                                        Ok(cascade_outcome) => {
+                                            let cascade_diagnostic = match &cascade_outcome {
+                                                UpdateOutcome::Success { .. } => None,
+                                                UpdateOutcome::PartialSuccess {
+                                                    diagnostic,
+                                                    ..
+                                                } => Some(diagnostic.clone()),
+                                            };
                                             observer.on_event(
                                                 &ExecutionEvent::CascadeUpdateSucceeded {
                                                     id: &cascade.id,
                                                 },
                                             );
+                                            let cascade_state =
+                                                cascade_outcome.into_state_for_writeback();
+                                            if let Some(diagnostic) = cascade_diagnostic {
+                                                cascade_diagnostics
+                                                    .push((cascade.id.clone(), diagnostic));
+                                            }
                                             let cascade_attrs =
                                                 resolved_to.as_resource().resolved_attributes();
                                             local_bindings.record_applied(
@@ -1093,6 +1109,7 @@ pub(super) async fn execute_effects_phased(
                                             idx,
                                             state,
                                             diagnostic,
+                                            cascade_diagnostics,
                                             cascade_states,
                                         },
                                     )
@@ -1156,6 +1173,7 @@ pub(super) async fn execute_effects_phased(
                     idx,
                     state,
                     diagnostic,
+                    cascade_diagnostics,
                     cascade_states,
                 } => {
                     let effect = &effects[idx];
@@ -1178,6 +1196,10 @@ pub(super) async fn execute_effects_phased(
                             &cascade_attrs,
                             &cascade_state,
                         );
+                    }
+                    for (cascade_id, diagnostic) in cascade_diagnostics {
+                        partial_count += 1;
+                        partial_diagnostics.push((cascade_id, diagnostic));
                     }
                     replace_start_times.insert(idx, started);
                     cbd_create_states.insert(idx, state);
@@ -1673,17 +1695,22 @@ pub(super) async fn execute_effects_phased(
                                     patch: rename_patch,
                                 };
                                 match provider.update(&id, new_identifier, rename_request).await {
-                                    Ok(renamed_state) => {
+                                    Ok(rename_outcome) => {
                                         observer.on_event(&ExecutionEvent::RenameSucceeded {
                                             id: &id,
                                             from: &temp.temporary_value,
                                             to: &temp.original_value,
                                         });
+                                        let rename_diagnostic = match &rename_outcome {
+                                            UpdateOutcome::Success { .. } => None,
+                                            UpdateOutcome::PartialSuccess {
+                                                diagnostic, ..
+                                            } => Some(diagnostic.clone()),
+                                        };
                                         let renamed_state =
-                                            diagnostic.clone().map_or(renamed_state.clone(), |d| {
-                                                d.into_state_for_writeback(renamed_state)
-                                            });
-                                        if let Some(diagnostic) = &diagnostic {
+                                            rename_outcome.into_state_for_writeback();
+                                        let final_diagnostic = rename_diagnostic.or(diagnostic);
+                                        if let Some(diagnostic) = &final_diagnostic {
                                             observer.on_event(
                                                 &ExecutionEvent::EffectPartiallySucceeded {
                                                     effect: &effect_for_future,
@@ -1706,6 +1733,7 @@ pub(super) async fn execute_effects_phased(
                                             PhaseEffectResult::CbdFinalizeSuccess {
                                                 state: renamed_state,
                                                 resource_id: to.id.clone(),
+                                                diagnostic: final_diagnostic,
                                                 permanent_overrides: None,
                                             },
                                         )
@@ -1768,6 +1796,7 @@ pub(super) async fn execute_effects_phased(
                                     PhaseEffectResult::CbdFinalizeSuccess {
                                         state,
                                         resource_id: to.id.clone(),
+                                        diagnostic,
                                         permanent_overrides,
                                     },
                                 )
@@ -1932,13 +1961,17 @@ pub(super) async fn execute_effects_phased(
                 PhaseEffectResult::CbdFinalizeSuccess {
                     state,
                     resource_id,
+                    diagnostic,
                     permanent_overrides,
                 } => {
                     cbd_create_states.remove(&finished_idx);
-                    if let Some(diagnostic) = cbd_create_diagnostics.remove(&finished_idx) {
+                    if let Some(diagnostic) =
+                        diagnostic.or_else(|| cbd_create_diagnostics.remove(&finished_idx))
+                    {
                         partial_count += 1;
                         partial_diagnostics.push((resource_id.clone(), diagnostic));
                     } else {
+                        cbd_create_diagnostics.remove(&finished_idx);
                         success_count += 1;
                     }
                     applied_states.insert(resource_id, state);
@@ -2360,7 +2393,7 @@ mod tests {
             _id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
             Box::pin(async { Err(ProviderError::internal("update not used")) })
         }
 

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1709,16 +1709,10 @@ pub(super) async fn execute_effects_phased(
                                         };
                                         let mut renamed_state =
                                             rename_outcome.into_state_for_writeback();
-                                        let final_diagnostic = match (rename_diagnostic, diagnostic)
-                                        {
-                                            (Some(mut rename), Some(create)) => {
-                                                rename.merge_in(create);
-                                                Some(rename)
-                                            }
-                                            (Some(rename), None) => Some(rename),
-                                            (None, Some(create)) => Some(create),
-                                            (None, None) => None,
-                                        };
+                                        let final_diagnostic = PartialReadDiagnostic::merge_options(
+                                            rename_diagnostic,
+                                            diagnostic,
+                                        );
                                         if let Some(diagnostic) = final_diagnostic.clone() {
                                             renamed_state =
                                                 diagnostic.into_state_for_writeback(renamed_state);

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -1707,9 +1707,22 @@ pub(super) async fn execute_effects_phased(
                                                 diagnostic, ..
                                             } => Some(diagnostic.clone()),
                                         };
-                                        let renamed_state =
+                                        let mut renamed_state =
                                             rename_outcome.into_state_for_writeback();
-                                        let final_diagnostic = rename_diagnostic.or(diagnostic);
+                                        let final_diagnostic = match (rename_diagnostic, diagnostic)
+                                        {
+                                            (Some(mut rename), Some(create)) => {
+                                                rename.merge_in(create);
+                                                Some(rename)
+                                            }
+                                            (Some(rename), None) => Some(rename),
+                                            (None, Some(create)) => Some(create),
+                                            (None, None) => None,
+                                        };
+                                        if let Some(diagnostic) = final_diagnostic.clone() {
+                                            renamed_state =
+                                                diagnostic.into_state_for_writeback(renamed_state);
+                                        }
                                         if let Some(diagnostic) = &final_diagnostic {
                                             observer.on_event(
                                                 &ExecutionEvent::EffectPartiallySucceeded {

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -325,15 +325,10 @@ pub(super) async fn execute_cbd_replace_parallel(
                                     }
                                 };
                                 final_state = rename_outcome.into_state_for_writeback();
-                                diagnostic = match (rename_diagnostic, diagnostic) {
-                                    (Some(mut rename), Some(create)) => {
-                                        rename.merge_in(create);
-                                        Some(rename)
-                                    }
-                                    (Some(rename), None) => Some(rename),
-                                    (None, Some(create)) => Some(create),
-                                    (None, None) => None,
-                                };
+                                diagnostic = PartialReadDiagnostic::merge_options(
+                                    rename_diagnostic,
+                                    diagnostic,
+                                );
                                 if let Some(diagnostic) = diagnostic.clone() {
                                     final_state = diagnostic.into_state_for_writeback(final_state);
                                 }

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -10,8 +10,8 @@ use crate::differ::{
 use crate::effect::Effect;
 use crate::executor::UnresolvedResource;
 use crate::provider::{
-    CreateRequest, DeleteRequest, PartialCreateDiagnostic, PatchOp, PatchOpKind, Provider,
-    UpdatePatch, UpdateRequest, build_update_patch,
+    CreateRequest, DeleteRequest, PartialReadDiagnostic, PatchOp, PatchOpKind, Provider,
+    UpdateOutcome, UpdatePatch, UpdateRequest, build_update_patch,
 };
 use crate::resource::{ConcreteValue, ResolvedResource, Resource, ResourceId, State, Value};
 use crate::schema::SchemaRegistry;
@@ -102,7 +102,8 @@ pub(super) enum SingleEffectResult {
         success: bool,
         state: Option<State>,
         resource_id: ResourceId,
-        diagnostic: Option<PartialCreateDiagnostic>,
+        diagnostic: Option<PartialReadDiagnostic>,
+        cascade_diagnostics: Vec<(ResourceId, PartialReadDiagnostic)>,
         resolved_attrs: Option<HashMap<String, Value>>,
         binding: Option<String>,
         refreshes: Vec<(ResourceId, String)>,
@@ -186,7 +187,7 @@ pub(super) async fn execute_cbd_replace_parallel(
         .await
     {
         Ok(outcome) => {
-            let diagnostic = outcome.diagnostic().cloned();
+            let mut diagnostic = outcome.diagnostic().cloned();
             let state = outcome.into_state_for_writeback();
             // Build a local bindings clone for cascade resolution
             let mut local_bindings = ctx.bindings.clone();
@@ -194,6 +195,7 @@ pub(super) async fn execute_cbd_replace_parallel(
 
             // Execute cascading updates
             let mut cascade_failed = false;
+            let mut cascade_diagnostics = Vec::new();
             for cascade in ctx.cascading_updates {
                 let resolved_to = match resolve_resource(&cascade.to, &local_bindings, ctx.pipeline)
                     .await
@@ -226,7 +228,17 @@ pub(super) async fn execute_cbd_replace_parallel(
                     .update(&cascade.id, cascade_identifier, cascade_request)
                     .await
                 {
-                    Ok(cascade_state) => {
+                    Ok(cascade_outcome) => {
+                        let cascade_diagnostic = match &cascade_outcome {
+                            UpdateOutcome::Success { .. } => None,
+                            UpdateOutcome::PartialSuccess { diagnostic, .. } => {
+                                Some(diagnostic.clone())
+                            }
+                        };
+                        let cascade_state = cascade_outcome.into_state_for_writeback();
+                        if let Some(diagnostic) = cascade_diagnostic {
+                            cascade_diagnostics.push((cascade.id.clone(), diagnostic));
+                        }
                         observer
                             .on_event(&ExecutionEvent::CascadeUpdateSucceeded { id: &cascade.id });
                         local_bindings.record_applied(
@@ -258,6 +270,7 @@ pub(super) async fn execute_cbd_replace_parallel(
                     state: None,
                     resource_id: ctx.to.id.clone(),
                     diagnostic,
+                    cascade_diagnostics,
                     resolved_attrs: None,
                     binding: ctx.effect.binding_name(),
                     refreshes,
@@ -299,16 +312,26 @@ pub(super) async fn execute_cbd_replace_parallel(
                             .update(ctx.id, new_identifier, rename_request)
                             .await
                         {
-                            Ok(renamed_state) => {
+                            Ok(rename_outcome) => {
                                 observer.on_event(&ExecutionEvent::RenameSucceeded {
                                     id: ctx.id,
                                     from: &temp.temporary_value,
                                     to: &temp.original_value,
                                 });
-                                final_state =
-                                    diagnostic.clone().map_or(renamed_state.clone(), |d| {
-                                        d.into_state_for_writeback(renamed_state)
-                                    });
+                                let rename_diagnostic = match &rename_outcome {
+                                    UpdateOutcome::Success { .. } => None,
+                                    UpdateOutcome::PartialSuccess { diagnostic, .. } => {
+                                        Some(diagnostic.clone())
+                                    }
+                                };
+                                final_state = rename_outcome.into_state_for_writeback();
+                                if diagnostic.is_none() {
+                                    diagnostic = rename_diagnostic;
+                                } else if let Some(rename_diagnostic) = rename_diagnostic {
+                                    cascade_diagnostics.push((ctx.id.clone(), rename_diagnostic));
+                                } else if let Some(diagnostic) = diagnostic.clone() {
+                                    final_state = diagnostic.into_state_for_writeback(final_state);
+                                }
                             }
                             Err(e) => {
                                 let error_str = e.to_string();
@@ -339,6 +362,7 @@ pub(super) async fn execute_cbd_replace_parallel(
                             state: Some(final_state),
                             resource_id: ctx.to.id.clone(),
                             diagnostic,
+                            cascade_diagnostics,
                             resolved_attrs: Some(resolved_attrs.clone()),
                             binding: ctx.effect.binding_name(),
                             refreshes,
@@ -367,6 +391,7 @@ pub(super) async fn execute_cbd_replace_parallel(
                             state: Some(final_state),
                             resource_id: ctx.to.id.clone(),
                             diagnostic,
+                            cascade_diagnostics,
                             resolved_attrs: Some(resolved_attrs),
                             binding: ctx.to.binding.clone(),
                             refreshes,
@@ -392,6 +417,7 @@ pub(super) async fn execute_cbd_replace_parallel(
                         state: None,
                         resource_id: ctx.to.id.clone(),
                         diagnostic,
+                        cascade_diagnostics,
                         resolved_attrs: None,
                         binding: ctx.effect.binding_name(),
                         refreshes,
@@ -414,6 +440,7 @@ pub(super) async fn execute_cbd_replace_parallel(
                 state: None,
                 resource_id: ctx.to.id.clone(),
                 diagnostic: None,
+                cascade_diagnostics: Vec::new(),
                 resolved_attrs: None,
                 binding: ctx.effect.binding_name(),
                 refreshes,
@@ -470,6 +497,7 @@ pub(super) async fn execute_dbd_replace_parallel(
                         state: None,
                         resource_id: ctx.to.id.clone(),
                         diagnostic: None,
+                        cascade_diagnostics: Vec::new(),
                         resolved_attrs: None,
                         binding: ctx.effect.binding_name(),
                         refreshes,
@@ -498,6 +526,7 @@ pub(super) async fn execute_dbd_replace_parallel(
                             state: Some(state),
                             resource_id: ctx.to.id.clone(),
                             diagnostic: Some(diagnostic),
+                            cascade_diagnostics: Vec::new(),
                             resolved_attrs: Some(resolved_attrs),
                             binding: ctx.to.binding.clone(),
                             refreshes,
@@ -516,6 +545,7 @@ pub(super) async fn execute_dbd_replace_parallel(
                             state: Some(state),
                             resource_id: ctx.to.id.clone(),
                             diagnostic: None,
+                            cascade_diagnostics: Vec::new(),
                             resolved_attrs: Some(resolved_attrs),
                             binding: ctx.to.binding.clone(),
                             refreshes,
@@ -538,6 +568,7 @@ pub(super) async fn execute_dbd_replace_parallel(
                         state: None,
                         resource_id: ctx.to.id.clone(),
                         diagnostic: None,
+                        cascade_diagnostics: Vec::new(),
                         resolved_attrs: None,
                         binding: ctx.effect.binding_name(),
                         refreshes,
@@ -561,6 +592,7 @@ pub(super) async fn execute_dbd_replace_parallel(
                 state: None,
                 resource_id: ctx.to.id.clone(),
                 diagnostic: None,
+                cascade_diagnostics: Vec::new(),
                 resolved_attrs: None,
                 binding: ctx.effect.binding_name(),
                 refreshes,

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -325,7 +325,15 @@ pub(super) async fn execute_cbd_replace_parallel(
                                     }
                                 };
                                 final_state = rename_outcome.into_state_for_writeback();
-                                diagnostic = rename_diagnostic.or(diagnostic);
+                                diagnostic = match (rename_diagnostic, diagnostic) {
+                                    (Some(mut rename), Some(create)) => {
+                                        rename.merge_in(create);
+                                        Some(rename)
+                                    }
+                                    (Some(rename), None) => Some(rename),
+                                    (None, Some(create)) => Some(create),
+                                    (None, None) => None,
+                                };
                                 if let Some(diagnostic) = diagnostic.clone() {
                                     final_state = diagnostic.into_state_for_writeback(final_state);
                                 }

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -325,11 +325,8 @@ pub(super) async fn execute_cbd_replace_parallel(
                                     }
                                 };
                                 final_state = rename_outcome.into_state_for_writeback();
-                                if diagnostic.is_none() {
-                                    diagnostic = rename_diagnostic;
-                                } else if let Some(rename_diagnostic) = rename_diagnostic {
-                                    cascade_diagnostics.push((ctx.id.clone(), rename_diagnostic));
-                                } else if let Some(diagnostic) = diagnostic.clone() {
+                                diagnostic = rename_diagnostic.or(diagnostic);
+                                if let Some(diagnostic) = diagnostic.clone() {
                                     final_state = diagnostic.into_state_for_writeback(final_state);
                                 }
                             }

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -2831,6 +2831,78 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
 }
 
 #[tokio::test]
+async fn test_cbd_rename_partial_create_partial_counts_once() {
+    let provider = MockProvider::new();
+    let id = ResourceId::with_provider("test", "replace", "replace", None);
+    let from = State::existing(id.clone(), HashMap::new()).with_identifier("replace-old");
+    let mut to = Resource::with_provider("test", "replace", "replace", None);
+    to.binding = Some("replace".to_string());
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: id.clone(),
+        from: Box::new(from),
+        to,
+        directives: Directives {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
+            .unwrap(),
+        cascading_updates: vec![],
+        temporary_name: Some(crate::effect::TemporaryName {
+            attribute: "name".to_string(),
+            original_value: "replace-final".to_string(),
+            temporary_value: "replace-temp".to_string(),
+            can_rename: true,
+        }),
+        cascade_ref_hints: vec![],
+    });
+
+    provider.push_create_outcome(Ok(crate::provider::CreateOutcome::partial_success(
+        ok_state(&id),
+        "create read incomplete".to_string(),
+        vec!["create_attr".to_string()],
+    )));
+    provider.push_delete(Ok(()));
+    provider.push_update_outcome(Ok(crate::provider::UpdateOutcome::partial_success(
+        ok_state(&id),
+        "rename read incomplete".to_string(),
+        vec!["rename_attr".to_string()],
+    )));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    assert_eq!(provider.calls()[0].0, "create");
+    assert_eq!(provider.calls()[1].0, "delete");
+    assert_eq!(provider.calls()[2].0, "update");
+    assert_eq!(result.success_count, 0);
+    assert_eq!(result.failure_count, 0);
+    assert_eq!(result.partial_count, 1);
+    assert_eq!(result.partial_diagnostics.len(), 1);
+    assert_eq!(result.partial_diagnostics[0].0, id);
+    assert_eq!(
+        result.partial_diagnostics[0].1.reason(),
+        "rename read incomplete"
+    );
+}
+
+#[tokio::test]
 async fn test_dbd_deletes_before_creates() {
     // Non-CBD Replace: delete should happen before create
     let provider = MockProvider::new();

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -2900,6 +2900,86 @@ async fn test_cbd_rename_partial_create_partial_counts_once() {
         result.partial_diagnostics[0].1.reason(),
         "rename read incomplete"
     );
+    let marker = result.applied_states[&id]
+        .partial_read
+        .as_ref()
+        .expect("partial marker should be written back");
+    assert_eq!(marker.detail, "rename read incomplete");
+    assert!(marker.missing_attributes.contains("rename_attr"));
+    assert!(marker.missing_attributes.contains("create_attr"));
+    assert_eq!(marker.missing_attributes.len(), 2);
+}
+
+#[tokio::test]
+async fn test_cbd_rename_success_create_partial_keeps_create_marker() {
+    let provider = MockProvider::new();
+    let id = ResourceId::with_provider("test", "replace", "replace", None);
+    let from = State::existing(id.clone(), HashMap::new()).with_identifier("replace-old");
+    let mut to = Resource::with_provider("test", "replace", "replace", None);
+    to.binding = Some("replace".to_string());
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: id.clone(),
+        from: Box::new(from),
+        to,
+        directives: Directives {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
+            .unwrap(),
+        cascading_updates: vec![],
+        temporary_name: Some(crate::effect::TemporaryName {
+            attribute: "name".to_string(),
+            original_value: "replace-final".to_string(),
+            temporary_value: "replace-temp".to_string(),
+            can_rename: true,
+        }),
+        cascade_ref_hints: vec![],
+    });
+
+    provider.push_create_outcome(Ok(crate::provider::CreateOutcome::partial_success(
+        ok_state(&id),
+        "create read incomplete".to_string(),
+        vec!["create_attr".to_string()],
+    )));
+    provider.push_delete(Ok(()));
+    provider.push_update(Ok(ok_state(&id)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    assert_eq!(result.success_count, 0);
+    assert_eq!(result.failure_count, 0);
+    assert_eq!(result.partial_count, 1);
+    assert_eq!(result.partial_diagnostics.len(), 1);
+    assert_eq!(result.partial_diagnostics[0].0, id);
+    assert_eq!(
+        result.partial_diagnostics[0].1.reason(),
+        "create read incomplete"
+    );
+    let marker = result.applied_states[&id]
+        .partial_read
+        .as_ref()
+        .expect("partial marker should be written back");
+    assert_eq!(marker.detail, "create read incomplete");
+    assert!(marker.missing_attributes.contains("create_attr"));
+    assert_eq!(marker.missing_attributes.len(), 1);
 }
 
 #[tokio::test]

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -60,7 +60,7 @@ fn validation_deferred_for_expression() -> crate::parser::DeferredForExpression 
 struct MockProvider {
     create_results: Mutex<Vec<ProviderResult<crate::provider::CreateOutcome>>>,
     delete_results: Mutex<Vec<ProviderResult<()>>>,
-    update_results: Mutex<Vec<ProviderResult<State>>>,
+    update_results: Mutex<Vec<ProviderResult<crate::provider::UpdateOutcome>>>,
     read_results: Mutex<Vec<ProviderResult<State>>>,
     /// Records calls in order: ("create"|"delete"|"update"|"read", resource_id_string)
     call_log: Arc<Mutex<Vec<(String, String)>>>,
@@ -102,6 +102,13 @@ impl MockProvider {
     }
 
     fn push_update(&self, result: ProviderResult<State>) {
+        self.update_results
+            .lock()
+            .unwrap()
+            .push(result.map(|state| crate::provider::UpdateOutcome::Success { state }));
+    }
+
+    fn push_update_outcome(&self, result: ProviderResult<crate::provider::UpdateOutcome>) {
         self.update_results.lock().unwrap().push(result);
     }
 
@@ -169,7 +176,7 @@ impl Provider for MockProvider {
         id: &ResourceId,
         _identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
         let id_str = id.to_string();
         self.call_log
             .lock()
@@ -945,7 +952,7 @@ impl Provider for DelayedCountingProvider {
         id: &ResourceId,
         _identifier: &str,
         _request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
         let id = id.clone();
         let started = self.started.clone();
         Box::pin(async move {
@@ -958,7 +965,9 @@ impl Provider for DelayedCountingProvider {
                 "finalized".to_string(),
                 Value::Concrete(ConcreteValue::Bool(true)),
             );
-            Ok(State::existing(id, attrs).with_identifier("finalized-id"))
+            Ok(crate::provider::UpdateOutcome::Success {
+                state: State::existing(id, attrs).with_identifier("finalized-id"),
+            })
         })
     }
 
@@ -1045,7 +1054,7 @@ impl Provider for PendingWaitProvider {
         _id: &ResourceId,
         _identifier: &str,
         _request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
         Box::pin(async { Err(ProviderError::internal("update not used")) })
     }
 
@@ -1672,7 +1681,7 @@ async fn partial_create_records_state_and_diagnostic() {
     let provider = MockProvider::new();
     let resource = make_resource("a", &[]);
     let rid = resource.id.clone();
-    let diagnostic = crate::provider::PartialCreateDiagnostic::new(
+    let diagnostic = crate::provider::PartialReadDiagnostic::new(
         "mock partial create".to_string(),
         vec!["computed".to_string()],
     )
@@ -2783,7 +2792,11 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
     });
 
     provider.push_create(Ok(ok_state(&replace_id)));
-    provider.push_update(Ok(ok_state(&cascade_id)));
+    provider.push_update_outcome(Ok(crate::provider::UpdateOutcome::partial_success(
+        ok_state(&cascade_id),
+        "cascade read incomplete".to_string(),
+        vec!["description".to_string()],
+    )));
     provider.push_delete(Ok(()));
 
     let input = ExecutionInput {
@@ -2802,7 +2815,14 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
     let observer = MockObserver::new();
     let result =
         completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
-    assert_eq!(result.success_count, 1);
+    assert_eq!(result.success_count, 0);
+    assert_eq!(result.partial_count, 1);
+    assert_eq!(result.partial_diagnostics.len(), 1);
+    assert_eq!(result.partial_diagnostics[0].0, cascade_id);
+    assert_eq!(
+        result.partial_diagnostics[0].1.reason(),
+        "cascade read incomplete"
+    );
 
     let reqs = provider.captured_update_requests();
     assert_eq!(reqs.len(), 1);
@@ -3417,7 +3437,7 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
             _id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
             Box::pin(async { Err(ProviderError::internal("not implemented")) })
         }
 
@@ -3556,7 +3576,7 @@ impl Provider for DelayedUpdateProvider {
         id: &ResourceId,
         identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
         let id = id.clone();
         let identifier = identifier.to_string();
         let delay = self.delay;
@@ -3580,7 +3600,9 @@ impl Provider for DelayedUpdateProvider {
                     Value::Concrete(ConcreteValue::String("provider-violated-id".to_string())),
                 );
             }
-            Ok(State::existing(id, attrs).with_identifier(&identifier))
+            Ok(crate::provider::UpdateOutcome::Success {
+                state: State::existing(id, attrs).with_identifier(&identifier),
+            })
         })
     }
 
@@ -4220,7 +4242,7 @@ impl Provider for RecordingMockProvider {
         _id: &ResourceId,
         _identifier: &str,
         _request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
         Box::pin(async { Err(ProviderError::internal("not implemented")) })
     }
 
@@ -5184,7 +5206,7 @@ impl Provider for IdentifierAwareProvider {
         _id: &ResourceId,
         _identifier: &str,
         _request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
         Box::pin(async move { Err(ProviderError::api_error("update not expected")) })
     }
 
@@ -5819,7 +5841,7 @@ async fn expand_deferred_for_cancelled_after_upstream_create_reports_skipped() {
             _id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
             unreachable!("test does not update")
         }
 

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -549,9 +549,13 @@ mod tests {
             id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
             let id = id.clone();
-            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+            Box::pin(async move {
+                Ok(crate::provider::UpdateOutcome::Success {
+                    state: State::existing(id, HashMap::new()),
+                })
+            })
         }
 
         fn delete(

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -591,6 +591,19 @@ impl PartialReadDiagnostic {
         &self.missing_attributes
     }
 
+    /// Merge another partial-read diagnostic into this one.
+    ///
+    /// The receiver's reason is kept because it represents the most recent
+    /// operation that wrote the state. Missing attributes are unioned so the
+    /// next plan can surface every unobserved attribute as Unknown.
+    pub fn merge_in(&mut self, other: PartialReadDiagnostic) {
+        for attr in other.missing_attributes {
+            if !self.missing_attributes.contains(&attr) {
+                self.missing_attributes.push(attr);
+            }
+        }
+    }
+
     pub fn into_state_for_writeback(self, mut state: State) -> State {
         state.partial_read = Some(PartialReadMarker {
             detail: self.reason,

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -604,6 +604,24 @@ impl PartialReadDiagnostic {
         }
     }
 
+    /// Merge two optional diagnostics.
+    ///
+    /// When both are present, `a` keeps its reason because it represents the
+    /// more recent operation, while missing attributes are unioned with `b`.
+    /// Use this wherever two operations on the same resource may each report
+    /// partial; `.or()` silently drops the loser's missing attributes.
+    pub fn merge_options(a: Option<Self>, b: Option<Self>) -> Option<Self> {
+        match (a, b) {
+            (Some(mut a), Some(b)) => {
+                a.merge_in(b);
+                Some(a)
+            }
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        }
+    }
+
     pub fn into_state_for_writeback(self, mut state: State) -> State {
         state.partial_read = Some(PartialReadMarker {
             detail: self.reason,
@@ -1622,6 +1640,42 @@ mod tests {
 
         assert_eq!(outcome.diagnostic(), None);
         assert_eq!(outcome.into_state_for_writeback(), state);
+    }
+
+    #[test]
+    fn partial_read_diagnostic_merge_options_covers_all_cases() {
+        let a = PartialReadDiagnostic::new(
+            "rename partial".to_string(),
+            vec!["rename_attr".to_string(), "shared".to_string()],
+        )
+        .expect("missing attributes are non-empty");
+        let b = PartialReadDiagnostic::new(
+            "create partial".to_string(),
+            vec!["create_attr".to_string(), "shared".to_string()],
+        )
+        .expect("missing attributes are non-empty");
+
+        assert_eq!(PartialReadDiagnostic::merge_options(None, None), None);
+        assert_eq!(
+            PartialReadDiagnostic::merge_options(Some(a.clone()), None),
+            Some(a.clone())
+        );
+        assert_eq!(
+            PartialReadDiagnostic::merge_options(None, Some(b.clone())),
+            Some(b.clone())
+        );
+
+        let merged = PartialReadDiagnostic::merge_options(Some(a), Some(b))
+            .expect("both diagnostics should merge into one");
+        assert_eq!(merged.reason(), "rename partial");
+        assert_eq!(
+            merged.missing_attributes(),
+            &[
+                "rename_attr".to_string(),
+                "shared".to_string(),
+                "create_attr".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -496,20 +496,32 @@ pub enum CreateOutcome {
     /// Create completed but the provider could not fully observe state.
     PartialSuccess {
         state: State,
-        diagnostic: PartialCreateDiagnostic,
+        diagnostic: PartialReadDiagnostic,
     },
 }
 
-/// Diagnostic details for a partial create.
+/// Result of a provider update operation.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct PartialCreateDiagnostic {
+pub enum UpdateOutcome {
+    /// Update completed and the returned state is complete.
+    Success { state: State },
+    /// Update completed but the provider could not fully observe state.
+    PartialSuccess {
+        state: State,
+        diagnostic: PartialReadDiagnostic,
+    },
+}
+
+/// Diagnostic details for a partial post-mutation read.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PartialReadDiagnostic {
     reason: String,
     missing_attributes: Vec<String>,
 }
 
 impl CreateOutcome {
     pub fn partial_success(state: State, reason: String, missing_attributes: Vec<String>) -> Self {
-        match PartialCreateDiagnostic::new(reason, missing_attributes) {
+        match PartialReadDiagnostic::new(reason, missing_attributes) {
             Some(diagnostic) => CreateOutcome::PartialSuccess { state, diagnostic },
             None => CreateOutcome::Success { state },
         }
@@ -525,7 +537,7 @@ impl CreateOutcome {
         }
     }
 
-    pub fn diagnostic(&self) -> Option<&PartialCreateDiagnostic> {
+    pub fn diagnostic(&self) -> Option<&PartialReadDiagnostic> {
         match self {
             CreateOutcome::Success { .. } => None,
             CreateOutcome::PartialSuccess { diagnostic, .. } => Some(diagnostic),
@@ -533,7 +545,33 @@ impl CreateOutcome {
     }
 }
 
-impl PartialCreateDiagnostic {
+impl UpdateOutcome {
+    pub fn partial_success(state: State, reason: String, missing_attributes: Vec<String>) -> Self {
+        match PartialReadDiagnostic::new(reason, missing_attributes) {
+            Some(diagnostic) => UpdateOutcome::PartialSuccess { state, diagnostic },
+            None => UpdateOutcome::Success { state },
+        }
+    }
+
+    /// Consume the outcome and produce a State ready for writeback.
+    pub fn into_state_for_writeback(self) -> State {
+        match self {
+            UpdateOutcome::Success { state } => state,
+            UpdateOutcome::PartialSuccess { state, diagnostic } => {
+                diagnostic.into_state_for_writeback(state)
+            }
+        }
+    }
+
+    pub fn diagnostic(&self) -> Option<&PartialReadDiagnostic> {
+        match self {
+            UpdateOutcome::Success { .. } => None,
+            UpdateOutcome::PartialSuccess { diagnostic, .. } => Some(diagnostic),
+        }
+    }
+}
+
+impl PartialReadDiagnostic {
     pub fn new(reason: String, missing_attributes: Vec<String>) -> Option<Self> {
         if missing_attributes.is_empty() {
             None
@@ -655,7 +693,7 @@ pub trait Provider: Send + Sync {
         id: &ResourceId,
         identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>>;
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>>;
 
     /// Delete an existing resource. `identifier` is the cloud-side
     /// internal ID (e.g. `vpc-xxx`).
@@ -978,7 +1016,7 @@ impl Provider for ProviderRouter {
         id: &ResourceId,
         identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
         match self.get_provider_or_error(id) {
             Ok(provider) => provider.update(id, identifier, request),
             Err(e) => Box::pin(async move { Err(e) }),
@@ -1404,7 +1442,7 @@ impl Provider for Box<dyn Provider> {
         id: &ResourceId,
         identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
         (**self).update(id, identifier, request)
     }
 
@@ -1485,7 +1523,7 @@ mod tests {
             id: &ResourceId,
             _identifier: &str,
             request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
             let id = id.clone();
             // Apply the patch on top of `from` so the test sees the
             // user-specified changes round-tripped into State.
@@ -1502,7 +1540,11 @@ mod tests {
                     }
                 }
             }
-            Box::pin(async move { Ok(State::existing(id, attrs)) })
+            Box::pin(async move {
+                Ok(UpdateOutcome::Success {
+                    state: State::existing(id, attrs),
+                })
+            })
         }
 
         fn delete(
@@ -1531,7 +1573,7 @@ mod tests {
     fn create_outcome_exposes_state_and_diagnostic() {
         let id = ResourceId::new("test", "example");
         let state = State::existing(id, HashMap::new()).with_identifier("mock-id");
-        let diagnostic = PartialCreateDiagnostic::new(
+        let diagnostic = PartialReadDiagnostic::new(
             "mock partial create".to_string(),
             vec!["dns_name".to_string()],
         )
@@ -1631,7 +1673,7 @@ mod tests {
             _id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
             Box::pin(async { Err(ProviderError::internal("not supported")) })
         }
 
@@ -2230,7 +2272,11 @@ mod tests {
             from,
             patch: UpdatePatch::default(),
         };
-        let state = router.update(&id, "mock-id-123", request).await.unwrap();
+        let state = router
+            .update(&id, "mock-id-123", request)
+            .await
+            .unwrap()
+            .into_state_for_writeback();
         assert!(state.exists);
     }
 
@@ -2294,7 +2340,7 @@ mod tests {
             _id: &ResourceId,
             _identifier: &str,
             _request: UpdateRequest,
-        ) -> BoxFuture<'_, ProviderResult<State>> {
+        ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
             Box::pin(async { Err(ProviderError::internal("not supported")) })
         }
         fn delete(
@@ -2642,9 +2688,13 @@ mod tests {
                 id: &ResourceId,
                 _identifier: &str,
                 _request: UpdateRequest,
-            ) -> BoxFuture<'_, ProviderResult<State>> {
+            ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
                 let id = id.clone();
-                Box::pin(async move { Ok(State::not_found(id)) })
+                Box::pin(async move {
+                    Ok(UpdateOutcome::Success {
+                        state: State::not_found(id),
+                    })
+                })
             }
 
             fn delete(

--- a/carina-core/src/wait/augment.rs
+++ b/carina-core/src/wait/augment.rs
@@ -97,8 +97,10 @@ mod tests {
             _id: &ResourceId,
             _identifier: &str,
             _request: crate::provider::UpdateRequest,
-        ) -> crate::provider::BoxFuture<'_, crate::provider::ProviderResult<crate::resource::State>>
-        {
+        ) -> crate::provider::BoxFuture<
+            '_,
+            crate::provider::ProviderResult<crate::provider::UpdateOutcome>,
+        > {
             Box::pin(async { panic!("unexpected update") })
         }
 

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -38,7 +38,7 @@ use carina_core::module_resolver::resolve_modules;
 use carina_core::parser::ProviderContext;
 use carina_core::provider::{
     BoxFuture, CreateOutcome, CreateRequest, DeleteRequest, NoopNormalizer, Provider,
-    ProviderResult, ReadRequest, UpdateRequest,
+    ProviderResult, ReadRequest, UpdateOutcome, UpdateRequest,
 };
 use carina_core::resolver::resolve_refs_with_state_and_remote;
 use carina_core::resource::{ConcreteValue, ResourceId, State, Value};
@@ -128,9 +128,13 @@ impl Provider for MockProvider {
         id: &ResourceId,
         _identifier: &str,
         _request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
         let id = id.clone();
-        Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        Box::pin(async move {
+            Ok(UpdateOutcome::Success {
+                state: State::existing(id, HashMap::new()),
+            })
+        })
     }
 
     fn delete(

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -8,8 +8,8 @@ use carina_core::provider::{
     CreateOutcome as CoreCreateOutcome, CreateRequest as CoreCreateRequest,
     DeleteRequest as CoreDeleteRequest, ErrorDetail as CoreErrorDetail, PatchOp as CorePatchOp,
     PatchOpKind as CorePatchOpKind, ProviderError as CoreProviderError,
-    ReadRequest as CoreReadRequest, UpdatePatch as CoreUpdatePatch,
-    UpdateRequest as CoreUpdateRequest,
+    ReadRequest as CoreReadRequest, UpdateOutcome as CoreUpdateOutcome,
+    UpdatePatch as CoreUpdatePatch, UpdateRequest as CoreUpdateRequest,
 };
 use carina_core::resource::{
     ConcreteValue, DataSource as CoreDataSource, DeferredValue, Directives,
@@ -433,6 +433,22 @@ pub fn wit_to_core_create_outcome(
             state: wit_to_core_state(&state, id),
         },
         wit::CreateOutcome::PartialSuccess(partial) => CoreCreateOutcome::partial_success(
+            wit_to_core_state(&partial.state, id),
+            partial.diagnostic.reason,
+            partial.diagnostic.missing_attributes,
+        ),
+    }
+}
+
+pub fn wit_to_core_update_outcome(
+    outcome: wit::UpdateOutcome,
+    id: &CoreResourceId,
+) -> CoreUpdateOutcome {
+    match outcome {
+        wit::UpdateOutcome::Success(state) => CoreUpdateOutcome::Success {
+            state: wit_to_core_state(&state, id),
+        },
+        wit::UpdateOutcome::PartialSuccess(partial) => CoreUpdateOutcome::partial_success(
             wit_to_core_state(&partial.state, id),
             partial.diagnostic.reason,
             partial.diagnostic.missing_attributes,

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -23,7 +23,8 @@ use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
 use carina_core::effect::PlanOp;
 use carina_core::provider::{
     BoxFuture, CreateOutcome, CreateRequest, DeleteRequest, Provider, ProviderError,
-    ProviderFactory, ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
+    ProviderFactory, ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateOutcome,
+    UpdateRequest,
 };
 use carina_core::resource::{DataSource, Resource, ResourceId, State, Value};
 use carina_core::schema::{CompletionValue, ResourceSchema, TypeIdentity};
@@ -835,7 +836,7 @@ impl WasmBindings {
         id: &wit_types::ResourceId,
         identifier: &str,
         request: &wit_types::UpdateRequest,
-    ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
+    ) -> wasmtime::Result<Result<wit_types::UpdateOutcome, wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
@@ -2047,7 +2048,7 @@ impl Provider for WasmProvider {
         id: &ResourceId,
         identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
         let wit_id = wasm_convert::core_to_wit_resource_id(id);
         let identifier = identifier.to_string();
         let wit_request = match wasm_convert::core_to_wit_update_request(&request) {
@@ -2078,7 +2079,9 @@ impl Provider for WasmProvider {
                     }
                 })?;
                 match result {
-                    Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
+                    Ok(wit_outcome) => {
+                        Ok(wasm_convert::wit_to_core_update_outcome(wit_outcome, &id))
+                    }
                     Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(wit_err)),
                 }
             },

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -227,7 +227,8 @@ async fn test_wasm_mock_provider_update_and_delete() {
             },
         )
         .await
-        .expect("update should succeed");
+        .expect("update should succeed")
+        .into_state_for_writeback();
     assert_eq!(
         updated.attributes.get("color"),
         Some(&Value::Concrete(ConcreteValue::String("blue".into())))

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -159,7 +159,7 @@ pub trait CarinaProvider {
         id: &ResourceId,
         identifier: &str,
         request: UpdateRequest,
-    ) -> Result<State, ProviderError>;
+    ) -> Result<UpdateOutcome, ProviderError>;
 
     /// Delete an existing resource.
     fn delete(
@@ -364,7 +364,7 @@ fn dispatch(provider: &mut impl CarinaProvider, request: &Request) -> Response {
                 Err(e) => return Response::error(id, -32602, e),
             };
             match provider.update(&params.id, &params.identifier, params.request) {
-                Ok(state) => Response::success(id, methods::UpdateResult { state }),
+                Ok(outcome) => Response::success(id, methods::UpdateResult { outcome }),
                 Err(e) => Response::error(id, -1, e.message),
             }
         }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -240,7 +240,28 @@ macro_rules! export_provider {
                         wit_types::CreateOutcome::PartialSuccess(
                             wit_types::CreatePartialSuccess {
                                 state: proto_to_wit_state(state),
-                                diagnostic: wit_types::PartialCreateDiagnostic {
+                                diagnostic: wit_types::PartialReadDiagnostic {
+                                    reason: diagnostic.reason.clone(),
+                                    missing_attributes: diagnostic.missing_attributes.clone(),
+                                },
+                            },
+                        )
+                    }
+                }
+            }
+
+            fn proto_to_wit_update_outcome(
+                outcome: &proto::UpdateOutcome,
+            ) -> wit_types::UpdateOutcome {
+                match outcome {
+                    proto::UpdateOutcome::Success { state } => {
+                        wit_types::UpdateOutcome::Success(proto_to_wit_state(state))
+                    }
+                    proto::UpdateOutcome::PartialSuccess { state, diagnostic } => {
+                        wit_types::UpdateOutcome::PartialSuccess(
+                            wit_types::UpdatePartialSuccess {
+                                state: proto_to_wit_state(state),
+                                diagnostic: wit_types::PartialReadDiagnostic {
                                     reason: diagnostic.reason.clone(),
                                     missing_attributes: diagnostic.missing_attributes.clone(),
                                 },
@@ -485,7 +506,7 @@ macro_rules! export_provider {
                     id: wit_types::ResourceId,
                     identifier: String,
                     request: wit_types::UpdateRequest,
-                ) -> Result<wit_types::State, wit_types::ProviderError> {
+                ) -> Result<wit_types::UpdateOutcome, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
                     let proto_request = wit_to_proto_update_request(request, &proto_id);
@@ -495,7 +516,7 @@ macro_rules! export_provider {
                         &identifier,
                         proto_request,
                     ) {
-                        Ok(state) => Ok(proto_to_wit_state(&state)),
+                        Ok(outcome) => Ok(proto_to_wit_update_outcome(&outcome)),
                         Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
@@ -814,7 +835,28 @@ macro_rules! export_provider {
                         wit_types::CreateOutcome::PartialSuccess(
                             wit_types::CreatePartialSuccess {
                                 state: proto_to_wit_state(state),
-                                diagnostic: wit_types::PartialCreateDiagnostic {
+                                diagnostic: wit_types::PartialReadDiagnostic {
+                                    reason: diagnostic.reason.clone(),
+                                    missing_attributes: diagnostic.missing_attributes.clone(),
+                                },
+                            },
+                        )
+                    }
+                }
+            }
+
+            fn proto_to_wit_update_outcome(
+                outcome: &proto::UpdateOutcome,
+            ) -> wit_types::UpdateOutcome {
+                match outcome {
+                    proto::UpdateOutcome::Success { state } => {
+                        wit_types::UpdateOutcome::Success(proto_to_wit_state(state))
+                    }
+                    proto::UpdateOutcome::PartialSuccess { state, diagnostic } => {
+                        wit_types::UpdateOutcome::PartialSuccess(
+                            wit_types::UpdatePartialSuccess {
+                                state: proto_to_wit_state(state),
+                                diagnostic: wit_types::PartialReadDiagnostic {
                                     reason: diagnostic.reason.clone(),
                                     missing_attributes: diagnostic.missing_attributes.clone(),
                                 },
@@ -1061,7 +1103,7 @@ macro_rules! export_provider {
                     id: wit_types::ResourceId,
                     identifier: String,
                     request: wit_types::UpdateRequest,
-                ) -> Result<wit_types::State, wit_types::ProviderError> {
+                ) -> Result<wit_types::UpdateOutcome, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
                     let proto_request = wit_to_proto_update_request(request, &proto_id);
@@ -1071,7 +1113,7 @@ macro_rules! export_provider {
                         &identifier,
                         proto_request,
                     ) {
-                        Ok(state) => Ok(proto_to_wit_state(&state)),
+                        Ok(outcome) => Ok(proto_to_wit_update_outcome(&outcome)),
                         Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -8,18 +8,19 @@ use std::time::Duration;
 use carina_core::effect::PlanOp;
 use carina_core::provider::{
     BoxFuture, CreateOutcome, CreateRequest, DeleteRequest, PatchOpKind, Provider, ProviderError,
-    ProviderResult, ReadRequest, UpdateRequest,
+    ProviderResult, ReadRequest, UpdateOutcome, UpdateRequest,
 };
 use carina_core::resource::{DataSource, ResourceId, State, Value};
 use carina_core::value::{json_to_dsl_value, value_to_json};
 
 pub struct MockProvider {
     state_file: PathBuf,
-    partial_create: Option<PartialCreateConfig>,
+    partial_create: Option<PartialConfig>,
+    partial_update: Option<PartialConfig>,
 }
 
 #[derive(Clone, Debug)]
-struct PartialCreateConfig {
+struct PartialConfig {
     resource_id_pattern: String,
     missing_attributes: Vec<String>,
 }
@@ -57,6 +58,7 @@ impl MockProvider {
         Self {
             state_file,
             partial_create: partial_create_config_from_env(),
+            partial_update: partial_update_config_from_env(),
         }
     }
 
@@ -65,7 +67,19 @@ impl MockProvider {
         resource_id_pattern: impl Into<String>,
         missing_attributes: Vec<String>,
     ) -> Self {
-        self.partial_create = Some(PartialCreateConfig {
+        self.partial_create = Some(PartialConfig {
+            resource_id_pattern: resource_id_pattern.into(),
+            missing_attributes,
+        });
+        self
+    }
+
+    pub fn with_partial_update_for(
+        mut self,
+        resource_id_pattern: impl Into<String>,
+        missing_attributes: Vec<String>,
+    ) -> Self {
+        self.partial_update = Some(PartialConfig {
             resource_id_pattern: resource_id_pattern.into(),
             missing_attributes,
         });
@@ -95,18 +109,26 @@ impl MockProvider {
         format!("{}.{}", id.resource_type, id.name)
     }
 
-    fn partial_create_config_for(&self, id: &ResourceId) -> Option<&PartialCreateConfig> {
+    fn partial_create_config_for(&self, id: &ResourceId) -> Option<&PartialConfig> {
         let config = self.partial_create.as_ref()?;
+        Self::partial_config_matches(config, id).then_some(config)
+    }
+
+    fn partial_update_config_for(&self, id: &ResourceId) -> Option<&PartialConfig> {
+        let config = self.partial_update.as_ref()?;
+        Self::partial_config_matches(config, id).then_some(config)
+    }
+
+    fn partial_config_matches(config: &PartialConfig, id: &ResourceId) -> bool {
         let full = format!("{}.{}.{}", id.provider, id.resource_type, id.name);
         let short = Self::resource_key(id);
-        (config.resource_id_pattern == "*"
+        config.resource_id_pattern == "*"
             || config.resource_id_pattern == full
-            || config.resource_id_pattern == short)
-            .then_some(config)
+            || config.resource_id_pattern == short
     }
 }
 
-fn partial_create_config_from_env() -> Option<PartialCreateConfig> {
+fn partial_create_config_from_env() -> Option<PartialConfig> {
     let resource_id_pattern = env::var("CARINA_MOCK_PARTIAL_CREATE_FOR").ok()?;
     let missing_attributes = env::var("CARINA_MOCK_PARTIAL_CREATE_MISSING")
         .ok()
@@ -118,7 +140,25 @@ fn partial_create_config_from_env() -> Option<PartialCreateConfig> {
                 .collect()
         })
         .unwrap_or_else(|| vec!["computed".to_string()]);
-    Some(PartialCreateConfig {
+    Some(PartialConfig {
+        resource_id_pattern,
+        missing_attributes,
+    })
+}
+
+fn partial_update_config_from_env() -> Option<PartialConfig> {
+    let resource_id_pattern = env::var("CARINA_MOCK_PARTIAL_UPDATE_FOR").ok()?;
+    let missing_attributes = env::var("CARINA_MOCK_PARTIAL_UPDATE_MISSING")
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_else(|| vec!["computed".to_string()]);
+    Some(PartialConfig {
         resource_id_pattern,
         missing_attributes,
     })
@@ -231,7 +271,7 @@ impl Provider for MockProvider {
         id: &ResourceId,
         _identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
         let id = id.clone();
         Box::pin(async move {
             let _active = ActiveUpdateGuard::enter();
@@ -258,17 +298,35 @@ impl Provider for MockProvider {
 
             let mut states = self.load_states();
             let key = Self::resource_key(&id);
-            let attrs: HashMap<String, serde_json::Value> = attributes
+            let partial_update = self.partial_update_config_for(&id);
+            let mut attrs: HashMap<String, serde_json::Value> = attributes
                 .iter()
                 .map(|(k, v)| value_to_json(v).map(|jv| (k.clone(), jv)))
                 .collect::<Result<_, _>>()
                 .map_err(|e| ProviderError::internal(format!("Failed to convert value: {}", e)))?;
+            if let Some(config) = partial_update {
+                for attr in &config.missing_attributes {
+                    attrs.remove(attr);
+                }
+            }
 
             states.insert(key, attrs);
             self.save_states(&states)
                 .map_err(|e| ProviderError::internal("Failed to save state").with_cause(e))?;
 
-            Ok(State::existing(id, attributes))
+            let mut state = State::existing(id, attributes).with_identifier("mock-id");
+            if let Some(config) = partial_update {
+                for attr in &config.missing_attributes {
+                    state.attributes.remove(attr);
+                }
+                return Ok(UpdateOutcome::partial_success(
+                    state,
+                    "mock partial update".to_string(),
+                    config.missing_attributes.clone(),
+                ));
+            }
+
+            Ok(UpdateOutcome::Success { state })
         })
     }
 
@@ -310,6 +368,7 @@ mod tests {
         let provider = MockProvider {
             state_file: state_file.clone(),
             partial_create: None,
+            partial_update: None,
         };
         let mut states = HashMap::new();
         let mut entry = HashMap::new();

--- a/carina-provider-mock/src/main.rs
+++ b/carina-provider-mock/src/main.rs
@@ -108,7 +108,7 @@ impl CarinaProvider for MockProcessProvider {
         id: &ResourceId,
         _identifier: &str,
         request: UpdateRequest,
-    ) -> Result<State, ProviderError> {
+    ) -> Result<UpdateOutcome, ProviderError> {
         // Apply the patch on top of `from` to construct the post-update
         // attribute map. Also echo the patch op kinds into a sentinel
         // attribute so integration tests can assert the patch
@@ -145,12 +145,13 @@ impl CarinaProvider for MockProcessProvider {
         let key = Self::resource_key(id);
         states.insert(key, attributes.clone());
 
-        Ok(State {
+        let state = State {
             id: id.clone(),
             identifier: Some("mock-id".into()),
             attributes,
             exists: true,
-        })
+        };
+        Ok(UpdateOutcome::Success { state })
     }
 
     fn delete(

--- a/carina-provider-protocol/src/methods.rs
+++ b/carina-provider-protocol/src/methods.rs
@@ -89,7 +89,7 @@ pub struct UpdateParams {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateResult {
-    pub state: State,
+    pub outcome: UpdateOutcome,
 }
 
 // -- delete --

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -126,13 +126,26 @@ pub enum CreateOutcome {
     },
     PartialSuccess {
         state: State,
-        diagnostic: PartialCreateDiagnostic,
+        diagnostic: PartialReadDiagnostic,
     },
 }
 
-/// Diagnostic details for a partial create.
+/// Result of an update operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PartialCreateDiagnostic {
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum UpdateOutcome {
+    Success {
+        state: State,
+    },
+    PartialSuccess {
+        state: State,
+        diagnostic: PartialReadDiagnostic,
+    },
+}
+
+/// Diagnostic details for a partial post-mutation read.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartialReadDiagnostic {
     pub reason: String,
     #[serde(default)]
     pub missing_attributes: Vec<String>,


### PR DESCRIPTION
## Summary

Closes #3571.

Implements `UpdateOutcome` parallel to `CreateOutcome`. `Provider::update`
now returns `Result<UpdateOutcome, ProviderError>` instead of
`Result<State, _>`, so a provider can report "I mutated the cloud but
couldn't fully observe the result" without rolling state back.

`PartialCreateDiagnostic` is renamed to `PartialReadDiagnostic` and
shared between `CreateOutcome::PartialSuccess` and
`UpdateOutcome::PartialSuccess`. The semantics ("handler mutated the
cloud but couldn't fully observe the result") is identical — two
parallel diagnostic shapes would push the choice onto every new
caller as a convention.

The `PartialReadMarker` already on `State` is reused. It is
provenance-free by design; create-side and update-side partial paths
both round-trip through the same `state.partial_read` field. No
state-file version bump.

WIT submodule bumps to `53469e8` (carina-plugin-wit#26 merge), which
already added `update-outcome` / `update-partial-success` and renamed
`partial-create-diagnostic` to `partial-read-diagnostic`.

This is step 2 of the chain. Steps 3-4 (aws follow + awscc#371) land
afterwards.

## Three-lens check

- **Root-cause**: changes the shape of `Provider::update`. Every
  executor update call site — basic, phased (CBD finalize + cascade),
  replace (cascade update + rename update), parallel — pattern-matches
  `UpdateOutcome` exhaustively and routes the diagnostic through
  `cascade_diagnostics` back to `ExecutionState::partial_count` /
  `partial_diagnostics`.
- **Type safety**: `UpdateOutcome` is exhaustive; partial-update is
  unforgeable. No `#[non_exhaustive]`, no documentation convention.
  `UpdateOutcome::into_state_for_writeback` is the only way to extract
  a writeback-ready `State`. `PartialReadDiagnostic` fields are private;
  empty `missing_attributes` demote to `Success`.
- **Long-term**: future providers must match the new variant at
  compile time.

## Cascade-update aggregation

Five sibling code paths now share one aggregation seam:

- `executor/basic.rs` — plain update effect.
- `executor/phased.rs` — Phase-2 cascade update.
- `executor/phased.rs::CbdCreateSuccess` — CBD finalize cascades.
- `executor/replace.rs` — DBD/CBD replace's cascade update.
- `executor/replace.rs` — replace's rename update.

`SingleEffectResult::Replace` carries `cascade_diagnostics:
Vec<(ResourceId, PartialReadDiagnostic)>`; parallel walks the vec
once and increments `partial_count` / pushes into `partial_diagnostics`.
There is no empty `UpdateOutcome::Success | PartialSuccess => {}` arm
anywhere — review caught one in an earlier draft and the fix forced
the typed seam everywhere.

## Test plan

- New e2e: `partial_update_records_state_and_next_plan_surfaces_unknown_reason`
  and `replace_partial_create_records_state_and_next_plan_surfaces_unknown_reason`.
- New core test in `executor/tests.rs` for cascade-update partial
  aggregation.
- `cargo nextest run --all-features`: 4270 passed, 72 skipped.
- `cargo test --workspace --doc`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `bash scripts/check-*.sh`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
