### PR TITLE
fix(destroy): honor wait-binding dependencies via shared effect graph

### DIFF
--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -10,11 +10,13 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
-use carina_core::deps::{
-    build_dependents_map, find_failed_dependent, get_resource_dependencies,
-    sort_resources_for_destroy,
-};
+use carina_core::deps::get_resource_dependencies;
 use carina_core::effect::Effect;
+use carina_core::effect::deps::{
+    DependencyAnalysis, DestroyWaitAlias, ScheduleInputs, UnresolvedResource,
+    build_effect_dependency_analysis,
+};
+use carina_core::parser::WaitBinding;
 use carina_core::plan::Plan;
 use carina_core::provider::Provider;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
@@ -339,20 +341,14 @@ async fn run_destroy_locked(
         }
     }
 
-    // Sort all resources (managed + orphans) for destroy ordering.
-    // Uses depth-based pre-sorting to ensure stable ordering for independent
-    // branches, then reverses for destroy order (dependents before dependencies).
-    let destroy_order: Vec<Resource> =
-        sort_resources_for_destroy(&all_resources).map_err(AppError::Config)?;
-
     // Collect resources that exist and will be destroyed
     // Skip the state bucket if it matches the backend bucket
     let mut protected_resources: Vec<&Resource> = Vec::new();
     let mut prevent_destroy_resources: Vec<&Resource> = Vec::new();
-    let resources_to_destroy: Vec<&Resource> = destroy_order
+    let mut resources_to_destroy: Vec<&Resource> = all_resources
         .iter()
         .filter(|r| {
-            // carina#3181: `destroy_order` is managed-only — data
+            // carina#3181: `all_resources` is managed-only — data
             // sources and compositions never enter the destroy set.
             if !current_states.get(&r.id).map(|s| s.exists).unwrap_or(false) {
                 return false;
@@ -378,6 +374,64 @@ async fn run_destroy_locked(
             true
         })
         .collect();
+    resources_to_destroy.sort_by(|left, right| {
+        let left_key = left
+            .binding
+            .as_deref()
+            .unwrap_or_else(|| left.id.name_str());
+        let right_key = right
+            .binding
+            .as_deref()
+            .unwrap_or_else(|| right.id.name_str());
+        left_key.cmp(right_key)
+    });
+
+    let mut delete_effects = Vec::with_capacity(resources_to_destroy.len());
+    for resource in &resources_to_destroy {
+        let identifier = current_states
+            .get(&resource.id)
+            .and_then(|s| s.identifier.clone())
+            .unwrap_or_default();
+        let dependencies = get_resource_dependencies(resource);
+        let explicit_dependencies = resource.directives.depends_on.iter().cloned().collect();
+        delete_effects.push(Effect::Delete {
+            id: resource.id.clone(),
+            identifier,
+            directives: resource.directives.clone(),
+            binding: resource.binding.clone(),
+            dependencies,
+            explicit_dependencies,
+        });
+    }
+
+    let wait_aliases = build_destroy_wait_aliases(&parsed.wait_bindings, &resources_to_destroy);
+    let dependency_analysis = build_effect_dependency_analysis(
+        &delete_effects,
+        &HashMap::<ResourceId, UnresolvedResource>::new(),
+        &[],
+        ScheduleInputs::Destroy {
+            aliases: &wait_aliases,
+        },
+    );
+    let delete_count = delete_effects.len();
+    let deletion_deps = transitive_delete_deps(&dependency_analysis, delete_count);
+    let delete_depths = compute_delete_depths(delete_count, &deletion_deps);
+    let resource_names: Vec<String> = resources_to_destroy
+        .iter()
+        .map(|resource| {
+            resource
+                .binding
+                .clone()
+                .unwrap_or_else(|| resource.id.name_str().to_string())
+        })
+        .collect();
+    let display_order = topological_delete_order(
+        delete_count,
+        &deletion_deps,
+        &delete_depths,
+        &resource_names,
+    )
+    .map_err(AppError::Config)?;
 
     if resources_to_destroy.is_empty()
         && protected_resources.is_empty()
@@ -389,21 +443,8 @@ async fn run_destroy_locked(
 
     // Build a Plan from the delete effects for tree display
     let mut destroy_plan = Plan::new();
-    for resource in &resources_to_destroy {
-        let identifier = current_states
-            .get(&resource.id)
-            .and_then(|s| s.identifier.clone())
-            .unwrap_or_default();
-        let dependencies = get_resource_dependencies(resource);
-        let explicit_dependencies = resource.directives.depends_on.iter().cloned().collect();
-        destroy_plan.add(Effect::Delete {
-            id: resource.id.clone(),
-            identifier,
-            directives: resource.directives.clone(),
-            binding: resource.binding.clone(),
-            dependencies,
-            explicit_dependencies,
-        });
+    for idx in &display_order {
+        destroy_plan.add(delete_effects[*idx].clone());
     }
 
     // Build delete attributes map from current states for display
@@ -528,19 +569,14 @@ async fn run_destroy_locked(
     // Map from resource index to its spinner (populated lazily on dispatch)
     let mut spinners: HashMap<usize, ProgressBar> = HashMap::new();
 
-    // Build reverse dependency map: binding -> {bindings that depend on it}.
-    // For destroy ordering, a resource can only be deleted after ALL its
-    // dependents (resources that reference it) have been deleted first.
-    let dependents_map = build_dependents_map(&resources_to_destroy);
-
     let mut success_count = 0;
     let mut failure_count = 0;
     let mut skip_count = 0;
     let mut destroyed_ids: Vec<ResourceId> = Vec::new();
-    let mut failed_bindings: HashSet<String> = HashSet::new();
+    let mut failed_indices: HashSet<usize> = HashSet::new();
     let mut cancelled = false;
-    // timed_out_resources: binding -> (ResourceId, identifier)
-    let mut timed_out_resources: HashMap<String, (ResourceId, String)> = HashMap::new();
+    // timed_out_resources: delete index -> (ResourceId, identifier)
+    let mut timed_out_resources: HashMap<usize, (ResourceId, String)> = HashMap::new();
 
     let destroy_total = resources_to_destroy.len();
     let completed_counter = AtomicUsize::new(0);
@@ -548,54 +584,23 @@ async fn run_destroy_locked(
     // Pre-compute binding and effect for each resource by index
     let resource_info: Vec<(String, String, Effect)> = resources_to_destroy
         .iter()
-        .map(|resource| {
-            let identifier = current_states
-                .get(&resource.id)
-                .and_then(|s| s.identifier.clone())
-                .unwrap_or_default();
-            let dependencies = get_resource_dependencies(resource);
-            let explicit_dependencies = resource.directives.depends_on.iter().cloned().collect();
-            let effect = Effect::Delete {
-                id: resource.id.clone(),
-                identifier: identifier.clone(),
-                directives: resource.directives.clone(),
-                binding: resource.binding.clone(),
-                dependencies,
-                explicit_dependencies,
+        .zip(delete_effects.iter())
+        .map(|(resource, effect)| {
+            let identifier = match effect {
+                Effect::Delete { identifier, .. } => identifier.clone(),
+                _ => unreachable!("destroy resource_info only contains delete effects"),
             };
             let binding = resource.binding.clone().unwrap_or_else(|| {
                 format!("{}:{}", resource.id.resource_type, resource.id.name_str())
             });
-            (binding, identifier, effect)
+            (binding, identifier, effect.clone())
         })
         .collect();
-
-    // Build binding -> index mapping for ready-queue scheduling
-    let mut binding_to_idx: HashMap<String, usize> = HashMap::new();
-    for (idx, (binding, _, _)) in resource_info.iter().enumerate() {
-        binding_to_idx.insert(binding.clone(), idx);
-    }
-
-    // Build deletion dependency map: for each index, which indices must complete
-    // before this resource can be deleted. A resource's deletion prerequisites
-    // are its dependents (resources that reference it).
-    let mut deletion_deps: HashMap<usize, HashSet<usize>> = HashMap::new();
-    for (idx, (binding, _, _)) in resource_info.iter().enumerate() {
-        let mut deps = HashSet::new();
-        if let Some(dependents) = dependents_map.get(binding) {
-            for dependent_binding in dependents {
-                if let Some(&dep_idx) = binding_to_idx.get(dependent_binding) {
-                    deps.insert(dep_idx);
-                }
-            }
-        }
-        deletion_deps.insert(idx, deps);
-    }
 
     // Track completed and dispatched indices
     let mut completed_indices: HashSet<usize> = HashSet::new();
     let mut dispatched: HashSet<usize> = HashSet::new();
-    let all_indices: Vec<usize> = (0..resources_to_destroy.len()).collect();
+    let all_indices = display_order.clone();
 
     // Track retry counts for dependency-violation retries
     let max_retries: usize = 3;
@@ -631,7 +636,6 @@ async fn run_destroy_locked(
                     newly_ready.push(idx);
                 }
             }
-            newly_ready.sort();
             newly_ready.truncate(parallelism.get().saturating_sub(in_flight.len()));
 
             // Process newly ready resources
@@ -643,15 +647,19 @@ async fn run_destroy_locked(
 
                 dispatched.insert(idx);
 
-                let (binding, identifier, effect) = &resource_info[idx];
+                let (_binding, identifier, effect) = &resource_info[idx];
                 let resource = resources_to_destroy[idx];
 
                 // Check if any dependent has actually failed (non-timeout)
-                if let Some(failed_dep) =
-                    find_failed_dependent(binding, &dependents_map, &failed_bindings)
-                {
+                if let Some(failed_dep_idx) = delete_dependency_in_set(
+                    idx,
+                    &dependency_analysis,
+                    delete_count,
+                    &failed_indices,
+                ) {
                     let c = completed_counter.fetch_add(1, Ordering::Relaxed) + 1;
                     let counter = format!("{}/{}", c, destroy_total).dimmed();
+                    let failed_dep = &resource_info[failed_dep_idx].0;
                     let msg = format!(
                         "{} {} - skipped (dependent {} failed) {}",
                         "⊘".yellow(),
@@ -666,27 +674,22 @@ async fn run_destroy_locked(
                         eprintln!("  {}", msg);
                     }
                     skip_count += 1;
-                    failed_bindings.insert(binding.clone());
+                    failed_indices.insert(idx);
                     completed_indices.insert(idx);
                     continue;
                 }
 
                 // Check if any dependent timed out -- wait for it to complete
-                let timed_out_deps: Vec<String> = dependents_map
-                    .get(binding)
-                    .map(|deps| {
-                        deps.iter()
-                            .filter(|d| timed_out_resources.contains_key(d.as_str()))
-                            .cloned()
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                let timed_out_deps = delete_dependencies_in_set(
+                    idx,
+                    &dependency_analysis,
+                    delete_count,
+                    timed_out_resources.keys().copied().collect(),
+                );
 
                 let mut wait_failed = false;
-                for dep_binding in &timed_out_deps {
-                    if let Some((dep_id, dep_identifier)) =
-                        timed_out_resources.remove(dep_binding.as_str())
-                    {
+                for dep_idx in &timed_out_deps {
+                    if let Some((dep_id, dep_identifier)) = timed_out_resources.remove(dep_idx) {
                         multi
                             .println(format!(
                                 "  {} Waiting for {} to be deleted...",
@@ -726,7 +729,7 @@ async fn run_destroy_locked(
                                         format!("read error during wait: {}", msg).red()
                                     ))
                                     .ok();
-                                failed_bindings.insert(dep_binding.clone());
+                                failed_indices.insert(*dep_idx);
                                 failure_count += 1;
                                 wait_failed = true;
                             }
@@ -741,7 +744,7 @@ async fn run_destroy_locked(
                                         "still exists after extended wait".red()
                                     ))
                                     .ok();
-                                failed_bindings.insert(dep_binding.clone());
+                                failed_indices.insert(*dep_idx);
                                 failure_count += 1;
                                 wait_failed = true;
                             }
@@ -765,7 +768,7 @@ async fn run_destroy_locked(
                         eprintln!("  {}", msg);
                     }
                     skip_count += 1;
-                    failed_bindings.insert(binding.clone());
+                    failed_indices.insert(idx);
                     completed_indices.insert(idx);
                     continue;
                 }
@@ -781,7 +784,6 @@ async fn run_destroy_locked(
                 let resource_id = resource.id.clone();
                 let identifier = identifier.clone();
                 let directives = resource.directives.clone();
-                let binding = binding.clone();
 
                 let provider_ref = &provider;
                 in_flight.push(async move {
@@ -795,14 +797,7 @@ async fn run_destroy_locked(
                             },
                         )
                         .await;
-                    (
-                        idx,
-                        binding,
-                        resource_id,
-                        identifier,
-                        started,
-                        delete_result,
-                    )
+                    (idx, resource_id, identifier, started, delete_result)
                 });
             }
         }
@@ -851,8 +846,7 @@ async fn run_destroy_locked(
                     } else {
                         eprintln!("  {}", msg);
                     }
-                    let binding = &resource_info[idx].0;
-                    failed_bindings.insert(binding.clone());
+                    failed_indices.insert(idx);
                     dispatched.insert(idx);
                     completed_indices.insert(idx);
                     failure_count += 1;
@@ -869,8 +863,7 @@ async fn run_destroy_locked(
         }
 
         // Wait for the next deletion to complete
-        let (finished_idx, binding, resource_id, identifier, started, delete_result) = if cancelled
-        {
+        let (finished_idx, resource_id, identifier, started, delete_result) = if cancelled {
             in_flight.next().await.unwrap()
         } else {
             tokio::select! {
@@ -933,7 +926,7 @@ async fn run_destroy_locked(
                     format_effect(effect)
                 );
                 finish_spinner(&mut spinners, finished_idx, msg);
-                timed_out_resources.insert(binding.clone(), (resource_id, identifier));
+                timed_out_resources.insert(finished_idx, (resource_id, identifier));
             }
             Err(e) => {
                 let retries = retry_counts.get(&finished_idx).copied().unwrap_or(0);
@@ -972,7 +965,7 @@ async fn run_destroy_locked(
                     );
                     finish_spinner(&mut spinners, finished_idx, msg);
                     failure_count += 1;
-                    failed_bindings.insert(binding.clone());
+                    failed_indices.insert(finished_idx);
                 }
             }
         }
@@ -980,7 +973,7 @@ async fn run_destroy_locked(
 
     // Handle any remaining timed-out resources that no parent waited on.
     if !cancelled {
-        for (dep_binding, (dep_id, dep_identifier)) in &timed_out_resources {
+        for (dep_idx, (dep_id, dep_identifier)) in &timed_out_resources {
             if cancel.is_cancelled() {
                 cancelled = true;
                 break;
@@ -1024,7 +1017,7 @@ async fn run_destroy_locked(
                         "→".red(),
                         format!("read error during wait: {}", msg).red()
                     );
-                    failed_bindings.insert(dep_binding.clone());
+                    failed_indices.insert(*dep_idx);
                     failure_count += 1;
                 }
                 WaitResult::TimedOut => {
@@ -1034,7 +1027,7 @@ async fn run_destroy_locked(
                         "→".red(),
                         "still exists after extended wait".red()
                     );
-                    failed_bindings.insert(dep_binding.clone());
+                    failed_indices.insert(*dep_idx);
                     failure_count += 1;
                 }
             }
@@ -1123,6 +1116,267 @@ fn observe_destroy_success_for_tests(
 ) {
 }
 
+fn build_destroy_wait_aliases(
+    wait_bindings: &[WaitBinding],
+    resources_to_destroy: &[&Resource],
+) -> Vec<DestroyWaitAlias> {
+    let destroy_targets: HashSet<&str> = resources_to_destroy
+        .iter()
+        .filter_map(|resource| resource.binding.as_deref())
+        .collect();
+    let resource_dependencies: Vec<(&Resource, HashSet<String>)> = resources_to_destroy
+        .iter()
+        .map(|resource| (*resource, get_resource_dependencies(resource)))
+        .collect();
+    let referenced_bindings: HashSet<&str> = resource_dependencies
+        .iter()
+        .flat_map(|(_, dependencies)| dependencies.iter().map(String::as_str))
+        .collect();
+
+    wait_bindings
+        .iter()
+        .filter(|wait| referenced_bindings.contains(wait.binding.as_str()))
+        .filter_map(|wait| {
+            if !destroy_targets.contains(wait.target.as_str()) {
+                return None;
+            }
+            let consumers = resource_dependencies
+                .iter()
+                .filter(|(_, dependencies)| dependencies.contains(wait.binding.as_str()))
+                .map(|(resource, _)| {
+                    resource
+                        .binding
+                        .clone()
+                        .unwrap_or_else(|| resource.id.name_str().to_string())
+                })
+                .collect::<Vec<_>>();
+
+            DestroyWaitAlias::new(
+                wait.binding.as_str().to_string(),
+                wait.target.as_str().to_string(),
+                wait.depends_on
+                    .iter()
+                    .map(|dep| dep.as_str().to_string())
+                    .collect(),
+                consumers,
+            )
+        })
+        .collect()
+}
+
+fn transitive_delete_deps(
+    analysis: &DependencyAnalysis,
+    delete_count: usize,
+) -> HashMap<usize, HashSet<usize>> {
+    (0..delete_count)
+        .map(|idx| {
+            let mut deps = HashSet::new();
+            let mut seen = HashSet::new();
+            collect_delete_deps(idx, analysis, delete_count, &mut seen, &mut deps);
+            (idx, deps)
+        })
+        .collect()
+}
+
+fn collect_delete_deps(
+    idx: usize,
+    analysis: &DependencyAnalysis,
+    delete_count: usize,
+    seen: &mut HashSet<usize>,
+    deps: &mut HashSet<usize>,
+) {
+    let Some(children) = analysis.deps_of(idx) else {
+        return;
+    };
+
+    for &child in children {
+        if !seen.insert(child) {
+            continue;
+        }
+        if child < delete_count {
+            deps.insert(child);
+        } else {
+            collect_delete_deps(child, analysis, delete_count, seen, deps);
+        }
+    }
+}
+
+fn topological_delete_order(
+    delete_count: usize,
+    deletion_deps: &HashMap<usize, HashSet<usize>>,
+    depths: &[usize],
+    names: &[String],
+) -> Result<Vec<usize>, String> {
+    let mut emitted = HashSet::new();
+    let mut order = Vec::with_capacity(delete_count);
+
+    while order.len() < delete_count {
+        let ready = (0..delete_count)
+            .filter(|idx| {
+                !emitted.contains(idx)
+                    && deletion_deps
+                        .get(idx)
+                        .is_none_or(|deps| deps.iter().all(|dep| emitted.contains(dep)))
+            })
+            .max_by(|left, right| {
+                depths[*left]
+                    .cmp(&depths[*right])
+                    .then_with(|| names[*right].cmp(&names[*left]))
+                    .then_with(|| right.cmp(left))
+            });
+
+        let Some(idx) = ready else {
+            return Err(format!(
+                "Circular dependency detected: {}",
+                cycle_path(delete_count, deletion_deps, names)
+            ));
+        };
+
+        emitted.insert(idx);
+        order.push(idx);
+    }
+
+    Ok(order)
+}
+
+fn compute_delete_depths(
+    delete_count: usize,
+    deletion_deps: &HashMap<usize, HashSet<usize>>,
+) -> Vec<usize> {
+    let mut create_parents: HashMap<usize, HashSet<usize>> = HashMap::new();
+    for (&parent, children) in deletion_deps {
+        for &child in children {
+            create_parents.entry(child).or_default().insert(parent);
+        }
+    }
+
+    let mut memo = HashMap::new();
+    (0..delete_count)
+        .map(|idx| compute_delete_depth(idx, &create_parents, &mut memo, &mut HashSet::new()))
+        .collect()
+}
+
+fn compute_delete_depth(
+    idx: usize,
+    create_parents: &HashMap<usize, HashSet<usize>>,
+    memo: &mut HashMap<usize, usize>,
+    visiting: &mut HashSet<usize>,
+) -> usize {
+    if let Some(depth) = memo.get(&idx) {
+        return *depth;
+    }
+    if !visiting.insert(idx) {
+        return 0;
+    }
+    let depth = create_parents
+        .get(&idx)
+        .map(|parents| {
+            parents
+                .iter()
+                .map(|parent| compute_delete_depth(*parent, create_parents, memo, visiting) + 1)
+                .max()
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
+    visiting.remove(&idx);
+    memo.insert(idx, depth);
+    depth
+}
+
+fn cycle_path(
+    delete_count: usize,
+    deletion_deps: &HashMap<usize, HashSet<usize>>,
+    names: &[String],
+) -> String {
+    fn dfs(
+        idx: usize,
+        deletion_deps: &HashMap<usize, HashSet<usize>>,
+        visiting: &mut Vec<usize>,
+        visited: &mut HashSet<usize>,
+    ) -> Option<Vec<usize>> {
+        if let Some(pos) = visiting.iter().position(|node| *node == idx) {
+            let mut path = visiting[pos..].to_vec();
+            path.push(idx);
+            return Some(path);
+        }
+        if !visited.insert(idx) {
+            return None;
+        }
+        visiting.push(idx);
+        if let Some(deps) = deletion_deps.get(&idx) {
+            let mut sorted: Vec<_> = deps.iter().copied().collect();
+            sorted.sort_unstable();
+            for dep in sorted {
+                if let Some(path) = dfs(dep, deletion_deps, visiting, visited) {
+                    return Some(path);
+                }
+            }
+        }
+        visiting.pop();
+        None
+    }
+
+    let mut visited = HashSet::new();
+    for idx in 0..delete_count {
+        if let Some(path) = dfs(idx, deletion_deps, &mut Vec::new(), &mut visited) {
+            return path
+                .into_iter()
+                .map(|idx| names.get(idx).cloned().unwrap_or_else(|| idx.to_string()))
+                .collect::<Vec<_>>()
+                .join(" -> ");
+        }
+    }
+    "<unknown>".to_string()
+}
+
+fn delete_dependency_in_set(
+    idx: usize,
+    analysis: &DependencyAnalysis,
+    delete_count: usize,
+    candidates: &HashSet<usize>,
+) -> Option<usize> {
+    let mut sorted: Vec<_> = candidates.iter().copied().collect();
+    sorted.sort_unstable();
+    sorted.into_iter().find(|candidate| {
+        *candidate < delete_count && graph_reaches_delete_idx(*candidate, idx, analysis)
+    })
+}
+
+fn delete_dependencies_in_set(
+    idx: usize,
+    analysis: &DependencyAnalysis,
+    delete_count: usize,
+    candidates: HashSet<usize>,
+) -> Vec<usize> {
+    let mut deps: Vec<_> = candidates
+        .into_iter()
+        .filter(|candidate| {
+            *candidate < delete_count && graph_reaches_delete_idx(*candidate, idx, analysis)
+        })
+        .collect();
+    deps.sort_unstable();
+    deps
+}
+
+fn graph_reaches_delete_idx(start: usize, target: usize, analysis: &DependencyAnalysis) -> bool {
+    let mut stack = vec![start];
+    let mut seen = HashSet::new();
+
+    while let Some(idx) = stack.pop() {
+        if !seen.insert(idx) {
+            continue;
+        }
+        if idx == target {
+            return true;
+        }
+        if let Some(dependents) = analysis.dependents_of(idx) {
+            stack.extend(dependents.iter().copied());
+        }
+    }
+
+    false
+}
+
 pub(crate) struct FinalizeDestroyInput<'a> {
     pub backend: &'a dyn StateBackend,
     pub lock: Option<&'a LockInfo>,
@@ -1163,6 +1417,61 @@ mod tests {
     #[test]
     fn destroy_parallelism_default_is_eight() {
         assert_eq!(crate::DEFAULT_PARALLELISM.get(), 8);
+    }
+
+    #[test]
+    fn topological_delete_order_reports_cycles() {
+        let deletion_deps = HashMap::from([(0, HashSet::from([1])), (1, HashSet::from([0]))]);
+        let depths = compute_delete_depths(2, &deletion_deps);
+        let names = vec!["a".to_string(), "b".to_string()];
+
+        let err = topological_delete_order(2, &deletion_deps, &depths, &names).unwrap_err();
+
+        assert_eq!(err, "Circular dependency detected: a -> b -> a");
+    }
+
+    #[test]
+    fn topological_delete_order_uses_depth_tie_break_for_igw_nat_case() {
+        let names = vec![
+            "vpc".to_string(),
+            "igw".to_string(),
+            "subnet".to_string(),
+            "eip".to_string(),
+            "nat_gw".to_string(),
+            "rt".to_string(),
+            "route".to_string(),
+        ];
+        let deletion_deps = HashMap::from([
+            (0, HashSet::from([1, 2, 5])),
+            (1, HashSet::new()),
+            (2, HashSet::from([4])),
+            (3, HashSet::from([4])),
+            (4, HashSet::from([6])),
+            (5, HashSet::from([6])),
+            (6, HashSet::new()),
+        ]);
+        let depths = compute_delete_depths(names.len(), &deletion_deps);
+
+        let order = topological_delete_order(names.len(), &deletion_deps, &depths, &names)
+            .expect("fixture is acyclic");
+
+        let route_pos = order.iter().position(|idx| names[*idx] == "route").unwrap();
+        let nat_pos = order
+            .iter()
+            .position(|idx| names[*idx] == "nat_gw")
+            .unwrap();
+        let igw_pos = order.iter().position(|idx| names[*idx] == "igw").unwrap();
+
+        assert!(
+            route_pos < igw_pos,
+            "route must be destroyed before igw; order: {:?}",
+            order.iter().map(|idx| &names[*idx]).collect::<Vec<_>>()
+        );
+        assert!(
+            nat_pos < igw_pos,
+            "nat_gw must be destroyed before igw; order: {:?}",
+            order.iter().map(|idx| &names[*idx]).collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]

--- a/carina-cli/tests/destroy_wait_ordering_e2e.rs
+++ b/carina-cli/tests/destroy_wait_ordering_e2e.rs
@@ -1,0 +1,223 @@
+//! CLI-level regression coverage for destroy ordering through wait bindings.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use carina_state::{ResourceState, StateFile};
+use tempfile::TempDir;
+
+const DELETE_DELAY_MS: &str = "1500";
+
+struct Scenario {
+    _tmp: TempDir,
+    project: PathBuf,
+    state_path: PathBuf,
+    mock_state_path: PathBuf,
+    delete_log_path: PathBuf,
+}
+
+impl Scenario {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().to_path_buf();
+        Self {
+            state_path: project.join("carina.state.json"),
+            mock_state_path: project.join("mock-state.json"),
+            delete_log_path: project.join("delete.log"),
+            project,
+            _tmp: tmp,
+        }
+    }
+
+    fn write_config(&self) {
+        self.write_config_with_cert_name("cert");
+    }
+
+    fn write_config_with_cert_name(&self, cert_name: &str) {
+        fs::write(
+            self.project.join("main.crn"),
+            format!(
+                r#"backend local {{ path = "{}" }}
+provider mock {{}}
+
+let cert = mock.test.resource {{
+  name = "{cert_name}"
+  status = "ISSUED"
+}}
+
+let cert_issued = wait cert {{
+  until = cert.status == "ISSUED"
+}}
+
+let lst = mock.test.resource {{
+  name = "lst"
+  upstream = cert_issued.id
+}}
+"#,
+                self.state_path.display()
+            ),
+        )
+        .unwrap();
+    }
+
+    fn init(&self) {
+        let output = carina(&self.project)
+            .args(["init", "."])
+            .output()
+            .expect("failed to execute carina init");
+        assert_success("carina init", &output);
+    }
+
+    fn seed_carina_state(&self) {
+        self.seed_carina_state_with_cert_name("cert");
+    }
+
+    fn seed_carina_state_with_cert_name(&self, cert_name: &str) {
+        let mut state = StateFile::new();
+        let mut cert = ResourceState::new("test.resource", cert_name, "mock")
+            .with_identifier("mock-id")
+            .with_attribute("name", serde_json::json!(cert_name))
+            .with_attribute("id", serde_json::json!("cert-id"))
+            .with_attribute("status", serde_json::json!("ISSUED"));
+        cert.binding = Some("cert".to_string());
+        state.upsert_resource(cert);
+
+        let mut lst = ResourceState::new("test.resource", "lst", "mock")
+            .with_identifier("mock-id")
+            .with_attribute("name", serde_json::json!("lst"))
+            .with_attribute("id", serde_json::json!("lst-id"))
+            .with_attribute("upstream", serde_json::json!("cert-id"));
+        lst.binding = Some("lst".to_string());
+        lst.dependency_bindings.insert("cert_issued".to_string());
+        state.upsert_resource(lst);
+
+        fs::write(
+            &self.state_path,
+            carina_core::utils::pretty_with_newline(&state).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn seed_mock_provider_state(&self) {
+        self.seed_mock_provider_state_with_cert_name("cert");
+    }
+
+    fn seed_mock_provider_state_with_cert_name(&self, cert_name: &str) {
+        let provider_state = serde_json::json!({
+            format!("test.resource.{cert_name}"): {
+                "name": cert_name,
+                "id": "cert-id",
+                "status": "ISSUED"
+            },
+            "test.resource.lst": {
+                "name": "lst",
+                "id": "lst-id",
+                "upstream": "cert-id"
+            }
+        });
+        fs::write(
+            &self.mock_state_path,
+            carina_core::utils::pretty_with_newline(&provider_state).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn destroy(&self) -> Output {
+        carina(&self.project)
+            .args([
+                "destroy",
+                "--auto-approve",
+                ".",
+                "--lock=false",
+                "--parallelism",
+                "8",
+            ])
+            .env("CARINA_MOCK_STATE_FILE", &self.mock_state_path)
+            .env("CARINA_MOCK_DELETE_LOG", &self.delete_log_path)
+            .env("CARINA_MOCK_DELETE_DELAY_MS_FOR", "test.resource.lst")
+            .env("CARINA_MOCK_DELETE_DELAY_MS", DELETE_DELAY_MS)
+            .output()
+            .expect("failed to execute carina destroy")
+    }
+
+    fn delete_log(&self) -> Vec<String> {
+        fs::read_to_string(&self.delete_log_path)
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+}
+
+#[test]
+fn destroy_wait_ordering_uses_wait_target_binding_not_resource_name() {
+    let scenario = Scenario::new();
+    scenario.write_config_with_cert_name("primary-cert");
+    scenario.init();
+    scenario.seed_carina_state_with_cert_name("primary-cert");
+    scenario.seed_mock_provider_state_with_cert_name("primary-cert");
+
+    let output = scenario.destroy();
+    assert_success("carina destroy", &output);
+
+    let delete_log = scenario.delete_log();
+    let lst_pos = delete_log
+        .iter()
+        .position(|entry| entry == "test.resource.lst")
+        .expect("delete log should contain lst");
+    let cert_pos = delete_log
+        .iter()
+        .position(|entry| entry == "test.resource.primary-cert")
+        .expect("delete log should contain primary-cert");
+
+    assert!(
+        lst_pos < cert_pos,
+        "destroy must delete lst before cert even when cert's resource name differs from its binding; delete log: {delete_log:?}"
+    );
+}
+
+fn carina(project: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_carina"));
+    command
+        .current_dir(project)
+        .env("NO_COLOR", "1")
+        .env_remove("CLICOLOR_FORCE");
+    command
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn destroy_wait_ordering_deletes_dependent_before_wait_target() {
+    let scenario = Scenario::new();
+    scenario.write_config();
+    scenario.init();
+    scenario.seed_carina_state();
+    scenario.seed_mock_provider_state();
+
+    let output = scenario.destroy();
+    assert_success("carina destroy", &output);
+
+    let delete_log = scenario.delete_log();
+    let lst_pos = delete_log
+        .iter()
+        .position(|entry| entry == "test.resource.lst")
+        .expect("delete log should contain lst");
+    let cert_pos = delete_log
+        .iter()
+        .position(|entry| entry == "test.resource.cert")
+        .expect("delete log should contain cert");
+
+    assert!(
+        lst_pos < cert_pos,
+        "destroy must delete lst before cert when lst depends on wait binding cert_issued; delete log: {delete_log:?}"
+    );
+}

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -125,103 +125,17 @@ pub fn get_resource_value_ref_dependencies(
 /// Returns an error if a circular dependency is detected, with a message
 /// showing the cycle path (e.g., "Circular dependency detected: a -> b -> c -> a").
 pub fn sort_resources_by_dependencies(resources: &[Resource]) -> Result<Vec<Resource>, String> {
-    topological_sort(resources, false)
+    topological_sort(resources)
 }
 
-/// Sort resources for destroy ordering.
-///
-/// Like `sort_resources_by_dependencies`, but pre-sorts resources by dependency
-/// depth (ascending) before DFS traversal, then reverses the result. This ensures
-/// that shallower independent resources (like an internet gateway at depth 1)
-/// appear late in destroy order -- after deeper chains have been deleted.
-///
-/// The depth-based pre-sorting is only needed for destroy ordering. For apply
-/// (creation) ordering, the plain topological sort preserves the declaration
-/// order from the .crn file, which is the expected behavior (#1071).
-pub fn sort_resources_for_destroy(resources: &[Resource]) -> Result<Vec<Resource>, String> {
-    let sorted = topological_sort(resources, true)?;
-    Ok(sorted.into_iter().rev().collect())
-}
-
-/// Internal topological sort with optional depth-based pre-sorting.
-///
-/// When `depth_presort` is true, resources are pre-sorted by dependency depth
-/// (ascending) before DFS traversal. This makes the sort input-order-independent,
-/// ensuring stable results for independent branches.
-fn topological_sort(resources: &[Resource], depth_presort: bool) -> Result<Vec<Resource>, String> {
+/// Internal topological sort for creation ordering.
+fn topological_sort(resources: &[Resource]) -> Result<Vec<Resource>, String> {
     // Build binding name to resource mapping
     let mut binding_to_resource: HashMap<String, &Resource> = HashMap::new();
     for resource in resources {
         if let Some(ref binding_name) = resource.binding {
             binding_to_resource.insert(binding_name.clone(), resource);
         }
-    }
-
-    let mut presorted: Vec<&Resource> = resources.iter().collect();
-
-    if depth_presort {
-        // Compute the dependency depth for each resource: the length of the longest
-        // chain from a root (resource with no dependencies) to this resource.
-        let mut depth_cache: HashMap<String, usize> = HashMap::new();
-        fn compute_depth(
-            binding: &str,
-            binding_to_resource: &HashMap<String, &Resource>,
-            cache: &mut HashMap<String, usize>,
-            visiting: &mut HashSet<String>,
-        ) -> usize {
-            if let Some(&cached) = cache.get(binding) {
-                return cached;
-            }
-            // Guard against circular dependencies
-            if visiting.contains(binding) {
-                return 0;
-            }
-            visiting.insert(binding.to_string());
-            let depth = if let Some(resource) = binding_to_resource.get(binding) {
-                let deps = get_resource_dependencies(resource);
-                deps.iter()
-                    .map(|d| 1 + compute_depth(d, binding_to_resource, cache, visiting))
-                    .max()
-                    .unwrap_or(0)
-            } else {
-                0
-            };
-            visiting.remove(binding);
-            cache.insert(binding.to_string(), depth);
-            depth
-        }
-
-        let mut depth_visiting: HashSet<String> = HashSet::new();
-        for resource in resources {
-            let binding = resource.binding.clone().unwrap_or_else(|| {
-                format!("{}:{}", resource.id.resource_type, resource.id.name_str())
-            });
-            compute_depth(
-                &binding,
-                &binding_to_resource,
-                &mut depth_cache,
-                &mut depth_visiting,
-            );
-        }
-
-        // Pre-sort resources by dependency depth (ascending) so DFS visits
-        // shallower resources first. This ensures that "leaf" resources like
-        // an internet gateway (depth 1, no dependents) are emitted early in
-        // creation order, placing them late in destroy order -- after deeper
-        // chains (like nat_gw -> route) have been destroyed.
-        presorted.sort_by(|a, b| {
-            let a_binding = a
-                .binding
-                .clone()
-                .unwrap_or_else(|| format!("{}:{}", a.id.resource_type, a.id.name_str()));
-            let b_binding = b
-                .binding
-                .clone()
-                .unwrap_or_else(|| format!("{}:{}", b.id.resource_type, b.id.name_str()));
-            let a_depth = depth_cache.get(&a_binding).copied().unwrap_or(0);
-            let b_depth = depth_cache.get(&b_binding).copied().unwrap_or(0);
-            a_depth.cmp(&b_depth) // Ascending: shallower first
-        });
     }
 
     // Build dependency graph
@@ -272,7 +186,7 @@ fn topological_sort(resources: &[Resource], depth_presort: bool) -> Result<Vec<R
         Ok(())
     }
 
-    for resource in &presorted {
+    for resource in resources {
         visit(
             resource,
             &binding_to_resource,
@@ -283,49 +197,6 @@ fn topological_sort(resources: &[Resource], depth_presort: bool) -> Result<Vec<R
     }
 
     Ok(sorted)
-}
-
-/// Build a reverse dependency map: for each binding, which bindings depend on it.
-/// If resource A depends on resource B, then `dependents_map["b"]` contains "a".
-pub fn build_dependents_map(resources: &[&Resource]) -> HashMap<String, HashSet<String>> {
-    let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
-    for resource in resources {
-        let binding = resource
-            .binding
-            .clone()
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name_str()));
-
-        let deps = get_resource_dependencies(resource);
-        for dep in deps {
-            dependents_map
-                .entry(dep)
-                .or_default()
-                .insert(binding.clone());
-        }
-    }
-    dependents_map
-}
-
-/// Check if any dependent of the given binding has failed (is in failed_bindings).
-/// Returns the first failed dependent found, if any.
-pub fn find_failed_dependent<'a>(
-    binding: &str,
-    dependents_map: &'a HashMap<String, HashSet<String>>,
-    failed_bindings: &'a HashSet<String>,
-) -> Option<&'a String> {
-    // Check direct dependents
-    if let Some(dependents) = dependents_map.get(binding) {
-        for dep in dependents {
-            if failed_bindings.contains(dep) {
-                return Some(dep);
-            }
-            // Check transitive: if a dependent of this binding has a dependent that failed
-            if let Some(failed) = find_failed_dependent(dep, dependents_map, failed_bindings) {
-                return Some(failed);
-            }
-        }
-    }
-    None
 }
 
 #[cfg(test)]
@@ -499,21 +370,6 @@ mod tests {
     }
 
     #[test]
-    fn test_build_dependents_map() {
-        // A depends on B
-        let a = make_resource("a", &["b"]);
-        let b = make_resource("b", &[]);
-        let resources: Vec<&Resource> = vec![&a, &b];
-
-        let map = build_dependents_map(&resources);
-
-        // b's dependents should contain "a"
-        assert!(map.get("b").unwrap().contains("a"));
-        // a should have no dependents
-        assert!(!map.contains_key("a"));
-    }
-
-    #[test]
     fn wait_blocking_bindings_include_target_before_explicit_dependencies() {
         let effect = wait_effect_with_explicit_dependency(Some("other_failed"));
         let blocking_bindings = effect.blocking_bindings();
@@ -523,35 +379,6 @@ mod tests {
             blocking_bindings.into_iter().collect::<HashSet<_>>(),
             HashSet::from(["cert".to_string(), "other_failed".to_string()])
         );
-    }
-
-    #[test]
-    fn test_find_failed_dependent() {
-        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
-        dependents_map
-            .entry("b".to_string())
-            .or_default()
-            .insert("a".to_string());
-
-        let mut failed_bindings = HashSet::new();
-        failed_bindings.insert("a".to_string());
-
-        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
-        assert_eq!(result, Some(&"a".to_string()));
-    }
-
-    #[test]
-    fn test_find_failed_dependent_none() {
-        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
-        dependents_map
-            .entry("b".to_string())
-            .or_default()
-            .insert("a".to_string());
-
-        let failed_bindings: HashSet<String> = HashSet::new();
-
-        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
-        assert_eq!(result, None);
     }
 
     #[test]
@@ -577,148 +404,6 @@ mod tests {
             err.starts_with("Circular dependency detected:"),
             "Expected circular dependency error, got: {}",
             err
-        );
-    }
-
-    /// Reproduces the destroy ordering issue from #1067:
-    /// When IGW and NAT gateway both depend on VPC but are independent of each other,
-    /// the destroy order must delete NAT gateway (and its route) before IGW.
-    ///
-    /// Dependency graph (from nat_gateway.crn):
-    ///   vpc (root)
-    ///   igw -> vpc
-    ///   subnet -> vpc
-    ///   eip (no deps)
-    ///   nat_gw -> eip, subnet
-    ///   rt -> vpc
-    ///   route -> rt, nat_gw
-    ///
-    /// In destroy order (reversed creation), IGW must come after route and nat_gw
-    /// because AWS requires the NAT gateway to be deleted before the IGW can be detached.
-    #[test]
-    fn test_destroy_order_igw_after_nat_gateway() {
-        let vpc = make_resource("vpc", &[]);
-        let igw = make_resource("igw", &["vpc"]);
-        let subnet = make_resource("subnet", &["vpc"]);
-        let eip = make_resource("eip", &[]);
-        let nat_gw = make_resource("nat_gw", &["eip", "subnet"]);
-        let rt = make_resource("rt", &["vpc"]);
-        let route = make_resource("route", &["rt", "nat_gw"]);
-
-        // Single sort + reverse (the correct approach).
-        // The previous double-sort-reverse pattern (sort → reverse → sort → reverse)
-        // could produce incorrect ordering for independent branches (#1067).
-        //
-        // Test with multiple input orderings to ensure the result is correct
-        // regardless of declaration order in the .crn file.
-        let orderings: Vec<Vec<Resource>> = vec![
-            // Original .crn order
-            vec![
-                vpc.clone(),
-                igw.clone(),
-                subnet.clone(),
-                eip.clone(),
-                nat_gw.clone(),
-                rt.clone(),
-                route.clone(),
-            ],
-            // nat_gw before igw
-            vec![
-                vpc.clone(),
-                subnet.clone(),
-                eip.clone(),
-                nat_gw.clone(),
-                rt.clone(),
-                route.clone(),
-                igw.clone(),
-            ],
-            // igw last
-            vec![
-                eip.clone(),
-                vpc.clone(),
-                subnet.clone(),
-                nat_gw.clone(),
-                rt.clone(),
-                route.clone(),
-                igw.clone(),
-            ],
-        ];
-
-        for (i, input) in orderings.iter().enumerate() {
-            let destroy_order_resources = sort_resources_for_destroy(input).unwrap();
-            let destroy_order: Vec<&str> = destroy_order_resources
-                .iter()
-                .filter_map(|r| r.binding.as_deref())
-                .collect();
-
-            // IGW must come after route and nat_gw in destroy order
-            let igw_pos = destroy_order.iter().position(|&b| b == "igw").unwrap();
-            let route_pos = destroy_order.iter().position(|&b| b == "route").unwrap();
-            let nat_gw_pos = destroy_order.iter().position(|&b| b == "nat_gw").unwrap();
-
-            assert!(
-                igw_pos > route_pos,
-                "Ordering {}: IGW (pos {}) must be destroyed after route (pos {}). Destroy order: {:?}",
-                i,
-                igw_pos,
-                route_pos,
-                destroy_order
-            );
-            assert!(
-                igw_pos > nat_gw_pos,
-                "Ordering {}: IGW (pos {}) must be destroyed after nat_gw (pos {}). Destroy order: {:?}",
-                i,
-                igw_pos,
-                nat_gw_pos,
-                destroy_order
-            );
-        }
-    }
-
-    /// Regression test: the double-sort-reverse pattern that previously
-    /// caused IGW to be destroyed before NAT gateway (#1067).
-    /// This test verifies that even with orphans appended after the initial sort,
-    /// a single sort+reverse produces correct destroy ordering.
-    #[test]
-    fn test_destroy_order_with_orphans_appended() {
-        let vpc = make_resource("vpc", &[]);
-        let igw = make_resource("igw", &["vpc"]);
-        let subnet = make_resource("subnet", &["vpc"]);
-        let eip = make_resource("eip", &[]);
-        let nat_gw = make_resource("nat_gw", &["eip", "subnet"]);
-        let rt = make_resource("rt", &["vpc"]);
-        let route = make_resource("route", &["rt", "nat_gw"]);
-        // Simulate an orphan resource that depends on vpc
-        let orphan = make_resource("orphan", &["vpc"]);
-
-        // Append orphan after initial resources (simulating orphan discovery)
-        let all = vec![vpc, igw, subnet, eip, nat_gw, rt, route, orphan];
-
-        let destroy_order_resources = sort_resources_for_destroy(&all).unwrap();
-        let destroy_order: Vec<&str> = destroy_order_resources
-            .iter()
-            .filter_map(|r| r.binding.as_deref())
-            .collect();
-
-        let igw_pos = destroy_order.iter().position(|&b| b == "igw").unwrap();
-        let route_pos = destroy_order.iter().position(|&b| b == "route").unwrap();
-        let nat_gw_pos = destroy_order.iter().position(|&b| b == "nat_gw").unwrap();
-        let vpc_pos = destroy_order.iter().position(|&b| b == "vpc").unwrap();
-
-        assert!(
-            igw_pos > route_pos,
-            "IGW must be destroyed after route. Destroy order: {:?}",
-            destroy_order
-        );
-        assert!(
-            igw_pos > nat_gw_pos,
-            "IGW must be destroyed after nat_gw. Destroy order: {:?}",
-            destroy_order
-        );
-        assert!(
-            igw_pos < vpc_pos,
-            "IGW must be destroyed before vpc. Destroy order: {:?}",
-            destroy_order
         );
     }
 
@@ -875,28 +560,6 @@ mod tests {
             attach_pos,
             creation_order
         );
-    }
-
-    #[test]
-    fn test_transitive_chain() {
-        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
-        dependents_map
-            .entry("c".to_string())
-            .or_default()
-            .insert("b".to_string());
-        dependents_map
-            .entry("b".to_string())
-            .or_default()
-            .insert("a".to_string());
-
-        let mut failed_bindings = HashSet::new();
-        failed_bindings.insert("a".to_string());
-
-        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
-        assert_eq!(result, Some(&"a".to_string()));
-
-        let result = find_failed_dependent("c", &dependents_map, &failed_bindings);
-        assert_eq!(result, Some(&"a".to_string()));
     }
 
     #[test]

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -3,6 +3,12 @@
 //! An Effect describes "what to do" without actually performing the side effect.
 //! Side effects only occur when they are executed via a Provider.
 
+/// Dependency analysis over a slice of [`Effect`]s.
+///
+/// Centralizes the apply/destroy scheduling graph so the parallel scheduler,
+/// the phased scheduler, and the destroy CLI driver all see the same edges.
+pub mod deps;
+
 use std::{
     collections::{BTreeSet, HashSet},
     ops::Deref,
@@ -21,6 +27,17 @@ pub enum PlanOp {
     Read,
     Update,
     Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScheduleEdge {
+    /// This effect must wait for the named binding to complete.
+    DependsOn(String),
+    /// This effect must complete before the named binding can proceed.
+    BlockedBy(String),
+    /// This effect must complete before the named binding can proceed, but
+    /// only when that binding resolves to a delete effect.
+    BlockedByIfDelete(String),
 }
 
 /// Temporary name used during create-before-destroy replacement.
@@ -1004,6 +1021,72 @@ impl Effect {
                 deps.insert(upstream_binding.clone());
                 deps.into_iter().collect()
             }
+        }
+    }
+
+    /// Scheduling edges this effect contributes when running `apply`.
+    ///
+    /// Returned edges describe ordering constraints relative to other
+    /// bindings; resolving them to concrete effect indices is the
+    /// responsibility of [`crate::effect::deps::build_effect_dependency_analysis`].
+    pub fn apply_edges(&self) -> Vec<ScheduleEdge> {
+        match self {
+            Effect::Delete { dependencies, .. } => dependencies
+                .iter()
+                .cloned()
+                .map(ScheduleEdge::BlockedBy)
+                .collect(),
+            Effect::Replace { from, .. } => from
+                .dependency_bindings
+                .iter()
+                .cloned()
+                .map(ScheduleEdge::BlockedByIfDelete)
+                .collect(),
+            Effect::Wait { .. }
+            | Effect::DeferredCreate { .. }
+            | Effect::DeferredReplace { .. } => self
+                .blocking_bindings()
+                .into_iter()
+                .map(ScheduleEdge::DependsOn)
+                .collect(),
+            Effect::Read { .. }
+            | Effect::Create(_)
+            | Effect::Update { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Move { .. } => Vec::new(),
+        }
+    }
+
+    /// Scheduling edges this effect contributes when running `destroy`.
+    ///
+    /// Differs from [`Self::apply_edges`] in two ways: `Replace.from`
+    /// dependency bindings unconditionally block (rather than only when
+    /// they resolve to deletes), and meta effects (`Wait`, deferred
+    /// variants) contribute no edges because they are not present in
+    /// destroy plans.
+    pub fn destroy_edges(&self) -> Vec<ScheduleEdge> {
+        match self {
+            Effect::Delete { dependencies, .. } => dependencies
+                .iter()
+                .cloned()
+                .map(ScheduleEdge::BlockedBy)
+                .collect(),
+            Effect::Replace { from, .. } => from
+                .dependency_bindings
+                .iter()
+                .cloned()
+                .map(ScheduleEdge::BlockedBy)
+                .collect(),
+            Effect::Read { .. }
+            | Effect::Create(_)
+            | Effect::Update { .. }
+            | Effect::Import { .. }
+            | Effect::Remove { .. }
+            | Effect::Move { .. }
+            | Effect::Wait { .. }
+            | Effect::DeferredCreate { .. }
+            | Effect::DeferredReplace { .. } => Vec::new(),
         }
     }
 }

--- a/carina-core/src/effect/deps.rs
+++ b/carina-core/src/effect/deps.rs
@@ -1,0 +1,677 @@
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use crate::effect::{Effect, ScheduleEdge};
+use crate::non_empty::NonEmptyVec;
+use crate::parser::ResourceRef;
+use crate::resource::{Resource, ResourceId};
+
+#[derive(Debug, Clone)]
+pub struct UnresolvedResource(Resource);
+
+impl UnresolvedResource {
+    /// Pre-resolution snapshot used by dependency analysis and apply-time
+    /// reference re-resolution.
+    pub fn from_pre_resolve(resource: Resource) -> Self {
+        Self(resource)
+    }
+
+    pub fn as_resource(&self) -> &Resource {
+        &self.0
+    }
+}
+
+/// Selects which scheduling contract [`build_effect_dependency_analysis`]
+/// applies.
+///
+/// `Apply` follows the apply scheduler's rules (resource refs become edges,
+/// `Replace` from-bindings block only when they resolve to deletes, meta
+/// effects contribute `DependsOn` edges). `Destroy` ignores resource-ref
+/// edges and instead lets each effect's [`Effect::destroy_edges`] drive the
+/// graph; the typed `aliases` slot carries `wait`-binding bridges that
+/// would otherwise be dropped from the destroy plan, and the variant shape
+/// makes it impossible to pass aliases into an apply run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScheduleInputs<'a> {
+    Apply,
+    Destroy { aliases: &'a [DestroyWaitAlias] },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DestroyWaitAlias {
+    pub binding: String,
+    pub target_binding: String,
+    pub explicit_dependencies: HashSet<String>,
+    pub consumers: NonEmptyVec<String>,
+}
+
+impl DestroyWaitAlias {
+    /// Construct a destroy-wait alias node.
+    ///
+    /// Returns `None` when `consumers` is empty: an alias with no
+    /// consumers carries no scheduling information, so callers should
+    /// drop it rather than treat the `None` as an error.
+    pub fn new(
+        binding: String,
+        target_binding: String,
+        explicit_dependencies: HashSet<String>,
+        consumers: Vec<String>,
+    ) -> Option<Self> {
+        Some(Self {
+            binding,
+            target_binding,
+            explicit_dependencies,
+            consumers: NonEmptyVec::from_vec(consumers)?,
+        })
+    }
+
+    fn destroy_edges(&self) -> Vec<ScheduleEdge> {
+        let mut edges = vec![ScheduleEdge::BlockedBy(self.target_binding.clone())];
+        edges.extend(
+            self.explicit_dependencies
+                .iter()
+                .filter(|dependency| dependency.as_str() != self.target_binding)
+                .cloned()
+                .map(ScheduleEdge::BlockedBy),
+        );
+        edges.extend(self.consumers.iter().cloned().map(ScheduleEdge::DependsOn));
+        edges
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WritesSet {
+    attrs: BTreeSet<String>,
+}
+
+impl WritesSet {
+    pub(crate) fn from_update(effect: &Effect) -> Option<Self> {
+        let Effect::Update {
+            changed_attributes, ..
+        } = effect
+        else {
+            return None;
+        };
+        Some(Self {
+            attrs: changed_attributes.iter().cloned().collect(),
+        })
+    }
+}
+
+pub(crate) mod reads {
+    use std::collections::BTreeSet;
+
+    use crate::resource::AccessPath;
+
+    use super::WritesSet;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) struct KnownReads {
+        attrs: BTreeSet<String>,
+    }
+
+    impl KnownReads {
+        pub(crate) fn from_walker(path: &AccessPath) -> Self {
+            let mut attrs = BTreeSet::new();
+            attrs.insert(path.attribute().to_string());
+            Self { attrs }
+        }
+
+        #[cfg(test)]
+        pub(crate) fn from_attrs(attrs: &[&str]) -> Self {
+            Self {
+                attrs: attrs.iter().map(|attr| (*attr).to_string()).collect(),
+            }
+        }
+
+        pub(crate) fn attrs(&self) -> &BTreeSet<String> {
+            &self.attrs
+        }
+
+        fn union(mut self, other: KnownReads) -> Self {
+            self.attrs.extend(other.attrs);
+            self
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) enum ReadsSet {
+        Known(KnownReads),
+        Unknown,
+    }
+
+    impl ReadsSet {
+        pub(crate) fn from_walker(walker_result: KnownReads) -> Self {
+            Self::Known(walker_result)
+        }
+
+        pub(crate) fn unknown() -> Self {
+            Self::Unknown
+        }
+
+        pub(crate) fn merge(self, other: ReadsSet) -> ReadsSet {
+            match (self, other) {
+                (ReadsSet::Known(a), ReadsSet::Known(b)) => ReadsSet::Known(a.union(b)),
+                _ => ReadsSet::Unknown,
+            }
+        }
+
+        pub(crate) fn disjoint(&self, writes: &WritesSet) -> bool {
+            match self {
+                ReadsSet::Known(set) => set.attrs().is_disjoint(&writes.attrs),
+                ReadsSet::Unknown => false,
+            }
+        }
+
+        #[cfg(test)]
+        pub(crate) fn is_unknown(&self) -> bool {
+            matches!(self, ReadsSet::Unknown)
+        }
+    }
+}
+
+use reads::{KnownReads, ReadsSet};
+
+pub struct DependencyAnalysis {
+    deps_of: HashMap<usize, HashSet<usize>>,
+    dependents_of: HashMap<usize, HashSet<usize>>,
+    reads_by_edge: HashMap<usize, HashMap<usize, ReadsSet>>,
+}
+
+impl DependencyAnalysis {
+    fn new(effect_count: usize) -> Self {
+        let deps_of = (0..effect_count).map(|idx| (idx, HashSet::new())).collect();
+        let dependents_of = (0..effect_count).map(|idx| (idx, HashSet::new())).collect();
+        Self {
+            deps_of,
+            dependents_of,
+            reads_by_edge: HashMap::new(),
+        }
+    }
+
+    fn add_edge(&mut self, child: usize, parent: usize, reads: ReadsSet) {
+        self.deps_of.entry(child).or_default().insert(parent);
+        self.dependents_of.entry(parent).or_default().insert(child);
+        self.reads_by_edge
+            .entry(child)
+            .or_default()
+            .entry(parent)
+            .and_modify(|existing| {
+                let previous = std::mem::replace(existing, ReadsSet::unknown());
+                *existing = previous.merge(reads.clone());
+            })
+            .or_insert(reads);
+    }
+
+    fn remove_edge(&mut self, child: usize, parent: usize) {
+        if let Some(deps) = self.deps_of.get_mut(&child) {
+            deps.remove(&parent);
+        }
+        if let Some(dependents) = self.dependents_of.get_mut(&parent) {
+            dependents.remove(&child);
+        }
+    }
+
+    pub fn deps_of(&self, child: usize) -> Option<&HashSet<usize>> {
+        self.deps_of.get(&child)
+    }
+
+    pub fn dependents_of(&self, parent: usize) -> Option<&HashSet<usize>> {
+        self.dependents_of.get(&parent)
+    }
+
+    pub(crate) fn reads_for_edge(&self, child: usize, parent: usize) -> Option<&ReadsSet> {
+        self.reads_by_edge
+            .get(&child)
+            .and_then(|by_parent| by_parent.get(&parent))
+    }
+
+    pub fn into_deps_of(self) -> HashMap<usize, HashSet<usize>> {
+        self.deps_of
+    }
+}
+
+struct DependencyAnalyzer {
+    binding_to_idx: HashMap<String, usize>,
+    name_to_delete_idx: HashMap<String, usize>,
+    compositions_by_binding: HashMap<String, crate::resource::Composition>,
+}
+
+impl DependencyAnalyzer {
+    fn new(
+        binding_to_idx: HashMap<String, usize>,
+        name_to_delete_idx: HashMap<String, usize>,
+        compositions: &[crate::resource::Composition],
+    ) -> Self {
+        let compositions_by_binding = compositions
+            .iter()
+            .filter_map(|composition| {
+                composition
+                    .binding
+                    .clone()
+                    .map(|binding| (binding, composition.clone()))
+            })
+            .collect();
+        Self {
+            binding_to_idx,
+            name_to_delete_idx,
+            compositions_by_binding,
+        }
+    }
+
+    fn lookup_idx(&self, binding: &str) -> Option<usize> {
+        self.binding_to_idx
+            .get(binding)
+            .or_else(|| self.name_to_delete_idx.get(binding))
+            .copied()
+    }
+
+    fn collect_from_schedule_edges(
+        &self,
+        effects: &[Effect],
+        edges: Vec<ScheduleEdge>,
+        analysis: &mut DependencyAnalysis,
+        self_idx: usize,
+    ) {
+        for edge in edges {
+            match edge {
+                ScheduleEdge::DependsOn(binding) => {
+                    self.record_binding_edge(&binding, ReadsSet::unknown(), analysis, self_idx);
+                }
+                ScheduleEdge::BlockedBy(binding) => {
+                    if let Some(blocked_idx) = self.lookup_idx(&binding) {
+                        analysis.add_edge(blocked_idx, self_idx, ReadsSet::unknown());
+                    }
+                }
+                ScheduleEdge::BlockedByIfDelete(binding) => {
+                    if let Some(blocked_idx) = self.lookup_idx(&binding)
+                        && blocked_idx < effects.len()
+                        && matches!(effects[blocked_idx], Effect::Delete { .. })
+                    {
+                        analysis.add_edge(blocked_idx, self_idx, ReadsSet::unknown());
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_from_resource_ref(
+        &self,
+        resource: ResourceRef<'_>,
+        analysis: &mut DependencyAnalysis,
+        child: usize,
+    ) {
+        let attrs = resource.attributes();
+        let mut bindings_seen_in_values = HashSet::new();
+        for value in attrs.values() {
+            value.visit_resource_refs(&mut |path| {
+                bindings_seen_in_values.insert(path.binding().to_string());
+                self.record_binding_edge(
+                    path.binding(),
+                    ReadsSet::from_walker(KnownReads::from_walker(path)),
+                    analysis,
+                    child,
+                );
+            });
+            value.visit_binding_refs(&mut |binding| {
+                bindings_seen_in_values.insert(binding.to_string());
+                self.record_binding_edge(binding, ReadsSet::unknown(), analysis, child);
+            });
+        }
+        for binding in resource.dependency_bindings() {
+            if !bindings_seen_in_values.contains(binding) {
+                self.record_binding_edge(binding, ReadsSet::unknown(), analysis, child);
+            }
+        }
+        if let Some(directives) = resource.directives() {
+            for binding in &directives.depends_on {
+                self.record_binding_edge(binding, ReadsSet::unknown(), analysis, child);
+            }
+        }
+    }
+
+    fn collect_from_resource(
+        &self,
+        resource: &Resource,
+        analysis: &mut DependencyAnalysis,
+        child: usize,
+    ) {
+        self.collect_from_resource_ref(ResourceRef::Resource(resource), analysis, child);
+    }
+
+    fn record_binding_edge(
+        &self,
+        binding: &str,
+        reads: ReadsSet,
+        analysis: &mut DependencyAnalysis,
+        child: usize,
+    ) {
+        let mut visited = HashSet::new();
+        self.record_binding_edge_inner(binding, reads, analysis, child, &mut visited);
+    }
+
+    fn record_binding_edge_inner<'a>(
+        &'a self,
+        binding: &'a str,
+        reads: ReadsSet,
+        analysis: &mut DependencyAnalysis,
+        child: usize,
+        visited: &mut HashSet<&'a str>,
+    ) {
+        if !visited.insert(binding) {
+            return;
+        }
+        if let Some(parent) = self.lookup_idx(binding) {
+            analysis.add_edge(child, parent, reads);
+            return;
+        }
+        let Some(composition) = self.compositions_by_binding.get(binding) else {
+            return;
+        };
+        for inner in crate::deps::get_composition_dependencies(composition) {
+            let key: &'a str =
+                if let Some((k, _)) = self.compositions_by_binding.get_key_value(inner.as_str()) {
+                    k.as_str()
+                } else if let Some((k, _)) = self.binding_to_idx.get_key_value(inner.as_str()) {
+                    k.as_str()
+                } else {
+                    continue;
+                };
+            self.record_binding_edge_inner(key, ReadsSet::unknown(), analysis, child, visited);
+        }
+    }
+}
+
+/// Build the scheduling dependency graph for a slice of effects.
+///
+/// Single entry point shared by the parallel scheduler, the phased
+/// scheduler, and the destroy CLI driver. `inputs` chooses between the
+/// apply contract and the destroy contract (see [`ScheduleInputs`]); the
+/// resulting [`DependencyAnalysis`] is indexed by effect position, with
+/// any destroy `aliases` appearing at indices `effects.len()..` so callers
+/// can distinguish real effects from wait-binding bridges.
+pub fn build_effect_dependency_analysis(
+    effects: &[Effect],
+    unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
+    compositions: &[crate::resource::Composition],
+    inputs: ScheduleInputs<'_>,
+) -> DependencyAnalysis {
+    let mut binding_to_idx: HashMap<String, usize> = HashMap::new();
+    let mut name_to_delete_idx: HashMap<String, usize> = HashMap::new();
+    let aliases = match inputs {
+        ScheduleInputs::Apply => &[][..],
+        ScheduleInputs::Destroy { aliases } => aliases,
+    };
+    for (idx, effect) in effects.iter().enumerate() {
+        if let Some(binding) = effect.binding_name() {
+            binding_to_idx.insert(binding, idx);
+        }
+        if let Effect::Delete { id, binding, .. } = effect
+            && binding.is_none()
+        {
+            name_to_delete_idx.insert(id.name_str().to_string(), idx);
+        }
+    }
+    let alias_offset = effects.len();
+    for (alias_idx, alias) in aliases.iter().enumerate() {
+        binding_to_idx.insert(alias.binding.clone(), alias_offset + alias_idx);
+    }
+
+    let analyzer = DependencyAnalyzer::new(binding_to_idx, name_to_delete_idx, compositions);
+    let mut analysis = DependencyAnalysis::new(effects.len() + aliases.len());
+
+    for (idx, effect) in effects.iter().enumerate() {
+        match inputs {
+            ScheduleInputs::Apply => {
+                if effect.is_scheduler_meta() {
+                    analyzer.collect_from_schedule_edges(
+                        effects,
+                        effect.apply_edges(),
+                        &mut analysis,
+                        idx,
+                    );
+                    continue;
+                }
+                if effect.as_resource_ref().is_some() {
+                    if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
+                        analyzer.collect_from_resource(
+                            unresolved.as_resource(),
+                            &mut analysis,
+                            idx,
+                        );
+                    } else if let Some(resource) = effect.as_resource_ref() {
+                        analyzer.collect_from_resource_ref(resource, &mut analysis, idx);
+                    }
+                }
+                analyzer.collect_from_schedule_edges(
+                    effects,
+                    effect.apply_edges(),
+                    &mut analysis,
+                    idx,
+                );
+            }
+            ScheduleInputs::Destroy { .. } => {
+                analyzer.collect_from_schedule_edges(
+                    effects,
+                    effect.destroy_edges(),
+                    &mut analysis,
+                    idx,
+                );
+            }
+        }
+    }
+    if let ScheduleInputs::Destroy { .. } = inputs {
+        for (alias_idx, alias) in aliases.iter().enumerate() {
+            analyzer.collect_from_schedule_edges(
+                effects,
+                alias.destroy_edges(),
+                &mut analysis,
+                alias_offset + alias_idx,
+            );
+        }
+    }
+
+    analysis
+}
+
+pub fn relax_update_update_edges(effects: &[Effect], analysis: &mut DependencyAnalysis) {
+    for child in 0..effects.len() {
+        if !matches!(&effects[child], Effect::Update { .. }) {
+            continue;
+        }
+        let Some(parents) = analysis.deps_of(child).cloned() else {
+            continue;
+        };
+        for parent in parents {
+            let Some(writes) = WritesSet::from_update(&effects[parent]) else {
+                continue;
+            };
+            let Some(reads) = analysis.reads_for_edge(child, parent) else {
+                continue;
+            };
+            if reads.disjoint(&writes) {
+                analysis.remove_edge(child, parent);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::effect::ChangedCreateOnly;
+    use crate::resource::{State, Value};
+
+    fn state_for(id: &ResourceId) -> State {
+        State::not_found(id.clone())
+    }
+
+    fn update_effect(binding: &str, refs: &[(&str, &str)], changed: &[&str]) -> Effect {
+        let mut resource = Resource::new("test", binding);
+        resource.binding = Some(binding.to_string());
+        for (dep, attr) in refs {
+            resource.set_attr(
+                format!("{}_{}", dep, attr),
+                Value::resource_ref((*dep).to_string(), (*attr).to_string(), vec![]),
+            );
+        }
+        Effect::Update {
+            id: resource.id.clone(),
+            from: Box::new(state_for(&resource.id)),
+            to: resource,
+            changed_attributes: changed.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn destroy_delete_edges_block_dependencies_by_consumers() {
+        let parent = Effect::Delete {
+            id: ResourceId::new("test", "parent"),
+            identifier: "parent-id".to_string(),
+            directives: Default::default(),
+            binding: Some("parent".to_string()),
+            dependencies: HashSet::new(),
+            explicit_dependencies: HashSet::new(),
+        };
+        let child = Effect::Delete {
+            id: ResourceId::new("test", "child"),
+            identifier: "child-id".to_string(),
+            directives: Default::default(),
+            binding: Some("child".to_string()),
+            dependencies: HashSet::from(["parent".to_string()]),
+            explicit_dependencies: HashSet::new(),
+        };
+        let effects = vec![parent, child];
+
+        let deps = build_effect_dependency_analysis(
+            &effects,
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Destroy { aliases: &[] },
+        )
+        .into_deps_of();
+
+        assert!(deps[&0].contains(&1), "parent delete must wait for child");
+    }
+
+    #[test]
+    fn destroy_wait_alias_bridges_target_to_consumers() {
+        let cert = Effect::Delete {
+            id: ResourceId::new("test", "cert"),
+            identifier: "cert-id".to_string(),
+            directives: Default::default(),
+            binding: Some("cert".to_string()),
+            dependencies: HashSet::new(),
+            explicit_dependencies: HashSet::new(),
+        };
+        let listener = Effect::Delete {
+            id: ResourceId::new("test", "listener"),
+            identifier: "listener-id".to_string(),
+            directives: Default::default(),
+            binding: Some("listener".to_string()),
+            dependencies: HashSet::from(["cert_issued".to_string()]),
+            explicit_dependencies: HashSet::new(),
+        };
+        let wait = DestroyWaitAlias::new(
+            "cert_issued".to_string(),
+            "cert".to_string(),
+            HashSet::new(),
+            vec!["listener".to_string()],
+        )
+        .expect("test alias has a consumer");
+        let effects = vec![cert, listener];
+
+        let deps = build_effect_dependency_analysis(
+            &effects,
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Destroy { aliases: &[wait] },
+        )
+        .into_deps_of();
+
+        assert!(deps[&2].contains(&1), "wait must wait for listener");
+        assert!(deps[&0].contains(&2), "cert must wait for wait alias");
+    }
+
+    #[test]
+    fn destroy_wait_alias_rejects_empty_consumers() {
+        assert!(DestroyWaitAlias::new("w".into(), "t".into(), HashSet::new(), vec![]).is_none());
+    }
+
+    #[test]
+    fn replace_from_dependency_only_blocks_delete_targets() {
+        let mut x = Resource::new("test", "x");
+        x.binding = Some("x".to_string());
+
+        let from = State::existing(ResourceId::new("test", "replace_me"), HashMap::new())
+            .with_dependency_bindings(std::collections::BTreeSet::from(["x".to_string()]));
+        let mut to = Resource::new("test", "replace_me");
+        to.binding = Some("replace_me".to_string());
+
+        let effects = vec![
+            Effect::Create(x),
+            Effect::Replace {
+                id: ResourceId::new("test", "replace_me"),
+                from: Box::new(from),
+                to,
+                directives: Default::default(),
+                changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
+                cascading_updates: Vec::new(),
+                temporary_name: None,
+                cascade_ref_hints: Vec::new(),
+            },
+        ];
+
+        let deps =
+            build_effect_dependency_analysis(&effects, &HashMap::new(), &[], ScheduleInputs::Apply)
+                .into_deps_of();
+
+        assert!(
+            deps[&0].is_empty(),
+            "create target must not be blocked by replace"
+        );
+    }
+
+    #[test]
+    fn unknown_destroy_dependency_names_are_dropped() {
+        let orphan = Effect::Delete {
+            id: ResourceId::new("test", "listener"),
+            identifier: "listener-id".to_string(),
+            directives: Default::default(),
+            binding: Some("listener".to_string()),
+            dependencies: HashSet::from(["missing_wait".to_string()]),
+            explicit_dependencies: HashSet::new(),
+        };
+        let deps = build_effect_dependency_analysis(
+            &[orphan],
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Destroy { aliases: &[] },
+        )
+        .into_deps_of();
+
+        assert!(deps[&0].is_empty());
+    }
+
+    #[test]
+    fn relax_update_update_edge_when_child_reads_disjoint_attribute() {
+        let effects = vec![
+            update_effect("parent", &[], &["tags"]),
+            update_effect("child", &[("parent", "id")], &["tags"]),
+        ];
+        let unresolved: HashMap<ResourceId, UnresolvedResource> = effects
+            .iter()
+            .filter_map(|effect| match effect {
+                Effect::Update { to, .. } => Some((
+                    effect.resource_id().clone(),
+                    UnresolvedResource::from_pre_resolve(to.clone()),
+                )),
+                _ => None,
+            })
+            .collect();
+        let mut analysis =
+            build_effect_dependency_analysis(&effects, &unresolved, &[], ScheduleInputs::Apply);
+        relax_update_update_edges(&effects, &mut analysis);
+
+        assert!(!analysis.into_deps_of()[&1].contains(&0));
+    }
+}

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -23,7 +23,7 @@ mod replace;
 pub(super) mod scheduler;
 pub(crate) mod wait;
 
-pub use parallel::UnresolvedResource;
+pub use crate::effect::deps::UnresolvedResource;
 pub use replace::compute_full_diff_patch;
 
 use std::collections::{HashMap, HashSet};

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -1,13 +1,14 @@
 //! Dependency computation and parallel effect execution.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use tokio_util::sync::CancellationToken;
 
 use crate::effect::Effect;
-use crate::parser::ResourceRef;
+#[cfg(test)]
+use crate::effect::deps::UnresolvedResource;
 use crate::provider::Provider;
 use crate::resource::{Resource, ResourceId, Value};
 
@@ -85,433 +86,19 @@ pub(super) fn is_runtime_noop(effect: &Effect) -> bool {
         || (effect.is_state_operation() && !effect.is_scheduler_meta())
 }
 
-#[derive(Debug, Clone)]
-pub struct UnresolvedResource(Resource);
-
-impl UnresolvedResource {
-    /// Pre-resolution snapshot used by dependency analysis and apply-time
-    /// reference re-resolution.
-    ///
-    /// The executor deliberately accepts this newtype instead of a raw
-    /// [`Resource`] map so saved-plan and live-apply call sites cannot
-    /// accidentally pass resources after `ResourceRef` substitution. The
-    /// wrapped value may still be cloned from CLI-side parser output, but it
-    /// must cross this constructor seam at the pre-resolve snapshot point.
-    pub fn from_pre_resolve(resource: Resource) -> Self {
-        Self(resource)
-    }
-
-    pub fn as_resource(&self) -> &Resource {
-        &self.0
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct WritesSet {
-    attrs: BTreeSet<String>,
-}
-
-impl WritesSet {
-    /// Build the static scheduler write set from the plan-time update
-    /// effect only.
-    ///
-    /// Apply-time patch augmentation can still recompute the effective
-    /// patch, but after #3490 it uses the same type-aware comparison as
-    /// plan-time `changed_attributes`. Attributes that are equivalent
-    /// under that comparison are not widened into the provider patch, so
-    /// the scheduler's static safety predicate remains tied to this
-    /// plan-time set.
-    pub(crate) fn from_update(effect: &Effect) -> Option<Self> {
-        let Effect::Update {
-            changed_attributes, ..
-        } = effect
-        else {
-            return None;
-        };
-        Some(Self {
-            attrs: changed_attributes.iter().cloned().collect(),
-        })
-    }
-}
-
-mod reads {
-    use std::collections::BTreeSet;
-
-    use crate::resource::AccessPath;
-
-    use super::WritesSet;
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub(crate) struct KnownReads {
-        attrs: BTreeSet<String>,
-    }
-
-    impl KnownReads {
-        pub(crate) fn from_walker(path: &AccessPath) -> Self {
-            let mut attrs = BTreeSet::new();
-            attrs.insert(path.attribute().to_string());
-            Self { attrs }
-        }
-
-        #[cfg(test)]
-        pub(crate) fn from_attrs(attrs: &[&str]) -> Self {
-            Self {
-                attrs: attrs.iter().map(|attr| (*attr).to_string()).collect(),
-            }
-        }
-
-        pub(crate) fn attrs(&self) -> &BTreeSet<String> {
-            &self.attrs
-        }
-
-        fn union(mut self, other: KnownReads) -> Self {
-            self.attrs.extend(other.attrs);
-            self
-        }
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub(crate) enum ReadsSet {
-        Known(KnownReads),
-        Unknown,
-    }
-
-    impl ReadsSet {
-        pub(crate) fn from_walker(walker_result: KnownReads) -> Self {
-            Self::Known(walker_result)
-        }
-
-        pub(crate) fn unknown() -> Self {
-            Self::Unknown
-        }
-
-        pub(crate) fn merge(self, other: ReadsSet) -> ReadsSet {
-            match (self, other) {
-                (ReadsSet::Known(a), ReadsSet::Known(b)) => ReadsSet::Known(a.union(b)),
-                _ => ReadsSet::Unknown,
-            }
-        }
-
-        pub(crate) fn disjoint(&self, writes: &WritesSet) -> bool {
-            match self {
-                ReadsSet::Known(set) => set.attrs().is_disjoint(&writes.attrs),
-                ReadsSet::Unknown => false,
-            }
-        }
-
-        #[cfg(test)]
-        pub(crate) fn is_unknown(&self) -> bool {
-            matches!(self, ReadsSet::Unknown)
-        }
-    }
-}
-
-use reads::{KnownReads, ReadsSet};
-
-pub(super) struct DependencyAnalysis {
-    deps_of: HashMap<usize, HashSet<usize>>,
-    reads_by_edge: HashMap<usize, HashMap<usize, ReadsSet>>,
-}
-
-impl DependencyAnalysis {
-    fn new(effect_count: usize) -> Self {
-        let deps_of = (0..effect_count).map(|idx| (idx, HashSet::new())).collect();
-        Self {
-            deps_of,
-            reads_by_edge: HashMap::new(),
-        }
-    }
-
-    fn add_edge(&mut self, child: usize, parent: usize, reads: ReadsSet) {
-        self.deps_of.entry(child).or_default().insert(parent);
-        self.reads_by_edge
-            .entry(child)
-            .or_default()
-            .entry(parent)
-            .and_modify(|existing| {
-                let previous = std::mem::replace(existing, ReadsSet::unknown());
-                *existing = previous.merge(reads.clone());
-            })
-            .or_insert(reads);
-    }
-
-    fn remove_edge(&mut self, child: usize, parent: usize) {
-        if let Some(deps) = self.deps_of.get_mut(&child) {
-            deps.remove(&parent);
-        }
-    }
-
-    fn deps_for(&self, child: usize) -> Option<&HashSet<usize>> {
-        self.deps_of.get(&child)
-    }
-
-    fn reads_for_edge(&self, child: usize, parent: usize) -> Option<&ReadsSet> {
-        self.reads_by_edge
-            .get(&child)
-            .and_then(|by_parent| by_parent.get(&parent))
-    }
-
-    pub(super) fn into_deps_of(self) -> HashMap<usize, HashSet<usize>> {
-        self.deps_of
-    }
-}
-
-struct DependencyAnalyzer {
-    binding_to_idx: HashMap<String, usize>,
-    compositions_by_binding: HashMap<String, crate::resource::Composition>,
-}
-
-impl DependencyAnalyzer {
-    fn new(
-        binding_to_idx: HashMap<String, usize>,
-        compositions: &[crate::resource::Composition],
-    ) -> Self {
-        let compositions_by_binding = compositions
-            .iter()
-            .filter_map(|composition| {
-                composition
-                    .binding
-                    .clone()
-                    .map(|binding| (binding, composition.clone()))
-            })
-            .collect();
-        Self {
-            binding_to_idx,
-            compositions_by_binding,
-        }
-    }
-
-    fn collect_from_effect(
-        &self,
-        effect: &Effect,
-        analysis: &mut DependencyAnalysis,
-        child: usize,
-    ) {
-        if let Some(resource) = effect.as_resource_ref() {
-            self.collect_from_resource_ref(resource, analysis, child);
-            return;
-        }
-
-        for binding in effect.blocking_bindings() {
-            self.record_binding_edge(&binding, ReadsSet::unknown(), analysis, child);
-        }
-    }
-
-    fn collect_from_resource_ref(
-        &self,
-        resource: ResourceRef<'_>,
-        analysis: &mut DependencyAnalysis,
-        child: usize,
-    ) {
-        let attrs = resource.attributes();
-        let mut bindings_seen_in_values = HashSet::new();
-        for value in attrs.values() {
-            value.visit_resource_refs(&mut |path| {
-                bindings_seen_in_values.insert(path.binding().to_string());
-                self.record_binding_edge(
-                    path.binding(),
-                    ReadsSet::from_walker(KnownReads::from_walker(path)),
-                    analysis,
-                    child,
-                );
-            });
-            value.visit_binding_refs(&mut |binding| {
-                bindings_seen_in_values.insert(binding.to_string());
-                self.record_binding_edge(binding, ReadsSet::unknown(), analysis, child);
-            });
-        }
-        for binding in resource.dependency_bindings() {
-            if !bindings_seen_in_values.contains(binding) {
-                self.record_binding_edge(binding, ReadsSet::unknown(), analysis, child);
-            }
-        }
-        if let Some(directives) = resource.directives() {
-            for binding in &directives.depends_on {
-                self.record_binding_edge(binding, ReadsSet::unknown(), analysis, child);
-            }
-        }
-    }
-
-    fn collect_from_resource(
-        &self,
-        resource: &Resource,
-        analysis: &mut DependencyAnalysis,
-        child: usize,
-    ) {
-        self.collect_from_resource_ref(ResourceRef::Resource(resource), analysis, child);
-    }
-
-    fn record_binding_edge(
-        &self,
-        binding: &str,
-        reads: ReadsSet,
-        analysis: &mut DependencyAnalysis,
-        child: usize,
-    ) {
-        let mut visited = HashSet::new();
-        self.record_binding_edge_inner(binding, reads, analysis, child, &mut visited);
-    }
-
-    fn record_binding_edge_inner<'a>(
-        &'a self,
-        binding: &'a str,
-        reads: ReadsSet,
-        analysis: &mut DependencyAnalysis,
-        child: usize,
-        visited: &mut HashSet<&'a str>,
-    ) {
-        if !visited.insert(binding) {
-            return;
-        }
-        if let Some(&parent) = self.binding_to_idx.get(binding) {
-            analysis.add_edge(child, parent, reads);
-            return;
-        }
-        let Some(composition) = self.compositions_by_binding.get(binding) else {
-            return;
-        };
-        for inner in crate::deps::get_composition_dependencies(composition) {
-            let key: &'a str =
-                if let Some((k, _)) = self.compositions_by_binding.get_key_value(inner.as_str()) {
-                    k.as_str()
-                } else if let Some((k, _)) = self.binding_to_idx.get_key_value(inner.as_str()) {
-                    k.as_str()
-                } else {
-                    continue;
-                };
-            self.record_binding_edge_inner(key, ReadsSet::unknown(), analysis, child, visited);
-        }
-    }
-}
-
-pub(super) fn build_dependency_analysis(
-    effects: &[Effect],
-    unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
-    compositions: &[crate::resource::Composition],
-) -> DependencyAnalysis {
-    // Build binding -> effect index mapping
-    let mut binding_to_idx: HashMap<String, usize> = HashMap::new();
-    // Fallback: ResourceId name -> effect index for Delete effects without bindings.
-    // When a resource loses its `let` binding (e.g., becomes anonymous in a new .crn),
-    // the Delete effect has binding: None. But other effects may still reference the
-    // old binding name via state-recorded dependency_bindings. The name-based lookup
-    // allows resolving these dependencies.
-    let mut name_to_delete_idx: HashMap<String, usize> = HashMap::new();
-    for (idx, effect) in effects.iter().enumerate() {
-        if let Some(binding) = effect.binding_name() {
-            binding_to_idx.insert(binding, idx);
-        }
-        if let Effect::Delete { id, binding, .. } = effect
-            && binding.is_none()
-        {
-            name_to_delete_idx.insert(id.name_str().to_string(), idx);
-        }
-    }
-
-    let analyzer = DependencyAnalyzer::new(binding_to_idx.clone(), compositions);
-
-    let mut analysis = DependencyAnalysis::new(effects.len());
-    for (idx, effect) in effects.iter().enumerate() {
-        if effect.is_scheduler_meta() {
-            analyzer.collect_from_effect(effect, &mut analysis, idx);
-        } else if effect.as_resource_ref().is_some() {
-            if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
-                analyzer.collect_from_resource(unresolved.as_resource(), &mut analysis, idx);
-            } else {
-                analyzer.collect_from_effect(effect, &mut analysis, idx);
-            }
-        }
-    }
-
-    // Helper: look up effect index by binding name, falling back to Delete-by-name.
-    let lookup_idx = |binding: &str| -> Option<usize> {
-        binding_to_idx
-            .get(binding)
-            .or_else(|| name_to_delete_idx.get(binding))
-            .copied()
-    };
-
-    // For Delete effects, add reverse dependencies: if subnet depends on vpc,
-    // the vpc delete must wait for subnet delete (children deleted before parents).
-    let mut reverse_deps: Vec<(usize, usize)> = Vec::new();
-    for (idx, effect) in effects.iter().enumerate() {
-        if let Effect::Delete { dependencies, .. } = effect {
-            for dep_binding in dependencies {
-                if let Some(dep_idx) = lookup_idx(dep_binding) {
-                    reverse_deps.push((dep_idx, idx));
-                }
-            }
-        }
-        // For Replace effects (especially CBD), the old resource (from) may have
-        // depended on a resource that is now being deleted. The delete of that
-        // parent must wait for this Replace to complete first (the old resource
-        // is deleted during the Replace's delete phase).
-        // Use from.dependency_bindings (recorded in state) for the old dependencies.
-        if let Effect::Replace { from, .. } = effect {
-            for dep_binding in &from.dependency_bindings {
-                if let Some(dep_idx) = lookup_idx(dep_binding)
-                    && matches!(&effects[dep_idx], Effect::Delete { .. })
-                {
-                    reverse_deps.push((dep_idx, idx));
-                }
-            }
-        }
-    }
-    for (parent_idx, child_idx) in reverse_deps {
-        analysis.add_edge(parent_idx, child_idx, ReadsSet::unknown());
-    }
-
-    // Wait dependencies: each `Effect::Wait` depends on its blocking
-    // bindings, with the target binding first. This keeps the polling
-    // wait behind the effect that produces its target, plus any explicit
-    // `depends_on = [...]` entries from the wait block.
-    for (idx, effect) in effects.iter().enumerate() {
-        if let Effect::Wait { .. } = effect {
-            for dep_binding in effect.blocking_bindings() {
-                if let Some(dep_idx) = lookup_idx(&dep_binding) {
-                    analysis.add_edge(idx, dep_idx, ReadsSet::unknown());
-                }
-            }
-            // Defensive: ensure the wait has an entry even when it has
-            // no resolved deps (an isolated wait still needs to appear
-            // in deps_of so the scheduler's `&deps_of[&idx]` lookup
-            // doesn't panic).
-        }
-    }
-
-    analysis
-}
-
-pub(super) fn relax_update_update_edges(effects: &[Effect], analysis: &mut DependencyAnalysis) {
-    for child in 0..effects.len() {
-        if !matches!(&effects[child], Effect::Update { .. }) {
-            continue;
-        }
-        let Some(parents) = analysis.deps_for(child).cloned() else {
-            continue;
-        };
-        for parent in parents {
-            let Some(writes) = WritesSet::from_update(&effects[parent]) else {
-                continue;
-            };
-            let Some(reads) = analysis.reads_for_edge(child, parent) else {
-                continue;
-            };
-            if reads.disjoint(&writes) {
-                analysis.remove_edge(child, parent);
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 pub(super) fn build_dependency_levels(
     effects: &[Effect],
     unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
     compositions: &[crate::resource::Composition],
 ) -> Vec<Vec<usize>> {
-    let deps_of =
-        build_dependency_analysis(effects, unresolved_resources, compositions).into_deps_of();
+    let deps_of = crate::effect::deps::build_effect_dependency_analysis(
+        effects,
+        unresolved_resources,
+        compositions,
+        crate::effect::deps::ScheduleInputs::Apply,
+    )
+    .into_deps_of();
 
     // Assign levels: each effect's level is max(deps' levels) + 1, or 0 if no deps
     let mut levels: HashMap<usize, usize> = HashMap::new();
@@ -1144,6 +731,11 @@ pub(super) async fn execute_effects_sequential(
 mod tests {
     use super::*;
     use crate::effect::ChangedCreateOnly;
+    use crate::effect::deps::reads::{KnownReads, ReadsSet};
+    use crate::effect::deps::{
+        ScheduleInputs, WritesSet, build_effect_dependency_analysis as build_dependency_analysis,
+        relax_update_update_edges,
+    };
     use crate::plan::Plan;
     use crate::provider::{
         BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
@@ -1356,7 +948,8 @@ mod tests {
                 _ => None,
             })
             .collect();
-        let mut analysis = build_dependency_analysis(&effects, &unresolved, &[]);
+        let mut analysis =
+            build_dependency_analysis(&effects, &unresolved, &[], ScheduleInputs::Apply);
         relax_update_update_edges(&effects, &mut analysis);
         analysis.into_deps_of().remove(&1).unwrap()
     }
@@ -1497,7 +1090,9 @@ mod tests {
                 UnresolvedResource::from_pre_resolve(listener.clone()),
             ),
         ]);
-        let deps = build_dependency_analysis(plan.effects(), &unresolved, &[]).into_deps_of();
+        let deps =
+            build_dependency_analysis(plan.effects(), &unresolved, &[], ScheduleInputs::Apply)
+                .into_deps_of();
         assert!(
             deps.get(&3).is_some_and(|listener_deps| {
                 listener_deps.contains(&1) && listener_deps.contains(&2)
@@ -1664,7 +1259,7 @@ mod tests {
             (child_id, UnresolvedResource::from_pre_resolve(child)),
         ]);
 
-        let analysis = build_dependency_analysis(&effects, &unresolved, &[]);
+        let analysis = build_dependency_analysis(&effects, &unresolved, &[], ScheduleInputs::Apply);
         assert!(
             analysis
                 .reads_for_edge(1, 0)
@@ -1761,7 +1356,8 @@ mod tests {
             ),
             (child_id, UnresolvedResource::from_pre_resolve(child)),
         ]);
-        let mut analysis = build_dependency_analysis(&effects, &unresolved, &[virt]);
+        let mut analysis =
+            build_dependency_analysis(&effects, &unresolved, &[virt], ScheduleInputs::Apply);
         relax_update_update_edges(&effects, &mut analysis);
         let deps_of = analysis.into_deps_of();
 
@@ -1774,7 +1370,8 @@ mod tests {
     #[test]
     fn relax_update_update_edges_handles_empty_plan() {
         let effects = Vec::new();
-        let mut analysis = build_dependency_analysis(&effects, &HashMap::new(), &[]);
+        let mut analysis =
+            build_dependency_analysis(&effects, &HashMap::new(), &[], ScheduleInputs::Apply);
         relax_update_update_edges(&effects, &mut analysis);
         assert!(analysis.into_deps_of().is_empty());
     }
@@ -1783,7 +1380,8 @@ mod tests {
     fn relax_update_update_edges_handles_single_update_without_parent() {
         let effect = update_effect("only", &[], &["tags"]);
         let effects = vec![effect];
-        let mut analysis = build_dependency_analysis(&effects, &HashMap::new(), &[]);
+        let mut analysis =
+            build_dependency_analysis(&effects, &HashMap::new(), &[], ScheduleInputs::Apply);
         relax_update_update_edges(&effects, &mut analysis);
         assert!(analysis.into_deps_of()[&0].is_empty());
     }
@@ -1795,7 +1393,8 @@ mod tests {
             update_effect("parent", &[], &["tags"]),
             Effect::Create(child),
         ];
-        let mut analysis = build_dependency_analysis(&effects, &HashMap::new(), &[]);
+        let mut analysis =
+            build_dependency_analysis(&effects, &HashMap::new(), &[], ScheduleInputs::Apply);
         relax_update_update_edges(&effects, &mut analysis);
         assert!(analysis.into_deps_of()[&0].is_empty());
     }
@@ -1853,7 +1452,9 @@ mod tests {
             UnresolvedResource::from_pre_resolve(role_policy),
         );
 
-        let deps_of = build_dependency_analysis(&effects, &unresolved, &[virt]).into_deps_of();
+        let deps_of =
+            build_dependency_analysis(&effects, &unresolved, &[virt], ScheduleInputs::Apply)
+                .into_deps_of();
 
         assert!(
             deps_of[&1].contains(&0),

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -9,6 +9,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::deps::get_resource_dependencies;
 use crate::effect::Effect;
+use crate::effect::deps::{ScheduleInputs, build_effect_dependency_analysis};
 use crate::provider::{
     CreateRequest, DeleteRequest, PartialReadDiagnostic, Provider, UpdateOutcome, UpdateRequest,
 };
@@ -148,10 +149,9 @@ pub(super) fn topological_sort_replaces(
 /// Build a dependency map for a subset of effects identified by their indices.
 ///
 /// Only considers dependencies between effects in the given subset. Dependencies
-/// on effects outside the subset are ignored (assumed already completed). Wait
-/// blockers, including both target and explicit wait-block dependencies, are
-/// handled uniformly by `DepResolver::collect_from_effect` via
-/// `Effect::blocking_bindings()`.
+/// on effects outside the subset are ignored (assumed already completed).
+/// Edges are sourced from the same apply dependency analysis used by the
+/// parallel scheduler, then filtered down to the current phase.
 ///
 /// `Virtual` resources (the synthetic bindings module calls expose for their
 /// `attributes { }` block) have no Effect and would be invisible to a direct
@@ -165,149 +165,26 @@ pub(super) fn build_phase_dependency_map(
     unresolved_resources: &HashMap<ResourceId, UnresolvedResource>,
     compositions: &[crate::resource::Composition],
 ) -> HashMap<usize, HashSet<usize>> {
-    // Build binding -> effect index mapping for effects in this phase
     let phase_set: HashSet<usize> = phase_indices.iter().copied().collect();
-    let mut binding_to_idx: HashMap<String, usize> = HashMap::new();
-    for &idx in phase_indices {
-        if let Some(binding) = effects[idx].binding_name() {
-            binding_to_idx.insert(binding, idx);
-        }
-    }
+    let analysis = build_effect_dependency_analysis(
+        effects,
+        unresolved_resources,
+        compositions,
+        ScheduleInputs::Apply,
+    );
 
-    let resolver = DepResolver::new(&binding_to_idx, compositions, Some(&phase_set));
-
-    let mut deps_of: HashMap<usize, HashSet<usize>> = HashMap::new();
-    for &idx in phase_indices {
-        let mut dep_indices = HashSet::new();
-        let effect = &effects[idx];
-        match effect {
-            Effect::Wait { .. }
-            | Effect::DeferredCreate { .. }
-            | Effect::DeferredReplace { .. } => {
-                resolver.collect_from_effect(effect, &mut dep_indices);
-            }
-            _ if effect.as_resource_ref().is_some() => {
-                resolver.collect_from_effect(effect, &mut dep_indices);
-                if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
-                    resolver.collect_from_resource(unresolved.as_resource(), &mut dep_indices);
-                }
-            }
-            _ => {}
-        }
-        deps_of.insert(idx, dep_indices);
-    }
-    deps_of
-}
-
-/// Resolve binding-name dependencies to the effect indices they reach,
-/// expanding any [`Composition`] proxy bindings transparently
-/// through their own attribute references (#2543).
-///
-/// carina#3181: composition resources are a distinct typestate, supplied to
-/// [`DepResolver::new`] as their own slice and indexed by `binding`
-/// name. A binding present in `compositions_by_binding` *is* the "this is a
-/// composition" condition — the `expand` walk follows such a binding through
-/// the composition's own attribute references.
-pub(super) struct DepResolver<'a> {
-    binding_to_idx: &'a HashMap<String, usize>,
-    /// Virtual resources owned by the resolver, keyed by their
-    /// `binding` name.
-    compositions_by_binding: HashMap<String, crate::resource::Composition>,
-    /// `Some` filters output indices to those in the phase; `None` retains
-    /// every reachable index.
-    phase_set: Option<&'a HashSet<usize>>,
-}
-
-impl<'a> DepResolver<'a> {
-    pub(super) fn new(
-        binding_to_idx: &'a HashMap<String, usize>,
-        compositions: &[crate::resource::Composition],
-        phase_set: Option<&'a HashSet<usize>>,
-    ) -> Self {
-        // carina#3181: composition resources are a distinct typestate, so
-        // they arrive as their own slice. Index them by `binding` name —
-        // a binding being present in `compositions_by_binding` *is* the
-        // "this is a composition" condition the `expand` walk checks.
-        let compositions_by_binding: HashMap<String, crate::resource::Composition> = compositions
-            .iter()
-            .filter_map(|v| v.binding.clone().map(|b| (b, v.clone())))
-            .collect();
-        Self {
-            binding_to_idx,
-            compositions_by_binding,
-            phase_set,
-        }
-    }
-
-    /// Walk a resource's dependencies (via `get_resource_dependencies`) and
-    /// merge the reached effect indices into `out`.
-    pub(super) fn collect_from_resource(&self, resource: &Resource, out: &mut HashSet<usize>) {
-        let dep_bindings = get_resource_dependencies(resource);
-        let mut visited: HashSet<&str> = HashSet::new();
-        for binding in &dep_bindings {
-            self.expand(binding.as_str(), out, &mut visited);
-        }
-    }
-
-    /// Walk an effect's dependencies and merge the reached effect indices
-    /// into `out`.
-    ///
-    /// `Effect::blocking_bindings` concentrates the blocker set: managed
-    /// resources/data sources contribute value refs plus explicit
-    /// `depends_on`, and waits contribute their target plus explicit
-    /// wait-block dependencies.
-    pub(super) fn collect_from_effect(&self, effect: &Effect, out: &mut HashSet<usize>) {
-        let dep_bindings = effect.blocking_bindings();
-        let mut visited: HashSet<&str> = HashSet::new();
-        for binding in &dep_bindings {
-            self.expand(binding.as_str(), out, &mut visited);
-        }
-    }
-
-    /// Recursive dependency walk. The `'b` lifetime is bound to the
-    /// `&self` borrow at the call site so the borrowed keys live
-    /// inside the resolver (`compositions_by_binding` / `binding_to_idx`).
-    fn expand<'b>(
-        &'b self,
-        binding: &'b str,
-        out: &mut HashSet<usize>,
-        visited: &mut HashSet<&'b str>,
-    ) {
-        if !visited.insert(binding) {
-            return;
-        }
-        if let Some(&idx) = self.binding_to_idx.get(binding) {
-            if self.phase_set.is_none_or(|s| s.contains(&idx)) {
-                out.insert(idx);
-            }
-            return;
-        }
-        // No effect for this binding. If it names a `Composition`
-        // (a module's attributes-block proxy), follow the
-        // references in its own attributes to the underlying
-        // resources the module exposes. The typed map answers
-        // "is this a composition?" by presence — no `matches!` probe.
-        let Some(virt) = self.compositions_by_binding.get(binding) else {
-            return;
-        };
-        // `get_composition_dependencies` returns owned `String`s,
-        // but the visit set borrows from this resolver's keys to
-        // avoid per-binding allocation. Re-borrow each inner
-        // binding from the resolver's own keys so the borrow
-        // lifetime matches `'b` (the `&self` borrow lifetime).
-        for inner in crate::deps::get_composition_dependencies(virt) {
-            let key: &'b str =
-                if let Some((k, _)) = self.compositions_by_binding.get_key_value(inner.as_str()) {
-                    k.as_str()
-                } else if let Some((k, _)) = self.binding_to_idx.get_key_value(inner.as_str()) {
-                    k.as_str()
-                } else {
-                    // Unknown binding: not in the resource graph, skip.
-                    continue;
-                };
-            self.expand(key, out, visited);
-        }
-    }
+    phase_indices
+        .iter()
+        .map(|idx| {
+            let deps = analysis
+                .deps_of(*idx)
+                .into_iter()
+                .flat_map(|deps| deps.iter().copied())
+                .filter(|dep| phase_set.contains(dep))
+                .collect();
+            (*idx, deps)
+        })
+        .collect()
 }
 
 /// Result of a phased effect operation within a single phase.

--- a/carina-core/src/executor/scheduler.rs
+++ b/carina-core/src/executor/scheduler.rs
@@ -7,11 +7,12 @@ use crate::resource::ResourceId;
 
 use super::UnresolvedResource;
 use super::deferred_dispatch::{DeferredDispatchResult, PureMetaCtx, dispatch_deferred_create};
-use super::parallel::{
-    apply_deferred_replace_delete_deps, build_dependency_analysis, relax_update_update_edges,
-};
+use super::parallel::apply_deferred_replace_delete_deps;
 use super::wait::SKIP_REASON_CANCELLED;
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
+use crate::effect::deps::{
+    ScheduleInputs, build_effect_dependency_analysis, relax_update_update_edges,
+};
 
 pub(super) struct PureMetaStep<'a> {
     effect: &'a Effect,
@@ -91,7 +92,12 @@ pub(super) fn build_scheduler_deps(
     compositions: &[crate::resource::Composition],
     deferred_replace_delete_deps: &[(usize, usize)],
 ) -> HashMap<usize, HashSet<usize>> {
-    let mut analysis = build_dependency_analysis(effects, unresolved_resources, compositions);
+    let mut analysis = build_effect_dependency_analysis(
+        effects,
+        unresolved_resources,
+        compositions,
+        ScheduleInputs::Apply,
+    );
     relax_update_update_edges(effects, &mut analysis);
     let mut deps_of = analysis.into_deps_of();
     apply_deferred_replace_delete_deps(&mut deps_of, deferred_replace_delete_deps);

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::effect::deps::{
+    ScheduleInputs, build_effect_dependency_analysis as build_dependency_analysis,
+};
 use crate::effect::{DeferredReplaceDelete, NonEmptyDeletes};
 use crate::plan::Plan;
 use crate::provider::{
@@ -10,7 +13,7 @@ use crate::resource::{
     Value,
 };
 use crate::value::SerializationError;
-use parallel::{build_dependency_analysis, build_dependency_levels};
+use parallel::build_dependency_levels;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -4121,7 +4124,9 @@ fn test_build_dependency_levels_consistent_with_dependency_map() {
     plan.add(Effect::Create(d));
 
     let levels = build_dependency_levels(plan.effects(), &HashMap::new(), &[]);
-    let dep_map = build_dependency_analysis(plan.effects(), &HashMap::new(), &[]).into_deps_of();
+    let dep_map =
+        build_dependency_analysis(plan.effects(), &HashMap::new(), &[], ScheduleInputs::Apply)
+            .into_deps_of();
 
     // Verify levels are consistent with the dependency map:
     // For every effect, its level must be greater than all its dependencies' levels.
@@ -4217,7 +4222,9 @@ fn test_dependency_analysis_respects_delete_dependencies() {
         explicit_dependencies: std::collections::HashSet::new(),
     });
 
-    let deps = build_dependency_analysis(plan.effects(), &HashMap::new(), &[]).into_deps_of();
+    let deps =
+        build_dependency_analysis(plan.effects(), &HashMap::new(), &[], ScheduleInputs::Apply)
+            .into_deps_of();
 
     // vpc delete (idx 0) must depend on subnet delete (idx 1)
     // because subnet must be deleted before vpc (reverse dependency)

--- a/carina-provider-mock/Cargo.toml
+++ b/carina-provider-mock/Cargo.toml
@@ -17,7 +17,7 @@ carina-core = { path = "../carina-core" }
 carina-plugin-sdk = { path = "../carina-plugin-sdk" }
 carina-provider-protocol = { path = "../carina-provider-protocol" }
 serde_json = "1"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["rt", "time"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::env;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -125,6 +126,26 @@ impl MockProvider {
         config.resource_id_pattern == "*"
             || config.resource_id_pattern == full
             || config.resource_id_pattern == short
+    }
+
+    fn append_delete_log(path: PathBuf, id: &ResourceId) -> Result<(), std::io::Error> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+        writeln!(file, "{}", Self::resource_key(id))
+    }
+
+    fn delete_delay_for(id: &ResourceId) -> Option<Duration> {
+        let target = env::var("CARINA_MOCK_DELETE_DELAY_MS_FOR").ok()?;
+        if target != Self::resource_key(id) {
+            return None;
+        }
+        env::var("CARINA_MOCK_DELETE_DELAY_MS")
+            .ok()
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .filter(|millis| *millis > 0)
+            .map(Duration::from_millis)
     }
 }
 
@@ -338,6 +359,16 @@ impl Provider for MockProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         let id = id.clone();
         Box::pin(async move {
+            if let Some(delay) = Self::delete_delay_for(&id) {
+                tokio::time::sleep(delay).await;
+            }
+
+            if let Some(path) = env::var_os("CARINA_MOCK_DELETE_LOG").map(PathBuf::from) {
+                Self::append_delete_log(path, &id).map_err(|e| {
+                    ProviderError::internal("Failed to append delete log").with_cause(e)
+                })?;
+            }
+
             let mut states = self.load_states();
             let key = Self::resource_key(&id);
 
@@ -357,6 +388,10 @@ impl Provider for MockProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+    use std::time::Instant;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // Pin the byte-level shape so MockProvider's state file matches
     // the trailing-newline convention used by carina.state.json
@@ -391,6 +426,63 @@ mod tests {
         assert_eq!(
             provider.required_permissions(&id, carina_core::effect::PlanOp::Create),
             Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn append_delete_log_records_resource_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log_path = tmp.path().join("delete.log");
+        let first = ResourceId::with_provider("mock", "test.resource", "first", None);
+        let second = ResourceId::with_provider("mock", "test.resource", "second", None);
+
+        MockProvider::append_delete_log(log_path.clone(), &first).unwrap();
+        MockProvider::append_delete_log(log_path.clone(), &second).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(log_path).unwrap(),
+            "test.resource.first\ntest.resource.second\n"
+        );
+    }
+
+    #[test]
+    fn delete_delay_env_var_delays_matching_resource_delete() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state_file = tmp.path().join("mock-state.json");
+        let provider = MockProvider {
+            state_file,
+            partial_create: None,
+            partial_update: None,
+        };
+        let id = ResourceId::with_provider("mock", "test.resource", "slow", None);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+
+        // SAFETY: This test serializes access to the process environment with
+        // ENV_LOCK and clears the variables before releasing the lock.
+        unsafe {
+            env::set_var("CARINA_MOCK_DELETE_DELAY_MS_FOR", "test.resource.slow");
+            env::set_var("CARINA_MOCK_DELETE_DELAY_MS", "25");
+        }
+
+        let started = Instant::now();
+        runtime
+            .block_on(provider.delete(&id, "mock-id", DeleteRequest::default()))
+            .unwrap();
+        let elapsed = started.elapsed();
+
+        // SAFETY: See the set_var safety note above; ENV_LOCK is still held.
+        unsafe {
+            env::remove_var("CARINA_MOCK_DELETE_DELAY_MS_FOR");
+            env::remove_var("CARINA_MOCK_DELETE_DELAY_MS");
+        }
+
+        assert!(
+            elapsed >= Duration::from_millis(25),
+            "matching delete should be delayed by at least 25ms, elapsed {elapsed:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `carina destroy` was scheduling resource deletes in parallel with their `wait`-binding targets, causing failures like `aws.acm.Certificate` reporting "Certificate is in use" while the `Listener` consumer was still alive.
- Root cause: apply and destroy each had their own dependency-graph implementation, and destroy's version (`carina-core/src/deps.rs`'s `sort_resources_for_destroy` / `build_dependents_map` / `find_failed_dependent`) consumed only `Resource` objects. Wait bindings live outside that set, so the wait→target edge was dropped silently.
- Fix: factor the dependency graph into `carina-core/src/effect/deps.rs` and route both apply and destroy through the same builder. Destroy contributes `Effect::Delete` nodes plus standalone `DestroyWaitAlias` nodes synthesised from `parsed.wait_bindings`.

## Type-level guarantees that prevent the bug class from recurring

- `Effect::apply_edges()` / `Effect::destroy_edges()` are exhaustive matches. A new `Effect` variant must declare both directions or fail to compile.
- `ScheduleEdge::{DependsOn, BlockedBy, BlockedByIfDelete}` lets the builder stay direction-agnostic; no per-variant special-cases.
- `DestroyWaitAlias` is its own struct, not an `Effect` variant. Apply paths cannot see it. `consumers: NonEmptyVec<String>` makes the empty-consumer state unrepresentable; `new` returns `Option<Self>` so callers gracefully drop empty cases.
- `ScheduleInputs::{Apply, Destroy { aliases }}` ties destroy aliases to the destroy direction at the builder's entry point. Apply cannot pass aliases.
- `Effect::Replace::apply_edges` returns `BlockedByIfDelete`, restoring the pre-refactor "only add the back-edge when the dep is itself Delete" CBD semantics (otherwise unrelated Create/Update would have been serialized behind Replace).

## Other restorations from the prior destroy path

- Cycle detection returns `Result<_, String>` with the cycle path, matching the old `sort_resources_for_destroy` behaviour.
- `#1067` depth pre-sort comes back as a tie-breaker on the unified graph (deeper chains drain first).
- `executor/phased.rs` now routes through the shared analysis instead of hand-rolling edge collection from `blocking_bindings()` and value refs.

## Removed

- `sort_resources_for_destroy`, `build_dependents_map`, `find_failed_dependent` in `carina-core/src/deps.rs` — no remaining callers after the unification.

## Out of scope (deliberately not changed)

- Wait predicate parsing/evaluation.
- Apply behaviour beyond the mechanical factoring.
- `format_destroy_plan` tree rendering (snapshot tests all unchanged).
- Provider read/refresh, state migration.

## Test plan

- [x] `carina-cli/tests/destroy_wait_ordering_e2e.rs` — two e2e tests under `--parallelism 8`: basic wait-ordering reproducer + a binding-name-vs-resource-name regression (`name = "primary-cert"` on `let cert = ...`).
- [x] `carina-core/src/effect/deps.rs` unit tests — delete reverse edges, wait-alias bridging, unknown-dependency drop, `NonEmptyVec` empty rejection.
- [x] `carina-cli/src/commands/destroy.rs` unit tests — cycle detection error and depth-based tie-break on the VPC+IGW+NAT graph.
- [x] Mock-provider unit test for the new delete delay env-var hook.
- [x] `cargo nextest run --workspace` — 4354 passed, 72 skipped.
- [x] `cargo test --workspace --doc` — passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- [x] `bash scripts/check-*.sh` — all passed.
- [x] No destroy display snapshots required regeneration.

Closes #3622