### PR TITLE
fix(executor): remove sync-dispatch path to fix #3606 deadlock

### DIFF
--- a/carina-core/src/executor/deferred_dispatch.rs
+++ b/carina-core/src/executor/deferred_dispatch.rs
@@ -1,23 +1,10 @@
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use futures::stream::{self, StreamExt};
-
+use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 use crate::binding_index::ResolvedBindings;
-use crate::effect::{DeferredReplaceDelete, Effect};
-use crate::parser::{
-    DeferredForExpression, ProviderConfig, ShapeMismatch, expand_deferred_children,
-};
-use crate::provider::{Provider, ProviderFactory, ProviderNormalizer};
-use crate::resource::ResourceId;
-use crate::schema::SchemaRegistry;
-
-use super::basic::{
-    BasicEffectCtx, BasicEffectResult, ExecutionState, RenormalizePipeline, execute_basic_effect,
-    process_basic_result,
-};
-use super::{ExecutionEvent, ExecutionObserver, ProgressInfo, UnresolvedResource};
+use crate::effect::Effect;
+use crate::parser::{DeferredForExpression, ShapeMismatch, expand_deferred_children};
 
 /// Failure while expanding a deferred-for create half against apply-time
 /// upstream state.
@@ -107,24 +94,13 @@ pub(super) enum DeferredDispatchResult {
     /// DeferredCreate or DeferredReplace create children were materialized and
     /// should be appended to the scheduler queue.
     Materialized(Vec<Effect>),
-    /// At least one DeferredReplace delete half failed. The helper already
-    /// processed those delete results, so callers must mark the template
-    /// binding failed but must not increment `failure_count` again.
-    DeleteFailed,
     /// Deferred-for materialization failed before any child effects existed.
     /// Callers must increment `failure_count` for this meta-effect failure.
     MaterializeFailed,
 }
 
-/// Shared inputs required to dispatch DeferredCreate and DeferredReplace
-/// scheduler-meta effects.
-pub(super) struct DeferredDispatchCtx<'a> {
-    pub(super) provider: &'a dyn Provider,
-    pub(super) unresolved: &'a HashMap<ResourceId, UnresolvedResource>,
-    pub(super) normalizer: &'a dyn ProviderNormalizer,
-    pub(super) provider_configs: &'a [ProviderConfig],
-    pub(super) factories: &'a [Box<dyn ProviderFactory>],
-    pub(super) schemas: &'a SchemaRegistry,
+/// Shared inputs required to materialize deferred scheduler-meta effects.
+pub(super) struct PureMetaCtx<'a> {
     pub(super) completed: &'a AtomicUsize,
     pub(super) total: usize,
     pub(super) observer: &'a dyn ExecutionObserver,
@@ -138,7 +114,7 @@ pub(super) fn dispatch_deferred_create(
     upstream_binding: &str,
     template: &DeferredForExpression,
     bindings: &ResolvedBindings,
-    ctx: &DeferredDispatchCtx<'_>,
+    ctx: &PureMetaCtx<'_>,
 ) -> DeferredDispatchResult {
     match materialize_deferred_create(upstream_binding, template, bindings) {
         Ok(children) => DeferredDispatchResult::Materialized(children),
@@ -155,75 +131,5 @@ pub(super) fn dispatch_deferred_create(
             });
             DeferredDispatchResult::MaterializeFailed
         }
-    }
-}
-
-/// Dispatch a DeferredReplace meta-effect.
-///
-/// The delete half is executed through the basic delete path and joined before
-/// the create half is materialized, preserving the "deletes before create"
-/// invariant while allowing independent absorbed deletes to run concurrently.
-pub(super) async fn dispatch_deferred_replace(
-    effect: &Effect,
-    deletes: &[DeferredReplaceDelete],
-    upstream_binding: &str,
-    template: &DeferredForExpression,
-    ctx: &DeferredDispatchCtx<'_>,
-    exec: &mut ExecutionState<'_>,
-) -> DeferredDispatchResult {
-    let binding_snapshot = exec.bindings.clone();
-    let pipeline = RenormalizePipeline {
-        normalizer: ctx.normalizer,
-        provider_configs: ctx.provider_configs,
-        factories: ctx.factories,
-        schemas: ctx.schemas,
-    };
-
-    let provider = ctx.provider;
-    let unresolved = ctx.unresolved;
-    let completed = ctx.completed;
-    let total = ctx.total;
-    let observer = ctx.observer;
-    let concurrency = deletes.len().max(1);
-    let binding_snapshot = &binding_snapshot;
-    let pipeline = &pipeline;
-
-    let results = stream::iter(deletes)
-        .map(|delete| {
-            let delete_effect = delete.to_delete_effect();
-            async move {
-                let basic = delete_effect
-                    .as_basic()
-                    .expect("deferred replace delete half must narrow to BasicEffect");
-                execute_basic_effect(
-                    basic,
-                    &BasicEffectCtx {
-                        provider,
-                        bindings: binding_snapshot,
-                        unresolved,
-                        pipeline,
-                        completed,
-                        total,
-                    },
-                    observer,
-                )
-                .await
-            }
-        })
-        .buffer_unordered(concurrency)
-        .collect::<Vec<BasicEffectResult>>()
-        .await;
-
-    let delete_failed = results
-        .iter()
-        .any(|result| matches!(result, BasicEffectResult::Failure { .. }));
-    for result in results {
-        process_basic_result(result, exec);
-    }
-
-    if delete_failed {
-        DeferredDispatchResult::DeleteFailed
-    } else {
-        dispatch_deferred_create(effect, upstream_binding, template, exec.bindings, ctx)
     }
 }

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -6,20 +6,16 @@ use std::time::Instant;
 
 use tokio_util::sync::CancellationToken;
 
-use crate::deps::find_failed_dependency;
 use crate::effect::Effect;
-use crate::parser::ResourceRef;
+use crate::parser::{DeferredForExpression, ResourceRef};
 use crate::provider::Provider;
 use crate::resource::{Resource, ResourceId, Value};
 
 use super::basic::{
-    BasicEffectCtx, ExecutionState, RenormalizePipeline, count_actionable_effects,
-    execute_basic_effect, process_basic_result, refresh_pending_states,
+    BasicEffectCtx, BasicEffectResult, RenormalizePipeline, count_actionable_effects,
+    execute_basic_effect, refresh_pending_states,
 };
-use super::deferred_dispatch::{
-    DeferredDispatchCtx, DeferredDispatchResult, dispatch_deferred_create,
-    dispatch_deferred_replace,
-};
+use super::deferred_dispatch::{DeferredDispatchResult, PureMetaCtx, dispatch_deferred_create};
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
 use super::wait::{
     AppliedStates, SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
@@ -27,6 +23,135 @@ use super::wait::{
     unsatisfiable_reason_message, wait_failure_message,
 };
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
+
+struct PureMetaStep<'a> {
+    effect: &'a Effect,
+    upstream_binding: &'a str,
+    template: &'a DeferredForExpression,
+}
+
+impl<'a> PureMetaStep<'a> {
+    fn from_effect(effect: &'a Effect) -> Option<Self> {
+        match effect {
+            Effect::DeferredCreate {
+                upstream_binding,
+                template,
+                ..
+            }
+            | Effect::DeferredReplace {
+                upstream_binding,
+                template,
+                ..
+            } => Some(Self {
+                effect,
+                upstream_binding,
+                template,
+            }),
+            Effect::Create(_)
+            | Effect::Update { .. }
+            | Effect::Replace { .. }
+            | Effect::Delete { .. }
+            | Effect::Wait { .. }
+            | Effect::Read { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Move { .. } => None,
+        }
+    }
+}
+
+fn failure_binding_name(effect: &Effect) -> Option<String> {
+    match effect {
+        Effect::DeferredCreate { template, .. } | Effect::DeferredReplace { template, .. } => {
+            Some(template.binding_name.clone())
+        }
+        _ => effect.binding_name(),
+    }
+}
+
+pub(super) struct ExpandedEffects {
+    pub(super) effects: Vec<Effect>,
+    pub(super) deferred_replace_delete_deps: Vec<(usize, usize)>,
+}
+
+pub(super) fn expand_deferred_replace_effects(plan_effects: &[Effect]) -> ExpandedEffects {
+    let mut effects = Vec::with_capacity(plan_effects.len());
+    let mut deferred_replace_delete_deps = Vec::new();
+
+    for effect in plan_effects {
+        if let Effect::DeferredReplace { deletes, .. } = effect {
+            let mut delete_indices = Vec::with_capacity(deletes.len());
+            for delete in deletes.iter() {
+                let delete_idx = effects.len();
+                effects.push(delete.to_delete_effect());
+                delete_indices.push(delete_idx);
+            }
+            let gate_idx = effects.len();
+            effects.push(effect.clone());
+            deferred_replace_delete_deps.extend(
+                delete_indices
+                    .into_iter()
+                    .map(|delete_idx| (gate_idx, delete_idx)),
+            );
+        } else {
+            effects.push(effect.clone());
+        }
+    }
+
+    ExpandedEffects {
+        effects,
+        deferred_replace_delete_deps,
+    }
+}
+
+pub(super) fn apply_deferred_replace_delete_deps(
+    deps_of: &mut HashMap<usize, HashSet<usize>>,
+    deferred_replace_delete_deps: &[(usize, usize)],
+) {
+    for &(gate_idx, delete_idx) in deferred_replace_delete_deps {
+        if deps_of.contains_key(&gate_idx) && deps_of.contains_key(&delete_idx) {
+            deps_of.entry(gate_idx).or_default().insert(delete_idx);
+        }
+    }
+}
+
+fn build_scheduler_deps(
+    effects: &[Effect],
+    unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
+    compositions: &[crate::resource::Composition],
+    deferred_replace_delete_deps: &[(usize, usize)],
+) -> HashMap<usize, HashSet<usize>> {
+    let mut analysis = build_dependency_analysis(effects, unresolved_resources, compositions);
+    relax_update_update_edges(effects, &mut analysis);
+    let mut deps_of = analysis.into_deps_of();
+    apply_deferred_replace_delete_deps(&mut deps_of, deferred_replace_delete_deps);
+    deps_of
+}
+
+fn find_failed_dependency_index(
+    idx: usize,
+    deps_of: &HashMap<usize, HashSet<usize>>,
+    failed_indices: &HashSet<usize>,
+    effects: &[Effect],
+) -> Option<String> {
+    deps_of.get(&idx).and_then(|deps| {
+        deps.iter()
+            .find(|dep_idx| failed_indices.contains(dep_idx))
+            .map(|dep_idx| {
+                effects
+                    .get(*dep_idx)
+                    .and_then(failure_binding_name)
+                    .unwrap_or_else(|| format!("#{dep_idx}"))
+            })
+    })
+}
+
+fn failed_binding_names(effects: &[Effect], failed_indices: &HashSet<usize>) -> HashSet<String> {
+    failed_indices
+        .iter()
+        .filter_map(|idx| effects.get(*idx).and_then(failure_binding_name))
+        .collect()
+}
 
 pub(super) fn is_runtime_dispatchable(effect: &Effect) -> bool {
     !matches!(effect, Effect::Read { .. })
@@ -560,30 +685,37 @@ pub(super) async fn execute_effects_sequential(
     let mut partial_diagnostics = Vec::new();
     let mut skip_count = 0;
     let (mut applied_states, wait_identifiers) = AppliedStates::with_initial(&input.current_states);
-    let mut failed_bindings: HashSet<String> = HashSet::new();
     let mut successfully_deleted: HashSet<ResourceId> = HashSet::new();
     let mut permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>> = HashMap::new();
     let mut pending_refreshes: HashMap<ResourceId, String> = HashMap::new();
     let mut runtime_synthesized_resources: Vec<Resource> = Vec::new();
 
-    let mut effects = input.plan.effects().to_vec();
-    let mut total = count_actionable_effects(input.plan.effects());
+    let ExpandedEffects {
+        effects: expanded_effects,
+        deferred_replace_delete_deps,
+    } = expand_deferred_replace_effects(input.plan.effects());
+    let mut effects = expanded_effects;
+    let mut total = count_actionable_effects(&effects);
     let completed = AtomicUsize::new(0);
 
-    let mut analysis =
-        build_dependency_analysis(&effects, input.unresolved_resources, input.compositions);
-    relax_update_update_edges(&effects, &mut analysis);
-    let mut deps_of = analysis.into_deps_of();
+    let mut deps_of = build_scheduler_deps(
+        &effects,
+        input.unresolved_resources,
+        input.compositions,
+        &deferred_replace_delete_deps,
+    );
 
     // Build effect index -> binding name mapping for resolving dependency names
     let mut idx_to_binding: HashMap<usize, String> = effects
         .iter()
         .enumerate()
-        .filter_map(|(idx, effect)| effect.binding_name().map(|b| (idx, b)))
+        .filter_map(|(idx, effect)| failure_binding_name(effect).map(|b| (idx, b)))
         .collect();
 
     // Track which effect indices have completed (successfully or not)
     let mut completed_indices: HashSet<usize> = HashSet::new();
+    // Track effect indices whose failure should poison direct scheduler dependents.
+    let mut failed_indices: HashSet<usize> = HashSet::new();
     // Track which effect indices have been dispatched (spawned or skipped)
     let mut dispatched: HashSet<usize> = HashSet::new();
     // All actionable effect indices (excluding Read and state operations)
@@ -664,7 +796,9 @@ pub(super) async fn execute_effects_sequential(
             dispatched.insert(idx);
             let effect = effects[idx].clone();
 
-            if let Some(failed_dep) = find_failed_dependency(&effect, &failed_bindings) {
+            if let Some(failed_dep) =
+                find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
+            {
                 let c = if effect.is_scheduler_meta() {
                     completed.load(Ordering::Relaxed)
                 } else {
@@ -688,125 +822,28 @@ pub(super) async fn execute_effects_sequential(
                     },
                 });
                 skip_count += 1;
-                if let Some(binding) = effect.binding_name() {
-                    failed_bindings.insert(binding);
-                }
+                failed_indices.insert(idx);
                 completed_indices.insert(idx);
                 continue;
             }
 
-            if let Effect::DeferredCreate {
-                upstream_binding,
-                template,
-                ..
-            } = &effect
-            {
-                let dispatch_ctx = DeferredDispatchCtx {
-                    provider,
-                    unresolved: input.unresolved_resources,
-                    normalizer: input.normalizer,
-                    provider_configs: input.provider_configs,
-                    factories: input.factories,
-                    schemas: input.schemas,
+            if let Some(step) = PureMetaStep::from_effect(&effect) {
+                let dispatch_ctx = PureMetaCtx {
                     completed: &completed,
                     total,
                     observer,
                 };
                 let children = match dispatch_deferred_create(
-                    &effect,
-                    upstream_binding,
-                    template,
+                    step.effect,
+                    step.upstream_binding,
+                    step.template,
                     &input.bindings,
                     &dispatch_ctx,
                 ) {
                     DeferredDispatchResult::Materialized(children) => children,
                     DeferredDispatchResult::MaterializeFailed => {
                         failure_count += 1;
-                        failed_bindings.insert(template.binding_name.clone());
-                        completed_indices.insert(idx);
-                        completed_synchronous_dispatch = true;
-                        break;
-                    }
-                    DeferredDispatchResult::DeleteFailed => {
-                        unreachable!("deferred create dispatch cannot run delete halves")
-                    }
-                };
-                if !children.is_empty() {
-                    total += count_actionable_effects(&children);
-                    for child in children {
-                        let child_idx = effects.len();
-                        if let Effect::Create(resource) = &child {
-                            runtime_synthesized_resources.push(resource.clone());
-                        }
-                        if let Some(binding) = child.binding_name() {
-                            idx_to_binding.insert(child_idx, binding);
-                        }
-                        effects.push(child);
-                        actionable_indices.push(child_idx);
-                    }
-                    let mut analysis = build_dependency_analysis(
-                        &effects,
-                        input.unresolved_resources,
-                        input.compositions,
-                    );
-                    relax_update_update_edges(&effects, &mut analysis);
-                    deps_of = analysis.into_deps_of();
-                }
-                completed_indices.insert(idx);
-                completed_synchronous_dispatch = true;
-                break;
-            }
-
-            if let Effect::DeferredReplace {
-                deletes,
-                upstream_binding,
-                template,
-                ..
-            } = &effect
-            {
-                total += deletes.len();
-                let dispatch_ctx = DeferredDispatchCtx {
-                    provider,
-                    unresolved: input.unresolved_resources,
-                    normalizer: input.normalizer,
-                    provider_configs: input.provider_configs,
-                    factories: input.factories,
-                    schemas: input.schemas,
-                    completed: &completed,
-                    total,
-                    observer,
-                };
-                let mut exec = ExecutionState {
-                    success_count: &mut success_count,
-                    failure_count: &mut failure_count,
-                    partial_count: &mut partial_count,
-                    partial_diagnostics: &mut partial_diagnostics,
-                    applied_states: &mut applied_states,
-                    failed_bindings: &mut failed_bindings,
-                    successfully_deleted: &mut successfully_deleted,
-                    pending_refreshes: &mut pending_refreshes,
-                    bindings: &mut input.bindings,
-                };
-                let children = match dispatch_deferred_replace(
-                    &effect,
-                    deletes,
-                    upstream_binding,
-                    template,
-                    &dispatch_ctx,
-                    &mut exec,
-                )
-                .await
-                {
-                    DeferredDispatchResult::Materialized(children) => children,
-                    DeferredDispatchResult::DeleteFailed => {
-                        failed_bindings.insert(template.binding_name.clone());
-                        completed_indices.insert(idx);
-                        completed_synchronous_dispatch = true;
-                        break;
-                    }
-                    DeferredDispatchResult::MaterializeFailed => {
-                        failure_count += 1;
-                        failed_bindings.insert(template.binding_name.clone());
+                        failed_indices.insert(idx);
                         completed_indices.insert(idx);
                         completed_synchronous_dispatch = true;
                         break;
@@ -819,19 +856,18 @@ pub(super) async fn execute_effects_sequential(
                         if let Effect::Create(resource) = &child {
                             runtime_synthesized_resources.push(resource.clone());
                         }
-                        if let Some(binding) = child.binding_name() {
+                        if let Some(binding) = failure_binding_name(&child) {
                             idx_to_binding.insert(child_idx, binding);
                         }
                         effects.push(child);
                         actionable_indices.push(child_idx);
                     }
-                    let mut analysis = build_dependency_analysis(
+                    deps_of = build_scheduler_deps(
                         &effects,
                         input.unresolved_resources,
                         input.compositions,
+                        &deferred_replace_delete_deps,
                     );
-                    relax_update_update_edges(&effects, &mut analysis);
-                    deps_of = analysis.into_deps_of();
                 }
                 completed_indices.insert(idx);
                 completed_synchronous_dispatch = true;
@@ -987,17 +1023,17 @@ pub(super) async fn execute_effects_sequential(
             continue;
         }
 
-        let count_undispatched =
-            |dispatched: &HashSet<usize>, failed_bindings: &HashSet<String>| {
-                count_effectively_undispatched(
-                    &actionable_indices,
-                    dispatched,
-                    &effects,
-                    failed_bindings,
-                )
-            };
+        let count_undispatched = |dispatched: &HashSet<usize>, failed_indices: &HashSet<usize>| {
+            let failed_bindings = failed_binding_names(&effects, failed_indices);
+            count_effectively_undispatched(
+                &actionable_indices,
+                dispatched,
+                &effects,
+                &failed_bindings,
+            )
+        };
         in_flight
-            .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+            .check_terminal(count_undispatched(&dispatched, &failed_indices))
             .cancel_if_terminal()
             .drop_without_awaiting();
 
@@ -1037,7 +1073,7 @@ pub(super) async fn execute_effects_sequential(
         // Wait for the next effect to complete
         let (finished_idx, result) = if cancelled {
             let Some(finished) = in_flight
-                .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                .check_terminal(count_undispatched(&dispatched, &failed_indices))
                 .cancel_if_terminal()
                 .next_completed()
                 .await
@@ -1054,7 +1090,7 @@ pub(super) async fn execute_effects_sequential(
                     continue;
                 }
                 finished = in_flight
-                    .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                    .check_terminal(count_undispatched(&dispatched, &failed_indices))
                     .cancel_if_terminal()
                     .next_completed() => {
                     let Some(finished) = finished else {
@@ -1068,22 +1104,53 @@ pub(super) async fn execute_effects_sequential(
 
         // Process the result and update shared state immediately
         match result {
-            SingleEffectResult::Basic(basic) => {
-                process_basic_result(
-                    basic,
-                    &mut ExecutionState {
-                        success_count: &mut success_count,
-                        failure_count: &mut failure_count,
-                        partial_count: &mut partial_count,
-                        partial_diagnostics: &mut partial_diagnostics,
-                        applied_states: &mut applied_states,
-                        failed_bindings: &mut failed_bindings,
-                        successfully_deleted: &mut successfully_deleted,
-                        pending_refreshes: &mut pending_refreshes,
-                        bindings: &mut input.bindings,
-                    },
-                );
-            }
+            SingleEffectResult::Basic(basic) => match basic {
+                BasicEffectResult::Success {
+                    state,
+                    resource_id,
+                    resolved_attrs,
+                    binding,
+                } => {
+                    success_count += 1;
+                    if let Some(state) = state {
+                        if let Some(attrs) = &resolved_attrs {
+                            input
+                                .bindings
+                                .record_applied(binding.as_deref(), attrs, &state);
+                        }
+                        applied_states.insert(resource_id, state);
+                    }
+                }
+                BasicEffectResult::Failure { refresh, .. } => {
+                    failure_count += 1;
+                    failed_indices.insert(finished_idx);
+                    if let Some((id, identifier)) = refresh
+                        && !identifier.is_empty()
+                    {
+                        pending_refreshes.insert(id, identifier);
+                    }
+                }
+                BasicEffectResult::PartialSuccess {
+                    state,
+                    resource_id,
+                    diagnostic,
+                    resolved_attrs,
+                    binding,
+                } => {
+                    partial_count += 1;
+                    if let Some(attrs) = &resolved_attrs {
+                        input
+                            .bindings
+                            .record_applied(binding.as_deref(), attrs, &state);
+                    }
+                    applied_states.insert(resource_id.clone(), state);
+                    partial_diagnostics.push((resource_id, diagnostic));
+                }
+                BasicEffectResult::Deleted { resource_id } => {
+                    success_count += 1;
+                    successfully_deleted.insert(resource_id);
+                }
+            },
             SingleEffectResult::Replace {
                 success,
                 state,
@@ -1123,9 +1190,7 @@ pub(super) async fn execute_effects_sequential(
                     }
                 } else {
                     failure_count += 1;
-                    if let Some(binding) = binding {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(finished_idx);
                 }
                 for (id, identifier) in refreshes {
                     if !identifier.is_empty() {
@@ -1175,7 +1240,7 @@ pub(super) async fn execute_effects_sequential(
                         progress,
                     });
                     skip_count += 1;
-                    failed_bindings.insert(binding);
+                    failed_indices.insert(finished_idx);
                 }
                 WaitOutcome::Cancelled => {
                     observer.on_event(&ExecutionEvent::EffectSkipped {
@@ -1196,12 +1261,12 @@ pub(super) async fn execute_effects_sequential(
                         progress,
                     });
                     failure_count += 1;
-                    failed_bindings.insert(binding);
+                    failed_indices.insert(finished_idx);
                 }
             },
         }
         in_flight
-            .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+            .check_terminal(count_undispatched(&dispatched, &failed_indices))
             .cancel_if_terminal()
             .drop_without_awaiting();
     }

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -19,11 +19,10 @@ use super::basic::{
     count_actionable_effects, execute_basic_effect, process_basic_result, queue_state_refresh,
     refresh_pending_states, resolve_resource, resolve_resource_with_source,
 };
-use super::deferred_dispatch::{
-    DeferredDispatchCtx, DeferredDispatchResult, dispatch_deferred_create,
-    dispatch_deferred_replace,
+use super::deferred_dispatch::{DeferredDispatchResult, PureMetaCtx, dispatch_deferred_create};
+use super::parallel::{
+    apply_deferred_replace_delete_deps, expand_deferred_replace_effects, is_runtime_dispatchable,
 };
-use super::parallel::is_runtime_dispatchable;
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::wait::{
     AppliedStates, SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
@@ -417,10 +416,12 @@ pub(super) async fn execute_effects_phased(
     let mut pending_refreshes: HashMap<ResourceId, String> = HashMap::new();
     let mut runtime_synthesized_resources: Vec<Resource> = Vec::new();
 
-    let mut total = count_actionable_effects(input.plan.effects());
+    let expanded = expand_deferred_replace_effects(input.plan.effects());
+    let deferred_replace_delete_deps = expanded.deferred_replace_delete_deps;
+    let mut total = count_actionable_effects(&expanded.effects);
     let completed = AtomicUsize::new(0);
 
-    let mut effects = input.plan.effects().to_vec();
+    let mut effects = expanded.effects;
     let replace_bindings = collect_replace_bindings(&effects);
     let sorted_indices = topological_sort_replaces(&effects, &replace_bindings);
     let replaced_ids: HashSet<ResourceId> = effects
@@ -471,6 +472,7 @@ pub(super) async fn execute_effects_phased(
             input.unresolved_resources,
             input.compositions,
         );
+        apply_deferred_replace_delete_deps(&mut deps_of, &deferred_replace_delete_deps);
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
         let mut in_flight: WaitAwareInFlight<'_, PhaseEffectResult> = WaitAwareInFlight::new();
@@ -544,13 +546,7 @@ pub(super) async fn execute_effects_phased(
                     ..
                 } = &effect
                 {
-                    let dispatch_ctx = DeferredDispatchCtx {
-                        provider,
-                        unresolved: input.unresolved_resources,
-                        normalizer: input.normalizer,
-                        provider_configs: input.provider_configs,
-                        factories: input.factories,
-                        schemas: input.schemas,
+                    let dispatch_ctx = PureMetaCtx {
                         completed: &completed,
                         total,
                         observer,
@@ -570,9 +566,6 @@ pub(super) async fn execute_effects_phased(
                             completed_synchronous_dispatch = true;
                             break;
                         }
-                        DeferredDispatchResult::DeleteFailed => {
-                            unreachable!("deferred create dispatch cannot run delete halves")
-                        }
                     };
                     if !children.is_empty() {
                         total += count_actionable_effects(&children);
@@ -590,6 +583,10 @@ pub(super) async fn execute_effects_phased(
                             input.unresolved_resources,
                             input.compositions,
                         );
+                        apply_deferred_replace_delete_deps(
+                            &mut deps_of,
+                            &deferred_replace_delete_deps,
+                        );
                     }
                     completed_indices.insert(idx);
                     completed_synchronous_dispatch = true;
@@ -597,52 +594,24 @@ pub(super) async fn execute_effects_phased(
                 }
 
                 if let Effect::DeferredReplace {
-                    deletes,
                     upstream_binding,
                     template,
                     ..
                 } = &effect
                 {
-                    total += deletes.len();
-                    let dispatch_ctx = DeferredDispatchCtx {
-                        provider,
-                        unresolved: input.unresolved_resources,
-                        normalizer: input.normalizer,
-                        provider_configs: input.provider_configs,
-                        factories: input.factories,
-                        schemas: input.schemas,
+                    let dispatch_ctx = PureMetaCtx {
                         completed: &completed,
                         total,
                         observer,
                     };
-                    let mut exec = ExecutionState {
-                        success_count: &mut success_count,
-                        failure_count: &mut failure_count,
-                        partial_count: &mut partial_count,
-                        partial_diagnostics: &mut partial_diagnostics,
-                        applied_states: &mut applied_states,
-                        failed_bindings: &mut failed_bindings,
-                        successfully_deleted: &mut successfully_deleted,
-                        pending_refreshes: &mut pending_refreshes,
-                        bindings: &mut input.bindings,
-                    };
-                    let children = match dispatch_deferred_replace(
+                    let children = match dispatch_deferred_create(
                         &effect,
-                        deletes,
                         upstream_binding,
                         template,
+                        &input.bindings,
                         &dispatch_ctx,
-                        &mut exec,
-                    )
-                    .await
-                    {
+                    ) {
                         DeferredDispatchResult::Materialized(children) => children,
-                        DeferredDispatchResult::DeleteFailed => {
-                            failed_bindings.insert(template.binding_name.clone());
-                            completed_indices.insert(idx);
-                            completed_synchronous_dispatch = true;
-                            break;
-                        }
                         DeferredDispatchResult::MaterializeFailed => {
                             failure_count += 1;
                             failed_bindings.insert(template.binding_name.clone());
@@ -666,6 +635,10 @@ pub(super) async fn execute_effects_phased(
                             &phase1_indices,
                             input.unresolved_resources,
                             input.compositions,
+                        );
+                        apply_deferred_replace_delete_deps(
+                            &mut deps_of,
+                            &deferred_replace_delete_deps,
                         );
                     }
                     completed_indices.insert(idx);
@@ -1587,6 +1560,7 @@ pub(super) async fn execute_effects_phased(
             input.unresolved_resources,
             input.compositions,
         );
+        apply_deferred_replace_delete_deps(&mut deps_of, &deferred_replace_delete_deps);
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
         type PhaseFuture<'a> =
@@ -1655,13 +1629,7 @@ pub(super) async fn execute_effects_phased(
                     ..
                 } = &effect
                 {
-                    let dispatch_ctx = DeferredDispatchCtx {
-                        provider,
-                        unresolved: input.unresolved_resources,
-                        normalizer: input.normalizer,
-                        provider_configs: input.provider_configs,
-                        factories: input.factories,
-                        schemas: input.schemas,
+                    let dispatch_ctx = PureMetaCtx {
                         completed: &completed,
                         total,
                         observer,
@@ -1680,9 +1648,6 @@ pub(super) async fn execute_effects_phased(
                             completed_indices.insert(idx);
                             completed_synchronous_dispatch = true;
                             break;
-                        }
-                        DeferredDispatchResult::DeleteFailed => {
-                            unreachable!("deferred create dispatch cannot run delete halves")
                         }
                     };
                     if !children.is_empty() {
@@ -1705,6 +1670,10 @@ pub(super) async fn execute_effects_phased(
                             input.unresolved_resources,
                             input.compositions,
                         );
+                        apply_deferred_replace_delete_deps(
+                            &mut deps_of,
+                            &deferred_replace_delete_deps,
+                        );
                     }
                     completed_indices.insert(idx);
                     completed_synchronous_dispatch = true;
@@ -1712,52 +1681,24 @@ pub(super) async fn execute_effects_phased(
                 }
 
                 if let Effect::DeferredReplace {
-                    deletes,
                     upstream_binding,
                     template,
                     ..
                 } = &effect
                 {
-                    total += deletes.len();
-                    let dispatch_ctx = DeferredDispatchCtx {
-                        provider,
-                        unresolved: input.unresolved_resources,
-                        normalizer: input.normalizer,
-                        provider_configs: input.provider_configs,
-                        factories: input.factories,
-                        schemas: input.schemas,
+                    let dispatch_ctx = PureMetaCtx {
                         completed: &completed,
                         total,
                         observer,
                     };
-                    let mut exec = ExecutionState {
-                        success_count: &mut success_count,
-                        failure_count: &mut failure_count,
-                        partial_count: &mut partial_count,
-                        partial_diagnostics: &mut partial_diagnostics,
-                        applied_states: &mut applied_states,
-                        failed_bindings: &mut failed_bindings,
-                        successfully_deleted: &mut successfully_deleted,
-                        pending_refreshes: &mut pending_refreshes,
-                        bindings: &mut input.bindings,
-                    };
-                    let children = match dispatch_deferred_replace(
+                    let children = match dispatch_deferred_create(
                         &effect,
-                        deletes,
                         upstream_binding,
                         template,
+                        &input.bindings,
                         &dispatch_ctx,
-                        &mut exec,
-                    )
-                    .await
-                    {
+                    ) {
                         DeferredDispatchResult::Materialized(children) => children,
-                        DeferredDispatchResult::DeleteFailed => {
-                            failed_bindings.insert(template.binding_name.clone());
-                            completed_indices.insert(idx);
-                            completed_synchronous_dispatch = true;
-                            break;
-                        }
                         DeferredDispatchResult::MaterializeFailed => {
                             failure_count += 1;
                             failed_bindings.insert(template.binding_name.clone());
@@ -1785,6 +1726,10 @@ pub(super) async fn execute_effects_phased(
                             &phase4_indices,
                             input.unresolved_resources,
                             input.compositions,
+                        );
+                        apply_deferred_replace_delete_deps(
+                            &mut deps_of,
+                            &deferred_replace_delete_deps,
                         );
                     }
                     completed_indices.insert(idx);

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -15,7 +15,7 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use tokio::sync::Barrier;
+use tokio::sync::{Barrier, Mutex as AsyncMutex, Notify};
 use tokio_util::sync::CancellationToken;
 
 fn validation_deferred_for_expression() -> crate::parser::DeferredForExpression {
@@ -6440,6 +6440,283 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
         "create half must not dispatch after delete failure; calls: {:?}",
         provider.calls()
     );
+}
+
+#[tokio::test]
+async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_normalizer() {
+    #[derive(Clone)]
+    struct LockOrderScenario {
+        aws_normalize: Arc<AsyncMutex<()>>,
+        awscc_shared: Arc<AsyncMutex<()>>,
+        alb_waiting_for_awscc: Arc<Notify>,
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl LockOrderScenario {
+        fn new() -> Self {
+            Self {
+                aws_normalize: Arc::new(AsyncMutex::new(())),
+                awscc_shared: Arc::new(AsyncMutex::new(())),
+                alb_waiting_for_awscc: Arc::new(Notify::new()),
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn record(&self, call: impl Into<String>) {
+            self.calls.lock().unwrap().push(call.into());
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[derive(Clone)]
+    struct LockOrderNormalizer {
+        scenario: LockOrderScenario,
+    }
+
+    impl crate::provider::ProviderNormalizer for LockOrderNormalizer {
+        fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+            Box::pin(async move {
+                let is_alb = resources
+                    .iter()
+                    .any(|resource| resource.id.name_str() == "alb");
+                {
+                    let _aws = self.scenario.aws_normalize.lock().await;
+                    tokio::task::yield_now().await;
+                }
+                if is_alb {
+                    self.scenario.record("alb-normalize-wait-awscc");
+                    self.scenario.alb_waiting_for_awscc.notify_one();
+                }
+                let _awscc = self.scenario.awscc_shared.lock().await;
+                tokio::task::yield_now().await;
+            })
+        }
+
+        fn normalize_state<'a>(
+            &'a self,
+            _current_states: &'a mut HashMap<ResourceId, State>,
+        ) -> BoxFuture<'a, ()> {
+            crate::provider::ready_noop()
+        }
+
+        fn hydrate_read_state<'a>(
+            &'a self,
+            _current_states: &'a mut HashMap<ResourceId, State>,
+            _saved_attrs: &'a crate::provider::SavedAttrs,
+        ) -> BoxFuture<'a, ()> {
+            crate::provider::ready_noop()
+        }
+
+        fn merge_default_tags<'a>(
+            &'a self,
+            _resources: &'a mut [Resource],
+            _default_tags: &'a indexmap::IndexMap<String, Value>,
+            _registry: &'a crate::schema::SchemaRegistry,
+        ) -> BoxFuture<'a, ()> {
+            crate::provider::ready_noop()
+        }
+    }
+
+    #[derive(Clone)]
+    struct LockOrderProvider {
+        scenario: LockOrderScenario,
+    }
+
+    impl LockOrderProvider {
+        async fn create_state(
+            &self,
+            id: &ResourceId,
+        ) -> ProviderResult<crate::provider::CreateOutcome> {
+            self.scenario.record(format!("create:{id}"));
+            if id.name_str() == "cert" {
+                let _provider_lock = self.scenario.awscc_shared.lock().await;
+                self.scenario.alb_waiting_for_awscc.notified().await;
+                return Ok(crate::provider::CreateOutcome::Success {
+                    state: cert_state_for_deferred_replace_deadlock(id),
+                });
+            }
+
+            if id.name_str() == "alb" {
+                let _provider_lock = self.scenario.awscc_shared.lock().await;
+                return Ok(crate::provider::CreateOutcome::Success {
+                    state: State::existing(id.clone(), HashMap::new()).with_identifier("alb-id"),
+                });
+            }
+
+            Ok(crate::provider::CreateOutcome::Success {
+                state: State::existing(id.clone(), HashMap::new())
+                    .with_identifier(format!("{}-id", id.name_str())),
+            })
+        }
+
+        async fn delete_id(&self, id: &ResourceId) -> ProviderResult<()> {
+            self.scenario.record(format!("delete:{id}"));
+            let _provider_lock = self.scenario.awscc_shared.lock().await;
+            Ok(())
+        }
+    }
+
+    impl Provider for LockOrderProvider {
+        fn name(&self) -> &str {
+            "lock-order"
+        }
+
+        fn read(
+            &self,
+            id: &ResourceId,
+            _identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        }
+
+        fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
+            self.read(&resource.id, None, ReadRequest)
+        }
+
+        fn create(
+            &self,
+            id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<crate::provider::CreateOutcome>> {
+            let id = id.clone();
+            Box::pin(async move { self.create_state(&id).await })
+        }
+
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<crate::provider::UpdateOutcome>> {
+            Box::pin(async { Err(ProviderError::internal("update not used")) })
+        }
+
+        fn delete(
+            &self,
+            id: &ResourceId,
+            _identifier: &str,
+            _request: DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            let id = id.clone();
+            Box::pin(async move { self.delete_id(&id).await })
+        }
+
+        fn required_permissions(
+            &self,
+            _id: &ResourceId,
+            _op: crate::effect::PlanOp,
+        ) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    let scenario = LockOrderScenario::new();
+    let provider = LockOrderProvider {
+        scenario: scenario.clone(),
+    };
+    let normalizer = LockOrderNormalizer {
+        scenario: scenario.clone(),
+    };
+    let mut plan = Plan::new();
+    let cert = resource_with_binding("cert", "cert");
+    let cert_id = cert.id.clone();
+    plan.add(Effect::Create(cert.clone()));
+    plan.add(Effect::Create(resource_with_binding("alb", "alb")));
+    plan.add(Effect::DeferredReplace {
+        deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
+            id: ResourceId::new("test", "validation_records[0]"),
+            identifier: "old-validation".to_string(),
+            directives: Directives::default(),
+            binding: Some("validation_records[0]".to_string()),
+            dependencies: HashSet::from(["cert".to_string()]),
+            explicit_dependencies: HashSet::new(),
+        }])
+        .expect("fixture has one delete"),
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "cert".to_string(),
+        template: Box::new(validation_deferred_for_expression()),
+    });
+
+    let unresolved = HashMap::from([(cert_id, UnresolvedResource::from_pre_resolve(cert.clone()))]);
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &unresolved,
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+        normalizer: &normalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: NonZeroUsize::new(2).unwrap(),
+    };
+    let observer = MockObserver::new();
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        execute_plan(&provider, input, &observer, CancellationToken::new()),
+    )
+    .await
+    .expect("expanded DeferredReplace deletes must stay in in_flight");
+    let result = completed_result(outcome);
+
+    assert_eq!(result.failure_count, 0);
+    assert!(
+        result
+            .runtime_synthesized_resources
+            .iter()
+            .any(|resource| resource.id == ResourceId::new("test", "validation_records[0]")),
+        "deferred replace gate must synthesize the child create"
+    );
+    assert!(
+        result
+            .applied_states
+            .contains_key(&ResourceId::new("test", "validation_records[0]")),
+        "post-state must include the synthesized child create"
+    );
+    assert!(
+        scenario
+            .calls()
+            .iter()
+            .any(|call| call == "delete:test.validation_records[0]"),
+        "absorbed delete must run through the provider delete path"
+    );
+}
+
+fn resource_with_binding(name: &str, binding: &str) -> Resource {
+    let mut resource = Resource::new("test", name);
+    resource.binding = Some(binding.to_string());
+    resource
+}
+
+fn cert_state_for_deferred_replace_deadlock(id: &ResourceId) -> State {
+    State::existing(
+        id.clone(),
+        HashMap::from([(
+            "domain_validation_options".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(indexmap::IndexMap::from([(
+                    "resource_record".to_string(),
+                    Value::Concrete(ConcreteValue::Map(indexmap::IndexMap::from([
+                        (
+                            "name".to_string(),
+                            Value::Concrete(ConcreteValue::String("_name".to_string())),
+                        ),
+                        (
+                            "value".to_string(),
+                            Value::Concrete(ConcreteValue::String("_value".to_string())),
+                        ),
+                    ]))),
+                )])),
+            )])),
+        )]),
+    )
+    .with_identifier("cert-id")
 }
 
 /// Regression for carina#3164: a plan that mixes `Effect::Move` with


### PR DESCRIPTION
Closes #3606.
Refs #3607 (design).

`carina apply` の cert 作成直後に起きる沈黙ハングを、計器付きビルドで
追跡したところ、原因は `execute_effects_sequential`
（`carina-core/src/executor/parallel.rs`）が
`dispatch_deferred_replace` を scheduler のループと同一の async タスク
で同期 await する経路にあった。await 中は `in_flight`
（FuturesUnordered）が誰にも poll されないので、別 effect が
`tokio::sync::Mutex` で待っている wake が届いても acquire に
遷移できず、続いて来る delete がその後ろに並んで全タスクが park する。
詳細は設計 PR #3607 と Issue #3606 のコメントを参照。

## 変更点

- **scheduler 内部での DR 展開**: executor 入口で
  `Effect::DeferredReplace` を `Effect::Delete` × N と純粋な
  materialize gate に展開し、両方を通常の `in_flight` 経路に
  乗せる。I/O 半分は `Effect::Delete` と同じ runtime 経路で動き、
  scheduler ループが I/O 系の future を同期 await することは
  なくなる。`carina-core/src/executor/parallel.rs` と
  `carina-core/src/executor/phased.rs` の両方で同じ展開を適用。
- **typestate 分離**: `dispatch_deferred_create` を含む materialize
  経路は `PureMetaCtx`（`Provider` / `ProviderNormalizer` / HTTP に
  触れる手段を持たない）に閉じ込めた。これによって「scheduler の
  pure dispatch から I/O を呼ぶ」状態が型として書けなくなる。
  対応する `PureMetaStep` は `&Effect` を借用で受け、不要な clone を
  作らない。
- **failed bookkeeping の一本化**: `parallel.rs` の scheduler が
  保持していた `failed_bindings`（string）と新規 `failed_indices`
  （idx）の二重簿記を `failed_indices` 一本に統一。`count_undispatched`
  と `cancel_waits_if_terminal` は必要な箇所で
  `failed_binding_names` から派生計算する。

## 回帰テスト

`deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_normalizer`
を `carina-core/src/executor/tests.rs` に追加。aws/awscc の Store
mutex を模した二つの `tokio::sync::Mutex` を持つ mock provider と
normalizer を用意し、cert と alb 相当の Create を同じ in_flight に
並べたうえで cert に依存する DR（delete 1 件）を `execute_plan` に
渡す。修正後の scheduler では 5 秒以内に完了し、materialize された
child Create が `runtime_synthesized_resources` と
`applied_states` の両方に入ること、absorbed delete が provider の
delete 経路を通っていることを assert する。修正をロールバックすると
このテストが 5 秒の `tokio::time::timeout` で必ず失敗する。

## 触っていないこと

- `Effect` enum の variant、plan、display、`plan_tree`、writeback、
  state、`carina-cli`、provider crate。本 PR の変更は
  `carina-core::executor` の内部に閉じている。
- `ProviderRouter::normalize_desired`。これを「resource の所属
  provider のみ呼ぶ」形に変える案は設計段階で明示的に却下している
  （同 provider 内の複数 resource が並列 in_flight にある場合に
  同型 deadlock が再発するため、症状を移すだけになる）。
- `with_operation_timeout` の 20 分上限。今回のハングは provider
  呼び出しに到達する前で起きているのでここに来ない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)