### PR TITLE
display: use ▾ as module sigil instead of + (lifecycle marker)

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -87,8 +87,8 @@ impl Sigil {
 
     fn module_header() -> Self {
         Self {
-            raw: "+",
-            rendered: "+".cyan().bold(),
+            raw: "▾",
+            rendered: "▾".cyan().bold(),
         }
     }
 
@@ -1258,7 +1258,7 @@ fn format_plan_tree<'a>(
 
 /// Header row for a composition group in the folded plan layout.
 ///
-/// Renders `+ module "<binding>" (<source_path>)`, dropping the
+/// Renders `▾ module "<binding>" (<source_path>)`, dropping the
 /// parenthesized suffix when the call site has no recorded
 /// `source_path` (hand-built traces, test fixtures). The keyword
 /// `module` matches the DSL `module_call` construct the operator

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -2064,7 +2064,7 @@ fn test_refresh_plan_separator_no_blank_line_without_refresh() {
 }
 
 /// carina#3322: the composition group header reads
-/// `+ module "<binding>" (<source_path>)`. The keyword is `module`,
+/// `▾ module "<binding>" (<source_path>)`. The keyword is `module`,
 /// not the internal `Composition`; the binding name is the user's
 /// `let` LHS, and the parenthesized suffix surfaces the DSL `use`
 /// path so the operator can trace the group back to a real `.crn`
@@ -2072,17 +2072,29 @@ fn test_refresh_plan_separator_no_blank_line_without_refresh() {
 #[test]
 fn test_composition_header_renders_module_with_source_path() {
     let header = strip_ansi(&format_composition_header("r", Some("./modules/infra")));
-    assert_eq!(header, r#"  + module "r" (./modules/infra)"#);
+    assert_eq!(header, r#"  ▾ module "r" (./modules/infra)"#);
 }
 
 /// Fallback shape when no `use` path was recorded for the call site
 /// (test fixtures, hand-built traces). The parenthesized suffix is
-/// dropped so the header still reads as a clean `+ module "<binding>"`
+/// dropped so the header still reads as a clean `▾ module "<binding>"`
 /// line — never as a literal "None" or an empty `()`.
 #[test]
 fn test_composition_header_drops_parens_for_none_source_path() {
     let header = strip_ansi(&format_composition_header("r", None));
-    assert_eq!(header, r#"  + module "r""#);
+    assert_eq!(header, r#"  ▾ module "r""#);
+}
+
+#[test]
+fn module_header_sigil_is_module_specific_not_create() {
+    let module_sigil = Sigil::module_header();
+    let create_sigil = Effect::Create(Resource::new("aws.s3.Bucket", "x")).display_glyph();
+
+    assert_eq!(module_sigil.raw, "▾");
+    assert_ne!(
+        module_sigil.raw, create_sigil,
+        "module header sigil must differ from Effect::Create's display glyph"
+    );
 }
 
 #[test]
@@ -2162,7 +2174,7 @@ fn module_children_render_with_tree_connectors() {
 
     assert!(
         output.contains(
-            "  + module \"cluster\" (./modules/cluster)\n     ├─ + aws.eks.Cluster cluster/inner\n     └─ + aws.iam.Role cluster/inner-role"
+            "  ▾ module \"cluster\" (./modules/cluster)\n     ├─ + aws.eks.Cluster cluster/inner\n     └─ + aws.iam.Role cluster/inner-role"
         ),
         "module leaves must render as connector children:\n{output}",
     );
@@ -2269,11 +2281,11 @@ fn module_group_with_only_suppressed_move_does_not_emit_orphan_gutter() {
     );
     assert!(
         !ctx.out
-            .contains("  + module \"cluster\" (./modules/cluster)\n     │\n"),
+            .contains("  ▾ module \"cluster\" (./modules/cluster)\n     │\n"),
         "module group with only suppressed children must not emit an orphan gutter:\n{output}",
         output = ctx.out,
     );
-    assert_eq!(ctx.out, "  + module \"cluster\" (./modules/cluster)\n");
+    assert_eq!(ctx.out, "  ▾ module \"cluster\" (./modules/cluster)\n");
     assert!(
         ctx.printed.contains(&0),
         "suppressed move should be consumed"

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -2250,7 +2250,7 @@ fn snapshot_top_level_sigil_alignment() {
         ("+", "aws.s3.Bucket", "create resource"),
         ("<=", "aws.iam.Roles", "read data source"),
         ("+", "aws.route53.RecordSet", "deferred for-expression"),
-        ("+", "module", "module header"),
+        ("▾", "module", "module header"),
     ];
     for (sigil, content, label) in rows {
         let line = output
@@ -2259,7 +2259,8 @@ fn snapshot_top_level_sigil_alignment() {
             .unwrap_or_else(|| panic!("missing {label} row in:\n{output}"));
         let expected_prefix = format!("  {sigil} ");
         assert_eq!(
-            line.find(sigil),
+            line.chars()
+                .position(|c| c == sigil.chars().next().unwrap()),
             Some(2),
             "{label} sigil must start at column 2: {line:?}",
         );
@@ -2299,8 +2300,8 @@ fn snapshot_module_header_renders_use_source_path_for_real_fixture() {
     ));
 
     assert!(
-        output.contains(r#"module "bootstrap" (./oidc-module)"#),
-        "expected `module \"bootstrap\" (./oidc-module)` header from real \
+        output.contains(r#"▾ module "bootstrap" (./oidc-module)"#),
+        "expected `▾ module \"bootstrap\" (./oidc-module)` header from real \
          fixture in:\n{}",
         output,
     );

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_composition_folding.snap
@@ -5,7 +5,7 @@ expression: output
 Execution Plan:
 
   + aws.s3.Bucket logs
-  + module "cluster" (./modules/cluster)
+  ▾ module "cluster" (./modules/cluster)
      ├─ + aws.eks.Cluster cluster/inner
      └─ + aws.iam.Role cluster/inner-role
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_top_level_sigil_alignment.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_top_level_sigil_alignment.snap
@@ -6,7 +6,7 @@ Execution Plan:
 
   <= aws.iam.Roles admin_roles (data source)
   + aws.s3.Bucket logs
-  + module "cluster" (./modules/cluster)
+  ▾ module "cluster" (./modules/cluster)
      └─ + aws.eks.Cluster cluster/inner
   + aws.route53.RecordSet (N records after cert.domain_validation_options resolves)
       <- for option in cert.domain_validation_options

--- a/carina-core/src/resource/expansion_trace.rs
+++ b/carina-core/src/resource/expansion_trace.rs
@@ -8,7 +8,7 @@
 //! it can fold leaf rows under their originating composition row:
 //!
 //! ```text
-//! + module "cluster" (./modules/cluster)
+//! ▾ module "cluster" (./modules/cluster)
 //!      │
 //!      ├─ + aws.eks.Cluster cluster/inner
 //!      └─ + aws.iam.Role cluster/inner-role


### PR DESCRIPTION
## Summary

The `+` sigil on the `module` row of `plan` output reads as the "create" lifecycle marker. A module isn't being created — it's a structural grouping declared by `use { source = '...' }` in the calling .crn. Re-applying with no diff would render the same `+ module` line again, and the `+` doesn't count toward the `Plan: N to add, ...` summary.

Replace `+` with `▾` (U+25BE, "BLACK DOWN-POINTING SMALL TRIANGLE") — a tree-disclosure expanded marker semantically consistent with the `├─`/`└─` connectors added in #3592.

Before:
```
  + module "cluster" (./modules/cluster)
     ├─ + aws.eks.Cluster cluster/inner
     └─ + aws.iam.Role cluster/inner-role
```

After:
```
  ▾ module "cluster" (./modules/cluster)
     ├─ + aws.eks.Cluster cluster/inner
     └─ + aws.iam.Role cluster/inner-role
```

## Design

Single-call-site fix: `Sigil::module_header()` in `carina-cli/src/display/mod.rs` returns `raw: "▾", rendered: "▾".cyan().bold()`. The `Sigil` newtype from #3593 means raw and rendered cannot drift. All composition-group rendering routes through this one constructor, so apply, destroy, and saved-plan paths all pick up the new sigil for free.

The chosen glyph is structurally distinct from every `Effect::display_glyph()` value, so it cannot be confused for a lifecycle action. `▾` is single-column display width and in the Geometric Shapes Unicode block (covered by SF Mono, Cascadia Code, Fira Code, JetBrains Mono, and standard terminal fonts).

## Test gates

Pin the new behavior at three layers:

- `module_header_sigil_is_module_specific_not_create`: asserts `Sigil::module_header().raw == "▾"` AND `!= Effect::Create(...).display_glyph()`, tying the invariant to the source-of-truth Create glyph rather than a literal.
- `every_top_level_sigil_starts_at_left_margin_column`: iterates Sigil constructors and asserts each starts at column 2. The assertion was changed from `line.find(sigil)` (byte offset, wrong for the 3-byte UTF-8 `▾`) to `line.chars().position(...)` (column-aware).
- `snapshot_module_header_renders_use_source_path_for_real_fixture`: pins `▾ module "bootstrap" (./oidc-module)` in the real-fixture end-to-end test.

Also updated stale doc-comments in `format_composition_header` and `expansion_trace.rs` that still showed `+ module ...` in their rendered-output examples.

## Test plan

- [x] `cargo nextest run -p carina-cli` (4323 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] 5-round self-review (round 1 surfaced 5 cleanups — stale docs, weak test assertions, byte-vs-column drift — all fixed; rounds 2-5 clean)
- [x] Snapshots updated: `composition_folding`, `top_level_sigil_alignment`

Closes #3596

🤖 Generated with [Claude Code](https://claude.com/claude-code)
