### PR TITLE
fix(validate): catch typos in <wait>.<attr> references via target schema

### DIFF
--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -22,15 +22,18 @@
 //! (no schema), `BindingNameSet` requires only the name and an origin
 //! tag. Callers that need more than one view hold them side by side.
 //!
-//! Built once at the parse → validate boundary, then borrowed. The walk
-//! is **top-level only** (`parsed.resources`) on purpose: for-body
-//! template resources carry a parser-synthesised binding name used for
-//! address derivation, but those names are an internal detail and were
-//! never visible to validation's `binding_map` pre-#2231. Surfacing them
-//! through `BindingIndex` would let ResourceRefs name them, which is a
-//! behaviour change neither validation nor the LSP wants. The LSP still
-//! walks `iter_all_resources` separately for its own checks (so for-body
-//! type/enum diagnostics fire); only the binding-name table is scoped.
+//! Built once at the parse → validate boundary, then borrowed. Resource
+//! discovery is **top-level only** (`parsed.resources`) on purpose:
+//! for-body template resources carry a parser-synthesised binding name
+//! used for address derivation, but those names are an internal detail
+//! and were never visible to validation's `binding_map` pre-#2231.
+//! Surfacing them through `BindingIndex` would let ResourceRefs name
+//! them, which is a behaviour change neither validation nor the LSP
+//! wants. Wait bindings are then layered on top as aliases of their
+//! target resource schema because `<wait>.<attr>` is addressable DSL.
+//! The LSP still walks `iter_all_resources` separately for its own
+//! checks (so for-body type/enum diagnostics fire); only the
+//! binding-name table is scoped.
 //!
 //! ```ignore
 //! let index = BindingIndex::from_parsed(&parsed, &registry);
@@ -114,6 +117,22 @@ impl<'a> BindingIndex<'a> {
                 continue;
             };
             entries.insert(binding_name.to_string(), BindingEntry { schema });
+        }
+        // Wait bindings are addressable aliases for their target
+        // resource (`let ready = wait cert { ... }` means
+        // `ready.certificate_arn` has the same schema surface as
+        // `cert.certificate_arn`). The target binding has already been
+        // processed above for managed resources and data sources. If the
+        // target lacks an entry (composition target, unknown resource
+        // type, or future parser expansion), keep the wait name in
+        // `known_names` so callers preserve the "known binding, schema
+        // absent" diagnostic split.
+        for wb in &parsed.wait_bindings {
+            let wait_name = wb.binding.as_str();
+            known_names.insert(wait_name.to_string());
+            if let Some(schema) = entries.get(wb.target.as_str()).map(|entry| entry.schema) {
+                entries.insert(wait_name.to_string(), BindingEntry { schema });
+            }
         }
         Self {
             entries,
@@ -918,6 +937,30 @@ let vpc = aws.ec2.Vpc {
         assert!(
             index.is_declared("vpc"),
             "binding declared in source must show up in `known_names`",
+        );
+    }
+
+    #[test]
+    fn build_records_wait_binding_name_when_target_schema_is_unknown() {
+        let src = r#"
+let cert = aws.acm.Certificate {
+    name = "cert"
+}
+
+let cert_issued = wait cert {
+    until = cert.status == "issued"
+}
+"#;
+        let parsed = parse(src, &Default::default()).expect("parse");
+        let registry = SchemaRegistry::new();
+
+        let index = BindingIndex::from_parsed(&parsed, &registry);
+        assert!(index.get("cert").is_none());
+        assert!(index.get("cert_issued").is_none());
+        assert!(index.is_declared("cert"));
+        assert!(
+            index.is_declared("cert_issued"),
+            "wait binding declared in source must show up in `known_names`",
         );
     }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::parser::{ParsedFile, ProviderContext};
+use crate::parser::{BindingName, ParsedFile, ProviderContext, UntilPredicateAst, WaitBinding};
 use crate::resource::Resource;
 use crate::schema::{ResourceSchema, SchemaRegistry, TypeIdentity};
 
@@ -658,6 +658,132 @@ fn unknown_attribute_reference_suggests_similar_name() {
         "Expected 'did you mean' suggestion, got: {}",
         err
     );
+}
+
+#[test]
+fn unknown_attribute_reference_through_wait_binding_reports_error() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "aws",
+        make_schema(
+            "acm.Certificate",
+            vec![
+                ("certificate_arn", AttributeType::string()),
+                ("status", AttributeType::string()),
+            ],
+        ),
+    );
+    schemas.insert(
+        "awscc",
+        make_schema(
+            "elasticloadbalancingv2.Listener",
+            vec![("certificate_arn", AttributeType::string())],
+        ),
+    );
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "cert", None)
+        .with_binding("cert")
+        .with_attribute(
+            "status",
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        );
+    let listener =
+        Resource::with_provider("awscc", "elasticloadbalancingv2.Listener", "listener", None)
+            .with_attribute(
+                "certificate_arn",
+                Value::resource_ref(
+                    "cert_issued".to_string(),
+                    "certificate_arnn".to_string(),
+                    vec![],
+                ),
+            );
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.wait_bindings.push(WaitBinding {
+        binding: BindingName::from("cert_issued"),
+        target: BindingName::from("cert"),
+        until_raw: "cert.status == 'issued'".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        timeout_secs: None,
+        depends_on: Vec::new(),
+        line: 1,
+    });
+    parsed.resources.push(listener); // allow: direct — fixture test inspection
+
+    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    assert!(
+        err.contains("unknown attribute 'certificate_arnn' on 'cert_issued'"),
+        "expected wait binding attribute error, got: {err}",
+    );
+    assert!(
+        err.contains("reference cert_issued.certificate_arnn"),
+        "expected wait binding reference in error, got: {err}",
+    );
+    assert!(
+        err.contains("Did you mean 'certificate_arn'?"),
+        "expected target schema suggestion, got: {err}",
+    );
+}
+
+#[test]
+fn known_attribute_reference_through_wait_binding_is_accepted() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "aws",
+        make_schema(
+            "acm.Certificate",
+            vec![
+                ("certificate_arn", AttributeType::string()),
+                ("status", AttributeType::string()),
+            ],
+        ),
+    );
+    schemas.insert(
+        "awscc",
+        make_schema(
+            "elasticloadbalancingv2.Listener",
+            vec![("certificate_arn", AttributeType::string())],
+        ),
+    );
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "cert", None)
+        .with_binding("cert")
+        .with_attribute(
+            "status",
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        );
+    let listener =
+        Resource::with_provider("awscc", "elasticloadbalancingv2.Listener", "listener", None)
+            .with_attribute(
+                "certificate_arn",
+                Value::resource_ref(
+                    "cert_issued".to_string(),
+                    "certificate_arn".to_string(),
+                    vec![],
+                ),
+            );
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.wait_bindings.push(WaitBinding {
+        binding: BindingName::from("cert_issued"),
+        target: BindingName::from("cert"),
+        until_raw: "cert.status == 'issued'".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        timeout_secs: None,
+        depends_on: Vec::new(),
+        line: 1,
+    });
+    parsed.resources.push(listener); // allow: direct — fixture test inspection
+
+    assert!(validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Closes #3609.

`carina validate` was missing the static typo because `BindingIndex::from_parsed` only indexed top-level resource bindings. A `let cert_issued = wait cert { ... }` binding therefore was absent from the schema-aware lookup used by `validate_resource_ref_types`; references like `cert_issued.arn` could be mis-attributed later by apply as "has not been published yet" even though the real issue was that the attribute did not exist on the target schema.

This fixes the root cause in the shared index instead of adding validator-site carve-outs: `BindingIndex::from_parsed` now layers `parsed.wait_bindings` onto the entries map after the resource walk, registering each wait binding with the target binding's schema. If the target schema is unavailable, the wait name is still recorded in `known_names` so the existing "unknown binding" vs "known binding with missing schema" diagnostic split is preserved.

Tests:

- Added a red/green validation pair covering a typo through a wait binding (`cert_issued.certificate_arnn`) and a valid target-schema attribute through the same wait binding (`cert_issued.certificate_arn`).
- Added a `BindingIndex` regression test for the defensive known-name-only branch when the wait target schema is unavailable.

LSP sibling-path audit: case (a). `carina-lsp` diagnostics build `BindingIndex::from_parsed` once and pass `schemas_by_name()` into the ResourceRef type and unknown-attribute checks, so the LSP inherits the wait-binding schema fix transparently. No separate LSP carve-out was needed.

Explicitly deferred: the apply-time "has not been published yet" wording is untouched. With validation now catching this class of static typo earlier, that downstream message path is no longer the fix point for #3609.
