### PR TITLE
docs(CLAUDE.md): add carina-specific review checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,51 @@ See the codex skill for the full subcontracting protocol.
 - When bugs are found or issues are pointed out, write a test that captures the fix so the regression is caught and the expected behavior is documented.
 - Run full verify/review/CI gates before merge.
 
+## Review Checklist — Carina-Specific Concerns
+
+In addition to generic review dimensions (correctness, scope, tests,
+OWASP), the following concerns must be checked on every review round
+in this codebase.
+
+### Parser Output Boundary Validation
+
+Verify that raw values from the pest parser (strings, token sequences)
+do not flow into domain types without validation. A successful parse
+does not equal domain-level validation. At conversion points from
+`Rule` matches to `ResourceType`, `AttributeValue`, `NamespacedId`,
+etc., confirm that a step exists to reject inputs that are syntactically
+valid but domain-invalid.
+
+### Credential and Secret Leakage
+
+Confirm that AWS access keys, session tokens, and credentials included
+in provider responses do not leak into log output, `Debug` impls, error
+messages, or unintended fields in state files. Also check `tracing` span
+attributes and `Display` impls that expand provider responses verbatim.
+
+### Error Chain Preservation
+
+Check that `format!("{}", err)` or `.to_string()` is not used to
+stringify errors in a way that severs the `#[source]` chain. Also flag
+duplicate logging where the same error is emitted via `tracing::error!`
+at both the adapter layer and the use-case layer.
+
+### State Operation Atomicity
+
+Verify that the read → diff → write sequence for state is performed
+under a lock (`apply`/`destroy` paths). `plan` intentionally does not
+acquire a lock (see the plan concurrency contract), but drift detection
+must be functional. When adding a new state operation path, confirm
+consistency with the existing contract.
+
+### Property-Based Testing Applicability
+
+When modifying code with obvious invariants — parser round-trips
+(parse → display → re-parse yields identical result), `NamespacedId`
+parse/display round-trips, differ idempotency (same input → same plan)
+— consider adding property-based tests. Not required when existing
+example-based tests already provide sufficient coverage.
+
 ---
 
 # Part 2 — Build, Test, Verify


### PR DESCRIPTION
## Summary

- Compared kamae-rs-review's 105-item checklist against carina's existing review practices and identified five uncovered dimensions
- Added a "Review Checklist — Carina-Specific Concerns" section at the end of Part 1 in CLAUDE.md
- The review skill (pick-issue Step 8) references CLAUDE.md, so review coverage is extended without modifying the skill itself

### Added review dimensions

1. **Parser Output Boundary Validation** — raw pest parser values must not flow into domain types without validation
2. **Credential and Secret Leakage** — AWS credentials must not leak into logs, Debug impls, or error messages
3. **Error Chain Preservation** — `format!` must not sever `#[source]` chains; duplicate error logging flagged
4. **State Operation Atomicity** — state read/diff/write must happen under lock; drift detection must be functional
5. **Property-Based Testing Applicability** — consider property tests for code with obvious invariants (round-trips, idempotency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)