### PR TITLE
fix(validate): walk nested ResourceRefs across all three ref-type validators

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -56,6 +56,7 @@ impl ProviderFactory for FailBCreateFactory {
     fn schemas(&self) -> Vec<ResourceSchema> {
         vec![
             ResourceSchema::new("test.resource")
+                .attribute(AttributeSchema::new("id", AttributeType::string()))
                 .attribute(AttributeSchema::new("name", AttributeType::string())),
         ]
     }

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -453,11 +453,7 @@ pub fn validate_and_resolve_errors_with_factories(
             parsed,
             &argument_names,
         ));
-        errors.extend(validate_attribute_param_ref_types_with_ctx(
-            &ctx,
-            &parsed.attribute_params,
-            &parsed.resources,
-        ));
+        errors.extend(validate_attribute_param_ref_types_with_ctx(&ctx, parsed));
         if !errors.is_empty() {
             return errors;
         }

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -471,10 +471,11 @@ pub fn validate_and_resolve_errors_with_factories(
         ) {
             errors.extend(split_validation_message(&msg));
         }
-        if let Err(msg) = carina_core::validation::validate_export_param_ref_types(
+        let export_bindings =
+            carina_core::binding_index::BindingIndex::from_parsed(parsed, ctx.schemas());
+        if let Err(msg) = carina_core::validation::validate_export_param_ref_types_with_bindings(
             &parsed.export_params,
-            &parsed.resources,
-            ctx.schemas(),
+            &export_bindings,
         ) {
             errors.extend(split_validation_message(&msg));
         }

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -312,23 +312,26 @@ pub fn validate_resource_ref_types_with_ctx<E>(
     parsed: &carina_core::parser::File<E>,
     argument_names: &HashSet<String>,
 ) -> Vec<AppError> {
+    let bindings = carina_core::binding_index::BindingIndex::from_parsed(parsed, ctx.schemas());
     lift_validation_result(validation::validate_resource_ref_types(
         parsed,
         ctx.schemas(),
         argument_names,
+        &bindings,
     ))
 }
 
-pub fn validate_attribute_param_ref_types_with_ctx(
+pub fn validate_attribute_param_ref_types_with_ctx<E>(
     ctx: &WiringContext,
-    attribute_params: &[carina_core::parser::AttributeParameter],
-    resources: &[Resource],
+    parsed: &carina_core::parser::File<E>,
 ) -> Vec<AppError> {
-    lift_validation_result(validation::validate_attribute_param_ref_types(
-        attribute_params,
-        resources,
-        ctx.schemas(),
-    ))
+    let bindings = carina_core::binding_index::BindingIndex::from_parsed(parsed, ctx.schemas());
+    lift_validation_result(
+        validation::validate_attribute_param_ref_types_with_bindings(
+            &parsed.attribute_params,
+            &bindings,
+        ),
+    )
 }
 
 /// Reject any resolved value that still carries
@@ -919,10 +922,11 @@ pub fn validate_module_attribute_param_types<E>(
         if module_parsed.attribute_params.is_empty() {
             continue;
         }
-        if let Err(joined) = validation::validate_attribute_param_ref_types(
+        let bindings =
+            carina_core::binding_index::BindingIndex::from_parsed(&module_parsed, ctx.schemas());
+        if let Err(joined) = validation::validate_attribute_param_ref_types_with_bindings(
             &module_parsed.attribute_params,
-            &module_parsed.resources,
-            ctx.schemas(),
+            &bindings,
         ) {
             // Preserve the module-path prefix the legacy wrapper emitted
             // so diagnostics point at which imported module failed.

--- a/carina-cli/tests/wait_validate_e2e.rs
+++ b/carina-cli/tests/wait_validate_e2e.rs
@@ -15,7 +15,7 @@ use carina_core::provider::{
     BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
 };
 use carina_core::resource::{DataSource, Value};
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 use indexmap::IndexMap;
 use std::collections::HashMap;
 use tempfile::TempDir;
@@ -65,7 +65,7 @@ impl ProviderFactory for WaitTestFactory {
         Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
     }
     fn schemas(&self) -> Vec<ResourceSchema> {
-        vec![cert_schema()]
+        vec![cert_schema(), nested_holder_schema()]
     }
 }
 
@@ -77,7 +77,20 @@ fn cert_schema() -> ResourceSchema {
             AttributeType::string(),
         ))
         .attribute(AttributeSchema::new("status", AttributeType::string()))
-        .attribute(AttributeSchema::new("arn", AttributeType::string()))
+        .attribute(AttributeSchema::new(
+            "certificate_arn",
+            AttributeType::string(),
+        ))
+}
+
+fn nested_holder_schema() -> ResourceSchema {
+    ResourceSchema::new("test.NestedHolder").attribute(AttributeSchema::new(
+        "inner",
+        AttributeType::struct_(
+            "CertificateRef".to_string(),
+            vec![StructField::new("certificate_arn", AttributeType::string())],
+        ),
+    ))
 }
 
 struct NoopProvider;
@@ -269,6 +282,47 @@ fn validate_flags_wait_unknown_attribute() {
             .iter()
             .any(|d| d.contains("statu") && d.contains("unknown attribute")),
         "validate must surface unknown wait attribute; got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn validate_flags_wait_binding_bad_attr_inside_nested_struct() {
+    let fixture = write_fixture(&[
+        (
+            "providers.crn",
+            r#"provider aws {
+    region = "us-east-1"
+}
+"#,
+        ),
+        (
+            "main.crn",
+            r#"let cert = aws.acm.Certificate {
+    domain_name       = "publish.example.com"
+    validation_method = "DNS"
+}
+
+let holder = aws.test.NestedHolder {
+    inner = { certificate_arn = cert_issued.arn }
+}
+"#,
+        ),
+        (
+            "wait.crn",
+            r#"let cert_issued = wait cert {
+    until = cert.status == "ISSUED"
+}
+"#,
+        ),
+    ]);
+
+    let diags = cli_validate(&fixture);
+    assert!(
+        diags
+            .iter()
+            .any(|d| { d.contains("unknown attribute 'arn'") && d.contains("cert_issued") }),
+        "validate must surface wait binding bad attr inside nested struct; got: {:?}",
         diags
     );
 }

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -172,7 +172,7 @@ pub fn bindings_from_parsed(parsed: &crate::parser::ParsedFile) -> InferenceBind
 
 /// Build an [`InferenceBindings`] map from already-extracted resource
 /// and upstream-state slices. Used by callers that already work in
-/// terms of the slice arguments (e.g. `validate_export_param_ref_types`)
+/// terms of the slice arguments (e.g. `validate_export_param_ref_types_with_bindings`)
 /// so the binding-collection logic is in one place.
 ///
 /// Both resource bindings (`let <name> = <provider>.<resource> { ... }`)

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -360,9 +360,8 @@ pub fn validate_attribute_param_ref_types(
             );
         } else {
             value.visit_resource_refs(&mut |path| {
-                check_attribute_param_ref_type(
+                check_attribute_param_ref_existence(
                     &param.name,
-                    expected_type,
                     path,
                     &binding_map,
                     registry,
@@ -415,6 +414,32 @@ fn check_attribute_param_ref_type(
     errors.push(format!(
         "attribute '{}': type mismatch: expected {}, got {} (from {}.{})",
         param_name, expected_type, ref_type_snake, ref_binding, ref_attr
+    ));
+}
+
+fn check_attribute_param_ref_existence(
+    param_name: &str,
+    path: &crate::resource::AccessPath,
+    binding_map: &HashMap<String, &Resource>,
+    registry: &SchemaRegistry,
+    errors: &mut Vec<String>,
+) {
+    let ref_binding = path.binding();
+    let ref_attr = path.attribute();
+
+    let Some(ref_resource) = binding_map.get(ref_binding) else {
+        return;
+    };
+    let Some(ref_schema) = registry.get_for(ref_resource) else {
+        return;
+    };
+    if ref_schema.attributes.contains_key(ref_attr) {
+        return;
+    }
+
+    errors.push(format!(
+        "attribute '{}': unknown attribute '{}' on '{}' in reference {}.{}",
+        param_name, ref_attr, ref_binding, ref_binding, ref_attr,
     ));
 }
 

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -448,18 +448,10 @@ fn check_attribute_param_ref_existence(
 ///
 /// This catches mismatches like `exports { x: list(bool) = [vpc.vpc_id] }` where
 /// `vpc_id` is a string attribute but the export declares `bool`.
-pub fn validate_export_param_ref_types(
+pub fn validate_export_param_ref_types_with_bindings(
     export_params: &[crate::parser::InferredExportParam],
-    resources: &[Resource],
-    registry: &SchemaRegistry,
+    bindings: &BindingIndex<'_>,
 ) -> Result<(), String> {
-    let mut binding_map: HashMap<String, &Resource> = HashMap::new();
-    for resource in resources {
-        if let Some(ref binding_name) = resource.binding {
-            binding_map.insert(binding_name.clone(), resource);
-        }
-    }
-
     let mut errors = Vec::new();
 
     for param in export_params {
@@ -473,14 +465,7 @@ pub fn validate_export_param_ref_types(
             continue;
         }
 
-        collect_ref_type_errors(
-            &param.type_expr,
-            value,
-            &param.name,
-            &binding_map,
-            registry,
-            &mut errors,
-        );
+        collect_ref_type_errors(&param.type_expr, value, &param.name, bindings, &mut errors);
     }
 
     if errors.is_empty() {
@@ -495,8 +480,7 @@ fn collect_ref_type_errors(
     type_expr: &crate::parser::TypeExpr,
     value: &Value,
     param_name: &str,
-    binding_map: &HashMap<String, &Resource>,
-    registry: &SchemaRegistry,
+    bindings: &BindingIndex<'_>,
     errors: &mut Vec<String>,
 ) {
     use crate::parser::TypeExpr;
@@ -506,15 +490,10 @@ fn collect_ref_type_errors(
             let ref_binding = path.binding();
             let ref_attr = path.attribute();
 
-            // TODO: `binding_map` is managed-resource only here. Thread
-            // `BindingIndex` through export-param validation before expecting
-            // wait aliases or data-source bindings to report this diagnostic.
-            let Some(ref_resource) = binding_map.get(ref_binding) else {
+            let Some(ref_entry) = bindings.get(ref_binding) else {
                 return;
             };
-            let Some(ref_schema) = registry.get_for(ref_resource) else {
-                return;
-            };
+            let ref_schema = ref_entry.schema;
             let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr) else {
                 let known_attrs: Vec<&str> =
                     ref_schema.attributes.keys().map(|s| s.as_str()).collect();
@@ -530,7 +509,30 @@ fn collect_ref_type_errors(
                 return;
             };
 
-            let ref_type = &ref_attr_schema.attr_type;
+            let ref_type = match narrow_attribute_type(
+                &ref_attr_schema.attr_type,
+                path.segments(),
+                &ref_schema.defs,
+            ) {
+                Ok(ref_type) => ref_type,
+                Err(NarrowError::UnknownStructField {
+                    field,
+                    known_fields,
+                    ..
+                }) => {
+                    let known_attrs: Vec<&str> = known_fields.iter().map(|s| s.as_str()).collect();
+                    errors.push(format!(
+                        "export '{}': unknown attribute '{}' on '{}' in reference {}{}",
+                        param_name,
+                        field,
+                        ref_binding,
+                        path.to_dot_string(),
+                        did_you_mean(&field, &known_attrs),
+                    ));
+                    return;
+                }
+                Err(NarrowError::ShapeMismatch) => return,
+            };
             if !is_type_expr_compatible_with_schema(type_expr, ref_type, &ref_schema.defs) {
                 let ref_type_name = ref_type.type_name();
                 errors.push(format!(
@@ -541,25 +543,18 @@ fn collect_ref_type_errors(
         }
         (TypeExpr::List(inner), Value::Concrete(ConcreteValue::List(items))) => {
             for item in items {
-                collect_ref_type_errors(inner, item, param_name, binding_map, registry, errors);
+                collect_ref_type_errors(inner, item, param_name, bindings, errors);
             }
         }
         (TypeExpr::Map(inner), Value::Concrete(ConcreteValue::Map(map))) => {
             for value in map.values() {
-                collect_ref_type_errors(inner, value, param_name, binding_map, registry, errors);
+                collect_ref_type_errors(inner, value, param_name, bindings, errors);
             }
         }
         (TypeExpr::Struct { fields }, Value::Concrete(ConcreteValue::Map(map))) => {
             for (name, field_ty) in fields {
                 if let Some(value) = map.get(name) {
-                    collect_ref_type_errors(
-                        field_ty,
-                        value,
-                        param_name,
-                        binding_map,
-                        registry,
-                        errors,
-                    );
+                    collect_ref_type_errors(field_ty, value, param_name, bindings, errors);
                 }
             }
         }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -215,8 +215,16 @@ pub fn validate_resource_ref_types<E>(
                 continue;
             }
 
-            // Get the expected type for this attribute
             let Some(attr_schema) = schema.attributes.get(attr_name) else {
+                attr_value.visit_resource_refs(&mut |ref_path| {
+                    let _ = check_resource_ref_existence(
+                        resource_id,
+                        ref_path,
+                        argument_names,
+                        &bindings,
+                        &mut all_errors,
+                    );
+                });
                 continue;
             };
 
@@ -473,6 +481,9 @@ fn collect_ref_type_errors(
             let ref_binding = path.binding();
             let ref_attr = path.attribute();
 
+            // TODO: `binding_map` is managed-resource only here. Thread
+            // `BindingIndex` through export-param validation before expecting
+            // wait aliases or data-source bindings to report this diagnostic.
             let Some(ref_resource) = binding_map.get(ref_binding) else {
                 return;
             };
@@ -480,6 +491,17 @@ fn collect_ref_type_errors(
                 return;
             };
             let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr) else {
+                let known_attrs: Vec<&str> =
+                    ref_schema.attributes.keys().map(|s| s.as_str()).collect();
+                errors.push(format!(
+                    "export '{}': unknown attribute '{}' on '{}' in reference {}.{}{}",
+                    param_name,
+                    ref_attr,
+                    ref_binding,
+                    ref_binding,
+                    ref_attr,
+                    did_you_mean(ref_attr, &known_attrs),
+                ));
                 return;
             };
 

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -14,7 +14,7 @@ use crate::parser::{
     ModuleCall, ProviderContext, ResourceRef, ResourceTypePath, TypeExpr, validate_custom_type,
 };
 use crate::provider::ProviderFactory;
-use crate::resource::{ConcreteValue, DeferredValue, Resource, Value};
+use crate::resource::{ConcreteValue, DeferredValue, Value};
 use crate::schema::{AttributeType, SchemaRegistry, Shape, TypeIdentity, suggest_similar_name};
 
 /// Render the trailing `" Did you mean 'X'?"` segment for an unknown
@@ -76,6 +76,24 @@ fn check_resource_ref_existence<'a>(
     };
 
     Some((ref_schema, ref_attr_schema))
+}
+
+fn check_nested_resource_ref_existence(
+    resource_id: &crate::resource::ResourceId,
+    attr_value: &Value,
+    argument_names: &HashSet<String>,
+    bindings: &BindingIndex<'_>,
+    all_errors: &mut Vec<String>,
+) {
+    attr_value.visit_resource_refs(&mut |ref_path| {
+        let _ = check_resource_ref_existence(
+            resource_id,
+            ref_path,
+            argument_names,
+            bindings,
+            all_errors,
+        );
+    });
 }
 
 /// Validate resources against their schemas.
@@ -187,13 +205,9 @@ pub fn validate_resource_ref_types<E>(
     parsed: &crate::parser::File<E>,
     registry: &SchemaRegistry,
     argument_names: &HashSet<String>,
+    bindings: &BindingIndex<'_>,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
-
-    // Single source of truth for `binding_name → (resource, schema)` —
-    // shared with the LSP via `BindingIndex` so the two paths cannot drift
-    // (#2231).
-    let bindings = BindingIndex::from_parsed(parsed, registry);
 
     for rref in parsed.iter_all_resources() {
         // A deferred for-expression template body is always managed.
@@ -216,15 +230,13 @@ pub fn validate_resource_ref_types<E>(
             }
 
             let Some(attr_schema) = schema.attributes.get(attr_name) else {
-                attr_value.visit_resource_refs(&mut |ref_path| {
-                    let _ = check_resource_ref_existence(
-                        resource_id,
-                        ref_path,
-                        argument_names,
-                        &bindings,
-                        &mut all_errors,
-                    );
-                });
+                check_nested_resource_ref_existence(
+                    resource_id,
+                    attr_value,
+                    argument_names,
+                    bindings,
+                    &mut all_errors,
+                );
                 continue;
             };
 
@@ -233,7 +245,7 @@ pub fn validate_resource_ref_types<E>(
                     resource_id,
                     ref_path,
                     argument_names,
-                    &bindings,
+                    bindings,
                     &mut all_errors,
                 ) else {
                     continue;
@@ -296,15 +308,13 @@ pub fn validate_resource_ref_types<E>(
                 // existence only. Assignability for these refs needs the
                 // nested field type context from the surrounding Map/List/Struct
                 // shape and should be added where that context is threaded.
-                attr_value.visit_resource_refs(&mut |ref_path| {
-                    let _ = check_resource_ref_existence(
-                        resource_id,
-                        ref_path,
-                        argument_names,
-                        &bindings,
-                        &mut all_errors,
-                    );
-                });
+                check_nested_resource_ref_existence(
+                    resource_id,
+                    attr_value,
+                    argument_names,
+                    bindings,
+                    &mut all_errors,
+                );
             }
         }
     }
@@ -321,18 +331,10 @@ pub fn validate_resource_ref_types<E>(
 ///
 /// For example, `attributes { role_arn: iam_role_arn = role.role_name }` should
 /// be rejected because `role_name` is `String`, not `IamRoleArn`.
-pub fn validate_attribute_param_ref_types(
+pub fn validate_attribute_param_ref_types_with_bindings(
     attribute_params: &[crate::parser::AttributeParameter],
-    resources: &[Resource],
-    registry: &SchemaRegistry,
+    bindings: &BindingIndex<'_>,
 ) -> Result<(), String> {
-    let mut binding_map: HashMap<String, &Resource> = HashMap::new();
-    for resource in resources {
-        if let Some(ref binding_name) = resource.binding {
-            binding_map.insert(binding_name.clone(), resource);
-        }
-    }
-
     let mut errors = Vec::new();
 
     for param in attribute_params {
@@ -350,23 +352,10 @@ pub fn validate_attribute_param_ref_types(
         };
 
         if let Value::Deferred(DeferredValue::ResourceRef { path }) = value {
-            check_attribute_param_ref_type(
-                &param.name,
-                expected_type,
-                path,
-                &binding_map,
-                registry,
-                &mut errors,
-            );
+            check_attribute_param_ref_type(&param.name, expected_type, path, bindings, &mut errors);
         } else {
             value.visit_resource_refs(&mut |path| {
-                check_attribute_param_ref_existence(
-                    &param.name,
-                    path,
-                    &binding_map,
-                    registry,
-                    &mut errors,
-                );
+                check_attribute_param_ref_existence(&param.name, path, bindings, &mut errors);
             });
         }
     }
@@ -382,20 +371,16 @@ fn check_attribute_param_ref_type(
     param_name: &str,
     expected_type: &str,
     path: &crate::resource::AccessPath,
-    binding_map: &HashMap<String, &Resource>,
-    registry: &SchemaRegistry,
+    bindings: &BindingIndex<'_>,
     errors: &mut Vec<String>,
 ) {
     let ref_binding = path.binding();
     let ref_attr = path.attribute();
 
-    // Look up referenced resource's schema
-    let Some(ref_resource) = binding_map.get(ref_binding) else {
+    let Some(ref_entry) = bindings.get(ref_binding) else {
         return;
     };
-    let Some(ref_schema) = registry.get_for(ref_resource) else {
-        return;
-    };
+    let ref_schema = ref_entry.schema;
     let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr) else {
         errors.push(format!(
             "attribute '{}': unknown attribute '{}' on '{}' in reference {}.{}",
@@ -420,19 +405,16 @@ fn check_attribute_param_ref_type(
 fn check_attribute_param_ref_existence(
     param_name: &str,
     path: &crate::resource::AccessPath,
-    binding_map: &HashMap<String, &Resource>,
-    registry: &SchemaRegistry,
+    bindings: &BindingIndex<'_>,
     errors: &mut Vec<String>,
 ) {
     let ref_binding = path.binding();
     let ref_attr = path.attribute();
 
-    let Some(ref_resource) = binding_map.get(ref_binding) else {
+    let Some(ref_entry) = bindings.get(ref_binding) else {
         return;
     };
-    let Some(ref_schema) = registry.get_for(ref_resource) else {
-        return;
-    };
+    let ref_schema = ref_entry.schema;
     if ref_schema.attributes.contains_key(ref_attr) {
         return;
     }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -27,6 +27,57 @@ fn did_you_mean(unknown: &str, known: &[&str]) -> String {
         .unwrap_or_default()
 }
 
+fn check_resource_ref_existence<'a>(
+    resource_id: &crate::resource::ResourceId,
+    ref_path: &crate::resource::AccessPath,
+    argument_names: &HashSet<String>,
+    bindings: &BindingIndex<'a>,
+    all_errors: &mut Vec<String>,
+) -> Option<(
+    &'a crate::schema::ResourceSchema,
+    &'a crate::schema::AttributeSchema,
+)> {
+    let ref_binding = ref_path.binding();
+    let ref_attr = ref_path.attribute();
+
+    // Skip type checking for argument parameter references (resolved at call site)
+    if argument_names.contains(ref_binding) {
+        return None;
+    }
+
+    // Look up the referenced binding's schema. `BindingIndex::get`
+    // returns `Some` only when both the binding and its schema
+    // resolved; `contains_name` distinguishes "unknown binding"
+    // from "known binding, schema absent" so we keep the original
+    // diagnostic shape (only the former gets reported here).
+    let Some(ref_entry) = bindings.get(ref_binding) else {
+        if !bindings.is_declared(ref_binding) {
+            all_errors.push(format!(
+                "{}: unknown binding '{}' in reference {}.{}",
+                resource_id, ref_binding, ref_binding, ref_attr,
+            ));
+        }
+        return None;
+    };
+
+    let ref_schema = ref_entry.schema;
+    let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr) else {
+        let known_attrs: Vec<&str> = ref_schema.attributes.keys().map(|s| s.as_str()).collect();
+        all_errors.push(format!(
+            "{}: unknown attribute '{}' on '{}' in reference {}.{}{}",
+            resource_id,
+            ref_attr,
+            ref_binding,
+            ref_binding,
+            ref_attr,
+            did_you_mean(ref_attr, &known_attrs),
+        ));
+        return None;
+    };
+
+    Some((ref_schema, ref_attr_schema))
+}
+
 /// Validate resources against their schemas.
 ///
 /// Two-sided check: a `read` resource requires a `DataSource` registry entry,
@@ -164,108 +215,89 @@ pub fn validate_resource_ref_types<E>(
                 continue;
             }
 
-            let (ref_binding, ref_attr, ref_path) = match attr_value {
-                Value::Deferred(DeferredValue::ResourceRef { path }) => (
-                    path.binding().to_string(),
-                    path.attribute().to_string(),
-                    path,
-                ),
-                _ => continue,
-            };
-
             // Get the expected type for this attribute
             let Some(attr_schema) = schema.attributes.get(attr_name) else {
                 continue;
             };
-            let expected_type_name = attr_schema.attr_type.type_name();
 
-            // Skip type checking for argument parameter references (resolved at call site)
-            if argument_names.contains(ref_binding.as_str()) {
-                continue;
-            }
-
-            // Look up the referenced binding's schema. `BindingIndex::get`
-            // returns `Some` only when both the binding and its schema
-            // resolved; `contains_name` distinguishes "unknown binding"
-            // from "known binding, schema absent" so we keep the original
-            // diagnostic shape (only the former gets reported here).
-            let Some(ref_entry) = bindings.get(ref_binding.as_str()) else {
-                if !bindings.is_declared(ref_binding.as_str()) {
-                    all_errors.push(format!(
-                        "{}: unknown binding '{}' in reference {}.{}",
-                        resource_id, ref_binding, ref_binding, ref_attr,
-                    ));
-                }
-                continue;
-            };
-            let ref_schema = ref_entry.schema;
-            let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr.as_str()) else {
-                let known_attrs: Vec<&str> =
-                    ref_schema.attributes.keys().map(|s| s.as_str()).collect();
-                all_errors.push(format!(
-                    "{}: unknown attribute '{}' on '{}' in reference {}.{}{}",
+            if let Value::Deferred(DeferredValue::ResourceRef { path: ref_path }) = attr_value {
+                let Some((ref_schema, ref_attr_schema)) = check_resource_ref_existence(
                     resource_id,
-                    ref_attr,
-                    ref_binding,
-                    ref_binding,
-                    ref_attr,
-                    did_you_mean(&ref_attr, &known_attrs),
-                ));
-                continue;
-            };
-
-            // Narrow through the path's segments — `[idx]` peels one
-            // `List<T>` / `Map<_,V>` layer, `.field` descends a
-            // `Struct`. carina#3028. Unknown struct fields are a
-            // real typo (carina#3041) and get reported here with a
-            // suggestion; other shape mismatches stay silent because
-            // resolver-time evaluation catches them with full location
-            // context.
-            let narrowed = match narrow_attribute_type(
-                &ref_attr_schema.attr_type,
-                ref_path.segments(),
-                &ref_schema.defs,
-            ) {
-                Ok(t) => t,
-                Err(NarrowError::UnknownStructField {
-                    field,
-                    struct_name,
-                    known_fields,
-                }) => {
-                    let known: Vec<&str> = known_fields.iter().map(|s| s.as_str()).collect();
-                    all_errors.push(format!(
-                        "{}: unknown field '{}' on struct '{}' in reference {}; \
-                         known fields: {}.{}",
-                        resource_id,
+                    ref_path,
+                    argument_names,
+                    &bindings,
+                    &mut all_errors,
+                ) else {
+                    continue;
+                };
+                // Narrow through the path's segments — `[idx]` peels one
+                // `List<T>` / `Map<_,V>` layer, `.field` descends a
+                // `Struct`. carina#3028. Unknown struct fields are a
+                // real typo (carina#3041) and get reported here with a
+                // suggestion; other shape mismatches stay silent because
+                // resolver-time evaluation catches them with full location
+                // context.
+                let narrowed = match narrow_attribute_type(
+                    &ref_attr_schema.attr_type,
+                    ref_path.segments(),
+                    &ref_schema.defs,
+                ) {
+                    Ok(t) => t,
+                    Err(NarrowError::UnknownStructField {
                         field,
                         struct_name,
-                        ref_path.to_dot_string(),
-                        known.join(", "),
-                        did_you_mean(&field, &known),
-                    ));
+                        known_fields,
+                    }) => {
+                        let known: Vec<&str> = known_fields.iter().map(|s| s.as_str()).collect();
+                        all_errors.push(format!(
+                            "{}: unknown field '{}' on struct '{}' in reference {}; \
+                             known fields: {}.{}",
+                            resource_id,
+                            field,
+                            struct_name,
+                            ref_path.to_dot_string(),
+                            known.join(", "),
+                            did_you_mean(&field, &known),
+                        ));
+                        continue;
+                    }
+                    Err(NarrowError::ShapeMismatch) => continue,
+                };
+                let ref_type_name = narrowed.type_name();
+                let expected_type_name = attr_schema.attr_type.type_name();
+
+                // Directional check: source (the referenced attribute, post
+                // path narrowing) must be assignable to the sink (the
+                // current resource's attribute).
+                if narrowed.is_assignable_to(&attr_schema.attr_type) {
                     continue;
                 }
-                Err(NarrowError::ShapeMismatch) => continue,
-            };
-            let ref_type_name = narrowed.type_name();
 
-            // Directional check: source (the referenced attribute, post
-            // path narrowing) must be assignable to the sink (the
-            // current resource's attribute).
-            if narrowed.is_assignable_to(&attr_schema.attr_type) {
-                continue;
+                all_errors.push(format!(
+                    "{}: cannot assign {} to '{}': expected {}, got {} (from {}.{})",
+                    resource_id,
+                    ref_type_name,
+                    attr_name,
+                    expected_type_name,
+                    ref_type_name,
+                    ref_path.binding(),
+                    ref_path.attribute(),
+                ));
+            } else {
+                // Nested ResourceRefs are checked for binding/attribute
+                // existence only. Assignability for these refs needs the
+                // nested field type context from the surrounding Map/List/Struct
+                // shape and should be added where that context is threaded.
+                attr_value.visit_resource_refs(&mut |ref_path| {
+                    let _ = check_resource_ref_existence(
+                        resource_id,
+                        ref_path,
+                        argument_names,
+                        &bindings,
+                        &mut all_errors,
+                    );
+                });
             }
-
-            all_errors.push(format!(
-                "{}: cannot assign {} to '{}': expected {}, got {} (from {}.{})",
-                resource_id,
-                ref_type_name,
-                attr_name,
-                expected_type_name,
-                ref_type_name,
-                ref_binding,
-                ref_attr,
-            ));
         }
     }
 

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -335,41 +335,33 @@ pub fn validate_attribute_param_ref_types(
             continue;
         };
 
-        // Only check ResourceRef values
-        let Value::Deferred(DeferredValue::ResourceRef { path }) = value else {
-            continue;
-        };
-        let ref_binding = path.binding().to_string();
-        let ref_attr = path.attribute().to_string();
-
         // Get expected type name from TypeExpr
         let expected_type = match type_expr {
             crate::parser::TypeExpr::Simple(name) => name.as_str(),
             _ => continue, // String, Bool, etc. are handled by validate_type_expr_value
         };
 
-        // Look up referenced resource's schema
-        let Some(ref_resource) = binding_map.get(&ref_binding) else {
-            continue;
-        };
-        let Some(ref_schema) = registry.get_for(ref_resource) else {
-            continue;
-        };
-        let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr.as_str()) else {
-            continue;
-        };
-
-        let ref_type_name = ref_attr_schema.attr_type.type_name();
-        let ref_type_snake = crate::parser::pascal_to_snake(&ref_type_name);
-
-        if ref_type_snake == expected_type {
-            continue;
+        if let Value::Deferred(DeferredValue::ResourceRef { path }) = value {
+            check_attribute_param_ref_type(
+                &param.name,
+                expected_type,
+                path,
+                &binding_map,
+                registry,
+                &mut errors,
+            );
+        } else {
+            value.visit_resource_refs(&mut |path| {
+                check_attribute_param_ref_type(
+                    &param.name,
+                    expected_type,
+                    path,
+                    &binding_map,
+                    registry,
+                    &mut errors,
+                );
+            });
         }
-
-        errors.push(format!(
-            "attribute '{}': type mismatch: expected {}, got {} (from {}.{})",
-            param.name, expected_type, ref_type_snake, ref_binding, ref_attr
-        ));
     }
 
     if errors.is_empty() {
@@ -377,6 +369,45 @@ pub fn validate_attribute_param_ref_types(
     } else {
         Err(errors.join("\n"))
     }
+}
+
+fn check_attribute_param_ref_type(
+    param_name: &str,
+    expected_type: &str,
+    path: &crate::resource::AccessPath,
+    binding_map: &HashMap<String, &Resource>,
+    registry: &SchemaRegistry,
+    errors: &mut Vec<String>,
+) {
+    let ref_binding = path.binding();
+    let ref_attr = path.attribute();
+
+    // Look up referenced resource's schema
+    let Some(ref_resource) = binding_map.get(ref_binding) else {
+        return;
+    };
+    let Some(ref_schema) = registry.get_for(ref_resource) else {
+        return;
+    };
+    let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr) else {
+        errors.push(format!(
+            "attribute '{}': unknown attribute '{}' on '{}' in reference {}.{}",
+            param_name, ref_attr, ref_binding, ref_binding, ref_attr,
+        ));
+        return;
+    };
+
+    let ref_type_name = ref_attr_schema.attr_type.type_name();
+    let ref_type_snake = crate::parser::pascal_to_snake(&ref_type_name);
+
+    if ref_type_snake == expected_type {
+        return;
+    }
+
+    errors.push(format!(
+        "attribute '{}': type mismatch: expected {}, got {} (from {}.{})",
+        param_name, expected_type, ref_type_snake, ref_binding, ref_attr
+    ));
 }
 
 /// Validate export parameter values that are ResourceRef against their declared

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -2056,6 +2056,43 @@ fn attribute_param_ref_type_mismatch_detected() {
 }
 
 #[test]
+fn attribute_param_ref_types_flags_unknown_attribute_inside_nested_struct() {
+    use crate::parser::AttributeParameter;
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
+        .with_binding("vpc")
+        .with_attribute(
+            "vpc_id",
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        );
+
+    let mut vpc_schema = ResourceSchema::new("ec2.Vpc");
+    vpc_schema = vpc_schema.attribute(AttributeSchema::new("vpc_id", AttributeType::string()));
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", vpc_schema);
+
+    let mut nested = IndexMap::new();
+    nested.insert(
+        "id".to_string(),
+        Value::resource_ref("vpc".to_string(), "bad_attr".to_string(), vec![]),
+    );
+    let params = vec![AttributeParameter {
+        name: "network".to_string(),
+        type_expr: Some(TypeExpr::Simple("vpc_id".to_string())),
+        value: Some(Value::Concrete(ConcreteValue::Map(nested))),
+    }];
+
+    let resources = vec![vpc];
+    let err = validate_attribute_param_ref_types(&params, &resources, &schemas).unwrap_err();
+    assert!(
+        err.contains("attribute 'network': unknown attribute 'bad_attr' on 'vpc'"),
+        "expected nested attribute-param ResourceRef error, got: {err}",
+    );
+}
+
+#[test]
 fn validate_export_params_rejects_invalid_custom_type() {
     use crate::parser::InferredExportParam;
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -919,6 +919,39 @@ fn unknown_attribute_reference_through_managed_binding_inside_nested_struct_repo
 }
 
 #[test]
+fn unknown_outer_attr_does_not_mask_nested_unknown_binding_ref() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "awscc",
+        make_schema(
+            "elasticloadbalancingv2.Listener",
+            vec![("certificates", AttributeType::string())],
+        ),
+    );
+
+    let mut nested = IndexMap::new();
+    nested.insert(
+        "certificate_arn".to_string(),
+        Value::resource_ref("unknown_binding".to_string(), "foo".to_string(), vec![]),
+    );
+    let listener =
+        Resource::with_provider("awscc", "elasticloadbalancingv2.Listener", "listener", None)
+            .with_attribute(
+                "certificates_typo",
+                Value::Concrete(ConcreteValue::Map(nested)),
+            );
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(listener); // allow: direct — fixture test inspection
+
+    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    assert!(
+        err.contains("unknown binding 'unknown_binding' in reference unknown_binding.foo"),
+        "expected nested unknown binding under unknown outer attr, got: {err}",
+    );
+}
+
+#[test]
 fn unknown_attribute_reference_no_suggestion_when_too_different() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert(
@@ -2513,6 +2546,40 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
     assert!(
         err.contains("accounts") && err.contains("type mismatch"),
         "error should mention the export name and type mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn export_param_ref_types_flags_unknown_attribute() {
+    use crate::parser::InferredExportParam;
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "awscc",
+        make_schema("ec2.Vpc", vec![("vpc_id", AttributeType::string())]),
+    );
+
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
+        .with_binding("vpc")
+        .with_attribute(
+            "vpc_id",
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        );
+
+    let exports = vec![InferredExportParam {
+        name: "x".to_string(),
+        type_expr: TypeExpr::String,
+        value: Some(Value::resource_ref(
+            "vpc".to_string(),
+            "bad_attr".to_string(),
+            vec![],
+        )),
+    }];
+
+    let err = validate_export_param_ref_types(&exports, &[vpc], &schemas).unwrap_err();
+    assert!(
+        err.contains("export 'x': unknown attribute 'bad_attr' on 'vpc' in reference vpc.bad_attr"),
+        "expected export unknown attribute error, got: {err}",
     );
 }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -2126,6 +2126,43 @@ fn attribute_param_ref_types_flags_unknown_attribute_inside_nested_struct() {
 }
 
 #[test]
+fn attribute_param_ref_types_does_not_misreport_type_mismatch_for_nested_ref_to_existing_attribute()
+{
+    use crate::parser::AttributeParameter;
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
+        .with_binding("vpc")
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+        );
+
+    let mut vpc_schema = ResourceSchema::new("ec2.Vpc");
+    vpc_schema = vpc_schema.attribute(AttributeSchema::new("cidr_block", AttributeType::string()));
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", vpc_schema);
+
+    let mut nested = IndexMap::new();
+    nested.insert(
+        "id".to_string(),
+        Value::resource_ref("vpc".to_string(), "cidr_block".to_string(), vec![]),
+    );
+    let params = vec![AttributeParameter {
+        name: "network".to_string(),
+        type_expr: Some(TypeExpr::Simple("vpc_id".to_string())),
+        value: Some(Value::Concrete(ConcreteValue::Map(nested))),
+    }];
+
+    let result = validate_attribute_param_ref_types(&params, &[vpc], &schemas);
+    assert!(
+        result.is_ok(),
+        "nested refs should be existence-checked only, got: {result:?}",
+    );
+}
+
+#[test]
 fn validate_export_params_rejects_invalid_custom_type() {
     use crate::parser::InferredExportParam;
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -2529,7 +2529,10 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
         value: Some(Value::Concrete(ConcreteValue::Map(map_value))),
     }];
 
-    let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
+    let mut parsed = empty_parsed();
+    parsed.resources.push(registry_prod); // allow: direct — fixture test inspection
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let result = validate_export_param_ref_types_with_bindings(&exports, &bindings);
     assert!(
         result.is_ok(),
         "map(String) = {{ prod = registry_prod.account_id (String) }} should pass, got: {:?}",
@@ -2574,7 +2577,10 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
         value: Some(Value::Concrete(ConcreteValue::Map(map_value))),
     }];
 
-    let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
+    let mut parsed = empty_parsed();
+    parsed.resources.push(registry_prod); // allow: direct — fixture test inspection
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let result = validate_export_param_ref_types_with_bindings(&exports, &bindings);
     assert!(
         result.is_err(),
         "map(Bool) = {{ prod = registry_prod.account_id }} (String) should be flagged as type mismatch"
@@ -2613,10 +2619,71 @@ fn export_param_ref_types_flags_unknown_attribute() {
         )),
     }];
 
-    let err = validate_export_param_ref_types(&exports, &[vpc], &schemas).unwrap_err();
+    let mut parsed = empty_parsed();
+    parsed.resources.push(vpc); // allow: direct — fixture test inspection
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let err = validate_export_param_ref_types_with_bindings(&exports, &bindings).unwrap_err();
     assert!(
         err.contains("export 'x': unknown attribute 'bad_attr' on 'vpc' in reference vpc.bad_attr"),
         "expected export unknown attribute error, got: {err}",
+    );
+}
+
+#[test]
+fn export_param_ref_types_flags_unknown_attribute_through_wait_binding() {
+    use crate::parser::InferredExportParam;
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "aws",
+        make_schema(
+            "acm.Certificate",
+            vec![
+                ("certificate_arn", AttributeType::string()),
+                ("status", AttributeType::string()),
+            ],
+        ),
+    );
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "cert", None)
+        .with_binding("cert")
+        .with_attribute(
+            "status",
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        );
+
+    let exports = vec![InferredExportParam {
+        name: "x".to_string(),
+        type_expr: TypeExpr::String,
+        value: Some(Value::resource_ref(
+            "cert_issued".to_string(),
+            "bad_attr".to_string(),
+            vec![],
+        )),
+    }];
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.wait_bindings.push(WaitBinding {
+        binding: BindingName::from("cert_issued"),
+        target: BindingName::from("cert"),
+        until_raw: "cert.status == 'issued'".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        timeout_secs: None,
+        depends_on: Vec::new(),
+        line: 1,
+    });
+
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let err = validate_export_param_ref_types_with_bindings(&exports, &bindings).unwrap_err();
+    assert!(
+        err.contains(
+            "export 'x': unknown attribute 'bad_attr' on 'cert_issued' in reference cert_issued.bad_attr"
+        ),
+        "expected export wait binding unknown attribute error, got: {err}",
     );
 }
 
@@ -2635,7 +2702,8 @@ fn validate_export_param_ref_types_skips_unknown_sentinel() {
         ))),
     }];
 
-    let result = validate_export_param_ref_types(&exports, &[], &SchemaRegistry::new());
+    let bindings = crate::binding_index::BindingIndex::default();
+    let result = validate_export_param_ref_types_with_bindings(&exports, &bindings);
     assert!(
         result.is_ok(),
         "Unknown sentinel must be skipped, got {:?}",
@@ -2677,7 +2745,10 @@ fn validate_export_param_ref_types_against_inferred_inputs() {
     }];
 
     let _: &[UpstreamState] = &[]; // signature no longer takes upstream_states; doc only.
-    let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
+    let mut parsed = empty_parsed();
+    parsed.resources.push(registry_prod); // allow: direct — fixture test inspection
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let result = validate_export_param_ref_types_with_bindings(&exports, &bindings);
     assert!(result.is_ok(), "got {:?}", result);
 }
 

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -787,6 +787,138 @@ fn known_attribute_reference_through_wait_binding_is_accepted() {
 }
 
 #[test]
+fn unknown_attribute_reference_through_wait_binding_inside_nested_struct_reports_error() {
+    use crate::schema::StructField;
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "aws",
+        make_schema(
+            "acm.Certificate",
+            vec![
+                ("certificate_arn", AttributeType::string()),
+                ("status", AttributeType::string()),
+            ],
+        ),
+    );
+    schemas.insert(
+        "awscc",
+        make_schema(
+            "elasticloadbalancingv2.Listener",
+            vec![(
+                "certificates",
+                AttributeType::list(AttributeType::struct_(
+                    "Certificate".to_string(),
+                    vec![StructField::new("certificate_arn", AttributeType::string())],
+                )),
+            )],
+        ),
+    );
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "cert", None)
+        .with_binding("cert")
+        .with_attribute(
+            "status",
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        );
+    let mut certificate = IndexMap::new();
+    certificate.insert(
+        "certificate_arn".to_string(),
+        Value::resource_ref("cert_issued".to_string(), "arn".to_string(), vec![]),
+    );
+    let listener =
+        Resource::with_provider("awscc", "elasticloadbalancingv2.Listener", "listener", None)
+            .with_attribute(
+                "certificates",
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(certificate),
+                )])),
+            );
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.wait_bindings.push(WaitBinding {
+        binding: BindingName::from("cert_issued"),
+        target: BindingName::from("cert"),
+        until_raw: "cert.status == 'issued'".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        timeout_secs: None,
+        depends_on: Vec::new(),
+        line: 1,
+    });
+    parsed.resources.push(listener); // allow: direct — fixture test inspection
+
+    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    assert!(
+        err.contains("unknown attribute 'arn' on 'cert_issued'"),
+        "expected nested wait binding attribute error, got: {err}",
+    );
+}
+
+#[test]
+fn unknown_attribute_reference_through_managed_binding_inside_nested_struct_reports_error() {
+    use crate::schema::StructField;
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "aws",
+        make_schema(
+            "acm.Certificate",
+            vec![
+                ("certificate_arn", AttributeType::string()),
+                ("status", AttributeType::string()),
+            ],
+        ),
+    );
+    schemas.insert(
+        "awscc",
+        make_schema(
+            "elasticloadbalancingv2.Listener",
+            vec![(
+                "certificates",
+                AttributeType::list(AttributeType::struct_(
+                    "Certificate".to_string(),
+                    vec![StructField::new("certificate_arn", AttributeType::string())],
+                )),
+            )],
+        ),
+    );
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "cert", None)
+        .with_binding("cert")
+        .with_attribute(
+            "status",
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        );
+    let mut certificate = IndexMap::new();
+    certificate.insert(
+        "certificate_arn".to_string(),
+        Value::resource_ref("cert".to_string(), "arn".to_string(), vec![]),
+    );
+    let listener =
+        Resource::with_provider("awscc", "elasticloadbalancingv2.Listener", "listener", None)
+            .with_attribute(
+                "certificates",
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(certificate),
+                )])),
+            );
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.resources.push(listener); // allow: direct — fixture test inspection
+
+    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    assert!(
+        err.contains("unknown attribute 'arn' on 'cert'"),
+        "expected nested managed binding attribute error, got: {err}",
+    );
+}
+
+#[test]
 fn unknown_attribute_reference_no_suggestion_when_too_different() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert(

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -28,6 +28,15 @@ fn empty_parsed() -> ParsedFile {
     }
 }
 
+fn validate_resource_ref_types_for_test<E>(
+    parsed: &crate::parser::File<E>,
+    schemas: &SchemaRegistry,
+    argument_names: &HashSet<String>,
+) -> Result<(), String> {
+    let bindings = crate::binding_index::BindingIndex::from_parsed(parsed, schemas);
+    super::validate_resource_ref_types(parsed, schemas, argument_names, &bindings)
+}
+
 fn context_with_iam_policy_arn_validator() -> ProviderContext {
     use crate::parser::ValidatorFn;
 
@@ -571,7 +580,7 @@ fn unknown_binding_reference_reports_error() {
 
     let mut parsed = empty_parsed();
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
-    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
+    let result = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new());
     assert_eq!(
         result.unwrap_err(),
         "awscc.ec2.Subnet.web-subnet: unknown binding 'vpc' in reference vpc.vpc_id"
@@ -607,7 +616,7 @@ fn unknown_attribute_reference_reports_error() {
     let mut parsed = empty_parsed();
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
-    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
+    let result = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new());
     assert_eq!(
         result.unwrap_err(),
         "awscc.ec2.Subnet.web-subnet: unknown attribute 'nonexistent_attr' on 'vpc' in reference vpc.nonexistent_attr"
@@ -651,7 +660,7 @@ fn unknown_attribute_reference_suggests_similar_name() {
     let mut parsed = empty_parsed();
     parsed.resources.push(igw); // allow: direct — fixture test inspection
     parsed.resources.push(route); // allow: direct — fixture test inspection
-    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
+    let result = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new());
     let err = result.unwrap_err();
     assert!(
         err.contains("Did you mean 'internet_gateway_id'?"),
@@ -714,7 +723,7 @@ fn unknown_attribute_reference_through_wait_binding_reports_error() {
     });
     parsed.resources.push(listener); // allow: direct — fixture test inspection
 
-    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    let err = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new()).unwrap_err();
     assert!(
         err.contains("unknown attribute 'certificate_arnn' on 'cert_issued'"),
         "expected wait binding attribute error, got: {err}",
@@ -783,7 +792,7 @@ fn known_attribute_reference_through_wait_binding_is_accepted() {
     });
     parsed.resources.push(listener); // allow: direct — fixture test inspection
 
-    assert!(validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).is_ok());
+    assert!(validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new()).is_ok());
 }
 
 #[test]
@@ -851,7 +860,7 @@ fn unknown_attribute_reference_through_wait_binding_inside_nested_struct_reports
     });
     parsed.resources.push(listener); // allow: direct — fixture test inspection
 
-    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    let err = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new()).unwrap_err();
     assert!(
         err.contains("unknown attribute 'arn' on 'cert_issued'"),
         "expected nested wait binding attribute error, got: {err}",
@@ -911,7 +920,7 @@ fn unknown_attribute_reference_through_managed_binding_inside_nested_struct_repo
     parsed.resources.push(cert); // allow: direct — fixture test inspection
     parsed.resources.push(listener); // allow: direct — fixture test inspection
 
-    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    let err = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new()).unwrap_err();
     assert!(
         err.contains("unknown attribute 'arn' on 'cert'"),
         "expected nested managed binding attribute error, got: {err}",
@@ -944,7 +953,7 @@ fn unknown_outer_attr_does_not_mask_nested_unknown_binding_ref() {
     let mut parsed = empty_parsed();
     parsed.resources.push(listener); // allow: direct — fixture test inspection
 
-    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    let err = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new()).unwrap_err();
     assert!(
         err.contains("unknown binding 'unknown_binding' in reference unknown_binding.foo"),
         "expected nested unknown binding under unknown outer attr, got: {err}",
@@ -978,7 +987,7 @@ fn unknown_attribute_reference_no_suggestion_when_too_different() {
     let mut parsed = empty_parsed();
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
-    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
+    let result = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new());
     let err = result.unwrap_err();
     assert!(
         !err.contains("Did you mean"),
@@ -1018,7 +1027,7 @@ fn ref_type_mismatch_inside_for_body_is_rejected() {
         make_schema("r.pool_user", vec![("pool_id", AttributeType::bool())]),
     );
 
-    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
+    let result = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new());
     assert!(result.is_err(), "expected type-mismatch error in for body");
     let msg = result.unwrap_err();
     assert!(
@@ -2048,7 +2057,9 @@ fn attribute_param_ref_type_mismatch_detected() {
     let mut schemas = SchemaRegistry::new();
     schemas.insert("awscc", role_schema);
 
-    let resources = vec![role];
+    let mut parsed = empty_parsed();
+    parsed.resources.push(role); // allow: direct — fixture test inspection
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
 
     // Attribute param: role_arn: iam_role_arn = role.role_name (MISMATCH: String vs iam_role_arn)
     let params_mismatch = vec![AttributeParameter {
@@ -2061,7 +2072,7 @@ fn attribute_param_ref_type_mismatch_detected() {
         )),
     }];
 
-    let result = validate_attribute_param_ref_types(&params_mismatch, &resources, &schemas);
+    let result = validate_attribute_param_ref_types_with_bindings(&params_mismatch, &bindings);
     assert!(
         result.is_err(),
         "Should reject String assigned to iam_role_arn"
@@ -2081,7 +2092,7 @@ fn attribute_param_ref_type_mismatch_detected() {
         )),
     }];
 
-    let result = validate_attribute_param_ref_types(&params_match, &resources, &schemas);
+    let result = validate_attribute_param_ref_types_with_bindings(&params_match, &bindings);
     assert!(
         result.is_ok(),
         "Should accept IamRoleArn assigned to iam_role_arn"
@@ -2117,11 +2128,68 @@ fn attribute_param_ref_types_flags_unknown_attribute_inside_nested_struct() {
         value: Some(Value::Concrete(ConcreteValue::Map(nested))),
     }];
 
-    let resources = vec![vpc];
-    let err = validate_attribute_param_ref_types(&params, &resources, &schemas).unwrap_err();
+    let mut parsed = empty_parsed();
+    parsed.resources.push(vpc); // allow: direct — fixture test inspection
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let err = validate_attribute_param_ref_types_with_bindings(&params, &bindings).unwrap_err();
     assert!(
         err.contains("attribute 'network': unknown attribute 'bad_attr' on 'vpc'"),
         "expected nested attribute-param ResourceRef error, got: {err}",
+    );
+}
+
+#[test]
+fn attribute_param_ref_types_flags_unknown_attribute_through_wait_binding() {
+    use crate::parser::AttributeParameter;
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let cert = Resource::with_provider("aws", "acm.Certificate", "cert", None)
+        .with_binding("cert")
+        .with_attribute(
+            "status",
+            Value::Concrete(ConcreteValue::String("pending".to_string())),
+        );
+
+    let mut cert_schema = ResourceSchema::new("acm.Certificate");
+    cert_schema = cert_schema.attribute(AttributeSchema::new(
+        "certificate_arn",
+        AttributeType::string(),
+    ));
+    cert_schema = cert_schema.attribute(AttributeSchema::new("status", AttributeType::string()));
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("aws", cert_schema);
+
+    let params = vec![AttributeParameter {
+        name: "certificate_arn".to_string(),
+        type_expr: Some(TypeExpr::Simple("string".to_string())),
+        value: Some(Value::resource_ref(
+            "cert_issued".to_string(),
+            "bad_attr".to_string(),
+            vec![],
+        )),
+    }];
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(cert); // allow: direct — fixture test inspection
+    parsed.wait_bindings.push(WaitBinding {
+        binding: BindingName::from("cert_issued"),
+        target: BindingName::from("cert"),
+        until_raw: "cert.status == 'issued'".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::Concrete(ConcreteValue::String("issued".to_string())),
+        },
+        timeout_secs: None,
+        depends_on: Vec::new(),
+        line: 1,
+    });
+
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let err = validate_attribute_param_ref_types_with_bindings(&params, &bindings).unwrap_err();
+    assert!(
+        err.contains("attribute 'certificate_arn': unknown attribute 'bad_attr' on 'cert_issued'"),
+        "expected attribute-param wait binding unknown attribute error, got: {err}",
     );
 }
 
@@ -2155,7 +2223,10 @@ fn attribute_param_ref_types_does_not_misreport_type_mismatch_for_nested_ref_to_
         value: Some(Value::Concrete(ConcreteValue::Map(nested))),
     }];
 
-    let result = validate_attribute_param_ref_types(&params, &[vpc], &schemas);
+    let mut parsed = empty_parsed();
+    parsed.resources.push(vpc); // allow: direct — fixture test inspection
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let result = validate_attribute_param_ref_types_with_bindings(&params, &bindings);
     assert!(
         result.is_ok(),
         "nested refs should be existence-checked only, got: {result:?}",
@@ -2684,6 +2755,55 @@ fn export_param_ref_types_flags_unknown_attribute_through_wait_binding() {
             "export 'x': unknown attribute 'bad_attr' on 'cert_issued' in reference cert_issued.bad_attr"
         ),
         "expected export wait binding unknown attribute error, got: {err}",
+    );
+}
+
+#[test]
+fn export_param_ref_types_flags_unknown_struct_field_inside_path() {
+    use crate::parser::InferredExportParam;
+    use crate::schema::StructField;
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "awscc",
+        make_schema(
+            "ec2.Vpc",
+            vec![(
+                "config",
+                AttributeType::struct_(
+                    "VpcConfig".to_string(),
+                    vec![StructField::new("sub_attr", AttributeType::string())],
+                ),
+            )],
+        ),
+    );
+
+    let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc", None)
+        .with_binding("vpc")
+        .with_attribute(
+            "config",
+            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+        );
+
+    let exports = vec![InferredExportParam {
+        name: "x".to_string(),
+        type_expr: TypeExpr::String,
+        value: Some(Value::resource_ref(
+            "vpc".to_string(),
+            "config".to_string(),
+            vec!["bad_field".to_string()],
+        )),
+    }];
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(vpc); // allow: direct — fixture test inspection
+    let bindings = crate::binding_index::BindingIndex::from_parsed(&parsed, &schemas);
+    let err = validate_export_param_ref_types_with_bindings(&exports, &bindings).unwrap_err();
+    assert!(
+        err.contains(
+            "export 'x': unknown attribute 'bad_field' on 'vpc' in reference vpc.config.bad_field"
+        ),
+        "expected export unknown struct field error, got: {err}",
     );
 }
 
@@ -3232,7 +3352,7 @@ fn ref_with_chained_subscript_then_field_narrows_through_list() {
     let mut parsed = empty_parsed();
     parsed.resources.push(cert); // allow: direct — fixture test inspection
     parsed.resources.push(record); // allow: direct — fixture test inspection
-    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
+    let result = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new());
     assert!(
         result.is_ok(),
         "chained subscript-then-field should narrow List<Struct> → Struct → String, got: {:?}",
@@ -3291,7 +3411,7 @@ fn ref_with_chained_subscript_then_field_rejects_real_mismatch() {
     let mut parsed = empty_parsed();
     parsed.resources.push(cert); // allow: direct — fixture test inspection
     parsed.resources.push(record); // allow: direct — fixture test inspection
-    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    let err = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new()).unwrap_err();
     assert!(
         err.contains("expected String"),
         "expected real Int→String mismatch to be flagged, got: {err}"
@@ -3375,7 +3495,7 @@ fn ref_with_chained_field_on_struct_flags_unknown_field() {
     let mut parsed = empty_parsed();
     parsed.resources.push(cert); // allow: direct — fixture test inspection
     parsed.resources.push(record); // allow: direct — fixture test inspection
-    let err = validate_resource_ref_types(&parsed, &schemas, &HashSet::new()).unwrap_err();
+    let err = validate_resource_ref_types_for_test(&parsed, &schemas, &HashSet::new()).unwrap_err();
     assert!(
         err.contains("resource_record_name"),
         "error must name the unknown field, got: {err}",

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -8,7 +8,7 @@ use crate::document::Document;
 use crate::position;
 use carina_core::builtins;
 use carina_core::parser::{ArgumentParameter, ParsedFile, TypeExpr};
-use carina_core::resource::{ConcreteValue, DeferredValue, Resource, Value};
+use carina_core::resource::{ConcreteValue, DeferredValue, Value};
 use carina_core::schema::{ResourceSchema, suggest_similar_name};
 use carina_core::upstream_exports::UpstreamRefDiagnostic;
 
@@ -1347,9 +1347,6 @@ impl DiagnosticEngine {
 
     /// Validate export parameter values against their type annotations.
     ///
-    /// `all_resources` provides cross-file resources for schema-level ref type
-    /// checking. If None, falls back to the current file's resources.
-    ///
     /// `merged` is the directory-merged parse used to feed inference so
     /// module-call / `upstream_state` bindings declared in sibling
     /// `.crn` files are visible — without it the export inference would
@@ -1360,7 +1357,6 @@ impl DiagnosticEngine {
         doc: &Document,
         parsed: &ParsedFile,
         merged: Option<&ParsedFile>,
-        all_resources: Option<&[Resource]>,
         sibling_bindings: &HashMap<String, String>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
@@ -1404,7 +1400,6 @@ impl DiagnosticEngine {
         // whole `InferredFile`. Use the merged parse when available so
         // sibling-file `let` bindings (module calls, upstream_states)
         // are visible to inference (#2493).
-        let resources = all_resources.unwrap_or(&parsed.resources);
         let inference_input = merged.unwrap_or(parsed);
         let (inferred_export_params, inference_errors) =
             carina_core::validation::inference::infer_export_params(inference_input, &self.schemas);
@@ -1425,11 +1420,14 @@ impl DiagnosticEngine {
                 ));
             }
         }
-        if let Err(ref_errors) = carina_core::validation::validate_export_param_ref_types(
-            &inferred_export_params,
-            resources,
-            &self.schemas,
-        ) {
+        let export_bindings =
+            carina_core::binding_index::BindingIndex::from_parsed(inference_input, &self.schemas);
+        if let Err(ref_errors) =
+            carina_core::validation::validate_export_param_ref_types_with_bindings(
+                &inferred_export_params,
+                &export_bindings,
+            )
+        {
             for error_msg in ref_errors.split('\n') {
                 if let Some((line, col)) = self.find_ref_error_position(doc, error_msg) {
                     diagnostics.push(carina_diagnostic(

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -956,7 +956,6 @@ impl DiagnosticEngine {
                 doc,
                 parsed,
                 merged.as_ref(),
-                None,
                 &sibling_bindings,
             ));
 


### PR DESCRIPTION
Closes #3620.

## 何が問題だったか

PR #3610(carina#3609 の修正)で `BindingIndex::from_parsed` に wait バインディングを target スキーマと一緒に登録するようにしたものの、ユーザが報告したとおり `carina validate` は依然として `<wait>.<bad-attr>` を通してしまっていた。

根本原因は **wait に限った話ではなかった**: `validate_resource_ref_types` の属性ループはトップレベルの `Value::Deferred(DeferredValue::ResourceRef { ... })` だけを見ていて、ネストされた構造体 / マップ / リスト(`certificate { certificate_arn = cert_issued.arn }` のような形)に埋め込まれた `ResourceRef` は **走査対象外** だった。同じ根本原因の sibling site が attribute parameter / export parameter の検証ロジックにも残っていて、こちらは一部 wait・data-source バインディング自体が見えていない状態でもあった。

## 何をしたか

3つの ResourceRef 型検証関数(`validate_resource_ref_types`, `validate_attribute_param_ref_types_with_bindings`, `validate_export_param_ref_types_with_bindings`)で:

- 属性値を `Value::visit_resource_refs` で再帰走査し、ネスト構造体内のすべての `ResourceRef` を存在チェックする
- どの関数も `&BindingIndex` を取るシグネチャに統一(以前は各自で managed-only な `HashMap<String, &Resource>` を作っていた)。これにより、wait alias / data-source バインディング経由の参照が3つの検証経路すべてで同じく見える状態を、シグネチャ・レベルで保証
- トップレベルの直接 ResourceRef は従来通り存在 + 型整合性 + assignability の full check、ネストされた ResourceRef は existence-only にとどめる(nested の field 型コンテキストを差し込むのは将来の PR スコープ)
- 外側の属性名がスキーマ未登録だった場合も、内側のネスト ResourceRef は existence チェックを走らせる
- 古い slice ベースの公開関数は削除(no backwards-compat shim、CLAUDE.md の方針通り)

## CLI / LSP 側

`carina-cli` と `carina-lsp` の検証フローはどちらも、すでに `validate_resource_ref_types` のために `BindingIndex::from_parsed(parsed, schemas)` を作っているので、その index を `validate_attribute_param_ref_types_with_bindings` と `validate_export_param_ref_types_with_bindings` にも渡すだけ。Validate / LSP parity は維持。

CLI 側のテスト fixture（`carina-cli/src/commands/apply/tests.rs`）の mock schema に `id` を追加。既存テストの `exports { b = ... b.id }` を新しい厳しい検証が(正しく)拒否したため。

## 追加したテスト

carina-core ユニット:
- `unknown_attribute_reference_through_wait_binding_inside_nested_struct_reports_error`
- `unknown_attribute_reference_through_managed_binding_inside_nested_struct_reports_error`
- `attribute_param_ref_types_flags_unknown_attribute_inside_nested_struct`
- `attribute_param_ref_types_does_not_misreport_type_mismatch_for_nested_ref_to_existing_attribute`
- `attribute_param_ref_types_flags_unknown_attribute_through_wait_binding`
- `export_param_ref_types_flags_unknown_attribute`
- `export_param_ref_types_flags_unknown_attribute_through_wait_binding`
- `export_param_ref_types_flags_unknown_struct_field_inside_path`
- `unknown_outer_attr_does_not_mask_nested_unknown_binding_ref`

CLI e2e:
- `validate_flags_wait_binding_bad_attr_inside_nested_struct`(issue#3620 の repro shape をそのまま再現)

すべて red-first で確認済み。

## 残されたスコープ外項目

- **ネスト ResourceRef の assignability チェック** — 今の実装はネストでは existence チェックのみ。Map/List/Struct の各層で expected な `AttributeType` を thread する walker が必要で、これは構造的に別 PR の話。コードコメントに残してある。
- **3つの validator を一つの typed walker に統合** — 同じパターンを3箇所に書いていて、`Opus が新しい関数 A,B,C を別形で書く可能性` は残っている。これも refactor PR としての方が筋がいい。

## Test plan

- [x] `cargo nextest run --workspace` — 4348 passed, 72 skipped
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] CLI e2e `validate_flags_wait_binding_bad_attr_inside_nested_struct` が #3620 の repro shape を再現

🤖 Generated with [Claude Code](https://claude.com/claude-code)