### PR TITLE
fix(executor): unify phased and parallel scheduler primitives (#3611-#3615)

### DIFF
--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -57,7 +57,6 @@ pub(super) enum BasicEffectResult {
         binding: Option<String>,
     },
     Failure {
-        binding: Option<String>,
         refresh: Option<(ResourceId, String)>,
     },
     Deleted {
@@ -70,12 +69,13 @@ pub(super) enum BasicEffectResult {
 /// Groups the counters, result maps, and binding state that are threaded
 /// through every call to `process_basic_result`, reducing parameter count.
 pub(super) struct ExecutionState<'a> {
+    pub(super) idx: usize,
     pub(super) success_count: &'a mut usize,
     pub(super) failure_count: &'a mut usize,
     pub(super) partial_count: &'a mut usize,
     pub(super) partial_diagnostics: &'a mut Vec<(ResourceId, PartialReadDiagnostic)>,
     pub(super) applied_states: &'a mut AppliedStates,
-    pub(super) failed_bindings: &'a mut std::collections::HashSet<String>,
+    pub(super) failed_indices: &'a mut std::collections::HashSet<usize>,
     pub(super) successfully_deleted: &'a mut std::collections::HashSet<ResourceId>,
     pub(super) pending_refreshes: &'a mut HashMap<ResourceId, String>,
     pub(super) bindings: &'a mut ResolvedBindings,
@@ -435,13 +435,9 @@ pub(super) fn process_basic_result(result: BasicEffectResult, exec: &mut Executi
                 exec.applied_states.insert(resource_id, s);
             }
         }
-        BasicEffectResult::Failure {
-            binding, refresh, ..
-        } => {
+        BasicEffectResult::Failure { refresh } => {
             *exec.failure_count += 1;
-            if let Some(binding) = binding {
-                exec.failed_bindings.insert(binding);
-            }
+            exec.failed_indices.insert(exec.idx);
             if let Some((id, identifier)) = &refresh {
                 queue_state_refresh(exec.pending_refreshes, id, Some(identifier.as_str()));
             }
@@ -534,10 +530,7 @@ pub(super) async fn execute_basic_effect<'a>(
                         duration: started.elapsed(),
                         progress,
                     });
-                    return BasicEffectResult::Failure {
-                        binding: effect.binding_name(),
-                        refresh: None,
-                    };
+                    return BasicEffectResult::Failure { refresh: None };
                 }
             };
             let resolved_attrs = resolved.as_resource().resolved_attributes();
@@ -586,10 +579,7 @@ pub(super) async fn execute_basic_effect<'a>(
                         duration: started.elapsed(),
                         progress,
                     });
-                    BasicEffectResult::Failure {
-                        binding: effect.binding_name(),
-                        refresh: None,
-                    }
+                    BasicEffectResult::Failure { refresh: None }
                 }
             }
         }
@@ -613,10 +603,7 @@ pub(super) async fn execute_basic_effect<'a>(
                             duration: started.elapsed(),
                             progress,
                         });
-                        return BasicEffectResult::Failure {
-                            binding: effect.binding_name(),
-                            refresh: None,
-                        };
+                        return BasicEffectResult::Failure { refresh: None };
                     }
                 };
             let identifier = from.identifier.as_deref().unwrap_or("");
@@ -720,7 +707,6 @@ pub(super) async fn execute_basic_effect<'a>(
                         progress,
                     });
                     BasicEffectResult::Failure {
-                        binding: effect.binding_name(),
                         refresh: Some((id.clone(), identifier.to_string())),
                     }
                 }
@@ -761,7 +747,6 @@ pub(super) async fn execute_basic_effect<'a>(
                     progress,
                 });
                 BasicEffectResult::Failure {
-                    binding: None,
                     refresh: Some((id.clone(), identifier.to_string())),
                 }
             }
@@ -791,17 +776,18 @@ mod process_basic_result_tests {
         let mut failure_count = 0;
         let mut partial_count = 0;
         let mut partial_diagnostics = Vec::new();
-        let mut failed_bindings = HashSet::new();
+        let mut failed_indices = HashSet::new();
         let mut successfully_deleted = HashSet::new();
         let mut pending_refreshes = HashMap::new();
         let mut bindings = ResolvedBindings::default();
         let mut exec = ExecutionState {
+            idx: 7,
             success_count: &mut success_count,
             failure_count: &mut failure_count,
             partial_count: &mut partial_count,
             partial_diagnostics: &mut partial_diagnostics,
             applied_states: &mut applied_states,
-            failed_bindings: &mut failed_bindings,
+            failed_indices: &mut failed_indices,
             successfully_deleted: &mut successfully_deleted,
             pending_refreshes: &mut pending_refreshes,
             bindings: &mut bindings,

--- a/carina-core/src/executor/deferred_dispatch.rs
+++ b/carina-core/src/executor/deferred_dispatch.rs
@@ -85,7 +85,13 @@ pub(super) fn materialize_deferred_create(
             mismatch,
         })?
         .into_iter()
-        .map(Effect::Create)
+        .map(|resource| {
+            debug_assert!(
+                resource.dependency_bindings.contains(upstream_binding),
+                "apply-time deferred-for child must retain iterable dependency"
+            );
+            Effect::Create(resource)
+        })
         .collect())
 }
 

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -20,6 +20,7 @@ mod normalized_tests;
 mod parallel;
 mod phased;
 mod replace;
+pub(super) mod scheduler;
 pub(crate) mod wait;
 
 pub use parallel::UnresolvedResource;

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -7,67 +7,28 @@ use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use crate::effect::Effect;
-use crate::parser::{DeferredForExpression, ResourceRef};
+use crate::parser::ResourceRef;
 use crate::provider::Provider;
 use crate::resource::{Resource, ResourceId, Value};
 
 use super::basic::{
-    BasicEffectCtx, BasicEffectResult, RenormalizePipeline, count_actionable_effects,
-    execute_basic_effect, refresh_pending_states,
+    BasicEffectCtx, ExecutionState, RenormalizePipeline, count_actionable_effects,
+    execute_basic_effect, process_basic_result, refresh_pending_states,
 };
-use super::deferred_dispatch::{DeferredDispatchResult, PureMetaCtx, dispatch_deferred_create};
+use super::deferred_dispatch::PureMetaCtx;
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
+use super::scheduler::{
+    PureMetaOutcome, build_scheduler_deps, dependency_failed_reason,
+    emit_cancelled_skips_with_progress, failed_binding_names_for_wait_terminal_check,
+    failure_binding_name, find_failed_dependency_index, try_dispatch_pure_meta,
+    wait_dependency_failed_reason,
+};
 use super::wait::{
-    AppliedStates, SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
-    WaitSignal, count_effectively_undispatched, resolve_wait_identifier,
-    unsatisfiable_reason_message, wait_failure_message,
+    AppliedStates, SKIP_REASON_CANCELLED, WaitAwareInFlight, WaitOutcome, WaitSignal,
+    count_effectively_undispatched, resolve_wait_identifier, unsatisfiable_reason_message,
+    wait_failure_message,
 };
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
-
-struct PureMetaStep<'a> {
-    effect: &'a Effect,
-    upstream_binding: &'a str,
-    template: &'a DeferredForExpression,
-}
-
-impl<'a> PureMetaStep<'a> {
-    fn from_effect(effect: &'a Effect) -> Option<Self> {
-        match effect {
-            Effect::DeferredCreate {
-                upstream_binding,
-                template,
-                ..
-            }
-            | Effect::DeferredReplace {
-                upstream_binding,
-                template,
-                ..
-            } => Some(Self {
-                effect,
-                upstream_binding,
-                template,
-            }),
-            Effect::Create(_)
-            | Effect::Update { .. }
-            | Effect::Replace { .. }
-            | Effect::Delete { .. }
-            | Effect::Wait { .. }
-            | Effect::Read { .. }
-            | Effect::Import { .. }
-            | Effect::Remove { .. }
-            | Effect::Move { .. } => None,
-        }
-    }
-}
-
-fn failure_binding_name(effect: &Effect) -> Option<String> {
-    match effect {
-        Effect::DeferredCreate { template, .. } | Effect::DeferredReplace { template, .. } => {
-            Some(template.binding_name.clone())
-        }
-        _ => effect.binding_name(),
-    }
-}
 
 pub(super) struct ExpandedEffects {
     pub(super) effects: Vec<Effect>,
@@ -109,48 +70,10 @@ pub(super) fn apply_deferred_replace_delete_deps(
     deferred_replace_delete_deps: &[(usize, usize)],
 ) {
     for &(gate_idx, delete_idx) in deferred_replace_delete_deps {
-        if deps_of.contains_key(&gate_idx) && deps_of.contains_key(&delete_idx) {
+        if deps_of.contains_key(&gate_idx) {
             deps_of.entry(gate_idx).or_default().insert(delete_idx);
         }
     }
-}
-
-fn build_scheduler_deps(
-    effects: &[Effect],
-    unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
-    compositions: &[crate::resource::Composition],
-    deferred_replace_delete_deps: &[(usize, usize)],
-) -> HashMap<usize, HashSet<usize>> {
-    let mut analysis = build_dependency_analysis(effects, unresolved_resources, compositions);
-    relax_update_update_edges(effects, &mut analysis);
-    let mut deps_of = analysis.into_deps_of();
-    apply_deferred_replace_delete_deps(&mut deps_of, deferred_replace_delete_deps);
-    deps_of
-}
-
-fn find_failed_dependency_index(
-    idx: usize,
-    deps_of: &HashMap<usize, HashSet<usize>>,
-    failed_indices: &HashSet<usize>,
-    effects: &[Effect],
-) -> Option<String> {
-    deps_of.get(&idx).and_then(|deps| {
-        deps.iter()
-            .find(|dep_idx| failed_indices.contains(dep_idx))
-            .map(|dep_idx| {
-                effects
-                    .get(*dep_idx)
-                    .and_then(failure_binding_name)
-                    .unwrap_or_else(|| format!("#{dep_idx}"))
-            })
-    })
-}
-
-fn failed_binding_names(effects: &[Effect], failed_indices: &HashSet<usize>) -> HashSet<String> {
-    failed_indices
-        .iter()
-        .filter_map(|idx| effects.get(*idx).and_then(failure_binding_name))
-        .collect()
 }
 
 pub(super) fn is_runtime_dispatchable(effect: &Effect) -> bool {
@@ -285,39 +208,6 @@ mod reads {
 }
 
 use reads::{KnownReads, ReadsSet};
-
-struct CancelSkipCtx<'a> {
-    effects: &'a [Effect],
-    completed: &'a AtomicUsize,
-    total: usize,
-    observer: &'a dyn ExecutionObserver,
-}
-
-fn emit_cancelled_skips(
-    ctx: &CancelSkipCtx<'_>,
-    indices: &[usize],
-    dispatched: &mut HashSet<usize>,
-    completed_indices: &mut HashSet<usize>,
-    skip_count: &mut usize,
-) {
-    for &idx in indices {
-        if dispatched.contains(&idx) {
-            continue;
-        }
-        dispatched.insert(idx);
-        completed_indices.insert(idx);
-        let c = ctx.completed.fetch_add(1, Ordering::Relaxed) + 1;
-        ctx.observer.on_event(&ExecutionEvent::EffectSkipped {
-            effect: &ctx.effects[idx],
-            reason: SKIP_REASON_CANCELLED,
-            progress: ProgressInfo {
-                completed: c,
-                total: ctx.total,
-            },
-        });
-        *skip_count += 1;
-    }
-}
 
 pub(super) struct DependencyAnalysis {
     deps_of: HashMap<usize, HashSet<usize>>,
@@ -805,13 +695,9 @@ pub(super) async fn execute_effects_sequential(
                     completed.fetch_add(1, Ordering::Relaxed) + 1
                 };
                 let reason = if effect.is_wait() {
-                    let detail =
-                        unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
-                            binding: failed_dep,
-                        });
-                    format!("unsatisfiable: {detail}")
+                    wait_dependency_failed_reason(&failed_dep)
                 } else {
-                    format!("dependency '{}' failed", failed_dep)
+                    dependency_failed_reason(&failed_dep)
                 };
                 observer.on_event(&ExecutionEvent::EffectSkipped {
                     effect: &effect,
@@ -827,51 +713,45 @@ pub(super) async fn execute_effects_sequential(
                 continue;
             }
 
-            if let Some(step) = PureMetaStep::from_effect(&effect) {
-                let dispatch_ctx = PureMetaCtx {
-                    completed: &completed,
-                    total,
-                    observer,
-                };
-                let children = match dispatch_deferred_create(
-                    step.effect,
-                    step.upstream_binding,
-                    step.template,
-                    &input.bindings,
-                    &dispatch_ctx,
-                ) {
-                    DeferredDispatchResult::Materialized(children) => children,
-                    DeferredDispatchResult::MaterializeFailed => {
-                        failure_count += 1;
-                        failed_indices.insert(idx);
-                        completed_indices.insert(idx);
-                        completed_synchronous_dispatch = true;
-                        break;
-                    }
-                };
-                if !children.is_empty() {
-                    total += count_actionable_effects(&children);
-                    for child in children {
-                        let child_idx = effects.len();
-                        if let Effect::Create(resource) = &child {
-                            runtime_synthesized_resources.push(resource.clone());
-                        }
-                        if let Some(binding) = failure_binding_name(&child) {
-                            idx_to_binding.insert(child_idx, binding);
-                        }
-                        effects.push(child);
-                        actionable_indices.push(child_idx);
-                    }
-                    deps_of = build_scheduler_deps(
-                        &effects,
-                        input.unresolved_resources,
-                        input.compositions,
-                        &deferred_replace_delete_deps,
-                    );
+            let dispatch_ctx = PureMetaCtx {
+                completed: &completed,
+                total,
+                observer,
+            };
+            match try_dispatch_pure_meta(&effect, &input.bindings, &dispatch_ctx) {
+                PureMetaOutcome::NotPureMeta => {}
+                PureMetaOutcome::Failed => {
+                    failure_count += 1;
+                    failed_indices.insert(idx);
+                    completed_indices.insert(idx);
+                    completed_synchronous_dispatch = true;
+                    break;
                 }
-                completed_indices.insert(idx);
-                completed_synchronous_dispatch = true;
-                break;
+                PureMetaOutcome::Materialized(children) => {
+                    if !children.is_empty() {
+                        total += count_actionable_effects(&children);
+                        for child in children {
+                            let child_idx = effects.len();
+                            if let Effect::Create(resource) = &child {
+                                runtime_synthesized_resources.push(resource.clone());
+                            }
+                            if let Some(binding) = failure_binding_name(&child) {
+                                idx_to_binding.insert(child_idx, binding);
+                            }
+                            effects.push(child);
+                            actionable_indices.push(child_idx);
+                        }
+                        deps_of = build_scheduler_deps(
+                            &effects,
+                            input.unresolved_resources,
+                            input.compositions,
+                            &deferred_replace_delete_deps,
+                        );
+                    }
+                    completed_indices.insert(idx);
+                    completed_synchronous_dispatch = true;
+                    break;
+                }
             }
 
             // Snapshot bindings for this effect's resolution.
@@ -1024,7 +904,8 @@ pub(super) async fn execute_effects_sequential(
         }
 
         let count_undispatched = |dispatched: &HashSet<usize>, failed_indices: &HashSet<usize>| {
-            let failed_bindings = failed_binding_names(&effects, failed_indices);
+            let failed_bindings =
+                failed_binding_names_for_wait_terminal_check(&effects, failed_indices);
             count_effectively_undispatched(
                 &actionable_indices,
                 dispatched,
@@ -1045,17 +926,18 @@ pub(super) async fn execute_effects_sequential(
                 .filter(|idx| !dispatched.contains(idx))
                 .count();
             if cancelled {
-                emit_cancelled_skips(
-                    &CancelSkipCtx {
-                        effects: &effects,
-                        completed: &completed,
-                        total,
-                        observer,
-                    },
+                let mut progress_for = |_| ProgressInfo {
+                    completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
+                    total,
+                };
+                emit_cancelled_skips_with_progress(
+                    &effects,
                     &actionable_indices,
                     &mut dispatched,
                     &mut completed_indices,
                     &mut skip_count,
+                    observer,
+                    &mut progress_for,
                 );
             } else if remaining > 0 {
                 // Cycle detected: skip remaining effects as failures
@@ -1104,53 +986,23 @@ pub(super) async fn execute_effects_sequential(
 
         // Process the result and update shared state immediately
         match result {
-            SingleEffectResult::Basic(basic) => match basic {
-                BasicEffectResult::Success {
-                    state,
-                    resource_id,
-                    resolved_attrs,
-                    binding,
-                } => {
-                    success_count += 1;
-                    if let Some(state) = state {
-                        if let Some(attrs) = &resolved_attrs {
-                            input
-                                .bindings
-                                .record_applied(binding.as_deref(), attrs, &state);
-                        }
-                        applied_states.insert(resource_id, state);
-                    }
-                }
-                BasicEffectResult::Failure { refresh, .. } => {
-                    failure_count += 1;
-                    failed_indices.insert(finished_idx);
-                    if let Some((id, identifier)) = refresh
-                        && !identifier.is_empty()
-                    {
-                        pending_refreshes.insert(id, identifier);
-                    }
-                }
-                BasicEffectResult::PartialSuccess {
-                    state,
-                    resource_id,
-                    diagnostic,
-                    resolved_attrs,
-                    binding,
-                } => {
-                    partial_count += 1;
-                    if let Some(attrs) = &resolved_attrs {
-                        input
-                            .bindings
-                            .record_applied(binding.as_deref(), attrs, &state);
-                    }
-                    applied_states.insert(resource_id.clone(), state);
-                    partial_diagnostics.push((resource_id, diagnostic));
-                }
-                BasicEffectResult::Deleted { resource_id } => {
-                    success_count += 1;
-                    successfully_deleted.insert(resource_id);
-                }
-            },
+            SingleEffectResult::Basic(basic) => {
+                process_basic_result(
+                    basic,
+                    &mut ExecutionState {
+                        idx: finished_idx,
+                        success_count: &mut success_count,
+                        failure_count: &mut failure_count,
+                        partial_count: &mut partial_count,
+                        partial_diagnostics: &mut partial_diagnostics,
+                        applied_states: &mut applied_states,
+                        failed_indices: &mut failed_indices,
+                        successfully_deleted: &mut successfully_deleted,
+                        pending_refreshes: &mut pending_refreshes,
+                        bindings: &mut input.bindings,
+                    },
+                );
+            }
             SingleEffectResult::Replace {
                 success,
                 state,

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio_util::sync::CancellationToken;
 
-use crate::deps::{find_failed_dependency, get_resource_dependencies};
+use crate::deps::get_resource_dependencies;
 use crate::effect::Effect;
 use crate::provider::{
     CreateRequest, DeleteRequest, PartialReadDiagnostic, Provider, UpdateOutcome, UpdateRequest,
@@ -19,13 +19,17 @@ use super::basic::{
     count_actionable_effects, execute_basic_effect, process_basic_result, queue_state_refresh,
     refresh_pending_states, resolve_resource, resolve_resource_with_source,
 };
-use super::deferred_dispatch::{DeferredDispatchResult, PureMetaCtx, dispatch_deferred_create};
-use super::parallel::{
-    apply_deferred_replace_delete_deps, expand_deferred_replace_effects, is_runtime_dispatchable,
-};
+use super::deferred_dispatch::PureMetaCtx;
+use super::parallel::{expand_deferred_replace_effects, is_runtime_dispatchable};
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
+use super::scheduler::{
+    PureMetaOutcome, build_phase_scheduler_deps, build_post_replace_wait_scheduler_deps,
+    dependency_failed_reason, emit_cancelled_skips_with_progress,
+    failed_binding_names_for_wait_terminal_check, find_failed_dependency_index,
+    try_dispatch_pure_meta, wait_dependency_failed_reason,
+};
 use super::wait::{
-    AppliedStates, SKIP_REASON_CANCELLED, UnsatisfiableReason, WaitAwareInFlight, WaitOutcome,
+    AppliedStates, SKIP_REASON_CANCELLED, WaitAwareInFlight, WaitOutcome,
     count_effectively_undispatched, resolve_wait_identifier, unsatisfiable_reason_message,
     wait_failure_message,
 };
@@ -33,32 +37,6 @@ use super::{
     ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo,
     UnresolvedResource,
 };
-
-fn emit_cancelled_skips_with_progress<F>(
-    effects: &[Effect],
-    indices: &[usize],
-    dispatched: &mut HashSet<usize>,
-    completed_indices: &mut HashSet<usize>,
-    skip_count: &mut usize,
-    observer: &dyn ExecutionObserver,
-    mut progress_for: F,
-) where
-    F: FnMut(usize) -> ProgressInfo,
-{
-    for &idx in indices {
-        if dispatched.contains(&idx) {
-            continue;
-        }
-        dispatched.insert(idx);
-        completed_indices.insert(idx);
-        observer.on_event(&ExecutionEvent::EffectSkipped {
-            effect: &effects[idx],
-            reason: SKIP_REASON_CANCELLED,
-            progress: progress_for(idx),
-        });
-        *skip_count += 1;
-    }
-}
 
 /// Check if the plan contains multiple Replace effects that depend on each other.
 pub(super) fn has_interdependent_replaces(effects: &[Effect]) -> bool {
@@ -355,14 +333,12 @@ pub(super) enum PhaseEffectResult {
     },
     /// Phase 2: CBD create failed
     CbdCreateFailure {
-        binding: Option<String>,
         refreshes: Vec<(ResourceId, String)>,
     },
     /// Phase 3: Replace delete succeeded
     ReplaceDeleteSuccess,
     /// Phase 3: Replace delete failed
     ReplaceDeleteFailure {
-        binding: Option<String>,
         refresh: Option<(ResourceId, String)>,
         cbd_refresh: Option<(ResourceId, String)>,
     },
@@ -375,7 +351,7 @@ pub(super) enum PhaseEffectResult {
         binding: Option<String>,
     },
     /// Phase 4: Non-CBD create failed
-    NonCbdCreateFailure { binding: Option<String> },
+    NonCbdCreateFailure,
     /// Phase 4: CBD finalization succeeded
     CbdFinalizeSuccess {
         state: State,
@@ -387,7 +363,6 @@ pub(super) enum PhaseEffectResult {
     CbdFinalizeFailed {
         state: State,
         resource_id: ResourceId,
-        binding: Option<String>,
     },
 }
 
@@ -410,7 +385,7 @@ pub(super) async fn execute_effects_phased(
     let mut partial_diagnostics = Vec::new();
     let mut skip_count = 0;
     let (mut applied_states, wait_identifiers) = AppliedStates::with_initial(&input.current_states);
-    let mut failed_bindings: HashSet<String> = HashSet::new();
+    let mut failed_indices: HashSet<usize> = HashSet::new();
     let mut successfully_deleted: HashSet<ResourceId> = HashSet::new();
     let mut permanent_name_overrides: HashMap<ResourceId, HashMap<String, String>> = HashMap::new();
     let mut pending_refreshes: HashMap<ResourceId, String> = HashMap::new();
@@ -441,6 +416,8 @@ pub(super) async fn execute_effects_phased(
         .collect();
     let post_replace_wait_set: HashSet<usize> = post_replace_wait_indices.iter().copied().collect();
     let mut cancelled = false;
+    let phase1_completed_indices_for_later: HashSet<usize>;
+    let mut phase4_completed_indices_for_later: HashSet<usize> = HashSet::new();
 
     // -----------------------------------------------------------------------
     // Phase 1: Non-Replace effects with parallel execution
@@ -466,13 +443,13 @@ pub(super) async fn execute_effects_phased(
             .collect();
 
         let mut phase1_indices = phase1_indices;
-        let mut deps_of = build_phase_dependency_map(
+        let mut deps_of = build_phase_scheduler_deps(
             &effects,
             &phase1_indices,
             input.unresolved_resources,
             input.compositions,
+            &deferred_replace_delete_deps,
         );
-        apply_deferred_replace_delete_deps(&mut deps_of, &deferred_replace_delete_deps);
         let mut completed_indices: HashSet<usize> = HashSet::new();
         let mut dispatched: HashSet<usize> = HashSet::new();
         let mut in_flight: WaitAwareInFlight<'_, PhaseEffectResult> = WaitAwareInFlight::new();
@@ -509,20 +486,18 @@ pub(super) async fn execute_effects_phased(
                 dispatched.insert(idx);
                 let effect = effects[idx].clone();
 
-                if let Some(failed_dep) = find_failed_dependency(&effect, &failed_bindings) {
+                if let Some(failed_dep) =
+                    find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
+                {
                     let c = if effect.is_scheduler_meta() {
                         completed.load(Ordering::Relaxed)
                     } else {
                         completed.fetch_add(1, Ordering::Relaxed) + 1
                     };
                     let reason = if effect.is_wait() {
-                        let detail =
-                            unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
-                                binding: failed_dep,
-                            });
-                        format!("unsatisfiable: {detail}")
+                        wait_dependency_failed_reason(&failed_dep)
                     } else {
-                        format!("dependency '{}' failed", failed_dep)
+                        dependency_failed_reason(&failed_dep)
                     };
                     observer.on_event(&ExecutionEvent::EffectSkipped {
                         effect: &effect,
@@ -533,117 +508,48 @@ pub(super) async fn execute_effects_phased(
                         },
                     });
                     skip_count += 1;
-                    if let Some(binding) = effect.binding_name() {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(idx);
                     completed_indices.insert(idx);
                     continue;
                 }
 
-                if let Effect::DeferredCreate {
-                    upstream_binding,
-                    template,
-                    ..
-                } = &effect
-                {
-                    let dispatch_ctx = PureMetaCtx {
-                        completed: &completed,
-                        total,
-                        observer,
-                    };
-                    let children = match dispatch_deferred_create(
-                        &effect,
-                        upstream_binding,
-                        template,
-                        &input.bindings,
-                        &dispatch_ctx,
-                    ) {
-                        DeferredDispatchResult::Materialized(children) => children,
-                        DeferredDispatchResult::MaterializeFailed => {
-                            failure_count += 1;
-                            failed_bindings.insert(template.binding_name.clone());
-                            completed_indices.insert(idx);
-                            completed_synchronous_dispatch = true;
-                            break;
-                        }
-                    };
-                    if !children.is_empty() {
-                        total += count_actionable_effects(&children);
-                        for child in children {
-                            let child_idx = effects.len();
-                            if let Effect::Create(resource) = &child {
-                                runtime_synthesized_resources.push(resource.clone());
-                            }
-                            effects.push(child);
-                            phase1_indices.push(child_idx);
-                        }
-                        deps_of = build_phase_dependency_map(
-                            &effects,
-                            &phase1_indices,
-                            input.unresolved_resources,
-                            input.compositions,
-                        );
-                        apply_deferred_replace_delete_deps(
-                            &mut deps_of,
-                            &deferred_replace_delete_deps,
-                        );
+                let dispatch_ctx = PureMetaCtx {
+                    completed: &completed,
+                    total,
+                    observer,
+                };
+                match try_dispatch_pure_meta(&effect, &input.bindings, &dispatch_ctx) {
+                    PureMetaOutcome::NotPureMeta => {}
+                    PureMetaOutcome::Failed => {
+                        failure_count += 1;
+                        failed_indices.insert(idx);
+                        completed_indices.insert(idx);
+                        completed_synchronous_dispatch = true;
+                        break;
                     }
-                    completed_indices.insert(idx);
-                    completed_synchronous_dispatch = true;
-                    break;
-                }
-
-                if let Effect::DeferredReplace {
-                    upstream_binding,
-                    template,
-                    ..
-                } = &effect
-                {
-                    let dispatch_ctx = PureMetaCtx {
-                        completed: &completed,
-                        total,
-                        observer,
-                    };
-                    let children = match dispatch_deferred_create(
-                        &effect,
-                        upstream_binding,
-                        template,
-                        &input.bindings,
-                        &dispatch_ctx,
-                    ) {
-                        DeferredDispatchResult::Materialized(children) => children,
-                        DeferredDispatchResult::MaterializeFailed => {
-                            failure_count += 1;
-                            failed_bindings.insert(template.binding_name.clone());
-                            completed_indices.insert(idx);
-                            completed_synchronous_dispatch = true;
-                            break;
-                        }
-                    };
-                    if !children.is_empty() {
-                        total += count_actionable_effects(&children);
-                        for child in children {
-                            let child_idx = effects.len();
-                            if let Effect::Create(resource) = &child {
-                                runtime_synthesized_resources.push(resource.clone());
+                    PureMetaOutcome::Materialized(children) => {
+                        if !children.is_empty() {
+                            total += count_actionable_effects(&children);
+                            for child in children {
+                                let child_idx = effects.len();
+                                if let Effect::Create(resource) = &child {
+                                    runtime_synthesized_resources.push(resource.clone());
+                                }
+                                effects.push(child);
+                                phase1_indices.push(child_idx);
                             }
-                            effects.push(child);
-                            phase1_indices.push(child_idx);
+                            deps_of = build_phase_scheduler_deps(
+                                &effects,
+                                &phase1_indices,
+                                input.unresolved_resources,
+                                input.compositions,
+                                &deferred_replace_delete_deps,
+                            );
                         }
-                        deps_of = build_phase_dependency_map(
-                            &effects,
-                            &phase1_indices,
-                            input.unresolved_resources,
-                            input.compositions,
-                        );
-                        apply_deferred_replace_delete_deps(
-                            &mut deps_of,
-                            &deferred_replace_delete_deps,
-                        );
+                        completed_indices.insert(idx);
+                        completed_synchronous_dispatch = true;
+                        break;
                     }
-                    completed_indices.insert(idx);
-                    completed_synchronous_dispatch = true;
-                    break;
                 }
 
                 if let Effect::Wait {
@@ -752,22 +658,27 @@ pub(super) async fn execute_effects_phased(
                 continue;
             }
 
-            let count_undispatched =
-                |dispatched: &HashSet<usize>, failed_bindings: &HashSet<String>| {
-                    count_effectively_undispatched(
-                        &phase1_indices,
-                        dispatched,
-                        &effects,
-                        failed_bindings,
-                    )
-                };
+            let failed_binding_name_set =
+                failed_binding_names_for_wait_terminal_check(&effects, &failed_indices);
+            let count_undispatched = |dispatched: &HashSet<usize>| {
+                count_effectively_undispatched(
+                    &phase1_indices,
+                    dispatched,
+                    &effects,
+                    &failed_binding_name_set,
+                )
+            };
             in_flight
-                .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                .check_terminal(count_undispatched(&dispatched))
                 .cancel_if_terminal()
                 .drop_without_awaiting();
 
             if in_flight.is_empty() {
                 if cancelled {
+                    let mut progress_for = |_| ProgressInfo {
+                        completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
+                        total,
+                    };
                     emit_cancelled_skips_with_progress(
                         &effects,
                         &phase1_indices,
@@ -775,10 +686,7 @@ pub(super) async fn execute_effects_phased(
                         &mut completed_indices,
                         &mut skip_count,
                         observer,
-                        |_| ProgressInfo {
-                            completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
-                            total,
-                        },
+                        &mut progress_for,
                     );
                 }
                 break;
@@ -786,7 +694,7 @@ pub(super) async fn execute_effects_phased(
 
             let (finished_idx, result) = if cancelled {
                 let Some(finished) = in_flight
-                    .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                    .check_terminal(count_undispatched(&dispatched))
                     .cancel_if_terminal()
                     .next_completed()
                     .await
@@ -803,7 +711,7 @@ pub(super) async fn execute_effects_phased(
                         continue;
                     }
                     finished = in_flight
-                        .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                        .check_terminal(count_undispatched(&dispatched))
                         .cancel_if_terminal()
                         .next_completed() => {
                         let Some(finished) = finished else {
@@ -820,12 +728,13 @@ pub(super) async fn execute_effects_phased(
                     process_basic_result(
                         basic,
                         &mut ExecutionState {
+                            idx: finished_idx,
                             success_count: &mut success_count,
                             failure_count: &mut failure_count,
                             partial_count: &mut partial_count,
                             partial_diagnostics: &mut partial_diagnostics,
                             applied_states: &mut applied_states,
-                            failed_bindings: &mut failed_bindings,
+                            failed_indices: &mut failed_indices,
                             successfully_deleted: &mut successfully_deleted,
                             pending_refreshes: &mut pending_refreshes,
                             bindings: &mut input.bindings,
@@ -866,7 +775,7 @@ pub(super) async fn execute_effects_phased(
                             progress,
                         });
                         skip_count += 1;
-                        failed_bindings.insert(binding);
+                        failed_indices.insert(finished_idx);
                     }
                     WaitOutcome::Cancelled => {
                         observer.on_event(&ExecutionEvent::EffectSkipped {
@@ -888,16 +797,17 @@ pub(super) async fn execute_effects_phased(
                             progress,
                         });
                         failure_count += 1;
-                        failed_bindings.insert(binding);
+                        failed_indices.insert(finished_idx);
                     }
                 },
                 _ => unreachable!(),
             }
             in_flight
-                .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                .check_terminal(count_undispatched(&dispatched))
                 .cancel_if_terminal()
                 .drop_without_awaiting();
         }
+        phase1_completed_indices_for_later = completed_indices;
     }
     // -----------------------------------------------------------------------
     // Phase 2: CBD creates with parallel execution (forward dependency order)
@@ -977,16 +887,16 @@ pub(super) async fn execute_effects_phased(
                 let effect = &effects[idx];
                 let progress = replace_progress[&idx];
 
-                if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
-                    let reason = format!("dependency '{}' failed", failed_dep);
+                if let Some(failed_dep) =
+                    find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
+                {
+                    let reason = dependency_failed_reason(&failed_dep);
                     observer.on_event(&ExecutionEvent::EffectSkipped {
                         effect,
                         reason: &reason,
                         progress,
                     });
-                    if let Some(binding) = effect.binding_name() {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(idx);
                     completed_indices.insert(idx);
                     continue;
                 }
@@ -1033,7 +943,6 @@ pub(super) async fn execute_effects_phased(
                                     idx,
                                     started,
                                     PhaseEffectResult::Basic(BasicEffectResult::Failure {
-                                        binding: effect.binding_name(),
                                         refresh: None,
                                     }),
                                 );
@@ -1161,10 +1070,7 @@ pub(super) async fn execute_effects_phased(
                                     (
                                         idx,
                                         started,
-                                        PhaseEffectResult::CbdCreateFailure {
-                                            binding: effect.binding_name(),
-                                            refreshes,
-                                        },
+                                        PhaseEffectResult::CbdCreateFailure { refreshes },
                                     )
                                 } else {
                                     (
@@ -1192,7 +1098,6 @@ pub(super) async fn execute_effects_phased(
                                     idx,
                                     started,
                                     PhaseEffectResult::CbdCreateFailure {
-                                        binding: effect.binding_name(),
                                         refreshes: Vec::new(),
                                     },
                                 )
@@ -1206,6 +1111,7 @@ pub(super) async fn execute_effects_phased(
 
             if in_flight.is_empty() {
                 if cancelled {
+                    let mut progress_for = |idx| replace_progress[&idx];
                     emit_cancelled_skips_with_progress(
                         &effects,
                         &cbd_indices,
@@ -1213,7 +1119,7 @@ pub(super) async fn execute_effects_phased(
                         &mut completed_indices,
                         &mut skip_count,
                         observer,
-                        |idx| replace_progress[&idx],
+                        &mut progress_for,
                     );
                 }
                 break;
@@ -1269,13 +1175,9 @@ pub(super) async fn execute_effects_phased(
                     replace_start_times.insert(idx, started);
                     cbd_create_states.insert(idx, state);
                 }
-                PhaseEffectResult::CbdCreateFailure {
-                    binding, refreshes, ..
-                } => {
+                PhaseEffectResult::CbdCreateFailure { refreshes, .. } => {
                     failure_count += 1;
-                    if let Some(binding) = binding {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(finished_idx);
                     for (id, identifier) in refreshes {
                         queue_state_refresh(&mut pending_refreshes, &id, Some(&identifier));
                     }
@@ -1284,12 +1186,13 @@ pub(super) async fn execute_effects_phased(
                     process_basic_result(
                         basic,
                         &mut ExecutionState {
+                            idx: finished_idx,
                             success_count: &mut success_count,
                             failure_count: &mut failure_count,
                             partial_count: &mut partial_count,
                             partial_diagnostics: &mut partial_diagnostics,
                             applied_states: &mut applied_states,
-                            failed_bindings: &mut failed_bindings,
+                            failed_indices: &mut failed_indices,
                             successfully_deleted: &mut successfully_deleted,
                             pending_refreshes: &mut pending_refreshes,
                             bindings: &mut input.bindings,
@@ -1304,6 +1207,12 @@ pub(super) async fn execute_effects_phased(
     // Phase 3: All deletes with parallel execution (reverse dependency order)
     // -----------------------------------------------------------------------
     if !cancelled {
+        let replace_deps_of = build_phase_dependency_map(
+            &effects,
+            &sorted_indices,
+            input.unresolved_resources,
+            input.compositions,
+        );
         // Collect indices for deletes that should execute: all Replace effects
         // that haven't been failed/skipped. For CBD, skip if create phase failed.
         let delete_indices: Vec<usize> = sorted_indices
@@ -1314,7 +1223,14 @@ pub(super) async fn execute_effects_phased(
                 let effect = &effects[idx];
                 if let Effect::Replace { directives, .. } = effect {
                     // Skip if dependency failed
-                    if find_failed_dependency(effect, &failed_bindings).is_some() {
+                    if find_failed_dependency_index(
+                        idx,
+                        &replace_deps_of,
+                        &failed_indices,
+                        &effects,
+                    )
+                    .is_some()
+                    {
                         return false;
                     }
                     // For CBD, skip if create didn't succeed
@@ -1330,26 +1246,12 @@ pub(super) async fn execute_effects_phased(
 
         // For phase 3, dependencies are reversed: dependents should delete before parents.
         // Build a reverse dependency map for the delete phase.
-        let phase_set: HashSet<usize> = delete_indices.iter().copied().collect();
-        let mut binding_to_idx: HashMap<String, usize> = HashMap::new();
-        for &idx in &delete_indices {
-            if let Some(binding) = effects[idx].binding_name() {
-                binding_to_idx.insert(binding, idx);
-            }
-        }
-        let resolver = DepResolver::new(&binding_to_idx, input.compositions, Some(&phase_set));
-        let mut deps_of: HashMap<usize, HashSet<usize>> = HashMap::new();
-        for &idx in &delete_indices {
-            let effect = &effects[idx];
-            let mut dep_indices = HashSet::new();
-            if effect.as_resource_ref().is_some() {
-                resolver.collect_from_effect(effect, &mut dep_indices);
-                if let Some(unresolved) = input.unresolved_resources.get(effect.resource_id()) {
-                    resolver.collect_from_resource(unresolved.as_resource(), &mut dep_indices);
-                }
-            }
-            deps_of.insert(idx, dep_indices);
-        }
+        let deps_of = build_phase_dependency_map(
+            &effects,
+            &delete_indices,
+            input.unresolved_resources,
+            input.compositions,
+        );
 
         // For reverse order: swap the dependency direction.
         // In forward order, parent has no deps, child depends on parent.
@@ -1457,7 +1359,6 @@ pub(super) async fn execute_effects_phased(
                                 (
                                     idx,
                                     PhaseEffectResult::ReplaceDeleteFailure {
-                                        binding: effect.binding_name(),
                                         refresh: Some((id.clone(), identifier.to_string())),
                                         cbd_refresh: cbd_refresh_info,
                                     },
@@ -1472,6 +1373,7 @@ pub(super) async fn execute_effects_phased(
 
             if in_flight.is_empty() {
                 if cancelled {
+                    let mut progress_for = |idx| replace_progress[&idx];
                     emit_cancelled_skips_with_progress(
                         &effects,
                         &delete_indices,
@@ -1479,7 +1381,7 @@ pub(super) async fn execute_effects_phased(
                         &mut completed_indices,
                         &mut skip_count,
                         observer,
-                        |idx| replace_progress[&idx],
+                        &mut progress_for,
                     );
                 }
                 break;
@@ -1504,14 +1406,11 @@ pub(super) async fn execute_effects_phased(
                     // Delete succeeded, will be finalized in phase 4
                 }
                 PhaseEffectResult::ReplaceDeleteFailure {
-                    binding,
                     refresh,
                     cbd_refresh,
                 } => {
                     failure_count += 1;
-                    if let Some(binding) = binding {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(finished_idx);
                     if let Some((id, identifier)) = refresh {
                         queue_state_refresh(&mut pending_refreshes, &id, Some(&identifier));
                     }
@@ -1554,14 +1453,23 @@ pub(super) async fn execute_effects_phased(
         ));
         phase4_indices.sort();
 
-        let mut deps_of = build_phase_dependency_map(
+        let phase4_set: HashSet<usize> = phase4_indices.iter().copied().collect();
+        let phase4_pre_completed_indices: HashSet<usize> = deferred_replace_delete_deps
+            .iter()
+            .filter_map(|&(gate_idx, delete_idx)| {
+                (phase4_set.contains(&gate_idx)
+                    && phase1_completed_indices_for_later.contains(&delete_idx))
+                .then_some(delete_idx)
+            })
+            .collect();
+        let mut deps_of = build_phase_scheduler_deps(
             &effects,
             &phase4_indices,
             input.unresolved_resources,
             input.compositions,
+            &deferred_replace_delete_deps,
         );
-        apply_deferred_replace_delete_deps(&mut deps_of, &deferred_replace_delete_deps);
-        let mut completed_indices: HashSet<usize> = HashSet::new();
+        let mut completed_indices: HashSet<usize> = phase4_pre_completed_indices;
         let mut dispatched: HashSet<usize> = HashSet::new();
         type PhaseFuture<'a> =
             std::pin::Pin<Box<dyn std::future::Future<Output = (usize, PhaseEffectResult)> + 'a>>;
@@ -1601,8 +1509,10 @@ pub(super) async fn execute_effects_phased(
                 dispatched.insert(idx);
                 let effect = effects[idx].clone();
 
-                if let Some(failed_dep) = find_failed_dependency(&effect, &failed_bindings) {
-                    let reason = format!("dependency '{}' failed", failed_dep);
+                if let Some(failed_dep) =
+                    find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
+                {
+                    let reason = dependency_failed_reason(&failed_dep);
                     let progress =
                         replace_progress
                             .get(&idx)
@@ -1616,125 +1526,48 @@ pub(super) async fn execute_effects_phased(
                         reason: &reason,
                         progress,
                     });
-                    if let Some(binding) = effect.binding_name() {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(idx);
                     completed_indices.insert(idx);
                     continue;
                 }
 
-                if let Effect::DeferredCreate {
-                    upstream_binding,
-                    template,
-                    ..
-                } = &effect
-                {
-                    let dispatch_ctx = PureMetaCtx {
-                        completed: &completed,
-                        total,
-                        observer,
-                    };
-                    let children = match dispatch_deferred_create(
-                        &effect,
-                        upstream_binding,
-                        template,
-                        &input.bindings,
-                        &dispatch_ctx,
-                    ) {
-                        DeferredDispatchResult::Materialized(children) => children,
-                        DeferredDispatchResult::MaterializeFailed => {
-                            failure_count += 1;
-                            failed_bindings.insert(template.binding_name.clone());
-                            completed_indices.insert(idx);
-                            completed_synchronous_dispatch = true;
-                            break;
-                        }
-                    };
-                    if !children.is_empty() {
-                        total += count_actionable_effects(&children);
-                        for child in children {
-                            let child_idx = effects.len();
-                            if let Effect::Create(resource) = &child {
-                                runtime_synthesized_resources.push(resource.clone());
-                                debug_assert!(
-                                    resource.dependency_bindings.contains(upstream_binding),
-                                    "apply-time deferred-for child must retain iterable dependency"
-                                );
-                            }
-                            effects.push(child);
-                            phase4_indices.push(child_idx);
-                        }
-                        deps_of = build_phase_dependency_map(
-                            &effects,
-                            &phase4_indices,
-                            input.unresolved_resources,
-                            input.compositions,
-                        );
-                        apply_deferred_replace_delete_deps(
-                            &mut deps_of,
-                            &deferred_replace_delete_deps,
-                        );
+                let dispatch_ctx = PureMetaCtx {
+                    completed: &completed,
+                    total,
+                    observer,
+                };
+                match try_dispatch_pure_meta(&effect, &input.bindings, &dispatch_ctx) {
+                    PureMetaOutcome::NotPureMeta => {}
+                    PureMetaOutcome::Failed => {
+                        failure_count += 1;
+                        failed_indices.insert(idx);
+                        completed_indices.insert(idx);
+                        completed_synchronous_dispatch = true;
+                        break;
                     }
-                    completed_indices.insert(idx);
-                    completed_synchronous_dispatch = true;
-                    break;
-                }
-
-                if let Effect::DeferredReplace {
-                    upstream_binding,
-                    template,
-                    ..
-                } = &effect
-                {
-                    let dispatch_ctx = PureMetaCtx {
-                        completed: &completed,
-                        total,
-                        observer,
-                    };
-                    let children = match dispatch_deferred_create(
-                        &effect,
-                        upstream_binding,
-                        template,
-                        &input.bindings,
-                        &dispatch_ctx,
-                    ) {
-                        DeferredDispatchResult::Materialized(children) => children,
-                        DeferredDispatchResult::MaterializeFailed => {
-                            failure_count += 1;
-                            failed_bindings.insert(template.binding_name.clone());
-                            completed_indices.insert(idx);
-                            completed_synchronous_dispatch = true;
-                            break;
-                        }
-                    };
-                    if !children.is_empty() {
-                        total += count_actionable_effects(&children);
-                        for child in children {
-                            let child_idx = effects.len();
-                            if let Effect::Create(resource) = &child {
-                                runtime_synthesized_resources.push(resource.clone());
-                                debug_assert!(
-                                    resource.dependency_bindings.contains(upstream_binding),
-                                    "apply-time deferred-for child must retain iterable dependency"
-                                );
+                    PureMetaOutcome::Materialized(children) => {
+                        if !children.is_empty() {
+                            total += count_actionable_effects(&children);
+                            for child in children {
+                                let child_idx = effects.len();
+                                if let Effect::Create(resource) = &child {
+                                    runtime_synthesized_resources.push(resource.clone());
+                                }
+                                effects.push(child);
+                                phase4_indices.push(child_idx);
                             }
-                            effects.push(child);
-                            phase4_indices.push(child_idx);
+                            deps_of = build_phase_scheduler_deps(
+                                &effects,
+                                &phase4_indices,
+                                input.unresolved_resources,
+                                input.compositions,
+                                &deferred_replace_delete_deps,
+                            );
                         }
-                        deps_of = build_phase_dependency_map(
-                            &effects,
-                            &phase4_indices,
-                            input.unresolved_resources,
-                            input.compositions,
-                        );
-                        apply_deferred_replace_delete_deps(
-                            &mut deps_of,
-                            &deferred_replace_delete_deps,
-                        );
+                        completed_indices.insert(idx);
+                        completed_synchronous_dispatch = true;
+                        break;
                     }
-                    completed_indices.insert(idx);
-                    completed_synchronous_dispatch = true;
-                    break;
                 }
 
                 if effect.as_basic().is_some() {
@@ -1890,7 +1723,6 @@ pub(super) async fn execute_effects_phased(
                                             PhaseEffectResult::CbdFinalizeFailed {
                                                 state,
                                                 resource_id: to.id.clone(),
-                                                binding: effect_for_future.binding_name(),
                                             },
                                         )
                                     }
@@ -1939,9 +1771,7 @@ pub(super) async fn execute_effects_phased(
                         }));
                     } else {
                         // Non-CBD: skip if own delete failed
-                        if let Some(binding) = effect.binding_name()
-                            && failed_bindings.contains(&binding)
-                        {
+                        if failed_indices.contains(&idx) {
                             completed_indices.insert(idx);
                             continue;
                         }
@@ -1973,7 +1803,6 @@ pub(super) async fn execute_effects_phased(
                                         return (
                                             idx,
                                             PhaseEffectResult::Basic(BasicEffectResult::Failure {
-                                                binding: effect_for_future.binding_name(),
                                                 refresh: None,
                                             }),
                                         );
@@ -2035,12 +1864,7 @@ pub(super) async fn execute_effects_phased(
                                             duration: started.elapsed(),
                                             progress,
                                         });
-                                        (
-                                            idx,
-                                            PhaseEffectResult::NonCbdCreateFailure {
-                                                binding: effect_for_future.binding_name(),
-                                            },
-                                        )
+                                        (idx, PhaseEffectResult::NonCbdCreateFailure)
                                     }
                                 }
                             } else {
@@ -2057,6 +1881,15 @@ pub(super) async fn execute_effects_phased(
 
             if in_flight.is_empty() {
                 if cancelled {
+                    let mut progress_for = |idx| {
+                        replace_progress
+                            .get(&idx)
+                            .copied()
+                            .unwrap_or_else(|| ProgressInfo {
+                                completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
+                                total,
+                            })
+                    };
                     emit_cancelled_skips_with_progress(
                         &effects,
                         &phase4_indices,
@@ -2064,15 +1897,7 @@ pub(super) async fn execute_effects_phased(
                         &mut completed_indices,
                         &mut skip_count,
                         observer,
-                        |idx| {
-                            replace_progress
-                                .get(&idx)
-                                .copied()
-                                .unwrap_or_else(|| ProgressInfo {
-                                    completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
-                                    total,
-                                })
-                        },
+                        &mut progress_for,
                     );
                 }
                 break;
@@ -2114,18 +1939,12 @@ pub(super) async fn execute_effects_phased(
                         permanent_name_overrides.insert(id, overrides);
                     }
                 }
-                PhaseEffectResult::CbdFinalizeFailed {
-                    state,
-                    resource_id,
-                    binding,
-                } => {
+                PhaseEffectResult::CbdFinalizeFailed { state, resource_id } => {
                     cbd_create_states.remove(&finished_idx);
                     cbd_create_diagnostics.remove(&finished_idx);
                     failure_count += 1;
                     applied_states.insert(resource_id, state);
-                    if let Some(binding) = binding {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(finished_idx);
                 }
                 PhaseEffectResult::NonCbdCreateSuccess {
                     state,
@@ -2145,22 +1964,21 @@ pub(super) async fn execute_effects_phased(
                         .bindings
                         .record_applied(binding.as_deref(), &resolved_attrs, &state);
                 }
-                PhaseEffectResult::NonCbdCreateFailure { binding } => {
+                PhaseEffectResult::NonCbdCreateFailure => {
                     failure_count += 1;
-                    if let Some(binding) = binding {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(finished_idx);
                 }
                 PhaseEffectResult::Basic(basic) => {
                     process_basic_result(
                         basic,
                         &mut ExecutionState {
+                            idx: finished_idx,
                             success_count: &mut success_count,
                             failure_count: &mut failure_count,
                             partial_count: &mut partial_count,
                             partial_diagnostics: &mut partial_diagnostics,
                             applied_states: &mut applied_states,
-                            failed_bindings: &mut failed_bindings,
+                            failed_indices: &mut failed_indices,
                             successfully_deleted: &mut successfully_deleted,
                             pending_refreshes: &mut pending_refreshes,
                             bindings: &mut input.bindings,
@@ -2170,19 +1988,30 @@ pub(super) async fn execute_effects_phased(
                 _ => unreachable!(),
             }
         }
+        phase4_completed_indices_for_later = completed_indices;
     }
 
     // -----------------------------------------------------------------------
     // Phase 5: Waits whose targets were replaced in this phased run
     // -----------------------------------------------------------------------
     if !cancelled && !post_replace_wait_indices.is_empty() {
-        let deps_of = build_phase_dependency_map(
+        let deps_of = build_post_replace_wait_scheduler_deps(
             &effects,
             &post_replace_wait_indices,
             input.unresolved_resources,
             input.compositions,
         );
-        let mut completed_indices: HashSet<usize> = HashSet::new();
+        let post_replace_wait_set: HashSet<usize> =
+            post_replace_wait_indices.iter().copied().collect();
+        let mut completed_indices: HashSet<usize> = deps_of
+            .values()
+            .flat_map(|deps| deps.iter().copied())
+            .filter(|dep_idx| {
+                !post_replace_wait_set.contains(dep_idx)
+                    && (phase4_completed_indices_for_later.contains(dep_idx)
+                        || failed_indices.contains(dep_idx))
+            })
+            .collect();
         let mut dispatched: HashSet<usize> = HashSet::new();
         let mut in_flight: WaitAwareInFlight<'_, PhaseEffectResult> = WaitAwareInFlight::new();
 
@@ -2215,13 +2044,11 @@ pub(super) async fn execute_effects_phased(
                 dispatched.insert(idx);
                 let effect = &effects[idx];
 
-                if let Some(failed_dep) = find_failed_dependency(effect, &failed_bindings) {
+                if let Some(failed_dep) =
+                    find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
+                {
                     let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
-                    let detail =
-                        unsatisfiable_reason_message(&UnsatisfiableReason::DependencyFailed {
-                            binding: failed_dep,
-                        });
-                    let reason = format!("unsatisfiable: {detail}");
+                    let reason = wait_dependency_failed_reason(&failed_dep);
                     observer.on_event(&ExecutionEvent::EffectSkipped {
                         effect,
                         reason: &reason,
@@ -2231,9 +2058,7 @@ pub(super) async fn execute_effects_phased(
                         },
                     });
                     skip_count += 1;
-                    if let Some(binding) = effect.binding_name() {
-                        failed_bindings.insert(binding);
-                    }
+                    failed_indices.insert(idx);
                     completed_indices.insert(idx);
                     continue;
                 }
@@ -2285,22 +2110,27 @@ pub(super) async fn execute_effects_phased(
                 }
             }
 
-            let count_undispatched =
-                |dispatched: &HashSet<usize>, failed_bindings: &HashSet<String>| {
-                    count_effectively_undispatched(
-                        &post_replace_wait_indices,
-                        dispatched,
-                        &effects,
-                        failed_bindings,
-                    )
-                };
+            let failed_binding_name_set =
+                failed_binding_names_for_wait_terminal_check(&effects, &failed_indices);
+            let count_undispatched = |dispatched: &HashSet<usize>| {
+                count_effectively_undispatched(
+                    &post_replace_wait_indices,
+                    dispatched,
+                    &effects,
+                    &failed_binding_name_set,
+                )
+            };
             in_flight
-                .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                .check_terminal(count_undispatched(&dispatched))
                 .cancel_if_terminal()
                 .drop_without_awaiting();
 
             if in_flight.is_empty() {
                 if cancelled {
+                    let mut progress_for = |_| ProgressInfo {
+                        completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
+                        total,
+                    };
                     emit_cancelled_skips_with_progress(
                         &effects,
                         &post_replace_wait_indices,
@@ -2308,10 +2138,7 @@ pub(super) async fn execute_effects_phased(
                         &mut completed_indices,
                         &mut skip_count,
                         observer,
-                        |_| ProgressInfo {
-                            completed: completed.fetch_add(1, Ordering::Relaxed) + 1,
-                            total,
-                        },
+                        &mut progress_for,
                     );
                 }
                 break;
@@ -2319,7 +2146,7 @@ pub(super) async fn execute_effects_phased(
 
             let (finished_idx, result) = if cancelled {
                 let Some(finished) = in_flight
-                    .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                    .check_terminal(count_undispatched(&dispatched))
                     .cancel_if_terminal()
                     .next_completed()
                     .await
@@ -2336,7 +2163,7 @@ pub(super) async fn execute_effects_phased(
                         continue;
                     }
                     finished = in_flight
-                        .check_terminal(count_undispatched(&dispatched, &failed_bindings))
+                        .check_terminal(count_undispatched(&dispatched))
                         .cancel_if_terminal()
                         .next_completed() => {
                         let Some(finished) = finished else {
@@ -2383,7 +2210,7 @@ pub(super) async fn execute_effects_phased(
                             progress,
                         });
                         skip_count += 1;
-                        failed_bindings.insert(binding);
+                        failed_indices.insert(finished_idx);
                     }
                     WaitOutcome::Cancelled => {
                         observer.on_event(&ExecutionEvent::EffectSkipped {
@@ -2405,7 +2232,7 @@ pub(super) async fn execute_effects_phased(
                             progress,
                         });
                         failure_count += 1;
-                        failed_bindings.insert(binding);
+                        failed_indices.insert(finished_idx);
                     }
                 },
                 _ => unreachable!(),

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -173,10 +173,7 @@ pub(super) async fn execute_cbd_replace_parallel(
                 duration: ctx.started.elapsed(),
                 progress: ctx.progress,
             });
-            return SingleEffectResult::Basic(BasicEffectResult::Failure {
-                binding: ctx.effect.binding_name(),
-                refresh: None,
-            });
+            return SingleEffectResult::Basic(BasicEffectResult::Failure { refresh: None });
         }
     };
     let resolved_attrs = resolved.as_resource().resolved_attributes();

--- a/carina-core/src/executor/scheduler.rs
+++ b/carina-core/src/executor/scheduler.rs
@@ -1,0 +1,273 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::binding_index::ResolvedBindings;
+use crate::effect::Effect;
+use crate::parser::DeferredForExpression;
+use crate::resource::ResourceId;
+
+use super::UnresolvedResource;
+use super::deferred_dispatch::{DeferredDispatchResult, PureMetaCtx, dispatch_deferred_create};
+use super::parallel::{
+    apply_deferred_replace_delete_deps, build_dependency_analysis, relax_update_update_edges,
+};
+use super::wait::SKIP_REASON_CANCELLED;
+use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
+
+pub(super) struct PureMetaStep<'a> {
+    effect: &'a Effect,
+    upstream_binding: &'a str,
+    template: &'a DeferredForExpression,
+}
+
+impl<'a> PureMetaStep<'a> {
+    fn from_effect(effect: &'a Effect) -> Option<Self> {
+        match effect {
+            Effect::DeferredCreate {
+                upstream_binding,
+                template,
+                ..
+            }
+            | Effect::DeferredReplace {
+                upstream_binding,
+                template,
+                ..
+            } => Some(Self {
+                effect,
+                upstream_binding,
+                template,
+            }),
+            Effect::Create(_)
+            | Effect::Update { .. }
+            | Effect::Replace { .. }
+            | Effect::Delete { .. }
+            | Effect::Wait { .. }
+            | Effect::Read { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Move { .. } => None,
+        }
+    }
+}
+
+pub(super) enum PureMetaOutcome {
+    NotPureMeta,
+    Materialized(Vec<Effect>),
+    Failed,
+}
+
+pub(super) fn try_dispatch_pure_meta(
+    effect: &Effect,
+    bindings: &ResolvedBindings,
+    ctx: &PureMetaCtx<'_>,
+) -> PureMetaOutcome {
+    let Some(step) = PureMetaStep::from_effect(effect) else {
+        return PureMetaOutcome::NotPureMeta;
+    };
+
+    match dispatch_deferred_create(
+        step.effect,
+        step.upstream_binding,
+        step.template,
+        bindings,
+        ctx,
+    ) {
+        DeferredDispatchResult::Materialized(children) => PureMetaOutcome::Materialized(children),
+        DeferredDispatchResult::MaterializeFailed => PureMetaOutcome::Failed,
+    }
+}
+
+pub(super) fn failure_binding_name(effect: &Effect) -> Option<String> {
+    match effect {
+        Effect::DeferredCreate { template, .. } | Effect::DeferredReplace { template, .. } => {
+            Some(template.binding_name.clone())
+        }
+        _ => effect.binding_name(),
+    }
+}
+
+pub(super) fn build_scheduler_deps(
+    effects: &[Effect],
+    unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
+    compositions: &[crate::resource::Composition],
+    deferred_replace_delete_deps: &[(usize, usize)],
+) -> HashMap<usize, HashSet<usize>> {
+    let mut analysis = build_dependency_analysis(effects, unresolved_resources, compositions);
+    relax_update_update_edges(effects, &mut analysis);
+    let mut deps_of = analysis.into_deps_of();
+    apply_deferred_replace_delete_deps(&mut deps_of, deferred_replace_delete_deps);
+    deps_of
+}
+
+pub(super) fn build_phase_scheduler_deps(
+    effects: &[Effect],
+    phase_indices: &[usize],
+    unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
+    compositions: &[crate::resource::Composition],
+    deferred_replace_delete_deps: &[(usize, usize)],
+) -> HashMap<usize, HashSet<usize>> {
+    let mut deps_of = super::phased::build_phase_dependency_map(
+        effects,
+        phase_indices,
+        unresolved_resources,
+        compositions,
+    );
+    apply_deferred_replace_delete_deps(&mut deps_of, deferred_replace_delete_deps);
+    deps_of
+}
+
+/// Build the dependency map for a "post-replace wait" phase. Combines
+/// `build_phase_dependency_map`'s binding-based edges with cross-phase
+/// target-id edges: each wait's target effect is looked up across the full
+/// effect list, so anonymous replaces still gate their waits.
+pub(super) fn build_post_replace_wait_scheduler_deps(
+    effects: &[Effect],
+    post_replace_wait_indices: &[usize],
+    unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
+    compositions: &[crate::resource::Composition],
+) -> HashMap<usize, HashSet<usize>> {
+    let mut deps_of = super::phased::build_phase_dependency_map(
+        effects,
+        post_replace_wait_indices,
+        unresolved_resources,
+        compositions,
+    );
+    for &idx in post_replace_wait_indices {
+        if let Effect::Wait { target_id, .. } = &effects[idx] {
+            let target_deps = effects.iter().enumerate().filter_map(|(dep_idx, effect)| {
+                (dep_idx != idx && effect.resource_id() == target_id).then_some(dep_idx)
+            });
+            deps_of.entry(idx).or_default().extend(target_deps);
+        }
+    }
+    deps_of
+}
+
+/// Format the user-facing skip reason for a non-Wait effect whose
+/// dependency failed. Centralizing this here keeps both schedulers
+/// (phased / parallel) and both `Named` / `Anonymous` cases in one
+/// place — adding a new variant to [`FailedDependency`] is a compile
+/// error here, not a silent message-format drift across call sites.
+pub(super) fn dependency_failed_reason(failed: &FailedDependency) -> String {
+    match failed {
+        FailedDependency::Named(binding) => format!("dependency '{binding}' failed"),
+        FailedDependency::Anonymous => "dependency failed".to_string(),
+    }
+}
+
+/// Format the user-facing skip reason for a Wait effect whose
+/// dependency failed (renders as `"unsatisfiable: ..."`). Anonymous
+/// dependencies render as a plain `dependency-failed` token rather
+/// than fabricating a binding-shaped placeholder.
+pub(super) fn wait_dependency_failed_reason(failed: &FailedDependency) -> String {
+    match failed {
+        FailedDependency::Named(binding) => {
+            let detail = super::wait::unsatisfiable_reason_message(
+                &super::wait::UnsatisfiableReason::DependencyFailed {
+                    binding: binding.clone(),
+                },
+            );
+            format!("unsatisfiable: {detail}")
+        }
+        FailedDependency::Anonymous => "unsatisfiable: dependency-failed".to_string(),
+    }
+}
+
+/// A failed dependency that blocks `effects[idx]` from dispatching.
+///
+/// The two variants are distinct concepts that callers must handle
+/// separately — they are not interchangeable strings. `Named` carries a
+/// real binding name (suitable for `"dependency '<name>' failed"` style
+/// messages); `Anonymous` means the failed dependency has no binding
+/// identity (e.g. an anonymous `Replace` whose `to.binding` is `None`),
+/// and the message must NOT fabricate a binding-shaped placeholder for
+/// it. Returning a single `String` here would force every consumer to
+/// re-derive that distinction with a `starts_with('#')` check; the
+/// enum makes the broken state unrepresentable.
+#[derive(Debug, Clone)]
+pub(super) enum FailedDependency {
+    Named(String),
+    Anonymous,
+}
+
+/// Find a failed dependency for `effects[idx]`, returning a typed
+/// [`FailedDependency`]. Checks both the in-phase dependency graph
+/// (`deps_of`) and cross-phase failures (any `Effect::blocking_bindings()`
+/// match on a failed-binding name derived from `failed_indices`).
+///
+/// The cross-phase set is derived internally rather than taken as a
+/// parameter: every caller would otherwise have to remember to compute it
+/// from the same `(effects, failed_indices)` it already passes, and a future
+/// caller passing an empty set would silently re-introduce the
+/// cross-phase-failure-missed class of bug (carina#3611).
+pub(super) fn find_failed_dependency_index(
+    idx: usize,
+    deps_of: &HashMap<usize, HashSet<usize>>,
+    failed_indices: &HashSet<usize>,
+    effects: &[Effect],
+) -> Option<FailedDependency> {
+    let graph_failed_dep = deps_of.get(&idx).and_then(|deps| {
+        deps.iter()
+            .find(|dep_idx| failed_indices.contains(dep_idx))
+            .map(|dep_idx| {
+                effects
+                    .get(*dep_idx)
+                    .and_then(failure_binding_name)
+                    .map_or(FailedDependency::Anonymous, FailedDependency::Named)
+            })
+    });
+    graph_failed_dep.or_else(|| {
+        let blocking = effects[idx].blocking_bindings();
+        if blocking.is_empty() {
+            return None;
+        }
+        let failed_binding_names: HashSet<String> = failed_indices
+            .iter()
+            .filter_map(|i| effects.get(*i).and_then(failure_binding_name))
+            .collect();
+        blocking
+            .into_iter()
+            .find(|binding| failed_binding_names.contains(binding))
+            .map(FailedDependency::Named)
+    })
+}
+
+/// Collect the binding names of failed effects.
+///
+/// Used by the Wait-terminal-check path (`count_effectively_undispatched`)
+/// where the set is consumed standalone, not as input to
+/// `find_failed_dependency_index`. Do not pass the result of this function
+/// to `find_failed_dependency_index` — that function derives its own
+/// cross-phase set internally to keep failure attribution single-source.
+pub(super) fn failed_binding_names_for_wait_terminal_check(
+    effects: &[Effect],
+    failed_indices: &HashSet<usize>,
+) -> HashSet<String> {
+    failed_indices
+        .iter()
+        .filter_map(|idx| effects.get(*idx).and_then(failure_binding_name))
+        .collect()
+}
+
+pub(super) fn emit_cancelled_skips_with_progress(
+    effects: &[Effect],
+    indices: &[usize],
+    dispatched: &mut HashSet<usize>,
+    completed_indices: &mut HashSet<usize>,
+    skip_count: &mut usize,
+    observer: &dyn ExecutionObserver,
+    progress_for: &mut dyn FnMut(usize) -> ProgressInfo,
+) {
+    for &idx in indices {
+        if dispatched.contains(&idx) {
+            continue;
+        }
+        dispatched.insert(idx);
+        completed_indices.insert(idx);
+        observer.on_event(&ExecutionEvent::EffectSkipped {
+            effect: &effects[idx],
+            reason: SKIP_REASON_CANCELLED,
+            progress: progress_for(idx),
+        });
+        *skip_count += 1;
+    }
+}

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -6443,6 +6443,481 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
 }
 
 #[tokio::test]
+async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
+    use crate::effect::ChangedCreateOnly;
+
+    // Regression for carina#3611: current phased.rs records failures by
+    // binding string only, so an expanded DeferredReplace delete failure can
+    // be missed by the DR gate and the child Create is materialized anyway.
+    let cert_id = ResourceId::new("test", "cert_delete_failure_phased");
+    let mut cert = Resource::new("test", "cert_delete_failure_phased");
+    cert.binding = Some("cert".to_string());
+    let old_cert_state =
+        State::existing(cert_id.clone(), HashMap::new()).with_identifier("cert-old");
+
+    let dep_id = ResourceId::new("test", "dep_delete_failure_phased");
+    let mut dep = Resource::new("test", "dep_delete_failure_phased");
+    dep.binding = Some("dep".to_string());
+    dep.dependency_bindings.insert("cert".to_string());
+    let old_dep_state = State::existing(dep_id.clone(), HashMap::new()).with_identifier("dep-old");
+
+    let validation_id = ResourceId::new("test", "validation_records[0]");
+    let validation_state =
+        State::existing(validation_id.clone(), HashMap::new()).with_identifier("new-validation");
+
+    let provider = MockProvider::new();
+    provider.push_delete(Err(ProviderError::api_error("delete failed")));
+    provider.push_delete(Ok(()));
+    provider.push_delete(Ok(()));
+    provider.push_create(Ok(cert_state_for_deferred_replace_deadlock(&cert_id)));
+    provider.push_create(Ok(ok_state(&dep_id)));
+    provider.push_create(Ok(validation_state));
+    for _ in 0..8 {
+        provider.push_read(Ok(State::not_found(validation_id.clone())));
+    }
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: cert_id.clone(),
+        from: Box::new(old_cert_state.clone()),
+        to: cert,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Replace {
+        id: dep_id.clone(),
+        from: Box::new(old_dep_state.clone()),
+        to: dep,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::DeferredReplace {
+        deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
+            id: validation_id.clone(),
+            identifier: "old-validation".to_string(),
+            directives: Directives::default(),
+            binding: Some("validation_records[0]".to_string()),
+            dependencies: HashSet::new(),
+            explicit_dependencies: HashSet::new(),
+        }])
+        .expect("fixture has one delete"),
+        id: ResourceId::new("__deferred_for", "validation_records"),
+        upstream_binding: "cert".to_string(),
+        template: Box::new(validation_deferred_for_expression()),
+    });
+    assert!(
+        has_interdependent_replaces(plan.effects()),
+        "test must exercise phased execution"
+    );
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([
+            (cert_id.clone(), old_cert_state),
+            (dep_id.clone(), old_dep_state),
+        ]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    let calls = provider.calls();
+    assert!(
+        calls
+            .iter()
+            .any(|(op, id)| op == "delete" && id == &validation_id.to_string()),
+        "absorbed delete must be attempted; calls: {calls:?}"
+    );
+    assert!(
+        !calls
+            .iter()
+            .any(|(op, id)| op == "create" && id == &validation_id.to_string()),
+        "DR child Create must not run after absorbed delete failure; calls: {calls:?}"
+    );
+    assert_eq!(
+        result.failure_count,
+        1,
+        "the absorbed delete failure must be reported; events: {:?}",
+        observer.events()
+    );
+    let events = observer.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| event.starts_with("failed:test.validation_records[0]:")),
+        "delete failure must be visible in events: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| {
+            event.starts_with("skipped:__deferred_for.validation_records:")
+                || event.starts_with("failed:__deferred_for.validation_records:")
+        }),
+        "DR gate must be skipped or failed, not silently successful; events: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event == "succeeded:__deferred_for.validation_records"),
+        "DR gate must not be reported as success; events: {events:?}"
+    );
+    assert!(
+        !result
+            .runtime_synthesized_resources
+            .iter()
+            .any(|resource| resource.id == validation_id),
+        "failed DR gate must not synthesize a phantom child"
+    );
+}
+
+#[tokio::test]
+async fn phased_cbd_replace_skips_when_phase1_dependency_fails() {
+    use crate::effect::ChangedCreateOnly;
+
+    let mut bucket = Resource::new("test", "bucket_phase1_cbd_dep");
+    bucket.binding = Some("bucket".to_string());
+
+    let anchor_id = ResourceId::new("test", "anchor_phase1_cbd_dep");
+    let mut anchor_to = Resource::new("test", "anchor_phase1_cbd_dep");
+    anchor_to.binding = Some("anchor".to_string());
+    let anchor_from =
+        State::existing(anchor_id.clone(), HashMap::new()).with_identifier("old-anchor");
+
+    let policy_id = ResourceId::new("test", "policy_phase1_cbd_dep");
+    let mut policy_to = make_resource("policy", &["anchor"]);
+    policy_to.id = policy_id.clone();
+    policy_to.directives = Directives {
+        create_before_destroy: true,
+        depends_on: vec!["bucket".to_string()],
+        ..Default::default()
+    };
+    let policy_from =
+        State::existing(policy_id.clone(), HashMap::new()).with_identifier("old-policy");
+
+    let provider = MockProvider::new();
+    provider.push_create(Err(ProviderError::api_error("bucket create failed")));
+    provider.push_create(Ok(ok_state(&anchor_id)));
+    provider.push_delete(Ok(()));
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(bucket));
+    plan.add(Effect::Replace {
+        id: anchor_id.clone(),
+        from: Box::new(anchor_from.clone()),
+        to: anchor_to,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Replace {
+        id: policy_id.clone(),
+        from: Box::new(policy_from.clone()),
+        to: policy_to,
+        directives: Directives {
+            create_before_destroy: true,
+            depends_on: vec!["bucket".to_string()],
+            ..Default::default()
+        },
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    assert!(
+        has_interdependent_replaces(plan.effects()),
+        "test must exercise phased execution"
+    );
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([
+            (anchor_id.clone(), anchor_from),
+            (policy_id.clone(), policy_from),
+        ]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    let events = observer.events();
+    assert_eq!(result.failure_count, 1, "events: {events:?}");
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "skipped:test.policy_phase1_cbd_dep:dependency 'bucket' failed"),
+        "CBD Replace must be skipped by the failed Phase 1 dependency; events: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("failed:test.policy_phase1_cbd_dep:")),
+        "CBD Replace must not fail from value-ref resolution; events: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn phased_replace_delete_skips_when_phase1_dependency_fails() {
+    use crate::effect::ChangedCreateOnly;
+
+    let mut bucket = Resource::new("test", "bucket_phase1_delete_dep");
+    bucket.binding = Some("bucket".to_string());
+
+    let anchor_id = ResourceId::new("test", "anchor_phase1_delete_dep");
+    let mut anchor_to = Resource::new("test", "anchor_phase1_delete_dep");
+    anchor_to.binding = Some("anchor".to_string());
+    let anchor_from =
+        State::existing(anchor_id.clone(), HashMap::new()).with_identifier("old-anchor");
+
+    let target_id = ResourceId::new("test", "anonymous_phase1_delete_dep");
+    let mut target_to = make_resource("anonymous_phase1_delete_dep", &["anchor"]);
+    target_to.binding = None;
+    target_to.directives.depends_on.push("bucket".to_string());
+    let target_from =
+        State::existing(target_id.clone(), HashMap::new()).with_identifier("old-target");
+
+    let provider = MockProvider::new();
+    provider.push_create(Err(ProviderError::api_error("bucket create failed")));
+    provider.push_create(Ok(ok_state(&anchor_id)));
+    provider.push_delete(Ok(()));
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(bucket));
+    plan.add(Effect::Replace {
+        id: anchor_id.clone(),
+        from: Box::new(anchor_from.clone()),
+        to: anchor_to,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Replace {
+        id: target_id.clone(),
+        from: Box::new(target_from.clone()),
+        to: target_to,
+        directives: Directives {
+            depends_on: vec!["bucket".to_string()],
+            ..Default::default()
+        },
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    assert!(
+        has_interdependent_replaces(plan.effects()),
+        "test must exercise phased execution"
+    );
+    assert_eq!(
+        plan.effects()[2].binding_name(),
+        None,
+        "fixture must cover an anonymous Replace"
+    );
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([
+            (anchor_id.clone(), anchor_from),
+            (target_id.clone(), target_from),
+        ]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    let calls = provider.calls();
+    assert!(
+        !calls
+            .iter()
+            .any(|(op, id)| op == "delete" && id == &target_id.to_string()),
+        "target Replace delete must not run after its Phase 1 dependency fails; calls: {calls:?}"
+    );
+    let events = observer.events();
+    assert_eq!(result.failure_count, 1, "events: {events:?}");
+    assert!(
+        events
+            .iter()
+            .any(|event| event
+                == "skipped:test.anonymous_phase1_delete_dep:dependency 'bucket' failed"),
+        "anonymous Replace must be skipped by the failed Phase 1 dependency; events: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
+    use crate::effect::ChangedCreateOnly;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    // Regression for carina#3611 + carina#3615: current phased.rs keeps
+    // failed_bindings: HashSet<String>, so a failed anonymous Replace
+    // (binding_name() == None) is not recorded and a dependent Wait can run
+    // until timeout instead of being skipped as dependency-failed.
+    let a_id = ResourceId::new("test", "a_anonymous_wait_gate");
+    let mut a = Resource::new("test", "a_anonymous_wait_gate");
+    a.binding = Some("a".to_string());
+    let old_a_state = State::existing(a_id.clone(), HashMap::new()).with_identifier("a-old");
+
+    let b_id = ResourceId::new("test", "b_anonymous_wait_gate");
+    let mut b = Resource::new("test", "b_anonymous_wait_gate");
+    b.binding = Some("b".to_string());
+    b.dependency_bindings.insert("a".to_string());
+    let old_b_state = State::existing(b_id.clone(), HashMap::new()).with_identifier("b-old");
+
+    let anonymous_id = ResourceId::new("test", "anonymous_wait_target");
+    let old_anonymous_state =
+        State::existing(anonymous_id.clone(), HashMap::new()).with_identifier("anon-old");
+    let anonymous_to = Resource::new("test", "anonymous_wait_target");
+
+    let provider = MockProvider::new();
+    provider.push_delete(Ok(()));
+    provider.push_delete(Err(ProviderError::api_error("anonymous replace failed")));
+    provider.push_delete(Ok(()));
+    provider.push_create(Ok(ok_state(&b_id)));
+    provider.push_create(Ok(ok_state(&a_id)));
+    provider.push_create(Ok(ok_state(&anonymous_id)));
+    provider.push_create(Ok(ok_state(&anonymous_id)));
+    for _ in 0..8 {
+        provider.push_read(Ok(State::existing(
+            anonymous_id.clone(),
+            HashMap::from([(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("pending".to_string())),
+            )]),
+        )));
+    }
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: a_id.clone(),
+        from: Box::new(old_a_state.clone()),
+        to: a,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Replace {
+        id: b_id.clone(),
+        from: Box::new(old_b_state.clone()),
+        to: b,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Replace {
+        id: anonymous_id.clone(),
+        from: Box::new(old_anonymous_state.clone()),
+        to: anonymous_to,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Wait {
+        binding: "anonymous_ready".to_string(),
+        target_id: anonymous_id.clone(),
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("ready".to_string())),
+        },
+        until_surface: "anonymous_wait_target.status == \"ready\"".to_string(),
+        timeout: std::time::Duration::ZERO,
+        interval: std::time::Duration::from_millis(1),
+        explicit_dependencies: HashSet::new(),
+    });
+    assert!(
+        has_interdependent_replaces(plan.effects()),
+        "test must exercise phased execution"
+    );
+    assert_eq!(
+        plan.effects()[2].binding_name(),
+        None,
+        "fixture must use an anonymous Replace"
+    );
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([
+            (a_id.clone(), old_a_state),
+            (b_id.clone(), old_b_state),
+            (anonymous_id.clone(), old_anonymous_state),
+        ]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    let events = observer.events();
+    // The skipped event carries the *real* Wait effect, whose
+    // resource_id is its `target_id` (the anonymous resource), and the
+    // reason renders the typed `FailedDependency::Anonymous` branch as
+    // `dependency-failed` rather than fabricating a `#N` placeholder
+    // shaped like a binding name. carina#3611 round-4 self-review: do
+    // not assert against a synthetic `__wait.<binding>` id — that was
+    // the bandaid we removed.
+    assert!(
+        events.iter().any(|event| {
+            event == "skipped:test.anonymous_wait_target:unsatisfiable: dependency-failed"
+        }),
+        "dependent wait must be skipped as dependency-failed; events: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event == "succeeded:test.anonymous_wait_target"),
+        "dependent wait must not be reported as success; events: {events:?}"
+    );
+    assert_eq!(
+        result.skip_count, 1,
+        "dependent wait should be skipped, not polled to timeout; events: {events:?}"
+    );
+}
+
+#[tokio::test]
 async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_normalizer() {
     #[derive(Clone)]
     struct LockOrderScenario {


### PR DESCRIPTION
## Summary

5 件の sibling-drift を一括解消する scheduler 統一 PR です。

#3608 で executor を `failed_indices` + `build_scheduler_deps` + `PureMetaStep` + `failure_binding_name` という primitive 群に書き換えたものの、反映は `parallel.rs` だけで `phased.rs` は元の `failed_bindings: HashSet<String>` のまま残っていました。結果として #3611 (DR gate が absorbed delete 失敗を無視) と #3612-#3615 (3 種の convention seam) が同居していました。本 PR は CLAUDE.md「sibling 経路の同種バグは同じ PR で潰す」「root cause を直すのが topic」に従って 5 件を 1 PR で対応します。

設計書は #3616 で別 merge 済み: `notes/specs/2026-06-26-phased-parallel-scheduler-unification-design.md`

### 主な変更

- 新規 `carina-core/src/executor/scheduler.rs` に共有 primitive を集約: `PureMetaStep` / `try_dispatch_pure_meta` / `FailedDependency` enum / `find_failed_dependency_index` / `failure_binding_name` / `build_scheduler_deps` / `build_phase_scheduler_deps` / `build_post_replace_wait_scheduler_deps` / `emit_cancelled_skips_with_progress`
- `phased.rs` の 5 phase 全てを `failed_indices: HashSet<usize>` に統一。匿名 Replace / Move / Remove の失敗が name 集合から脱落する #3611 と #3615 の根を同時に塞ぐ
- `apply_deferred_replace_delete_deps` の 7 サイト手呼び出しを `build_scheduler_deps` 系 1 呼び出しに集約 (#3612)
- DC / DR dispatch の 4 サイトコピペを `try_dispatch_pure_meta` 共有 fn にまとめる (#3613)
- `failure_binding_name` を scheduler-internal helper として共有化 (#3614 (b))
- `parallel.rs` の `BasicEffectResult` 処理を `process_basic_result` 経由に統一 (これも sibling drift)
- `#N` placeholder 文字列を typed `FailedDependency::{Named, Anonymous}` enum に置き換え (self-review round 4 で typed reshape)
- Phase 5 (post-replace Wait) の cross-phase target-id edge 構築を `build_post_replace_wait_scheduler_deps` helper に吸収

### 設計上の判断

`find_failed_dependency_index` は dep graph に edge がない場合に `effect.blocking_bindings()` ベースの fallback を内部で持ちます。これは phased の phase-scoped dep graph 構造に由来する cross-phase visibility のため必要で、self-review 5 round を通じて「caller が必ず name set を派生して渡す convention seam」を消し、API 内部で完結する形に整理しています。phase 構造そのものを撤廃して 1 つの index ベース graph に統合する根本解は radius が大きく、別 issue として後で対応する余地を残しています。

Wait API (`count_effectively_undispatched`) は依然として name 集合を per-iteration で derive して受け取ります。これは #3615 の本来の解決 (Wait API を index 直接受け取りに変える) の対象で、本 PR では phased / parallel 双方を「派生だけ残った同じ形」に揃え、後続 PR で同時に消せる状態にしています。

### 回帰テスト

4 本追加 (全て phased 経路を強制し、`has_interdependent_replaces()` で確認):

- `phased_deferred_replace_gate_skips_on_absorbed_delete_failure` — #3611 本体。DR gate が absorbed delete 失敗時に child Create を materialize しないこと
- `phased_anonymous_replace_failure_propagates_to_dependent_wait` — #3611 + #3615 合流。匿名 Replace 失敗が依存 Wait に dependency-failed として伝わること
- `phased_cbd_replace_skips_when_phase1_dependency_fails` — code-review で見つけた cross-phase visibility 後退の regression test
- `phased_replace_delete_skips_when_phase1_dependency_fails` — 同上、Phase 3 delete 経路

## Test plan

- [x] `cargo nextest run --workspace` — 4345 tests / 全 pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — 全 pass
- [x] /code-review medium — 8 findings 全て対応 (3 件は機能後退 regression、5 件は cleanup)
- [x] /self-review 5 rounds — round 2 / 3 / 4 で must-fix を順次解消、round 5 で clean