### PR TITLE
fix(plan): stop double-counting DeferredReplace in summary totals

### DIFF
--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1203,7 +1203,7 @@ fn test_deferred_replace_renders_top_level() {
           <- for opt in cert.domain_validation_options
           name: (known after cert resolves)
 
-    Plan: 0 to add, 0 to change, 1 to replace, 1 to destroy.
+    Plan: 0 to add, 0 to change, 0 to destroy.
            N to replace after cert resolves.
     ");
 }
@@ -1247,7 +1247,7 @@ fn test_deferred_replace_renders_dependent_children() {
             └─ + acm.CertificateValidation cert-validation
                   validation_record_id: __deferred_for.validation_records.id
 
-    Plan: 1 to add, 0 to change, 1 to replace, 1 to destroy.
+    Plan: 1 to add, 0 to change, 0 to destroy.
            N to replace after cert resolves.
     ");
 }
@@ -1283,7 +1283,7 @@ fn test_deferred_replace_keeps_unrelated_same_type_delete() {
             │
             └─ - route53.Record old_record
 
-    Plan: 1 to add, 0 to change, 1 to replace, 2 to destroy.
+    Plan: 1 to add, 0 to change, 1 to destroy.
            N to replace after cert applies.
     ");
 }

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_deferred_for_with_dependent_wait.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_deferred_for_with_dependent_wait.snap
@@ -20,5 +20,5 @@ Execution Plan:
                     certificate_arn: "arn:aws:acm:us-east-1:123456789012:certificate/example"
                     validation_record_id: "known-after-validation-records"
 
-Plan: 2 to add, 0 to change, 1 to replace, 1 to destroy.
+Plan: 2 to add, 0 to change, 0 to destroy.
        N to replace after cert applies.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_deferred_for_with_paired_destroy.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_deferred_for_with_paired_destroy.snap
@@ -16,5 +16,5 @@ Execution Plan:
               ttl: 60
               type: (known after cert applies)
 
-Plan: 1 to add, 0 to change, 1 to replace, 1 to destroy.
+Plan: 1 to add, 0 to change, 0 to destroy.
        N to replace after cert applies.

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -216,10 +216,7 @@ impl Plan {
                     summary.update += cascading_updates.len();
                 }
                 Effect::Delete { .. } => {}
-                Effect::DeferredReplace { deletes, .. } => {
-                    summary.replace += 1;
-                    summary.delete += deletes.len();
-                }
+                Effect::DeferredReplace { .. } => {}
                 Effect::Import { .. } => summary.import += 1,
                 Effect::Remove { .. } => summary.remove += 1,
                 Effect::Move { .. } => summary.moved += 1,
@@ -708,7 +705,7 @@ mod tests {
     }
 
     #[test]
-    fn plan_summary_counts_deferred_replace_deletes_individually() {
+    fn plan_summary_excludes_deferred_replace_from_totals() {
         use crate::effect::{DeferredReplaceDelete, NonEmptyDeletes};
         use crate::parser::{DeferredForExpression, ForBinding};
         use crate::resource::{Directives, ResourceId};
@@ -747,8 +744,15 @@ mod tests {
         });
 
         let summary = plan.summary();
-        assert_eq!(summary.replace, 1);
-        assert_eq!(summary.delete, 3);
+        assert_eq!(summary.replace, 0);
+        assert_eq!(summary.delete, 0);
+        assert_eq!(summary.deferred.len(), 1);
+        assert_eq!(summary.deferred[0].upstream_binding, "cert");
+        assert_eq!(summary.deferred[0].action, DeferredSummaryAction::Replace);
+        assert_eq!(
+            summary.deferred_lines(),
+            vec!["N to replace after cert resolves."]
+        );
     }
 
     #[test]

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_deferred_replace.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_deferred_replace.snap
@@ -2,7 +2,7 @@
 source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
-┌ Plan (Plan: 1 to create, 0 to update, 1 to replace, 1 to delete; N to replace after cert applies.) ──────────────────┐
+┌ Plan (Plan: 1 to create, 0 to update, 0 to delete; N to replace after cert applies.) ────────────────────────────────┐
 │+ acm.Certificate cert                                                                                                │
 │    └── +/- aws.route53.Record validation_records[*] (N records after cert applies)                                   │
 │                                                                                                                      │


### PR DESCRIPTION
`Plan::summary()`'s `Effect::DeferredReplace` arm was incrementing both `summary.replace += 1` and `summary.delete += deletes.len()` into the totals line. Each increment was wrong, for three independent reasons:

1. **Wrong cardinality.** At plan time, `Effect::DeferredReplace` represents N apply-time replacements where N is the upstream's not-yet-resolved iterable count. Reporting `+ 1 to replace` and `+ deletes.len() to destroy` puts a number on the totals line whose denominator does not exist yet.
2. **Double-counted with the deferred-summary line.** The same operation is already reported on the deferred summary block ("N to replace after \<upstream\> applies"). The totals line was a second reporter of the same fact.
3. **Inconsistent with the sibling arms.** `Effect::DeferredCreate` correctly contributes nothing to totals. `Effect::Replace` increments `summary.replace` only, NOT `summary.delete` — because replace is one logical "destroy+create" operation, not two. `DeferredReplace` was alone in adding both, with no defensible reason.

Treat `Effect::DeferredReplace` exactly like `Effect::DeferredCreate`: contribute nothing to totals, and let the deferred-summary block report the apply-time cardinality.

The bug was introduced by `carina#3601`'s self-review hardening commit (`4e310327`), which also added a unit test (`plan_summary_counts_deferred_replace_deletes_individually`) asserting the wrong behavior. That test is replaced by a positive guard that asserts `DeferredReplace` stays out of totals.

Six snapshots revert to their pre-`carina#3601` totals (rendered tree unchanged, summary line only):

- `snapshot_deferred_for_with_dependent_wait.snap`: `2 to add, 0 to change, 1 to replace, 1 to destroy` → `2 to add, 0 to change, 0 to destroy`
- `snapshot_deferred_for_with_paired_destroy.snap`: same
- TUI `snapshot_deferred_replace.snap`: `1 to create, 0 to update, 1 to replace, 1 to delete` → `1 to create, 0 to update, 0 to delete`
- Three inline snapshots in `display/tests.rs`: same summary-line-only revert

When the `carina#3602` group-id reshape (design merged in PR #3603) lands and removes `Effect::DeferredReplace`, the same rule will need to hold for `Effect::Delete { deferred_replace_group: Some(_), .. }` — it should stay out of totals because the apply-time `Effect::DeferredCreate` half on the same group already reports the operation on the deferred-summary line.

Closes #3604
