### PR TITLE
display: emit box-drawing connectors for module-to-child edges

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -28,6 +28,34 @@ use crate::DetailLevel;
 
 const LEFT_MARGIN: &str = "  ";
 const ATTR_BASE: &str = "    ";
+const VERTICAL_CONNECTOR: &str = "│";
+const VERTICAL_CONTINUATION: &str = "│  ";
+/// Width consumed by a child-list connector (`├─ ` / `└─ `).
+const CONNECTOR_WIDTH: usize = 3;
+/// `├─ ` — branch connector (non-last child).
+const BRANCH_CONNECTOR: &str = "├─ ";
+/// `└─ ` — corner connector (last child).
+const CORNER_CONNECTOR: &str = "└─ ";
+/// Spaces-only continuation when no `│` spine continues at this depth.
+const SPACE_CONTINUATION: &str = "   ";
+
+const fn utf8_char_count(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut count = 0;
+    while i < bytes.len() {
+        if bytes[i] & 0b1100_0000 != 0b1000_0000 {
+            count += 1;
+        }
+        i += 1;
+    }
+    count
+}
+
+const _: () = assert!(utf8_char_count(BRANCH_CONNECTOR) == CONNECTOR_WIDTH);
+const _: () = assert!(utf8_char_count(CORNER_CONNECTOR) == CONNECTOR_WIDTH);
+const _: () = assert!(utf8_char_count(VERTICAL_CONTINUATION) == CONNECTOR_WIDTH);
+const _: () = assert!(SPACE_CONTINUATION.len() == CONNECTOR_WIDTH);
 
 /// A plan-display sigil. Construction is the only place that fixes both the
 /// raw glyph (column width) and the colored rendering (visual output), so
@@ -105,40 +133,33 @@ impl Sigil {
 }
 
 /// Returns the full leading prefix for a top-level row.
-fn top_level_sigil_prefix(sigil: &Sigil, extra_left_pad: usize) -> String {
+fn top_level_sigil_prefix(sigil: &Sigil) -> String {
     debug_assert!(
         !sigil.raw.is_empty(),
         "plan sigil raw glyph must not be empty"
     );
-    format!(
-        "{}{}{} ",
-        LEFT_MARGIN,
-        " ".repeat(extra_left_pad),
-        sigil.rendered,
-    )
+    format!("{}{} ", LEFT_MARGIN, sigil.rendered,)
 }
 
-fn tree_sigil_prefix(
-    indent: usize,
-    is_last: bool,
-    prefix: &str,
-    sigil: &Sigil,
-    top_level_extra_left_pad: usize,
-) -> String {
+fn tree_sigil_prefix(indent: usize, is_last: bool, prefix: &str, sigil: &Sigil) -> String {
     if indent == 0 {
-        top_level_sigil_prefix(sigil, top_level_extra_left_pad)
+        top_level_sigil_prefix(sigil)
     } else {
         let connector = if is_last {
-            format!("{}└─ ", prefix)
+            format!("{}{}", prefix, CORNER_CONNECTOR)
         } else {
-            format!("{}├─ ", prefix)
+            format!("{}{}", prefix, BRANCH_CONNECTOR)
         };
         format!("{}{}{} ", LEFT_MARGIN, connector, sigil.rendered)
     }
 }
 
-fn attr_base_indent() -> &'static str {
-    ATTR_BASE
+fn vertical_connector_line(child_prefix: &str) -> String {
+    format!("{}{}{}\n", LEFT_MARGIN, child_prefix, VERTICAL_CONNECTOR)
+}
+
+fn module_child_prefix() -> String {
+    SPACE_CONTINUATION.to_string()
 }
 
 /// Separator emitted between the state-refresh progress block and the plan's
@@ -247,7 +268,7 @@ fn format_export_change(change: &crate::commands::plan::ExportChange) -> String 
             writeln!(
                 out,
                 "{}{}{} = {}",
-                top_level_sigil_prefix(&Sigil::export_added(), 0),
+                top_level_sigil_prefix(&Sigil::export_added()),
                 name,
                 type_str.dimmed(),
                 format_export_value(new_value)
@@ -267,7 +288,7 @@ fn format_export_change(change: &crate::commands::plan::ExportChange) -> String 
             writeln!(
                 out,
                 "{}{}{} = {} {} {}",
-                top_level_sigil_prefix(&Sigil::export_modified(), 0),
+                top_level_sigil_prefix(&Sigil::export_modified()),
                 name,
                 type_str.dimmed(),
                 format_json_export_value(old_json),
@@ -280,7 +301,7 @@ fn format_export_change(change: &crate::commands::plan::ExportChange) -> String 
             writeln!(
                 out,
                 "{}{} = {}",
-                top_level_sigil_prefix(&Sigil::export_removed(), 0),
+                top_level_sigil_prefix(&Sigil::export_removed()),
                 name,
                 format_json_export_value(old_json)
             )
@@ -458,8 +479,8 @@ fn format_deferred_for_expression(deferred: &carina_core::parser::DeferredForExp
     let mut out = String::new();
     let upstream = deferred_for_source(deferred);
     let sigil = Sigil::deferred_for_expression();
-    let line_prefix = top_level_sigil_prefix(&sigil, 0);
-    let attr_base = attr_base_indent();
+    let line_prefix = top_level_sigil_prefix(&sigil);
+    let attr_base = ATTR_BASE;
     writeln!(
         out,
         "{}{} {}",
@@ -554,7 +575,6 @@ impl<'a> TreeRenderContext<'a> {
         is_last: bool,
         prefix: &str,
         parent_binding: Option<&str>,
-        top_level_extra_left_pad: usize,
     ) -> bool {
         if self.printed.contains(&idx) {
             return false;
@@ -563,10 +583,9 @@ impl<'a> TreeRenderContext<'a> {
 
         let effect = &self.plan.effects()[idx];
         let sigil = Sigil::from_effect(effect);
-        let line_prefix =
-            tree_sigil_prefix(indent, is_last, prefix, &sigil, top_level_extra_left_pad);
-        let base_indent = format!("{}{}", LEFT_MARGIN, " ".repeat(top_level_extra_left_pad));
-        let attr_base = attr_base_indent();
+        let line_prefix = tree_sigil_prefix(indent, is_last, prefix, &sigil);
+        let base_indent = LEFT_MARGIN;
+        let attr_base = ATTR_BASE;
 
         let mut has_displayed_attrs = false;
 
@@ -794,11 +813,11 @@ impl<'a> TreeRenderContext<'a> {
                     format!("{}{}", base_indent, attr_base)
                 } else {
                     let continuation = if is_last {
-                        format!("{}   ", prefix)
+                        format!("{}{}", prefix, SPACE_CONTINUATION)
                     } else {
-                        format!("{}│  ", prefix)
+                        format!("{}{}", prefix, VERTICAL_CONTINUATION)
                     };
-                    format!("{}{}   ", base_indent, continuation)
+                    format!("{}{}{}", base_indent, continuation, SPACE_CONTINUATION)
                 };
                 for row in deferred_for_detail_rows(template, upstream_binding, verb) {
                     render_detail_row(&mut self.out, &row, effect, &attr_prefix);
@@ -813,11 +832,11 @@ impl<'a> TreeRenderContext<'a> {
                 format!("{}{}", base_indent, attr_base)
             } else {
                 let continuation = if is_last {
-                    format!("{}   ", prefix)
+                    format!("{}{}", prefix, SPACE_CONTINUATION)
                 } else {
-                    format!("{}│  ", prefix)
+                    format!("{}{}", prefix, VERTICAL_CONTINUATION)
                 };
-                format!("{}{}   ", base_indent, continuation)
+                format!("{}{}{}", base_indent, continuation, SPACE_CONTINUATION)
             };
 
             let detail_rows = build_detail_rows(
@@ -848,7 +867,6 @@ impl<'a> TreeRenderContext<'a> {
             }
         };
 
-        // Print children (dependents)
         let children = self.dependents.get(&idx).cloned().unwrap_or_default();
         let unprinted_children: Vec<_> = children
             .iter()
@@ -857,51 +875,19 @@ impl<'a> TreeRenderContext<'a> {
             .collect();
         let child_render_items = self.child_render_items(&unprinted_children);
 
-        // New prefix for children: align with attribute indentation
-        let new_prefix = if indent == 0 {
-            format!("{}  ", attr_base)
-        } else {
-            let continuation = if is_last {
-                format!("{}   ", prefix)
-            } else {
-                format!("{}│  ", prefix)
-            };
-            format!("{}   ", continuation)
-        };
-
-        // Insert tree continuation line between attribute block and child resources
-        if has_displayed_attrs && !child_render_items.is_empty() {
-            writeln!(self.out, "{}{}│", base_indent, new_prefix).unwrap();
-        }
-
-        for (i, item) in child_render_items.iter().enumerate() {
-            let child_is_last = i == child_render_items.len() - 1;
-            let child_had_attrs = self.format_render_item(
-                item,
-                indent + 1,
-                child_is_last,
-                &new_prefix,
-                current_binding.as_deref(),
-                top_level_extra_left_pad,
-            );
-            // Add separator line between siblings when previous sibling displayed attributes
-            if child_had_attrs && !child_is_last {
-                let separator_continuation = if is_last {
-                    format!("{}   ", prefix)
-                } else {
-                    format!("{}│  ", prefix)
-                };
-                let separator_prefix = if indent == 0 {
-                    format!("{}  ", attr_base)
-                } else {
-                    format!("{}   ", separator_continuation)
-                };
-                writeln!(self.out, "{}{}│", base_indent, separator_prefix).unwrap();
-            }
-            if child_had_attrs {
-                has_displayed_attrs = true;
-            }
-        }
+        has_displayed_attrs |= self.render_children(
+            &child_render_items,
+            ChildRenderOptions {
+                parent_indent: indent,
+                parent_is_last: is_last,
+                parent_prefix: prefix,
+                parent_binding: current_binding.as_deref(),
+                leading: LeadingConnector::FromParentAttrs {
+                    displayed: has_displayed_attrs,
+                },
+                child_prefix_override: None,
+            },
+        );
 
         has_displayed_attrs
     }
@@ -913,17 +899,11 @@ impl<'a> TreeRenderContext<'a> {
         is_last: bool,
         prefix: &str,
         parent_binding: Option<&str>,
-        top_level_extra_left_pad: usize,
     ) -> bool {
         match item {
-            ChildRenderItem::Normal(idx) => self.format_effect_tree(
-                *idx,
-                indent,
-                is_last,
-                prefix,
-                parent_binding,
-                top_level_extra_left_pad,
-            ),
+            ChildRenderItem::Normal(idx) => {
+                self.format_effect_tree(*idx, indent, is_last, prefix, parent_binding)
+            }
             ChildRenderItem::PairedDeferredFor {
                 expand_idx,
                 delete_indices,
@@ -933,13 +913,79 @@ impl<'a> TreeRenderContext<'a> {
                 indent,
                 is_last,
                 prefix,
-                top_level_extra_left_pad,
             ),
         }
     }
 
     fn child_render_items(&self, child_indices: &[usize]) -> Vec<ChildRenderItem> {
         child_render_items(self.plan.effects(), child_indices)
+    }
+
+    fn will_render(&self, item: &ChildRenderItem) -> bool {
+        match item {
+            ChildRenderItem::Normal(idx) => self.will_render_effect_tree(*idx),
+            ChildRenderItem::PairedDeferredFor { expand_idx, .. } => {
+                !self.printed.contains(expand_idx)
+                    && matches!(
+                        self.plan.effects().get(*expand_idx),
+                        Some(Effect::ExpandDeferredFor { .. })
+                    )
+            }
+        }
+    }
+
+    fn will_render_effect_tree(&self, idx: usize) -> bool {
+        if self.printed.contains(&idx) {
+            return false;
+        }
+
+        let Some(effect) = self.plan.effects().get(idx) else {
+            return false;
+        };
+
+        match effect {
+            Effect::Move { to, .. } => !self.update_or_replace_targets.contains(to),
+            Effect::Create(_)
+            | Effect::Update { .. }
+            | Effect::Replace { .. }
+            | Effect::Delete { .. }
+            | Effect::Read { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Wait { .. }
+            | Effect::ExpandDeferredFor { .. } => true,
+        }
+    }
+
+    fn consume_suppressed_item(&mut self, item: &ChildRenderItem) {
+        match item {
+            ChildRenderItem::Normal(idx) => {
+                if !self.will_render_effect_tree(*idx)
+                    && !self.printed.contains(idx)
+                    && matches!(
+                        self.plan.effects().get(*idx),
+                        Some(Effect::Move { to, .. })
+                            if self.update_or_replace_targets.contains(to)
+                    )
+                {
+                    self.printed.insert(*idx);
+                }
+            }
+            ChildRenderItem::PairedDeferredFor {
+                expand_idx,
+                delete_indices,
+            } => {
+                if !self.printed.contains(expand_idx)
+                    && !matches!(
+                        self.plan.effects().get(*expand_idx),
+                        Some(Effect::ExpandDeferredFor { .. })
+                    )
+                {
+                    self.printed.insert(*expand_idx);
+                    self.printed.extend(delete_indices.iter().copied());
+                }
+            }
+        }
     }
 
     fn format_paired_deferred_for(
@@ -949,7 +995,6 @@ impl<'a> TreeRenderContext<'a> {
         indent: usize,
         is_last: bool,
         prefix: &str,
-        top_level_extra_left_pad: usize,
     ) -> bool {
         if self.printed.contains(&expand_idx) {
             return false;
@@ -971,10 +1016,9 @@ impl<'a> TreeRenderContext<'a> {
         // ExpandDeferredFor carries no replacement directive; paired deferred-for
         // display has always represented create-before-destroy ordering.
         let sigil = Sigil::paired_deferred_for_create_before_destroy();
-        let line_prefix =
-            tree_sigil_prefix(indent, is_last, prefix, &sigil, top_level_extra_left_pad);
-        let base_indent = format!("{}{}", LEFT_MARGIN, " ".repeat(top_level_extra_left_pad));
-        let attr_base = attr_base_indent();
+        let line_prefix = tree_sigil_prefix(indent, is_last, prefix, &sigil);
+        let base_indent = LEFT_MARGIN;
+        let attr_base = ATTR_BASE;
         let verb = deferred_for_verb(self.plan, upstream_binding);
         writeln!(
             self.out,
@@ -991,11 +1035,11 @@ impl<'a> TreeRenderContext<'a> {
             format!("{}{}", base_indent, attr_base)
         } else {
             let continuation = if is_last {
-                format!("{}   ", prefix)
+                format!("{}{}", prefix, SPACE_CONTINUATION)
             } else {
-                format!("{}│  ", prefix)
+                format!("{}{}", prefix, VERTICAL_CONTINUATION)
             };
-            format!("{}{}   ", base_indent, continuation)
+            format!("{}{}{}", base_indent, continuation, SPACE_CONTINUATION)
         };
 
         for row in deferred_for_detail_rows(template, upstream_binding, verb) {
@@ -1019,51 +1063,108 @@ impl<'a> TreeRenderContext<'a> {
             .collect();
         let child_render_items = self.child_render_items(&unprinted_children);
 
-        let new_prefix = if indent == 0 {
-            format!("{}  ", attr_base)
-        } else {
-            let continuation = if is_last {
-                format!("{}   ", prefix)
-            } else {
-                format!("{}│  ", prefix)
-            };
-            format!("{}   ", continuation)
-        };
+        let _ = self.render_children(
+            &child_render_items,
+            ChildRenderOptions {
+                parent_indent: indent,
+                parent_is_last: is_last,
+                parent_prefix: prefix,
+                parent_binding: None,
+                leading: LeadingConnector::FromParentAttrs { displayed: true },
+                child_prefix_override: None,
+            },
+        );
 
-        if !child_render_items.is_empty() {
-            writeln!(self.out, "{}{}│", base_indent, new_prefix).unwrap();
+        true
+    }
+
+    fn render_children(
+        &mut self,
+        items: &[ChildRenderItem],
+        options: ChildRenderOptions<'_>,
+    ) -> bool {
+        for item in items {
+            self.consume_suppressed_item(item);
         }
 
-        let mut has_displayed_attrs = true;
-        for (i, item) in child_render_items.iter().enumerate() {
-            let child_is_last = i == child_render_items.len() - 1;
+        let rendering_items: Vec<_> = items.iter().filter(|item| self.will_render(item)).collect();
+        if rendering_items.is_empty() {
+            return false;
+        }
+
+        let child_prefix = options.child_prefix_override.unwrap_or_else(|| {
+            child_prefix_for_parent(
+                options.parent_indent,
+                options.parent_is_last,
+                options.parent_prefix,
+            )
+        });
+
+        if options.leading.emit() {
+            self.out.push_str(&vertical_connector_line(&child_prefix));
+        }
+
+        let mut any_child_displayed_attrs = false;
+        for (i, item) in rendering_items.iter().enumerate() {
+            let child_is_last = i == rendering_items.len() - 1;
             let child_had_attrs = self.format_render_item(
                 item,
-                indent + 1,
+                options.parent_indent + 1,
                 child_is_last,
-                &new_prefix,
-                None,
-                top_level_extra_left_pad,
+                &child_prefix,
+                options.parent_binding,
             );
-            if child_had_attrs && !child_is_last {
-                let separator_continuation = if is_last {
-                    format!("{}   ", prefix)
-                } else {
-                    format!("{}│  ", prefix)
-                };
-                let separator_prefix = if indent == 0 {
-                    format!("{}  ", attr_base)
-                } else {
-                    format!("{}   ", separator_continuation)
-                };
-                writeln!(self.out, "{}{}│", base_indent, separator_prefix).unwrap();
-            }
             if child_had_attrs {
-                has_displayed_attrs = true;
+                any_child_displayed_attrs = true;
+            }
+            if child_had_attrs && !child_is_last {
+                self.out.push_str(&vertical_connector_line(&child_prefix));
             }
         }
 
-        has_displayed_attrs
+        any_child_displayed_attrs
+    }
+}
+
+enum LeadingConnector {
+    /// Emit the leading connector only when the parent displayed attribute rows.
+    FromParentAttrs { displayed: bool },
+    /// Force a leading connector for a virtual parent that has no attribute rows.
+    Forced,
+}
+
+impl LeadingConnector {
+    fn emit(&self) -> bool {
+        match self {
+            Self::FromParentAttrs { displayed } => *displayed,
+            Self::Forced => true,
+        }
+    }
+}
+
+struct ChildRenderOptions<'a> {
+    parent_indent: usize,
+    parent_is_last: bool,
+    parent_prefix: &'a str,
+    parent_binding: Option<&'a str>,
+    leading: LeadingConnector,
+    child_prefix_override: Option<String>,
+}
+
+fn child_prefix_for_parent(
+    parent_indent: usize,
+    parent_is_last: bool,
+    parent_prefix: &str,
+) -> String {
+    if parent_indent == 0 {
+        format!("{}  ", ATTR_BASE)
+    } else {
+        let continuation = if parent_is_last {
+            format!("{}{}", parent_prefix, SPACE_CONTINUATION)
+        } else {
+            format!("{}{}", parent_prefix, VERTICAL_CONTINUATION)
+        };
+        format!("{}{}", continuation, SPACE_CONTINUATION)
     }
 }
 
@@ -1126,11 +1227,11 @@ fn format_plan_tree<'a>(
         let ungrouped_items = ctx.child_render_items(&composition_groups.ungrouped);
         for (i, item) in ungrouped_items.iter().enumerate() {
             let last = i == ungrouped_items.len() - 1 && composition_groups.grouped.is_empty();
-            ctx.format_render_item(item, 0, last, "", None, 0);
+            ctx.format_render_item(item, 0, last, "", None);
         }
-        // Then: each composition group with its header. Each leaf
-        // renders without tree connectors, but with one extra top-level
-        // padding step so it remains visually nested under the module header.
+        // Then: each composition group with its header. The header is a
+        // virtual parent, and the leaves render through the same child path
+        // used by resource dependents.
         for group in &composition_groups.grouped {
             writeln!(
                 ctx.out,
@@ -1139,18 +1240,24 @@ fn format_plan_tree<'a>(
             )
             .unwrap();
             let leaf_items = ctx.child_render_items(&group.leaves);
-            for (li, item) in leaf_items.iter().enumerate() {
-                let leaf_last = li == leaf_items.len() - 1;
-                // Top-level rows derive their own left margin from the sigil prefix.
-                ctx.format_render_item(item, 0, leaf_last, "", None, 2);
-            }
+            ctx.render_children(
+                &leaf_items,
+                ChildRenderOptions {
+                    parent_indent: 0,
+                    parent_is_last: true,
+                    parent_prefix: "",
+                    parent_binding: None,
+                    leading: LeadingConnector::Forced,
+                    child_prefix_override: Some(module_child_prefix()),
+                },
+            );
         }
     } else {
         // No trace, or trace empty for this plan's leaves — use the
         // pre-#3307 flat layout so existing snapshots remain valid.
         let root_items = ctx.child_render_items(&roots);
         for (i, item) in root_items.iter().enumerate() {
-            ctx.format_render_item(item, 0, i == root_items.len() - 1, "", None, 0);
+            ctx.format_render_item(item, 0, i == root_items.len() - 1, "", None);
         }
     }
 
@@ -1161,7 +1268,7 @@ fn format_plan_tree<'a>(
         .collect();
     let remaining_items = ctx.child_render_items(&remaining);
     for (i, item) in remaining_items.iter().enumerate() {
-        ctx.format_render_item(item, 0, i == remaining_items.len() - 1, "", None, 0);
+        ctx.format_render_item(item, 0, i == remaining_items.len() - 1, "", None);
     }
 
     ctx.out
@@ -1178,7 +1285,7 @@ fn format_plan_tree<'a>(
 /// `Composition` label (carina#3322).
 fn format_composition_header(binding: &str, source_path: Option<&str>) -> String {
     let sigil = Sigil::module_header();
-    let prefix = top_level_sigil_prefix(&sigil, 0);
+    let prefix = top_level_sigil_prefix(&sigil);
     match source_path {
         None => format!("{}module \"{}\"", prefix, binding.cyan().bold()),
         Some(path) => format!(

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -882,9 +882,7 @@ impl<'a> TreeRenderContext<'a> {
                 parent_is_last: is_last,
                 parent_prefix: prefix,
                 parent_binding: current_binding.as_deref(),
-                leading: LeadingConnector::FromParentAttrs {
-                    displayed: has_displayed_attrs,
-                },
+                parent_displayed_attrs: has_displayed_attrs,
                 child_prefix_override: None,
             },
         );
@@ -1070,7 +1068,7 @@ impl<'a> TreeRenderContext<'a> {
                 parent_is_last: is_last,
                 parent_prefix: prefix,
                 parent_binding: None,
-                leading: LeadingConnector::FromParentAttrs { displayed: true },
+                parent_displayed_attrs: true,
                 child_prefix_override: None,
             },
         );
@@ -1100,7 +1098,7 @@ impl<'a> TreeRenderContext<'a> {
             )
         });
 
-        if options.leading.emit() {
+        if options.parent_displayed_attrs {
             self.out.push_str(&vertical_connector_line(&child_prefix));
         }
 
@@ -1126,28 +1124,12 @@ impl<'a> TreeRenderContext<'a> {
     }
 }
 
-enum LeadingConnector {
-    /// Emit the leading connector only when the parent displayed attribute rows.
-    FromParentAttrs { displayed: bool },
-    /// Force a leading connector for a virtual parent that has no attribute rows.
-    Forced,
-}
-
-impl LeadingConnector {
-    fn emit(&self) -> bool {
-        match self {
-            Self::FromParentAttrs { displayed } => *displayed,
-            Self::Forced => true,
-        }
-    }
-}
-
 struct ChildRenderOptions<'a> {
     parent_indent: usize,
     parent_is_last: bool,
     parent_prefix: &'a str,
     parent_binding: Option<&'a str>,
-    leading: LeadingConnector,
+    parent_displayed_attrs: bool,
     child_prefix_override: Option<String>,
 }
 
@@ -1247,7 +1229,7 @@ fn format_plan_tree<'a>(
                     parent_is_last: true,
                     parent_prefix: "",
                     parent_binding: None,
-                    leading: LeadingConnector::Forced,
+                    parent_displayed_attrs: false,
                     child_prefix_override: Some(module_child_prefix()),
                 },
             );

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -2162,7 +2162,7 @@ fn module_children_render_with_tree_connectors() {
 
     assert!(
         output.contains(
-            "  + module \"cluster\" (./modules/cluster)\n     │\n     ├─ + aws.eks.Cluster cluster/inner\n     └─ + aws.iam.Role cluster/inner-role"
+            "  + module \"cluster\" (./modules/cluster)\n     ├─ + aws.eks.Cluster cluster/inner\n     └─ + aws.iam.Role cluster/inner-role"
         ),
         "module leaves must render as connector children:\n{output}",
     );
@@ -2258,7 +2258,7 @@ fn module_group_with_only_suppressed_move_does_not_emit_orphan_gutter() {
             parent_is_last: true,
             parent_prefix: "",
             parent_binding: None,
-            leading: LeadingConnector::Forced,
+            parent_displayed_attrs: false,
             child_prefix_override: Some(module_child_prefix()),
         },
     );

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -2116,7 +2116,7 @@ fn every_top_level_sigil_starts_at_left_margin_column() {
     ];
 
     for (label, sigil) in cases {
-        let prefix = top_level_sigil_prefix(&sigil, 0);
+        let prefix = top_level_sigil_prefix(&sigil);
         let plain = strip_ansi(&prefix);
         assert_eq!(
             plain.find(sigil.raw),
@@ -2127,18 +2127,208 @@ fn every_top_level_sigil_starts_at_left_margin_column() {
 }
 
 #[test]
-fn module_child_sigil_starts_at_left_margin_plus_two() {
-    let sigil = Sigil {
-        raw: "+",
-        rendered: "+".normal(),
-    };
-    let prefix = top_level_sigil_prefix(&sigil, 2);
-    let plain = strip_ansi(&prefix);
+fn module_children_render_with_tree_connectors() {
+    use carina_core::resource::{CallSite, EphemeralId, ExpansionTrace, PersistentId};
+    use carina_core::schema::SchemaRegistry;
 
-    assert_eq!(
-        plain.find(sigil.raw),
-        Some(LEFT_MARGIN.len() + 2),
-        "module-child sigil did not start at the inset column: {plain:?}",
+    let inner = make_resource("aws.eks.Cluster", "cluster/inner", "inner", &[]);
+    let role = make_resource("aws.iam.Role", "cluster/inner-role", "inner_role", &[]);
+    let inner_id = inner.id.clone();
+    let role_id = role.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(inner));
+    plan.add(Effect::Create(role));
+
+    let cluster_site = CallSite::new(
+        EphemeralId::new(ResourceId::new("_virtual", "cluster")),
+        "./modules/cluster",
+    );
+    let mut trace = ExpansionTrace::new();
+    trace.record(PersistentId::new(inner_id), vec![cluster_site.clone()]);
+    trace.record(PersistentId::new(role_id), vec![cluster_site]);
+
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::None,
+        &HashMap::new(),
+        Some(&SchemaRegistry::new()),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        Some(&trace),
+    ));
+
+    assert!(
+        output.contains(
+            "  + module \"cluster\" (./modules/cluster)\n     │\n     ├─ + aws.eks.Cluster cluster/inner\n     └─ + aws.iam.Role cluster/inner-role"
+        ),
+        "module leaves must render as connector children:\n{output}",
+    );
+}
+
+#[test]
+fn module_child_connector_gutter_extends_through_nested_dependents() {
+    use carina_core::resource::{CallSite, EphemeralId, ExpansionTrace, PersistentId};
+    use carina_core::schema::SchemaRegistry;
+
+    let cluster = make_resource("aws.eks.Cluster", "cluster/inner", "inner", &[]);
+    let node_role = make_resource("aws.iam.Role", "cluster/node-role", "node_role", &["inner"]);
+    let bucket = make_resource("aws.s3.Bucket", "cluster/logs", "logs", &[]);
+    let cluster_id = cluster.id.clone();
+    let bucket_id = bucket.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cluster));
+    plan.add(Effect::Create(node_role));
+    plan.add(Effect::Create(bucket));
+
+    let cluster_site = CallSite::new(
+        EphemeralId::new(ResourceId::new("_virtual", "cluster")),
+        "./modules/cluster",
+    );
+    let mut trace = ExpansionTrace::new();
+    trace.record(PersistentId::new(cluster_id), vec![cluster_site.clone()]);
+    trace.record(PersistentId::new(bucket_id), vec![cluster_site]);
+
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::None,
+        &HashMap::new(),
+        Some(&SchemaRegistry::new()),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+        Some(&trace),
+    ));
+
+    assert!(
+        output.contains(
+            "     ├─ + aws.eks.Cluster cluster/inner\n     │     └─ + aws.iam.Role cluster/node-role\n     └─ + aws.s3.Bucket cluster/logs"
+        ),
+        "outer module gutter must continue through the child subtree:\n{output}",
+    );
+}
+
+#[test]
+fn module_group_with_only_suppressed_move_does_not_emit_orphan_gutter() {
+    let from_id = ResourceId::new("aws.s3.Bucket", "cluster/old_logs");
+    let to_id = ResourceId::new("aws.s3.Bucket", "cluster/logs");
+    let mut updated = Resource::new("aws.s3.Bucket", "cluster/logs");
+    updated.id = to_id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Move {
+        from: from_id,
+        to: to_id.clone(),
+    });
+    plan.add(Effect::Update {
+        id: to_id.clone(),
+        from: Box::new(State::not_found(to_id.clone())),
+        to: updated,
+        changed_attributes: Vec::new(),
+    });
+
+    let moved_origins = HashMap::new();
+    let mut ctx = TreeRenderContext {
+        out: format!(
+            "{}\n",
+            strip_ansi(&format_composition_header(
+                "cluster",
+                Some("./modules/cluster")
+            ))
+        ),
+        printed: HashSet::new(),
+        plan: &plan,
+        dependents: HashMap::new(),
+        detail: DetailLevel::None,
+        delete_attributes: None,
+        schemas: None,
+        moved_origins: &moved_origins,
+        prev_explicit: None,
+        update_or_replace_targets: [to_id].into_iter().collect(),
+    };
+
+    let rendered_attrs = ctx.render_children(
+        &[ChildRenderItem::Normal(0)],
+        ChildRenderOptions {
+            parent_indent: 0,
+            parent_is_last: true,
+            parent_prefix: "",
+            parent_binding: None,
+            leading: LeadingConnector::Forced,
+            child_prefix_override: Some(module_child_prefix()),
+        },
+    );
+
+    assert!(
+        !rendered_attrs,
+        "suppressed children should not report displayed attributes"
+    );
+    assert!(
+        !ctx.out
+            .contains("  + module \"cluster\" (./modules/cluster)\n     │\n"),
+        "module group with only suppressed children must not emit an orphan gutter:\n{output}",
+        output = ctx.out,
+    );
+    assert_eq!(ctx.out, "  + module \"cluster\" (./modules/cluster)\n");
+    assert!(
+        ctx.printed.contains(&0),
+        "suppressed move should be consumed"
+    );
+}
+
+#[test]
+fn resource_with_only_suppressed_move_dependent_does_not_emit_orphan_gutter() {
+    let parent = make_resource("aws.s3.Bucket", "parent", "parent", &[]).with_attribute(
+        "bucket",
+        Value::Concrete(ConcreteValue::String("parent".to_string())),
+    );
+    let from_id = ResourceId::new("aws.s3.Bucket", "old_child");
+    let to_id = ResourceId::new("aws.s3.Bucket", "new_child");
+    let mut updated = Resource::new("aws.s3.Bucket", "new_child");
+    updated.id = to_id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(parent));
+    plan.add(Effect::Move {
+        from: from_id,
+        to: to_id.clone(),
+    });
+    plan.add(Effect::Update {
+        id: to_id.clone(),
+        from: Box::new(State::not_found(to_id.clone())),
+        to: updated,
+        changed_attributes: Vec::new(),
+    });
+
+    let moved_origins = HashMap::new();
+    let mut ctx = TreeRenderContext {
+        out: String::new(),
+        printed: HashSet::new(),
+        plan: &plan,
+        dependents: HashMap::from([(0, vec![1])]),
+        detail: DetailLevel::Full,
+        delete_attributes: None,
+        schemas: None,
+        moved_origins: &moved_origins,
+        prev_explicit: None,
+        update_or_replace_targets: [to_id].into_iter().collect(),
+    };
+
+    let rendered_attrs = ctx.format_render_item(&ChildRenderItem::Normal(0), 0, true, "", None);
+    let output = strip_ansi(&ctx.out);
+
+    assert!(rendered_attrs, "parent create should display attributes");
+    assert!(
+        !output.lines().any(|line| line == "        │"),
+        "resource with only suppressed move dependent must not emit an orphan gutter:\n{output}",
+    );
+    assert!(
+        ctx.printed.contains(&1),
+        "suppressed move dependent should be consumed"
     );
 }
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
@@ -6,7 +6,8 @@ Execution Plan:
 
   + aws.s3.Bucket logs
   + module "cluster" (./modules/cluster)
-    + aws.eks.Cluster cluster/inner
-    + aws.iam.Role cluster/inner-role
+     │
+     ├─ + aws.eks.Cluster cluster/inner
+     └─ + aws.iam.Role cluster/inner-role
 
 Plan: 3 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
@@ -6,7 +6,6 @@ Execution Plan:
 
   + aws.s3.Bucket logs
   + module "cluster" (./modules/cluster)
-     │
      ├─ + aws.eks.Cluster cluster/inner
      └─ + aws.iam.Role cluster/inner-role
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_top_level_sigil_alignment.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_top_level_sigil_alignment.snap
@@ -7,7 +7,8 @@ Execution Plan:
   <= aws.iam.Roles admin_roles (data source)
   + aws.s3.Bucket logs
   + module "cluster" (./modules/cluster)
-    + aws.eks.Cluster cluster/inner
+     │
+     └─ + aws.eks.Cluster cluster/inner
   + aws.route53.RecordSet (N records after cert.domain_validation_options resolves)
       <- for option in cert.domain_validation_options
       name: option.name

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_top_level_sigil_alignment.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_top_level_sigil_alignment.snap
@@ -7,7 +7,6 @@ Execution Plan:
   <= aws.iam.Roles admin_roles (data source)
   + aws.s3.Bucket logs
   + module "cluster" (./modules/cluster)
-     │
      └─ + aws.eks.Cluster cluster/inner
   + aws.route53.RecordSet (N records after cert.domain_validation_options resolves)
       <- for option in cert.domain_validation_options

--- a/carina-core/src/resource/expansion_trace.rs
+++ b/carina-core/src/resource/expansion_trace.rs
@@ -9,8 +9,9 @@
 //!
 //! ```text
 //! + module "cluster" (./modules/cluster)
-//!     + aws.eks.Cluster      cluster/inner
-//!     + aws.iam.Role         cluster/inner-role
+//!      │
+//!      ├─ + aws.eks.Cluster cluster/inner
+//!      └─ + aws.iam.Role cluster/inner-role
 //! + aws.s3.Bucket            logs
 //! ```
 //!


### PR DESCRIPTION
## Summary

`plan`'s tree used `├─` / `└─` / `│` connectors for resource-to-dependent edges but not for module-to-child edges. A reader had to infer module membership from indentation depth alone.

Before:
```
  + module "cluster" (./modules/cluster)
    + aws.eks.Cluster cluster/inner
    + aws.iam.Role cluster/inner-role
```

After:
```
  + module "cluster" (./modules/cluster)
     │
     ├─ + aws.eks.Cluster cluster/inner
     └─ + aws.iam.Role cluster/inner-role
```

## Design

The bug was one root cause: there were two paths emitting children — one for resource dependents (with connectors) and one for module leaves (without). The fix unifies them into `TreeRenderContext::render_children`, the single seam every child-list rendering now flows through. The module header becomes a virtual parent rendered through the same helper, with `LeadingConnector::Forced` signalling that the header has no attribute rows but the gutter `│` must still appear above the first child.

The `extra_left_pad` mechanism added in #3593 (interim 2-space inset for module children) is removed — connectors now signal nesting.

Type-safety hardening so the seam is load-bearing:

- `LeadingConnector::{FromParentAttrs { displayed }, Forced}` enum replaces the two booleans that previously encoded the leading-`│` decision. Inconsistent combinations become unrepresentable.
- `BRANCH_CONNECTOR` / `CORNER_CONNECTOR` / `SPACE_CONTINUATION` / `VERTICAL_CONTINUATION` constants with `const _: () = assert!(...)` width checks centralize glyph emission.
- `module_child_prefix()` derives the module-child connector indent from `CONNECTOR_WIDTH` rather than a magic literal.
- `will_render_effect_tree` exhaustively matches every `Effect` variant — a future variant added without updating the predicate is a compile error.

## Orphan-`│` bug found in review

Initial implementation wrote the leading `│` unconditionally before iterating items. When every item is a no-op — e.g. the only child is an `Effect::Move` whose target is also `Update`d, suppressed by `update_or_replace_targets` — the parent printed a stranded `│` with no row beneath it. Fix pre-filters items to those that will render. Regression tests cover both the module-header path (`module_group_with_only_suppressed_move_does_not_emit_orphan_gutter`) and the resource-dependent path (`resource_with_only_suppressed_move_dependent_does_not_emit_orphan_gutter`).

## Test plan

- [x] `cargo nextest run -p carina-cli` (4322 tests pass, including 2 new orphan-gutter regression tests)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] 5-round self-review (rounds 1-3 surfaced and fixed issues — orphan-`│` bug, type-shape weakening, dead variant, magic literals; rounds 4-5 clean)
- [x] Snapshots updated: `composition_folding`, `top_level_sigil_alignment`
- [x] New tests: `module_children_render_with_tree_connectors`, `module_child_connector_gutter_extends_through_nested_dependents`, `module_group_with_only_suppressed_move_does_not_emit_orphan_gutter`, `resource_with_only_suppressed_move_dependent_does_not_emit_orphan_gutter`

Closes #3592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
