### PR TITLE
fix(plan): treat provider NotFound as drift, not fatal

### DIFF
--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -2842,6 +2842,14 @@ pub async fn read_with_retry(
             .await
         {
             Ok(state) => return Ok(state),
+            Err(ProviderError::NotFound(_)) => {
+                // carina-rs/carina-provider-aws#462: ProviderError::NotFound is
+                // the canonical drift signal — the resource is recorded in state
+                // but no longer exists in the cloud. Translate it into
+                // State::not_found(id) so the planner emits a Create-this-back
+                // plan instead of aborting.
+                return Ok(State::not_found(id.clone()));
+            }
             Err(e) if attempt < max_retries && is_throttling_error(&e) => {
                 let delay = Duration::from_secs(1 << attempt); // 1s, 2s, 4s
                 eprintln!(

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -1,4 +1,151 @@
 use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use carina_core::effect::PlanOp;
+use carina_core::provider::{
+    BoxFuture, CreateOutcome, DeleteRequest, ProviderResult, ReadRequest, UpdateOutcome,
+    UpdateRequest,
+};
+
+enum ReadBehavior {
+    NotFound,
+    ApiError,
+    NotFoundThenSuccess,
+}
+
+struct ReadWithRetryProvider {
+    behavior: ReadBehavior,
+    read_calls: AtomicUsize,
+}
+
+impl ReadWithRetryProvider {
+    fn new(behavior: ReadBehavior) -> Self {
+        Self {
+            behavior,
+            read_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn read_calls(&self) -> usize {
+        self.read_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl Provider for ReadWithRetryProvider {
+    fn name(&self) -> &str {
+        "test"
+    }
+
+    fn read(
+        &self,
+        id: &ResourceId,
+        _identifier: Option<&str>,
+        _request: ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        let attempt = self.read_calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move {
+            match self.behavior {
+                ReadBehavior::NotFound => Err(ProviderError::not_found("missing")),
+                ReadBehavior::ApiError => Err(ProviderError::api_error("boom")),
+                ReadBehavior::NotFoundThenSuccess if attempt == 0 => {
+                    Err(ProviderError::not_found("missing"))
+                }
+                ReadBehavior::NotFoundThenSuccess => {
+                    Ok(State::existing(id, HashMap::new()).with_identifier("read-on-retry"))
+                }
+            }
+        })
+    }
+
+    fn read_data_source(
+        &self,
+        resource: &carina_core::resource::DataSource,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+    }
+
+    fn create(
+        &self,
+        id: &ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<CreateOutcome>> {
+        let id = id.clone();
+        Box::pin(async move {
+            Ok(CreateOutcome::Success {
+                state: State::existing(id, HashMap::new()),
+            })
+        })
+    }
+
+    fn update(
+        &self,
+        id: &ResourceId,
+        _identifier: &str,
+        _request: UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
+        let id = id.clone();
+        Box::pin(async move {
+            Ok(UpdateOutcome::Success {
+                state: State::existing(id, HashMap::new()),
+            })
+        })
+    }
+
+    fn delete(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _request: DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn required_permissions(&self, _id: &ResourceId, _op: PlanOp) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+#[tokio::test]
+async fn read_with_retry_translates_not_found_to_state_not_found() {
+    let provider = ReadWithRetryProvider::new(ReadBehavior::NotFound);
+    let id = ResourceId::new("test.Resource", "gone");
+
+    let state = read_with_retry(&provider, &id, Some("some-identifier"))
+        .await
+        .expect("not found should translate into a not_found state");
+
+    assert!(!state.exists);
+    assert_eq!(state.id, id);
+    assert_eq!(state.identifier, None);
+}
+
+#[tokio::test]
+async fn read_with_retry_propagates_other_errors() {
+    let provider = ReadWithRetryProvider::new(ReadBehavior::ApiError);
+    let id = ResourceId::new("test.Resource", "broken");
+
+    let result = read_with_retry(&provider, &id, Some("some-identifier")).await;
+
+    assert!(matches!(result, Err(ProviderError::ApiError(_))));
+}
+
+#[tokio::test]
+async fn read_with_retry_does_not_retry_not_found() {
+    let provider = ReadWithRetryProvider::new(ReadBehavior::NotFoundThenSuccess);
+    let id = ResourceId::new("test.Resource", "gone");
+
+    let state = read_with_retry(&provider, &id, Some("some-identifier"))
+        .await
+        .expect("not found should translate into a not_found state");
+
+    assert!(!state.exists);
+    assert_eq!(state.id, id);
+    assert_eq!(state.identifier, None);
+    assert_eq!(provider.read_calls(), 1);
+}
+
 use carina_core::parser::ParsedFile;
 
 #[test]


### PR DESCRIPTION
## Summary

The host's `read_with_retry` was propagating `ProviderError::NotFound` as
a fatal error, so a provider that surfaces "this resource is gone from
the cloud" via the error path caused `carina plan` to abort with no way
to recover except hand-editing the state file. Translate
`Err(ProviderError::NotFound)` into `Ok(State::not_found(id))` at the
host's single read entry point so the planner emits a Create-this-back
plan instead.

The NotFound arm sits between the success arm and the throttling-retry
guard so NotFound is never retried (it is not transient).

refs carina-rs/carina-provider-aws#462

## Why this is the upstream seam

`refresh_resource_set` / `read_with_retry` is the single place every
managed-resource refresh on both the plan path and the apply path runs
through. Translating the `ProviderError::NotFound` variant here makes
the variant actually usable as a drift signal for **every** current and
future provider — instead of forcing each provider's per-resource read
implementation to remember to return `Ok(State::not_found(id))` directly
(which works today only for IAM Role, S3 Bucket, and EC2 Security
Group; ACM and many others still abort).

The WIT boundary already carries the `not-found` variant losslessly in
both directions (`carina-plugin-host/src/wasm_convert.rs`), so no
protocol change is needed.

## Follow-up

A follow-up PR in carina-provider-aws will land the AWS-error-code
classification in `api_error_with_meta` so the AWS provider actually
surfaces `ProviderError::NotFound` for the resource shapes that need
it (ACM `ResourceNotFoundException`, IAM `NoSuchEntity`, S3
`NoSuchBucket`, EC2 `InvalidGroup.NotFound`, etc.). That PR closes
carina-rs/carina-provider-aws#462.

## Test plan

- [x] `read_with_retry_translates_not_found_to_state_not_found` — mock
      returns `Err(ProviderError::NotFound)` → assert
      `Ok(State { exists: false, id, identifier: None })`.
- [x] `read_with_retry_propagates_other_errors` — mock returns
      `Err(ProviderError::ApiError)` → assert `Err(ApiError)`. Guards
      against over-broad refactoring.
- [x] `read_with_retry_does_not_retry_not_found` — mock returns
      NotFound once then would succeed → assert `read_calls == 1` so
      NotFound never enters the throttling retry loop.
- [x] `cargo nextest run -p carina-cli`, `cargo test --workspace --doc`,
      `cargo clippy --workspace --all-targets -- -D warnings`,
      `bash scripts/check-*.sh` — all green.