### PR TITLE
feat(value): preserve StringList tag across the WIT boundary (#3584)

### DIFF
--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -56,6 +56,50 @@ fn diff_update_when_different() {
 }
 
 #[test]
+fn diff_reports_string_list_vs_generic_string_list_shape_mismatch() {
+    let mut statement = IndexMap::new();
+    statement.insert(
+        "action".to_string(),
+        Value::Concrete(ConcreteValue::StringList(vec!["s3:GetObject".to_string()])),
+    );
+    let desired_policy = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+        "statement".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(statement),
+        )])),
+    )])));
+    let desired = Resource::new("awscc.ec2.VpcEndpoint", "vpce")
+        .with_attribute("policy_document", desired_policy);
+
+    let mut statement = IndexMap::new();
+    statement.insert(
+        "action".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::String("s3:GetObject".to_string()),
+        )])),
+    );
+    let current_policy = Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+        "statement".to_string(),
+        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(statement),
+        )])),
+    )])));
+    let current = State::existing(
+        desired.id.clone(),
+        HashMap::from([("policy_document".to_string(), current_policy)]),
+    );
+
+    let result = diff(&desired, &current, None, None, None);
+
+    match result {
+        Diff::Update {
+            changed_attributes, ..
+        } => assert_eq!(changed_attributes, vec!["policy_document".to_string()]),
+        other => panic!("expected Update for non-canonical generic List shape, got {other:?}"),
+    }
+}
+
+#[test]
 fn create_plan_from_resources() {
     let resources = vec![
         Resource::new("bucket", "new-bucket"),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -4211,6 +4211,56 @@ mod tests {
     }
 
     #[test]
+    fn canonicalize_iam_policy_document_statement_action_to_string_list() {
+        let statement = AttributeType::struct_(
+            "Statement".to_string(),
+            vec![
+                crate::schema::StructField::new("action", string_or_list_of_strings()),
+                crate::schema::StructField::new("resource", string_or_list_of_strings()),
+            ],
+        );
+        let policy_document = AttributeType::struct_(
+            "PolicyDocument".to_string(),
+            vec![crate::schema::StructField::new(
+                "statement",
+                AttributeType::list(statement),
+            )],
+        );
+        let schema = crate::schema::Schema::flat(policy_document);
+
+        let mut statement = IndexMap::new();
+        statement.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::String("sts:AssumeRole".to_string())),
+        );
+        let mut policy = IndexMap::new();
+        policy.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(statement),
+            )])),
+        );
+
+        let canon = schema.canonicalize(Value::Concrete(ConcreteValue::Map(policy)));
+        let Value::Concrete(ConcreteValue::Map(policy)) = canon else {
+            panic!("expected policy document map");
+        };
+        let Some(Value::Concrete(ConcreteValue::List(statements))) = policy.get("statement") else {
+            panic!("expected statement list, got {policy:?}");
+        };
+        let Some(Value::Concrete(ConcreteValue::Map(statement))) = statements.first() else {
+            panic!("expected first statement map, got {statements:?}");
+        };
+
+        assert_eq!(
+            statement.get("action"),
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "sts:AssumeRole".to_string()
+            ])))
+        );
+    }
+
+    #[test]
     fn canonicalize_recurses_into_struct_via_provider_name() {
         let t = AttributeType::struct_(
             "Statement".to_string(),

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -121,17 +121,9 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
             Ok(wit::Value::ListVal(json_str))
         }
         CoreValue::Concrete(ConcreteValue::StringList(items)) => {
-            // Cross the WASM boundary as a plain JSON array of strings —
-            // the provider sees the same shape as `Value::Concrete(ConcreteValue::List([String]))`,
-            // matching AWS's wire-format expectation for the
-            // `string_or_list_of_strings` IAM shape.
-            let json_arr: Vec<serde_json::Value> = items
-                .iter()
-                .map(|s| serde_json::Value::String(s.clone()))
-                .collect();
-            let json_str = serde_json::to_string(&json_arr)
-                .expect("serde_json::Value -> String is infallible");
-            Ok(wit::Value::ListVal(json_str))
+            let json_str =
+                serde_json::to_string(items).expect("Vec<String> -> String is infallible");
+            Ok(wit::Value::StringListVal(json_str))
         }
         CoreValue::Concrete(ConcreteValue::Map(map)) => {
             let json_map: Result<serde_json::Map<String, serde_json::Value>, _> = map
@@ -187,6 +179,10 @@ pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
         wit::Value::IntVal(i) => CoreValue::Concrete(ConcreteValue::Int(*i)),
         wit::Value::FloatVal(f) => CoreValue::Concrete(ConcreteValue::Float(*f)),
         wit::Value::BoolVal(b) => CoreValue::Concrete(ConcreteValue::Bool(*b)),
+        wit::Value::StringListVal(json) => {
+            let items: Vec<String> = serde_json::from_str(json).unwrap_or_default();
+            CoreValue::Concrete(ConcreteValue::StringList(items))
+        }
         wit::Value::ListVal(json) => {
             let items: Vec<serde_json::Value> = serde_json::from_str(json).unwrap_or_default();
             CoreValue::Concrete(ConcreteValue::List(
@@ -1266,6 +1262,18 @@ mod tests {
     }
 
     #[test]
+    fn test_string_list_roundtrip_preserves_variant() {
+        let core = CoreValue::Concrete(ConcreteValue::StringList(vec![
+            "s3:GetObject".into(),
+            "s3:ListBucket".into(),
+        ]));
+        let wit = core_to_wit_value(&core).unwrap();
+        assert!(matches!(wit, wit::Value::StringListVal(_)));
+        let back = wit_to_core_value(&wit);
+        assert_eq!(core, back);
+    }
+
+    #[test]
     fn test_map_roundtrip() {
         let core = CoreValue::Concrete(ConcreteValue::Map(
             vec![
@@ -1478,6 +1486,16 @@ mod tests {
         match wit_v {
             wit::Value::ListVal(json) => assert_eq!(json, "[\"p\"]"),
             other => panic!("expected ListVal, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn string_list_uses_dedicated_wit_variant() {
+        let v = CoreValue::Concrete(ConcreteValue::StringList(vec!["p".into()]));
+        let wit_v = core_to_wit_value(&v).unwrap();
+        match wit_v {
+            wit::Value::StringListVal(json) => assert_eq!(json, "[\"p\"]"),
+            other => panic!("expected StringListVal, got: {other:?}"),
         }
     }
 

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -39,6 +39,12 @@ pub fn proto_value_to_json(v: &proto::Value) -> serde_json::Value {
             .map(serde_json::Value::Number)
             .unwrap_or(serde_json::Value::Null),
         proto::Value::String(s) => serde_json::Value::String(s.clone()),
+        proto::Value::StringList(items) => serde_json::Value::Array(
+            items
+                .iter()
+                .map(|s| serde_json::Value::String(s.clone()))
+                .collect(),
+        ),
         proto::Value::List(items) => {
             serde_json::Value::Array(items.iter().map(proto_value_to_json).collect())
         }
@@ -139,6 +145,10 @@ macro_rules! export_provider {
                     wit_types::Value::IntVal(i) => proto::Value::Int(*i),
                     wit_types::Value::FloatVal(f) => proto::Value::Float(*f),
                     wit_types::Value::StrVal(s) => proto::Value::String(s.clone()),
+                    wit_types::Value::StringListVal(json) => {
+                        let items: Vec<String> = serde_json::from_str(json).unwrap_or_default();
+                        proto::Value::StringList(items)
+                    }
                     wit_types::Value::ListVal(json) => {
                         let items: Vec<serde_json::Value> =
                             serde_json::from_str(json).unwrap_or_default();
@@ -177,6 +187,9 @@ macro_rules! export_provider {
                     proto::Value::Int(i) => wit_types::Value::IntVal(*i),
                     proto::Value::Float(f) => wit_types::Value::FloatVal(*f),
                     proto::Value::String(s) => wit_types::Value::StrVal(s.clone()),
+                    proto::Value::StringList(items) => {
+                        wit_types::Value::StringListVal(serde_json::to_string(items).unwrap())
+                    }
                     proto::Value::List(items) => {
                         let json_items: Vec<serde_json::Value> =
                             items.iter().map(helpers::proto_value_to_json).collect();
@@ -734,6 +747,10 @@ macro_rules! export_provider {
                     wit_types::Value::IntVal(i) => proto::Value::Int(*i),
                     wit_types::Value::FloatVal(f) => proto::Value::Float(*f),
                     wit_types::Value::StrVal(s) => proto::Value::String(s.clone()),
+                    wit_types::Value::StringListVal(json) => {
+                        let items: Vec<String> = serde_json::from_str(json).unwrap_or_default();
+                        proto::Value::StringList(items)
+                    }
                     wit_types::Value::ListVal(json) => {
                         let items: Vec<serde_json::Value> =
                             serde_json::from_str(json).unwrap_or_default();
@@ -772,6 +789,9 @@ macro_rules! export_provider {
                     proto::Value::Int(i) => wit_types::Value::IntVal(*i),
                     proto::Value::Float(f) => wit_types::Value::FloatVal(*f),
                     proto::Value::String(s) => wit_types::Value::StrVal(s.clone()),
+                    proto::Value::StringList(items) => {
+                        wit_types::Value::StringListVal(serde_json::to_string(items).unwrap())
+                    }
                     proto::Value::List(items) => {
                         let json_items: Vec<serde_json::Value> =
                             items.iter().map(helpers::proto_value_to_json).collect();

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -45,6 +45,7 @@ pub enum Value {
     Int(i64),
     Float(f64),
     String(String),
+    StringList(Vec<String>),
     List(Vec<Value>),
     Map(HashMap<String, Value>),
 }
@@ -56,6 +57,14 @@ impl Serialize for Value {
             Value::Int(i) => serializer.serialize_i64(*i),
             Value::Float(f) => serializer.serialize_f64(*f),
             Value::String(s) => serializer.serialize_str(s),
+            Value::StringList(l) => {
+                use serde::ser::SerializeSeq;
+                let mut seq = serializer.serialize_seq(Some(l.len()))?;
+                for v in l {
+                    seq.serialize_element(v)?;
+                }
+                seq.end()
+            }
             Value::List(l) => {
                 use serde::ser::SerializeSeq;
                 let mut seq = serializer.serialize_seq(Some(l.len()))?;


### PR DESCRIPTION
## Summary

Preserve the `ConcreteValue::StringList` type tag across the WIT host↔guest boundary so carina-rs/carina#3584 actually closes.

`Schema::canonicalize` for `Union<String, List<String>>` schema attributes (e.g. `iam_policy_document.statement[*].action`) produces `ConcreteValue::StringList`. The carina-core differ treats `StringList` and `List<String>` as distinct shapes — both as a deliberate design choice (schema-typed vs schema-free) and because reshaping the differ to normalize them would be invasive. Until now the WIT `value` union had only `list-val`, so on the host↔guest trip every `StringList` collapsed to a generic `List`, and the apply-time desired-state ended up tagged differently than the provider-returned read state. That's the persistent `+` diff carina-rs/carina-provider-awscc#377's read-side fix could not actually close.

## What this PR does

1. Bump the `carina-plugin-wit` submodule to `facd597` (which is `carina-rs/carina-plugin-wit#27`, already merged), adding `string-list-val(string)` to the WIT `value` union.
2. `carina-provider-protocol/src/types.rs`: add the `Value::StringList(Vec<String>)` variant on the protocol side so providers can return it directly.
3. `carina-plugin-host/src/wasm_convert.rs`: convert `ConcreteValue::StringList` ↔ `Value::StringListVal(JSON-array-of-strings)` in both directions.
4. `carina-plugin-sdk/src/wasm_guest.rs`: add the guest-side decoder so plugins compiled against this SDK can return `StringList`.
5. `carina-core/src/value.rs`: regression test pinning that `Schema::canonicalize` for `Union<String, List<String>>` produces `StringList`.
6. `carina-core/src/differ/diff_tests.rs`: regression test pinning that the differ reports `StringList(["x"])` and `List([String("x")])` as distinct shapes — i.e. *not* fixing this in the differ is intentional; the fix lives at the WIT boundary so both sides agree on the canonical tag.

## Cross-repo coordination

The WIT change (PR `carina-rs/carina-plugin-wit#27`) is already merged. Provider companion PRs (rev bumps) will follow once this merges into `carina-rs/carina` main.

## Test plan

- [x] `cargo check -p carina-core` — passes.
- [x] `cargo nextest run --workspace` — passes.
- [x] `cargo test --workspace --doc` — passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes.
- [x] `bash scripts/check-*.sh` — `docs OK`.

Refs carina-rs/carina#3584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
