### PR TITLE
fix(executor): unify dispatch and terminal-check failure detection through FailureView (#3618)

### DIFF
--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::effect::Effect;
 use crate::resource::{Resource, Value};
 
 /// Extract binding names that a resource depends on.
@@ -307,18 +306,6 @@ pub fn build_dependents_map(resources: &[&Resource]) -> HashMap<String, HashSet<
     dependents_map
 }
 
-/// Check if an effect has any dependency on failed bindings.
-/// Returns the name of the first failed dependency found, or None.
-pub fn find_failed_dependency(
-    effect: &Effect,
-    failed_bindings: &HashSet<String>,
-) -> Option<String> {
-    effect
-        .blocking_bindings()
-        .into_iter()
-        .find(|dep| failed_bindings.contains(dep))
-}
-
 /// Check if any dependent of the given binding has failed (is in failed_bindings).
 /// Returns the first failed dependent found, if any.
 pub fn find_failed_dependent<'a>(
@@ -344,7 +331,8 @@ pub fn find_failed_dependent<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{DeferredValue, Directives, Resource, ResourceId, Value};
+    use crate::effect::Effect;
+    use crate::resource::{DeferredValue, Resource, ResourceId, Value};
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
     fn wait_effect_with_explicit_dependency(binding: Option<&str>) -> Effect {
@@ -526,110 +514,6 @@ mod tests {
     }
 
     #[test]
-    fn test_find_failed_dependency_direct() {
-        let resource = make_resource("b", &["a"]);
-        let effect = Effect::Create(resource.clone());
-
-        let mut failed = HashSet::new();
-        failed.insert("a".to_string());
-
-        let result = find_failed_dependency(&effect, &failed);
-        assert_eq!(result, Some("a".to_string()));
-    }
-
-    #[test]
-    fn test_find_failed_dependency_none() {
-        let resource = make_resource("b", &["a"]);
-        let effect = Effect::Create(resource.clone());
-
-        let failed: HashSet<String> = HashSet::new();
-
-        let result = find_failed_dependency(&effect, &failed);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_find_failed_dependency_no_deps() {
-        let resource = make_resource("a", &[]);
-        let effect = Effect::Create(resource.clone());
-
-        let mut failed = HashSet::new();
-        failed.insert("x".to_string());
-
-        let result = find_failed_dependency(&effect, &failed);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_find_failed_dependency_transitive_propagation() {
-        let resource_c = make_resource("c", &["b"]);
-        let effect_c = Effect::Create(resource_c.clone());
-
-        let mut failed = HashSet::new();
-        failed.insert("a".to_string());
-        failed.insert("b".to_string());
-
-        let result = find_failed_dependency(&effect_c, &failed);
-        assert_eq!(result, Some("b".to_string()));
-    }
-
-    #[test]
-    fn test_find_failed_dependency_delete_effect() {
-        let effect = Effect::Delete {
-            id: ResourceId::new("test", "a"),
-            identifier: "id-123".to_string(),
-            directives: Directives::default(),
-            binding: None,
-            dependencies: HashSet::new(),
-            explicit_dependencies: std::collections::HashSet::new(),
-        };
-
-        let mut failed = HashSet::new();
-        failed.insert("some_binding".to_string());
-
-        let result = find_failed_dependency(&effect, &failed);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn find_failed_dependency_returns_wait_explicit_dependency_when_failed() {
-        let effect = wait_effect_with_explicit_dependency(Some("failed_binding"));
-        let failed_bindings: HashSet<String> =
-            ["failed_binding"].into_iter().map(String::from).collect();
-
-        assert_eq!(
-            find_failed_dependency(&effect, &failed_bindings),
-            Some("failed_binding".to_string())
-        );
-    }
-
-    #[test]
-    fn find_failed_dependency_returns_wait_target_binding_when_failed() {
-        let effect = wait_effect_with_explicit_dependency(None);
-        let failed_bindings: HashSet<String> = ["cert"].into_iter().map(String::from).collect();
-
-        assert_eq!(
-            find_failed_dependency(&effect, &failed_bindings),
-            Some("cert".to_string())
-        );
-    }
-
-    #[test]
-    fn find_failed_dependency_returns_wait_target_binding_in_preference_to_explicit_when_both_fail()
-    {
-        let effect = wait_effect_with_explicit_dependency(Some("other_failed"));
-        let failed_bindings: HashSet<String> = ["cert", "other_failed"]
-            .into_iter()
-            .map(String::from)
-            .collect();
-
-        assert_eq!(
-            find_failed_dependency(&effect, &failed_bindings),
-            Some("cert".to_string())
-        );
-    }
-
-    #[test]
     fn wait_blocking_bindings_include_target_before_explicit_dependencies() {
         let effect = wait_effect_with_explicit_dependency(Some("other_failed"));
         let blocking_bindings = effect.blocking_bindings();
@@ -639,14 +523,6 @@ mod tests {
             blocking_bindings.into_iter().collect::<HashSet<_>>(),
             HashSet::from(["cert".to_string(), "other_failed".to_string()])
         );
-    }
-
-    #[test]
-    fn find_failed_dependency_returns_none_when_wait_explicit_dependency_did_not_fail() {
-        let effect = wait_effect_with_explicit_dependency(Some("failed_binding"));
-        let failed_bindings: HashSet<String> = HashSet::new();
-
-        assert_eq!(find_failed_dependency(&effect, &failed_bindings), None);
     }
 
     #[test]

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -18,9 +18,8 @@ use super::basic::{
 use super::deferred_dispatch::PureMetaCtx;
 use super::replace::{ReplaceContext, SingleEffectResult, execute_replace_parallel};
 use super::scheduler::{
-    PureMetaOutcome, build_scheduler_deps, dependency_failed_reason,
-    emit_cancelled_skips_with_progress, failed_binding_names_for_wait_terminal_check,
-    failure_binding_name, find_failed_dependency_index, try_dispatch_pure_meta,
+    FailureView, PureMetaOutcome, build_scheduler_deps, dependency_failed_reason,
+    emit_cancelled_skips_with_progress, failure_binding_name, try_dispatch_pure_meta,
     wait_dependency_failed_reason,
 };
 use super::wait::{
@@ -686,9 +685,8 @@ pub(super) async fn execute_effects_sequential(
             dispatched.insert(idx);
             let effect = effects[idx].clone();
 
-            if let Some(failed_dep) =
-                find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
-            {
+            let failure_view = FailureView::new(&effects, &deps_of, &failed_indices);
+            if let Some(failed_dep) = failure_view.find_failed_dependency(idx) {
                 let c = if effect.is_scheduler_meta() {
                     completed.load(Ordering::Relaxed)
                 } else {
@@ -904,14 +902,8 @@ pub(super) async fn execute_effects_sequential(
         }
 
         let count_undispatched = |dispatched: &HashSet<usize>, failed_indices: &HashSet<usize>| {
-            let failed_bindings =
-                failed_binding_names_for_wait_terminal_check(&effects, failed_indices);
-            count_effectively_undispatched(
-                &actionable_indices,
-                dispatched,
-                &effects,
-                &failed_bindings,
-            )
+            let failure_view = FailureView::new(&effects, &deps_of, failed_indices);
+            count_effectively_undispatched(&actionable_indices, dispatched, &failure_view)
         };
         in_flight
             .check_terminal(count_undispatched(&dispatched, &failed_indices))

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -23,10 +23,9 @@ use super::deferred_dispatch::PureMetaCtx;
 use super::parallel::{expand_deferred_replace_effects, is_runtime_dispatchable};
 use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::scheduler::{
-    PureMetaOutcome, build_phase_scheduler_deps, build_post_replace_wait_scheduler_deps,
-    dependency_failed_reason, emit_cancelled_skips_with_progress,
-    failed_binding_names_for_wait_terminal_check, find_failed_dependency_index,
-    try_dispatch_pure_meta, wait_dependency_failed_reason,
+    FailureView, PureMetaOutcome, build_phase_scheduler_deps,
+    build_post_replace_wait_scheduler_deps, dependency_failed_reason,
+    emit_cancelled_skips_with_progress, try_dispatch_pure_meta, wait_dependency_failed_reason,
 };
 use super::wait::{
     AppliedStates, SKIP_REASON_CANCELLED, WaitAwareInFlight, WaitOutcome,
@@ -486,9 +485,8 @@ pub(super) async fn execute_effects_phased(
                 dispatched.insert(idx);
                 let effect = effects[idx].clone();
 
-                if let Some(failed_dep) =
-                    find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
-                {
+                let failure_view = FailureView::new(&effects, &deps_of, &failed_indices);
+                if let Some(failed_dep) = failure_view.find_failed_dependency(idx) {
                     let c = if effect.is_scheduler_meta() {
                         completed.load(Ordering::Relaxed)
                     } else {
@@ -658,18 +656,13 @@ pub(super) async fn execute_effects_phased(
                 continue;
             }
 
-            let failed_binding_name_set =
-                failed_binding_names_for_wait_terminal_check(&effects, &failed_indices);
-            let count_undispatched = |dispatched: &HashSet<usize>| {
-                count_effectively_undispatched(
-                    &phase1_indices,
-                    dispatched,
-                    &effects,
-                    &failed_binding_name_set,
-                )
-            };
+            let count_undispatched =
+                |dispatched: &HashSet<usize>, failed_indices: &HashSet<usize>| {
+                    let failure_view = FailureView::new(&effects, &deps_of, failed_indices);
+                    count_effectively_undispatched(&phase1_indices, dispatched, &failure_view)
+                };
             in_flight
-                .check_terminal(count_undispatched(&dispatched))
+                .check_terminal(count_undispatched(&dispatched, &failed_indices))
                 .cancel_if_terminal()
                 .drop_without_awaiting();
 
@@ -694,7 +687,7 @@ pub(super) async fn execute_effects_phased(
 
             let (finished_idx, result) = if cancelled {
                 let Some(finished) = in_flight
-                    .check_terminal(count_undispatched(&dispatched))
+                    .check_terminal(count_undispatched(&dispatched, &failed_indices))
                     .cancel_if_terminal()
                     .next_completed()
                     .await
@@ -711,7 +704,7 @@ pub(super) async fn execute_effects_phased(
                         continue;
                     }
                     finished = in_flight
-                        .check_terminal(count_undispatched(&dispatched))
+                        .check_terminal(count_undispatched(&dispatched, &failed_indices))
                         .cancel_if_terminal()
                         .next_completed() => {
                         let Some(finished) = finished else {
@@ -803,7 +796,7 @@ pub(super) async fn execute_effects_phased(
                 _ => unreachable!(),
             }
             in_flight
-                .check_terminal(count_undispatched(&dispatched))
+                .check_terminal(count_undispatched(&dispatched, &failed_indices))
                 .cancel_if_terminal()
                 .drop_without_awaiting();
         }
@@ -887,9 +880,8 @@ pub(super) async fn execute_effects_phased(
                 let effect = &effects[idx];
                 let progress = replace_progress[&idx];
 
-                if let Some(failed_dep) =
-                    find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
-                {
+                let failure_view = FailureView::new(&effects, &deps_of, &failed_indices);
+                if let Some(failed_dep) = failure_view.find_failed_dependency(idx) {
                     let reason = dependency_failed_reason(&failed_dep);
                     observer.on_event(&ExecutionEvent::EffectSkipped {
                         effect,
@@ -1223,14 +1215,9 @@ pub(super) async fn execute_effects_phased(
                 let effect = &effects[idx];
                 if let Effect::Replace { directives, .. } = effect {
                     // Skip if dependency failed
-                    if find_failed_dependency_index(
-                        idx,
-                        &replace_deps_of,
-                        &failed_indices,
-                        &effects,
-                    )
-                    .is_some()
-                    {
+                    let failure_view =
+                        FailureView::new(&effects, &replace_deps_of, &failed_indices);
+                    if failure_view.find_failed_dependency(idx).is_some() {
                         return false;
                     }
                     // For CBD, skip if create didn't succeed
@@ -1509,9 +1496,8 @@ pub(super) async fn execute_effects_phased(
                 dispatched.insert(idx);
                 let effect = effects[idx].clone();
 
-                if let Some(failed_dep) =
-                    find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
-                {
+                let failure_view = FailureView::new(&effects, &deps_of, &failed_indices);
+                if let Some(failed_dep) = failure_view.find_failed_dependency(idx) {
                     let reason = dependency_failed_reason(&failed_dep);
                     let progress =
                         replace_progress
@@ -2044,9 +2030,8 @@ pub(super) async fn execute_effects_phased(
                 dispatched.insert(idx);
                 let effect = &effects[idx];
 
-                if let Some(failed_dep) =
-                    find_failed_dependency_index(idx, &deps_of, &failed_indices, &effects)
-                {
+                let failure_view = FailureView::new(&effects, &deps_of, &failed_indices);
+                if let Some(failed_dep) = failure_view.find_failed_dependency(idx) {
                     let c = completed.fetch_add(1, Ordering::Relaxed) + 1;
                     let reason = wait_dependency_failed_reason(&failed_dep);
                     observer.on_event(&ExecutionEvent::EffectSkipped {
@@ -2110,18 +2095,17 @@ pub(super) async fn execute_effects_phased(
                 }
             }
 
-            let failed_binding_name_set =
-                failed_binding_names_for_wait_terminal_check(&effects, &failed_indices);
-            let count_undispatched = |dispatched: &HashSet<usize>| {
-                count_effectively_undispatched(
-                    &post_replace_wait_indices,
-                    dispatched,
-                    &effects,
-                    &failed_binding_name_set,
-                )
-            };
+            let count_undispatched =
+                |dispatched: &HashSet<usize>, failed_indices: &HashSet<usize>| {
+                    let failure_view = FailureView::new(&effects, &deps_of, failed_indices);
+                    count_effectively_undispatched(
+                        &post_replace_wait_indices,
+                        dispatched,
+                        &failure_view,
+                    )
+                };
             in_flight
-                .check_terminal(count_undispatched(&dispatched))
+                .check_terminal(count_undispatched(&dispatched, &failed_indices))
                 .cancel_if_terminal()
                 .drop_without_awaiting();
 
@@ -2146,7 +2130,7 @@ pub(super) async fn execute_effects_phased(
 
             let (finished_idx, result) = if cancelled {
                 let Some(finished) = in_flight
-                    .check_terminal(count_undispatched(&dispatched))
+                    .check_terminal(count_undispatched(&dispatched, &failed_indices))
                     .cancel_if_terminal()
                     .next_completed()
                     .await
@@ -2163,7 +2147,7 @@ pub(super) async fn execute_effects_phased(
                         continue;
                     }
                     finished = in_flight
-                        .check_terminal(count_undispatched(&dispatched))
+                        .check_terminal(count_undispatched(&dispatched, &failed_indices))
                         .cancel_if_terminal()
                         .next_completed() => {
                         let Some(finished) = finished else {

--- a/carina-core/src/executor/scheduler.rs
+++ b/carina-core/src/executor/scheduler.rs
@@ -189,63 +189,58 @@ pub(super) enum FailedDependency {
     Anonymous,
 }
 
-/// Find a failed dependency for `effects[idx]`, returning a typed
-/// [`FailedDependency`]. Checks both the in-phase dependency graph
-/// (`deps_of`) and cross-phase failures (any `Effect::blocking_bindings()`
-/// match on a failed-binding name derived from `failed_indices`).
-///
-/// The cross-phase set is derived internally rather than taken as a
-/// parameter: every caller would otherwise have to remember to compute it
-/// from the same `(effects, failed_indices)` it already passes, and a future
-/// caller passing an empty set would silently re-introduce the
-/// cross-phase-failure-missed class of bug (carina#3611).
-pub(super) fn find_failed_dependency_index(
-    idx: usize,
-    deps_of: &HashMap<usize, HashSet<usize>>,
-    failed_indices: &HashSet<usize>,
-    effects: &[Effect],
-) -> Option<FailedDependency> {
-    let graph_failed_dep = deps_of.get(&idx).and_then(|deps| {
-        deps.iter()
-            .find(|dep_idx| failed_indices.contains(dep_idx))
-            .map(|dep_idx| {
-                effects
-                    .get(*dep_idx)
-                    .and_then(failure_binding_name)
-                    .map_or(FailedDependency::Anonymous, FailedDependency::Named)
-            })
-    });
-    graph_failed_dep.or_else(|| {
-        let blocking = effects[idx].blocking_bindings();
-        if blocking.is_empty() {
-            return None;
-        }
-        let failed_binding_names: HashSet<String> = failed_indices
-            .iter()
-            .filter_map(|i| effects.get(*i).and_then(failure_binding_name))
-            .collect();
-        blocking
-            .into_iter()
-            .find(|binding| failed_binding_names.contains(binding))
-            .map(FailedDependency::Named)
-    })
+/// A snapshot of cumulative cross-phase failure state, paired with the
+/// dependency graph and effect list. Dispatch-time failure detection and
+/// Wait terminal checks share this view so their visibility cannot drift.
+pub(super) struct FailureView<'a> {
+    pub(super) effects: &'a [Effect],
+    pub(super) deps_of: &'a HashMap<usize, HashSet<usize>>,
+    pub(super) failed_indices: &'a HashSet<usize>,
+    failed_binding_names: HashSet<String>,
 }
 
-/// Collect the binding names of failed effects.
-///
-/// Used by the Wait-terminal-check path (`count_effectively_undispatched`)
-/// where the set is consumed standalone, not as input to
-/// `find_failed_dependency_index`. Do not pass the result of this function
-/// to `find_failed_dependency_index` — that function derives its own
-/// cross-phase set internally to keep failure attribution single-source.
-pub(super) fn failed_binding_names_for_wait_terminal_check(
-    effects: &[Effect],
-    failed_indices: &HashSet<usize>,
-) -> HashSet<String> {
-    failed_indices
-        .iter()
-        .filter_map(|idx| effects.get(*idx).and_then(failure_binding_name))
-        .collect()
+impl<'a> FailureView<'a> {
+    pub(super) fn new(
+        effects: &'a [Effect],
+        deps_of: &'a HashMap<usize, HashSet<usize>>,
+        failed_indices: &'a HashSet<usize>,
+    ) -> Self {
+        let failed_binding_names = failed_indices
+            .iter()
+            .filter_map(|idx| effects.get(*idx).and_then(failure_binding_name))
+            .collect();
+        Self {
+            effects,
+            deps_of,
+            failed_indices,
+            failed_binding_names,
+        }
+    }
+
+    /// Find the failed dependency that would cause `effects[idx]` to be
+    /// skipped before dispatch. Checks both in-phase graph edges and the
+    /// cross-phase binding fallback used for phase-scoped dependency maps.
+    pub(super) fn find_failed_dependency(&self, idx: usize) -> Option<FailedDependency> {
+        if let Some(deps) = self.deps_of.get(&idx)
+            && let Some(&dep_idx) = deps.iter().find(|d| self.failed_indices.contains(d))
+        {
+            let name = self.effects.get(dep_idx).and_then(failure_binding_name);
+            return Some(match name {
+                Some(name) => FailedDependency::Named(name),
+                None => FailedDependency::Anonymous,
+            });
+        }
+
+        self.effects[idx]
+            .blocking_bindings()
+            .into_iter()
+            .find(|binding| self.failed_binding_names.contains(binding))
+            .map(FailedDependency::Named)
+    }
+
+    pub(super) fn is_effectively_pre_skipped(&self, idx: usize) -> bool {
+        self.find_failed_dependency(idx).is_some()
+    }
 }
 
 pub(super) fn emit_cancelled_skips_with_progress(

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -6780,8 +6780,8 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
     use crate::effect::ChangedCreateOnly;
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
-    // Regression for carina#3611 + carina#3615: current phased.rs keeps
-    // failed_bindings: HashSet<String>, so a failed anonymous Replace
+    // Regression for carina#3611 + carina#3615: phased execution previously
+    // kept failed_bindings: HashSet<String>, so a failed anonymous Replace
     // (binding_name() == None) is not recorded and a dependent Wait can run
     // until timeout instead of being skipped as dependency-failed.
     let a_id = ResourceId::new("test", "a_anonymous_wait_gate");
@@ -6914,6 +6914,222 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
     assert_eq!(
         result.skip_count, 1,
         "dependent wait should be skipped, not polled to timeout; events: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal() {
+    use crate::effect::ChangedCreateOnly;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let failed_id = ResourceId::new("test", "failed_cross_phase_update");
+    let old_failed_state =
+        State::existing(failed_id.clone(), HashMap::new()).with_identifier("failed-old");
+    let mut failed_to = Resource::new("test", "failed_cross_phase_update");
+    failed_to.binding = Some("b".to_string());
+
+    let parent_id = ResourceId::new("test", "cross_phase_wait_parent");
+    let mut parent = Resource::new("test", "cross_phase_wait_parent");
+    parent.binding = Some("parent".to_string());
+    let old_parent_state =
+        State::existing(parent_id.clone(), HashMap::new()).with_identifier("parent-old");
+
+    let child_id = ResourceId::new("test", "cross_phase_wait_child");
+    let mut child = Resource::new("test", "cross_phase_wait_child");
+    child.binding = Some("child".to_string());
+    child.dependency_bindings.insert("parent".to_string());
+    let old_child_state =
+        State::existing(child_id.clone(), HashMap::new()).with_identifier("child-old");
+
+    let provider = MockProvider::new();
+    provider.push_update(Err(ProviderError::api_error("phase1 update failed")));
+    provider.push_delete(Ok(()));
+    provider.push_delete(Ok(()));
+    provider.push_create(Ok(ok_state(&parent_id)));
+    provider.push_create(Ok(ok_state(&child_id)));
+    for _ in 0..100 {
+        provider.push_read(Ok(State::existing(
+            parent_id.clone(),
+            HashMap::from([(
+                "status".to_string(),
+                Value::Concrete(ConcreteValue::String("pending".to_string())),
+            )]),
+        )));
+    }
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Update {
+        id: failed_id.clone(),
+        from: Box::new(old_failed_state.clone()),
+        to: failed_to,
+        changed_attributes: vec!["name".to_string()],
+    });
+    plan.add(Effect::Replace {
+        id: parent_id.clone(),
+        from: Box::new(old_parent_state.clone()),
+        to: parent,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Replace {
+        id: child_id.clone(),
+        from: Box::new(old_child_state.clone()),
+        to: child,
+        directives: Directives::default(),
+        changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+        cascading_updates: Vec::new(),
+        temporary_name: None,
+        cascade_ref_hints: Vec::new(),
+    });
+    plan.add(Effect::Wait {
+        binding: "sibling_ready".to_string(),
+        target_id: parent_id.clone(),
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("ready".to_string())),
+        },
+        until_surface: "cross_phase_wait_parent.status == \"ready\"".to_string(),
+        timeout: std::time::Duration::from_millis(80),
+        interval: std::time::Duration::from_millis(1),
+        explicit_dependencies: HashSet::new(),
+    });
+    plan.add(Effect::Wait {
+        binding: "blocked_ready".to_string(),
+        target_id: child_id.clone(),
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::Concrete(ConcreteValue::String("ready".to_string())),
+        },
+        until_surface: "cross_phase_wait_child.status == \"ready\"".to_string(),
+        timeout: std::time::Duration::from_millis(80),
+        interval: std::time::Duration::from_millis(1),
+        explicit_dependencies: HashSet::from(["b".to_string(), "sibling_ready".to_string()]),
+    });
+    assert!(
+        has_interdependent_replaces(plan.effects()),
+        "test must exercise phased execution"
+    );
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        compositions: &[],
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::from([
+            (failed_id.clone(), old_failed_state),
+            (parent_id.clone(), old_parent_state),
+            (child_id.clone(), old_child_state),
+        ]),
+        normalizer: &NoopNormalizer,
+        provider_configs: &[],
+        factories: &[],
+        schemas: &TEST_SCHEMAS,
+        parallelism: crate::executor::TEST_UNCAPPED,
+    };
+    let observer = MockObserver::new();
+    let result =
+        completed_result(execute_plan(&provider, input, &observer, CancellationToken::new()).await);
+
+    let events = observer.events();
+    assert!(
+        events.iter().any(|event| {
+            event
+                == "skipped:test.cross_phase_wait_child:unsatisfiable: dependency 'sibling_ready' failed"
+        }),
+        "blocked wait must be skipped as dependency-failed after terminal cancellation completes the sibling dependency; events: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| {
+            event == "skipped:test.cross_phase_wait_parent:unsatisfiable: no mutator remaining"
+        }),
+        "terminal check must cancel the in-flight sibling wait instead of letting it time out; events: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("failed:test.cross_phase_wait_parent:wait")),
+        "sibling wait must not poll to timeout; events: {events:?}"
+    );
+    assert_eq!(
+        result.failure_count, 1,
+        "only the update should fail; events: {events:?}"
+    );
+    assert_eq!(
+        result.skip_count, 2,
+        "both waits should be skipped after terminal detection; events: {events:?}"
+    );
+}
+
+#[test]
+fn phased_anonymous_replace_failure_unblocks_wait_terminal_check() {
+    use crate::effect::ChangedCreateOnly;
+    use crate::executor::scheduler::{FailedDependency, FailureView};
+    use crate::executor::wait::count_effectively_undispatched;
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    // Regression for carina#3618: this isolates the phased Wait terminal
+    // check instead of the dispatch-time skip covered by
+    // `phased_anonymous_replace_failure_propagates_to_dependent_wait`.
+    // The scheduler graph proves the Wait depends on the failed anonymous
+    // Replace, and the terminal counter must consult the same FailureView
+    // rather than a lossy failed-binding-name projection.
+    let anonymous_id = ResourceId::new("test", "anonymous_wait_terminal_target");
+    let old_anonymous_state =
+        State::existing(anonymous_id.clone(), HashMap::new()).with_identifier("anon-old");
+    let anonymous_to = Resource::new("test", "anonymous_wait_terminal_target");
+
+    let effects = vec![
+        Effect::Replace {
+            id: anonymous_id.clone(),
+            from: Box::new(old_anonymous_state),
+            to: anonymous_to,
+            directives: Directives::default(),
+            changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+            cascading_updates: Vec::new(),
+            temporary_name: None,
+            cascade_ref_hints: Vec::new(),
+        },
+        Effect::Wait {
+            binding: "anonymous_terminal_ready".to_string(),
+            target_id: anonymous_id.clone(),
+            until: WaitPredicate::Equals {
+                attr: AttrPath::single("status"),
+                value: Value::Concrete(ConcreteValue::String("ready".to_string())),
+            },
+            until_surface: "anonymous_wait_terminal_target.status == \"ready\"".to_string(),
+            timeout: std::time::Duration::from_millis(20),
+            interval: std::time::Duration::from_millis(1),
+            explicit_dependencies: HashSet::new(),
+        },
+    ];
+    assert_eq!(
+        effects[0].binding_name(),
+        None,
+        "fixture must use an anonymous Replace"
+    );
+
+    let wait_idx = 1;
+    let mut failed_indices = HashSet::new();
+    failed_indices.insert(0);
+    let deps_of = HashMap::from([(wait_idx, HashSet::from([0]))]);
+    let failure_view = FailureView::new(&effects, &deps_of, &failed_indices);
+    assert!(
+        matches!(
+            failure_view.find_failed_dependency(wait_idx),
+            Some(FailedDependency::Anonymous)
+        ),
+        "dispatch-time dependency check must already see the anonymous failed Replace"
+    );
+
+    let dispatched = HashSet::new();
+
+    assert_eq!(
+        count_effectively_undispatched(&[wait_idx], &dispatched, &failure_view),
+        0,
+        "terminal check must treat the Wait as effectively dispatched/skippable once its anonymous Replace dependency failed"
     );
 }
 

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -15,8 +15,7 @@ use std::time::{Duration, Instant};
 
 use futures::stream::{FuturesUnordered, StreamExt};
 
-use crate::deps::find_failed_dependency;
-use crate::effect::Effect;
+use crate::executor::scheduler::FailureView;
 use crate::executor::{ExecutionEvent, ExecutionObserver};
 use crate::provider::{Provider, ProviderError, ReadRequest};
 use crate::resource::{ResourceId, State, Value};
@@ -215,20 +214,19 @@ pub(super) fn cancel_waits_if_terminal(
 
 /// Count effects that are not yet dispatched and not effectively
 /// pre-skipped by a failed dependency. An effect whose direct dependency is
-/// already in `failed_bindings` will be skipped on its next dispatch attempt
+/// already visible through `view` will be skipped on its next dispatch attempt
 /// without producing work; treating it as still "undispatched" for the
 /// terminal-with-pending-waits check would keep waits polling forever when
 /// their consumer downstream is blocked on a failing sibling. (carina#3544)
 pub(super) fn count_effectively_undispatched(
     actionable_indices: &[usize],
     dispatched: &HashSet<usize>,
-    effects: &[Effect],
-    failed_bindings: &HashSet<String>,
+    view: &FailureView<'_>,
 ) -> usize {
     actionable_indices
         .iter()
         .filter(|&&idx| !dispatched.contains(&idx))
-        .filter(|&&idx| find_failed_dependency(&effects[idx], failed_bindings).is_none())
+        .filter(|&&idx| !view.is_effectively_pre_skipped(idx))
         .count()
 }
 


### PR DESCRIPTION
## Summary

#3617 で完成した phased↔parallel scheduler 統一の最後のピース、Wait 終端判定の name 集合派生を削除する作業です。素朴に `failed_indices` 直接受け取りに変えると、旧 `find_failed_dependency_index` が内部で持っていた cross-phase `blocking_bindings()` fallback が消え、 dispatch と terminal-check で失敗の見え方が非対称になる回帰が出ました。 `/code-review medium` で検出。

回帰の具体例: Phase 1 で binding `b` の Update が失敗 + Phase 5 の Wait `W` が `explicit_dependencies = {b}` を持つ場合、 `build_post_replace_wait_scheduler_deps` は phase 内の binding しか edge を貼らないため、 `deps_of[W]` に `U` の index が無い。 dispatch は `blocking_bindings()` fallback で `b` を捕まえて skip するが、terminal-check は `deps_of` だけ見るので Wait を「まだ未 dispatch」とカウント → 兄弟 Wait が timeout まで polling。

### 解決: `FailureView<'a>` typed reshape

新規 `FailureView<'a>` を `carina-core/src/executor/scheduler.rs` に追加し、 `(effects, deps_of, failed_indices)` の triple をカプセル化。 constructor で cross-phase `failed_binding_names` を lazily 派生して cache。 `view.find_failed_dependency(idx)` と `view.is_effectively_pre_skipped(idx)` が dispatch と terminal-check の **共通判定**。両者が同じ実装を経由するので、CLAUDE.md「sibling-site drift」が type レベルで不可能になります。

- 削除: `find_failed_dependency_index` (free fn) / `failed_binding_names_for_wait_terminal_check` helper / `deps.rs::find_failed_dependency`
- 全 9 サイト (6 dispatch + 3 terminal-check) が `FailureView` 経由
- 6 サイトで毎回 bare の `(idx, &deps_of, &failed_indices, &effects)` を渡していた convention seam が `view` 1 引数に圧縮

### 回帰テスト

- `phased_anonymous_replace_failure_unblocks_wait_terminal_check` (#3618 当初の unit test)
- `phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal` (新規、 code-review で検出した cross-phase 回帰の e2e test) — `execute_plan` を end-to-end で driven、 Phase 1 Update 失敗 + post-replace Wait の explicit_dependency で terminal check が発火 (= 兄弟 Wait が timeout でなく cancel) することを確認
- #3617 の 4 件はそのまま green

## Test plan

- [x] `cargo nextest run --workspace` — 4338 tests / 全 pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — 全 pass
- [x] /code-review medium — 重大 finding 2 件 (cross-phase regression + typed reshape requirement) を本 reshape で同時解決
- [x] /self-review 5 rounds — 全 round must-fix 0 件

Closes #3618