### PR TITLE
feat: introduce ResourceIdentity opaque type, replace ResourceName

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -808,7 +808,7 @@ async fn run_apply_with_observer_factory(
                         .ok_or("Backend does not specify a resource type")?;
                     let bucket_resource_name = parsed
                         .find_resource_by_attr(backend_resource_type, "bucket", &bucket_name)
-                        .map(|r| r.id.name_str().to_string())
+                        .map(|r| r.id.identity_or_empty().to_string())
                         .ok_or_else(|| {
                             format!(
                                 "Auto-injected state bucket resource '{}' not found after re-parse",
@@ -1066,8 +1066,11 @@ async fn run_apply_locked(
             sorted_resources
                 .iter()
                 .filter_map(|r| {
-                    let rs =
-                        sf.find_resource(&r.id.provider, &r.id.resource_type, r.id.name_str())?;
+                    let rs = sf.find_resource(
+                        &r.id.provider,
+                        &r.id.resource_type,
+                        r.id.identity_or_empty(),
+                    )?;
                     if rs.dependency_bindings.is_empty() {
                         None
                     } else {

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -91,7 +91,7 @@ impl Provider for FailBCreateProvider {
     ) -> BoxFuture<'_, ProviderResult<carina_core::provider::CreateOutcome>> {
         let id = id.clone();
         Box::pin(async move {
-            if id.name_str() == "b" {
+            if id.identity_or_empty() == "b" {
                 return Err(ProviderError::api_error("create failed").for_resource(id));
             }
             let resource = request.resource.as_resource().clone();
@@ -536,8 +536,12 @@ fn build_state_after_apply_preserves_block_name_attribute() {
 
     // Now simulate second plan: build_saved_attrs should return the policies
     let saved_attrs = state.build_saved_attrs();
-    let id =
-        carina_core::resource::ResourceId::with_provider("awscc", "iam.role", "test-role", None);
+    let id = carina_core::resource::ResourceId::with_provider_identity(
+        "awscc",
+        "iam.role",
+        "test-role",
+        None,
+    );
     let attrs = saved_attrs.get(&id).unwrap();
     assert!(
         attrs.contains_key("policies"),
@@ -767,8 +771,12 @@ fn block_name_attribute_state_roundtrip() {
 
     // Verify roundtrip through saved_attrs
     let saved_attrs = state.build_saved_attrs();
-    let id =
-        carina_core::resource::ResourceId::with_provider("awscc", "ec2.ipam", "test-ipam", None);
+    let id = carina_core::resource::ResourceId::with_provider_identity(
+        "awscc",
+        "ec2.ipam",
+        "test-ipam",
+        None,
+    );
     let attrs = saved_attrs.get(&id).unwrap();
     let operating_regions = attrs
         .get("operating_regions")
@@ -824,7 +832,7 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
     // Desired resource lives at the post-rename SimHash address with
     // the post-rename role_name + policy_name (the values the user
     // wrote in .crn after the IAM Role rename).
-    let new_id = ResourceId::with_provider(
+    let new_id = ResourceId::with_provider_identity(
         "awscc",
         "iam.RolePolicy",
         "rd.awscc_iam_role_policy_0cd2c914",
@@ -835,7 +843,7 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
         ..Resource::with_provider(
             new_id.provider.clone(),
             new_id.resource_type.clone(),
-            new_id.name.as_str(),
+            new_id.identity_or_empty(),
             None,
         )
     };
@@ -911,7 +919,7 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
     // Plan has Replace (handled via applied_states in Phase 1) plus
     // Move from the old address to the new one (Phase 2).
     let mut plan = Plan::new();
-    let from_id = ResourceId::with_provider(
+    let from_id = ResourceId::with_provider_identity(
         "awscc",
         "iam.RolePolicy",
         "rd.awscc_iam_role_policy_02942703",
@@ -1007,7 +1015,7 @@ fn move_plus_update_keeps_post_update_attributes() {
         .attribute(AttributeSchema::new("value", AttributeType::string()));
     schemas.insert("awscc", schema);
 
-    let new_id = ResourceId::with_provider("awscc", "ec2.Tag", "tag_new", None);
+    let new_id = ResourceId::with_provider_identity("awscc", "ec2.Tag", "tag_new", None);
     let mut resource = Resource::with_provider("awscc", "ec2.Tag", "tag_new", None);
     resource.set_attr(
         "key".to_string(),
@@ -1041,7 +1049,7 @@ fn move_plus_update_keeps_post_update_attributes() {
     state_file.resources.push(old_row);
 
     let mut plan = Plan::new();
-    let from_id = ResourceId::with_provider("awscc", "ec2.Tag", "tag_old", None);
+    let from_id = ResourceId::with_provider_identity("awscc", "ec2.Tag", "tag_old", None);
     plan.add(Effect::Update {
         id: new_id.clone(),
         from: Box::new(State::existing(from_id.clone(), HashMap::new())),
@@ -1098,7 +1106,7 @@ fn move_alone_carries_attributes_via_current_states() {
             .attribute(AttributeSchema::new("bucket_name", AttributeType::string()).create_only()),
     );
 
-    let new_id = ResourceId::with_provider("awscc", "s3.Bucket", "bucket_new", None);
+    let new_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "bucket_new", None);
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "bucket_new", None);
     resource.set_attr(
         "bucket_name".to_string(),
@@ -1118,7 +1126,7 @@ fn move_alone_carries_attributes_via_current_states() {
 
     // State file still has the pre-move address — that's what the
     // Move's `from` cleanup targets.
-    let from_id = ResourceId::with_provider("awscc", "s3.Bucket", "bucket_old", None);
+    let from_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "bucket_old", None);
     let old_row = ResourceState::new("s3.Bucket", "bucket_old", "awscc")
         .with_identifier("my-bucket")
         .with_attribute("bucket_name", serde_json::Value::String("my-bucket".into()));
@@ -1175,8 +1183,8 @@ fn move_with_absent_from_is_no_op() {
     use carina_state::StateFile;
 
     let schemas = SchemaRegistry::new();
-    let from_id = ResourceId::with_provider("awscc", "s3.Bucket", "stale_from", None);
-    let to_id = ResourceId::with_provider("awscc", "s3.Bucket", "stale_to", None);
+    let from_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "stale_from", None);
+    let to_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "stale_to", None);
 
     let mut plan = Plan::new();
     plan.add(Effect::Move {
@@ -1215,7 +1223,7 @@ fn failed_refresh_preserves_existing_row() {
             .attribute(AttributeSchema::new("bucket_name", AttributeType::string()).create_only()),
     );
 
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "stuck", None);
+    let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "stuck", None);
     let resource = Resource::with_provider("awscc", "s3.Bucket", "stuck", None);
     let sorted_resources = vec![resource];
 
@@ -1268,7 +1276,7 @@ fn move_from_overlapping_desired_resource_errors() {
             .attribute(AttributeSchema::new("bucket_name", AttributeType::string()).create_only()),
     );
 
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "collision", None);
+    let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "collision", None);
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "collision", None);
     resource.set_attr(
         "bucket_name".to_string(),
@@ -1282,7 +1290,7 @@ fn move_from_overlapping_desired_resource_errors() {
         State::existing(id.clone(), HashMap::new()).with_identifier("x"),
     );
 
-    let to_id = ResourceId::with_provider("awscc", "s3.Bucket", "elsewhere", None);
+    let to_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "elsewhere", None);
     let mut plan = Plan::new();
     plan.add(Effect::Move {
         from: id.clone(),
@@ -1326,7 +1334,7 @@ fn remove_overlapping_desired_resource_errors() {
             .attribute(AttributeSchema::new("bucket_name", AttributeType::string()).create_only()),
     );
 
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "collision", None);
+    let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "collision", None);
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "collision", None);
     resource.set_attr(
         "bucket_name".to_string(),
@@ -1378,7 +1386,7 @@ fn self_move_overlapping_desired_resource_errors() {
             .attribute(AttributeSchema::new("bucket_name", AttributeType::string()).create_only()),
     );
 
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "self", None);
+    let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "self", None);
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "self", None);
     resource.set_attr(
         "bucket_name".to_string(),
@@ -1569,7 +1577,7 @@ fn resolve_exports_resolves_module_call_attribute_via_composition() {
         )),
     );
     let composition = Composition {
-        id: carina_core::resource::ResourceId::new("_virtual", "github_actions_carina"),
+        id: carina_core::resource::ResourceId::with_identity("_virtual", "github_actions_carina"),
         signature: carina_core::resource::Signature {
             arguments: indexmap::IndexMap::new(),
             attributes: virt_attrs,
@@ -1672,7 +1680,7 @@ fn resolve_exports_resolves_chained_module_call_attribute_via_two_compositions()
             )),
         );
         Composition {
-            id: carina_core::resource::ResourceId::new("_virtual", id_name),
+            id: carina_core::resource::ResourceId::with_identity("_virtual", id_name),
             signature: carina_core::resource::Signature {
                 arguments: indexmap::IndexMap::new(),
                 attributes,
@@ -1819,7 +1827,7 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
     // pipeline resolver sees. Holds the OLD ARN, so the pre-apply
     // pass freezes composition `role_arn` to OLD_ARN.
     let pre_apply_current_states: HashMap<ResourceId, ResourceState> = {
-        let id = ResourceId::with_provider("awscc", "iam.Role", "carina_role", None);
+        let id = ResourceId::with_provider_identity("awscc", "iam.Role", "carina_role", None);
         let mut attrs: HashMap<String, Value> = HashMap::new();
         attrs.insert(
             "arn".to_string(),
@@ -1851,7 +1859,7 @@ fn resolve_exports_picks_post_apply_role_arn_after_replace_3169() {
         )),
     );
     let composition = Composition {
-        id: ResourceId::new("_virtual", "carina_module"),
+        id: ResourceId::with_identity("_virtual", "carina_module"),
         signature: carina_core::resource::Signature {
             arguments: indexmap::IndexMap::new(),
             attributes: virt_attrs,
@@ -1969,7 +1977,7 @@ fn resolve_exports_resolves_data_source_attribute_after_apply_3266() {
     };
 
     // The authored data source: `let admin_access_roles = read aws.iam.Roles { ... }`.
-    let ds_id = ResourceId::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+    let ds_id = ResourceId::with_provider_identity("aws", "iam.Roles", "admin_access_roles", None);
     let mut ds = DataSource::with_provider("aws", "iam.Roles", "admin_access_roles", None);
     ds.binding = Some("admin_access_roles".to_string());
     ds.attributes.insert(

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -378,11 +378,11 @@ async fn run_destroy_locked(
         let left_key = left
             .binding
             .as_deref()
-            .unwrap_or_else(|| left.id.name_str());
+            .unwrap_or_else(|| left.id.identity_or_empty());
         let right_key = right
             .binding
             .as_deref()
-            .unwrap_or_else(|| right.id.name_str());
+            .unwrap_or_else(|| right.id.identity_or_empty());
         left_key.cmp(right_key)
     });
 
@@ -422,7 +422,7 @@ async fn run_destroy_locked(
             resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name_str().to_string())
+                .unwrap_or_else(|| resource.id.identity_or_empty().to_string())
         })
         .collect();
     let display_order = topological_delete_order(
@@ -591,7 +591,11 @@ async fn run_destroy_locked(
                 _ => unreachable!("destroy resource_info only contains delete effects"),
             };
             let binding = resource.binding.clone().unwrap_or_else(|| {
-                format!("{}:{}", resource.id.resource_type, resource.id.name_str())
+                format!(
+                    "{}:{}",
+                    resource.id.resource_type,
+                    resource.id.identity_or_empty()
+                )
             });
             (binding, identifier, effect.clone())
         })
@@ -1147,7 +1151,7 @@ fn build_destroy_wait_aliases(
                     resource
                         .binding
                         .clone()
-                        .unwrap_or_else(|| resource.id.name_str().to_string())
+                        .unwrap_or_else(|| resource.id.identity_or_empty().to_string())
                 })
                 .collect::<Vec<_>>();
 
@@ -1643,7 +1647,9 @@ mod tests {
             .exports
             .insert("vpc_id".to_string(), serde_json::json!("vpc-12345"));
 
-        let destroyed = vec![ResourceId::with_provider("awscc", "ec2.Vpc", "main", None)];
+        let destroyed = vec![ResourceId::with_provider_identity(
+            "awscc", "ec2.Vpc", "main", None,
+        )];
         apply_destroy_to_state(&mut state, &destroyed);
 
         assert!(state.resources.is_empty(), "resource should be removed");
@@ -1652,7 +1658,7 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_deletion_succeeds_when_resource_disappears() {
-        let id = ResourceId::new("s3.Bucket", "test");
+        let id = ResourceId::with_identity("s3.Bucket", "test");
         let provider = SequenceProvider::new(vec![Ok(State::not_found(id.clone()))]);
 
         let result = wait_for_deletion(
@@ -1669,7 +1675,7 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_deletion_returns_read_error_on_provider_error() {
-        let id = ResourceId::new("s3.Bucket", "test");
+        let id = ResourceId::with_identity("s3.Bucket", "test");
         let provider = SequenceProvider::new(vec![Err(ProviderError::api_error("auth expired"))]);
 
         let result = wait_for_deletion(
@@ -1697,7 +1703,7 @@ mod tests {
         // Previously, Err(_) from provider.read() was treated as successful
         // deletion, causing live infrastructure to be orphaned while the user
         // was told it was destroyed.
-        let id = ResourceId::new("s3.Bucket", "test");
+        let id = ResourceId::with_identity("s3.Bucket", "test");
         let provider = SequenceProvider::new(vec![Err(ProviderError::timeout("network timeout"))]);
 
         let result = wait_for_deletion(
@@ -1715,7 +1721,7 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_deletion_times_out_when_resource_keeps_existing() {
-        let id = ResourceId::new("s3.Bucket", "test");
+        let id = ResourceId::with_identity("s3.Bucket", "test");
         let existing_state = State::existing(id.clone(), HashMap::new());
         let provider = SequenceProvider::new(vec![
             Ok(existing_state.clone()),
@@ -1738,7 +1744,7 @@ mod tests {
     #[tokio::test]
     async fn wait_for_deletion_succeeds_after_transient_exists() {
         // Resource exists on first poll, then disappears on second.
-        let id = ResourceId::new("s3.Bucket", "test");
+        let id = ResourceId::with_identity("s3.Bucket", "test");
         let existing_state = State::existing(id.clone(), HashMap::new());
         let provider =
             SequenceProvider::new(vec![Ok(existing_state), Ok(State::not_found(id.clone()))]);

--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -822,12 +822,12 @@ mod tests {
         let mut plan = Plan::new();
         let read = DataSource::with_provider("awscc", "identity.User", "me", None);
         let create = Resource::with_provider("awscc", "ec2.Vpc", "new", None);
-        let update_id = ResourceId::with_provider("awscc", "ec2.Subnet", "old", None);
+        let update_id = ResourceId::with_provider_identity("awscc", "ec2.Subnet", "old", None);
         let update_to = Resource::with_provider("awscc", "ec2.Subnet", "old", None);
-        let replace_id = ResourceId::with_provider("awscc", "s3.Bucket", "old", None);
+        let replace_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "old", None);
         let replace_to = Resource::with_provider("awscc", "s3.Bucket", "new", None);
-        let delete_id = ResourceId::with_provider("awscc", "iam.Role", "old", None);
-        let import_id = ResourceId::with_provider("awscc", "logs.Group", "existing", None);
+        let delete_id = ResourceId::with_provider_identity("awscc", "iam.Role", "old", None);
+        let import_id = ResourceId::with_provider_identity("awscc", "logs.Group", "existing", None);
 
         plan.add(Effect::Read { resource: read });
         plan.add(Effect::Create(create));
@@ -860,11 +860,11 @@ mod tests {
             identifier: Value::Concrete(ConcreteValue::String("group".to_string())),
         });
         plan.add(Effect::Remove {
-            id: ResourceId::with_provider("awscc", "skip.Remove", "x", None),
+            id: ResourceId::with_provider_identity("awscc", "skip.Remove", "x", None),
         });
         plan.add(Effect::Move {
-            from: ResourceId::with_provider("awscc", "skip.Move", "x", None),
-            to: ResourceId::with_provider("awscc", "skip.Move", "y", None),
+            from: ResourceId::with_provider_identity("awscc", "skip.Move", "x", None),
+            to: ResourceId::with_provider_identity("awscc", "skip.Move", "y", None),
         });
 
         let entries = collect_required_actions(&plan, &PermissionProvider);
@@ -890,7 +890,7 @@ mod tests {
             Resource::with_provider("aws", "route53.RecordSet", "validation_records", None);
         let mut plan = Plan::new();
         plan.add(Effect::DeferredCreate {
-            id: ResourceId::new("__deferred_for", "validation_records"),
+            id: ResourceId::with_identity("__deferred_for", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(DeferredForExpression {
                 file: None,

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -981,8 +981,8 @@ exports {
         assert!(errors.is_empty(), "aws spelling errors: {errors:?}");
 
         assert_eq!(
-            awscc.resources[0].id.name_str(),
-            aws.resources[0].id.name_str(),
+            awscc.resources[0].id.identity_or_empty(),
+            aws.resources[0].id.identity_or_empty(),
             "resource create-only enum spelling must canonicalize before anonymous hash"
         );
     }

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -217,7 +217,7 @@ mod tests {
     /// gates that path.
     #[tokio::test]
     async fn execute_import_effects_rejects_deferred_identifier_without_calling_provider() {
-        let id = ResourceId::new("aws.route53.RecordSet", "r");
+        let id = ResourceId::with_identity("aws.route53.RecordSet", "r");
         let deferred = Value::Deferred(DeferredValue::Interpolation(vec![
             InterpolationPart::Expr(Value::Deferred(DeferredValue::Unknown(
                 UnknownReason::UpstreamBareRef {
@@ -256,7 +256,7 @@ mod tests {
     /// would block the happy path.
     #[tokio::test]
     async fn execute_import_effects_passes_concrete_identifier_through() {
-        let id = ResourceId::new("aws.s3.Bucket", "b");
+        let id = ResourceId::with_identity("aws.s3.Bucket", "b");
         let mut plan = Plan::new();
         plan.add(Effect::Import {
             id: id.clone(),
@@ -281,7 +281,8 @@ mod tests {
     #[test]
     fn remove_effect_line_has_no_failure_shaped_glyph() {
         colored::control::set_override(true);
-        let id = ResourceId::new("aws.route53.RecordSet", "aws_route53_record_set_7059de08");
+        let id =
+            ResourceId::with_identity("aws.route53.RecordSet", "aws_route53_record_set_7059de08");
         let line = format_state_only_effect_line(&Effect::Remove { id: id.clone() })
             .expect("Remove must render a line");
         colored::control::unset_override();
@@ -316,8 +317,8 @@ mod tests {
     #[test]
     fn move_effect_line_format_is_unchanged() {
         colored::control::set_override(false);
-        let from = ResourceId::new("aws.s3.Bucket", "old");
-        let to = ResourceId::new("aws.s3.Bucket", "new");
+        let from = ResourceId::with_identity("aws.s3.Bucket", "old");
+        let to = ResourceId::with_identity("aws.s3.Bucket", "new");
         let line = format_state_only_effect_line(&Effect::Move {
             from: from.clone(),
             to: to.clone(),

--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn wait_observed_attr_is_deterministic() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let attrs = HashMap::from([
             (
                 "status".to_string(),
@@ -442,7 +442,7 @@ mod tests {
 
     #[test]
     fn wait_observed_attr_uses_predicate_attr_when_present() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let status = AttrPath::single("status");
         let predicate = equals_predicate(status, "pending");
         let attrs = HashMap::from([
@@ -462,7 +462,7 @@ mod tests {
 
     #[test]
     fn wait_observed_attr_formats_multi_segment_predicate_attr() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let renewal_status =
             AttrPath::try_new(vec!["renewal_summary".into(), "renewal_status".into()]).unwrap();
         let predicate = equals_predicate(renewal_status, "PENDING");
@@ -483,7 +483,7 @@ mod tests {
 
     #[test]
     fn wait_observed_attr_falls_back_to_sort_first_when_predicate_attr_missing() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let xyz = AttrPath::single("xyz");
         let predicate = equals_predicate(xyz, "present");
         let attrs = HashMap::from([
@@ -503,7 +503,7 @@ mod tests {
 
     #[test]
     fn wait_observed_attr_uses_display_formatting() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let attrs = HashMap::from([(
             "arn".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -521,7 +521,7 @@ mod tests {
 
     #[test]
     fn wait_observed_attr_handles_unknown_value() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let attrs = HashMap::from([(
             "status".to_string(),
             Value::Deferred(DeferredValue::Unknown(UnknownReason::ForValue)),

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -102,7 +102,7 @@ impl PostApplyStates {
     ) -> Self {
         let mut map = current_states.clone();
         for rs in &state.resources {
-            let id = ResourceId::with_provider(
+            let id = ResourceId::with_provider_name_compat(
                 &rs.provider,
                 &rs.resource_type,
                 &rs.name,
@@ -716,7 +716,7 @@ pub(crate) fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateF
 
     for (id, planned) in &writeback.upserts {
         let resource = planned.resource;
-        let existing = state.find_resource(&id.provider, &id.resource_type, id.name_str());
+        let existing = state.find_resource(&id.provider, &id.resource_type, id.identity_or_empty());
         let write_only_keys: Vec<String> = schemas
             .get_for(resource)
             .map(|schema| {
@@ -745,7 +745,7 @@ pub(crate) fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateF
     }
 
     for id in &writeback.cleanups {
-        state.remove_resource(&id.provider, &id.resource_type, id.name_str());
+        state.remove_resource(&id.provider, &id.resource_type, id.identity_or_empty());
     }
 
     Ok(state)
@@ -758,7 +758,7 @@ pub(crate) fn apply_destroy_to_state(
     destroyed_ids: &[ResourceId],
 ) {
     for id in destroyed_ids {
-        state.remove_resource(&id.provider, &id.resource_type, id.name_str());
+        state.remove_resource(&id.provider, &id.resource_type, id.identity_or_empty());
     }
     state.exports.clear();
 }
@@ -770,7 +770,7 @@ pub(crate) fn apply_destroy_to_state(
 /// and tree display work correctly.
 pub(crate) fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceId) -> Resource {
     let rs = sf
-        .find_resource(&id.provider, &id.resource_type, id.name_str())
+        .find_resource(&id.provider, &id.resource_type, id.identity_or_empty())
         .expect("orphan must exist in state file");
     let attributes: HashMap<String, Value> = rs
         .attributes
@@ -807,7 +807,8 @@ mod post_apply_states_tests {
     ///    the pre-apply snapshot.
     #[test]
     fn data_source_only_in_current_states_survives() {
-        let ds_id = ResourceId::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+        let ds_id =
+            ResourceId::with_provider_identity("aws", "iam.Roles", "admin_access_roles", None);
         let mut ds_attrs = HashMap::new();
         ds_attrs.insert(
             "arns".to_string(),
@@ -835,7 +836,7 @@ mod post_apply_states_tests {
 
     #[test]
     fn state_resources_entry_wins_over_current_states_on_collision() {
-        let id = ResourceId::with_provider("awscc", "s3.Bucket", "log", None);
+        let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "log", None);
 
         // current_states carries the PRE-apply attribute value.
         let mut pre_attrs = HashMap::new();
@@ -945,7 +946,7 @@ mod apply_state_save_tests {
         Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![deferred_replace_delete(id)])
                 .expect("fixture has one delete"),
-            id: ResourceId::new("__deferred_for", "validation_records"),
+            id: ResourceId::with_identity("__deferred_for", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(DeferredForExpression {
                 file: Some("main.crn".to_string()),
@@ -964,7 +965,12 @@ mod apply_state_save_tests {
 
     #[test]
     fn deferred_replace_delete_and_create_same_id_writes_one_upsert_no_cleanup() {
-        let id = ResourceId::with_provider("aws", "route53.Record", "validation_records[0]", None);
+        let id = ResourceId::with_provider_identity(
+            "aws",
+            "route53.Record",
+            "validation_records[0]",
+            None,
+        );
         let runtime_child =
             Resource::with_provider("aws", "route53.Record", "validation_records[0]", None)
                 .with_binding("validation_records[0]");
@@ -999,7 +1005,12 @@ mod apply_state_save_tests {
 
     #[test]
     fn deferred_replace_delete_success_create_failure_writes_cleanup() {
-        let id = ResourceId::with_provider("aws", "route53.Record", "validation_records[0]", None);
+        let id = ResourceId::with_provider_identity(
+            "aws",
+            "route53.Record",
+            "validation_records[0]",
+            None,
+        );
         let mut plan = Plan::new();
         plan.add(deferred_replace_effect(&id));
         let current_states = HashMap::new();
@@ -1024,7 +1035,12 @@ mod apply_state_save_tests {
 
     #[test]
     fn move_from_overlapping_desired_resource_still_errors() {
-        let id = ResourceId::with_provider("aws", "route53.Record", "validation_records[0]", None);
+        let id = ResourceId::with_provider_identity(
+            "aws",
+            "route53.Record",
+            "validation_records[0]",
+            None,
+        );
         let desired =
             Resource::with_provider("aws", "route53.Record", "validation_records[0]", None);
         let applied_state =
@@ -1032,7 +1048,12 @@ mod apply_state_save_tests {
         let mut plan = Plan::new();
         plan.add(Effect::Move {
             from: id.clone(),
-            to: ResourceId::with_provider("aws", "route53.Record", "validation_records[1]", None),
+            to: ResourceId::with_provider_identity(
+                "aws",
+                "route53.Record",
+                "validation_records[1]",
+                None,
+            ),
         });
         let current_states = HashMap::new();
         let applied_states = HashMap::from([(id.clone(), applied_state)]);

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -790,7 +790,7 @@ async fn run_state_bucket_delete(
     // Delete the bucket resource (identifier is the bucket name)
     // Backend bucket is provider-default; named-instance routing is
     // a DSL concern that doesn't apply to the implicit state bucket.
-    let bucket_id = ResourceId::with_provider(
+    let bucket_id = ResourceId::with_provider_identity(
         backend_provider_name,
         backend_resource_type,
         bucket_name,
@@ -991,8 +991,11 @@ pub(crate) async fn run_state_refresh_locked(
             sorted_resources
                 .iter()
                 .filter_map(|r| {
-                    let rs =
-                        sf.find_resource(&r.id.provider, &r.id.resource_type, r.id.name_str())?;
+                    let rs = sf.find_resource(
+                        &r.id.provider,
+                        &r.id.resource_type,
+                        r.id.identity_or_empty(),
+                    )?;
                     if rs.dependency_bindings.is_empty() {
                         None
                     } else {
@@ -1039,7 +1042,7 @@ pub(crate) async fn run_state_refresh_locked(
             sf.resources
                 .iter()
                 .filter_map(|rs| {
-                    let id = ResourceId::with_provider(
+                    let id = ResourceId::with_provider_name_compat(
                         &rs.provider,
                         &rs.resource_type,
                         &rs.name,
@@ -1304,7 +1307,7 @@ fn diff_display_update_resource(
     updated_count: &mut u32,
     unchanged_count: &mut u32,
 ) -> Result<(), AppError> {
-    let existing = state.find_resource(&id.provider, &id.resource_type, id.name_str());
+    let existing = state.find_resource(&id.provider, &id.resource_type, id.identity_or_empty());
     let existing_rs = match existing {
         Some(rs) => rs,
         None => return Ok(()),
@@ -1376,7 +1379,7 @@ fn diff_display_update_resource(
         println!(
             "  {} \"{}\"{}:",
             id.display_type().cyan(),
-            id.name,
+            id.identity_or_empty(),
             label_suffix,
         );
         for change in &changes {
@@ -1396,17 +1399,18 @@ fn diff_display_update_resource(
                 owned_resource = Resource::with_provider(
                     &id.provider,
                     &id.resource_type,
-                    id.name_str(),
+                    id.identity_or_empty(),
                     id.provider_instance.clone(),
                 );
                 &owned_resource
             }
         };
-        let existing_rs = state.find_resource(&id.provider, &id.resource_type, id.name_str());
+        let existing_rs =
+            state.find_resource(&id.provider, &id.resource_type, id.identity_or_empty());
         let resource_state = ResourceState::from_provider_state(res, fresh_state, existing_rs)?;
         state.upsert_resource(resource_state);
     } else {
-        state.remove_resource(&id.provider, &id.resource_type, id.name_str());
+        state.remove_resource(&id.provider, &id.resource_type, id.identity_or_empty());
     }
 
     Ok(())

--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -9,7 +9,7 @@ use carina_core::config_loader::{
 };
 use carina_core::lint::find_duplicate_attrs;
 use carina_core::parser::{File, ProviderContext, ResourceRef, UpstreamState};
-use carina_core::resource::{ResourceId, ResourceName};
+use carina_core::resource::ResourceId;
 
 use super::validate_and_resolve_errors;
 use crate::error::AppError;
@@ -154,15 +154,15 @@ fn format_inference_errors(
 /// resource can never silently render as a trailing-dot string
 /// (carina#3121). `Display` is the *only* place an entry becomes text.
 enum ValidatedEntry<'a> {
-    /// A direct resource whose name is already bound — the common
+    /// A direct resource whose identity is already assigned — the common
     /// case, renders exactly as its [`ResourceId`].
     Resolved(&'a ResourceId),
-    /// A direct resource still carrying a `Pending` name (anonymous,
-    /// `name` attribute not yet promoted at the point validate
+    /// A direct resource still missing identity (anonymous,
+    /// identity not yet assigned at the point validate
     /// enumerates). Rendering its `ResourceId` directly would emit a
     /// meaningless trailing-dot string; this variant makes the
-    /// not-yet-named state explicit instead of relying on the empty
-    /// string `ResourceName::Pending` produces.
+    /// not-yet-assigned state explicit instead of relying on an empty
+    /// identity string.
     PendingDirect(&'a ResourceId),
     /// The body of a `for` loop whose iterable is unresolved at parse
     /// time (e.g. a same-config provider-read attribute). It is a
@@ -232,12 +232,13 @@ fn validated_entries<E>(parsed: &File<E>) -> Vec<ValidatedEntry<'_>> {
                 line: d.line,
             },
             // Managed / Virtual / DataSource — all direct, classified
-            // by whether the id has a resolved name.
+            // by whether the id has a resolved identity.
             other => {
                 let id = other.id();
-                match id.name {
-                    ResourceName::Bound(_) => ValidatedEntry::Resolved(id),
-                    ResourceName::Pending => ValidatedEntry::PendingDirect(id),
+                if id.identity.is_some() {
+                    ValidatedEntry::Resolved(id)
+                } else {
+                    ValidatedEntry::PendingDirect(id)
                 }
             }
         })
@@ -496,12 +497,11 @@ mod tests {
         );
     }
 
-    /// Type-safety guarantee: a direct resource still carrying a
-    /// `Pending` name must NOT render as a trailing-dot string
+    /// Type-safety guarantee: a direct resource still missing identity
+    /// must NOT render as a trailing-dot string
     /// (`aws.s3.Bucket.`). The `ValidatedEntry::PendingDirect` variant
     /// makes the not-yet-named state explicit at the type level
-    /// instead of leaking the empty string `ResourceName::Pending`
-    /// produces. Guards the [[feedback_type_safety_over_runtime_checks]]
+    /// instead of leaking an empty identity string. Guards the [[feedback_type_safety_over_runtime_checks]]
     /// concern raised reviewing carina#3128.
     #[test]
     fn pending_named_direct_resource_does_not_render_trailing_dot() {
@@ -512,7 +512,7 @@ mod tests {
         let mut res = Resource::new("s3.Bucket", "placeholder");
         res.id.provider = "aws".to_string();
         // Force the anonymous/not-yet-promoted state explicitly.
-        res.id.name = ResourceName::Pending;
+        res.id.identity = None;
         parsed.resources.push(res); // allow: direct — fixture test inspection
 
         let entries = validated_entries(&parsed);

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -587,7 +587,7 @@ impl<'a> TreeRenderContext<'a> {
                 if self.detail == DetailLevel::None {
                     let name_part = format_compact_name(
                         carina_core::parser::ResourceRef::Resource(r),
-                        r.id.name_str(),
+                        r.id.identity_or_empty(),
                         parent_binding,
                     );
                     writeln!(
@@ -604,7 +604,7 @@ impl<'a> TreeRenderContext<'a> {
                         "{}{} {}",
                         line_prefix,
                         r.id.display_type().cyan().bold(),
-                        r.id.name_str().white().bold()
+                        r.id.identity_or_empty().white().bold()
                     )
                     .unwrap();
                 }
@@ -613,11 +613,11 @@ impl<'a> TreeRenderContext<'a> {
                 let moved_note = self
                     .moved_origins
                     .get(id)
-                    .map(|from| format!(" (moved from: {})", from.name_str()));
+                    .map(|from| format!(" (moved from: {})", from.identity_or_empty()));
                 if self.detail == DetailLevel::None {
                     let name_part = format_compact_name(
                         carina_core::parser::ResourceRef::Resource(to),
-                        id.name_str(),
+                        id.identity_or_empty(),
                         parent_binding,
                     );
                     writeln!(
@@ -635,7 +635,7 @@ impl<'a> TreeRenderContext<'a> {
                         "{}{} {}{}",
                         line_prefix,
                         id.display_type().cyan().bold(),
-                        id.name_str().yellow().bold(),
+                        id.identity_or_empty().yellow().bold(),
                         moved_note.as_deref().unwrap_or("").yellow()
                     )
                     .unwrap();
@@ -652,11 +652,11 @@ impl<'a> TreeRenderContext<'a> {
                 let moved_note = self
                     .moved_origins
                     .get(id)
-                    .map(|from| format!(" (moved from: {})", from.name_str()));
+                    .map(|from| format!(" (moved from: {})", from.identity_or_empty()));
                 if self.detail == DetailLevel::None {
                     let name_part = format_compact_name(
                         carina_core::parser::ResourceRef::Resource(to),
-                        id.name_str(),
+                        id.identity_or_empty(),
                         parent_binding,
                     );
                     writeln!(
@@ -675,7 +675,7 @@ impl<'a> TreeRenderContext<'a> {
                         "{}{} {} {}{}",
                         line_prefix,
                         id.display_type().cyan().bold(),
-                        id.name_str().magenta().bold(),
+                        id.identity_or_empty().magenta().bold(),
                         replace_note.magenta(),
                         moved_note.as_deref().unwrap_or("").magenta()
                     )
@@ -683,7 +683,7 @@ impl<'a> TreeRenderContext<'a> {
                 }
             }
             Effect::Delete { id, binding, .. } => {
-                let display_name = binding.as_deref().unwrap_or(id.name_str());
+                let display_name = binding.as_deref().unwrap_or(id.identity_or_empty());
                 writeln!(
                     self.out,
                     "{}{} {}",
@@ -697,7 +697,7 @@ impl<'a> TreeRenderContext<'a> {
                 if self.detail == DetailLevel::None {
                     let name_part = format_compact_name(
                         carina_core::parser::ResourceRef::DataSource(resource),
-                        resource.id.name_str(),
+                        resource.id.identity_or_empty(),
                         parent_binding,
                     );
                     writeln!(
@@ -715,7 +715,7 @@ impl<'a> TreeRenderContext<'a> {
                         "{}{} {} {}",
                         line_prefix,
                         resource.id.display_type().cyan().bold(),
-                        resource.id.name_str().cyan().bold(),
+                        resource.id.identity_or_empty().cyan().bold(),
                         "(data source)".dimmed()
                     )
                     .unwrap();
@@ -734,7 +734,7 @@ impl<'a> TreeRenderContext<'a> {
                     "{}{} {} {}",
                     line_prefix,
                     id.display_type().cyan().bold(),
-                    id.name_str().cyan().bold(),
+                    id.identity_or_empty().cyan().bold(),
                     format!("(import: {})", identifier_str).dimmed()
                 )
                 .unwrap();
@@ -750,7 +750,7 @@ impl<'a> TreeRenderContext<'a> {
                     // "state-only success looks like failure" misread
                     // even after the leading `x` glyph fix. Yellow
                     // matches the `~` symbol family and Move's row.
-                    id.name_str().yellow().bold(),
+                    id.identity_or_empty().yellow().bold(),
                     "(remove from state)".dimmed()
                 )
                 .unwrap();
@@ -767,8 +767,8 @@ impl<'a> TreeRenderContext<'a> {
                     "{}{} {} {}",
                     line_prefix,
                     to.display_type().cyan().bold(),
-                    to.name_str().yellow().bold(),
-                    format!("(moved from: {})", from.name_str()).dimmed()
+                    to.identity_or_empty().yellow().bold(),
+                    format!("(moved from: {})", from.identity_or_empty()).dimmed()
                 )
                 .unwrap();
             }
@@ -2209,7 +2209,7 @@ pub fn format_effect(effect: &Effect) -> String {
             }
         }
         Effect::Delete { id, binding, .. } => {
-            let display_name = binding.as_deref().unwrap_or(id.name_str());
+            let display_name = binding.as_deref().unwrap_or(id.identity_or_empty());
             format!("Delete {} {}", id.display_type(), display_name)
         }
         Effect::Read { resource } => {

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -744,7 +744,7 @@ fn test_cascading_update_shows_attribute_diffs() {
 
     // Build a Replace effect with a cascading update that changes vpc_id
     let vpc_from = State::existing(
-        ResourceId::new("ec2.Vpc", "vpc"),
+        ResourceId::with_identity("ec2.Vpc", "vpc"),
         HashMap::from([(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -758,7 +758,7 @@ fn test_cascading_update_shows_attribute_diffs() {
         );
 
     let subnet_from = State::existing(
-        ResourceId::new("ec2.Subnet", "subnet"),
+        ResourceId::with_identity("ec2.Subnet", "subnet"),
         HashMap::from([
             (
                 "vpc_id".to_string(),
@@ -781,7 +781,7 @@ fn test_cascading_update_shows_attribute_diffs() {
         );
 
     let replace_effect = Effect::Replace {
-        id: ResourceId::new("ec2.Vpc", "vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "vpc"),
         from: Box::new(vpc_from),
         to: vpc_to,
         directives: Directives {
@@ -793,7 +793,7 @@ fn test_cascading_update_shows_attribute_diffs() {
         ])
         .unwrap(),
         cascading_updates: vec![CascadingUpdate {
-            id: ResourceId::new("ec2.Subnet", "subnet"),
+            id: ResourceId::with_identity("ec2.Subnet", "subnet"),
             from: Box::new(subnet_from),
             to: subnet_to,
         }],
@@ -823,9 +823,9 @@ fn test_format_cascading_update_attr_diff() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: ResourceId::new("ec2.Subnet", "subnet"),
+        id: ResourceId::with_identity("ec2.Subnet", "subnet"),
         from: Box::new(State::existing(
-            ResourceId::new("ec2.Subnet", "subnet"),
+            ResourceId::with_identity("ec2.Subnet", "subnet"),
             HashMap::from([
                 (
                     "vpc_id".to_string(),
@@ -883,7 +883,7 @@ fn test_format_cascading_update_attr_diff() {
 /// NOT be hidden even though `semantically_equal` returns true.
 #[test]
 fn test_replace_changed_create_only_same_value_shown_as_known_after_apply() {
-    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "subnet", None);
+    let id = ResourceId::with_provider_identity("awscc", "ec2.Subnet", "subnet", None);
     let from = State::existing(
         id.clone(),
         [
@@ -975,7 +975,7 @@ fn test_replace_changed_create_only_same_value_shown_as_known_after_apply() {
 /// binding instead of the resolved value for cascade-triggered same-value attributes.
 #[test]
 fn test_replace_cascade_ref_hints_show_binding() {
-    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "subnet", None);
+    let id = ResourceId::with_provider_identity("awscc", "ec2.Subnet", "subnet", None);
     let from = State::existing(
         id.clone(),
         [(
@@ -1068,7 +1068,7 @@ fn test_deferred_create_renders_deferred_until_apply_marker() {
 
     let mut plan = Plan::new();
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -1125,7 +1125,7 @@ fn deferred_validation_records_effect() -> Effect {
     };
 
     Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     }
@@ -1133,7 +1133,7 @@ fn deferred_validation_records_effect() -> Effect {
 
 fn delete_record_effect(binding: &str) -> Effect {
     Effect::Delete {
-        id: ResourceId::new("route53.Record", binding),
+        id: ResourceId::with_identity("route53.Record", binding),
         identifier: format!("{binding}-id"),
         directives: Directives::default(),
         binding: Some(binding.to_string()),
@@ -1295,9 +1295,9 @@ fn test_format_cascading_update_diff_excludes_non_ref_attributes() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: ResourceId::new("ec2.Subnet", "subnet"),
+        id: ResourceId::with_identity("ec2.Subnet", "subnet"),
         from: Box::new(State::existing(
-            ResourceId::new("ec2.Subnet", "subnet"),
+            ResourceId::with_identity("ec2.Subnet", "subnet"),
             HashMap::from([
                 (
                     "vpc_id".to_string(),
@@ -1361,9 +1361,9 @@ fn test_format_cascading_update_diff_includes_list_with_ref() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: ResourceId::new("ec2.Instance", "instance"),
+        id: ResourceId::with_identity("ec2.Instance", "instance"),
         from: Box::new(State::existing(
-            ResourceId::new("ec2.Instance", "instance"),
+            ResourceId::with_identity("ec2.Instance", "instance"),
             HashMap::from([(
                 "security_group_ids".to_string(),
                 Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
@@ -1420,7 +1420,7 @@ fn test_mixed_plan_tree_with_delete_effect() {
     // VPC: Update effect (has `to` resource with binding)
     let vpc_to = make_resource("ec2.Vpc", "vpc", "vpc", &[]);
     let vpc_from = State::existing(
-        ResourceId::new("ec2.Vpc", "vpc"),
+        ResourceId::with_identity("ec2.Vpc", "vpc"),
         HashMap::from([(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -1430,7 +1430,7 @@ fn test_mixed_plan_tree_with_delete_effect() {
     // SG: Replace effect (has `to` resource that depends on VPC)
     let sg_to = make_resource("ec2.SecurityGroup", "sg", "sg", &["vpc"]);
     let sg_from = State::existing(
-        ResourceId::new("ec2.SecurityGroup", "sg"),
+        ResourceId::with_identity("ec2.SecurityGroup", "sg"),
         HashMap::from([(
             "ref_vpc".to_string(),
             Value::Concrete(ConcreteValue::String("vpc-old123".to_string())),
@@ -1440,7 +1440,7 @@ fn test_mixed_plan_tree_with_delete_effect() {
     // Subnet: Delete effect (only has id and identifier — no resource, no deps)
     // In the original DSL, subnet depends on VPC, but Delete loses that info.
     let subnet_delete = Effect::Delete {
-        id: ResourceId::new("ec2.Subnet", "subnet"),
+        id: ResourceId::with_identity("ec2.Subnet", "subnet"),
         identifier: "subnet-12345".to_string(),
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
@@ -1450,13 +1450,13 @@ fn test_mixed_plan_tree_with_delete_effect() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ResourceId::new("ec2.Vpc", "vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "vpc"),
         from: Box::new(vpc_from),
         to: vpc_to,
         changed_attributes: vec!["cidr_block".to_string()],
     });
     plan.add(Effect::Replace {
-        id: ResourceId::new("ec2.SecurityGroup", "sg"),
+        id: ResourceId::with_identity("ec2.SecurityGroup", "sg"),
         from: Box::new(sg_from),
         to: sg_to,
         directives: Directives::default(),
@@ -1523,7 +1523,7 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
     // VPC: Update effect (tags changed)
     let vpc_to = make_resource("ec2.Vpc", "vpc", "vpc", &[]);
     let vpc_from = State::existing(
-        ResourceId::new("ec2.Vpc", "vpc"),
+        ResourceId::with_identity("ec2.Vpc", "vpc"),
         HashMap::from([(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -1550,7 +1550,7 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ResourceId::new("ec2.Vpc", "vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "vpc"),
         from: Box::new(vpc_from),
         to: vpc_to,
         changed_attributes: vec!["tags".to_string()],
@@ -1587,7 +1587,7 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
 #[test]
 fn format_effect_delete_uses_binding_name() {
     let effect = Effect::Delete {
-        id: ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None),
+        id: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None),
         identifier: "vpc-12345".to_string(),
         directives: Directives::default(),
         binding: Some("my_vpc".to_string()),
@@ -1600,7 +1600,7 @@ fn format_effect_delete_uses_binding_name() {
 #[test]
 fn format_effect_delete_falls_back_to_id_name() {
     let effect = Effect::Delete {
-        id: ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None),
+        id: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None),
         identifier: "vpc-12345".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -1619,19 +1619,19 @@ fn format_effect_delete_falls_back_to_id_name() {
 #[test]
 fn format_effect_create_separates_type_and_name_with_space() {
     let mut r = Resource::new("s3.Bucket", "state_bucket");
-    r.id = ResourceId::with_provider("aws", "s3.Bucket", "state_bucket", None);
+    r.id = ResourceId::with_provider_identity("aws", "s3.Bucket", "state_bucket", None);
     let effect = Effect::Create(r);
     assert_eq!(format_effect(&effect), "Create aws.s3.Bucket state_bucket");
 }
 
 #[test]
 fn format_effect_update_separates_type_and_name_with_space() {
-    let id = ResourceId::with_provider("awscc", "iam.Role", "bs.bootstrap.role", None);
+    let id = ResourceId::with_provider_identity("awscc", "iam.Role", "bs.bootstrap.role", None);
     let mut to = Resource::new("iam.Role", "bs.bootstrap.role");
     to.id = id.clone();
     let effect = Effect::Update {
         id,
-        from: Box::new(State::not_found(ResourceId::with_provider(
+        from: Box::new(State::not_found(ResourceId::with_provider_identity(
             "awscc",
             "iam.Role",
             "bs.bootstrap.role",
@@ -1648,12 +1648,12 @@ fn format_effect_update_separates_type_and_name_with_space() {
 
 #[test]
 fn format_effect_replace_separates_type_and_name_with_space() {
-    let id = ResourceId::with_provider("awscc", "ec2.Vpc", "vpc", None);
+    let id = ResourceId::with_provider_identity("awscc", "ec2.Vpc", "vpc", None);
     let mut to = Resource::new("ec2.Vpc", "vpc");
     to.id = id.clone();
     let effect = Effect::Replace {
         id,
-        from: Box::new(State::not_found(ResourceId::with_provider(
+        from: Box::new(State::not_found(ResourceId::with_provider_identity(
             "awscc", "ec2.Vpc", "vpc", None,
         ))),
         to,
@@ -1669,7 +1669,7 @@ fn format_effect_replace_separates_type_and_name_with_space() {
 
 #[test]
 fn format_replace_with_removed_create_only_attribute_shows_forcing_detail() {
-    let id = ResourceId::with_provider("test", "Widget", "beta", None);
+    let id = ResourceId::with_provider_identity("test", "Widget", "beta", None);
     let from = State::existing(
         id.clone(),
         [(
@@ -1722,7 +1722,7 @@ fn format_replace_with_removed_create_only_attribute_shows_forcing_detail() {
 #[test]
 fn format_effect_import_separates_type_and_name_with_space() {
     let effect = Effect::Import {
-        id: ResourceId::with_provider("aws", "s3.Bucket", "logs", None),
+        id: ResourceId::with_provider_identity("aws", "s3.Bucket", "logs", None),
         identifier: carina_core::resource::Value::Concrete(
             carina_core::resource::ConcreteValue::String("my-logs-bucket".to_string()),
         ),
@@ -1736,7 +1736,7 @@ fn format_effect_import_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_remove_separates_type_and_name_with_space() {
     let effect = Effect::Remove {
-        id: ResourceId::with_provider("awscc", "ec2.Vpc", "old_vpc", None),
+        id: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "old_vpc", None),
     };
     assert_eq!(
         format_effect(&effect),
@@ -1747,8 +1747,8 @@ fn format_effect_remove_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_move_separates_type_and_name_with_space() {
     let effect = Effect::Move {
-        from: ResourceId::with_provider("awscc", "ec2.Vpc", "vpc_a", None),
-        to: ResourceId::with_provider("awscc", "ec2.Vpc", "vpc_b", None),
+        from: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "vpc_a", None),
+        to: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "vpc_b", None),
     };
     assert_eq!(
         format_effect(&effect),
@@ -1958,7 +1958,7 @@ fn delete_pretty_attribute_does_not_strike_indentation() {
         value: Value::Concrete(ConcreteValue::Map(cache_behavior)),
     };
     let effect = Effect::Delete {
-        id: carina_core::resource::ResourceId::new("cloudfront.Distribution", "dist"),
+        id: carina_core::resource::ResourceId::with_identity("cloudfront.Distribution", "dist"),
         identifier: "E123".to_string(),
         directives: Default::default(),
         binding: None,
@@ -2034,9 +2034,9 @@ fn forcing_changed_uses_plain_green_cli_value() {
         new: "\"new\"".to_string(),
     };
     let effect = Effect::Update {
-        id: ResourceId::new("test.Widget", "w"),
+        id: ResourceId::with_identity("test.Widget", "w"),
         from: Box::new(State::existing(
-            ResourceId::new("test.Widget", "w"),
+            ResourceId::with_identity("test.Widget", "w"),
             HashMap::new(),
         )),
         to: Resource::new("test.Widget", "w"),
@@ -2062,9 +2062,9 @@ fn forcing_changed_multiline_green_style_does_not_cross_newline() {
         new: "[\n  \"new\"\n]".to_string(),
     };
     let effect = Effect::Update {
-        id: ResourceId::new("test.Widget", "w"),
+        id: ResourceId::with_identity("test.Widget", "w"),
         from: Box::new(State::existing(
-            ResourceId::new("test.Widget", "w"),
+            ResourceId::with_identity("test.Widget", "w"),
             HashMap::new(),
         )),
         to: Resource::new("test.Widget", "w"),
@@ -2183,7 +2183,7 @@ fn module_children_render_with_tree_connectors() {
     plan.add(Effect::Create(role));
 
     let cluster_site = CallSite::new(
-        EphemeralId::new(ResourceId::new("_virtual", "cluster")),
+        EphemeralId::new(ResourceId::with_identity("_virtual", "cluster")),
         "./modules/cluster",
     );
     let mut trace = ExpansionTrace::new();
@@ -2227,7 +2227,7 @@ fn module_child_connector_gutter_extends_through_nested_dependents() {
     plan.add(Effect::Create(bucket));
 
     let cluster_site = CallSite::new(
-        EphemeralId::new(ResourceId::new("_virtual", "cluster")),
+        EphemeralId::new(ResourceId::with_identity("_virtual", "cluster")),
         "./modules/cluster",
     );
     let mut trace = ExpansionTrace::new();
@@ -2256,8 +2256,8 @@ fn module_child_connector_gutter_extends_through_nested_dependents() {
 
 #[test]
 fn module_group_with_only_suppressed_move_does_not_emit_orphan_gutter() {
-    let from_id = ResourceId::new("aws.s3.Bucket", "cluster/old_logs");
-    let to_id = ResourceId::new("aws.s3.Bucket", "cluster/logs");
+    let from_id = ResourceId::with_identity("aws.s3.Bucket", "cluster/old_logs");
+    let to_id = ResourceId::with_identity("aws.s3.Bucket", "cluster/logs");
     let mut updated = Resource::new("aws.s3.Bucket", "cluster/logs");
     updated.id = to_id.clone();
 
@@ -2328,8 +2328,8 @@ fn resource_with_only_suppressed_move_dependent_does_not_emit_orphan_gutter() {
         "bucket",
         Value::Concrete(ConcreteValue::String("parent".to_string())),
     );
-    let from_id = ResourceId::new("aws.s3.Bucket", "old_child");
-    let to_id = ResourceId::new("aws.s3.Bucket", "new_child");
+    let from_id = ResourceId::with_identity("aws.s3.Bucket", "old_child");
+    let to_id = ResourceId::with_identity("aws.s3.Bucket", "new_child");
     let mut updated = Resource::new("aws.s3.Bucket", "new_child");
     updated.id = to_id.clone();
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -199,7 +199,10 @@ fn multi_instance_create_propagates_provider_instance() {
     let mut by_name: HashMap<String, Option<String>> = HashMap::new();
     for effect in plan.effects() {
         let id = effect.resource_id();
-        by_name.insert(id.name_str().to_string(), id.provider_instance.clone());
+        by_name.insert(
+            id.identity_or_empty().to_string(),
+            id.provider_instance.clone(),
+        );
     }
 
     assert_eq!(
@@ -234,7 +237,10 @@ fn module_routed_instance_propagates_provider_instance() {
         .iter()
         .map(|e| {
             let id = e.resource_id();
-            (id.name_str().to_string(), id.provider_instance.clone())
+            (
+                id.identity_or_empty().to_string(),
+                id.provider_instance.clone(),
+            )
         })
         .collect();
 
@@ -2136,7 +2142,7 @@ fn snapshot_composition_folding() {
     // path so the rendered header reads
     // `module "cluster" (./modules/cluster)`.
     let cluster_site = CallSite::new(
-        EphemeralId::new(ResourceId::new("_virtual", "cluster")),
+        EphemeralId::new(ResourceId::with_identity("_virtual", "cluster")),
         "./modules/cluster",
     );
     trace.record(PersistentId::new(inner_id), vec![cluster_site.clone()]);
@@ -2227,7 +2233,7 @@ fn snapshot_top_level_sigil_alignment() {
 
     let mut trace = ExpansionTrace::new();
     let cluster_site = CallSite::new(
-        EphemeralId::new(ResourceId::new("_virtual", "cluster")),
+        EphemeralId::new(ResourceId::with_identity("_virtual", "cluster")),
         "./modules/cluster",
     );
     trace.record(PersistentId::new(cluster_id), vec![cluster_site]);

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -288,7 +288,7 @@ fn plan_file_serde_round_trip() {
         ),
     ));
     plan.add(Effect::Delete {
-        id: ResourceId::with_provider("aws", "s3.Bucket", "old-bucket", None),
+        id: ResourceId::with_provider_identity("aws", "s3.Bucket", "old-bucket", None),
         identifier: "old-bucket".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -304,8 +304,8 @@ fn plan_file_serde_round_trip() {
     ];
 
     let current_states = vec![CurrentStateEntry {
-        id: ResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None),
-        state: State::not_found(ResourceId::with_provider(
+        id: ResourceId::with_provider_identity("aws", "s3.Bucket", "my-bucket", None),
+        state: State::not_found(ResourceId::with_provider_identity(
             "aws",
             "s3.Bucket",
             "my-bucket",
@@ -658,12 +658,12 @@ fn test_anonymous_id_different_regions_produce_different_identifiers() {
     compute_anonymous_identifiers(&mut resources_west, &providers_west).unwrap();
 
     // Both should have identifiers assigned
-    assert!(!resources_east[0].id.name_str().is_empty());
-    assert!(!resources_west[0].id.name_str().is_empty());
+    assert!(!resources_east[0].id.identity_or_empty().is_empty());
+    assert!(!resources_west[0].id.identity_or_empty().is_empty());
     // They must be different because providers have different regions
     assert_ne!(
-        resources_east[0].id.name_str(),
-        resources_west[0].id.name_str()
+        resources_east[0].id.identity_or_empty(),
+        resources_west[0].id.identity_or_empty()
     );
 }
 
@@ -710,9 +710,12 @@ fn test_anonymous_id_different_create_only_same_region_no_collision() {
     let mut resources = vec![r1, r2];
     compute_anonymous_identifiers(&mut resources, &providers).unwrap();
 
-    assert!(!resources[0].id.name_str().is_empty());
-    assert!(!resources[1].id.name_str().is_empty());
-    assert_ne!(resources[0].id.name_str(), resources[1].id.name_str());
+    assert!(!resources[0].id.identity_or_empty().is_empty());
+    assert!(!resources[1].id.identity_or_empty().is_empty());
+    assert_ne!(
+        resources[0].id.identity_or_empty(),
+        resources[1].id.identity_or_empty()
+    );
 }
 
 #[test]
@@ -729,7 +732,7 @@ fn test_anonymous_id_named_resources_are_skipped() {
     compute_anonymous_identifiers(&mut resources, &providers).unwrap();
 
     // Name should remain unchanged
-    assert_eq!(resources[0].id.name_str(), "my_vpc");
+    assert_eq!(resources[0].id.identity_or_empty(), "my_vpc");
 }
 
 #[test]
@@ -874,7 +877,11 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
 
     // 3. compute_anonymous_identifiers
     compute_anonymous_identifiers(&mut resources_run1, &providers).unwrap();
-    let run1_name = resources_run1[0].id.name_str().to_string();
+    let run1_name = resources_run1[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
     assert!(
         !run1_name.is_empty(),
         "Anonymous identifier should be assigned"
@@ -914,7 +921,11 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
 
     // 3. compute_anonymous_identifiers - should produce SAME identifier
     compute_anonymous_identifiers(&mut resources_run2, &providers).unwrap();
-    let run2_name = resources_run2[0].id.name_str().to_string();
+    let run2_name = resources_run2[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
 
     assert_eq!(
         run1_name, run2_name,
@@ -976,7 +987,11 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     let mut resources_run1 = vec![resource_run1];
     resolve_names(&mut resources_run1).unwrap();
     compute_anonymous_identifiers(&mut resources_run1, &providers).unwrap();
-    let run1_name = resources_run1[0].id.name_str().to_string();
+    let run1_name = resources_run1[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
 
     // Simulate state after apply
     let run1_role_name = match resources_run1[0].get_attr("role_name") {
@@ -1034,7 +1049,11 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     let mut resources_run2 = vec![resource_run2];
     resolve_names(&mut resources_run2).unwrap();
     compute_anonymous_identifiers(&mut resources_run2, &providers).unwrap();
-    let run2_name = resources_run2[0].id.name_str().to_string();
+    let run2_name = resources_run2[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
 
     assert_eq!(
         run1_name, run2_name,
@@ -1103,7 +1122,11 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
 
     let mut resources_run1 = vec![resource_run1];
     compute_anonymous_identifiers(&mut resources_run1, &providers).unwrap();
-    let run1_name = resources_run1[0].id.name_str().to_string();
+    let run1_name = resources_run1[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
 
     // Simulate state after apply
     let applied_state = State::existing(resources_run1[0].id.clone(), HashMap::new())
@@ -1160,7 +1183,11 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
 
     let mut resources_run2 = vec![resource_run2];
     compute_anonymous_identifiers(&mut resources_run2, &providers).unwrap();
-    let run2_name = resources_run2[0].id.name_str().to_string();
+    let run2_name = resources_run2[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
 
     assert_eq!(
         run1_name, run2_name,
@@ -1346,7 +1373,7 @@ fn orphaned_state_resource_produces_delete_effect() {
 
     match &delete_effects[0] {
         Effect::Delete { id, identifier, .. } => {
-            assert_eq!(id.name_str(), "removed-bucket");
+            assert_eq!(id.identity_or_empty(), "removed-bucket");
             assert_eq!(identifier, "removed-bucket");
         }
         _ => unreachable!(),
@@ -1699,7 +1726,7 @@ impl Provider for RecordingProvider {
         let mut to = Resource::with_provider(
             &id.provider,
             &id.resource_type,
-            id.name_str(),
+            id.identity_or_empty(),
             id.provider_instance.clone(),
         );
         for (k, v) in &attrs {
@@ -1796,7 +1823,7 @@ impl Provider for RenameFailProvider {
 async fn rename_failure_in_create_before_destroy_counts_as_failure() {
     use carina_core::effect::TemporaryName;
 
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "my-bucket", None);
 
     let old_state = State::existing(
         id.clone(),
@@ -1888,8 +1915,8 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
 /// should reference the new (post-replacement) resource ID, not the old one.
 #[tokio::test]
 async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     // --- Unresolved resources (before ref resolution) ---
     let vpc_unresolved = Resource::new("ec2.Vpc", "my-vpc")
@@ -2415,7 +2442,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
     }
 
     // Verify state was loaded from state file
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "my-bucket", None);
     let cached_state = current_states.get(&id).unwrap();
     assert!(cached_state.exists, "State should exist from state file");
     assert_eq!(
@@ -2909,7 +2936,7 @@ fn plan_file_serialization_redacts_secrets() {
     );
     state_attrs.insert("master_password".to_string(), secret_password.clone());
     let state_with_secret = State::existing(
-        ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None),
+        ResourceId::with_provider_identity("awscc", "rds.db_instance", "my-db", None),
         state_attrs,
     );
 
@@ -2929,7 +2956,7 @@ fn plan_file_serialization_redacts_secrets() {
         compositions: vec![],
         data_sources: vec![],
         current_states: vec![CurrentStateEntry {
-            id: ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None),
+            id: ResourceId::with_provider_identity("awscc", "rds.db_instance", "my-db", None),
             state: redact_secrets_in_state(&state_with_secret).unwrap(),
         }],
         upstream_snapshot: HashMap::new(),

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1315,8 +1315,13 @@ pub struct DeferredCreateTarget {
 
 impl DeferredCreateTarget {
     fn from_deferred(deferred: &carina_core::parser::DeferredForExpression) -> Self {
-        let mut id = deferred.template_resource.id.clone();
-        id.set_name(deferred.binding_name.clone());
+        let template_id = &deferred.template_resource.id;
+        let id = ResourceId::with_provider_identity(
+            &template_id.provider,
+            &template_id.resource_type,
+            deferred.binding_name.clone(),
+            template_id.provider_instance.clone(),
+        );
         Self {
             id,
             upstream_binding: deferred.iterable_binding.clone(),
@@ -1790,8 +1795,11 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
                 sorted_resources
                     .iter()
                     .filter_map(|r| {
-                        let rs =
-                            sf.find_resource(&r.id.provider, &r.id.resource_type, r.id.name_str())?;
+                        let rs = sf.find_resource(
+                            &r.id.provider,
+                            &r.id.resource_type,
+                            r.id.identity_or_empty(),
+                        )?;
                         if rs.dependency_bindings.is_empty() {
                             None
                         } else {
@@ -2293,7 +2301,7 @@ fn materialize_moved_states_with_warning_sink(
             let resolved_from = state_file.as_ref().and_then(|sf| {
                 sf.find_resource(&from.provider, &from.resource_type, from.name_str())
                     .map(|rs| {
-                        ResourceId::with_provider(
+                        ResourceId::with_provider_identity(
                             &rs.provider,
                             &rs.resource_type,
                             &rs.name,
@@ -2406,7 +2414,7 @@ pub fn resolve_state_blocks(
                         removed_from.name_str(),
                     )
                     .map(|rs| {
-                        ResourceId::with_provider(
+                        ResourceId::with_provider_identity(
                             &rs.provider,
                             &rs.resource_type,
                             &rs.name,
@@ -2517,7 +2525,11 @@ pub fn validate_plan_time_state_block_collisions(
 
     for (from, to) in moved_pairs {
         let from_exists = sf
-            .find_resource(&from.provider, &from.resource_type, from.name_str())
+            .find_resource(
+                &from.provider,
+                &from.resource_type,
+                from.identity_or_empty(),
+            )
             .is_some();
         if from == to && from_exists {
             return Err(AppError::Validation(format!(
@@ -2526,7 +2538,7 @@ pub fn validate_plan_time_state_block_collisions(
             )));
         }
         let to_exists = sf
-            .find_resource(&to.provider, &to.resource_type, to.name_str())
+            .find_resource(&to.provider, &to.resource_type, to.identity_or_empty())
             .is_some();
         if from_exists && to_exists {
             return Err(AppError::Validation(format!(
@@ -2557,7 +2569,7 @@ fn find_desired_id<V>(
         .find(|k| {
             k.provider == to.provider
                 && k.resource_type == to.resource_type
-                && k.name_str() == to.name_str()
+                && k.identity_or_empty() == to.name_str()
         })
         .cloned()
 }
@@ -2572,7 +2584,7 @@ fn resolve_import_target_in_desired(
         StateBlockAddress::new(
             &resource.id.provider,
             &resource.id.resource_type,
-            resource.id.name_str(),
+            resource.id.identity_or_empty(),
         )
     })
 }
@@ -2632,7 +2644,7 @@ pub fn add_state_block_effects(
                     sf.find_resource(
                         &effective_to.provider,
                         &effective_to.resource_type,
-                        effective_to.name_str(),
+                        effective_to.identity_or_empty(),
                     )
                     .is_some()
                 });
@@ -2673,7 +2685,7 @@ pub fn add_state_block_effects(
                 let resolved_from = state_file.as_ref().and_then(|sf| {
                     sf.find_resource(&from.provider, &from.resource_type, from.name_str())
                         .map(|rs| {
-                            ResourceId::with_provider(
+                            ResourceId::with_provider_identity(
                                 &rs.provider,
                                 &rs.resource_type,
                                 &rs.name,
@@ -2838,7 +2850,7 @@ fn resolve_import_target(
             if let Some(serde_json::Value::String(s)) = rs.attributes.get(attr)
                 && s == to.name_str()
             {
-                return ResourceId::with_provider(
+                return ResourceId::with_provider_identity(
                     &rs.provider,
                     &rs.resource_type,
                     &rs.name,
@@ -2874,7 +2886,7 @@ fn match_import_target<'a>(
         if resource.id.provider != to.provider || resource.id.resource_type != to.resource_type {
             continue;
         }
-        if resource.id.name_str() == to.name_str() {
+        if resource.id.identity_or_empty() == to.name_str() {
             return Some(resource);
         }
         if fallback.is_none()

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -111,7 +111,7 @@ impl Provider for ReadWithRetryProvider {
 #[tokio::test]
 async fn read_with_retry_translates_not_found_to_state_not_found() {
     let provider = ReadWithRetryProvider::new(ReadBehavior::NotFound);
-    let id = ResourceId::new("test.Resource", "gone");
+    let id = ResourceId::with_identity("test.Resource", "gone");
 
     let state = read_with_retry(&provider, &id, Some("some-identifier"))
         .await
@@ -125,7 +125,7 @@ async fn read_with_retry_translates_not_found_to_state_not_found() {
 #[tokio::test]
 async fn read_with_retry_propagates_other_errors() {
     let provider = ReadWithRetryProvider::new(ReadBehavior::ApiError);
-    let id = ResourceId::new("test.Resource", "broken");
+    let id = ResourceId::with_identity("test.Resource", "broken");
 
     let result = read_with_retry(&provider, &id, Some("some-identifier")).await;
 
@@ -135,7 +135,7 @@ async fn read_with_retry_propagates_other_errors() {
 #[tokio::test]
 async fn read_with_retry_does_not_retry_not_found() {
     let provider = ReadWithRetryProvider::new(ReadBehavior::NotFoundThenSuccess);
-    let id = ResourceId::new("test.Resource", "gone");
+    let id = ResourceId::with_identity("test.Resource", "gone");
 
     let state = read_with_retry(&provider, &id, Some("some-identifier"))
         .await
@@ -225,7 +225,8 @@ fn test_resolve_enum_aliases_aws_provider() {
 fn test_resolve_enum_aliases_in_states() {
     // Current states should also have aliases resolved
     let ctx = WiringContext::new(vec![]);
-    let id = ResourceId::with_provider("awscc", "ec2.security_group_egress", "test-rule", None);
+    let id =
+        ResourceId::with_provider_identity("awscc", "ec2.security_group_egress", "test-rule", None);
     let mut attrs = HashMap::new();
     attrs.insert(
         "ip_protocol".to_string(),
@@ -581,7 +582,7 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     match &effects[0] {
         Effect::Import { id, identifier } => {
             assert_eq!(
-                id.name_str(),
+                id.identity_or_empty(),
                 "s3_bucket_1d43a664",
                 "Import should target the anonymous hash name"
             );
@@ -621,7 +622,7 @@ fn moved_block_resolves_routed_instance_on_from_and_to() {
 
     // Pre-populate `current_states` with the routed `from` id (mirrors
     // what `build_state_for_resource` would produce).
-    let routed_from = ResourceId::with_provider(
+    let routed_from = ResourceId::with_provider_identity(
         "aws",
         "route53.RecordSet",
         "old_record",
@@ -695,7 +696,7 @@ fn removed_block_suppresses_delete_when_state_resource_is_routed_to_named_instan
     // The orphan Delete effect carries the same routed instance.
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: ResourceId::with_provider(
+        id: ResourceId::with_provider_identity(
             "aws",
             "route53.RecordSet",
             "r.delegation_ns",
@@ -964,7 +965,7 @@ fn test_materialize_moved_states_warns_on_missing_from() {
 }
 
 fn bucket_id(name: &str) -> ResourceId {
-    ResourceId::with_provider("awscc", "s3.Bucket", name, None)
+    ResourceId::with_provider_identity("awscc", "s3.Bucket", name, None)
 }
 
 fn bucket_resource(name: &str) -> Resource {
@@ -1467,7 +1468,7 @@ fn import_claimed_name_attribute_target_excludes_desired_from_reconciliation() {
     reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file, &claims);
 
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         desired_name,
         "import-claimed desired resource must not adopt the matching old hash name"
     );
@@ -1510,7 +1511,7 @@ fn assert_claimed_association_stays_orphaned_after_reconcile() {
     reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file, &claims);
 
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         desired_name,
         "claimed state entry must not be rebound to the desired resource"
     );
@@ -1587,7 +1588,7 @@ fn reconcile_anonymous_identifiers_with_ctx_resolves_deferred_create_only_from_s
 
     let names: Vec<_> = resources
         .iter()
-        .map(|resource| resource.id.name_str())
+        .map(|resource| resource.id.identity_or_empty())
         .collect();
     assert_eq!(
         names,
@@ -1646,7 +1647,7 @@ fn test_stale_moved_block_releases_claims() {
     reconcile_anonymous_identifiers_with_ctx(&ctx, &mut resources, &mut state_file, &claims);
 
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         "ec2_subnet_route_table_association_11111111",
         "stale moved block must release claims so meaning-based matching can preserve the no-op"
     );
@@ -1684,8 +1685,12 @@ fn moved_blocks_are_honored_before_heuristic_reconciliation_for_five_renames() {
             to: StateBlockAddress::new("awscc", "ec2.SubnetRouteTableAssociation", &desired_name),
         });
 
-        let old_id =
-            ResourceId::with_provider("awscc", "ec2.SubnetRouteTableAssociation", &old_name, None);
+        let old_id = ResourceId::with_provider_identity(
+            "awscc",
+            "ec2.SubnetRouteTableAssociation",
+            &old_name,
+            None,
+        );
         current_states.insert(old_id.clone(), State::not_found(old_id));
         old_names.push(old_name);
         desired_names.push(desired_name);
@@ -1701,7 +1706,7 @@ fn moved_blocks_are_honored_before_heuristic_reconciliation_for_five_renames() {
     assert_eq!(
         resources
             .iter()
-            .map(|resource| resource.id.name_str().to_string())
+            .map(|resource| resource.id.identity_or_empty().to_string())
             .collect::<Vec<_>>(),
         desired_names,
         "heuristics must not re-key desired resources whose names are moved.to claims"
@@ -1716,18 +1721,28 @@ fn moved_blocks_are_honored_before_heuristic_reconciliation_for_five_renames() {
     );
     assert_eq!(moved_pairs.len(), 5);
     for (idx, (from, to)) in moved_pairs.iter().enumerate() {
-        assert_eq!(from.name_str(), old_names[idx]);
-        assert_eq!(to.name_str(), desired_names[idx]);
+        assert_eq!(from.identity_or_empty(), old_names[idx]);
+        assert_eq!(to.identity_or_empty(), desired_names[idx]);
     }
     for name in old_names {
-        let id = ResourceId::with_provider("awscc", "ec2.SubnetRouteTableAssociation", name, None);
+        let id = ResourceId::with_provider_identity(
+            "awscc",
+            "ec2.SubnetRouteTableAssociation",
+            name,
+            None,
+        );
         assert!(
             !current_states.contains_key(&id),
             "old state key must be removed after materialized move"
         );
     }
     for name in desired_names {
-        let id = ResourceId::with_provider("awscc", "ec2.SubnetRouteTableAssociation", name, None);
+        let id = ResourceId::with_provider_identity(
+            "awscc",
+            "ec2.SubnetRouteTableAssociation",
+            name,
+            None,
+        );
         assert!(
             current_states.contains_key(&id),
             "desired state key must exist after materialized move"
@@ -2070,8 +2085,8 @@ fn compute_anonymous_identifiers_with_ctx_canonicalizes_provider_config_identity
     assert!(errors.is_empty(), "aws spelling errors: {errors:?}");
 
     assert_eq!(
-        resources_awscc[0].id.name_str(),
-        resources_aws[0].id.name_str(),
+        resources_awscc[0].id.identity_or_empty(),
+        resources_aws[0].id.identity_or_empty(),
         "provider config region spelling must canonicalize before anonymous hash"
     );
 }
@@ -2090,10 +2105,10 @@ fn apply_anonymous_to_named_renames_canonicalizes_provider_config_identity_enums
     let errors =
         compute_anonymous_identifiers_with_ctx(&ctx, canonical_anonymous, &providers_awscc);
     assert!(errors.is_empty(), "anonymous setup errors: {errors:?}");
-    let old_name = anonymous[0].id.name_str().to_string();
+    let old_name = anonymous[0].id.identity_or_empty().to_string();
 
     let mut named = anonymous_route_resource();
-    named.id = ResourceId::with_provider("awscc", "ec2.Route", "route", None);
+    named.id = ResourceId::with_provider_identity("awscc", "ec2.Route", "route", None);
     named.binding = Some("route".to_string());
     let resources = vec![named.clone()];
 
@@ -2119,7 +2134,7 @@ fn apply_anonymous_to_named_renames_canonicalizes_provider_config_identity_enums
     assert_eq!(
         renames,
         vec![(
-            ResourceId::with_provider("awscc", "ec2.Route", old_name, None),
+            ResourceId::with_provider_identity("awscc", "ec2.Route", old_name, None),
             named.id
         )],
         "provider config region spelling must canonicalize before rename simhash"
@@ -2475,7 +2490,7 @@ mod read_with_retry_identifier_tests {
     #[tokio::test]
     async fn read_with_retry_short_circuits_when_identifier_is_none() {
         let provider = RecordingProvider::new();
-        let id = ResourceId::with_provider("awscc", "iam.Role", "fresh", None);
+        let id = ResourceId::with_provider_identity("awscc", "iam.Role", "fresh", None);
 
         let state = read_with_retry(&provider, &id, None).await.unwrap();
 
@@ -2494,7 +2509,7 @@ mod read_with_retry_identifier_tests {
     #[tokio::test]
     async fn read_with_retry_forwards_when_identifier_is_some() {
         let provider = RecordingProvider::new();
-        let id = ResourceId::with_provider("awscc", "iam.Role", "existing", None);
+        let id = ResourceId::with_provider_identity("awscc", "iam.Role", "existing", None);
 
         let _state = read_with_retry(&provider, &id, Some("AROABC123"))
             .await
@@ -2568,7 +2583,7 @@ fn deferred_replace_test_template() -> carina_core::parser::DeferredForExpressio
 
 fn deferred_replace_test_target() -> DeferredCreateTarget {
     DeferredCreateTarget {
-        id: ResourceId::with_provider("aws", "__deferred_for", "validation_records", None),
+        id: ResourceId::with_provider_identity("aws", "__deferred_for", "validation_records", None),
         upstream_binding: "cert".to_string(),
         template: deferred_replace_test_template(),
     }
@@ -2576,7 +2591,7 @@ fn deferred_replace_test_target() -> DeferredCreateTarget {
 
 fn delete_effect_for_binding(binding: &str) -> Effect {
     Effect::Delete {
-        id: ResourceId::with_provider("aws", "route53.Record", binding, None),
+        id: ResourceId::with_provider_identity("aws", "route53.Record", binding, None),
         identifier: format!("{binding}-old-id"),
         directives: Directives::default(),
         binding: Some(binding.to_string()),
@@ -2586,7 +2601,7 @@ fn delete_effect_for_binding(binding: &str) -> Effect {
 }
 
 fn cert_replace_effect() -> Effect {
-    let id = ResourceId::with_provider("aws", "acm.Certificate", "cert", None);
+    let id = ResourceId::with_provider_identity("aws", "acm.Certificate", "cert", None);
     Effect::Replace {
         id: id.clone(),
         from: Box::new(State::existing(id, HashMap::new()).with_identifier("cert-old-id")),
@@ -2633,7 +2648,7 @@ fn deferred_create_targets_absorb_matching_orphan_deletes_into_deferred_replace(
     assert_eq!(deletes.len(), 1);
     assert_eq!(
         deletes[0].id,
-        ResourceId::with_provider("aws", "route53.Record", "validation_records[0]", None)
+        ResourceId::with_provider_identity("aws", "route53.Record", "validation_records[0]", None)
     );
     assert_eq!(deletes[0].binding.as_deref(), Some("validation_records[0]"));
 
@@ -3914,7 +3929,7 @@ mod wait_until_enum_alias {
     }
 
     fn cert_state() -> HashMap<ResourceId, State> {
-        let id = ResourceId::with_provider("aws", "acm.Certificate", "cert", None);
+        let id = ResourceId::with_provider_identity("aws", "acm.Certificate", "cert", None);
         let mut attrs = HashMap::new();
         attrs.insert(
             "status".to_string(),

--- a/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
+++ b/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
@@ -167,7 +167,7 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
     };
 
     let validation_id =
-        ResourceId::with_provider("mock", "test.resource", "validation_records[0]", None);
+        ResourceId::with_provider_identity("mock", "test.resource", "validation_records[0]", None);
     let mut plan = Plan::new();
     plan.add(Effect::Create(lb.clone()));
     plan.add(Effect::Create(cert.clone()));
@@ -181,7 +181,7 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(template),
     });

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -1084,7 +1084,7 @@ mod resolved_bindings_tests {
 
     #[test]
     fn local_binding_merges_state_attributes_when_dsl_missing_them() {
-        let rid = ResourceId::new("test.resource", "my-vpc");
+        let rid = ResourceId::with_identity("test.resource", "my-vpc");
         let resources = vec![make_resource(
             "my-vpc",
             Some("vpc"),
@@ -1148,8 +1148,8 @@ mod resolved_bindings_tests {
 
     #[test]
     fn pre_apply_materializes_partial_read_unknown_for_sibling_ref() {
-        let id_a = ResourceId::new("test.resource", "a");
-        let id_b = ResourceId::new("test.resource", "b");
+        let id_a = ResourceId::with_identity("test.resource", "a");
+        let id_b = ResourceId::with_identity("test.resource", "b");
         let a = make_resource("a", Some("a"), vec![]);
         let b = make_resource(
             "b",
@@ -1324,7 +1324,7 @@ mod resolved_bindings_tests {
         // `State.exists = false` represents a tombstone (resource was
         // destroyed since the last apply). The resolver must not merge
         // its attributes — they describe a no-longer-real resource.
-        let rid = ResourceId::new("test.resource", "my-vpc");
+        let rid = ResourceId::with_identity("test.resource", "my-vpc");
         let resources = vec![make_resource(
             "my-vpc",
             Some("vpc"),
@@ -1390,7 +1390,7 @@ mod resolved_bindings_tests {
         .into_iter()
         .collect();
         let state = State {
-            id: ResourceId::new("test.resource", "my-vpc"),
+            id: ResourceId::with_identity("test.resource", "my-vpc"),
             identifier: None,
             exists: true,
             attributes: vec![
@@ -1442,7 +1442,7 @@ mod resolved_bindings_tests {
         let mut resolved = ResolvedBindings::default();
         let attrs: HashMap<String, Value> = HashMap::new();
         let state = State {
-            id: ResourceId::new("test.resource", "anon"),
+            id: ResourceId::with_identity("test.resource", "anon"),
             identifier: None,
             exists: true,
             attributes: HashMap::new(),
@@ -1483,7 +1483,7 @@ mod resolved_bindings_tests {
 
         let mut child = parent.clone();
         let extra_state = State {
-            id: ResourceId::new("test.resource", "subnet"),
+            id: ResourceId::with_identity("test.resource", "subnet"),
             identifier: None,
             exists: true,
             attributes: vec![(
@@ -1742,7 +1742,7 @@ mod resolved_bindings_tests {
     /// what the provider *returned*.
     #[test]
     fn data_source_binding_merges_state_attributes() {
-        let ds_id = ResourceId::new("aws.iam.Roles", "admin_access_roles");
+        let ds_id = ResourceId::with_identity("aws.iam.Roles", "admin_access_roles");
         let mut ds = DataSource::new("aws.iam.Roles", "admin_access_roles");
         ds.id = ds_id.clone();
         ds.binding = Some("admin_access_roles".to_string());
@@ -1828,7 +1828,7 @@ mod resolved_bindings_tests {
     /// view must surface the post-read value, not the pre-read filter.
     #[test]
     fn data_source_binding_state_wins_on_key_collision() {
-        let ds_id = ResourceId::new("aws.example.Echo", "echo");
+        let ds_id = ResourceId::with_identity("aws.example.Echo", "echo");
         let mut ds = DataSource::new("aws.example.Echo", "echo");
         ds.id = ds_id.clone();
         ds.binding = Some("echo".to_string());
@@ -1884,7 +1884,7 @@ mod resolved_bindings_tests {
     /// so it pins the state-only variant.
     #[test]
     fn data_source_binding_with_no_dsl_inputs_exposes_state_only() {
-        let ds_id = ResourceId::with_provider("aws", "sts.CallerIdentity", "caller", None);
+        let ds_id = ResourceId::with_provider_identity("aws", "sts.CallerIdentity", "caller", None);
         let mut ds = DataSource::with_provider("aws", "sts.CallerIdentity", "caller", None);
         ds.id = ds_id.clone();
         ds.binding = Some("caller".to_string());

--- a/carina-core/src/binding_index_split_tests.rs
+++ b/carina-core/src/binding_index_split_tests.rs
@@ -25,7 +25,7 @@ fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> Resource {
         attributes.insert((*k).into(), v.clone());
     }
     Resource {
-        id: ResourceId::new("aws.s3.Bucket", binding),
+        id: ResourceId::with_identity("aws.s3.Bucket", binding),
         attributes,
         directives: Default::default(),
         prefixes: HashMap::new(),
@@ -45,7 +45,7 @@ fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> Composition {
         );
     }
     Composition {
-        id: ResourceId::new("_virtual.module", binding),
+        id: ResourceId::with_identity("_virtual.module", binding),
         signature: Signature {
             arguments: IndexMap::new(),
             attributes,

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -150,10 +150,13 @@ fn topological_sort(resources: &[Resource]) -> Result<Vec<Resource>, String> {
         visiting: &mut Vec<String>,
         sorted: &mut Vec<Resource>,
     ) -> Result<(), String> {
-        let binding_name = resource
-            .binding
-            .clone()
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name_str()));
+        let binding_name = resource.binding.clone().unwrap_or_else(|| {
+            format!(
+                "{}:{}",
+                resource.id.resource_type,
+                resource.id.identity_or_empty()
+            )
+        });
 
         if visited.contains(&binding_name) {
             return Ok(());
@@ -209,7 +212,7 @@ mod tests {
     fn wait_effect_with_explicit_dependency(binding: Option<&str>) -> Effect {
         Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::new("acm.Certificate", "cert"),
+            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(crate::resource::ConcreteValue::String(
@@ -266,7 +269,7 @@ mod tests {
         let mut dep_bindings = BTreeSet::new();
         dep_bindings.insert("explicit_dep".to_string());
         let virt = Composition {
-            id: ResourceId::new("_virtual.module", "v"),
+            id: ResourceId::with_identity("_virtual.module", "v"),
             signature: Signature {
                 arguments: IndexMap::new(),
                 attributes,
@@ -454,9 +457,9 @@ mod tests {
         let creation_order: Vec<String> = sorted
             .iter()
             .map(|r| {
-                r.binding
-                    .clone()
-                    .unwrap_or_else(|| format!("{}:{}", r.id.resource_type, r.id.name_str()))
+                r.binding.clone().unwrap_or_else(|| {
+                    format!("{}:{}", r.id.resource_type, r.id.identity_or_empty())
+                })
             })
             .collect();
 
@@ -538,9 +541,9 @@ mod tests {
         let creation_order: Vec<String> = sorted
             .iter()
             .map(|r| {
-                r.binding
-                    .clone()
-                    .unwrap_or_else(|| format!("{}:{}", r.id.resource_type, r.id.name_str()))
+                r.binding.clone().unwrap_or_else(|| {
+                    format!("{}:{}", r.id.resource_type, r.id.identity_or_empty())
+                })
             })
             .collect();
 

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -1056,7 +1056,7 @@ fn build_replace_rows(
 
             updates.push(CascadingUpdateIR {
                 display_type: cascade.id.display_type(),
-                name: cascade.id.name_str().to_string(),
+                name: cascade.id.identity_or_empty().to_string(),
                 changed_attrs,
             });
         }
@@ -1940,7 +1940,7 @@ mod tests {
     #[test]
     fn test_update_changed_attributes() {
         let from = State::existing(
-            ResourceId::new("s3.Bucket", "my-bucket"),
+            ResourceId::with_identity("s3.Bucket", "my-bucket"),
             [(
                 "versioning".to_string(),
                 Value::Concrete(ConcreteValue::String("Disabled".to_string())),
@@ -1953,7 +1953,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         );
         let effect = Effect::Update {
-            id: ResourceId::new("s3.Bucket", "my-bucket"),
+            id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["versioning".to_string()],
@@ -1967,7 +1967,7 @@ mod tests {
     #[test]
     fn test_update_hidden_unchanged_in_full_mode() {
         let from = State::existing(
-            ResourceId::new("s3.Bucket", "my-bucket"),
+            ResourceId::with_identity("s3.Bucket", "my-bucket"),
             [
                 (
                     "name".to_string(),
@@ -1999,7 +1999,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("Enabled".to_string())),
             );
         let effect = Effect::Update {
-            id: ResourceId::new("s3.Bucket", "my-bucket"),
+            id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["versioning".to_string()],
@@ -2021,7 +2021,7 @@ mod tests {
         use crate::explicit::ExplicitFields;
 
         let from = State::existing(
-            ResourceId::new("s3.Bucket", "my-bucket"),
+            ResourceId::with_identity("s3.Bucket", "my-bucket"),
             [
                 (
                     "authored".to_string(),
@@ -2053,7 +2053,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("new-value".to_string())),
             );
         let effect = Effect::Update {
-            id: ResourceId::new("s3.Bucket", "my-bucket"),
+            id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["trigger_diff".to_string()],
@@ -2076,7 +2076,7 @@ mod tests {
         // projected out, leaving only "authored" as the unchanged tally.
         let mut explicit_map = HashMap::new();
         explicit_map.insert(
-            ResourceId::new("s3.Bucket", "my-bucket"),
+            ResourceId::with_identity("s3.Bucket", "my-bucket"),
             ExplicitFields::Struct {
                 children: HashMap::from([
                     ("authored".to_string(), ExplicitFields::Leaf),
@@ -2098,7 +2098,7 @@ mod tests {
 
     #[test]
     fn test_delete_with_attributes() {
-        let id = ResourceId::new("s3.Bucket", "old-bucket");
+        let id = ResourceId::with_identity("s3.Bucket", "old-bucket");
         let effect = Effect::Delete {
             id: id.clone(),
             identifier: "old-bucket".to_string(),
@@ -2125,7 +2125,7 @@ mod tests {
     #[test]
     fn test_update_removed_attribute() {
         let from = State::existing(
-            ResourceId::new("s3.Bucket", "my-bucket"),
+            ResourceId::with_identity("s3.Bucket", "my-bucket"),
             [
                 (
                     "name".to_string(),
@@ -2144,7 +2144,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("test".to_string())),
         );
         let effect = Effect::Update {
-            id: ResourceId::new("s3.Bucket", "my-bucket"),
+            id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["removed_attr".to_string()],
@@ -2169,12 +2169,12 @@ mod tests {
             ConcreteValue::Map(rule.clone()),
         )]));
         let from = State::existing(
-            ResourceId::new("test.Widget", "beta"),
+            ResourceId::with_identity("test.Widget", "beta"),
             [("rules".to_string(), old_rules)].into_iter().collect(),
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Update {
-            id: ResourceId::new("test.Widget", "beta"),
+            id: ResourceId::with_identity("test.Widget", "beta"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["rules".to_string()],
@@ -2318,7 +2318,7 @@ mod tests {
 
     #[test]
     fn test_delete_map_expanded() {
-        let id = ResourceId::new("s3.Bucket", "old-bucket");
+        let id = ResourceId::with_identity("s3.Bucket", "old-bucket");
         let effect = Effect::Delete {
             id: id.clone(),
             identifier: "old-bucket".to_string(),
@@ -2364,7 +2364,7 @@ mod tests {
         // one long line (asymmetric with build_create_rows). A list-of-maps
         // like `domain_validation_options` must route through
         // PrettyAttribute so format_value_pretty's vertical layout applies.
-        let id = ResourceId::new("acm.Certificate", "cert");
+        let id = ResourceId::with_identity("acm.Certificate", "cert");
         let effect = Effect::Delete {
             id: id.clone(),
             identifier: "cert".to_string(),
@@ -2419,7 +2419,7 @@ mod tests {
     #[test]
     fn test_replace_basic() {
         let from = State::existing(
-            ResourceId::new("ec2.Vpc", "my-vpc"),
+            ResourceId::with_identity("ec2.Vpc", "my-vpc"),
             [(
                 "cidr_block".to_string(),
                 Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -2432,7 +2432,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
         let effect = Effect::Replace {
-            id: ResourceId::new("ec2.Vpc", "my-vpc"),
+            id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2455,7 +2455,7 @@ mod tests {
     #[test]
     fn replace_removed_create_only_attribute_emits_detail_row() {
         let from = State::existing(
-            ResourceId::new("test.Widget", "beta"),
+            ResourceId::with_identity("test.Widget", "beta"),
             [(
                 "legacy_token".to_string(),
                 Value::Concrete(ConcreteValue::String("tok".to_string())),
@@ -2465,7 +2465,7 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "beta"),
+            id: ResourceId::with_identity("test.Widget", "beta"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2501,7 +2501,7 @@ mod tests {
             Value::Concrete(ConcreteValue::Int(1)),
         );
         let from = State::existing(
-            ResourceId::new("test.Widget", "beta"),
+            ResourceId::with_identity("test.Widget", "beta"),
             [(
                 "settings".to_string(),
                 Value::Concrete(ConcreteValue::Map(settings)),
@@ -2511,7 +2511,7 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "beta"),
+            id: ResourceId::with_identity("test.Widget", "beta"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2560,12 +2560,12 @@ mod tests {
             ConcreteValue::Map(rule.clone()),
         )]));
         let from = State::existing(
-            ResourceId::new("test.Widget", "beta"),
+            ResourceId::with_identity("test.Widget", "beta"),
             [("rules".to_string(), old_rules)].into_iter().collect(),
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "beta"),
+            id: ResourceId::with_identity("test.Widget", "beta"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2607,7 +2607,7 @@ mod tests {
     #[test]
     fn replace_rows_include_non_forcing_attribute_diffs_and_count_only_equal_attributes() {
         let from = State::existing(
-            ResourceId::new("wafv2.WebAcl", "edge"),
+            ResourceId::with_identity("wafv2.WebAcl", "edge"),
             [
                 (
                     "name".to_string(),
@@ -2655,7 +2655,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("CLOUDFRONT".to_string())),
             );
         let effect = Effect::Replace {
-            id: ResourceId::new("wafv2.WebAcl", "edge"),
+            id: ResourceId::with_identity("wafv2.WebAcl", "edge"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2712,7 +2712,7 @@ mod tests {
         use crate::resource::InterpolationPart;
 
         let from = State::existing(
-            ResourceId::new("wafv2.WebAcl", "edge"),
+            ResourceId::with_identity("wafv2.WebAcl", "edge"),
             [(
                 "name".to_string(),
                 Value::Concrete(ConcreteValue::String("edge-old".to_string())),
@@ -2737,7 +2737,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("old comment".to_string())),
         );
         let cascade_from = State::existing(
-            ResourceId::new("cloudfront.Distribution", "cdn"),
+            ResourceId::with_identity("cloudfront.Distribution", "cdn"),
             [(
                 "distribution_config".to_string(),
                 Value::Concrete(ConcreteValue::Map(old_config)),
@@ -2762,14 +2762,14 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(new_config)),
         );
         let effect = Effect::Replace {
-            id: ResourceId::new("wafv2.WebAcl", "edge"),
+            id: ResourceId::with_identity("wafv2.WebAcl", "edge"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
                 .unwrap(),
             cascading_updates: vec![CascadingUpdate {
-                id: ResourceId::new("cloudfront.Distribution", "cdn"),
+                id: ResourceId::with_identity("cloudfront.Distribution", "cdn"),
                 from: Box::new(cascade_from),
                 to: cascade_to,
             }],
@@ -2801,7 +2801,7 @@ mod tests {
         use crate::effect::CascadingUpdate;
 
         let from = State::existing(
-            ResourceId::new("wafv2.WebAcl", "edge"),
+            ResourceId::with_identity("wafv2.WebAcl", "edge"),
             [(
                 "name".to_string(),
                 Value::Concrete(ConcreteValue::String("edge-old".to_string())),
@@ -2826,7 +2826,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("arn:old-web-acl".to_string())),
         );
         let cascade_from = State::existing(
-            ResourceId::new("test.RuleSet", "rules"),
+            ResourceId::with_identity("test.RuleSet", "rules"),
             [(
                 "rules".to_string(),
                 Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
@@ -2854,14 +2854,14 @@ mod tests {
         );
 
         let effect = Effect::Replace {
-            id: ResourceId::new("wafv2.WebAcl", "edge"),
+            id: ResourceId::with_identity("wafv2.WebAcl", "edge"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
                 .unwrap(),
             cascading_updates: vec![CascadingUpdate {
-                id: ResourceId::new("test.RuleSet", "rules"),
+                id: ResourceId::with_identity("test.RuleSet", "rules"),
                 from: Box::new(cascade_from),
                 to: cascade_to,
             }],
@@ -2912,7 +2912,7 @@ mod tests {
     #[test]
     fn replace_same_forcing_key_prefers_cascade_ref_hint() {
         let from = State::existing(
-            ResourceId::new("test.Widget", "w"),
+            ResourceId::with_identity("test.Widget", "w"),
             [(
                 "arn".to_string(),
                 Value::Concrete(ConcreteValue::String("arn:old".to_string())),
@@ -2925,7 +2925,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("arn:old".to_string())),
         );
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "w"),
+            id: ResourceId::with_identity("test.Widget", "w"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2951,7 +2951,7 @@ mod tests {
     #[test]
     fn replace_same_forcing_key_without_cascade_ref_hint_formats_new_value() {
         let from = State::existing(
-            ResourceId::new("test.Widget", "w"),
+            ResourceId::with_identity("test.Widget", "w"),
             [(
                 "arn".to_string(),
                 Value::Concrete(ConcreteValue::String("arn:old".to_string())),
@@ -2964,7 +2964,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("arn:old".to_string())),
         );
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "w"),
+            id: ResourceId::with_identity("test.Widget", "w"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3020,7 +3020,7 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(new_condition)),
         );
         let from = State::existing(
-            ResourceId::new("test.Widget", "w"),
+            ResourceId::with_identity("test.Widget", "w"),
             [(
                 "rules".to_string(),
                 Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
@@ -3037,7 +3037,7 @@ mod tests {
             )])),
         );
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "w"),
+            id: ResourceId::with_identity("test.Widget", "w"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3076,7 +3076,7 @@ mod tests {
             )])),
         );
         let from = State::existing(
-            ResourceId::new("test.Widget", "w"),
+            ResourceId::with_identity("test.Widget", "w"),
             [(
                 "settings".to_string(),
                 Value::Concrete(ConcreteValue::Map(old_settings)),
@@ -3089,7 +3089,7 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(new_settings)),
         );
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "w"),
+            id: ResourceId::with_identity("test.Widget", "w"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3116,7 +3116,7 @@ mod tests {
     #[test]
     fn replace_forcing_display_equal_scalar_still_renders_forcing_row() {
         let from = State::existing(
-            ResourceId::new("test.Widget", "w"),
+            ResourceId::with_identity("test.Widget", "w"),
             [(
                 "aliases".to_string(),
                 Value::Concrete(ConcreteValue::StringList(vec!["only-one".to_string()])),
@@ -3131,7 +3131,7 @@ mod tests {
             )])),
         );
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "w"),
+            id: ResourceId::with_identity("test.Widget", "w"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3158,7 +3158,7 @@ mod tests {
     fn replace_forcing_key_uses_raw_old_value_when_explicit_projection_omits_it() {
         use crate::explicit::ExplicitFields;
 
-        let id = ResourceId::new("test.Widget", "w");
+        let id = ResourceId::with_identity("test.Widget", "w");
         let from = State::existing(
             id.clone(),
             [
@@ -3220,7 +3220,7 @@ mod tests {
     #[test]
     fn replace_rows_include_non_forcing_removed_attributes() {
         let from = State::existing(
-            ResourceId::new("test.Widget", "w"),
+            ResourceId::with_identity("test.Widget", "w"),
             [
                 (
                     "external_name".to_string(),
@@ -3239,7 +3239,7 @@ mod tests {
             Value::Concrete(ConcreteValue::String("new-name".to_string())),
         );
         let effect = Effect::Replace {
-            id: ResourceId::new("test.Widget", "w"),
+            id: ResourceId::with_identity("test.Widget", "w"),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3520,7 +3520,7 @@ mod tests {
     #[test]
     fn update_with_only_enum_equal_leaves_emits_no_phantom_row() {
         let from = State::existing(
-            ResourceId::new("iam.Role", "r"),
+            ResourceId::with_identity("iam.Role", "r"),
             [(
                 "policy".to_string(),
                 iam_policy_value(
@@ -3539,7 +3539,7 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: ResourceId::new("iam.Role", "r"),
+            id: ResourceId::with_identity("iam.Role", "r"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string()],
@@ -3558,7 +3558,7 @@ mod tests {
     #[test]
     fn update_real_sibling_change_still_renders_without_enum_phantom() {
         let from = State::existing(
-            ResourceId::new("iam.Role", "r"),
+            ResourceId::with_identity("iam.Role", "r"),
             [
                 (
                     "policy".to_string(),
@@ -3588,7 +3588,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("new".to_string())),
             );
         let effect = Effect::Update {
-            id: ResourceId::new("iam.Role", "r"),
+            id: ResourceId::with_identity("iam.Role", "r"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string(), "description".to_string()],
@@ -3613,7 +3613,7 @@ mod tests {
     #[test]
     fn update_without_registry_keeps_schema_blind_behavior() {
         let from = State::existing(
-            ResourceId::new("iam.Role", "r"),
+            ResourceId::with_identity("iam.Role", "r"),
             [(
                 "policy".to_string(),
                 iam_policy_value(
@@ -3632,7 +3632,7 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: ResourceId::new("iam.Role", "r"),
+            id: ResourceId::with_identity("iam.Role", "r"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string()],
@@ -3653,7 +3653,7 @@ mod tests {
     #[test]
     fn update_full_mode_counts_enum_equal_attr_as_unchanged() {
         let from = State::existing(
-            ResourceId::new("iam.Role", "r"),
+            ResourceId::with_identity("iam.Role", "r"),
             [(
                 "policy".to_string(),
                 iam_policy_value(
@@ -3672,7 +3672,7 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: ResourceId::new("iam.Role", "r"),
+            id: ResourceId::with_identity("iam.Role", "r"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string()],
@@ -3723,7 +3723,7 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(m))
         };
         let from = State::existing(
-            ResourceId::new("x.Thing", "t"),
+            ResourceId::with_identity("x.Thing", "t"),
             [(
                 "modes".to_string(),
                 mk(ConcreteValue::enum_identifier("on".to_string())),
@@ -3734,7 +3734,7 @@ mod tests {
         let to = Resource::new("x.Thing", "t")
             .with_attribute("modes", mk(ConcreteValue::String("On".to_string())));
         let effect = Effect::Update {
-            id: ResourceId::new("x.Thing", "t"),
+            id: ResourceId::with_identity("x.Thing", "t"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["modes".to_string()],
@@ -3753,7 +3753,7 @@ mod tests {
     #[test]
     fn update_real_enum_change_still_renders_with_registry() {
         let from = State::existing(
-            ResourceId::new("iam.Role", "r"),
+            ResourceId::with_identity("iam.Role", "r"),
             [(
                 "policy".to_string(),
                 iam_policy_value(
@@ -3774,7 +3774,7 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: ResourceId::new("iam.Role", "r"),
+            id: ResourceId::with_identity("iam.Role", "r"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string()],
@@ -3797,7 +3797,7 @@ mod tests {
     #[test]
     fn update_full_mode_multi_attr_tally_balances() {
         let from = State::existing(
-            ResourceId::new("iam.Role", "r"),
+            ResourceId::with_identity("iam.Role", "r"),
             [
                 (
                     "policy".to_string(),
@@ -3835,7 +3835,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
             );
         let effect = Effect::Update {
-            id: ResourceId::new("iam.Role", "r"),
+            id: ResourceId::with_identity("iam.Role", "r"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string(), "description".to_string()],
@@ -3916,7 +3916,7 @@ mod tests {
     fn update_string_list_of_enum_only_genuine_add_renders() {
         let registry = modes_registry();
         let from = State::existing(
-            ResourceId::new("x.Thing", "t"),
+            ResourceId::with_identity("x.Thing", "t"),
             [("modes".to_string(), enum_list(&["allow"]))]
                 .into_iter()
                 .collect(),
@@ -3924,7 +3924,7 @@ mod tests {
         let to =
             Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
         let effect = Effect::Update {
-            id: ResourceId::new("x.Thing", "t"),
+            id: ResourceId::with_identity("x.Thing", "t"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["modes".to_string()],
@@ -4124,7 +4124,7 @@ mod tests {
         // `StringList(["x"])` to `List([String("x")])` as unequal even
         // though both `format_value` to `["x"]`.
         let from = State::existing(
-            ResourceId::new("x.Thing", "t"),
+            ResourceId::with_identity("x.Thing", "t"),
             [(
                 "tags".to_string(),
                 Value::Concrete(ConcreteValue::StringList(vec!["only-one".to_string()])),
@@ -4139,7 +4139,7 @@ mod tests {
             )])),
         );
         let effect = Effect::Update {
-            id: ResourceId::new("x.Thing", "t"),
+            id: ResourceId::with_identity("x.Thing", "t"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["tags".to_string()],
@@ -4165,7 +4165,7 @@ mod tests {
     #[test]
     fn top_level_changed_keeps_secret_rotation_visible() {
         let from = State::existing(
-            ResourceId::new("x.Thing", "t"),
+            ResourceId::with_identity("x.Thing", "t"),
             [(
                 "password".to_string(),
                 Value::Deferred(DeferredValue::Secret(Box::new(Value::Concrete(
@@ -4182,7 +4182,7 @@ mod tests {
             )))),
         );
         let effect = Effect::Update {
-            id: ResourceId::new("x.Thing", "t"),
+            id: ResourceId::with_identity("x.Thing", "t"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["password".to_string()],
@@ -4396,7 +4396,7 @@ mod tests {
     #[test]
     fn update_string_list_of_enum_no_registry_keeps_schema_blind() {
         let from = State::existing(
-            ResourceId::new("x.Thing", "t"),
+            ResourceId::with_identity("x.Thing", "t"),
             [("modes".to_string(), enum_list(&["allow"]))]
                 .into_iter()
                 .collect(),
@@ -4404,7 +4404,7 @@ mod tests {
         let to =
             Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
         let effect = Effect::Update {
-            id: ResourceId::new("x.Thing", "t"),
+            id: ResourceId::with_identity("x.Thing", "t"),
             from: Box::new(from),
             to,
             changed_attributes: vec!["modes".to_string()],

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -7,8 +7,8 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     // Subnet depends on VPC via ResourceRef
     // cascade_dependent_updates should add a CascadingUpdate to the Replace
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
@@ -118,8 +118,8 @@ fn cascade_skips_resources_already_in_plan() {
     // If the dependent resource already has its own effect (e.g., Update),
     // cascade should not add a duplicate
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -214,7 +214,7 @@ fn cascade_skips_resources_already_in_plan() {
 fn cascade_no_op_without_create_before_destroy() {
     // Replace without create_before_destroy should not trigger cascading
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -277,9 +277,9 @@ fn cascade_transitive_dependencies() {
     // VPC → Subnet → Instance (transitive chain)
     // Only Subnet directly depends on VPC, so only Subnet gets cascading update
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
-    let instance_id = ResourceId::new("ec2.Instance", "my-instance");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
+    let instance_id = ResourceId::with_identity("ec2.Instance", "my-instance");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -383,8 +383,8 @@ fn cascade_anonymous_resource_dependent() {
     // Anonymous resource (no _binding) that depends on a replaced resource
     // should still get a cascading update
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -475,8 +475,8 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
 
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
@@ -629,8 +629,8 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
 fn cascade_generates_replace_when_create_only_list_contains_nested_ref() {
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let attachment_id = ResourceId::new("ec2.RouteTableAssociation", "my-assoc");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let attachment_id = ResourceId::with_identity("ec2.RouteTableAssociation", "my-assoc");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -756,8 +756,8 @@ fn cascade_generates_replace_when_create_only_list_contains_nested_ref() {
 fn cascade_hint_prefers_resource_ref_over_binding_ref_in_mixed_list() {
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let attachment_id = ResourceId::new("ec2.RouteTableAssociation", "my-assoc");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let attachment_id = ResourceId::with_identity("ec2.RouteTableAssociation", "my-assoc");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -861,8 +861,8 @@ fn cascade_hint_prefers_resource_ref_over_binding_ref_in_mixed_list() {
 fn cascade_generates_replace_when_create_only_map_contains_nested_ref() {
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let tagged_id = ResourceId::new("ec2.TaggedResource", "my-tagged");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let tagged_id = ResourceId::with_identity("ec2.TaggedResource", "my-tagged");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -1000,8 +1000,8 @@ fn cascade_generates_replace_when_create_only_map_contains_nested_ref() {
 fn cascade_prevent_destroy_blocks_nested_map_ref_promotion_to_replace() {
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let tagged_id = ResourceId::new("ec2.TaggedResource", "my-tagged");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let tagged_id = ResourceId::with_identity("ec2.TaggedResource", "my-tagged");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -1126,8 +1126,8 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
 
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
@@ -1292,8 +1292,8 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
 
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
@@ -1415,8 +1415,8 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
 
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     // Unresolved resources (before ref resolution)
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
@@ -1558,8 +1558,8 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
 
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")
@@ -1683,8 +1683,8 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
 
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    let vpc_id = ResourceId::new("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::new("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
 
     let vpc = Resource::new("ec2.Vpc", "my-vpc")
         .with_binding("vpc")

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -676,8 +676,8 @@ pub(super) fn find_changed_attributes(
         });
 
         // Build secret hash context from resource ID and attribute key
-        let secret_ctx =
-            resource_id.map(|id| SecretHashContext::new(id.display_type(), id.name_str(), key));
+        let secret_ctx = resource_id
+            .map(|id| SecretHashContext::new(id.display_type(), id.identity_or_empty(), key));
 
         if key_should_enter_patch(
             key,

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -152,7 +152,10 @@ fn type_aware_diff_no_change_with_schema() {
         "port".to_string(),
         Value::Concrete(ConcreteValue::Float(443.0)),
     );
-    let current = State::existing(ResourceId::new("test.resource", "test"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("test.resource", "test"),
+        current_attrs,
+    );
 
     // Without schema: detects a change (Int != Float)
     let result = diff(&desired, &current, None, None, None);
@@ -1011,10 +1014,10 @@ fn secret_with_context_no_change_when_hash_matches() {
     use crate::resource::{ConcreteValue, DeferredValue, ResourceId};
     use crate::value::{SecretHashContext, value_to_json_with_context};
 
-    let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None);
+    let resource_id = ResourceId::with_provider_identity("awscc", "rds.db_instance", "my-db", None);
     let ctx = SecretHashContext::new(
         resource_id.display_type(),
-        resource_id.name_str(),
+        resource_id.identity_or_empty(),
         "master_password",
     );
 
@@ -1045,10 +1048,10 @@ fn secret_with_context_detects_change() {
     use crate::resource::ResourceId;
     use crate::value::{SecretHashContext, value_to_json_with_context};
 
-    let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db", None);
+    let resource_id = ResourceId::with_provider_identity("awscc", "rds.db_instance", "my-db", None);
     let ctx = SecretHashContext::new(
         resource_id.display_type(),
-        resource_id.name_str(),
+        resource_id.identity_or_empty(),
         "master_password",
     );
 
@@ -1096,7 +1099,7 @@ fn secret_same_password_different_resources_produces_different_hashes() {
     );
 
     // Each hash should match its own context
-    let id1 = ResourceId::with_provider("awscc", "rds.db_instance", "db-1", None);
+    let id1 = ResourceId::with_provider_identity("awscc", "rds.db_instance", "db-1", None);
     let desired1 = HashMap::from([("master_password".to_string(), secret.clone())]);
     let current1 = HashMap::from([(
         "master_password".to_string(),
@@ -1109,7 +1112,7 @@ fn secret_same_password_different_resources_produces_different_hashes() {
     );
 
     // But not the other resource's context
-    let id2 = ResourceId::with_provider("awscc", "rds.db_instance", "db-2", None);
+    let id2 = ResourceId::with_provider_identity("awscc", "rds.db_instance", "db-2", None);
     let desired2 = HashMap::from([("master_password".to_string(), secret)]);
     let current2 = HashMap::from([(
         "master_password".to_string(),
@@ -1182,7 +1185,8 @@ fn secret_in_map_with_refresh_no_false_diff() {
     use crate::resource::ResourceId;
     use crate::schema::{AttributeSchema, ResourceSchema};
 
-    let resource_id = ResourceId::with_provider("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None);
+    let resource_id =
+        ResourceId::with_provider_identity("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None);
 
     // Desired: tags map with a secret value (as written in .crn)
     let desired_tags = Value::Concrete(ConcreteValue::Map(IndexMap::from([
@@ -1383,7 +1387,7 @@ fn carina3080_principal_scalar_vs_singleton_is_no_change_via_pipeline() {
         "principal".to_string(),
         Value::Concrete(ConcreteValue::Map(state_inner)),
     );
-    let mut id = ResourceId::new("iam.policy", "p1");
+    let mut id = ResourceId::with_identity("iam.policy", "p1");
     id.provider = "aws".to_string();
     let mut states = std::collections::HashMap::new();
     let st = State::existing(id, state_attrs);
@@ -1637,7 +1641,7 @@ fn carina3122_cloudfront_allowed_methods_set_is_no_change_via_pipeline() {
         "distribution_config".to_string(),
         Value::Concrete(ConcreteValue::Map(state_dc)),
     );
-    let mut id = ResourceId::new("cloudfront.Distribution", "d1");
+    let mut id = ResourceId::with_identity("cloudfront.Distribution", "d1");
     id.provider = "awscc".to_string();
     let mut states = std::collections::HashMap::new();
     let st = State::existing(id, state_attrs);
@@ -1759,7 +1763,7 @@ fn carina3122_cloudfront_allowed_methods_ordered_list_does_change_via_pipeline()
 
     let mut state_attrs = HashMap::new();
     state_attrs.insert("distribution_config".to_string(), dcb("head", "get"));
-    let mut id = ResourceId::new("cloudfront.Distribution", "d1");
+    let mut id = ResourceId::with_identity("cloudfront.Distribution", "d1");
     id.provider = "awscc".to_string();
     let mut states = std::collections::HashMap::new();
     let st = State::existing(id, state_attrs);

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 #[test]
 fn diff_create_when_not_exists() {
     let desired = Resource::new("bucket", "test");
-    let current = State::not_found(ResourceId::new("bucket", "test"));
+    let current = State::not_found(ResourceId::with_identity("bucket", "test"));
 
     let result = diff(&desired, &current, None, None, None);
     assert!(matches!(result, Diff::Create(_)));
@@ -24,7 +24,7 @@ fn diff_no_change_when_same() {
         "region".to_string(),
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
-    let current = State::existing(ResourceId::new("bucket", "test"), attrs);
+    let current = State::existing(ResourceId::with_identity("bucket", "test"), attrs);
 
     let result = diff(&desired, &current, None, None, None);
     assert!(matches!(result, Diff::NoChange(_)));
@@ -42,7 +42,7 @@ fn diff_update_when_different() {
         "region".to_string(),
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
-    let current = State::existing(ResourceId::new("bucket", "test"), attrs);
+    let current = State::existing(ResourceId::with_identity("bucket", "test"), attrs);
 
     let result = diff(&desired, &current, None, None, None);
     match result {
@@ -114,8 +114,11 @@ fn create_plan_from_resources() {
         Value::Concrete(ConcreteValue::Bool(false)),
     );
     current_states.insert(
-        ResourceId::new("bucket", "existing-bucket"),
-        State::existing(ResourceId::new("bucket", "existing-bucket"), attrs),
+        ResourceId::with_identity("bucket", "existing-bucket"),
+        State::existing(
+            ResourceId::with_identity("bucket", "existing-bucket"),
+            attrs,
+        ),
     );
 
     let plan = create_plan(
@@ -214,7 +217,7 @@ fn diff_update_when_list_of_maps_changed() {
         )])),
     );
     let current = State::existing(
-        ResourceId::new("ec2_security_group", "test-sg"),
+        ResourceId::with_identity("ec2_security_group", "test-sg"),
         current_attrs,
     );
 
@@ -241,8 +244,11 @@ fn create_plan_detects_orphaned_resources_for_deletion() {
     let mut current_states = HashMap::new();
     // "keep-this" exists and matches
     current_states.insert(
-        ResourceId::new("bucket", "keep-this"),
-        State::existing(ResourceId::new("bucket", "keep-this"), HashMap::new()),
+        ResourceId::with_identity("bucket", "keep-this"),
+        State::existing(
+            ResourceId::with_identity("bucket", "keep-this"),
+            HashMap::new(),
+        ),
     );
     // "orphaned-bucket" exists in state but not in desired
     let mut orphan_attrs = HashMap::new();
@@ -251,8 +257,11 @@ fn create_plan_detects_orphaned_resources_for_deletion() {
         Value::Concrete(ConcreteValue::String("orphaned-bucket".to_string())),
     );
     current_states.insert(
-        ResourceId::new("bucket", "orphaned-bucket"),
-        State::existing(ResourceId::new("bucket", "orphaned-bucket"), orphan_attrs),
+        ResourceId::with_identity("bucket", "orphaned-bucket"),
+        State::existing(
+            ResourceId::with_identity("bucket", "orphaned-bucket"),
+            orphan_attrs,
+        ),
     );
 
     let plan = create_plan(
@@ -303,8 +312,11 @@ fn read_only_resource_always_generates_read_effect() {
         Value::Concrete(ConcreteValue::String("existing-bucket".to_string())),
     );
     current_states.insert(
-        ResourceId::new("bucket", "existing-bucket"),
-        State::existing(ResourceId::new("bucket", "existing-bucket"), attrs),
+        ResourceId::with_identity("bucket", "existing-bucket"),
+        State::existing(
+            ResourceId::with_identity("bucket", "existing-bucket"),
+            attrs,
+        ),
     );
 
     let plan = create_plan(
@@ -342,7 +354,7 @@ fn no_false_update_without_name_attribute() {
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
-    let current = State::existing(ResourceId::new("ec2.Vpc", "vpc"), attrs);
+    let current = State::existing(ResourceId::with_identity("ec2.Vpc", "vpc"), attrs);
 
     let result = diff(&desired, &current, None, None, None);
     assert!(
@@ -368,8 +380,8 @@ fn replace_when_create_only_attr_changed() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
-        State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "my-vpc"), attrs),
     );
 
     // Build schema with cidr_block marked as create-only
@@ -421,8 +433,8 @@ fn normal_update_when_non_create_only_attr_changed() {
         Value::Concrete(ConcreteValue::Bool(false)),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
-        State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "my-vpc"), attrs),
     );
 
     // cidr_block is create-only, but enable_dns_support is not
@@ -485,8 +497,8 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
         Value::Concrete(ConcreteValue::Bool(false)),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
-        State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "my-vpc"), attrs),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -544,8 +556,8 @@ fn replace_carries_create_before_destroy_directives() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
-        State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "my-vpc"), attrs),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -631,7 +643,7 @@ fn diff_no_change_when_list_of_maps_reordered() {
         ])),
     );
     let current = State::existing(
-        ResourceId::new("ec2_security_group", "test-sg"),
+        ResourceId::with_identity("ec2_security_group", "test-sg"),
         current_attrs,
     );
 
@@ -663,9 +675,9 @@ fn replace_with_provider_prefixed_schema_key() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::with_provider("awscc", "ec2.Vpc", "my-vpc", None),
+        ResourceId::with_provider_identity("awscc", "ec2.Vpc", "my-vpc", None),
         State::existing(
-            ResourceId::with_provider("awscc", "ec2.Vpc", "my-vpc", None),
+            ResourceId::with_provider_identity("awscc", "ec2.Vpc", "my-vpc", None),
             attrs,
         ),
     );
@@ -734,7 +746,10 @@ fn diff_no_change_when_struct_has_extra_fields_with_saved() {
             ),
         ]))),
     )]);
-    let current = State::existing(ResourceId::new("ec2.Subnet", "test-subnet"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("ec2.Subnet", "test-subnet"),
+        current_attrs,
+    );
 
     let saved = IndexMap::from([
         (
@@ -798,7 +813,10 @@ fn diff_detects_drift_on_unmanaged_field() {
             ),
         ]))),
     )]);
-    let current = State::existing(ResourceId::new("ec2.Subnet", "test-subnet"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("ec2.Subnet", "test-subnet"),
+        current_attrs,
+    );
 
     let saved = IndexMap::from([
         (
@@ -864,7 +882,10 @@ fn diff_no_change_when_bare_struct_with_extra_fields() {
             ),
         ]))),
     )]);
-    let current = State::existing(ResourceId::new("ec2.Subnet", "test-subnet"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("ec2.Subnet", "test-subnet"),
+        current_attrs,
+    );
 
     // Saved state has the same Map with extra fields
     let saved_map = HashMap::from([(
@@ -915,7 +936,10 @@ fn diff_works_without_saved_state() {
             ("c".to_string(), Value::Concrete(ConcreteValue::Int(3))),
         ]))),
     )]);
-    let current = State::existing(ResourceId::new("ec2.Subnet", "test-subnet"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("ec2.Subnet", "test-subnet"),
+        current_attrs,
+    );
 
     // Without saved state, the map comparison uses semantically_equal which
     // checks both key count AND values. Since desired map has 2 keys and current
@@ -945,8 +969,11 @@ fn orphan_delete_preserves_binding_and_dependencies() {
         Value::resource_ref("my_vpc".to_string(), "vpc_id".to_string(), vec![]),
     );
     current_states.insert(
-        ResourceId::new("subnet", "my-subnet"),
-        State::existing(ResourceId::new("subnet", "my-subnet"), orphan_attrs),
+        ResourceId::with_identity("subnet", "my-subnet"),
+        State::existing(
+            ResourceId::with_identity("subnet", "my-subnet"),
+            orphan_attrs,
+        ),
     );
 
     let plan = create_plan(
@@ -1139,7 +1166,7 @@ fn diff_no_change_for_struct_list_with_saved_state_egress_rules() {
         ])),
     )]);
     let current = State::existing(
-        ResourceId::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None),
+        ResourceId::with_provider_identity("awscc", "ec2.SecurityGroup", "test-sg", None),
         current_attrs,
     );
 
@@ -1289,7 +1316,7 @@ fn diff_false_positive_when_ordered_true_for_struct_list() {
             Value::Concrete(ConcreteValue::List(vec![item_a.clone(), item_b.clone()])),
         );
     let current = State::existing(
-        ResourceId::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None),
+        ResourceId::with_provider_identity("awscc", "ec2.SecurityGroup", "test-sg", None),
         HashMap::from([(
             "security_group_egress".to_string(),
             // AWS returns items in reversed order
@@ -1381,7 +1408,7 @@ fn diff_no_change_for_compound_word_dsl_alias() {
         )),
     );
     let current = State::existing(
-        ResourceId::with_provider("aws", "s3.BucketOwnershipControls", "test", None),
+        ResourceId::with_provider_identity("aws", "s3.BucketOwnershipControls", "test", None),
         attrs,
     );
 

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -496,18 +496,18 @@ pub fn create_plan(
             .or_else(|| {
                 managed
                     .iter()
-                    .find(|r| r.id.name.as_str() == wb.target)
+                    .find(|r| r.id.identity_str() == Some(wb.target.as_str()))
                     .map(|r| r.id.clone())
             })
             .or_else(|| {
                 data_sources
                     .iter()
-                    .find(|r| r.id.name.as_str() == wb.target)
+                    .find(|r| r.id.identity_str() == Some(wb.target.as_str()))
                     .map(|r| r.id.clone())
             });
         let Some(target_id_resolved) = resolved else {
             plan.add_error(PlanError {
-                resource_id: ResourceId::new("__wait", wb.binding.as_str()),
+                resource_id: ResourceId::with_identity("__wait", wb.binding.as_str()),
                 message: format!(
                     "wait `{}`: target binding `{}` is not a known resource",
                     wb.binding, wb.target
@@ -683,10 +683,13 @@ pub fn cascade_dependent_updates(
     // (without _binding) are also found.
     let mut binding_to_unresolved: HashMap<String, &Resource> = HashMap::new();
     for resource in unresolved_managed {
-        let key = resource
-            .binding
-            .clone()
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name_str()));
+        let key = resource.binding.clone().unwrap_or_else(|| {
+            format!(
+                "{}:{}",
+                resource.id.resource_type,
+                resource.id.identity_or_empty()
+            )
+        });
         binding_to_unresolved.insert(key, resource);
     }
 
@@ -762,7 +765,11 @@ pub fn cascade_dependent_updates(
         for dep in &deps {
             if replaced_bindings.contains(dep) {
                 let binding = resource.binding.clone().unwrap_or_else(|| {
-                    format!("{}:{}", resource.id.resource_type, resource.id.name_str())
+                    format!(
+                        "{}:{}",
+                        resource.id.resource_type,
+                        resource.id.identity_or_empty()
+                    )
                 });
                 dependents_of_replaced
                     .entry(dep.clone())

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -116,8 +116,8 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
         Value::Concrete(ConcreteValue::Bool(false)),
     );
     current_states.insert(
-        ResourceId::new("s3.Bucket", "my-bucket"),
-        State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
+        ResourceId::with_identity("s3.Bucket", "my-bucket"),
+        State::existing(ResourceId::with_identity("s3.Bucket", "my-bucket"), attrs),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -202,8 +202,11 @@ fn create_before_destroy_generates_temporary_name_with_can_rename() {
         Value::Concrete(ConcreteValue::String("old-key".to_string())),
     );
     current_states.insert(
-        ResourceId::new("logs.LogGroup", "my-log-group"),
-        State::existing(ResourceId::new("logs.LogGroup", "my-log-group"), attrs),
+        ResourceId::with_identity("logs.LogGroup", "my-log-group"),
+        State::existing(
+            ResourceId::with_identity("logs.LogGroup", "my-log-group"),
+            attrs,
+        ),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -272,8 +275,8 @@ fn no_temporary_name_without_create_before_destroy() {
         Value::Concrete(ConcreteValue::Bool(false)),
     );
     current_states.insert(
-        ResourceId::new("s3.Bucket", "my-bucket"),
-        State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
+        ResourceId::with_identity("s3.Bucket", "my-bucket"),
+        State::existing(ResourceId::with_identity("s3.Bucket", "my-bucket"), attrs),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -344,8 +347,8 @@ fn no_temporary_name_when_name_prefix_is_used() {
         Value::Concrete(ConcreteValue::Bool(false)),
     );
     current_states.insert(
-        ResourceId::new("s3.Bucket", "my-bucket"),
-        State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
+        ResourceId::with_identity("s3.Bucket", "my-bucket"),
+        State::existing(ResourceId::with_identity("s3.Bucket", "my-bucket"), attrs),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -403,8 +406,8 @@ fn no_temporary_name_without_name_attribute_in_schema() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
-        State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "my-vpc"), attrs),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -470,8 +473,8 @@ fn no_temporary_name_when_name_attribute_changes() {
         Value::Concrete(ConcreteValue::Bool(true)),
     );
     current_states.insert(
-        ResourceId::new("s3.Bucket", "my-bucket"),
-        State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
+        ResourceId::with_identity("s3.Bucket", "my-bucket"),
+        State::existing(ResourceId::with_identity("s3.Bucket", "my-bucket"), attrs),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -530,7 +533,10 @@ fn diff_detects_attribute_removal_with_prev_desired_keys() {
             Value::Concrete(ConcreteValue::String("test".to_string())),
         )]))),
     );
-    let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("s3.Bucket", "test"),
+        current_attrs,
+    );
 
     // Previous desired state had both "region" and "tags"
     let prev_explicit = explicit_top_level(&["region", "tags"]);
@@ -565,7 +571,10 @@ fn diff_ignores_attributes_not_in_prev_desired_keys() {
         "arn".to_string(),
         Value::Concrete(ConcreteValue::String("arn:aws:s3:::test".to_string())),
     );
-    let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("s3.Bucket", "test"),
+        current_attrs,
+    );
 
     // User previously only specified "region", not "arn"
     let prev_explicit = explicit_top_level(&["region"]);
@@ -626,7 +635,10 @@ fn server_default_struct_field_does_not_appear_in_diff() {
         "lifecycle_configuration".to_string(),
         Value::Concrete(ConcreteValue::Map(current_lc)),
     );
-    let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("s3.Bucket", "test"),
+        current_attrs,
+    );
 
     // prev_explicit reflects what the user wrote: lifecycle_configuration > rules
     let prev_explicit = ExplicitFields::Struct {
@@ -672,7 +684,10 @@ fn explicit_top_level_removal_still_detected() {
             Value::Concrete(ConcreteValue::String("prod".to_string())),
         )]))),
     );
-    let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("s3.Bucket", "test"),
+        current_attrs,
+    );
 
     let prev_explicit = explicit_top_level(&["tags"]);
     let result = diff(&desired, &current, None, Some(&prev_explicit), None);
@@ -711,7 +726,10 @@ fn diff_no_change_without_prev_desired_keys() {
             Value::Concrete(ConcreteValue::String("test".to_string())),
         )]))),
     );
-    let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("s3.Bucket", "test"),
+        current_attrs,
+    );
 
     let result = diff(&desired, &current, None, None, None);
     assert!(
@@ -744,13 +762,13 @@ fn create_plan_detects_attribute_removal() {
         )]))),
     );
     current_states.insert(
-        ResourceId::new("s3.Bucket", "test"),
-        State::existing(ResourceId::new("s3.Bucket", "test"), attrs),
+        ResourceId::with_identity("s3.Bucket", "test"),
+        State::existing(ResourceId::with_identity("s3.Bucket", "test"), attrs),
     );
 
     let mut prev_explicit = HashMap::new();
     prev_explicit.insert(
-        ResourceId::new("s3.Bucket", "test"),
+        ResourceId::with_identity("s3.Bucket", "test"),
         explicit_top_level(&["region", "tags"]),
     );
 
@@ -799,13 +817,13 @@ fn create_plan_filters_non_removable_attribute_removal() {
         )]))),
     );
     current_states.insert(
-        ResourceId::new("s3.Bucket", "test"),
-        State::existing(ResourceId::new("s3.Bucket", "test"), attrs),
+        ResourceId::with_identity("s3.Bucket", "test"),
+        State::existing(ResourceId::with_identity("s3.Bucket", "test"), attrs),
     );
 
     let mut prev_explicit = HashMap::new();
     prev_explicit.insert(
-        ResourceId::new("s3.Bucket", "test"),
+        ResourceId::with_identity("s3.Bucket", "test"),
         explicit_top_level(&["region", "tags"]),
     );
 
@@ -874,13 +892,13 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
         Value::Concrete(ConcreteValue::String("ap-northeast-1".to_string())),
     );
     current_states.insert(
-        ResourceId::new("s3.Bucket", "test"),
-        State::existing(ResourceId::new("s3.Bucket", "test"), attrs),
+        ResourceId::with_identity("s3.Bucket", "test"),
+        State::existing(ResourceId::with_identity("s3.Bucket", "test"), attrs),
     );
 
     let mut prev_explicit = HashMap::new();
     prev_explicit.insert(
-        ResourceId::new("s3.Bucket", "test"),
+        ResourceId::with_identity("s3.Bucket", "test"),
         explicit_top_level(&["bucket", "region"]),
     );
 
@@ -930,7 +948,10 @@ fn diff_skips_internal_attributes_in_removal_detection() {
         "_internal".to_string(),
         Value::Concrete(ConcreteValue::String("something".to_string())),
     );
-    let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
+    let current = State::existing(
+        ResourceId::with_identity("s3.Bucket", "test"),
+        current_attrs,
+    );
 
     let prev_explicit = explicit_top_level(&["region", "_internal"]);
 
@@ -955,14 +976,14 @@ fn prevent_destroy_blocks_delete_for_orphaned_resource() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
-        State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "my-vpc"), attrs),
     );
 
     // Directives from state say prevent_destroy
     let mut directives_map = HashMap::new();
     directives_map.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
         Directives {
             prevent_destroy: true,
             ..Default::default()
@@ -999,7 +1020,7 @@ fn prevent_destroy_blocks_delete_for_orphaned_resource() {
     );
     assert_eq!(
         plan.errors()[0].resource_id,
-        ResourceId::new("ec2.Vpc", "my-vpc")
+        ResourceId::with_identity("ec2.Vpc", "my-vpc")
     );
 }
 
@@ -1024,8 +1045,8 @@ fn prevent_destroy_blocks_replace() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
-        State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "my-vpc"), attrs),
     );
 
     let mut schemas = SchemaRegistry::new();
@@ -1087,8 +1108,8 @@ fn prevent_destroy_does_not_block_update() {
         Value::Concrete(ConcreteValue::String("Disabled".to_string())),
     );
     current_states.insert(
-        ResourceId::new("s3.Bucket", "my-bucket"),
-        State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
+        ResourceId::with_identity("s3.Bucket", "my-bucket"),
+        State::existing(ResourceId::with_identity("s3.Bucket", "my-bucket"), attrs),
     );
 
     let plan = create_plan(
@@ -1169,8 +1190,8 @@ fn without_prevent_destroy_delete_works_normally() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
-        State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "my-vpc"), attrs),
     );
 
     let plan = create_plan(
@@ -1208,8 +1229,8 @@ fn prevent_destroy_collects_multiple_errors() {
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "vpc-1"),
-        State::existing(ResourceId::new("ec2.Vpc", "vpc-1"), attrs1),
+        ResourceId::with_identity("ec2.Vpc", "vpc-1"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "vpc-1"), attrs1),
     );
     let mut attrs2 = HashMap::new();
     attrs2.insert(
@@ -1217,20 +1238,20 @@ fn prevent_destroy_collects_multiple_errors() {
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     );
     current_states.insert(
-        ResourceId::new("ec2.Vpc", "vpc-2"),
-        State::existing(ResourceId::new("ec2.Vpc", "vpc-2"), attrs2),
+        ResourceId::with_identity("ec2.Vpc", "vpc-2"),
+        State::existing(ResourceId::with_identity("ec2.Vpc", "vpc-2"), attrs2),
     );
 
     let mut directives_map = HashMap::new();
     directives_map.insert(
-        ResourceId::new("ec2.Vpc", "vpc-1"),
+        ResourceId::with_identity("ec2.Vpc", "vpc-1"),
         Directives {
             prevent_destroy: true,
             ..Default::default()
         },
     );
     directives_map.insert(
-        ResourceId::new("ec2.Vpc", "vpc-2"),
+        ResourceId::with_identity("ec2.Vpc", "vpc-2"),
         Directives {
             prevent_destroy: true,
             ..Default::default()
@@ -1325,7 +1346,7 @@ fn wait_binding_lowers_to_wait_effect() {
         unreachable!();
     };
     assert_eq!(binding, "cert_issued");
-    assert_eq!(target_id.name.as_str(), "cert");
+    assert_eq!(target_id.identity_str(), Some("cert"));
     assert_eq!(target_id.resource_type, "acm.Certificate");
     assert_eq!(
         until,
@@ -1637,13 +1658,16 @@ fn wait_omitted_when_all_consumers_unchanged() {
     // so neither produces a mutating effect.
     let mut current_states = HashMap::new();
     current_states.insert(
-        ResourceId::new("acm.Certificate", "cert"),
-        State::existing(ResourceId::new("acm.Certificate", "cert"), HashMap::new()),
+        ResourceId::with_identity("acm.Certificate", "cert"),
+        State::existing(
+            ResourceId::with_identity("acm.Certificate", "cert"),
+            HashMap::new(),
+        ),
     );
     current_states.insert(
-        ResourceId::new("cloudfront.Distribution", "dist"),
+        ResourceId::with_identity("cloudfront.Distribution", "dist"),
         State::existing(
-            ResourceId::new("cloudfront.Distribution", "dist"),
+            ResourceId::with_identity("cloudfront.Distribution", "dist"),
             HashMap::new(),
         ),
     );
@@ -1766,9 +1790,12 @@ fn wait_omitted_when_already_satisfied_and_target_unchanged() {
     );
     let mut current_states = HashMap::new();
     current_states.insert(
-        ResourceId::new("acm.Certificate", "cert"),
-        State::existing(ResourceId::new("acm.Certificate", "cert"), cert_state_attrs)
-            .with_identifier("arn:aws:acm:::certificate/abc"),
+        ResourceId::with_identity("acm.Certificate", "cert"),
+        State::existing(
+            ResourceId::with_identity("acm.Certificate", "cert"),
+            cert_state_attrs,
+        )
+        .with_identifier("arn:aws:acm:::certificate/abc"),
     );
 
     let wait = WaitBinding {
@@ -1895,9 +1922,12 @@ fn wait_emitted_when_known_target_has_pending_update_even_if_cached_state_satisf
     );
     let mut current_states = HashMap::new();
     current_states.insert(
-        ResourceId::new("acm.Certificate", "cert"),
-        State::existing(ResourceId::new("acm.Certificate", "cert"), cert_state_attrs)
-            .with_identifier("arn:aws:acm:::certificate/abc"),
+        ResourceId::with_identity("acm.Certificate", "cert"),
+        State::existing(
+            ResourceId::with_identity("acm.Certificate", "cert"),
+            cert_state_attrs,
+        )
+        .with_identifier("arn:aws:acm:::certificate/abc"),
     );
 
     let wait = WaitBinding {
@@ -1933,7 +1963,7 @@ fn wait_emitted_when_known_target_has_pending_update_even_if_cached_state_satisf
         plan.effects()
             .iter()
             .any(|e| matches!(e, Effect::Update { id, .. }
-            if id == &ResourceId::new("acm.Certificate", "cert"))),
+            if id == &ResourceId::with_identity("acm.Certificate", "cert"))),
         "test precondition: cert must have a pending Update; effects were {:?}",
         plan.effects()
     );

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -477,7 +477,7 @@ impl Effect {
         use crate::wait::predicate::{AttrPath, WaitPredicate};
         use std::time::Duration;
 
-        let id = ResourceId::new("test", "x");
+        let id = ResourceId::with_identity("test", "x");
 
         macro_rules! effect_cases {
             ($(($effect:expr, $pattern:pat)),+ $(,)?) => {{
@@ -547,7 +547,7 @@ impl Effect {
             (
                 Effect::Move {
                     from: id.clone(),
-                    to: ResourceId::new("test", "y"),
+                    to: ResourceId::with_identity("test", "y"),
                 },
                 Effect::Move { .. }
             ),
@@ -568,7 +568,7 @@ impl Effect {
             ),
             (
                 Effect::DeferredCreate {
-                    id: ResourceId::new("route53.Record", "validation_records"),
+                    id: ResourceId::with_identity("route53.Record", "validation_records"),
                     upstream_binding: "cert".to_string(),
                     template: Box::new(crate::parser::DeferredForExpression {
                         file: Some("main.crn".to_string()),
@@ -588,7 +588,7 @@ impl Effect {
             (
                 Effect::DeferredReplace {
                     deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                        id: ResourceId::new("route53.Record", "validation_records[0]"),
+                        id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
                         identifier: "record-0".to_string(),
                         directives: Directives::default(),
                         binding: Some("validation_records[0]".to_string()),
@@ -596,7 +596,7 @@ impl Effect {
                         explicit_dependencies: HashSet::new(),
                     }])
                     .expect("test fixture has one delete"),
-                    id: ResourceId::new("route53.Record", "validation_records"),
+                    id: ResourceId::with_identity("route53.Record", "validation_records"),
                     upstream_binding: "cert".to_string(),
                     template: Box::new(crate::parser::DeferredForExpression {
                         file: Some("main.crn".to_string()),
@@ -618,7 +618,7 @@ impl Effect {
 
     #[cfg(test)]
     fn synthetic_replace_effect(create_before_destroy: bool) -> Self {
-        let id = ResourceId::new("test", "x");
+        let id = ResourceId::with_identity("test", "x");
         let directives = Directives {
             create_before_destroy,
             ..Directives::default()
@@ -967,7 +967,7 @@ impl Effect {
 
     /// Bindings whose failure must prevent this effect from being dispatched.
     ///
-    /// For [`Effect::Wait`] this is `target_id.name_str()` plus the wait's
+    /// For [`Effect::Wait`] this is `target_id.identity_or_empty()` plus the wait's
     /// explicit dependencies, with the target binding first. For other
     /// resource-carrying variants this is value-reference bindings plus
     /// explicit dependencies. State-only effects that do not carry dependency
@@ -982,7 +982,7 @@ impl Effect {
                 explicit_dependencies,
                 ..
             } => {
-                let target_binding = target_id.name_str();
+                let target_binding = target_id.identity_or_empty();
                 let mut out = Vec::with_capacity(1 + explicit_dependencies.len());
                 out.push(target_binding.to_string());
                 out.extend(
@@ -1186,7 +1186,7 @@ mod tests {
 
     fn deferred_create_effect() -> Effect {
         Effect::DeferredCreate {
-            id: ResourceId::new("route53.Record", "validation_records"),
+            id: ResourceId::with_identity("route53.Record", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred_for_template()),
         }
@@ -1198,7 +1198,7 @@ mod tests {
         template.line = 0;
         Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::new("route53.Record", "validation_records[0]"),
+                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
                 identifier: "old-record-id".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -1206,7 +1206,7 @@ mod tests {
                 explicit_dependencies: HashSet::new(),
             }])
             .expect("test fixture has one delete"),
-            id: ResourceId::new("__deferred_for", "validation_records"),
+            id: ResourceId::with_identity("__deferred_for", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
         }
@@ -1217,7 +1217,7 @@ mod tests {
         use crate::wait::predicate::{AttrPath, WaitPredicate};
         use std::time::Duration;
 
-        let rid = ResourceId::new("test", "x");
+        let rid = ResourceId::with_identity("test", "x");
         vec![
             (
                 "Read",
@@ -1271,7 +1271,7 @@ mod tests {
                 "Move",
                 Effect::Move {
                     from: rid.clone(),
-                    to: ResourceId::new("test", "y"),
+                    to: ResourceId::with_identity("test", "y"),
                 },
             ),
             (
@@ -1398,7 +1398,7 @@ mod tests {
         template.line = 0;
         let effect = Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::new("route53.Record", "validation_records[0]"),
+                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
                 identifier: "old-record-id".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -1406,7 +1406,7 @@ mod tests {
                 explicit_dependencies: HashSet::new(),
             }])
             .expect("fixture has one delete"),
-            id: ResourceId::new("__deferred_for", "validation_records"),
+            id: ResourceId::with_identity("__deferred_for", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
         };
@@ -1424,7 +1424,7 @@ mod tests {
         template.line = 0;
         let effect = Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::new("route53.Record", "validation_records[0]"),
+                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
                 identifier: "old-record-id".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -1432,7 +1432,7 @@ mod tests {
                 explicit_dependencies: HashSet::from(["foo".to_string()]),
             }])
             .expect("fixture has one delete"),
-            id: ResourceId::new("__deferred_for", "validation_records"),
+            id: ResourceId::with_identity("__deferred_for", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
         };
@@ -1454,7 +1454,7 @@ mod tests {
         let effect = deferred_create_effect();
         assert_eq!(
             effect.resource_id(),
-            &ResourceId::new("route53.Record", "validation_records")
+            &ResourceId::with_identity("route53.Record", "validation_records")
         );
     }
 
@@ -1540,7 +1540,7 @@ mod tests {
     #[test]
     fn resource_returns_none_for_delete() {
         let effect = Effect::Delete {
-            id: ResourceId::new("test", "a"),
+            id: ResourceId::with_identity("test", "a"),
             identifier: "id-123".to_string(),
             directives: Directives::default(),
             binding: None,
@@ -1579,9 +1579,9 @@ mod tests {
                 resource: DataSource::new("s3.Bucket", "existing"),
             },
             Effect::Update {
-                id: ResourceId::new("s3.Bucket", "my-bucket"),
+                id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
                 from: Box::new(State::existing(
-                    ResourceId::new("s3.Bucket", "my-bucket"),
+                    ResourceId::with_identity("s3.Bucket", "my-bucket"),
                     HashMap::from([(
                         "versioning".to_string(),
                         Value::Concrete(ConcreteValue::String("Disabled".to_string())),
@@ -1594,9 +1594,9 @@ mod tests {
                 changed_attributes: vec!["versioning".to_string()],
             },
             Effect::Replace {
-                id: ResourceId::new("ec2.Vpc", "my-vpc"),
+                id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
                 from: Box::new(State::existing(
-                    ResourceId::new("ec2.Vpc", "my-vpc"),
+                    ResourceId::with_identity("ec2.Vpc", "my-vpc"),
                     HashMap::from([(
                         "cidr_block".to_string(),
                         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -1614,8 +1614,11 @@ mod tests {
                 // carina#3181 PR D: cover `CascadingUpdate.to:
                 // Resource` in the serde round-trip.
                 cascading_updates: vec![CascadingUpdate {
-                    id: ResourceId::new("ec2.Subnet", "my-subnet"),
-                    from: Box::new(State::not_found(ResourceId::new("ec2.Subnet", "my-subnet"))),
+                    id: ResourceId::with_identity("ec2.Subnet", "my-subnet"),
+                    from: Box::new(State::not_found(ResourceId::with_identity(
+                        "ec2.Subnet",
+                        "my-subnet",
+                    ))),
                     to: Resource::new("ec2.Subnet", "my-subnet").with_attribute(
                         "vpc_id",
                         Value::Concrete(ConcreteValue::String("vpc.id".to_string())),
@@ -1625,7 +1628,7 @@ mod tests {
                 cascade_ref_hints: vec![],
             },
             Effect::Delete {
-                id: ResourceId::new("s3.Bucket", "old-bucket"),
+                id: ResourceId::with_identity("s3.Bucket", "old-bucket"),
                 identifier: "old-bucket".to_string(),
                 directives: Directives::default(),
                 binding: None,
@@ -1663,8 +1666,8 @@ mod tests {
     #[test]
     fn replace_changed_create_only_serializes_as_plain_array() {
         let effect = Effect::Replace {
-            id: ResourceId::new("test", "x"),
-            from: Box::new(State::not_found(ResourceId::new("test", "x"))),
+            id: ResourceId::with_identity("test", "x"),
+            from: Box::new(State::not_found(ResourceId::with_identity("test", "x"))),
             to: Resource::new("test", "x"),
             directives: Directives::default(),
             changed_create_only: ChangedCreateOnly::new(vec!["x".to_string()]).unwrap(),
@@ -1731,7 +1734,7 @@ mod tests {
     #[test]
     fn explicit_dependencies_for_delete_uses_stored_set() {
         let effect = Effect::Delete {
-            id: ResourceId::new("s3.Bucket", "b"),
+            id: ResourceId::with_identity("s3.Bucket", "b"),
             identifier: "x".to_string(),
             directives: Directives::default(),
             binding: Some("bucket".to_string()),
@@ -1746,17 +1749,17 @@ mod tests {
     #[test]
     fn explicit_dependencies_empty_for_state_only_effects() {
         let imp = Effect::Import {
-            id: ResourceId::new("s3.Bucket", "b"),
+            id: ResourceId::with_identity("s3.Bucket", "b"),
             identifier: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(
                 "x".to_string(),
             )),
         };
         let rem = Effect::Remove {
-            id: ResourceId::new("s3.Bucket", "b"),
+            id: ResourceId::with_identity("s3.Bucket", "b"),
         };
         let mov = Effect::Move {
-            from: ResourceId::new("s3.Bucket", "old"),
-            to: ResourceId::new("s3.Bucket", "new"),
+            from: ResourceId::with_identity("s3.Bucket", "old"),
+            to: ResourceId::with_identity("s3.Bucket", "new"),
         };
         for e in [imp, rem, mov] {
             assert!(
@@ -1801,7 +1804,7 @@ mod tests {
 
         let _ = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::new("acm.Certificate", "cert"),
+            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1821,7 +1824,7 @@ mod tests {
 
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::new("acm.Certificate", "cert"),
+            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1842,7 +1845,7 @@ mod tests {
 
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::new("acm.Certificate", "cert"),
+            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1864,7 +1867,7 @@ mod tests {
 
         let original = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::new("acm.Certificate", "cert"),
+            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1895,7 +1898,7 @@ mod tests {
     fn as_basic_narrows_to_create_update_and_delete_only() {
         use crate::resource::State as ResState;
 
-        let rid = ResourceId::new("test", "x");
+        let rid = ResourceId::with_identity("test", "x");
 
         // Basic variants must narrow.
         let create = Effect::Create(Resource::new("test", "x"));
@@ -1954,7 +1957,7 @@ mod tests {
         let remove = Effect::Remove { id: rid.clone() };
         let mov = Effect::Move {
             from: rid.clone(),
-            to: ResourceId::new("test", "y"),
+            to: ResourceId::with_identity("test", "y"),
         };
         let wait = Effect::Wait {
             binding: "w".to_string(),

--- a/carina-core/src/effect/deps.rs
+++ b/carina-core/src/effect/deps.rs
@@ -408,7 +408,7 @@ pub fn build_effect_dependency_analysis(
         if let Effect::Delete { id, binding, .. } = effect
             && binding.is_none()
         {
-            name_to_delete_idx.insert(id.name_str().to_string(), idx);
+            name_to_delete_idx.insert(id.identity_or_empty().to_string(), idx);
         }
     }
     let alias_offset = effects.len();
@@ -525,7 +525,7 @@ mod tests {
     #[test]
     fn destroy_delete_edges_block_dependencies_by_consumers() {
         let parent = Effect::Delete {
-            id: ResourceId::new("test", "parent"),
+            id: ResourceId::with_identity("test", "parent"),
             identifier: "parent-id".to_string(),
             directives: Default::default(),
             binding: Some("parent".to_string()),
@@ -533,7 +533,7 @@ mod tests {
             explicit_dependencies: HashSet::new(),
         };
         let child = Effect::Delete {
-            id: ResourceId::new("test", "child"),
+            id: ResourceId::with_identity("test", "child"),
             identifier: "child-id".to_string(),
             directives: Default::default(),
             binding: Some("child".to_string()),
@@ -556,7 +556,7 @@ mod tests {
     #[test]
     fn destroy_wait_alias_bridges_target_to_consumers() {
         let cert = Effect::Delete {
-            id: ResourceId::new("test", "cert"),
+            id: ResourceId::with_identity("test", "cert"),
             identifier: "cert-id".to_string(),
             directives: Default::default(),
             binding: Some("cert".to_string()),
@@ -564,7 +564,7 @@ mod tests {
             explicit_dependencies: HashSet::new(),
         };
         let listener = Effect::Delete {
-            id: ResourceId::new("test", "listener"),
+            id: ResourceId::with_identity("test", "listener"),
             identifier: "listener-id".to_string(),
             directives: Default::default(),
             binding: Some("listener".to_string()),
@@ -602,15 +602,18 @@ mod tests {
         let mut x = Resource::new("test", "x");
         x.binding = Some("x".to_string());
 
-        let from = State::existing(ResourceId::new("test", "replace_me"), HashMap::new())
-            .with_dependency_bindings(std::collections::BTreeSet::from(["x".to_string()]));
+        let from = State::existing(
+            ResourceId::with_identity("test", "replace_me"),
+            HashMap::new(),
+        )
+        .with_dependency_bindings(std::collections::BTreeSet::from(["x".to_string()]));
         let mut to = Resource::new("test", "replace_me");
         to.binding = Some("replace_me".to_string());
 
         let effects = vec![
             Effect::Create(x),
             Effect::Replace {
-                id: ResourceId::new("test", "replace_me"),
+                id: ResourceId::with_identity("test", "replace_me"),
                 from: Box::new(from),
                 to,
                 directives: Default::default(),
@@ -634,7 +637,7 @@ mod tests {
     #[test]
     fn unknown_destroy_dependency_names_are_dropped() {
         let orphan = Effect::Delete {
-            id: ResourceId::new("test", "listener"),
+            id: ResourceId::with_identity("test", "listener"),
             identifier: "listener-id".to_string(),
             directives: Default::default(),
             binding: Some("listener".to_string()),

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -632,7 +632,7 @@ pub(super) async fn execute_basic_effect<'a>(
                 });
                 let secret_ctx = Some(SecretHashContext::new(
                     id.display_type(),
-                    id.name_str(),
+                    id.identity_or_empty(),
                     key,
                 ));
                 let Some(comparison_value) =
@@ -763,7 +763,7 @@ mod process_basic_result_tests {
 
     #[test]
     fn partial_success_records_state_and_diagnostic() {
-        let id = ResourceId::with_provider("mock", "test.resource", "r1", None);
+        let id = ResourceId::with_provider_identity("mock", "test.resource", "r1", None);
         let state = State::existing(id.clone(), HashMap::new()).with_identifier("mock-id");
         let diagnostic = PartialReadDiagnostic::new(
             "mock partial create".to_string(),

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -651,7 +651,7 @@ pub(super) async fn execute_effects_sequential(
                     // resolve_refs sees the same attribute map. Wait
                     // effects do not persist to the state file
                     // (handled by `state_writeback_should_skip`).
-                    let synthetic = ResourceId::new("__wait", &binding);
+                    let synthetic = ResourceId::with_identity("__wait", &binding);
                     let attrs: HashMap<String, Value> = state
                         .attributes
                         .iter()
@@ -756,7 +756,7 @@ mod tests {
     }
 
     fn update_effect(binding: &str, reads: &[(&str, &str)], writes: &[&str]) -> Effect {
-        let id = ResourceId::new("test", binding);
+        let id = ResourceId::with_identity("test", binding);
         let mut to = Resource::new("test", binding);
         to.binding = Some(binding.to_string());
         for (dep, attr) in reads {
@@ -774,7 +774,7 @@ mod tests {
     }
 
     fn replace_effect(binding: &str, reads: &[(&str, &str)]) -> Effect {
-        let id = ResourceId::new("test", binding);
+        let id = ResourceId::with_identity("test", binding);
         let mut to = Resource::new("test", binding);
         to.binding = Some(binding.to_string());
         for (dep, attr) in reads {
@@ -839,10 +839,10 @@ mod tests {
             self.create_log
                 .lock()
                 .unwrap()
-                .push(id.name_str().to_string());
+                .push(id.identity_or_empty().to_string());
             let id = id.clone();
             Box::pin(async move {
-                if id.name_str() == "alb" {
+                if id.identity_or_empty() == "alb" {
                     tokio::time::sleep(std::time::Duration::from_millis(25)).await;
                     Err(ProviderError::api_error("alb create failed"))
                 } else {
@@ -1324,7 +1324,7 @@ mod tests {
             )),
         );
         let virt = Composition {
-            id: ResourceId::with_provider("_virtual", "_virtual", "module", None),
+            id: ResourceId::with_provider_identity("_virtual", "_virtual", "module", None),
             signature: crate::resource::Signature {
                 arguments: indexmap::IndexMap::new(),
                 attributes: virt_attrs,
@@ -1419,7 +1419,7 @@ mod tests {
             )),
         );
         let virt = Composition {
-            id: ResourceId::with_provider("_virtual", "_virtual", "bootstrap", None),
+            id: ResourceId::with_provider_identity("_virtual", "_virtual", "bootstrap", None),
             signature: crate::resource::Signature {
                 arguments: indexmap::IndexMap::new(),
                 attributes: virt_attrs,

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -625,7 +625,7 @@ pub(super) async fn execute_effects_phased(
                             progress,
                         });
                         success_count += 1;
-                        let synthetic = ResourceId::new("__wait", &binding);
+                        let synthetic = ResourceId::with_identity("__wait", &binding);
                         let attrs: HashMap<String, Value> = state
                             .attributes
                             .iter()
@@ -2051,7 +2051,7 @@ pub(super) async fn execute_effects_phased(
                             progress,
                         });
                         success_count += 1;
-                        let synthetic = ResourceId::new("__wait", &binding);
+                        let synthetic = ResourceId::with_identity("__wait", &binding);
                         let attrs: HashMap<String, Value> = state
                             .attributes
                             .iter()
@@ -2197,10 +2197,10 @@ mod tests {
             self.create_log
                 .lock()
                 .unwrap()
-                .push(id.name_str().to_string());
+                .push(id.identity_or_empty().to_string());
             let id = id.clone();
             Box::pin(async move {
-                if id.name_str() == "alb" {
+                if id.identity_or_empty() == "alb" {
                     tokio::time::sleep(std::time::Duration::from_millis(25)).await;
                     Err(ProviderError::api_error("alb create failed"))
                 } else {
@@ -2315,7 +2315,7 @@ mod tests {
             )),
         );
         Composition {
-            id: ResourceId::with_provider("_virtual", "_virtual", id_name, None),
+            id: ResourceId::with_provider_identity("_virtual", "_virtual", id_name, None),
             signature: crate::resource::Signature {
                 arguments: indexmap::IndexMap::new(),
                 attributes,

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -57,7 +57,7 @@ pub fn compute_full_diff_patch(
                 });
                 let secret_ctx = Some(SecretHashContext::new(
                     resource_id.display_type(),
-                    resource_id.name_str(),
+                    resource_id.identity_or_empty(),
                     key,
                 ));
                 let comparison_value =

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -790,8 +790,8 @@ fn create_independent_create_plan<const N: usize>(names: [&str; N]) -> Plan {
 }
 
 fn create_interdependent_replace_plan() -> Plan {
-    let a_id = ResourceId::new("test", "a");
-    let b_id = ResourceId::new("test", "b");
+    let a_id = ResourceId::with_identity("test", "a");
+    let b_id = ResourceId::with_identity("test", "b");
 
     let a_from = State::existing(a_id.clone(), HashMap::new()).with_identifier("a-old");
     let mut a_to = Resource::new("test", "a");
@@ -840,7 +840,7 @@ fn create_interdependent_replace_plan_with_renames<const N: usize>(names: [&str;
     };
     let mut plan = Plan::new();
     for (idx, name) in names.iter().enumerate() {
-        let id = ResourceId::new("test", *name);
+        let id = ResourceId::with_identity("test", *name);
         let from =
             State::existing(id.clone(), HashMap::new()).with_identifier(format!("{name}-old"));
         let mut to = Resource::new("test", *name);
@@ -904,7 +904,7 @@ impl DelayedCountingProvider {
 
     fn delay_for(&self, id: &ResourceId) -> std::time::Duration {
         self.delays
-            .get(id.name_str())
+            .get(id.identity_or_empty())
             .copied()
             .unwrap_or(self.default_delay)
     }
@@ -939,9 +939,12 @@ impl Provider for DelayedCountingProvider {
         let cancel_after_create = self.cancel_after_create.clone();
         let cancel = self.cancel.clone();
         Box::pin(async move {
-            started.lock().unwrap().push(id.name_str().to_string());
+            started
+                .lock()
+                .unwrap()
+                .push(id.identity_or_empty().to_string());
             tokio::time::sleep(delay).await;
-            if cancel_after_create.as_deref() == Some(id.name_str())
+            if cancel_after_create.as_deref() == Some(id.identity_or_empty())
                 && let Some(cancel) = cancel
             {
                 cancel.cancel();
@@ -964,7 +967,7 @@ impl Provider for DelayedCountingProvider {
             started
                 .lock()
                 .unwrap()
-                .push(format!("update:{}", id.name_str()));
+                .push(format!("update:{}", id.identity_or_empty()));
             let mut attrs = HashMap::new();
             attrs.insert(
                 "finalized".to_string(),
@@ -988,7 +991,7 @@ impl Provider for DelayedCountingProvider {
             started
                 .lock()
                 .unwrap()
-                .push(format!("delete:{}", id.name_str()));
+                .push(format!("delete:{}", id.identity_or_empty()));
             Ok(())
         })
     }
@@ -1199,7 +1202,7 @@ impl ExecutionObserver for RecordingCancelsWhenWaitStarted {
 impl ExecutionObserver for CancelsWhenStarted {
     fn on_event(&self, event: &ExecutionEvent) {
         if let ExecutionEvent::EffectStarted { effect } = event
-            && effect.resource_id().name_str() == self.name
+            && effect.resource_id().identity_or_empty() == self.name
         {
             self.token.cancel();
         }
@@ -1547,7 +1550,7 @@ async fn execute_plan_cancelled_while_effect_in_flight_records_that_effect() {
     assert!(
         result
             .applied_states
-            .contains_key(&ResourceId::new("test", "r2"))
+            .contains_key(&ResourceId::with_identity("test", "r2"))
     );
     assert_eq!(provider.started_names(), vec!["r1", "r2"]);
 }
@@ -1583,7 +1586,7 @@ async fn execute_plan_phased_cancel_during_phase4_preserves_unprocessed_cbd_crea
     for name in ["a", "b"] {
         let state = result
             .applied_states
-            .get(&ResourceId::new("test", name))
+            .get(&ResourceId::with_identity("test", name))
             .expect("finalized resource should be recorded");
         assert_eq!(
             state.attributes.get("finalized"),
@@ -1593,7 +1596,7 @@ async fn execute_plan_phased_cancel_during_phase4_preserves_unprocessed_cbd_crea
     for name in ["c", "d"] {
         let state = result
             .applied_states
-            .get(&ResourceId::new("test", name))
+            .get(&ResourceId::with_identity("test", name))
             .expect("unprocessed CBD create state should be preserved");
         assert_eq!(
             state.attributes.get("finalized"),
@@ -1633,7 +1636,7 @@ async fn execute_plan_phased_cancelled_between_phases_keeps_completed_resources_
     assert!(
         result
             .applied_states
-            .contains_key(&ResourceId::new("test", "a"))
+            .contains_key(&ResourceId::with_identity("test", "a"))
     );
     assert!(
         !provider
@@ -2282,8 +2285,11 @@ async fn test_apply_effective_changed_skips_matching_unwrapped_secret_hash() {
     ))));
     to_resource.set_attr("master_password", secret_value.clone());
 
-    let secret_ctx =
-        crate::value::SecretHashContext::new(rid.display_type(), rid.name_str(), "master_password");
+    let secret_ctx = crate::value::SecretHashContext::new(
+        rid.display_type(),
+        rid.identity_or_empty(),
+        "master_password",
+    );
     let hash_json = crate::value::value_to_json_with_context(&secret_value, Some(&secret_ctx))
         .expect("secret hash must serialize");
     let hash_str = hash_json
@@ -2348,8 +2354,11 @@ async fn test_apply_effective_changed_skips_secret_shape_divergence() {
         ])),
     );
 
-    let secret_ctx =
-        crate::value::SecretHashContext::new(rid.display_type(), rid.name_str(), "master_password");
+    let secret_ctx = crate::value::SecretHashContext::new(
+        rid.display_type(),
+        rid.identity_or_empty(),
+        "master_password",
+    );
     let hash_json = crate::value::value_to_json_with_context(&secret_value, Some(&secret_ctx))
         .expect("secret hash must serialize");
     let hash_str = hash_json
@@ -2620,7 +2629,7 @@ async fn test_async_normalizer_does_not_self_deadlock_on_apply_path() {
 #[tokio::test]
 async fn test_simple_delete() {
     let provider = MockProvider::new();
-    let rid = ResourceId::new("test", "a");
+    let rid = ResourceId::with_identity("test", "a");
 
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
@@ -2701,7 +2710,7 @@ async fn test_failed_effect_propagates_to_dependent() {
 async fn test_cbd_creates_before_deletes() {
     // CBD Replace: create should happen before delete
     let provider = MockProvider::new();
-    let rid = ResourceId::new("test", "a");
+    let rid = ResourceId::with_identity("test", "a");
     let from = State::existing(rid.clone(), HashMap::new()).with_identifier("old-id");
     let to = Resource::new("test", "a");
 
@@ -2752,13 +2761,13 @@ async fn test_cbd_creates_before_deletes() {
 #[tokio::test]
 async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
     let provider = MockProvider::new();
-    let replace_id = ResourceId::with_provider("test", "replace", "replace", None);
+    let replace_id = ResourceId::with_provider_identity("test", "replace", "replace", None);
     let replace_from =
         State::existing(replace_id.clone(), HashMap::new()).with_identifier("replace-old");
     let mut replace_to = Resource::with_provider("test", "replace", "replace", None);
     replace_to.binding = Some("replace".to_string());
 
-    let cascade_id = ResourceId::with_provider("test", "a", "a", None);
+    let cascade_id = ResourceId::with_provider_identity("test", "a", "a", None);
     let mut cascade_from_attrs = HashMap::new();
     cascade_from_attrs.insert(
         "description".to_string(),
@@ -2838,7 +2847,7 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
 #[tokio::test]
 async fn test_cbd_rename_partial_create_partial_counts_once() {
     let provider = MockProvider::new();
-    let id = ResourceId::with_provider("test", "replace", "replace", None);
+    let id = ResourceId::with_provider_identity("test", "replace", "replace", None);
     let from = State::existing(id.clone(), HashMap::new()).with_identifier("replace-old");
     let mut to = Resource::with_provider("test", "replace", "replace", None);
     to.binding = Some("replace".to_string());
@@ -2918,7 +2927,7 @@ async fn test_cbd_rename_partial_create_partial_counts_once() {
 #[tokio::test]
 async fn test_cbd_rename_success_create_partial_keeps_create_marker() {
     let provider = MockProvider::new();
-    let id = ResourceId::with_provider("test", "replace", "replace", None);
+    let id = ResourceId::with_provider_identity("test", "replace", "replace", None);
     let from = State::existing(id.clone(), HashMap::new()).with_identifier("replace-old");
     let mut to = Resource::with_provider("test", "replace", "replace", None);
     to.binding = Some("replace".to_string());
@@ -2991,7 +3000,7 @@ async fn test_cbd_rename_success_create_partial_keeps_create_marker() {
 async fn test_dbd_deletes_before_creates() {
     // Non-CBD Replace: delete should happen before create
     let provider = MockProvider::new();
-    let rid = ResourceId::new("test", "a");
+    let rid = ResourceId::with_identity("test", "a");
     let from = State::existing(rid.clone(), HashMap::new()).with_identifier("old-id");
     let to = Resource::new("test", "a");
 
@@ -3044,8 +3053,8 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
     //   Phase 3: delete subnet, delete vpc (reverse)
     //   Phase 4: finalize (success events)
     let provider = MockProvider::new();
-    let vpc_id = ResourceId::new("test", "vpc");
-    let subnet_id = ResourceId::new("test", "subnet");
+    let vpc_id = ResourceId::with_identity("test", "vpc");
+    let subnet_id = ResourceId::with_identity("test", "subnet");
 
     let vpc_from = State::existing(vpc_id.clone(), HashMap::new()).with_identifier("vpc-old");
     let mut vpc_to = Resource::new("test", "vpc");
@@ -3130,8 +3139,8 @@ async fn test_phased_noncbd_creates_after_deletes() {
     //   Phase 3: delete subnet, delete vpc (reverse dependency)
     //   Phase 4: create vpc, create subnet (forward dependency)
     let provider = MockProvider::new();
-    let vpc_id = ResourceId::new("test", "vpc");
-    let subnet_id = ResourceId::new("test", "subnet");
+    let vpc_id = ResourceId::with_identity("test", "vpc");
+    let subnet_id = ResourceId::with_identity("test", "subnet");
 
     let vpc_from = State::existing(vpc_id.clone(), HashMap::new()).with_identifier("vpc-old");
     let mut vpc_to = Resource::new("test", "vpc");
@@ -3566,7 +3575,7 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
             _request: CreateRequest,
         ) -> BoxFuture<'_, ProviderResult<crate::provider::CreateOutcome>> {
             let id_clone = id.clone();
-            let name = id.name_str().to_string();
+            let name = id.identity_or_empty().to_string();
             let delay = self.delays.get(&name).copied().unwrap_or(Duration::ZERO);
             let log = self.call_log.clone();
             Box::pin(async move {
@@ -3751,7 +3760,7 @@ impl Provider for DelayedUpdateProvider {
                 "tags".to_string(),
                 Value::Concrete(ConcreteValue::String("new".to_string())),
             );
-            if change_unrelated_id && id.name_str() == "vpc" {
+            if change_unrelated_id && id.identity_or_empty() == "vpc" {
                 attrs.insert(
                     "id".to_string(),
                     Value::Concrete(ConcreteValue::String("provider-violated-id".to_string())),
@@ -4011,8 +4020,8 @@ async fn test_waiting_events_emitted_for_dependent_effects() {
     let observer = MockObserver::new();
     let provider = MockProvider::new();
     // Push create results for both resources
-    let a_id = ResourceId::new("test", "a");
-    let c_id = ResourceId::new("test", "c");
+    let a_id = ResourceId::with_identity("test", "a");
+    let c_id = ResourceId::with_identity("test", "c");
     // Publish `id` in state.attributes so dependents resolve their
     // `ResourceRef(parent, "id")` refs (post-#3032 the executor
     // rejects unresolved refs at the apply seam).
@@ -4071,7 +4080,7 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
     // For deletion: vpc delete must wait for subnet delete → subnet first, then vpc
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: ResourceId::new("ec2.Vpc", "my-vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
         identifier: "vpc-123".to_string(),
         directives: Directives::default(),
         binding: Some("vpc".to_string()),
@@ -4079,7 +4088,7 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
         explicit_dependencies: HashSet::new(),
     });
     plan.add(Effect::Delete {
-        id: ResourceId::new("ec2.Subnet", "my-subnet"),
+        id: ResourceId::with_identity("ec2.Subnet", "my-subnet"),
         identifier: "subnet-456".to_string(),
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
@@ -4157,7 +4166,7 @@ fn test_build_dependency_levels_consistent_with_dependency_map() {
 #[tokio::test]
 async fn test_update_effect_binding_map_propagation() {
     let provider = MockProvider::new();
-    let ra_id = ResourceId::new("test", "a");
+    let ra_id = ResourceId::with_identity("test", "a");
 
     // Create initial state
     let from_state = State::existing(ra_id.clone(), HashMap::new()).with_identifier("id-original");
@@ -4206,7 +4215,7 @@ async fn test_update_effect_binding_map_propagation() {
 fn test_dependency_analysis_respects_delete_dependencies() {
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: ResourceId::new("ec2.Vpc", "my-vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
         identifier: "vpc-123".to_string(),
         directives: Directives::default(),
         binding: Some("vpc".to_string()),
@@ -4214,7 +4223,7 @@ fn test_dependency_analysis_respects_delete_dependencies() {
         explicit_dependencies: std::collections::HashSet::new(),
     });
     plan.add(Effect::Delete {
-        id: ResourceId::new("ec2.Subnet", "my-subnet"),
+        id: ResourceId::with_identity("ec2.Subnet", "my-subnet"),
         identifier: "subnet-456".to_string(),
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
@@ -4433,9 +4442,9 @@ impl Provider for RecordingMockProvider {
 #[tokio::test]
 async fn test_delete_waits_for_replace_cbd_of_dependent() {
     let provider = MockProvider::new();
-    let tgw_a_id = ResourceId::new("test", "tgw_a");
-    let tgw_b_id = ResourceId::new("test", "tgw_b");
-    let attachment_id = ResourceId::new("test", "attachment");
+    let tgw_a_id = ResourceId::with_identity("test", "tgw_a");
+    let tgw_b_id = ResourceId::with_identity("test", "tgw_b");
+    let attachment_id = ResourceId::with_identity("test", "attachment");
 
     // tgw_a is being deleted (binding removed from desired config)
     let tgw_a_deps: HashSet<String> = HashSet::new();
@@ -4534,9 +4543,9 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
 #[tokio::test]
 async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
     let provider = MockProvider::new();
-    let tgw_a_id = ResourceId::new("test", "tgw_a");
-    let tgw_b_id = ResourceId::new("test", "tgw_b");
-    let attachment_id = ResourceId::new("test", "attachment");
+    let tgw_a_id = ResourceId::with_identity("test", "tgw_a");
+    let tgw_b_id = ResourceId::with_identity("test", "tgw_b");
+    let attachment_id = ResourceId::with_identity("test", "attachment");
 
     // tgw_a Delete has binding: None (anonymous in step2 .crn)
     // but state recorded it as "tgw_a"
@@ -4937,7 +4946,7 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     // ResourceId. This is what guarantees state writeback never sees
     // it as a real resource — `sorted_resources` (the writeback input)
     // does not contain `__wait` IDs.
-    let synthetic = ResourceId::new("__wait", "cert_issued");
+    let synthetic = ResourceId::with_identity("__wait", "cert_issued");
     assert!(
         result.applied_states.contains_key(&synthetic),
         "wait should register its captured State under the __wait synthetic id"
@@ -5734,7 +5743,7 @@ async fn deferred_create_dispatches_after_upstream_replace_before_wait_phased() 
     )
     .with_identifier("new");
     let dep_state = State::existing(dep_id.clone(), HashMap::new()).with_identifier("dep-new");
-    let validation_id = ResourceId::new("test", "validation_records[0]");
+    let validation_id = ResourceId::with_identity("test", "validation_records[0]");
     let validation_state =
         State::existing(validation_id.clone(), HashMap::new()).with_identifier("validation");
 
@@ -5768,7 +5777,7 @@ async fn deferred_create_dispatches_after_upstream_replace_before_wait_phased() 
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -5894,7 +5903,7 @@ async fn deferred_create_emits_zero_children_when_collection_is_empty() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6049,7 +6058,7 @@ async fn deferred_create_cancelled_after_upstream_create_reports_skipped() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6088,7 +6097,7 @@ async fn deferred_create_returns_error_when_upstream_binding_missing() {
     let provider = MockProvider::new();
     let mut plan = Plan::new();
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "missing_cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6127,7 +6136,7 @@ async fn deferred_create_returns_error_when_iterable_attr_missing() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(cert));
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6174,7 +6183,7 @@ async fn apply_time_deferred_create_emits_failed_on_shape_mismatch() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(cert));
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6271,7 +6280,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
         }
     }
 
-    let cert_id = ResourceId::new("test", "cert_concurrent_deferred_replace");
+    let cert_id = ResourceId::with_identity("test", "cert_concurrent_deferred_replace");
     let cert_state = State::existing(
         cert_id.clone(),
         HashMap::from([(
@@ -6293,7 +6302,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
             )])),
         )]),
     );
-    let validation_id = ResourceId::new("test", "validation_records[0]");
+    let validation_id = ResourceId::with_identity("test", "validation_records[0]");
     let validation_state =
         State::existing(validation_id.clone(), HashMap::new()).with_identifier("new-validation");
     let entered_deletes = Arc::new(AtomicUsize::new(0));
@@ -6316,7 +6325,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![
             DeferredReplaceDelete {
-                id: ResourceId::new("test", "validation_records[0]"),
+                id: ResourceId::with_identity("test", "validation_records[0]"),
                 identifier: "old-validation-0".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -6324,7 +6333,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
                 explicit_dependencies: HashSet::new(),
             },
             DeferredReplaceDelete {
-                id: ResourceId::new("test", "validation_records[1]"),
+                id: ResourceId::with_identity("test", "validation_records[1]"),
                 identifier: "old-validation-1".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[1]".to_string()),
@@ -6333,7 +6342,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
             },
         ])
         .expect("fixture has deletes"),
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6373,7 +6382,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
 
 #[tokio::test]
 async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
-    let cert_id = ResourceId::new("test", "cert_delete_failure");
+    let cert_id = ResourceId::with_identity("test", "cert_delete_failure");
     let cert_state = State::existing(
         cert_id.clone(),
         HashMap::from([(
@@ -6398,7 +6407,7 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
     let provider = MockProvider::new();
     provider.push_create(Ok(cert_state));
     provider.push_delete(Err(ProviderError::api_error("delete failed")));
-    provider.push_read(Ok(State::not_found(ResourceId::new(
+    provider.push_read(Ok(State::not_found(ResourceId::with_identity(
         "test",
         "validation_records[0]",
     ))));
@@ -6409,7 +6418,7 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
     plan.add(Effect::Create(cert));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-            id: ResourceId::new("test", "validation_records[0]"),
+            id: ResourceId::with_identity("test", "validation_records[0]"),
             identifier: "old-validation".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -6417,7 +6426,7 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6456,19 +6465,19 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
     // Regression for carina#3611: current phased.rs records failures by
     // binding string only, so an expanded DeferredReplace delete failure can
     // be missed by the DR gate and the child Create is materialized anyway.
-    let cert_id = ResourceId::new("test", "cert_delete_failure_phased");
+    let cert_id = ResourceId::with_identity("test", "cert_delete_failure_phased");
     let mut cert = Resource::new("test", "cert_delete_failure_phased");
     cert.binding = Some("cert".to_string());
     let old_cert_state =
         State::existing(cert_id.clone(), HashMap::new()).with_identifier("cert-old");
 
-    let dep_id = ResourceId::new("test", "dep_delete_failure_phased");
+    let dep_id = ResourceId::with_identity("test", "dep_delete_failure_phased");
     let mut dep = Resource::new("test", "dep_delete_failure_phased");
     dep.binding = Some("dep".to_string());
     dep.dependency_bindings.insert("cert".to_string());
     let old_dep_state = State::existing(dep_id.clone(), HashMap::new()).with_identifier("dep-old");
 
-    let validation_id = ResourceId::new("test", "validation_records[0]");
+    let validation_id = ResourceId::with_identity("test", "validation_records[0]");
     let validation_state =
         State::existing(validation_id.clone(), HashMap::new()).with_identifier("new-validation");
 
@@ -6514,7 +6523,7 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6597,13 +6606,13 @@ async fn phased_cbd_replace_skips_when_phase1_dependency_fails() {
     let mut bucket = Resource::new("test", "bucket_phase1_cbd_dep");
     bucket.binding = Some("bucket".to_string());
 
-    let anchor_id = ResourceId::new("test", "anchor_phase1_cbd_dep");
+    let anchor_id = ResourceId::with_identity("test", "anchor_phase1_cbd_dep");
     let mut anchor_to = Resource::new("test", "anchor_phase1_cbd_dep");
     anchor_to.binding = Some("anchor".to_string());
     let anchor_from =
         State::existing(anchor_id.clone(), HashMap::new()).with_identifier("old-anchor");
 
-    let policy_id = ResourceId::new("test", "policy_phase1_cbd_dep");
+    let policy_id = ResourceId::with_identity("test", "policy_phase1_cbd_dep");
     let mut policy_to = make_resource("policy", &["anchor"]);
     policy_to.id = policy_id.clone();
     policy_to.directives = Directives {
@@ -6692,13 +6701,13 @@ async fn phased_replace_delete_skips_when_phase1_dependency_fails() {
     let mut bucket = Resource::new("test", "bucket_phase1_delete_dep");
     bucket.binding = Some("bucket".to_string());
 
-    let anchor_id = ResourceId::new("test", "anchor_phase1_delete_dep");
+    let anchor_id = ResourceId::with_identity("test", "anchor_phase1_delete_dep");
     let mut anchor_to = Resource::new("test", "anchor_phase1_delete_dep");
     anchor_to.binding = Some("anchor".to_string());
     let anchor_from =
         State::existing(anchor_id.clone(), HashMap::new()).with_identifier("old-anchor");
 
-    let target_id = ResourceId::new("test", "anonymous_phase1_delete_dep");
+    let target_id = ResourceId::with_identity("test", "anonymous_phase1_delete_dep");
     let mut target_to = make_resource("anonymous_phase1_delete_dep", &["anchor"]);
     target_to.binding = None;
     target_to.directives.depends_on.push("bucket".to_string());
@@ -6791,18 +6800,18 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
     // kept failed_bindings: HashSet<String>, so a failed anonymous Replace
     // (binding_name() == None) is not recorded and a dependent Wait can run
     // until timeout instead of being skipped as dependency-failed.
-    let a_id = ResourceId::new("test", "a_anonymous_wait_gate");
+    let a_id = ResourceId::with_identity("test", "a_anonymous_wait_gate");
     let mut a = Resource::new("test", "a_anonymous_wait_gate");
     a.binding = Some("a".to_string());
     let old_a_state = State::existing(a_id.clone(), HashMap::new()).with_identifier("a-old");
 
-    let b_id = ResourceId::new("test", "b_anonymous_wait_gate");
+    let b_id = ResourceId::with_identity("test", "b_anonymous_wait_gate");
     let mut b = Resource::new("test", "b_anonymous_wait_gate");
     b.binding = Some("b".to_string());
     b.dependency_bindings.insert("a".to_string());
     let old_b_state = State::existing(b_id.clone(), HashMap::new()).with_identifier("b-old");
 
-    let anonymous_id = ResourceId::new("test", "anonymous_wait_target");
+    let anonymous_id = ResourceId::with_identity("test", "anonymous_wait_target");
     let old_anonymous_state =
         State::existing(anonymous_id.clone(), HashMap::new()).with_identifier("anon-old");
     let anonymous_to = Resource::new("test", "anonymous_wait_target");
@@ -6929,19 +6938,19 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
     use crate::effect::ChangedCreateOnly;
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
-    let failed_id = ResourceId::new("test", "failed_cross_phase_update");
+    let failed_id = ResourceId::with_identity("test", "failed_cross_phase_update");
     let old_failed_state =
         State::existing(failed_id.clone(), HashMap::new()).with_identifier("failed-old");
     let mut failed_to = Resource::new("test", "failed_cross_phase_update");
     failed_to.binding = Some("b".to_string());
 
-    let parent_id = ResourceId::new("test", "cross_phase_wait_parent");
+    let parent_id = ResourceId::with_identity("test", "cross_phase_wait_parent");
     let mut parent = Resource::new("test", "cross_phase_wait_parent");
     parent.binding = Some("parent".to_string());
     let old_parent_state =
         State::existing(parent_id.clone(), HashMap::new()).with_identifier("parent-old");
 
-    let child_id = ResourceId::new("test", "cross_phase_wait_child");
+    let child_id = ResourceId::with_identity("test", "cross_phase_wait_child");
     let mut child = Resource::new("test", "cross_phase_wait_child");
     child.binding = Some("child".to_string());
     child.dependency_bindings.insert("parent".to_string());
@@ -7083,7 +7092,7 @@ fn phased_anonymous_replace_failure_unblocks_wait_terminal_check() {
     // The scheduler graph proves the Wait depends on the failed anonymous
     // Replace, and the terminal counter must consult the same FailureView
     // rather than a lossy failed-binding-name projection.
-    let anonymous_id = ResourceId::new("test", "anonymous_wait_terminal_target");
+    let anonymous_id = ResourceId::with_identity("test", "anonymous_wait_terminal_target");
     let old_anonymous_state =
         State::existing(anonymous_id.clone(), HashMap::new()).with_identifier("anon-old");
     let anonymous_to = Resource::new("test", "anonymous_wait_terminal_target");
@@ -7179,7 +7188,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
             Box::pin(async move {
                 let is_alb = resources
                     .iter()
-                    .any(|resource| resource.id.name_str() == "alb");
+                    .any(|resource| resource.id.identity_or_empty() == "alb");
                 {
                     let _aws = self.scenario.aws_normalize.lock().await;
                     tokio::task::yield_now().await;
@@ -7229,7 +7238,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
             id: &ResourceId,
         ) -> ProviderResult<crate::provider::CreateOutcome> {
             self.scenario.record(format!("create:{id}"));
-            if id.name_str() == "cert" {
+            if id.identity_or_empty() == "cert" {
                 let _provider_lock = self.scenario.awscc_shared.lock().await;
                 self.scenario.alb_waiting_for_awscc.notified().await;
                 return Ok(crate::provider::CreateOutcome::Success {
@@ -7237,7 +7246,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
                 });
             }
 
-            if id.name_str() == "alb" {
+            if id.identity_or_empty() == "alb" {
                 let _provider_lock = self.scenario.awscc_shared.lock().await;
                 return Ok(crate::provider::CreateOutcome::Success {
                     state: State::existing(id.clone(), HashMap::new()).with_identifier("alb-id"),
@@ -7246,7 +7255,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
 
             Ok(crate::provider::CreateOutcome::Success {
                 state: State::existing(id.clone(), HashMap::new())
-                    .with_identifier(format!("{}-id", id.name_str())),
+                    .with_identifier(format!("{}-id", id.identity_or_empty())),
             })
         }
 
@@ -7327,7 +7336,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
     plan.add(Effect::Create(resource_with_binding("alb", "alb")));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-            id: ResourceId::new("test", "validation_records[0]"),
+            id: ResourceId::with_identity("test", "validation_records[0]"),
             identifier: "old-validation".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -7335,7 +7344,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -7368,13 +7377,14 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
         result
             .runtime_synthesized_resources
             .iter()
-            .any(|resource| resource.id == ResourceId::new("test", "validation_records[0]")),
+            .any(|resource| resource.id
+                == ResourceId::with_identity("test", "validation_records[0]")),
         "deferred replace gate must synthesize the child create"
     );
     assert!(
         result
             .applied_states
-            .contains_key(&ResourceId::new("test", "validation_records[0]")),
+            .contains_key(&ResourceId::with_identity("test", "validation_records[0]")),
         "post-state must include the synthesized child create"
     );
     assert!(
@@ -7429,9 +7439,9 @@ fn cert_state_for_deferred_replace_deadlock(id: &ResourceId) -> State {
 async fn test_phased_move_with_interdependent_replace_does_not_panic() {
     let provider = MockProvider::new();
 
-    let role_id = ResourceId::new("test", "role");
-    let policy_old_id = ResourceId::new("test", "policy_old");
-    let policy_new_id = ResourceId::new("test", "policy_new");
+    let role_id = ResourceId::with_identity("test", "role");
+    let policy_old_id = ResourceId::with_identity("test", "policy_old");
+    let policy_new_id = ResourceId::with_identity("test", "policy_new");
 
     let role_from = State::existing(role_id.clone(), HashMap::new()).with_identifier("role-old");
     let mut role_to = Resource::new("test", "role");
@@ -7473,7 +7483,10 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
     provider.push_delete(Ok(()));
     provider.push_create(Ok(ok_state(&role_id)));
     provider.push_delete(Ok(()));
-    provider.push_create(Ok(ok_state(&ResourceId::new("test", "policy_new"))));
+    provider.push_create(Ok(ok_state(&ResourceId::with_identity(
+        "test",
+        "policy_new",
+    ))));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -7537,7 +7550,7 @@ async fn test_data_source_read_state_resolves_for_downstream_resource() {
     // The DSL attributes hold input filters only; the produced `arns`
     // list lives in `current_states[ds.id]`. `with_provider` matches
     // the id shape real apply uses.
-    let ds_id = ResourceId::with_provider("aws", "iam.Roles", "admin_access_roles", None);
+    let ds_id = ResourceId::with_provider_identity("aws", "iam.Roles", "admin_access_roles", None);
     let mut ds = DataSource::with_provider("aws", "iam.Roles", "admin_access_roles", None);
     ds.id = ds_id.clone();
     ds.binding = Some("admin_access_roles".to_string());
@@ -7570,7 +7583,7 @@ async fn test_data_source_read_state_resolves_for_downstream_resource() {
     // `admin_access_roles.arns`. (Modelled as a top-level attribute
     // for test concision; the production case nests it inside a
     // struct, but the resolve path is the same per-attribute one.)
-    let role_id = ResourceId::with_provider("awscc", "iam.Role", "rd.role", None);
+    let role_id = ResourceId::with_provider_identity("awscc", "iam.Role", "rd.role", None);
     let role = {
         let mut r = Resource::with_provider("awscc", "iam.Role", "rd.role", None);
         r.id = role_id.clone();

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -369,7 +369,7 @@ pub async fn execute_wait_effect(
 ) -> WaitOutcome {
     execute_wait_effect_with_heartbeat_gap(
         provider,
-        target_id.name_str(),
+        target_id.identity_or_empty(),
         target_id,
         identifier_resolver,
         until,
@@ -580,7 +580,7 @@ mod tests {
             "status".to_string(),
             Value::Concrete(ConcreteValue::String(status.to_string())),
         );
-        State::existing(ResourceId::new("acm.Certificate", "cert"), attrs)
+        State::existing(ResourceId::with_identity("acm.Certificate", "cert"), attrs)
     }
 
     fn equals_status(value: &str) -> WaitPredicate {
@@ -644,7 +644,7 @@ mod tests {
     async fn wait_returns_immediately_when_until_already_true() {
         let provider = ReadSequenceProvider::new(vec![state_with_status("ISSUED")]);
         let pred = equals_status("ISSUED");
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let result = execute_wait_effect(
@@ -678,7 +678,7 @@ mod tests {
             state_with_status("ISSUED"),
         ]);
         let pred = equals_status("ISSUED");
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let result = execute_wait_effect(
@@ -703,7 +703,7 @@ mod tests {
     async fn wait_returns_timeout_when_predicate_stays_false() {
         let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
         let pred = equals_status("ISSUED");
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let result = execute_wait_effect(
@@ -738,7 +738,7 @@ mod tests {
 
     #[test]
     fn wait_timeout_failure_message_uses_display_formatting_for_last_attrs() {
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let outcome = WaitOutcome::Timeout {
             last_attrs: HashMap::from([
                 (
@@ -766,7 +766,7 @@ mod tests {
 
     #[test]
     fn wait_timeout_failure_message_handles_empty_last_attrs() {
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let outcome = WaitOutcome::Timeout {
             last_attrs: HashMap::new(),
             elapsed: Duration::from_secs(1),
@@ -779,7 +779,7 @@ mod tests {
 
     #[test]
     fn wait_timeout_failure_message_handles_unknown_and_deferred_attrs() {
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let outcome = WaitOutcome::Timeout {
             last_attrs: HashMap::from([
                 (
@@ -811,10 +811,10 @@ mod tests {
     async fn wait_returns_not_found_when_target_disappears() {
         let provider = ReadSequenceProvider::new(vec![
             state_with_status("PENDING_VALIDATION"),
-            State::not_found(ResourceId::new("acm.Certificate", "cert")),
+            State::not_found(ResourceId::with_identity("acm.Certificate", "cert")),
         ]);
         let pred = equals_status("ISSUED");
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let result = execute_wait_effect(
@@ -838,7 +838,7 @@ mod tests {
     async fn wait_returns_unsatisfiable_when_cancelled() {
         let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
         let pred = equals_status("ISSUED");
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let (cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = NoopWaitObserver;
         let reads_seen = AtomicUsize::new(0);
@@ -884,7 +884,7 @@ mod tests {
     async fn wait_emits_heartbeat_at_max_interval() {
         let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
         let pred = equals_status("ISSUED");
-        let target = ResourceId::new("acm.Certificate", "cert");
+        let target = ResourceId::with_identity("acm.Certificate", "cert");
         let (_cancel_tx, cancel_rx) = watch::channel(WaitSignal::Continue);
         let observer = HeartbeatObserver::new();
 

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -169,7 +169,7 @@ pub fn reconcile_prefixed_names(
         let state_info = find_state(
             &resource.id.provider,
             &resource.id.resource_type,
-            resource.id.name_str(),
+            resource.id.identity_or_empty(),
         );
         let state_info = match state_info {
             Some(si) => si,
@@ -563,7 +563,7 @@ pub fn compute_anonymous_identifiers_for_test(
     )
 }
 
-/// Compute stable identifiers for anonymous resources (those with empty ResourceId.name).
+/// Compute stable identifiers for anonymous resources (those without ResourceId identity).
 /// Uses create-only properties and provider identity attributes to generate a deterministic hash.
 ///
 /// `identity_attributes_fn` takes a provider name and returns the list of identity attribute names
@@ -581,7 +581,7 @@ pub fn compute_anonymous_identifiers_with_provider_configs(
     let mut computed: Vec<(usize, String)> = Vec::new();
 
     for (idx, resource) in resources.iter().enumerate() {
-        if !resource.id.name.is_pending() {
+        if resource.id.identity.is_some() {
             continue;
         }
 
@@ -719,8 +719,12 @@ pub fn compute_anonymous_identifiers_with_provider_configs(
         let provider = resources[idx].id.provider.clone();
         let resource_type = resources[idx].id.resource_type.clone();
         let provider_instance = resources[idx].id.provider_instance.clone();
-        resources[idx].id =
-            ResourceId::with_provider(&provider, &resource_type, identifier, provider_instance);
+        resources[idx].id = ResourceId::with_provider_identity(
+            &provider,
+            &resource_type,
+            identifier,
+            provider_instance,
+        );
     }
 
     Ok(())
@@ -838,13 +842,13 @@ pub fn reconcile_anonymous_identifiers(
         used_names
             .entry(key)
             .or_default()
-            .insert(resource.id.name_str().to_string());
+            .insert(resource.id.identity_or_empty().to_string());
     }
 
     let mut claimed_names: HashMap<(String, String), HashSet<String>> = HashMap::new();
 
     for resource in resources.iter_mut() {
-        if resource.id.name.is_pending() {
+        if resource.id.identity.is_none() {
             continue;
         }
 
@@ -858,7 +862,7 @@ pub fn reconcile_anonymous_identifiers(
         if claims.claims_to(
             &resource.id.provider,
             &resource.id.resource_type,
-            resource.id.name_str(),
+            resource.id.identity_or_empty(),
         ) {
             continue;
         }
@@ -877,7 +881,7 @@ pub fn reconcile_anonymous_identifiers(
         // If the resource's name already exists in state, no reconciliation is needed.
         if state_entries
             .iter()
-            .any(|e| e.name == resource.id.name_str())
+            .any(|e| e.name == resource.id.identity_or_empty())
         {
             continue;
         }
@@ -897,14 +901,14 @@ pub fn reconcile_anonymous_identifiers(
             // No create-only properties or none set: use SimHash-based Hamming distance
             // matching to find the closest state entry.
             let Some(AnonymousHashSuffix::SimHash(resource_hash)) =
-                extract_hash_from_identifier(resource.id.name_str())
+                extract_hash_from_identifier(resource.id.identity_or_empty())
             else {
                 continue;
             };
 
             let candidates = state_entries
                 .iter()
-                .filter(|entry| entry.name != resource.id.name_str())
+                .filter(|entry| entry.name != resource.id.identity_or_empty())
                 .filter(|entry| {
                     !claims.claims_from(
                         &resource.id.provider,
@@ -932,7 +936,10 @@ pub fn reconcile_anonymous_identifiers(
                 // pre-provider-prefix). Keep our freshly-computed new-format
                 // name on the resource and record a rename so the wiring
                 // layer can re-key the state entry.
-                renames.push((state_name.to_string(), resource.id.name_str().to_string()));
+                renames.push((
+                    state_name.to_string(),
+                    resource.id.identity_or_empty().to_string(),
+                ));
                 claimed_names
                     .entry(key)
                     .or_default()
@@ -952,7 +959,7 @@ pub fn reconcile_anonymous_identifiers(
         let mut full_matches: Vec<&str> = Vec::new();
         let mut partial_matches: Vec<&str> = Vec::new();
         for entry in &state_entries {
-            if entry.name == resource.id.name_str() {
+            if entry.name == resource.id.identity_or_empty() {
                 // Same identifier, no reconciliation needed
                 continue;
             }
@@ -1001,7 +1008,7 @@ pub fn reconcile_anonymous_identifiers(
         };
 
         if let Some(matched_name) = matched_name {
-            resource.id = ResourceId::with_provider(
+            resource.id = ResourceId::with_provider_identity(
                 &resource.id.provider,
                 &resource.id.resource_type,
                 matched_name,
@@ -1061,7 +1068,7 @@ pub fn detect_anonymous_to_named_renames(
         used_names
             .entry(key)
             .or_default()
-            .insert(resource.id.name_str().to_string());
+            .insert(resource.id.identity_or_empty().to_string());
     }
 
     let mut renames: Vec<(ResourceId, ResourceId)> = Vec::new();
@@ -1074,7 +1081,7 @@ pub fn detect_anonymous_to_named_renames(
         if claims.claims_to(
             &resource.id.provider,
             &resource.id.resource_type,
-            resource.id.name_str(),
+            resource.id.identity_or_empty(),
         ) {
             continue;
         }
@@ -1088,7 +1095,7 @@ pub fn detect_anonymous_to_named_renames(
         // Skip if the binding name already exists in state — nothing to rename.
         if state_entries
             .iter()
-            .any(|e| e.name == resource.id.name_str())
+            .any(|e| e.name == resource.id.identity_or_empty())
         {
             continue;
         }
@@ -1164,7 +1171,7 @@ pub fn detect_anonymous_to_named_renames(
         };
 
         if let Some(name) = matched_name {
-            let from = ResourceId::with_provider(
+            let from = ResourceId::with_provider_identity(
                 &resource.id.provider,
                 &resource.id.resource_type,
                 name,

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -238,8 +238,8 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_identity() {
     .unwrap();
 
     assert_eq!(
-        resources_awscc[0].id.name_str(),
-        resources_aws[0].id.name_str()
+        resources_awscc[0].id.identity_or_empty(),
+        resources_aws[0].id.identity_or_empty()
     );
 }
 
@@ -281,8 +281,8 @@ fn test_anonymous_id_stable_across_provider_namespace_change_in_attribute() {
         .unwrap();
 
     assert_eq!(
-        resources_awscc[0].id.name_str(),
-        resources_aws[0].id.name_str()
+        resources_awscc[0].id.identity_or_empty(),
+        resources_aws[0].id.identity_or_empty()
     );
 }
 
@@ -332,8 +332,8 @@ fn test_anonymous_id_stable_for_nested_canonical_enum_create_only_values() {
         .unwrap();
 
     assert_eq!(
-        resources_awscc[0].id.name_str(),
-        resources_aws[0].id.name_str()
+        resources_awscc[0].id.identity_or_empty(),
+        resources_aws[0].id.identity_or_empty()
     );
 }
 
@@ -370,7 +370,7 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
     let mut old_resources = vec![make_resource("awscc.ec2.Eip.Domain.vpc", "pool-a")];
     compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
         .unwrap();
-    let state_name = old_resources[0].id.name_str().to_string();
+    let state_name = old_resources[0].id.identity_or_empty().to_string();
 
     let mut desired_resources = vec![make_resource("aws.ec2.Eip.Domain.vpc", "pool-b")];
     compute_anonymous_identifiers_for_test(
@@ -380,7 +380,7 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
         &identity_fn,
     )
     .unwrap();
-    assert_ne!(state_name, desired_resources[0].id.name_str());
+    assert_ne!(state_name, desired_resources[0].id.identity_or_empty());
 
     let state_entries = vec![AnonymousIdStateInfo {
         name: state_name.clone(),
@@ -398,7 +398,7 @@ fn test_reconcile_anonymous_id_after_provider_namespace_change() {
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(desired_resources[0].id.name_str(), state_name);
+    assert_eq!(desired_resources[0].id.identity_or_empty(), state_name);
 }
 
 #[test]
@@ -450,7 +450,7 @@ fn test_reconcile_anonymous_id_after_nested_enum_create_only_hash_migration() {
     let mut old_resources = vec![make_old_resource("pool-a")];
     compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
         .unwrap();
-    let state_name = old_resources[0].id.name_str().to_string();
+    let state_name = old_resources[0].id.identity_or_empty().to_string();
 
     let mut desired_resources = vec![make_new_resource("pool-b")];
     compute_anonymous_identifiers_for_test(
@@ -460,7 +460,7 @@ fn test_reconcile_anonymous_id_after_nested_enum_create_only_hash_migration() {
         &identity_fn,
     )
     .unwrap();
-    assert_ne!(state_name, desired_resources[0].id.name_str());
+    assert_ne!(state_name, desired_resources[0].id.identity_or_empty());
 
     let state_entries = vec![AnonymousIdStateInfo {
         name: state_name.clone(),
@@ -481,7 +481,7 @@ fn test_reconcile_anonymous_id_after_nested_enum_create_only_hash_migration() {
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(desired_resources[0].id.name_str(), state_name);
+    assert_eq!(desired_resources[0].id.identity_or_empty(), state_name);
 }
 
 #[test]
@@ -533,7 +533,7 @@ fn test_reconcile_anonymous_id_after_nested_enum_no_edit_upgrade_full_match() {
     let mut old_resources = vec![make_old_resource()];
     compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
         .unwrap();
-    let state_name = old_resources[0].id.name_str().to_string();
+    let state_name = old_resources[0].id.identity_or_empty().to_string();
 
     let mut desired_resources = vec![make_new_resource()];
     compute_anonymous_identifiers_for_test(
@@ -543,7 +543,7 @@ fn test_reconcile_anonymous_id_after_nested_enum_no_edit_upgrade_full_match() {
         &identity_fn,
     )
     .unwrap();
-    assert_ne!(state_name, desired_resources[0].id.name_str());
+    assert_ne!(state_name, desired_resources[0].id.identity_or_empty());
 
     let state_entries = vec![AnonymousIdStateInfo {
         name: state_name.clone(),
@@ -564,7 +564,7 @@ fn test_reconcile_anonymous_id_after_nested_enum_no_edit_upgrade_full_match() {
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(desired_resources[0].id.name_str(), state_name);
+    assert_eq!(desired_resources[0].id.identity_or_empty(), state_name);
 }
 
 #[test]
@@ -593,7 +593,7 @@ fn test_reconcile_anonymous_id_nested_enum_full_match_ambiguous_skips() {
         "public_ipv4_pool".to_string(),
         Value::Concrete(ConcreteValue::String("pool-a".to_string())),
     );
-    let original_id = resource.id.name_str().to_string();
+    let original_id = resource.id.identity_or_empty().to_string();
     let mut resources = vec![resource];
 
     let create_only_values: HashMap<String, String> = vec![
@@ -622,7 +622,7 @@ fn test_reconcile_anonymous_id_nested_enum_full_match_ambiguous_skips() {
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(resources[0].id.name_str(), original_id);
+    assert_eq!(resources[0].id.identity_or_empty(), original_id);
 }
 
 #[test]
@@ -662,7 +662,7 @@ fn test_reconcile_anonymous_id_mixed_string_and_enum_identifier_for_enum_attribu
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(resources[0].id.name_str(), state_name);
+    assert_eq!(resources[0].id.identity_or_empty(), state_name);
 }
 
 #[test]
@@ -882,7 +882,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     let mut resources1 = vec![r1];
     compute_anonymous_identifiers_for_test(&mut resources1, &providers, &schemas, &identity_fn)
         .unwrap();
-    let step1_id = resources1[0].id.name_str().to_string();
+    let step1_id = resources1[0].id.identity_or_empty().to_string();
 
     // Step 2: compute identifier with path="/carina/" (changed create-only)
     let mut r2 = Resource::with_provider("awscc", "iam.role", "", None);
@@ -897,7 +897,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     let mut resources2 = vec![r2];
     compute_anonymous_identifiers_for_test(&mut resources2, &providers, &schemas, &identity_fn)
         .unwrap();
-    let step2_id = resources2[0].id.name_str().to_string();
+    let step2_id = resources2[0].id.identity_or_empty().to_string();
 
     // Hash includes path, so identifiers differ
     assert_ne!(step1_id, step2_id);
@@ -920,7 +920,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     );
 
     // After reconciliation, step2 resource should have step1's identifier
-    assert_eq!(resources2[0].id.name_str(), step1_id);
+    assert_eq!(resources2[0].id.identity_or_empty(), step1_id);
 }
 
 #[test]
@@ -942,7 +942,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
         Value::Concrete(ConcreteValue::String("/new/".to_string())),
     );
 
-    let original_id = resource.id.name_str().to_string();
+    let original_id = resource.id.identity_or_empty().to_string();
     let mut resources = vec![resource];
 
     // State has completely different values
@@ -963,7 +963,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
     );
 
     // Identifier should remain unchanged
-    assert_eq!(resources[0].id.name_str(), original_id);
+    assert_eq!(resources[0].id.identity_or_empty(), original_id);
 }
 
 #[test]
@@ -1005,7 +1005,7 @@ fn test_reconcile_anonymous_id_unique_full_match_rebinds() {
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(resources[0].id.name_str(), "iam_role_11223344");
+    assert_eq!(resources[0].id.identity_or_empty(), "iam_role_11223344");
 }
 
 #[test]
@@ -1023,7 +1023,7 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
         Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
     );
 
-    let original_id = resource.id.name_str().to_string();
+    let original_id = resource.id.identity_or_empty().to_string();
     let mut resources = vec![resource];
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -1040,7 +1040,7 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
     );
 
     // No reconciliation: only one create-only prop and it changed
-    assert_eq!(resources[0].id.name_str(), original_id);
+    assert_eq!(resources[0].id.identity_or_empty(), original_id);
 }
 
 /// Anonymous resources declared inside a module instantiation must
@@ -1088,7 +1088,7 @@ fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
     compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .unwrap();
 
-    let name = resources[0].id.name_str();
+    let name = resources[0].id.identity_or_empty();
     assert!(
         name.starts_with("bootstrap."),
         "expected `bootstrap.<hash>` prefix, got {:?}",
@@ -1141,8 +1141,14 @@ fn test_anonymous_resource_no_create_only_properties() {
         .unwrap();
 
     // Should have computed an identifier
-    assert!(!resources[0].id.name_str().is_empty());
-    assert!(resources[0].id.name_str().starts_with("awscc_ec2_eip_"));
+    assert!(!resources[0].id.identity_or_empty().is_empty());
+    assert!(
+        resources[0]
+            .id
+            .identity_str()
+            .unwrap_or("")
+            .starts_with("awscc_ec2_eip_")
+    );
 }
 
 #[test]
@@ -1186,7 +1192,10 @@ fn test_anonymous_resource_no_create_only_deterministic() {
     compute_anonymous_identifiers_for_test(&mut resources2, &providers, &schemas, &identity_fn)
         .unwrap();
 
-    assert_eq!(resources1[0].id.name_str(), resources2[0].id.name_str());
+    assert_eq!(
+        resources1[0].id.identity_or_empty(),
+        resources2[0].id.identity_or_empty()
+    );
 }
 
 #[test]
@@ -1292,12 +1301,12 @@ fn test_identity_attribute_prevents_collision() {
         .expect("should not collide when identity attrs differ");
 
     // Both should have identifiers assigned
-    assert!(!resources[0].id.name_str().is_empty());
-    assert!(!resources[1].id.name_str().is_empty());
+    assert!(!resources[0].id.identity_or_empty().is_empty());
+    assert!(!resources[1].id.identity_or_empty().is_empty());
     // Identifiers should be different
     assert_ne!(
-        resources[0].id.name_str(),
-        resources[1].id.name_str(),
+        resources[0].id.identity_or_empty(),
+        resources[1].id.identity_or_empty(),
         "different identity attr values should produce different identifiers"
     );
 }
@@ -1317,8 +1326,8 @@ fn test_reconcile_anonymous_id_full_match_claims_state_entry_once() {
         .expect("identity attrs should produce distinct Route53 record identifiers");
 
     let old_state_name = "route53_record_set_11223344";
-    assert_ne!(resources[0].id.name_str(), old_state_name);
-    assert_ne!(resources[1].id.name_str(), old_state_name);
+    assert_ne!(resources[0].id.identity_or_empty(), old_state_name);
+    assert_ne!(resources[1].id.identity_or_empty(), old_state_name);
 
     let state_entries = vec![route53_state_entry(old_state_name)];
     reconcile_anonymous_identifiers(
@@ -1328,12 +1337,12 @@ fn test_reconcile_anonymous_id_full_match_claims_state_entry_once() {
         &|_binding| Vec::new(),
     );
 
-    let names: HashSet<&str> = resources.iter().map(|r| r.id.name_str()).collect();
+    let names: HashSet<&str> = resources.iter().map(|r| r.id.identity_or_empty()).collect();
     assert_eq!(names.len(), 2, "reconcile must not duplicate ResourceIds");
     assert_eq!(
         resources
             .iter()
-            .filter(|r| r.id.name_str() == old_state_name)
+            .filter(|r| r.id.identity_or_empty() == old_state_name)
             .count(),
         1,
         "only one resource may claim the migrated state entry"
@@ -1354,8 +1363,8 @@ fn test_reconcile_anonymous_id_full_match_does_not_steal_live_entry() {
     compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .expect("identity attrs should produce distinct Route53 record identifiers");
 
-    let live_a_name = resources[0].id.name_str().to_string();
-    let new_aaaa_name = resources[1].id.name_str().to_string();
+    let live_a_name = resources[0].id.identity_or_empty().to_string();
+    let new_aaaa_name = resources[1].id.identity_or_empty().to_string();
     let state_entries = vec![route53_state_entry(&live_a_name)];
 
     reconcile_anonymous_identifiers(
@@ -1365,9 +1374,9 @@ fn test_reconcile_anonymous_id_full_match_does_not_steal_live_entry() {
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(resources[0].id.name_str(), live_a_name);
+    assert_eq!(resources[0].id.identity_or_empty(), live_a_name);
     assert_eq!(
-        resources[1].id.name_str(),
+        resources[1].id.identity_or_empty(),
         new_aaaa_name,
         "new AAAA record must not steal the live A record state entry"
     );
@@ -1577,7 +1586,7 @@ fn test_reconcile_does_not_hamming_match_standard_hash_names() {
     assert_eq!(
         resources
             .iter()
-            .map(|r| r.id.name_str())
+            .map(|r| r.id.identity_or_empty())
             .collect::<Vec<_>>(),
         original_names
     );
@@ -1638,7 +1647,7 @@ fn test_reconcile_resolves_deferred_create_only_via_state_bindings() {
     assert_eq!(
         resources
             .iter()
-            .map(|resource| resource.id.name_str())
+            .map(|resource| resource.id.identity_or_empty())
             .collect::<Vec<_>>(),
         state_names
     );
@@ -1719,7 +1728,7 @@ fn test_reconcile_skips_state_entry_claimed_by_moved_from() {
     );
     assert!(create_only_renames.is_empty());
     assert_eq!(
-        create_only_resources[0].id.name_str(),
+        create_only_resources[0].id.identity_or_empty(),
         "awscc_ec2_route_aaaaaaaa",
         "claimed moved.from state row must be excluded from create-only full matches"
     );
@@ -1759,7 +1768,7 @@ fn test_reconcile_skips_desired_name_claimed_by_moved_to() {
     );
 
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         desired_name,
         "desired name claimed as moved.to must skip heuristic reconciliation"
     );
@@ -1811,7 +1820,7 @@ fn test_reconcile_deferred_create_only_ambiguous_refuses() {
     );
 
     assert!(renames.is_empty());
-    assert_eq!(resources[0].id.name_str(), original_name);
+    assert_eq!(resources[0].id.identity_or_empty(), original_name);
 }
 
 #[test]
@@ -1852,7 +1861,7 @@ fn test_reconcile_deferred_binding_ambiguous_yields_no_value() {
     );
 
     assert!(renames.is_empty());
-    assert_eq!(resources[0].id.name_str(), original_name);
+    assert_eq!(resources[0].id.identity_or_empty(), original_name);
 }
 
 #[test]
@@ -1884,7 +1893,7 @@ fn test_reconcile_module_argument_passed_root_binding_resolves() {
     );
 
     assert!(renames.is_empty());
-    assert_eq!(resources[0].id.name_str(), state_name);
+    assert_eq!(resources[0].id.identity_or_empty(), state_name);
 }
 
 #[test]
@@ -1916,7 +1925,7 @@ fn test_reconcile_module_intra_module_binding_resolves() {
     );
 
     assert!(renames.is_empty());
-    assert_eq!(resources[0].id.name_str(), state_name);
+    assert_eq!(resources[0].id.identity_or_empty(), state_name);
 }
 
 #[test]
@@ -1948,7 +1957,7 @@ fn test_reconcile_bare_binding_does_not_resolve_module_prefixed_state_entry() {
     );
 
     assert!(renames.is_empty());
-    assert_eq!(resources[0].id.name_str(), desired_name);
+    assert_eq!(resources[0].id.identity_or_empty(), desired_name);
 }
 
 #[test]
@@ -1983,7 +1992,7 @@ fn test_reconcile_simhash_tie_refused() {
     );
 
     assert!(renames.is_empty());
-    assert_eq!(resources[0].id.name_str(), original_name);
+    assert_eq!(resources[0].id.identity_or_empty(), original_name);
 }
 
 #[test]
@@ -2101,7 +2110,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     let mut resources1 = vec![r1];
     compute_anonymous_identifiers_for_test(&mut resources1, &providers, &schemas, &identity_fn)
         .unwrap();
-    let old_id = resources1[0].id.name_str().to_string();
+    let old_id = resources1[0].id.identity_or_empty().to_string();
 
     // Step 2: compute identifier with tag_env="staging" (one attribute changed)
     let mut r2 = Resource::with_provider("awscc", "ec2.eip", "", None);
@@ -2120,7 +2129,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     let mut resources2 = vec![r2];
     compute_anonymous_identifiers_for_test(&mut resources2, &providers, &schemas, &identity_fn)
         .unwrap();
-    let new_id = resources2[0].id.name_str().to_string();
+    let new_id = resources2[0].id.identity_or_empty().to_string();
 
     // Identifiers should differ (different attributes)
     assert_ne!(old_id, new_id);
@@ -2143,7 +2152,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     // resource.id with the state's old name) was changed when the
     // provider prefix was introduced — the rename path is now the
     // only mechanism for legacy state name reuse.
-    assert_eq!(resources2[0].id.name_str(), new_id);
+    assert_eq!(resources2[0].id.identity_or_empty(), new_id);
     assert_eq!(renames, vec![(old_id.clone(), new_id.clone())]);
 }
 
@@ -2160,8 +2169,8 @@ fn test_reconcile_anonymous_id_simhash_does_not_steal_live_entry() {
     ];
     compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .unwrap();
-    let live_name = resources[0].id.name_str().to_string();
-    let new_name = resources[1].id.name_str().to_string();
+    let live_name = resources[0].id.identity_or_empty().to_string();
+    let new_name = resources[1].id.identity_or_empty().to_string();
 
     let state_entries = vec![AnonymousIdStateInfo {
         name: live_name.clone(),
@@ -2174,8 +2183,8 @@ fn test_reconcile_anonymous_id_simhash_does_not_steal_live_entry() {
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(resources[0].id.name_str(), live_name);
-    assert_eq!(resources[1].id.name_str(), new_name);
+    assert_eq!(resources[0].id.identity_or_empty(), live_name);
+    assert_eq!(resources[1].id.identity_or_empty(), new_name);
     assert!(
         renames.is_empty(),
         "SimHash reconcile must not rename a live state row already used by another resource"
@@ -2192,7 +2201,7 @@ fn test_reconcile_anonymous_id_simhash_claims_state_entry_once() {
     let mut old_resources = vec![simhash_eip_resource("production")];
     compute_anonymous_identifiers_for_test(&mut old_resources, &providers, &schemas, &identity_fn)
         .unwrap();
-    let old_name = old_resources[0].id.name_str().to_string();
+    let old_name = old_resources[0].id.identity_or_empty().to_string();
     let old_hash = simhash_suffix_for_test(&old_name);
 
     let mut nearby_resources: Vec<Resource> = Vec::new();
@@ -2208,8 +2217,8 @@ fn test_reconcile_anonymous_id_simhash_claims_state_entry_once() {
         let mut candidate = vec![simhash_eip_resource(tag_env)];
         compute_anonymous_identifiers_for_test(&mut candidate, &providers, &schemas, &identity_fn)
             .unwrap();
-        let candidate_hash = simhash_suffix_for_test(candidate[0].id.name_str());
-        if candidate[0].id.name_str() != old_name
+        let candidate_hash = simhash_suffix_for_test(candidate[0].id.identity_or_empty());
+        if candidate[0].id.identity_or_empty() != old_name
             && old_hash.distance(candidate_hash) < SIMHASH_HAMMING_THRESHOLD
         {
             nearby_resources.push(candidate.remove(0));
@@ -2259,7 +2268,7 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
     );
 
-    let original_id = resource.id.name_str().to_string();
+    let original_id = resource.id.identity_or_empty().to_string();
     let mut resources = vec![resource];
 
     // State has a very different hash (flipped many bits)
@@ -2275,7 +2284,7 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
     );
 
     // Identifier should remain unchanged (too distant)
-    assert_eq!(resources[0].id.name_str(), original_id);
+    assert_eq!(resources[0].id.identity_or_empty(), original_id);
 }
 
 #[test]
@@ -2311,11 +2320,17 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
         .unwrap();
 
     // Should have computed an identifier (not errored)
-    assert!(!resources[0].id.name_str().is_empty());
-    assert!(resources[0].id.name_str().starts_with("awscc_ec2_eip_"));
+    assert!(!resources[0].id.identity_or_empty().is_empty());
+    assert!(
+        resources[0]
+            .id
+            .identity_str()
+            .unwrap_or("")
+            .starts_with("awscc_ec2_eip_")
+    );
 
     // Reconciliation should use Hamming distance (create-only values empty)
-    let current_id = resources[0].id.name_str().to_string();
+    let current_id = resources[0].id.identity_or_empty().to_string();
     let state_id = current_id.clone(); // Same id in state = no reconciliation needed
     let state_entries = vec![AnonymousIdStateInfo {
         name: state_id,
@@ -2329,7 +2344,7 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
     );
 
     // Same identifier in state, no change needed
-    assert_eq!(resources[0].id.name_str(), current_id);
+    assert_eq!(resources[0].id.identity_or_empty(), current_id);
 }
 
 // ==================== SimHash acceptance tests ====================
@@ -2517,7 +2532,11 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
     let mut resources_orig = vec![make_resource("production", "infra")];
     compute_anonymous_identifiers_for_test(&mut resources_orig, &providers, &schemas, &identity_fn)
         .unwrap();
-    let orig_id = resources_orig[0].id.name_str().to_string();
+    let orig_id = resources_orig[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
 
     // Distant: env=dev, team=frontend (2 attrs changed)
     let mut resources_distant = vec![make_resource("development", "frontend")];
@@ -2528,7 +2547,11 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         &identity_fn,
     )
     .unwrap();
-    let distant_id = resources_distant[0].id.name_str().to_string();
+    let distant_id = resources_distant[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
 
     // Current: env=staging, team=infra (1 attr changed from orig)
     let mut resources_current = vec![make_resource("staging", "infra")];
@@ -2552,7 +2575,11 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         },
     ];
 
-    let current_id_before = resources_current[0].id.name_str().to_string();
+    let current_id_before = resources_current[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .to_string();
     let renames = reconcile_anonymous_identifiers(
         &mut resources_current,
         &schemas,
@@ -2564,7 +2591,7 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
     // points from the closest state entry to the new identifier so the wiring
     // layer can re-key the legacy state row.
     assert_eq!(
-        resources_current[0].id.name_str(),
+        resources_current[0].id.identity_or_empty(),
         current_id_before,
         "Resource should retain its freshly-computed identifier",
     );
@@ -2622,7 +2649,7 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
     let mut resources = vec![r];
     compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .unwrap();
-    let id = resources[0].id.name_str().to_string();
+    let id = resources[0].id.identity_or_empty().to_string();
 
     // State has the exact same identifier
     let state_entries = vec![AnonymousIdStateInfo {
@@ -2637,7 +2664,7 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
     );
 
     // Should remain unchanged
-    assert_eq!(resources[0].id.name_str(), id);
+    assert_eq!(resources[0].id.identity_or_empty(), id);
 }
 
 #[test]
@@ -2654,7 +2681,7 @@ fn test_reconcile_no_create_only_empty_state() {
         "domain".to_string(),
         Value::Concrete(ConcreteValue::String("vpc".to_string())),
     );
-    let original_id = resource.id.name_str().to_string();
+    let original_id = resource.id.identity_or_empty().to_string();
     let mut resources = vec![resource];
 
     reconcile_anonymous_identifiers(
@@ -2664,7 +2691,7 @@ fn test_reconcile_no_create_only_empty_state() {
         &|_binding| Vec::new(),
     );
 
-    assert_eq!(resources[0].id.name_str(), original_id);
+    assert_eq!(resources[0].id.identity_or_empty(), original_id);
 }
 
 #[test]
@@ -2712,11 +2739,11 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
     compute_anonymous_identifiers_for_test(&mut r2, &providers, &schemas, &identity_fn).unwrap();
 
     // Different identifiers
-    assert_ne!(r1[0].id.name_str(), r2[0].id.name_str());
+    assert_ne!(r1[0].id.identity_or_empty(), r2[0].id.identity_or_empty());
 
     // But nearby (SimHash locality-sensitive property)
-    let hash1 = simhash_suffix_for_test(r1[0].id.name_str());
-    let hash2 = simhash_suffix_for_test(r2[0].id.name_str());
+    let hash1 = simhash_suffix_for_test(r1[0].id.identity_or_empty());
+    let hash2 = simhash_suffix_for_test(r2[0].id.identity_or_empty());
     let distance = hash1.distance(hash2);
     assert!(
         distance < SIMHASH_HAMMING_THRESHOLD,
@@ -2777,12 +2804,36 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
         .unwrap();
 
     // Both should have identifiers computed
-    assert!(resources[0].id.name_str().starts_with("awscc_ec2_vpc_"));
-    assert!(resources[1].id.name_str().starts_with("awscc_ec2_eip_"));
+    assert!(
+        resources[0]
+            .id
+            .identity_str()
+            .unwrap_or("")
+            .starts_with("awscc_ec2_vpc_")
+    );
+    assert!(
+        resources[1]
+            .id
+            .identity_str()
+            .unwrap_or("")
+            .starts_with("awscc_ec2_eip_")
+    );
 
     // VPC uses standard hash (8 hex chars), EIP uses SimHash (16 hex chars)
-    let vpc_hash_part = resources[0].id.name_str().rsplit('_').next().unwrap();
-    let eip_hash_part = resources[1].id.name_str().rsplit('_').next().unwrap();
+    let vpc_hash_part = resources[0]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .rsplit('_')
+        .next()
+        .unwrap();
+    let eip_hash_part = resources[1]
+        .id
+        .identity_str()
+        .unwrap_or("")
+        .rsplit('_')
+        .next()
+        .unwrap();
     assert_eq!(vpc_hash_part.len(), 8);
     assert_eq!(eip_hash_part.len(), 16);
 }
@@ -2808,7 +2859,7 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
         Value::Concrete(ConcreteValue::String("/new/".to_string())),
     );
 
-    let original_id = resource.id.name_str().to_string();
+    let original_id = resource.id.identity_or_empty().to_string();
     let mut resources = vec![resource];
 
     // State with partial match (role_name matches, path differs)
@@ -2830,8 +2881,8 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
     );
 
     // Should reconcile via partial create-only match (not Hamming distance)
-    assert_eq!(resources[0].id.name_str(), "iam_role_11223344");
-    assert_ne!(resources[0].id.name_str(), original_id);
+    assert_eq!(resources[0].id.identity_or_empty(), "iam_role_11223344");
+    assert_ne!(resources[0].id.identity_or_empty(), original_id);
 }
 
 #[test]
@@ -2875,8 +2926,8 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
 
     // Same prefix should produce the same anonymous identifier
     assert_eq!(
-        r1[0].id.name_str(),
-        r2[0].id.name_str(),
+        r1[0].id.identity_or_empty(),
+        r2[0].id.identity_or_empty(),
         "Prefixed create-only attributes should produce stable identifiers"
     );
 }
@@ -2919,8 +2970,8 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
 
     // Different prefixes should produce different identifiers
     assert_ne!(
-        r1[0].id.name_str(),
-        r2[0].id.name_str(),
+        r1[0].id.identity_or_empty(),
+        r2[0].id.identity_or_empty(),
         "Different prefixes should produce different identifiers"
     );
 }
@@ -2977,7 +3028,7 @@ fn test_reconcile_skips_let_bound_resources() {
 
     // Named resource must keep its original name
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         "ingress_new",
         "let-bound resource should not be reconciled"
     );
@@ -3015,7 +3066,7 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
         Value::Concrete(ConcreteValue::String("Allow gRPC".to_string())),
     );
 
-    let original_id = new_rule.id.name_str().to_string();
+    let original_id = new_rule.id.identity_or_empty().to_string();
     let mut resources = vec![new_rule];
 
     // State has TWO entries that partially match (same cidr_ip + ip_protocol,
@@ -3052,7 +3103,7 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
 
     // With multiple partial matches, reconciliation should be skipped
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         original_id,
         "ambiguous partial matches should not reconcile"
     );
@@ -3121,7 +3172,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     let mut resources1 = vec![r1];
     compute_anonymous_identifiers_for_test(&mut resources1, &providers, &schemas, &identity_fn)
         .unwrap();
-    let step1_id = resources1[0].id.name_str().to_string();
+    let step1_id = resources1[0].id.identity_or_empty().to_string();
 
     // Step 2: Change tag Environment=staging (only tags changed)
     let mut r2 = Resource::with_provider("awscc", "ec2.eip", "", None);
@@ -3146,7 +3197,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     let mut resources2 = vec![r2];
     compute_anonymous_identifiers_for_test(&mut resources2, &providers, &schemas, &identity_fn)
         .unwrap();
-    let step2_id = resources2[0].id.name_str().to_string();
+    let step2_id = resources2[0].id.identity_or_empty().to_string();
 
     // Identifiers should differ (different tag values)
     assert_ne!(step1_id, step2_id);
@@ -3168,7 +3219,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     // entry from step1's name to step2's name. This produces an
     // in-place update on the same state row instead of delete+create.
     assert_eq!(
-        resources2[0].id.name_str(),
+        resources2[0].id.identity_or_empty(),
         step2_id,
         "Resource should retain its freshly-computed identifier"
     );
@@ -3260,12 +3311,12 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
 
     // Names must remain unchanged - no swapping
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         "ingress_http",
         "ingress_http should not be renamed to ingress_https"
     );
     assert_eq!(
-        resources[1].id.name_str(),
+        resources[1].id.identity_or_empty(),
         "ingress_https",
         "ingress_https should not be renamed to ingress_http"
     );
@@ -3311,8 +3362,11 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
     );
 
     assert_eq!(renames.len(), 1);
-    assert_eq!(renames[0].0.name_str(), "sso_instance_0ac0620303071530");
-    assert_eq!(renames[0].1.name_str(), "sso");
+    assert_eq!(
+        renames[0].0.identity_or_empty(),
+        "sso_instance_0ac0620303071530"
+    );
+    assert_eq!(renames[0].1.identity_or_empty(), "sso");
 }
 
 #[test]
@@ -3431,7 +3485,7 @@ fn test_reconcile_skips_state_entry_claimed_by_removed_from() {
     );
 
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         "awscc_ec2_route_aaaaaaaa",
         "effective removed.from state row must be excluded from heuristic matching"
     );
@@ -3596,7 +3650,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     let mut anon_vec = vec![anon];
     compute_anonymous_identifiers_for_test(&mut anon_vec, &providers, &schemas, &identity_fn)
         .unwrap();
-    let anonymous_name = anon_vec[0].id.name_str().to_string();
+    let anonymous_name = anon_vec[0].id.identity_or_empty().to_string();
     assert!(
         anonymous_name.starts_with("awscc_sso_instance_"),
         "expected hash-derived name, got {anonymous_name}"
@@ -3627,8 +3681,8 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     );
 
     assert_eq!(renames.len(), 1, "expected one rename, got {:?}", renames);
-    assert_eq!(renames[0].0.name_str(), anonymous_name);
-    assert_eq!(renames[0].1.name_str(), "sso");
+    assert_eq!(renames[0].0.identity_or_empty(), anonymous_name);
+    assert_eq!(renames[0].1.identity_or_empty(), "sso");
 }
 
 #[test]
@@ -3663,7 +3717,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     let mut anon_vec = vec![anon];
     compute_anonymous_identifiers_for_test(&mut anon_vec, &providers, &schemas, &identity_fn)
         .unwrap();
-    let anonymous_name = anon_vec[0].id.name_str().to_string();
+    let anonymous_name = anon_vec[0].id.identity_or_empty().to_string();
 
     // Let-bound resource with wildly different attributes.
     let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso", None);
@@ -3728,7 +3782,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
     let mut anon_vec = vec![anon];
     compute_anonymous_identifiers_for_test(&mut anon_vec, &providers, &schemas, &identity_fn)
         .unwrap();
-    let exact_name = anon_vec[0].id.name_str().to_string();
+    let exact_name = anon_vec[0].id.identity_or_empty().to_string();
 
     // Construct a "close but not equal" orphan by flipping the last hex
     // char of the SimHash — guarantees a small nonzero Hamming distance
@@ -3770,7 +3824,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
 
     assert_eq!(renames.len(), 1);
     assert_eq!(
-        renames[0].0.name_str(),
+        renames[0].0.identity_or_empty(),
         exact_name,
         "should prefer the exact SimHash match over the nearby one"
     );
@@ -3830,7 +3884,7 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
     let mut anon_vec = vec![anon];
     compute_anonymous_identifiers_for_test(&mut anon_vec, &providers, &schemas, &identity_fn)
         .unwrap();
-    let anonymous_name = anon_vec[0].id.name_str().to_string();
+    let anonymous_name = anon_vec[0].id.identity_or_empty().to_string();
 
     // Two state entries with the exact same name hash → same distance (0).
     let state_entries = vec![
@@ -3894,7 +3948,7 @@ fn anonymous_identifier_includes_provider_prefix() {
     compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .unwrap();
 
-    let name = resources[0].id.name_str();
+    let name = resources[0].id.identity_or_empty();
     assert!(
         name.starts_with("awscc_"),
         "identifier should begin with the provider prefix, got: {name}"
@@ -3933,9 +3987,13 @@ fn anonymous_identifier_provider_prefix_for_aws_provider() {
     compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .unwrap();
     assert!(
-        resources[0].id.name_str().starts_with("aws_s3_bucket_"),
+        resources[0]
+            .id
+            .identity_str()
+            .unwrap_or("")
+            .starts_with("aws_s3_bucket_"),
         "identifier should begin with `aws_s3_bucket_`, got: {}",
-        resources[0].id.name_str()
+        resources[0].id.identity_or_empty()
     );
 }
 
@@ -3969,7 +4027,7 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
     let mut resources = vec![r];
     compute_anonymous_identifiers_for_test(&mut resources, &providers, &schemas, &identity_fn)
         .unwrap();
-    let new_name = resources[0].id.name_str().to_string();
+    let new_name = resources[0].id.identity_or_empty().to_string();
     assert!(new_name.starts_with("awscc_iam_role_policy_"));
 
     // Strip the provider prefix to simulate a state entry written under the
@@ -3991,7 +4049,7 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
     );
 
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         new_name,
         "resource id should retain the new-format identifier",
     );

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -373,7 +373,7 @@ impl RootConfigSignature {
             let binding_name = resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name_str().to_string());
+                .unwrap_or_else(|| resource.id.identity_or_empty().to_string());
 
             let resource_type_str = resource
                 .attributes
@@ -417,7 +417,7 @@ impl RootConfigSignature {
             let binding_name = resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name_str().to_string());
+                .unwrap_or_else(|| resource.id.identity_or_empty().to_string());
 
             for (attr_key, value) in &resource.attributes {
                 if attr_key.starts_with('_') {
@@ -848,7 +848,7 @@ impl ModuleSignature {
             let binding_name = resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name_str().to_string());
+                .unwrap_or_else(|| resource.id.identity_or_empty().to_string());
 
             let resource_type_str = resource
                 .attributes
@@ -881,7 +881,7 @@ impl ModuleSignature {
             let binding_name = resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name_str().to_string());
+                .unwrap_or_else(|| resource.id.identity_or_empty().to_string());
 
             for (attr_key, value) in &resource.attributes {
                 if attr_key.starts_with('_') {

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -10,7 +10,7 @@ use crate::parser::{
     ArgumentParameter, BindingName, DeferredForExpression, ModuleCall, ParsedFile, WaitBinding,
 };
 use crate::resource::{
-    Composition, ConcreteValue, DataSource, DeferredValue, Resource, ResourceId, ResourceName,
+    Composition, ConcreteValue, DataSource, DeferredValue, Resource, ResourceId, ResourceIdentity,
     Value,
 };
 
@@ -304,7 +304,7 @@ impl ModuleResolver<'_> {
             }
 
             let composition = Composition {
-                id: ResourceId::new("_virtual", binding_name),
+                id: ResourceId::with_identity("_virtual", binding_name),
                 signature: crate::resource::Signature {
                     arguments: signature_arguments,
                     attributes: composition_attrs,
@@ -441,7 +441,7 @@ pub(crate) fn build_expansion_trace(
     leaf_resources: &[Resource],
     leaf_data_sources: &[DataSource],
 ) -> crate::resource::ExpansionTrace {
-    let id = crate::resource::EphemeralId::new(crate::resource::ResourceId::new(
+    let id = crate::resource::EphemeralId::new(crate::resource::ResourceId::with_identity(
         "_virtual",
         instance_prefix,
     ));
@@ -585,12 +585,14 @@ fn prefix_module_resource(
 ) -> Resource {
     let mut new_resource = resource.clone();
 
-    // Only Bound names take the prefix here. Pending names stay
-    // Pending so `compute_anonymous_identifiers` can later attach both
+    // Only assigned identities take the prefix here. Anonymous resources
+    // stay `None` so `compute_anonymous_identifiers` can later attach both
     // the hash and the instance prefix in one shot (#2516).
-    if let ResourceName::Bound(name) = &new_resource.id.name {
-        let new_name = apply_instance_prefix(instance_prefix, name);
-        new_resource.id.set_name(new_name);
+    if let Some(identity) = &new_resource.id.identity {
+        let new_name = apply_instance_prefix(instance_prefix, identity.as_str());
+        new_resource
+            .id
+            .set_identity(ResourceIdentity::new(new_name));
     }
 
     if let Some(ref binding) = new_resource.binding {
@@ -623,7 +625,7 @@ fn prefix_module_resource(
 
 /// Instance-prefix one module data source — the [`DataSource`] analogue
 /// of [`prefix_module_resource`]. A `DataSource` carries no `prefixes`
-/// field, so only its `Bound` id name, `binding`, `module_source`, and
+/// field, so only its assigned identity, `binding`, `module_source`, and
 /// attributes take the module-boundary treatment.
 fn prefix_module_data_source(
     data_source: &DataSource,
@@ -634,9 +636,11 @@ fn prefix_module_data_source(
 ) -> DataSource {
     let mut new_data_source = data_source.clone();
 
-    if let ResourceName::Bound(name) = &new_data_source.id.name {
-        let new_name = apply_instance_prefix(instance_prefix, name);
-        new_data_source.id.set_name(new_name);
+    if let Some(identity) = &new_data_source.id.identity {
+        let new_name = apply_instance_prefix(instance_prefix, identity.as_str());
+        new_data_source
+            .id
+            .set_identity(ResourceIdentity::new(new_name));
     }
 
     if let Some(ref binding) = new_data_source.binding {
@@ -670,7 +674,7 @@ fn prefix_module_data_source(
 /// `Composition` carries no `module_source` (it has the flattened
 /// `module_name` / `instance` fields, left unchanged as the synthetic
 /// node's own provenance) and no `prefixes` / `directives`, so only its
-/// `Bound` id name, `binding`, and attributes take the prefix treatment.
+/// assigned identity, `binding`, and attributes take the prefix treatment.
 fn prefix_module_composition(
     composition: &Composition,
     instance_prefix: &str,
@@ -679,9 +683,9 @@ fn prefix_module_composition(
 ) -> Composition {
     let mut new_virtual = composition.clone();
 
-    if let ResourceName::Bound(name) = &new_virtual.id.name {
-        let new_name = apply_instance_prefix(instance_prefix, name);
-        new_virtual.id.set_name(new_name);
+    if let Some(identity) = &new_virtual.id.identity {
+        let new_name = apply_instance_prefix(instance_prefix, identity.as_str());
+        new_virtual.id.set_identity(ResourceIdentity::new(new_name));
     }
 
     if let Some(ref binding) = new_virtual.binding {
@@ -1029,7 +1033,7 @@ pub fn reconcile_anonymous_module_instances(
     // expanded DSL — we'll query state for matching entries.
     let mut touched_types: HashSet<(String, String)> = HashSet::new();
     for r in resources.iter() {
-        if split_instance_prefix(r.id.name_str()).is_none() {
+        if split_instance_prefix(r.id.identity_or_empty()).is_none() {
             continue;
         }
         touched_types.insert((r.id.provider.clone(), r.id.resource_type.clone()));
@@ -1045,7 +1049,7 @@ pub fn reconcile_anonymous_module_instances(
     let mut current_synthetic_by_module: HashMap<String, HashSet<SimHash>> = HashMap::new();
     let mut claimed_current_by_module: HashMap<String, HashSet<SimHash>> = HashMap::new();
     for r in resources.iter() {
-        let Some((prefix, _)) = split_instance_prefix(r.id.name_str()) else {
+        let Some((prefix, _)) = split_instance_prefix(r.id.identity_or_empty()) else {
             continue;
         };
         let Some((module, simhash)) = parse_synthetic_instance_prefix(prefix) else {
@@ -1055,7 +1059,11 @@ pub fn reconcile_anonymous_module_instances(
             .entry(module.to_string())
             .or_default()
             .insert(simhash);
-        if claims.claims_to(&r.id.provider, &r.id.resource_type, r.id.name_str()) {
+        if claims.claims_to(
+            &r.id.provider,
+            &r.id.resource_type,
+            r.id.identity_or_empty(),
+        ) {
             claimed_current_by_module
                 .entry(module.to_string())
                 .or_default()
@@ -1140,10 +1148,10 @@ pub fn reconcile_anonymous_module_instances(
         return;
     }
 
-    // Apply remaps: rewrite `id.name` and `binding` for every resource whose
+    // Apply remaps: rewrite identity and `binding` for every resource whose
     // instance prefix is in the remap table.
     for r in resources.iter_mut() {
-        let Some((prefix, rest)) = split_instance_prefix(r.id.name_str()) else {
+        let Some((prefix, rest)) = split_instance_prefix(r.id.identity_or_empty()) else {
             continue;
         };
         let Some((module, simhash)) = parse_synthetic_instance_prefix(prefix) else {
@@ -1152,7 +1160,7 @@ pub fn reconcile_anonymous_module_instances(
         if let Some(&target) = prefix_remap.get(&(module.to_string(), simhash)) {
             let new_prefix = format!("{}_{:016x}", module, target);
             let new_name = format!("{}.{}", new_prefix, rest);
-            r.id.set_name(new_name);
+            r.id.set_identity(ResourceIdentity::new(new_name));
             if let Some(ref binding) = r.binding
                 && let Some((_, binding_rest)) = split_instance_prefix(binding)
             {

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -33,7 +33,7 @@ fn create_test_module() -> ParsedFile {
         data_sources: vec![],
         compositions: vec![],
         resources: vec![Resource {
-            id: ResourceId::new("security_group", "sg"),
+            id: ResourceId::with_identity("security_group", "sg"),
             attributes: {
                 let mut attrs = HashMap::new();
                 attrs.insert(
@@ -143,7 +143,7 @@ fn test_substitute_arguments_nested() {
 /// no `let` binding). Used to verify that expansion preserves
 /// `Pending` rather than collapsing it to `Bound("<instance>.")` —
 /// a `Bound` value with a trailing dot would slip past
-/// `compute_anonymous_identifiers`'s `is_pending` filter and never
+/// `compute_anonymous_identifiers`'s absent-identity filter and never
 /// receive its hash-derived suffix (#2516).
 fn create_test_module_with_anonymous_resource() -> ParsedFile {
     ParsedFile {
@@ -151,7 +151,7 @@ fn create_test_module_with_anonymous_resource() -> ParsedFile {
         data_sources: vec![],
         compositions: vec![],
         resources: vec![Resource {
-            id: ResourceId::with_provider("awscc", "iam.RolePolicy", "", None),
+            id: ResourceId::with_provider("awscc", "iam.RolePolicy", None, None),
             attributes: {
                 let mut attrs = IndexMap::new();
                 attrs.insert(
@@ -187,9 +187,7 @@ fn create_test_module_with_anonymous_resource() -> ParsedFile {
 }
 
 #[test]
-fn test_expand_anonymous_resource_in_named_module_keeps_name_pending() {
-    use crate::resource::ResourceName;
-
+fn test_expand_anonymous_resource_in_named_module_keeps_identity_absent() {
     let resolver = {
         let mut r = ModuleResolver::new(".");
         r.imported_modules.insert(
@@ -211,11 +209,11 @@ fn test_expand_anonymous_resource_in_named_module_keeps_name_pending() {
     assert_eq!(expanded.len(), 1);
     let policy = &expanded[0];
     assert!(
-        matches!(policy.id.name, ResourceName::Pending),
-        "anonymous resource inside a module instance must remain Pending after expansion \
-         (compute_anonymous_identifiers filters on Pending and would skip a Bound value); \
+        policy.id.identity.is_none(),
+        "anonymous resource inside a module instance must keep identity absent after expansion \
+         (compute_anonymous_identifiers filters on absent identity and would skip an assigned value); \
          got {:?}",
-        policy.id.name,
+        policy.id.identity,
     );
     assert_eq!(
         policy.module_source,
@@ -257,7 +255,7 @@ fn test_expand_module_call() {
     assert_eq!(expanded.len(), 1);
 
     let sg = &expanded[0];
-    assert_eq!(sg.id.name_str(), "my_instance.sg");
+    assert_eq!(sg.id.identity_or_empty(), "my_instance.sg");
     assert_eq!(
         sg.get_attr("vpc_id"),
         Some(&Value::Concrete(ConcreteValue::String(
@@ -294,7 +292,12 @@ fn create_module_with_named_provider_instance() -> ParsedFile {
         data_sources: vec![],
         compositions: vec![],
         resources: vec![Resource {
-            id: ResourceId::with_provider("aws", "acm.Certificate", "cert", Some("us".to_string())),
+            id: ResourceId::with_provider_identity(
+                "aws",
+                "acm.Certificate",
+                "cert",
+                Some("us".to_string()),
+            ),
             attributes: {
                 let mut attrs = IndexMap::new();
                 attrs.insert(
@@ -387,7 +390,7 @@ fn test_reconcile_anonymous_module_instances_preserves_provider_instance() {
     let state_name = format!("thing_{:016x}.role", state_hash);
 
     let mut resources = vec![Resource {
-        id: ResourceId::with_provider(
+        id: ResourceId::with_provider_identity(
             "aws",
             "iam.Role",
             format!("{}.role", current_prefix),
@@ -419,7 +422,7 @@ fn test_reconcile_anonymous_module_instances_preserves_provider_instance() {
     reconcile_anonymous_module_instances(&mut resources, &state_lookup);
 
     assert_eq!(
-        resources[0].id.name_str(),
+        resources[0].id.identity_or_empty(),
         state_name,
         "precondition: remap must actually have rewritten the name",
     );
@@ -440,7 +443,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
         compositions: vec![],
         resources: vec![
             Resource {
-                id: ResourceId::new("ec2.Vpc", "main_vpc"),
+                id: ResourceId::with_identity("ec2.Vpc", "main_vpc"),
                 attributes: {
                     let mut attrs = HashMap::new();
                     attrs.insert(
@@ -459,7 +462,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
                 quoted_string_attrs: std::collections::HashSet::new(),
             },
             Resource {
-                id: ResourceId::new("ec2.Subnet", "sub"),
+                id: ResourceId::with_identity("ec2.Subnet", "sub"),
                 attributes: {
                     let mut attrs = HashMap::new();
                     attrs.insert(
@@ -587,8 +590,8 @@ fn test_multiple_module_instances_no_collision() {
     );
 
     // Resource names should also be distinct (dot notation)
-    assert_eq!(expanded_a[0].id.name_str(), "prod.main_vpc");
-    assert_eq!(expanded_b[0].id.name_str(), "staging.main_vpc");
+    assert_eq!(expanded_a[0].id.identity_or_empty(), "prod.main_vpc");
+    assert_eq!(expanded_b[0].id.identity_or_empty(), "staging.main_vpc");
 }
 
 /// Module with an attributes block that exposes a security_group binding.
@@ -600,7 +603,7 @@ fn create_module_with_attributes() -> ParsedFile {
         data_sources: vec![],
         compositions: vec![],
         resources: vec![Resource {
-            id: ResourceId::new("security_group", "sg"),
+            id: ResourceId::with_identity("security_group", "sg"),
             attributes: {
                 let mut attrs = HashMap::new();
                 attrs.insert(
@@ -766,8 +769,9 @@ fn test_expand_module_call_populates_expansion_trace_single_level() {
 
     // The chain element points at this call site's instance prefix
     // (`_virtual.<instance_prefix>`).
-    let expected_call_site =
-        crate::resource::EphemeralId::new(crate::resource::ResourceId::new("_virtual", "web"));
+    let expected_call_site = crate::resource::EphemeralId::new(
+        crate::resource::ResourceId::with_identity("_virtual", "web"),
+    );
     assert_eq!(chain[0].id, expected_call_site);
 }
 
@@ -850,9 +854,12 @@ fn test_build_expansion_trace_prepends_outer_call_site_to_inner_chain() {
     // Simulate an inner module that already finished its own
     // expansion: one leaf nested one level deep (inner_call_site).
     let mut inner_trace = ExpansionTrace::new();
-    let inner_leaf = PersistentId::new(ResourceId::new("aws.s3.Bucket", "outer.inner.logs"));
+    let inner_leaf = PersistentId::new(ResourceId::with_identity(
+        "aws.s3.Bucket",
+        "outer.inner.logs",
+    ));
     let inner_call_site = CallSite::new(
-        EphemeralId::new(ResourceId::new("_virtual", "outer.inner")),
+        EphemeralId::new(ResourceId::with_identity("_virtual", "outer.inner")),
         "./modules/inner",
     );
     inner_trace.record(inner_leaf.clone(), vec![inner_call_site.clone()]);
@@ -875,7 +882,7 @@ fn test_build_expansion_trace_prepends_outer_call_site_to_inner_chain() {
         2,
         "two-level expansion must produce a two-element chain, got {chain:?}",
     );
-    let expected_outer = EphemeralId::new(ResourceId::new("_virtual", "outer"));
+    let expected_outer = EphemeralId::new(ResourceId::with_identity("_virtual", "outer"));
     assert_eq!(
         chain[0].id, expected_outer,
         "outermost element must be the outer call site",
@@ -1179,7 +1186,7 @@ thing { name = 'beta'  }
         .resources
         .iter()
         .filter(|r| r.id.resource_type == "iam.Role")
-        .map(|r| r.id.name_str().to_string())
+        .map(|r| r.id.identity_or_empty().to_string())
         .collect();
     assert_eq!(role_addresses.len(), 2, "got {:?}", role_addresses);
 
@@ -1212,7 +1219,7 @@ thing              { name = 'anon-call'  }
     let addrs: Vec<&str> = parsed
         .resources
         .iter()
-        .map(|r| r.id.name.as_str())
+        .map(|r| r.id.identity_or_empty())
         .collect();
     assert!(addrs.iter().any(|n| n.starts_with("named.")), "{:?}", addrs);
     assert!(addrs.iter().any(|n| n.starts_with("thing_")), "{:?}", addrs);
@@ -1235,7 +1242,7 @@ thing { name = 'after-edit' }
         .resources
         .iter()
         .filter(|r| r.id.resource_type == "iam.Role")
-        .map(|r| r.id.name_str().to_string())
+        .map(|r| r.id.identity_or_empty().to_string())
         .collect();
     assert_eq!(before.len(), 1);
     let (new_prefix, _) = before[0].split_once('.').unwrap();
@@ -1254,7 +1261,7 @@ thing { name = 'after-edit' }
         .resources
         .iter()
         .filter(|r| r.id.resource_type == "iam.Role")
-        .map(|r| r.id.name_str().to_string())
+        .map(|r| r.id.identity_or_empty().to_string())
         .collect();
     assert_eq!(
         after,
@@ -1288,7 +1295,8 @@ thing { name = 'after-edit' }
         .find(|r| r.id.resource_type == "iam.Role")
         .unwrap()
         .id
-        .name_str()
+        .identity_str()
+        .unwrap_or("")
         .to_string();
     let (current_prefix, _) = before_name.split_once('.').unwrap();
     let (_, current_hash) = parse_synthetic_instance_prefix(current_prefix).unwrap();
@@ -1318,7 +1326,8 @@ thing { name = 'after-edit' }
             .find(|r| r.id.resource_type == "iam.Role")
             .unwrap()
             .id
-            .name_str(),
+            .identity_str()
+            .unwrap_or(""),
         before_name,
         "a claimed state child must exclude the whole state prefix from orphan candidates",
     );
@@ -1336,7 +1345,8 @@ thing { name = 'after-edit' }
         .find(|r| r.id.resource_type == "iam.Role")
         .unwrap()
         .id
-        .name_str()
+        .identity_str()
+        .unwrap_or("")
         .to_string();
     let (current_prefix, _) = before_name.split_once('.').unwrap();
     let (_, current_hash) = parse_synthetic_instance_prefix(current_prefix).unwrap();
@@ -1366,7 +1376,8 @@ thing { name = 'after-edit' }
             .find(|r| r.id.resource_type == "iam.Role")
             .unwrap()
             .id
-            .name_str(),
+            .identity_str()
+            .unwrap_or(""),
         before_name,
         "a claimed desired child must pin the whole current prefix",
     );
@@ -1390,7 +1401,8 @@ thing { name = 'a' }
         .find(|r| r.id.resource_type == "iam.Role")
         .unwrap()
         .id
-        .name_str()
+        .identity_str()
+        .unwrap_or("")
         .to_string();
 
     // State entry uses a different module name.
@@ -1403,7 +1415,8 @@ thing { name = 'a' }
         .find(|r| r.id.resource_type == "iam.Role")
         .unwrap()
         .id
-        .name_str()
+        .identity_str()
+        .unwrap_or("")
         .to_string();
     assert_eq!(before_name, after_name);
 }
@@ -1462,7 +1475,8 @@ thing { name = 'after-edit' }
         .find(|r| r.id.resource_type == "iam.Role")
         .unwrap()
         .id
-        .name_str()
+        .identity_str()
+        .unwrap_or("")
         .to_string();
     let (new_prefix, _) = role_name_before.split_once('.').unwrap();
     let (_, new_hash) = parse_synthetic_instance_prefix(new_prefix).unwrap();
@@ -1484,7 +1498,7 @@ thing { name = 'after-edit' }
         .find(|r| r.id.resource_type == "iam.Role")
         .unwrap();
     assert_eq!(
-        role_after.id.name_str(),
+        role_after.id.identity_or_empty(),
         format!("thing_{:016x}.role", state_hash),
         "Role address must be remapped to the state prefix",
     );
@@ -1494,7 +1508,7 @@ thing { name = 'after-edit' }
         .find(|r| r.id.resource_type == "iam.OidcProvider")
         .unwrap();
     assert_eq!(
-        provider_after.id.name_str(),
+        provider_after.id.identity_or_empty(),
         format!("thing_{:016x}.provider_res", state_hash),
         "OidcProvider address must be remapped to the state prefix",
     );
@@ -1519,7 +1533,8 @@ thing { name = 'a' }
         .find(|r| r.id.resource_type == "iam.Role")
         .unwrap()
         .id
-        .name_str()
+        .identity_str()
+        .unwrap_or("")
         .to_string();
     let (prefix, _) = before_name.split_once('.').unwrap();
     let (_, cur_hash) = parse_synthetic_instance_prefix(prefix).unwrap();
@@ -1545,7 +1560,8 @@ thing { name = 'a' }
         .find(|r| r.id.resource_type == "iam.Role")
         .unwrap()
         .id
-        .name_str()
+        .identity_str()
+        .unwrap_or("")
         .to_string();
     assert_eq!(before_name, after_name, "ambiguous match must not remap");
 }
@@ -1570,7 +1586,14 @@ thing { name = 'unchanged-but-different' }
         .resources
         .iter()
         .filter(|r| r.id.resource_type == "iam.Role")
-        .map(|r| r.id.name_str().split_once('.').unwrap().0.to_string())
+        .map(|r| {
+            r.id.identity_str()
+                .unwrap_or("")
+                .split_once('.')
+                .unwrap()
+                .0
+                .to_string()
+        })
         .collect();
     assert_eq!(prefixes_before.len(), 2);
     let mut iter = prefixes_before.iter();
@@ -1587,7 +1610,14 @@ thing { name = 'unchanged-but-different' }
         .resources
         .iter()
         .filter(|r| r.id.resource_type == "iam.Role")
-        .map(|r| r.id.name_str().split_once('.').unwrap().0.to_string())
+        .map(|r| {
+            r.id.identity_str()
+                .unwrap_or("")
+                .split_once('.')
+                .unwrap()
+                .0
+                .to_string()
+        })
         .collect();
     assert_eq!(
         prefixes_after, prefixes_before,
@@ -1644,7 +1674,7 @@ fn test_expand_module_call_uses_dot_path_addressing() {
 
     let sg = &expanded[0];
     // Resource name should use dot notation, not underscore
-    assert_eq!(sg.id.name_str(), "my_instance.sg");
+    assert_eq!(sg.id.identity_or_empty(), "my_instance.sg");
 }
 
 #[test]
@@ -1675,8 +1705,8 @@ fn test_module_dot_path_bindings_and_refs() {
         .resources;
 
     // Resource names should use dot notation
-    assert_eq!(expanded[0].id.name_str(), "prod.main_vpc");
-    assert_eq!(expanded[1].id.name_str(), "prod.sub");
+    assert_eq!(expanded[0].id.identity_or_empty(), "prod.main_vpc");
+    assert_eq!(expanded[1].id.identity_or_empty(), "prod.sub");
 
     // binding should use dot notation
     assert_eq!(expanded[0].binding, Some("prod.vpc".to_string()));
@@ -1706,7 +1736,7 @@ fn test_expand_module_call_propagates_and_prefixes_wait_bindings() {
         // A resource that consumes the wait binding the same way the
         // real CloudFront Distribution consumes `cert_issued`.
         m.resources.push(Resource {
-            id: ResourceId::new("cloudfront.Distribution", "distribution"),
+            id: ResourceId::with_identity("cloudfront.Distribution", "distribution"),
             attributes: {
                 let mut attrs = HashMap::new();
                 attrs.insert(
@@ -1946,7 +1976,7 @@ fn create_module_with_interpolation() -> ParsedFile {
         data_sources: vec![],
         compositions: vec![],
         resources: vec![Resource {
-            id: ResourceId::new("ec2.Vpc", "vpc"),
+            id: ResourceId::with_identity("ec2.Vpc", "vpc"),
             attributes: {
                 let mut attrs = HashMap::new();
                 attrs.insert(
@@ -4498,7 +4528,7 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
         // `rewrite_intra_module_refs`). Add it so this unit faithfully
         // models the real `let cert = aws.acm.Certificate { … }` case.
         m.resources.push(Resource {
-            id: ResourceId::new("acm.Certificate", "cert"),
+            id: ResourceId::with_identity("acm.Certificate", "cert"),
             attributes: HashMap::new().into_iter().collect(),
             directives: Directives::default(),
             prefixes: HashMap::new(),
@@ -4518,7 +4548,7 @@ fn test_expand_module_call_propagates_deferred_for_expressions() {
             iterable_attr: "domain_validation_options".to_string(),
             binding: ForBinding::Map("_".to_string(), "opt".to_string()),
             template_resource: Resource {
-                id: ResourceId::new("route53.RecordSet", "placeholder"),
+                id: ResourceId::with_identity("route53.RecordSet", "placeholder"),
                 attributes: {
                     // The loop body references the module-internal
                     // `cert` binding — the part of the template
@@ -4658,7 +4688,7 @@ fn deferred_for_iterable_binding_not_prefixed_when_not_module_internal() {
             iterable_attr: "list".to_string(),
             binding: ForBinding::Map("_".to_string(), "a".to_string()),
             template_resource: Resource {
-                id: ResourceId::new("sso.Assignment", "placeholder"),
+                id: ResourceId::with_identity("sso.Assignment", "placeholder"),
                 attributes: HashMap::new().into_iter().collect(),
                 directives: Directives::default(),
                 prefixes: HashMap::new(),

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -9,7 +9,7 @@ use super::util::snake_to_pascal;
 use crate::binding_index::IterableBindings;
 use crate::resource::{
     Composition, ConcreteValue, DataSource, DeferredValue, Directives, GraphNode, LeafNode,
-    Resource, ResourceId, UnknownReason, Value,
+    Resource, ResourceId, ResourceIdentity, UnknownReason, Value,
 };
 use crate::version_constraint::VersionConstraint;
 use indexmap::IndexMap;
@@ -575,7 +575,7 @@ impl ExportParamLike for ParsedExportParam {
 /// use carina_core::resource::ResourceId;
 ///
 /// let addr = StateBlockAddress::new("aws", "route53.RecordSet", "r");
-/// let routed = ResourceId::with_provider(
+/// let routed = ResourceId::with_provider_identity(
 ///     "aws",
 ///     "route53.RecordSet",
 ///     "r",
@@ -592,7 +592,7 @@ impl ExportParamLike for ParsedExportParam {
 pub struct StateBlockAddress {
     pub provider: String,
     pub resource_type: String,
-    pub name: crate::resource::ResourceName,
+    pub name: crate::resource::ResourceIdentity,
 }
 
 impl StateBlockAddress {
@@ -615,7 +615,7 @@ impl StateBlockAddress {
         Self {
             provider: provider.into(),
             resource_type: resource_type.into(),
-            name: crate::resource::ResourceName::from_string(canonical),
+            name: crate::resource::ResourceIdentity::new(canonical),
         }
     }
 
@@ -649,7 +649,7 @@ impl StateBlockAddress {
     /// method as a shortcut. Doing so re-introduces the carina#3324
     /// bug class.
     pub fn to_unrouted_resource_id(&self) -> crate::resource::ResourceId {
-        crate::resource::ResourceId::with_provider(
+        crate::resource::ResourceId::with_provider_identity(
             &self.provider,
             &self.resource_type,
             self.name_str(),
@@ -1567,7 +1567,9 @@ fn build_expanded_child(
     item: &Value,
 ) -> Resource {
     let mut resource = deferred.template_resource.clone();
-    resource.id.set_name(address.clone());
+    resource
+        .id
+        .set_identity(ResourceIdentity::new(address.clone()));
     resource.binding = Some(address);
     resource
         .dependency_bindings
@@ -1698,7 +1700,7 @@ mod substitute_placeholder_tests {
         parsed.data_sources.push(data_source);
 
         parsed.compositions.push(Composition {
-            id: ResourceId::new("_virtual", "composition_node"),
+            id: ResourceId::with_identity("_virtual", "composition_node"),
             signature: Signature {
                 arguments: IndexMap::new(),
                 attributes: IndexMap::new(),

--- a/carina-core/src/parser/blocks/resource.rs
+++ b/carina-core/src/parser/blocks/resource.rs
@@ -39,10 +39,6 @@ pub(in crate::parser) fn parse_anonymous_resource(
     let attributes = parse_block_contents_with_quoted(iter, ctx, &mut quoted_out)?;
     let quoted_string_attrs = quoted_out.unwrap_or_default();
 
-    // Anonymous resources get an empty name that will be replaced by a hash-based
-    // identifier computed from create-only properties after parsing.
-    let resource_name = String::new();
-
     let mut attributes = attributes;
     attributes.insert(
         "_type".to_string(),
@@ -55,7 +51,7 @@ pub(in crate::parser) fn parse_anonymous_resource(
     let id = ResourceId::with_provider(
         provider,
         resource_type,
-        resource_name,
+        None,
         directives.provider_instance.clone(),
     );
 
@@ -223,7 +219,7 @@ pub(crate) fn parse_resource_expr(
         Value::Concrete(ConcreteValue::String(namespaced_type.clone())),
     );
 
-    let id = ResourceId::with_provider(
+    let id = ResourceId::with_provider_identity(
         provider,
         resource_type,
         resource_name,
@@ -279,7 +275,7 @@ pub(crate) fn parse_read_resource_expr(
         Value::Concrete(ConcreteValue::String(namespaced_type.clone())),
     );
 
-    let id = ResourceId::with_provider(
+    let id = ResourceId::with_provider_identity(
         provider,
         resource_type,
         resource_name,

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -175,7 +175,7 @@ fn parse_resource_with_namespaced_type() {
 
     let resource = &result.resources[0];
     assert_eq!(resource.id.resource_type, "s3_bucket");
-    assert_eq!(resource.id.name_str(), "my_bucket"); // binding name becomes the resource ID
+    assert_eq!(resource.id.identity_or_empty(), "my_bucket"); // binding name becomes the resource ID
     assert_eq!(
         resource.get_attr("name"),
         Some(&Value::Concrete(ConcreteValue::String(
@@ -204,8 +204,8 @@ fn parse_multiple_resources() {
 
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(result.resources.len(), 2);
-    assert_eq!(result.resources[0].id.name_str(), "logs"); // binding name becomes the resource ID
-    assert_eq!(result.resources[1].id.name_str(), "data");
+    assert_eq!(result.resources[0].id.identity_or_empty(), "logs"); // binding name becomes the resource ID
+    assert_eq!(result.resources[1].id.identity_or_empty(), "data");
 }
 
 #[test]
@@ -319,7 +319,7 @@ fn parse_anonymous_resource() {
 
     let resource = &result.resources[0];
     assert_eq!(resource.id.resource_type, "s3_bucket");
-    assert_eq!(resource.id.name_str(), ""); // anonymous resources get empty name (computed later)
+    assert_eq!(resource.id.identity_or_empty(), ""); // anonymous resources get empty name (computed later)
 }
 
 #[test]
@@ -338,8 +338,8 @@ fn parse_mixed_resources() {
 
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(result.resources.len(), 2);
-    assert_eq!(result.resources[0].id.name_str(), ""); // anonymous gets empty name
-    assert_eq!(result.resources[1].id.name_str(), "named"); // binding name becomes the resource ID
+    assert_eq!(result.resources[0].id.identity_or_empty(), ""); // anonymous gets empty name
+    assert_eq!(result.resources[1].id.identity_or_empty(), "named"); // binding name becomes the resource ID
 }
 
 #[test]
@@ -353,7 +353,7 @@ fn parse_anonymous_resource_without_name_succeeds() {
     let result = parse(input, &ProviderContext::default());
     assert!(result.is_ok());
     let parsed = result.unwrap();
-    assert_eq!(parsed.resources[0].id.name_str(), ""); // empty name, computed later
+    assert_eq!(parsed.resources[0].id.identity_or_empty(), ""); // empty name, computed later
 }
 
 #[test]
@@ -1318,7 +1318,7 @@ fn parse_read_resource_expr() {
 
     let data_source = &result.data_sources[0];
     assert_eq!(data_source.id.resource_type, "s3_bucket");
-    assert_eq!(data_source.id.name_str(), "existing"); // binding name becomes the resource ID
+    assert_eq!(data_source.id.identity_or_empty(), "existing"); // binding name becomes the resource ID
 }
 
 #[test]
@@ -1352,7 +1352,7 @@ fn parse_read_resource_without_name_uses_binding() {
     assert!(result.is_ok());
     let parsed = result.unwrap();
     // carina#3181 PR C: `read` resources live in the `data_sources` slice.
-    assert_eq!(parsed.data_sources[0].id.name_str(), "existing"); // binding name
+    assert_eq!(parsed.data_sources[0].id.identity_or_empty(), "existing"); // binding name
 }
 
 #[test]
@@ -1374,10 +1374,13 @@ fn parse_read_with_regular_resources() {
     // carina#3181 PR C: the data source and the managed resource land
     // in separate typed slices.
     assert_eq!(result.data_sources.len(), 1);
-    assert_eq!(result.data_sources[0].id.name_str(), "existing_bucket"); // binding name
+    assert_eq!(
+        result.data_sources[0].id.identity_or_empty(),
+        "existing_bucket"
+    ); // binding name
 
     assert_eq!(result.resources.len(), 1);
-    assert_eq!(result.resources[0].id.name_str(), "new_bucket"); // binding name
+    assert_eq!(result.resources[0].id.identity_or_empty(), "new_bucket"); // binding name
 }
 
 #[test]
@@ -1446,7 +1449,7 @@ fn anonymous_resource_no_spurious_name_attribute() {
     assert_eq!(result.resources.len(), 1);
 
     let resource = &result.resources[0];
-    assert_eq!(resource.id.name_str(), ""); // anonymous → empty name
+    assert_eq!(resource.id.identity_or_empty(), ""); // anonymous → empty name
     // "name" must NOT appear in attributes unless the user explicitly wrote it
     assert!(
         !resource.attributes.contains_key("name"),
@@ -1469,7 +1472,7 @@ fn let_bound_resource_no_spurious_name_attribute() {
     assert_eq!(result.resources.len(), 1);
 
     let resource = &result.resources[0];
-    assert_eq!(resource.id.name_str(), "vpc"); // binding name → resource name
+    assert_eq!(resource.id.identity_or_empty(), "vpc"); // binding name → resource name
     // "name" must NOT appear in attributes (it's only the id.name, not an attribute)
     assert!(
         !resource.attributes.contains_key("name"),
@@ -3510,8 +3513,8 @@ fn parse_for_expression_over_list() {
     assert_eq!(result.resources.len(), 2);
 
     // Resources should be addressed as subnets[0] and subnets[1]
-    assert_eq!(result.resources[0].id.name_str(), "subnets[0]");
-    assert_eq!(result.resources[1].id.name_str(), "subnets[1]");
+    assert_eq!(result.resources[0].id.identity_or_empty(), "subnets[0]");
+    assert_eq!(result.resources[1].id.identity_or_empty(), "subnets[1]");
 
     // Each resource should have the loop variable substituted
     assert_eq!(
@@ -3542,8 +3545,8 @@ fn parse_for_expression_with_index() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(result.resources.len(), 2);
 
-    assert_eq!(result.resources[0].id.name_str(), "subnets[0]");
-    assert_eq!(result.resources[1].id.name_str(), "subnets[1]");
+    assert_eq!(result.resources[0].id.identity_or_empty(), "subnets[0]");
+    assert_eq!(result.resources[1].id.identity_or_empty(), "subnets[1]");
 
     // Check index variable is substituted
     if let Some(Value::Deferred(DeferredValue::FunctionCall { args, .. })) =
@@ -3586,7 +3589,7 @@ fn parse_for_expression_over_map() {
     let names: Vec<&str> = result
         .resources
         .iter()
-        .map(|r| r.id.name.as_str())
+        .map(|r| r.id.identity_or_empty())
         .collect();
     assert!(names.contains(&"networks.prod"));
     assert!(names.contains(&"networks.staging"));
@@ -4292,7 +4295,11 @@ fn for_expression_over_map_uses_canonical_dot_form() {
         }
     "#;
     let result = parse(input, &ProviderContext::default()).unwrap();
-    let names: Vec<&str> = result.resources.iter().map(|r| r.id.name_str()).collect();
+    let names: Vec<&str> = result
+        .resources
+        .iter()
+        .map(|r| r.id.identity_or_empty())
+        .collect();
     assert_eq!(names, vec!["resources.dev", "resources.prod"]);
 }
 
@@ -4314,8 +4321,8 @@ fn parse_for_expression_with_keys_function_call() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     // keys({Name = "web", Env = "prod"}) should evaluate to ["Env", "Name"] (sorted)
     assert_eq!(result.resources.len(), 2);
-    assert_eq!(result.resources[0].id.name_str(), "resources[0]");
-    assert_eq!(result.resources[1].id.name_str(), "resources[1]");
+    assert_eq!(result.resources[0].id.identity_or_empty(), "resources[0]");
+    assert_eq!(result.resources[1].id.identity_or_empty(), "resources[1]");
     assert_eq!(
         result.resources[0].get_attr("name"),
         Some(&Value::Concrete(ConcreteValue::String("Env".to_string())))
@@ -4425,7 +4432,7 @@ fn parse_if_true_condition_includes_resource() {
 
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(result.resources.len(), 1);
-    assert_eq!(result.resources[0].id.name_str(), "alarm");
+    assert_eq!(result.resources[0].id.identity_or_empty(), "alarm");
     assert_eq!(
         result.resources[0].get_attr("alarm_name"),
         Some(&Value::Concrete(ConcreteValue::String(
@@ -4813,7 +4820,7 @@ fn parse_top_level_multiple_for_no_collision() {
     let names: Vec<&str> = result
         .resources
         .iter()
-        .map(|r| r.id.name.as_str())
+        .map(|r| r.id.identity_or_empty())
         .collect();
     assert_eq!(names[0], "_for0[0]");
     assert_eq!(names[1], "_for0[1]");
@@ -4838,7 +4845,7 @@ fn parse_top_level_for_uses_iterable_name_as_binding() {
     let names: Vec<&str> = result
         .resources
         .iter()
-        .map(|r| r.id.name.as_str())
+        .map(|r| r.id.identity_or_empty())
         .collect();
     assert_eq!(names[0], "_azs[0]");
     assert_eq!(names[1], "_azs[1]");
@@ -4877,7 +4884,7 @@ fn parse_top_level_for_literal_list_uses_counter_fallback() {
     let names: Vec<&str> = result
         .resources
         .iter()
-        .map(|r| r.id.name.as_str())
+        .map(|r| r.id.identity_or_empty())
         .collect();
     assert_eq!(names[0], "_for0[0]");
     assert_eq!(names[1], "_for0[1]");
@@ -8867,11 +8874,13 @@ fn quoted_literal_marker_survives_anonymous_resource_rename() {
     let mut parsed = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(parsed.resources.len(), 1); // allow: direct — fixture test inspection
 
-    // Simulate the rename that compute_anonymous_identifiers would
-    // perform: the pending name becomes a hash-based bound identifier.
+    // Simulate the identity assignment that compute_anonymous_identifiers would
+    // perform: the absent identity becomes a hash-based identifier.
     let resource = &mut parsed.resources[0]; // allow: direct — fixture test inspection
-    assert!(resource.id.name.is_pending());
-    resource.id.name = crate::resource::ResourceName::Bound("hash123".to_string());
+    assert!(resource.id.identity.is_none());
+    resource
+        .id
+        .set_identity(crate::resource::ResourceIdentity::new("hash123"));
 
     // The "was quoted" marker must still be reachable on the
     // resource — it co-locates with the attributes, not in a
@@ -10294,7 +10303,7 @@ fn extract_directives_reads_depends_on_list() {
     let bucket = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "bucket")
+        .find(|r| r.id.identity_or_empty() == "bucket")
         .expect("bucket binding");
     assert_eq!(
         bucket.directives.depends_on,
@@ -10318,7 +10327,7 @@ fn parser_resolve_unions_directives_depends_on_into_dependency_bindings() {
     let bucket = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "bucket")
+        .find(|r| r.id.identity_or_empty() == "bucket")
         .expect("bucket binding");
     let deps = crate::deps::get_resource_dependencies(bucket);
     assert!(
@@ -10548,7 +10557,7 @@ fn extract_directives_accepts_empty_depends_on_list() {
     let bucket = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "bucket")
+        .find(|r| r.id.identity_or_empty() == "bucket")
         .expect("bucket binding");
     assert!(
         bucket.directives.depends_on.is_empty(),
@@ -10970,7 +10979,7 @@ fn extract_directives_reads_provider_binding() {
     let bucket = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "bucket")
+        .find(|r| r.id.identity_or_empty() == "bucket")
         .expect("bucket binding");
     assert_eq!(
         bucket.directives.provider_instance.as_deref(),
@@ -10998,7 +11007,7 @@ fn extract_directives_provider_default_is_none() {
     let bucket = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "bucket")
+        .find(|r| r.id.identity_or_empty() == "bucket")
         .expect("bucket binding");
     assert!(bucket.directives.provider_instance.is_none());
 }
@@ -11063,7 +11072,7 @@ fn extract_directives_provider_visible_across_files() {
     let cert = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "cert")
+        .find(|r| r.id.identity_or_empty() == "cert")
         .expect("cert binding");
     assert_eq!(
         cert.directives.provider_instance.as_deref(),
@@ -11417,7 +11426,7 @@ fn parser_propagates_directives_provider_instance_to_resource_id() {
     let cert = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "cert")
+        .find(|r| r.id.identity_or_empty() == "cert")
         .expect("cert binding");
     assert_eq!(
         cert.id.provider_instance.as_deref(),
@@ -11457,11 +11466,11 @@ fn parser_propagates_directives_provider_instance_to_resource_id() {
 
 #[test]
 fn resource_id_provider_instance_round_trips_serde() {
-    use crate::resource::{ResourceId, ResourceName};
+    use crate::resource::{ResourceId, ResourceIdentity};
     let id = ResourceId {
         provider: "aws".to_string(),
         resource_type: "s3.Bucket".to_string(),
-        name: ResourceName::Bound("x".to_string()),
+        identity: Some(ResourceIdentity::new("x")),
         provider_instance: Some("us".to_string()),
     };
     let json = serde_json::to_string(&id).unwrap();
@@ -11475,11 +11484,11 @@ fn resource_id_provider_instance_round_trips_serde() {
 
 #[test]
 fn resource_id_provider_instance_default_skipped_in_serde() {
-    use crate::resource::{ResourceId, ResourceName};
+    use crate::resource::{ResourceId, ResourceIdentity};
     let id = ResourceId {
         provider: "aws".to_string(),
         resource_type: "s3.Bucket".to_string(),
-        name: ResourceName::Bound("x".to_string()),
+        identity: Some(ResourceIdentity::new("x")),
         provider_instance: None,
     };
     let json = serde_json::to_string(&id).unwrap();
@@ -11497,17 +11506,17 @@ fn resource_id_provider_instance_default_skipped_in_serde() {
 fn resource_id_provider_instance_makes_distinct_ids() {
     // Same kind/type/name but different instances must compare unequal
     // so HashMap<ResourceId, _> treats them as separate resources.
-    use crate::resource::{ResourceId, ResourceName};
+    use crate::resource::{ResourceId, ResourceIdentity};
     let tokyo = ResourceId {
         provider: "aws".to_string(),
         resource_type: "s3.Bucket".to_string(),
-        name: ResourceName::Bound("x".to_string()),
+        identity: Some(ResourceIdentity::new("x")),
         provider_instance: None,
     };
     let us = ResourceId {
         provider: "aws".to_string(),
         resource_type: "s3.Bucket".to_string(),
-        name: ResourceName::Bound("x".to_string()),
+        identity: Some(ResourceIdentity::new("x")),
         provider_instance: Some("us".to_string()),
     };
     assert_ne!(tokyo, us, "instances differ → ResourceId differs");

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -582,7 +582,8 @@ mod tests {
     #[test]
     fn format_effect_brief_remove_has_no_failure_shaped_glyph() {
         use crate::resource::ResourceId;
-        let id = ResourceId::new("aws.route53.RecordSet", "aws_route53_record_set_7059de08");
+        let id =
+            ResourceId::with_identity("aws.route53.RecordSet", "aws_route53_record_set_7059de08");
         let s = format_effect_brief(&Effect::Remove { id: id.clone() });
         assert!(!s.contains('x'), "must not contain `x`; got: {s:?}");
         assert!(!s.contains('✗'), "must not contain `✗`; got: {s:?}");
@@ -604,7 +605,7 @@ mod tests {
 
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::new("acm.Certificate", "cert"),
+            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -630,7 +631,7 @@ mod tests {
         plan.add(Effect::Create(Resource::new("acm.Certificate", "cert")));
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::new("acm.Certificate", "cert"),
+            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -651,7 +652,7 @@ mod tests {
         plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
         plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
         plan.add(Effect::Delete {
-            id: crate::resource::ResourceId::new("s3.Bucket", "c"),
+            id: crate::resource::ResourceId::with_identity("s3.Bucket", "c"),
             identifier: String::new(),
             directives: crate::resource::Directives::default(),
             binding: None,
@@ -687,7 +688,7 @@ mod tests {
             Resource::new("acm.Certificate", "cert").with_binding("cert"),
         ));
         plan.add(Effect::DeferredCreate {
-            id: ResourceId::new("route53.RecordSet", "validation_records"),
+            id: ResourceId::with_identity("route53.RecordSet", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred),
         });
@@ -726,7 +727,10 @@ mod tests {
         };
         let deletes = (0..3)
             .map(|idx| DeferredReplaceDelete {
-                id: ResourceId::new("route53.RecordSet", format!("validation_records[{idx}]")),
+                id: ResourceId::with_identity(
+                    "route53.RecordSet",
+                    format!("validation_records[{idx}]"),
+                ),
                 identifier: format!("record-{idx}"),
                 directives: Directives::default(),
                 binding: Some(format!("validation_records[{idx}]")),
@@ -738,7 +742,7 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(deletes).expect("fixture has deletes"),
-            id: ResourceId::new("route53.RecordSet", "validation_records"),
+            id: ResourceId::with_identity("route53.RecordSet", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
         });
@@ -820,18 +824,19 @@ mod tests {
         let mut plan = Plan::new();
 
         // A Replace effect with one cascading update
-        let from = State::not_found(ResourceId::new("ec2.Vpc", "vpc")).with_identifier("vpc-123");
+        let from = State::not_found(ResourceId::with_identity("ec2.Vpc", "vpc"))
+            .with_identifier("vpc-123");
         let to = Resource::new("ec2.Vpc", "vpc");
         let cascading = CascadingUpdate {
-            id: ResourceId::new("ec2.Subnet", "subnet"),
+            id: ResourceId::with_identity("ec2.Subnet", "subnet"),
             from: Box::new(
-                State::not_found(ResourceId::new("ec2.Subnet", "subnet"))
+                State::not_found(ResourceId::with_identity("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
             ),
             to: (Resource::new("ec2.Subnet", "subnet")),
         };
         plan.add(Effect::Replace {
-            id: ResourceId::new("ec2.Vpc", "vpc"),
+            id: ResourceId::with_identity("ec2.Vpc", "vpc"),
             from: Box::new(from),
             to,
             directives: Directives::default(),
@@ -859,18 +864,19 @@ mod tests {
 
         let mut plan = Plan::new();
 
-        let from = State::not_found(ResourceId::new("ec2.Vpc", "vpc")).with_identifier("vpc-123");
+        let from = State::not_found(ResourceId::with_identity("ec2.Vpc", "vpc"))
+            .with_identifier("vpc-123");
         let to = Resource::new("ec2.Vpc", "vpc");
         let cascading = CascadingUpdate {
-            id: ResourceId::new("ec2.Subnet", "subnet"),
+            id: ResourceId::with_identity("ec2.Subnet", "subnet"),
             from: Box::new(
-                State::not_found(ResourceId::new("ec2.Subnet", "subnet"))
+                State::not_found(ResourceId::with_identity("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
             ),
             to: (Resource::new("ec2.Subnet", "subnet")),
         };
         plan.add(Effect::Replace {
-            id: ResourceId::new("ec2.Vpc", "vpc"),
+            id: ResourceId::with_identity("ec2.Vpc", "vpc"),
             from: Box::new(from),
             to,
             directives: Directives::default(),
@@ -903,7 +909,7 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
         plan.add(Effect::Delete {
-            id: ResourceId::new("s3.Bucket", "b"),
+            id: ResourceId::with_identity("s3.Bucket", "b"),
             identifier: "b-id".to_string(),
             directives: crate::resource::Directives::default(),
             binding: None,

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -238,7 +238,7 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
                     // uses only the target edge because it visualizes the
                     // structural "wait gates this resource" relationship.
                     let mut deps = HashSet::new();
-                    deps.insert(target_id.name_str().to_string());
+                    deps.insert(target_id.identity_or_empty().to_string());
                     binding_to_effect.insert(binding.clone(), idx);
                     effect_bindings.insert(idx, binding.clone());
                     effect_types.insert(idx, "wait".to_string());
@@ -602,7 +602,7 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::new("route53.Record", "validation_records[0]"),
+                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
                 identifier: "record-0".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -610,12 +610,12 @@ mod tests {
                 explicit_dependencies: HashSet::new(),
             }])
             .expect("fixture has one delete"),
-            id: ResourceId::new("__deferred_for", "validation_records"),
+            id: ResourceId::with_identity("__deferred_for", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred),
         });
         plan.add(Effect::Delete {
-            id: ResourceId::new("route53.Record", "old-record-0"),
+            id: ResourceId::with_identity("route53.Record", "old-record-0"),
             identifier: "record-0".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -623,7 +623,7 @@ mod tests {
             explicit_dependencies: HashSet::new(),
         });
         plan.add(Effect::Delete {
-            id: ResourceId::new("route53.Record", "old-record-abc"),
+            id: ResourceId::with_identity("route53.Record", "old-record-abc"),
             identifier: "record-abc".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[abc]".to_string()),
@@ -661,7 +661,7 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::new("route53.Record", "validation_records[0]"),
+                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
                 identifier: "record-0".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -669,13 +669,13 @@ mod tests {
                 explicit_dependencies: HashSet::new(),
             }])
             .expect("fixture has one delete"),
-            id: ResourceId::new("__deferred_for", "validation_records"),
+            id: ResourceId::with_identity("__deferred_for", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred),
         });
         plan.add(Effect::Wait {
             binding: "wait_validation_record_0".to_string(),
-            target_id: ResourceId::new("route53.Record", "validation_records[0]"),
+            target_id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ready".to_string())),

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -106,7 +106,13 @@ impl std::fmt::Display for ProviderError {
         // between the structured multi-line render and the legacy
         // chain-walk render so non-AWS errors keep the same shape.
         if let Some(ref id) = detail.resource_id {
-            write!(f, "[{}.{}] {}", id.resource_type, id.name, detail.message)?;
+            write!(
+                f,
+                "[{}.{}] {}",
+                id.resource_type,
+                id.identity_or_empty(),
+                detail.message
+            )?;
         } else {
             write!(f, "{}", detail.message)?;
         }
@@ -1595,14 +1601,14 @@ mod tests {
     #[tokio::test]
     async fn mock_provider_read_returns_not_found() {
         let provider = MockProvider;
-        let id = ResourceId::new("test", "example");
+        let id = ResourceId::with_identity("test", "example");
         let state = provider.read(&id, None, ReadRequest).await.unwrap();
         assert!(!state.exists);
     }
 
     #[test]
     fn create_outcome_exposes_state_and_diagnostic() {
-        let id = ResourceId::new("test", "example");
+        let id = ResourceId::with_identity("test", "example");
         let state = State::existing(id, HashMap::new()).with_identifier("mock-id");
         let diagnostic = PartialReadDiagnostic::new(
             "mock partial create".to_string(),
@@ -1629,7 +1635,7 @@ mod tests {
 
     #[test]
     fn create_outcome_empty_partial_diagnostic_becomes_success() {
-        let id = ResourceId::new("test", "example");
+        let id = ResourceId::with_identity("test", "example");
         let state = State::existing(id, HashMap::new()).with_identifier("mock-id");
 
         let outcome = CreateOutcome::partial_success(
@@ -1681,7 +1687,7 @@ mod tests {
     #[test]
     fn provider_default_satisfier_hint_is_empty() {
         let provider = MockProvider;
-        let id = ResourceId::new("test", "example");
+        let id = ResourceId::with_identity("test", "example");
         assert_eq!(
             provider.satisfier_hint(&id, &AttrPath::single("status")),
             Vec::new()
@@ -1865,7 +1871,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let id = ResourceId::with_provider("mock", "test", "example", None);
+        let id = ResourceId::with_provider_identity("mock", "test", "example", None);
         let state = router.read(&id, None, ReadRequest).await.unwrap();
         assert!(!state.exists);
     }
@@ -1972,7 +1978,7 @@ mod tests {
     #[test]
     fn provider_error_display_with_resource_id_and_cause() {
         let cause = std::io::Error::other("timeout");
-        let id = ResourceId::new("s3.Bucket", "my-bucket");
+        let id = ResourceId::with_identity("s3.Bucket", "my-bucket");
         let err = ProviderError::api_error("Failed to read")
             .with_cause(cause)
             .for_resource(id);
@@ -1996,7 +2002,7 @@ mod tests {
     /// non-AWS errors.
     #[test]
     fn provider_error_display_multi_line_when_structured_fields_populated() {
-        let id = ResourceId::new("iam.Roles", "admin_access_roles");
+        let id = ResourceId::with_identity("iam.Roles", "admin_access_roles");
         let err = ProviderError::api_error("Failed to list IAM roles")
             .for_resource(id)
             .with_operation("iam.ListRoles")
@@ -2174,7 +2180,7 @@ mod tests {
     #[test]
     fn provider_error_display_multi_line_all_fields_including_cause() {
         let cause = std::io::Error::other("tls handshake failed");
-        let id = ResourceId::new("iam.Roles", "admin_access_roles");
+        let id = ResourceId::with_identity("iam.Roles", "admin_access_roles");
         let err = ProviderError::api_error("Failed to list IAM roles")
             .with_cause(cause)
             .for_resource(id)
@@ -2282,7 +2288,7 @@ mod tests {
 
     #[test]
     fn build_update_patch_classifies_ops() {
-        let id = ResourceId::new("test", "example");
+        let id = ResourceId::with_identity("test", "example");
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
             "a".to_string(),
@@ -2333,7 +2339,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let id = ResourceId::with_provider("mock", "test", "example", None);
+        let id = ResourceId::with_provider_identity("mock", "test", "example", None);
         let from = State::existing(id.clone(), HashMap::new());
         let request = UpdateRequest {
             from,
@@ -2352,7 +2358,7 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let id = ResourceId::with_provider("mock", "test", "example", None);
+        let id = ResourceId::with_provider_identity("mock", "test", "example", None);
         let request = DeleteRequest::default();
         let result = router.delete(&id, "mock-id-123", request).await;
         assert!(result.is_ok());
@@ -2361,7 +2367,7 @@ mod tests {
     #[tokio::test]
     async fn provider_router_returns_error_for_unknown_provider() {
         let router = ProviderRouter::new();
-        let id = ResourceId::with_provider("nonexistent", "test", "example", None);
+        let id = ResourceId::with_provider_identity("nonexistent", "test", "example", None);
         let result = router.read(&id, None, ReadRequest).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -2439,7 +2445,7 @@ mod tests {
             Box::new(TaggedProvider { tag: "us" }),
         );
 
-        let default_id = ResourceId::with_provider("mock", "test", "a", None);
+        let default_id = ResourceId::with_provider_identity("mock", "test", "a", None);
         let state = router.read(&default_id, None, ReadRequest).await.unwrap();
         assert_eq!(
             state.attributes.get("tag"),
@@ -2449,7 +2455,7 @@ mod tests {
             "resources without provider_instance must route to the kind's default instance"
         );
 
-        let us_id = ResourceId::with_provider("mock", "test", "b", Some("us".to_string()));
+        let us_id = ResourceId::with_provider_identity("mock", "test", "b", Some("us".to_string()));
         let state = router.read(&us_id, None, ReadRequest).await.unwrap();
         assert_eq!(
             state.attributes.get("tag"),
@@ -2463,7 +2469,8 @@ mod tests {
         let mut router = ProviderRouter::new();
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
-        let id = ResourceId::with_provider("mock", "test", "x", Some("missing".to_string()));
+        let id =
+            ResourceId::with_provider_identity("mock", "test", "x", Some("missing".to_string()));
         let err = router.read(&id, None, ReadRequest).await.unwrap_err();
         let msg = err.message();
         assert!(
@@ -2691,7 +2698,7 @@ mod tests {
         );
 
         // Test hydrate_read_state
-        let id = ResourceId::new("test", "example");
+        let id = ResourceId::with_identity("test", "example");
         let mut states = HashMap::new();
         states.insert(id.clone(), State::existing(id.clone(), HashMap::new()));
         let mut saved: SavedAttrs = HashMap::new();

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -1312,7 +1312,7 @@ mod tests {
 
     #[test]
     fn test_state_attributes_merged_into_binding_map() {
-        let rid = ResourceId::new("test.resource", "my-vpc");
+        let rid = ResourceId::with_identity("test.resource", "my-vpc");
         let mut resources = vec![
             make_resource(
                 "my-vpc",

--- a/carina-core/src/resolver_split_tests.rs
+++ b/carina-core/src/resolver_split_tests.rs
@@ -39,7 +39,7 @@ fn make_managed(binding: &str, attrs: &[(&str, Value)]) -> Resource {
         attributes.insert((*k).into(), v.clone());
     }
     Resource {
-        id: ResourceId::new("aws.s3.Bucket", binding),
+        id: ResourceId::with_identity("aws.s3.Bucket", binding),
         attributes,
         directives: Default::default(),
         prefixes: HashMap::new(),
@@ -59,7 +59,7 @@ fn make_virtual(binding: &str, attrs: &[(&str, Value)]) -> Composition {
         );
     }
     Composition {
-        id: ResourceId::new("_virtual.module", binding),
+        id: ResourceId::with_identity("_virtual.module", binding),
         signature: Signature {
             arguments: IndexMap::new(),
             attributes,
@@ -311,17 +311,19 @@ fn resolve_managed_refs_legacy_shim_produces_identical_result() {
 
     for (m, l) in managed.iter().zip(legacy.iter()) {
         assert_eq!(
-            m.attributes, l.attributes,
+            m.attributes,
+            l.attributes,
             "managed/legacy attribute divergence for {}",
-            m.id.name,
+            m.id.identity_or_empty(),
         );
         // `dependency_bindings` is the second mutation the legacy
         // pipeline performs; the bridge's writeback contract names
         // both fields, so the equivalence guard does too.
         assert_eq!(
-            m.dependency_bindings, l.dependency_bindings,
+            m.dependency_bindings,
+            l.dependency_bindings,
             "managed/legacy dependency_bindings divergence for {}",
-            m.id.name,
+            m.id.identity_or_empty(),
         );
     }
 }

--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeSet, HashSet};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use super::{Directives, ModuleSource, ResourceId, Value};
+use super::{Directives, ModuleSource, ResourceId, Value, identity_if_present};
 
 /// A read-only resource (data source).
 ///
@@ -57,7 +57,7 @@ impl DataSource {
     /// Create a data source with an empty attribute map.
     pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
-            id: ResourceId::new(resource_type, name),
+            id: ResourceId::new(resource_type, identity_if_present(name)),
             attributes: IndexMap::new(),
             directives: Directives::default(),
             binding: None,
@@ -84,7 +84,12 @@ impl DataSource {
         provider_instance: Option<String>,
     ) -> Self {
         Self {
-            id: ResourceId::with_provider(provider, resource_type, name, provider_instance),
+            id: ResourceId::with_provider(
+                provider,
+                resource_type,
+                identity_if_present(name),
+                provider_instance,
+            ),
             attributes: IndexMap::new(),
             directives: Directives::default(),
             binding: None,

--- a/carina-core/src/resource/expansion_trace.rs
+++ b/carina-core/src/resource/expansion_trace.rs
@@ -89,7 +89,7 @@ impl CallSite {
 
     /// The call site's binding name (instance prefix), e.g. `cluster`.
     pub fn binding(&self) -> &str {
-        self.id.inner().name.as_str()
+        self.id.inner().identity_or_empty()
     }
 }
 
@@ -173,12 +173,12 @@ mod tests {
     use crate::resource::ResourceId;
 
     fn pid(name: &str) -> PersistentId {
-        PersistentId::new(ResourceId::new("aws.s3.Bucket", name))
+        PersistentId::new(ResourceId::with_identity("aws.s3.Bucket", name))
     }
 
     fn site(name: &str, source_path: &str) -> CallSite {
         CallSite::new(
-            EphemeralId::new(ResourceId::new("_virtual", name)),
+            EphemeralId::new(ResourceId::with_identity("_virtual", name)),
             source_path,
         )
     }
@@ -221,7 +221,8 @@ mod tests {
         // The renderer drops the parenthesized `(<path>)` suffix in
         // that case — `None` is syntactically distinct from a real
         // user-supplied empty path.
-        let s = CallSite::without_source(EphemeralId::new(ResourceId::new("_virtual", "r")));
+        let s =
+            CallSite::without_source(EphemeralId::new(ResourceId::with_identity("_virtual", "r")));
         assert_eq!(s.binding(), "r");
         assert_eq!(s.source_path, None);
     }
@@ -254,7 +255,10 @@ mod tests {
         // `HashMap`-backed iteration order is not guaranteed; only
         // the *set* of keys is observable. Verify every recorded leaf
         // shows up exactly once.
-        let mut names: Vec<&str> = t.iter().map(|(p, _)| p.inner().name.as_str()).collect();
+        let mut names: Vec<&str> = t
+            .iter()
+            .map(|(p, _)| p.inner().identity_or_empty())
+            .collect();
         names.sort();
         assert_eq!(names, vec!["a_leaf", "b_leaf"]);
     }

--- a/carina-core/src/resource/graph_node.rs
+++ b/carina-core/src/resource/graph_node.rs
@@ -162,7 +162,7 @@ mod tests {
         use indexmap::IndexMap;
         use std::collections::{BTreeSet, HashSet};
         let c = Composition {
-            id: ResourceId::new("_virtual", "m"),
+            id: ResourceId::with_identity("_virtual", "m"),
             signature: super::super::Signature {
                 arguments: IndexMap::new(),
                 attributes: IndexMap::new(),

--- a/carina-core/src/resource/leaf_node.rs
+++ b/carina-core/src/resource/leaf_node.rs
@@ -173,7 +173,7 @@ mod tests {
         use indexmap::IndexMap;
         use std::collections::{BTreeSet, HashSet};
         Composition {
-            id: ResourceId::new("_virtual", "m"),
+            id: ResourceId::with_identity("_virtual", "m"),
             signature: super::super::Signature {
                 arguments: IndexMap::new(),
                 attributes: IndexMap::new(),
@@ -254,7 +254,7 @@ mod tests {
     /// use indexmap::IndexMap;
     /// use std::collections::{BTreeSet, HashSet};
     /// let c = Composition {
-    ///     id: ResourceId::new("_virtual", "m"),
+    ///     id: ResourceId::with_identity("_virtual", "m"),
     ///     signature: Signature {
     ///         arguments: IndexMap::new(),
     ///         attributes: IndexMap::new(),

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -30,69 +30,47 @@ impl<'a> EnumAttr<'a> {
     }
 }
 
-/// The `name` portion of a `ResourceId`.
+/// Opaque resource identity.
 ///
-/// Anonymous resources start out as `Pending` because the parser sees
-/// the resource block before it has extracted the `name` attribute.
-/// A later post-processing pass converts `Pending` to `Bound(name)`
-/// once the attribute has been read. Encoding this transient state in
-/// the type makes it impossible to confuse "anonymous, ID not yet
-/// assigned" with "actual ID is the empty string" (#2225).
-///
-/// On disk the variant is collapsed to a plain JSON string for
-/// backward compatibility with v5 state files: `Pending` round-trips
-/// through `""`, `Bound(s)` through `s`. The discriminant is
-/// reconstructed on deserialization.
+/// Identity is independent from any schema `name` attribute. Empty
+/// strings are not valid identities; callers that do not yet have an
+/// identity must represent that as `None` on [`ResourceId`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ResourceName {
-    /// An identifier already extracted (from a `let` binding or the
-    /// `name` attribute of an anonymous resource).
-    Bound(String),
-    /// An anonymous resource whose `name` attribute has not yet been
-    /// promoted to the `ResourceId`. Must be replaced with `Bound`
-    /// before the value can flow to plan generation, state, or
-    /// providers.
-    Pending,
-}
+pub struct ResourceIdentity(String);
 
-impl ResourceName {
-    /// True when this `ResourceName` has not yet been bound to a
-    /// concrete identifier.
-    pub fn is_pending(&self) -> bool {
-        matches!(self, Self::Pending)
+impl ResourceIdentity {
+    pub(crate) fn new(s: impl Into<String>) -> Self {
+        let s = s.into();
+        assert!(!s.is_empty(), "resource identity cannot be empty");
+        Self(s)
     }
 
-    /// Borrow the bound identifier as a `&str`. `Pending` returns the
-    /// empty string — sites that need to distinguish must `match` on
-    /// the variant directly.
     pub fn as_str(&self) -> &str {
-        match self {
-            Self::Bound(s) => s,
-            Self::Pending => "",
-        }
+        &self.0
     }
 }
 
-impl std::fmt::Display for ResourceName {
+impl std::fmt::Display for ResourceIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-impl Serialize for ResourceName {
+impl Serialize for ResourceIdentity {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(self.as_str())
     }
 }
 
-impl<'de> Deserialize<'de> for ResourceName {
+impl<'de> Deserialize<'de> for ResourceIdentity {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        Ok(if s.is_empty() {
-            Self::Pending
-        } else {
-            Self::Bound(s)
-        })
+        if s.is_empty() {
+            return Err(serde::de::Error::custom(
+                "resource identity cannot be empty",
+            ));
+        }
+        Ok(Self(s))
     }
 }
 
@@ -103,13 +81,10 @@ pub struct ResourceId {
     pub provider: String,
     /// Resource type (e.g., "s3.Bucket", "ec2.Instance")
     pub resource_type: String,
-    /// Resource name (identifier specified in DSL).
-    ///
-    /// `Pending` means the resource is anonymous and the `name`
-    /// attribute has not yet been promoted into the `ResourceId`.
-    /// All downstream consumers (state, plan, providers) require
-    /// `Bound`.
-    pub name: ResourceName,
+    /// Resource identity. `None` means the parser has not assigned one
+    /// yet, which is only valid before the resolver boundary.
+    #[serde(default, alias = "name")]
+    pub identity: Option<ResourceIdentity>,
     /// Binding name of the provider instance this resource is routed
     /// to. `None` resolves to the kind's default instance.
     /// Hash/Eq include the field so two resources differing only in
@@ -119,13 +94,17 @@ pub struct ResourceId {
 }
 
 impl ResourceId {
-    pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
+    pub fn new(resource_type: impl Into<String>, identity: Option<ResourceIdentity>) -> Self {
         Self {
             provider: String::new(),
             resource_type: resource_type.into(),
-            name: ResourceName::from_string(name.into()),
+            identity,
             provider_instance: None,
         }
+    }
+
+    pub fn with_identity(resource_type: impl Into<String>, identity: impl Into<String>) -> Self {
+        Self::new(resource_type, Some(ResourceIdentity::new(identity)))
     }
 
     /// Construct a `ResourceId` with explicit routing.
@@ -140,28 +119,55 @@ impl ResourceId {
     pub fn with_provider(
         provider: impl Into<String>,
         resource_type: impl Into<String>,
-        name: impl Into<String>,
+        identity: Option<ResourceIdentity>,
         provider_instance: Option<String>,
     ) -> Self {
         Self {
             provider: provider.into(),
             resource_type: resource_type.into(),
-            name: ResourceName::from_string(name.into()),
+            identity,
             provider_instance,
         }
     }
 
-    /// Borrow the resolved identifier as `&str`. `Pending` returns
-    /// the empty string; sites that distinguish should `match` on
-    /// `self.name` directly.
-    pub fn name_str(&self) -> &str {
-        self.name.as_str()
+    pub fn with_provider_identity(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        identity: impl Into<String>,
+        provider_instance: Option<String>,
+    ) -> Self {
+        Self::with_provider(
+            provider,
+            resource_type,
+            Some(ResourceIdentity::new(identity)),
+            provider_instance,
+        )
     }
 
-    /// Set the resource's name, replacing any existing `Pending` or
-    /// `Bound` variant with `Bound(name)`.
-    pub fn set_name(&mut self, name: impl Into<String>) {
-        self.name = ResourceName::Bound(name.into());
+    /// Construct from state/WIT strings where an empty name means "no identity".
+    pub fn with_provider_name_compat(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        name: &str,
+        provider_instance: Option<String>,
+    ) -> Self {
+        if name.is_empty() {
+            Self::with_provider(provider, resource_type, None, provider_instance)
+        } else {
+            Self::with_provider_identity(provider, resource_type, name, provider_instance)
+        }
+    }
+
+    pub fn identity_str(&self) -> Option<&str> {
+        self.identity.as_ref().map(ResourceIdentity::as_str)
+    }
+
+    pub fn identity_or_empty(&self) -> &str {
+        self.identity_str().unwrap_or("")
+    }
+
+    pub fn set_identity(&mut self, identity: ResourceIdentity) {
+        self.identity = Some(identity);
     }
 
     /// Returns the display type including provider prefix if available
@@ -176,9 +182,9 @@ impl ResourceId {
     /// Borrow this id as a human-facing display value.
     ///
     /// Unlike the default `Display`, which renders the canonical dotted
-    /// form (`provider.resource_type.name`) used as a logical identifier
+    /// form (`provider.resource_type.identity`) used as a logical identifier
     /// for hashmap keys, binding fallbacks, and DSL syntax, this wrapper
-    /// renders `provider.resource_type` and `name` separated by a single
+    /// renders `provider.resource_type` and `identity` separated by a single
     /// space — making the type/address boundary visible to readers
     /// (carina-rs/carina#2572).
     ///
@@ -193,7 +199,7 @@ impl ResourceId {
 /// Human-facing display wrapper for [`ResourceId`].
 ///
 /// Construct with [`ResourceId::human`]; renders via `Display` as
-/// `provider.resource_type<SPACE>name` (or `resource_type<SPACE>name`
+/// `provider.resource_type<SPACE>identity` (or `resource_type<SPACE>identity`
 /// when the provider segment is empty).
 ///
 /// The wrapper exists as a distinct type, rather than as a second
@@ -206,35 +212,34 @@ pub struct ResourceIdDisplay<'a>(&'a ResourceId);
 impl std::fmt::Display for ResourceIdDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let id = self.0;
-        if id.provider.is_empty() {
-            write!(f, "{} {}", id.resource_type, id.name)
-        } else {
-            write!(f, "{}.{} {}", id.provider, id.resource_type, id.name)
-        }
-    }
-}
-
-impl ResourceName {
-    /// Convert a string into a `ResourceName`. Empty input becomes
-    /// `Pending`; any other input becomes `Bound`. Used by
-    /// `ResourceId::new` / `with_provider` to keep the legacy
-    /// `String` constructors compatible.
-    pub fn from_string(s: String) -> Self {
-        if s.is_empty() {
-            Self::Pending
-        } else {
-            Self::Bound(s)
+        match (id.provider.is_empty(), id.identity_str()) {
+            (true, Some(identity)) => write!(f, "{} {}", id.resource_type, identity),
+            (true, None) => write!(f, "{}", id.resource_type),
+            (false, Some(identity)) => {
+                write!(f, "{}.{} {}", id.provider, id.resource_type, identity)
+            }
+            (false, None) => write!(f, "{}.{}", id.provider, id.resource_type),
         }
     }
 }
 
 impl std::fmt::Display for ResourceId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.provider.is_empty() {
-            write!(f, "{}.{}", self.resource_type, self.name)
-        } else {
-            write!(f, "{}.{}.{}", self.provider, self.resource_type, self.name)
+        match (self.provider.is_empty(), self.identity_str()) {
+            (true, Some(id)) => write!(f, "{}.{}", self.resource_type, id),
+            (true, None) => write!(f, "{}", self.resource_type),
+            (false, Some(id)) => write!(f, "{}.{}.{}", self.provider, self.resource_type, id),
+            (false, None) => write!(f, "{}.{}", self.provider, self.resource_type),
         }
+    }
+}
+
+pub(crate) fn identity_if_present(identity: impl Into<String>) -> Option<ResourceIdentity> {
+    let identity = identity.into();
+    if identity.is_empty() {
+        None
+    } else {
+        Some(ResourceIdentity::new(identity))
     }
 }
 
@@ -1749,7 +1754,7 @@ pub struct Resource {
     /// radius. Sharing a struct with the attributes also makes the
     /// lookup rename-proof: there is no separate identifier keying
     /// the metadata, so `compute_anonymous_identifiers` can rewrite
-    /// `Resource.id.name` freely (#2229).
+    /// `Resource.id.identity` freely (#2229).
     ///
     /// Parse-time only; `#[serde(skip)]` keeps it out of state.
     #[serde(default, skip)]
@@ -1759,7 +1764,7 @@ pub struct Resource {
 impl Resource {
     pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
-            id: ResourceId::new(resource_type, name),
+            id: ResourceId::new(resource_type, identity_if_present(name)),
             attributes: IndexMap::new(),
             directives: Directives::default(),
             prefixes: HashMap::new(),
@@ -1787,7 +1792,12 @@ impl Resource {
         provider_instance: Option<String>,
     ) -> Self {
         Self {
-            id: ResourceId::with_provider(provider, resource_type, name, provider_instance),
+            id: ResourceId::with_provider(
+                provider,
+                resource_type,
+                identity_if_present(name),
+                provider_instance,
+            ),
             attributes: IndexMap::new(),
             directives: Directives::default(),
             prefixes: HashMap::new(),

--- a/carina-core/src/resource/persistent_id.rs
+++ b/carina-core/src/resource/persistent_id.rs
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn persistent_id_round_trip() {
-        let id = ResourceId::new("aws.s3.Bucket", "b");
+        let id = ResourceId::with_identity("aws.s3.Bucket", "b");
         let pid = PersistentId::new(id.clone());
         assert_eq!(pid.inner(), &id);
         assert_eq!(pid.into_inner(), id);
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn ephemeral_id_round_trip() {
-        let id = ResourceId::new("_virtual", "m");
+        let id = ResourceId::with_identity("_virtual", "m");
         let eid = EphemeralId::new(id.clone());
         assert_eq!(eid.inner(), &id);
         assert_eq!(eid.into_inner(), id);
@@ -190,13 +190,13 @@ mod tests {
     /// ```compile_fail
     /// use carina_core::resource::{EphemeralId, PersistentId, ResourceId};
     /// fn loads_from_state(_pid: &PersistentId) {}
-    /// let eid = EphemeralId::new(ResourceId::new("_virtual", "m"));
+    /// let eid = EphemeralId::new(ResourceId::with_identity("_virtual", "m"));
     /// loads_from_state(&eid);
     /// ```
     ///
     /// ```compile_fail
     /// use carina_core::resource::{EphemeralId, PersistentId, ResourceId};
-    /// let eid = EphemeralId::new(ResourceId::new("_virtual", "m"));
+    /// let eid = EphemeralId::new(ResourceId::with_identity("_virtual", "m"));
     /// let _pid: PersistentId = eid.into();
     /// ```
     #[allow(dead_code)]
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn node_id_from_persistent_id() {
-        let pid = PersistentId::new(ResourceId::new("aws.s3.Bucket", "b"));
+        let pid = PersistentId::new(ResourceId::with_identity("aws.s3.Bucket", "b"));
         let nid: NodeId = pid.clone().into();
         assert!(matches!(nid, NodeId::Persistent(_)));
         assert_eq!(nid.inner(), pid.inner());
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn node_id_from_ephemeral_id() {
-        let eid = EphemeralId::new(ResourceId::new("_virtual", "m"));
+        let eid = EphemeralId::new(ResourceId::with_identity("_virtual", "m"));
         let nid: NodeId = eid.clone().into();
         assert!(matches!(nid, NodeId::Ephemeral(_)));
         assert_eq!(nid.inner(), eid.inner());

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -57,55 +57,84 @@ fn value_serde_round_trip() {
 
 #[test]
 fn resource_id_serde_round_trip() {
-    let id = ResourceId::with_provider("awscc", "ec2.Vpc", "main-vpc", None);
+    let id = ResourceId::with_provider_identity("awscc", "ec2.Vpc", "main-vpc", None);
     let json = serde_json::to_string(&id).unwrap();
     let deserialized: ResourceId = serde_json::from_str(&json).unwrap();
     assert_eq!(id, deserialized);
 }
 
-// The "anonymous, awaiting `name` extraction" state is type-distinct
-// from a bound name, so the parser cannot accidentally produce a
-// `ResourceId` whose `name` is the empty string and have it be
-// mistaken for a valid identifier (#2225).
-
 #[test]
-fn resource_name_pending_is_distinct_from_bound_empty() {
-    let pending = ResourceName::Pending;
-    let bound_empty = ResourceName::Bound(String::new());
-    assert_ne!(pending, bound_empty);
-    assert!(pending.is_pending());
-    assert!(!bound_empty.is_pending());
+fn resource_identity_rejects_empty_string() {
+    let err = serde_json::from_str::<ResourceIdentity>(r#""""#).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("resource identity cannot be empty")
+    );
 }
 
 #[test]
-fn resource_id_pending_serde_round_trips_as_empty_string() {
-    // V5 state files persist `name` as a plain JSON string. To preserve
-    // backward compatibility, ResourceName::Pending serializes to "" and
-    // deserializes from "" — round-trip is exact.
+#[should_panic(expected = "resource identity cannot be empty")]
+fn resource_identity_new_rejects_empty() {
+    ResourceIdentity::new("");
+}
+
+#[test]
+fn identity_or_empty_returns_empty_for_none() {
+    let id = ResourceId::with_provider("aws", "s3.Bucket", None, None);
+    assert_eq!(id.identity_or_empty(), "");
+}
+
+#[test]
+fn with_provider_name_compat_maps_empty_to_none() {
+    let id = ResourceId::with_provider_name_compat("aws", "s3.Bucket", "", None);
+    assert!(id.identity.is_none());
+}
+
+#[test]
+fn with_provider_name_compat_maps_nonempty_to_some() {
+    let id = ResourceId::with_provider_name_compat("aws", "s3.Bucket", "my-bucket", None);
+    assert_eq!(id.identity_str(), Some("my-bucket"));
+}
+
+#[test]
+fn resource_id_absent_identity_serde_round_trips_as_null() {
     let id = ResourceId {
         provider: "aws".to_string(),
         resource_type: "ec2.Subnet".to_string(),
-        name: ResourceName::Pending,
+        identity: None,
         provider_instance: None,
     };
     let json = serde_json::to_string(&id).unwrap();
-    assert!(json.contains("\"name\":\"\""), "got: {json}");
+    assert!(json.contains("\"identity\":null"), "got: {json}");
     let deserialized: ResourceId = serde_json::from_str(&json).unwrap();
     assert_eq!(id, deserialized);
-    assert!(deserialized.name.is_pending());
+    assert!(deserialized.identity.is_none());
 }
 
 #[test]
-fn resource_id_bound_serde_round_trips_as_string() {
-    let id = ResourceId::with_provider("aws", "ec2.Subnet", "my-subnet", None);
+fn resource_id_identity_serde_round_trips_as_string() {
+    let id = ResourceId::with_provider_identity("aws", "ec2.Subnet", "my-subnet", None);
     let json = serde_json::to_string(&id).unwrap();
-    assert!(json.contains("\"name\":\"my-subnet\""), "got: {json}");
+    assert!(json.contains("\"identity\":\"my-subnet\""), "got: {json}");
     let deserialized: ResourceId = serde_json::from_str(&json).unwrap();
     assert_eq!(id, deserialized);
-    match deserialized.name {
-        ResourceName::Bound(s) => assert_eq!(s, "my-subnet"),
-        _ => panic!("expected Bound"),
-    }
+    assert_eq!(deserialized.identity_str(), Some("my-subnet"));
+}
+
+#[test]
+fn resource_id_deserializes_legacy_name_alias() {
+    let legacy = r#"{"provider":"aws","resource_type":"ec2.Subnet","name":"my-subnet"}"#;
+    let deserialized: ResourceId = serde_json::from_str(legacy).unwrap();
+    assert_eq!(deserialized.identity_str(), Some("my-subnet"));
+}
+
+#[test]
+fn resource_id_rejects_legacy_empty_name() {
+    let legacy = r#"{"provider":"aws","resource_type":"ec2.Subnet","name":""}"#;
+    assert!(
+        serde_json::from_str::<ResourceId>(legacy).is_err(),
+        "empty legacy name must fail — identity cannot be empty"
+    );
 }
 
 /// The AC test from #2225: lookups keyed by `ResourceId` must remain
@@ -118,18 +147,15 @@ fn resource_id_rename_pending_to_bound() {
     let mut id = ResourceId {
         provider: "aws".to_string(),
         resource_type: "ec2.Subnet".to_string(),
-        name: ResourceName::Pending,
+        identity: None,
         provider_instance: None,
     };
-    // The post-pass converts Pending → Bound with the extracted name.
-    id.set_name("app-subnet".to_string());
-    match &id.name {
-        ResourceName::Bound(s) => assert_eq!(s, "app-subnet"),
-        _ => panic!("expected Bound after set_name"),
-    }
+    // The post-pass assigns the extracted identity.
+    id.set_identity(ResourceIdentity::new("app-subnet".to_string()));
+    assert_eq!(id.identity_str(), Some("app-subnet"));
     // After renaming, the same string can produce an equal ResourceId
     // from any other code path (e.g. building a key for a sibling map).
-    let constructed = ResourceId::with_provider("aws", "ec2.Subnet", "app-subnet", None);
+    let constructed = ResourceId::with_provider_identity("aws", "ec2.Subnet", "app-subnet", None);
     assert_eq!(id, constructed);
 }
 
@@ -146,7 +172,7 @@ fn state_serde_round_trip() {
     );
 
     let state = State::existing(
-        ResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None),
+        ResourceId::with_provider_identity("aws", "s3.Bucket", "my-bucket", None),
         attrs,
     )
     .with_identifier("my-bucket");
@@ -759,7 +785,7 @@ fn resource_dependency_bindings_iteration_is_sorted() {
 /// that delete-ordering metadata is also dedup'd and stable (#2228).
 #[test]
 fn state_dependency_bindings_dedup_on_duplicate_insert() {
-    let mut state = State::not_found(ResourceId::new("ec2.Subnet", "my-subnet"));
+    let mut state = State::not_found(ResourceId::with_identity("ec2.Subnet", "my-subnet"));
     state.dependency_bindings.insert("vpc".to_string());
     state.dependency_bindings.insert("vpc".to_string());
     assert_eq!(state.dependency_bindings.len(), 1);
@@ -1386,7 +1412,7 @@ fn unknown_cannot_round_trip_through_serde_json() {
 
 #[test]
 fn human_display_separates_type_from_name_with_space() {
-    let id = ResourceId::with_provider(
+    let id = ResourceId::with_provider_identity(
         "awscc",
         "iam.OidcProvider",
         "bs.bootstrap.oidc_provider",
@@ -1402,9 +1428,9 @@ fn human_display_separates_type_from_name_with_space() {
 
 #[test]
 fn human_display_omits_provider_segment_when_empty() {
-    // ResourceId::new (no provider) is used in some early-pipeline code paths
+    // ResourceId::with_identity (no provider) is used in some early-pipeline code paths
     // and in tests. The human format must still separate type from name.
-    let id = ResourceId::new("s3.Bucket", "state_bucket");
+    let id = ResourceId::with_identity("s3.Bucket", "state_bucket");
     assert_eq!(format!("{}", id.human()), "s3.Bucket state_bucket");
 }
 
@@ -1413,17 +1439,21 @@ fn human_display_does_not_alter_logical_display() {
     // The default Display remains the canonical dotted form because state
     // files, hashmap keys, binding fallbacks, and DSL identifiers all rely
     // on it. Only the human() wrapper changes shape.
-    let id = ResourceId::with_provider("aws", "s3.Bucket", "state_bucket", None);
+    let id = ResourceId::with_provider_identity("aws", "s3.Bucket", "state_bucket", None);
     assert_eq!(format!("{}", id), "aws.s3.Bucket.state_bucket");
 }
 
 #[test]
-fn human_display_handles_pending_name() {
-    // ResourceName::Pending renders as empty in Display; human() should
-    // still emit the separating space so callers can rely on a stable shape.
-    let mut id = ResourceId::with_provider("awscc", "ec2.Vpc", "", None);
-    id.name = ResourceName::Pending;
-    assert_eq!(format!("{}", id.human()), "awscc.ec2.Vpc ");
+fn human_display_handles_absent_identity() {
+    // An absent identity omits the identity segment rather than leaving
+    // trailing separators in human-facing display.
+    let id = ResourceId::with_provider("awscc", "ec2.Vpc", None, None);
+    assert_eq!(format!("{}", id), "awscc.ec2.Vpc");
+    assert_eq!(format!("{}", id.human()), "awscc.ec2.Vpc");
+
+    let local_id = ResourceId::new("custom.Type", None);
+    assert_eq!(format!("{}", local_id), "custom.Type");
+    assert_eq!(format!("{}", local_id.human()), "custom.Type");
 }
 
 // ---------------------------------------------------------------------

--- a/carina-core/src/validation/deferred_populate.rs
+++ b/carina-core/src/validation/deferred_populate.rs
@@ -381,12 +381,12 @@ mod tests {
     /// that references the deferred field.
     fn parsed_with_unsynchronized_chained_ref() -> ParsedFile {
         let mut cert = Resource::new("acm.Certificate", "cert");
-        cert.id = ResourceId::new("acm.Certificate", "cert");
+        cert.id = ResourceId::with_identity("acm.Certificate", "cert");
         cert.id.provider = "aws".to_string();
         cert.binding = Some("cert".to_string());
 
         let mut record = Resource::new("route53.RecordSet", "record");
-        record.id = ResourceId::new("route53.RecordSet", "record");
+        record.id = ResourceId::with_identity("route53.RecordSet", "record");
         record.id.provider = "aws".to_string();
         record.binding = Some("record".to_string());
         record.set_attr(
@@ -450,13 +450,13 @@ mod tests {
     #[test]
     fn chained_ref_to_non_deferred_inner_field_is_not_flagged() {
         let mut record = Resource::new("route53.RecordSet", "record");
-        record.id = ResourceId::new("route53.RecordSet", "record");
+        record.id = ResourceId::with_identity("route53.RecordSet", "record");
         record.id.provider = "aws".to_string();
         record.binding = Some("record".to_string());
         record.set_attr("name", dvo_chained_ref("domain_name"));
 
         let mut cert = Resource::new("acm.Certificate", "cert");
-        cert.id = ResourceId::new("acm.Certificate", "cert");
+        cert.id = ResourceId::with_identity("acm.Certificate", "cert");
         cert.id.provider = "aws".to_string();
         cert.binding = Some("cert".to_string());
 
@@ -473,7 +473,7 @@ mod tests {
         // A typo in the binding name produces an undefined-identifier
         // error elsewhere; this pass must not pile on.
         let mut record = Resource::new("route53.RecordSet", "record");
-        record.id = ResourceId::new("route53.RecordSet", "record");
+        record.id = ResourceId::with_identity("route53.RecordSet", "record");
         record.id.provider = "aws".to_string();
         record.binding = Some("record".to_string());
         let path = AccessPath::with_segments(
@@ -524,12 +524,12 @@ mod tests {
         r.insert("aws", consumer);
 
         let mut db = Resource::new("rds.DBInstance", "db");
-        db.id = ResourceId::new("rds.DBInstance", "db");
+        db.id = ResourceId::with_identity("rds.DBInstance", "db");
         db.id.provider = "aws".to_string();
         db.binding = Some("db".to_string());
 
         let mut inst = Resource::new("ec2.Instance", "i");
-        inst.id = ResourceId::new("ec2.Instance", "i");
+        inst.id = ResourceId::with_identity("ec2.Instance", "i");
         inst.id.provider = "aws".to_string();
         inst.binding = Some("i".to_string());
         let path = AccessPath::with_segments(
@@ -558,7 +558,7 @@ mod tests {
         // Resource type not in the registry — pass should bail
         // silently. Other passes report unknown resource types.
         let mut record = Resource::new("unknown.thing", "x");
-        record.id = ResourceId::new("unknown.thing", "x");
+        record.id = ResourceId::with_identity("unknown.thing", "x");
         record.id.provider = "aws".to_string();
         record.binding = Some("x".to_string());
         record.set_attr(

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -1467,7 +1467,7 @@ mod tests {
             )),
         );
         let virt = crate::resource::Composition {
-            id: crate::resource::ResourceId::new("_virtual", "github_actions_carina"),
+            id: crate::resource::ResourceId::with_identity("_virtual", "github_actions_carina"),
             signature: crate::resource::Signature {
                 arguments: indexmap::IndexMap::new(),
                 attributes: virt_attrs,

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -385,7 +385,7 @@ let route = awscc.ec2.route {
     let route = parsed
         .resources
         .iter()
-        .find(|r| r.id.name_str() == "route")
+        .find(|r| r.id.identity_or_empty() == "route")
         .unwrap();
     let gateway_id = route.get_attr("gateway_id").unwrap();
     match gateway_id {

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -3387,7 +3387,7 @@ mod tests {
             )))),
         );
         let virt = Composition {
-            id: ResourceId::new("_virtual", "module_instance"),
+            id: ResourceId::with_identity("_virtual", "module_instance"),
             signature: Signature {
                 arguments: indexmap::IndexMap::new(),
                 attributes: attrs,
@@ -4600,7 +4600,7 @@ mod tests {
     }
 
     fn make_resource(attrs: Vec<(&str, Value)>) -> crate::resource::Resource {
-        use crate::resource::{Resource, ResourceId, ResourceName};
+        use crate::resource::{Resource, ResourceId, ResourceIdentity};
         use std::collections::{BTreeSet, HashMap, HashSet};
         let mut attributes = IndexMap::new();
         for (k, v) in attrs {
@@ -4610,7 +4610,7 @@ mod tests {
             id: ResourceId {
                 provider: "aws".to_string(),
                 resource_type: "iam.policy".to_string(),
-                name: ResourceName::Bound("p1".to_string()),
+                identity: Some(ResourceIdentity::new("p1")),
                 provider_instance: None,
             },
             attributes,
@@ -4718,7 +4718,7 @@ mod tests {
     // ---- canonicalize_states_with_schemas tests (#2481, #2513) ----
 
     fn make_state(attrs: Vec<(&str, Value)>) -> crate::resource::State {
-        use crate::resource::{ResourceId, ResourceName, State};
+        use crate::resource::{ResourceId, ResourceIdentity, State};
         use std::collections::{BTreeSet, HashMap};
         let mut attributes = HashMap::new();
         for (k, v) in attrs {
@@ -4728,7 +4728,7 @@ mod tests {
             id: ResourceId {
                 provider: "aws".to_string(),
                 resource_type: "iam.policy".to_string(),
-                name: ResourceName::Bound("p1".to_string()),
+                identity: Some(ResourceIdentity::new("p1")),
                 provider_instance: None,
             },
             identifier: Some("arn:aws:iam::123:policy/p1".to_string()),
@@ -4846,7 +4846,7 @@ mod tests {
         let mut registry = SchemaRegistry::new();
         registry.insert("awscc", schema.clone());
 
-        let id = ResourceId::with_provider("awscc", "ec2.Subnet", "subnet", None);
+        let id = ResourceId::with_provider_identity("awscc", "ec2.Subnet", "subnet", None);
         let mut desired = vec![
             Resource::with_provider("awscc", "ec2.Subnet", "subnet", None).with_attribute(
                 "availability_zone",
@@ -5070,7 +5070,7 @@ mod tests {
             InterpolationPart::Literal("|registry-dev.carina-rs.dev|NS".to_string()),
         ]));
         let effect = Effect::Import {
-            id: ResourceId::new("aws.route53.RecordSet", "r.delegation_ns"),
+            id: ResourceId::with_identity("aws.route53.RecordSet", "r.delegation_ns"),
             identifier,
         };
         let redacted = redact_secrets_in_effect(&effect)
@@ -5107,7 +5107,7 @@ mod tests {
             InterpolationPart::Literal("|tail".to_string()),
         ]));
         let effect = Effect::Import {
-            id: ResourceId::new("aws.s3.Bucket", "b"),
+            id: ResourceId::with_identity("aws.s3.Bucket", "b"),
             identifier,
         };
         let redacted = redact_secrets_in_effect(&effect).expect("redaction succeeds");
@@ -5161,7 +5161,7 @@ mod tests {
         let mut template_resource = Resource::new("aws.route53.RecordSet", "validation_records");
         template_resource.set_attr("name", placeholder.clone());
         let effect = Effect::DeferredCreate {
-            id: ResourceId::new("__deferred_for", "validation_records"),
+            id: ResourceId::with_identity("__deferred_for", "validation_records"),
             upstream_binding: "cert".to_string(),
             template: Box::new(DeferredForExpression {
                 file: None,

--- a/carina-core/src/wait/augment.rs
+++ b/carina-core/src/wait/augment.rs
@@ -135,7 +135,7 @@ mod tests {
         let known_bindings = known.iter().map(|name| (*name).to_string()).collect();
         satisfier_augmentation(
             &provider,
-            &ResourceId::new("acm.Certificate", "cert"),
+            &ResourceId::with_identity("acm.Certificate", "cert"),
             &AttrPath::single("status"),
             &known_bindings,
         )

--- a/carina-core/src/wait/observation.rs
+++ b/carina-core/src/wait/observation.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[test]
     fn primary_returns_first_watched_attr_present_in_last_attrs() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let status = AttrPath::single("status");
         let predicate = equals_predicate(status.clone(), "pending");
         let last_attrs = HashMap::from([
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn primary_walks_multi_segment_path() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let renewal_status =
             AttrPath::try_new(vec!["renewal_summary".into(), "renewal_status".into()]).unwrap();
         let predicate = equals_predicate(renewal_status.clone(), "PENDING");
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn primary_returns_none_when_no_watched_attr_present() {
-        let target_id = ResourceId::new("aws.test.Resource", "demo");
+        let target_id = ResourceId::with_identity("aws.test.Resource", "demo");
         let xyz = AttrPath::single("xyz");
         let predicate = equals_predicate(xyz, "present");
         let last_attrs = HashMap::from([("arn".to_string(), string_value("arn:demo"))]);

--- a/carina-core/tests/carina3122_live_phantom.rs
+++ b/carina-core/tests/carina3122_live_phantom.rs
@@ -90,7 +90,7 @@ fn carina3122_live_distribution_readback_defaults_are_projected_away() {
     let state_dc = load_dc("state_distribution_config.json");
     let prev_explicit = load_explicit();
 
-    let mut id = ResourceId::new("cloudfront.Distribution", "r.distribution");
+    let mut id = ResourceId::with_identity("cloudfront.Distribution", "r.distribution");
     id.provider = "awscc".to_string();
 
     let mut desired = Resource::new("cloudfront.Distribution", "r.distribution")

--- a/carina-core/tests/cyclic_schema_ref.rs
+++ b/carina-core/tests/cyclic_schema_ref.rs
@@ -145,7 +145,7 @@ fn differ_treats_equal_cyclic_values_as_unchanged() {
     // `type_aware_equal` resolves `Ref` at function entry and so
     // semantically equal cyclic values do not surface a phantom diff.
     let schema = cyclic_webacl_like_schema();
-    let id = ResourceId::new("wafv2.WebACL", "main");
+    let id = ResourceId::with_identity("wafv2.WebACL", "main");
 
     let rules_value = Value::Concrete(ConcreteValue::List(vec![rule_value("BlockBadIPs", 2)]));
     let desired = build_resource(&id, &[("rules", rules_value.clone())]);
@@ -168,7 +168,7 @@ fn differ_surfaces_a_real_change_inside_a_cyclic_value() {
     // the `Ref` resolution didn't accidentally collapse the inner
     // walk into a no-op.
     let schema = cyclic_webacl_like_schema();
-    let id = ResourceId::new("wafv2.WebACL", "main");
+    let id = ResourceId::with_identity("wafv2.WebACL", "main");
 
     let desired_rules = Value::Concrete(ConcreteValue::List(vec![rule_value("BlockBadIPs", 3)]));
     let desired = build_resource(&id, &[("rules", desired_rules)]);
@@ -415,7 +415,7 @@ fn build_resource(id: &ResourceId, attrs: &[(&str, Value)]) -> Resource {
     // touch the private `id` field, but immediately overwrite the
     // synthesized id with the one our test owns (same shape, plus an
     // explicit provider).
-    let mut r = Resource::new(id.resource_type.clone(), id.name.clone().to_string());
+    let mut r = Resource::new(id.resource_type.clone(), id.identity_or_empty().to_string());
     r.id = id.clone();
     for (k, v) in attrs {
         r = r.with_attribute(k.to_string(), v.clone());

--- a/carina-core/tests/depends_on_directory.rs
+++ b/carina-core/tests/depends_on_directory.rs
@@ -22,7 +22,7 @@ fn depends_on_resolves_across_sibling_files_in_directory() {
     let bucket = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "bucket")
+        .find(|r| r.id.identity_or_empty() == "bucket")
         .expect("bucket binding should be present");
 
     let deps = get_resource_dependencies(bucket);

--- a/carina-core/tests/wait_directory.rs
+++ b/carina-core/tests/wait_directory.rs
@@ -49,7 +49,7 @@ fn wait_resolves_target_and_depends_on_across_sibling_files() {
     let cert = parsed
         .resources
         .iter()
-        .find(|r| r.id.name.as_str() == "cert")
+        .find(|r| r.id.identity_or_empty() == "cert")
         .expect("cert binding should be present from main.crn");
     assert_eq!(cert.id.resource_type, "acm.Certificate");
 }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -385,7 +385,7 @@ pub fn core_to_wit_resource_id(id: &CoreResourceId) -> wit::ResourceId {
     wit::ResourceId {
         provider: id.provider.clone(),
         resource_type: id.resource_type.clone(),
-        name: id.name_str().to_string(),
+        name: id.identity_or_empty().to_string(),
     }
 }
 
@@ -395,7 +395,7 @@ pub fn wit_to_core_resource_id(id: &wit::ResourceId) -> CoreResourceId {
     // Tracked as a follow-up to extend the WIT contract; until then,
     // callers that need routing must thread it through alongside the
     // converted id.
-    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name, None)
+    CoreResourceId::with_provider_name_compat(&id.provider, &id.resource_type, &id.name, None)
 }
 
 // -- State --
@@ -483,8 +483,12 @@ pub fn wit_to_core_resource(resource: &wit::ResourceDef) -> CoreResource {
     // `id` came from `wit_to_core_resource_id`, which has no
     // `provider_instance` to forward (WIT contract limitation); pass
     // `None` explicitly to match.
-    let mut core_resource =
-        CoreResource::with_provider(&id.provider, &id.resource_type, id.name_str(), None);
+    let mut core_resource = CoreResource::with_provider(
+        &id.provider,
+        &id.resource_type,
+        id.identity_or_empty(),
+        None,
+    );
     core_resource.attributes = resource
         .attributes
         .iter()
@@ -1503,7 +1507,7 @@ mod tests {
 
     #[test]
     fn test_resource_id_roundtrip() {
-        let core = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None);
+        let core = CoreResourceId::with_provider_identity("aws", "s3.Bucket", "my-bucket", None);
         let wit = core_to_wit_resource_id(&core);
         assert_eq!(wit.provider, "aws");
         assert_eq!(wit.resource_type, "s3.Bucket");
@@ -1516,7 +1520,7 @@ mod tests {
 
     #[test]
     fn test_state_roundtrip() {
-        let id = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None);
+        let id = CoreResourceId::with_provider_identity("aws", "s3.Bucket", "my-bucket", None);
         let mut attrs = HashMap::new();
         attrs.insert(
             "name".into(),
@@ -1538,7 +1542,7 @@ mod tests {
 
     #[test]
     fn test_state_with_identifier_roundtrip() {
-        let id = CoreResourceId::with_provider("aws", "ec2.Vpc", "main", None);
+        let id = CoreResourceId::with_provider_identity("aws", "ec2.Vpc", "main", None);
         let attrs = HashMap::from([(
             "cidr".into(),
             CoreValue::Concrete(ConcreteValue::String("10.0.0.0/16".into())),
@@ -1655,7 +1659,7 @@ mod tests {
         // flattened to a string at the boundary because WIT cannot
         // carry `dyn std::error::Error`.
         let cause = std::io::Error::other("inner io error");
-        let id = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None);
+        let id = CoreResourceId::with_provider_identity("aws", "s3.Bucket", "my-bucket", None);
         let err = CoreProviderError::api_error("Failed to read")
             .with_cause(cause)
             .for_resource(id.clone())
@@ -1670,7 +1674,7 @@ mod tests {
         let rid = detail.resource_id.as_ref().expect("resource_id preserved");
         assert_eq!(rid.provider, "aws");
         assert_eq!(rid.resource_type, "s3.Bucket");
-        assert_eq!(rid.name_str(), "my-bucket");
+        assert_eq!(rid.identity_or_empty(), "my-bucket");
         let cause_str = detail
             .cause
             .as_ref()

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -93,7 +93,7 @@ async fn test_wasm_mock_provider_create_and_read() {
     assert_eq!(provider.name(), "mock");
 
     // Read before create - should return a state with no identifier and empty attributes
-    let id = ResourceId::with_provider("mock", "test.resource", "my-resource", None);
+    let id = ResourceId::with_provider_identity("mock", "test.resource", "my-resource", None);
     let state = provider
         .read(&id, None, ReadRequest)
         .await
@@ -172,7 +172,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
         .await
         .expect("provider should init");
 
-    let id = ResourceId::with_provider("mock", "test.resource", "updatable", None);
+    let id = ResourceId::with_provider_identity("mock", "test.resource", "updatable", None);
 
     // Create first
     let mut resource = Resource::with_provider("mock", "test.resource", "updatable", None);
@@ -304,7 +304,7 @@ async fn test_wasm_mock_provider_normalizer() {
     assert_eq!(resources[0].resolved_attributes(), original_attrs);
 
     // normalize_state: mock provider returns states unchanged
-    let id = ResourceId::with_provider("mock", "test.resource", "norm-test", None);
+    let id = ResourceId::with_provider_identity("mock", "test.resource", "norm-test", None);
     let attrs = HashMap::from([(
         "key".into(),
         Value::Concrete(ConcreteValue::String("value".into())),
@@ -421,9 +421,9 @@ async fn test_wasm_mock_provider_merge_default_tags_preserves_order() {
         .merge_default_tags(&mut resources, &default_tags, &registry)
         .await;
 
-    assert_eq!(resources[0].id.name.as_str(), "alpha");
-    assert_eq!(resources[1].id.name.as_str(), "beta");
-    assert_eq!(resources[2].id.name.as_str(), "gamma");
+    assert_eq!(resources[0].id.identity_or_empty(), "alpha");
+    assert_eq!(resources[1].id.identity_or_empty(), "beta");
+    assert_eq!(resources[2].id.identity_or_empty(), "gamma");
     for r in &resources {
         assert!(
             r.get_attr("__mock_merged_default_tags__").is_some(),
@@ -494,7 +494,7 @@ async fn test_wasm_mock_provider_required_permissions_dispatches_through_wit() {
         .create_provider(None, &indexmap::IndexMap::new())
         .await
         .expect("provider should init");
-    let id = ResourceId::with_provider("mock", "test.resource", "example", None);
+    let id = ResourceId::with_provider_identity("mock", "test.resource", "example", None);
 
     assert_eq!(
         provider.required_permissions(&id, PlanOp::Create),

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -107,7 +107,7 @@ impl MockProvider {
     }
 
     fn resource_key(id: &ResourceId) -> String {
-        format!("{}.{}", id.resource_type, id.name)
+        format!("{}.{}", id.resource_type, id.identity_or_empty())
     }
 
     fn partial_create_config_for(&self, id: &ResourceId) -> Option<&PartialConfig> {
@@ -121,7 +121,12 @@ impl MockProvider {
     }
 
     fn partial_config_matches(config: &PartialConfig, id: &ResourceId) -> bool {
-        let full = format!("{}.{}.{}", id.provider, id.resource_type, id.name);
+        let full = format!(
+            "{}.{}.{}",
+            id.provider,
+            id.resource_type,
+            id.identity_or_empty()
+        );
         let short = Self::resource_key(id);
         config.resource_id_pattern == "*"
             || config.resource_id_pattern == full
@@ -166,7 +171,7 @@ impl MockProvider {
     fn test_resource_identifier(id: &ResourceId, name: Option<&str>) -> Option<String> {
         (id.resource_type == "test.resource"
             && env::var_os("CARINA_MOCK_ENABLE_TEST_RESOURCE_SCHEMA").is_some())
-        .then(|| format!("{}-id", name.unwrap_or_else(|| id.name_str())))
+        .then(|| format!("{}-id", name.unwrap_or_else(|| id.identity_or_empty())))
     }
 
     fn populate_test_resource_identifier_json(
@@ -549,7 +554,7 @@ mod tests {
     #[test]
     fn required_permissions_returns_empty_vec() {
         let provider = MockProvider::default();
-        let id = ResourceId::with_provider("mock", "foo", "example", None);
+        let id = ResourceId::with_provider_identity("mock", "foo", "example", None);
         assert_eq!(
             provider.required_permissions(&id, carina_core::effect::PlanOp::Create),
             Vec::<String>::new()
@@ -560,8 +565,8 @@ mod tests {
     fn append_delete_log_records_resource_keys() {
         let tmp = tempfile::tempdir().unwrap();
         let log_path = tmp.path().join("delete.log");
-        let first = ResourceId::with_provider("mock", "test.resource", "first", None);
-        let second = ResourceId::with_provider("mock", "test.resource", "second", None);
+        let first = ResourceId::with_provider_identity("mock", "test.resource", "first", None);
+        let second = ResourceId::with_provider_identity("mock", "test.resource", "second", None);
 
         MockProvider::append_delete_log(log_path.clone(), &first).unwrap();
         MockProvider::append_delete_log(log_path.clone(), &second).unwrap();
@@ -585,7 +590,7 @@ mod tests {
             partial_create: None,
             partial_update: None,
         };
-        let id = ResourceId::with_provider("mock", "test.resource", "web-acl-new", None);
+        let id = ResourceId::with_provider_identity("mock", "test.resource", "web-acl-new", None);
         let resource = Resource::with_provider("mock", "test.resource", "web-acl-new", None)
             .with_attribute("name", string_value("web-acl-new"))
             .with_attribute("comment", string_value("v1"));
@@ -649,7 +654,7 @@ mod tests {
             partial_create: None,
             partial_update: None,
         };
-        let id = ResourceId::with_provider("mock", "test.resource", "blocked", None);
+        let id = ResourceId::with_provider_identity("mock", "test.resource", "blocked", None);
         let resource = Resource::with_provider("mock", "test.resource", "blocked", None)
             .with_attribute("name", string_value("blocked"));
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -685,7 +690,7 @@ mod tests {
             partial_create: None,
             partial_update: None,
         };
-        let id = ResourceId::with_provider("mock", "test.resource", "slow", None);
+        let id = ResourceId::with_provider_identity("mock", "test.resource", "slow", None);
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_time()
             .build()

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -166,7 +166,7 @@ impl StateFile {
         if let Some(resource_state) = self.find_resource(
             &resource.id.provider,
             &resource.id.resource_type,
-            resource.id.name_str(),
+            resource.id.identity_or_empty(),
         ) {
             return resource_state.identifier.clone();
         }
@@ -177,27 +177,26 @@ impl StateFile {
     pub fn build_directives(&self) -> HashMap<ResourceId, Directives> {
         let mut directives_map = HashMap::new();
         for rs in &self.resources {
-            let id = ResourceId::with_provider(
-                &rs.provider,
-                &rs.resource_type,
-                &rs.name,
-                rs.directives.provider_instance.clone(),
-            );
+            let id = Self::id_for_resource_state(rs);
             directives_map.insert(id, rs.directives.clone());
         }
         directives_map
+    }
+
+    fn id_for_resource_state(rs: &ResourceState) -> ResourceId {
+        ResourceId::with_provider_name_compat(
+            &rs.provider,
+            &rs.resource_type,
+            &rs.name,
+            rs.directives.provider_instance.clone(),
+        )
     }
 
     /// Build a map of saved attributes, converting JSON values to DSL values.
     pub fn build_saved_attrs(&self) -> HashMap<ResourceId, HashMap<String, Value>> {
         let mut result = HashMap::new();
         for rs in &self.resources {
-            let id = ResourceId::with_provider(
-                &rs.provider,
-                &rs.resource_type,
-                &rs.name,
-                rs.directives.provider_instance.clone(),
-            );
+            let id = Self::id_for_resource_state(rs);
             let attrs: HashMap<String, Value> = rs
                 .attributes
                 .iter()
@@ -216,7 +215,7 @@ impl StateFile {
                 continue;
             }
             let marker = self
-                .find_resource(&id.provider, &id.resource_type, id.name_str())
+                .find_resource(&id.provider, &id.resource_type, id.identity_or_empty())
                 .and_then(|rs| rs.partial_read.clone());
             if let Some(mut marker) = marker {
                 marker
@@ -239,12 +238,7 @@ impl StateFile {
         let mut result = HashMap::new();
         for rs in &self.resources {
             if !is_empty_explicit(&rs.explicit) {
-                let id = ResourceId::with_provider(
-                    &rs.provider,
-                    &rs.resource_type,
-                    &rs.name,
-                    rs.directives.provider_instance.clone(),
-                );
+                let id = Self::id_for_resource_state(rs);
                 result.insert(id, rs.explicit.clone());
             }
         }
@@ -256,7 +250,7 @@ impl StateFile {
     /// state file. Takes a `&ResourceId` so it works for managed
     /// resources and data sources alike (carina#3181).
     pub fn build_state_for_resource(&self, id: &ResourceId) -> State {
-        let rs = self.find_resource(&id.provider, &id.resource_type, id.name_str());
+        let rs = self.find_resource(&id.provider, &id.resource_type, id.identity_or_empty());
         if let Some(identifier) = rs.and_then(|r| r.identifier.as_deref()) {
             let attrs: HashMap<String, Value> = rs
                 .unwrap()
@@ -285,12 +279,7 @@ impl StateFile {
     ) -> HashMap<ResourceId, State> {
         let mut result = HashMap::new();
         for rs in &self.resources {
-            let id = ResourceId::with_provider(
-                &rs.provider,
-                &rs.resource_type,
-                &rs.name,
-                rs.directives.provider_instance.clone(),
-            );
+            let id = Self::id_for_resource_state(rs);
             if desired_ids.contains(&id) {
                 continue;
             }
@@ -330,12 +319,7 @@ impl StateFile {
     ) -> HashMap<ResourceId, BTreeSet<String>> {
         let mut result = HashMap::new();
         for rs in &self.resources {
-            let id = ResourceId::with_provider(
-                &rs.provider,
-                &rs.resource_type,
-                &rs.name,
-                rs.directives.provider_instance.clone(),
-            );
+            let id = Self::id_for_resource_state(rs);
             if desired_ids.contains(&id) {
                 continue;
             }
@@ -352,12 +336,7 @@ impl StateFile {
         let mut result = HashMap::new();
         for rs in &self.resources {
             if !rs.name_overrides.is_empty() {
-                let id = ResourceId::with_provider(
-                    &rs.provider,
-                    &rs.resource_type,
-                    &rs.name,
-                    rs.directives.provider_instance.clone(),
-                );
+                let id = Self::id_for_resource_state(rs);
                 result.insert(id, rs.name_overrides.clone());
             }
         }
@@ -848,7 +827,7 @@ impl ResourceState {
     ) -> Result<Self, String> {
         let mut rs = Self::new(
             &resource.id.resource_type,
-            resource.id.name_str(),
+            resource.id.identity_or_empty(),
             resource.id.provider.clone(),
         );
         rs.identifier = state.identifier.clone();
@@ -865,8 +844,11 @@ impl ResourceState {
         // the provider-returned structure to preserve extra keys from the provider.
         for (k, v) in &resource.attributes {
             if contains_secret(v) {
-                let ctx =
-                    SecretHashContext::new(resource.id.display_type(), resource.id.name_str(), k);
+                let ctx = SecretHashContext::new(
+                    resource.id.display_type(),
+                    resource.id.identity_or_empty(),
+                    k,
+                );
                 if let Some(provider_json) = rs.attributes.get(k).cloned() {
                     rs.attributes.insert(
                         k.clone(),

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -183,7 +183,7 @@ fn test_build_directives() {
     state.upsert_resource(rs);
 
     let directives_map = state.build_directives();
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "my-bucket", None);
     assert!(directives_map.get(&id).unwrap().force_delete);
 }
 
@@ -197,7 +197,7 @@ fn test_build_saved_attrs() {
     state.upsert_resource(rs);
 
     let saved = state.build_saved_attrs();
-    let id = ResourceId::with_provider("awscc", "s3.Bucket", "my-bucket", None);
+    let id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "my-bucket", None);
     let attrs = saved.get(&id).unwrap();
     assert_eq!(
         attrs.get("region"),
@@ -710,8 +710,8 @@ fn test_build_directives_provider_scoped() {
     state.upsert_resource(awscc_rs);
 
     let directives_map = state.build_directives();
-    let aws_id = ResourceId::with_provider("aws", "s3.Bucket", "main", None);
-    let awscc_id = ResourceId::with_provider("awscc", "s3.Bucket", "main", None);
+    let aws_id = ResourceId::with_provider_identity("aws", "s3.Bucket", "main", None);
+    let awscc_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "main", None);
 
     assert!(directives_map.get(&aws_id).unwrap().force_delete);
     assert!(!directives_map.get(&awscc_id).unwrap().force_delete);
@@ -731,8 +731,8 @@ fn test_build_saved_attrs_provider_scoped() {
     state.upsert_resource(awscc_rs);
 
     let saved = state.build_saved_attrs();
-    let aws_id = ResourceId::with_provider("aws", "s3.Bucket", "main", None);
-    let awscc_id = ResourceId::with_provider("awscc", "s3.Bucket", "main", None);
+    let aws_id = ResourceId::with_provider_identity("aws", "s3.Bucket", "main", None);
+    let awscc_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "main", None);
 
     assert_eq!(
         saved.get(&aws_id).unwrap().get("region"),
@@ -849,7 +849,7 @@ fn test_build_orphan_states_injects_binding() {
     let desired_ids = std::collections::HashSet::new();
     let orphans = state.build_orphan_states(&desired_ids);
 
-    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "orphan-subnet", None);
+    let id = ResourceId::with_provider_identity("awscc", "ec2.Subnet", "orphan-subnet", None);
     let orphan_state = orphans.get(&id).unwrap();
     assert!(orphan_state.exists);
     assert_eq!(
@@ -874,7 +874,7 @@ fn test_build_orphan_dependencies() {
     let desired_ids = std::collections::HashSet::new();
     let deps = state.build_orphan_dependencies(&desired_ids);
 
-    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "orphan-subnet", None);
+    let id = ResourceId::with_provider_identity("awscc", "ec2.Subnet", "orphan-subnet", None);
     assert_eq!(
         deps.get(&id).unwrap(),
         &BTreeSet::from(["my_vpc".to_string()])
@@ -897,7 +897,7 @@ fn test_build_orphan_dependencies_excludes_desired() {
     rs.dependency_bindings = BTreeSet::from(["my_vpc".to_string()]);
     state.upsert_resource(rs);
 
-    let id = ResourceId::with_provider("awscc", "ec2.Subnet", "kept-subnet", None);
+    let id = ResourceId::with_provider_identity("awscc", "ec2.Subnet", "kept-subnet", None);
     let mut desired_ids = std::collections::HashSet::new();
     desired_ids.insert(id.clone());
 
@@ -1721,7 +1721,7 @@ fn build_explicit_yields_per_resource_trees() {
     state.upsert_resource(rs);
 
     let map = state.build_explicit();
-    let id = ResourceId::with_provider("aws", "s3.Bucket", "my-bucket", None);
+    let id = ResourceId::with_provider_identity("aws", "s3.Bucket", "my-bucket", None);
     assert!(map.contains_key(&id));
     assert!(matches!(map[&id], ExplicitFields::Struct { .. }));
 }
@@ -1742,15 +1742,19 @@ fn build_directives_keys_include_provider_instance() {
     state.upsert_resource(rs);
 
     let map = state.build_directives();
-    let expected =
-        ResourceId::with_provider("aws", "s3.Bucket", "shared-name", Some("us".to_string()));
+    let expected = ResourceId::with_provider_identity(
+        "aws",
+        "s3.Bucket",
+        "shared-name",
+        Some("us".to_string()),
+    );
     assert!(
         map.contains_key(&expected),
         "build_directives must construct ResourceId with provider_instance, got keys: {:?}",
         map.keys().collect::<Vec<_>>()
     );
     // Without the instance, the legacy ResourceId must NOT match.
-    let legacy = ResourceId::with_provider("aws", "s3.Bucket", "shared-name", None);
+    let legacy = ResourceId::with_provider_identity("aws", "s3.Bucket", "shared-name", None);
     assert!(
         !map.contains_key(&legacy),
         "ResourceId without provider_instance must not match a Some(_) entry"

--- a/carina-tui/src/app/mod.rs
+++ b/carina-tui/src/app/mod.rs
@@ -645,7 +645,7 @@ fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
                 // For bound resources, show the binding name
                 r.binding()
                     .map(str::to_string)
-                    .unwrap_or_else(|| r.id().name_str().to_string())
+                    .unwrap_or_else(|| r.id().identity_or_empty().to_string())
             } else {
                 // For anonymous resources, try to extract a compact hint
                 let parent_binding = nodes[idx].parent.and_then(|p_idx| {
@@ -660,7 +660,7 @@ fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
                 if let Some(hint) = extract_compact_hint(r, parent_binding.as_deref()) {
                     format!("({})", hint)
                 } else {
-                    r.id().name_str().to_string()
+                    r.id().identity_or_empty().to_string()
                 }
             };
 
@@ -669,9 +669,10 @@ fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
             nodes[idx].effect_label = format!("{} {}", display_type, name_part);
         } else if let Effect::Delete { id, .. } = effect {
             let display_type = id.display_type();
+            let name_part = id.identity_or_empty().to_string();
             nodes[idx].resource_type = display_type.clone();
-            nodes[idx].name_part = id.name_str().to_string();
-            nodes[idx].effect_label = format!("{} {}", display_type, id.name);
+            nodes[idx].name_part = name_part.clone();
+            nodes[idx].effect_label = format!("{} {}", display_type, name_part);
         }
     }
 }
@@ -683,7 +684,7 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
         Effect::Read { resource } => TreeNode {
             effect_label: format!("{}", resource.id.human()),
             resource_type: resource.id.display_type(),
-            name_part: resource.id.name_str().to_string(),
+            name_part: resource.id.identity_or_empty().to_string(),
             symbol: effect.display_glyph().to_string(),
             kind: EffectKind::Read,
             detail_rows,
@@ -694,7 +695,7 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
         Effect::Create(resource) => TreeNode {
             effect_label: format!("{}", resource.id.human()),
             resource_type: resource.id.display_type(),
-            name_part: resource.id.name_str().to_string(),
+            name_part: resource.id.identity_or_empty().to_string(),
             symbol: effect.display_glyph().to_string(),
             kind: EffectKind::Create,
             detail_rows,
@@ -705,7 +706,7 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
         Effect::Update { id, .. } => TreeNode {
             effect_label: format!("{}", id.human()),
             resource_type: id.display_type(),
-            name_part: id.name_str().to_string(),
+            name_part: id.identity_or_empty().to_string(),
             symbol: effect.display_glyph().to_string(),
             kind: EffectKind::Update,
             detail_rows,
@@ -716,7 +717,7 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
         Effect::Replace { id, .. } => TreeNode {
             effect_label: format!("{}", id.human()),
             resource_type: id.display_type(),
-            name_part: id.name_str().to_string(),
+            name_part: id.identity_or_empty().to_string(),
             symbol: effect.display_glyph().to_string(),
             kind: EffectKind::Replace,
             detail_rows,
@@ -739,7 +740,7 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
             TreeNode {
                 effect_label: format!("{}", id.human()),
                 resource_type: id.display_type(),
-                name_part: id.name_str().to_string(),
+                name_part: id.identity_or_empty().to_string(),
                 symbol: effect.display_glyph().to_string(),
                 kind: EffectKind::Delete,
                 detail_rows: rows,
@@ -751,7 +752,7 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
         Effect::Import { id, .. } => TreeNode {
             effect_label: format!("{}", id.human()),
             resource_type: id.display_type(),
-            name_part: id.name_str().to_string(),
+            name_part: id.identity_or_empty().to_string(),
             symbol: effect.display_glyph().to_string(),
             kind: EffectKind::Read,
             detail_rows,
@@ -762,7 +763,7 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
         Effect::Remove { id } => TreeNode {
             effect_label: format!("{}", id.human()),
             resource_type: id.display_type(),
-            name_part: id.name_str().to_string(),
+            name_part: id.identity_or_empty().to_string(),
             // carina#3332: avoid the `x` glyph that shape-collides with
             // the `✗` failure indicator. `~` matches the CLI plan
             // tree's Remove symbol; `(remove from state)` annotation
@@ -781,7 +782,7 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
         Effect::Move { from, to } => TreeNode {
             effect_label: format!("{} -> {}", from.human(), to.human()),
             resource_type: to.display_type(),
-            name_part: to.name_str().to_string(),
+            name_part: to.identity_or_empty().to_string(),
             symbol: effect.display_glyph().to_string(),
             kind: EffectKind::Update,
             detail_rows,

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -16,7 +16,7 @@ fn app_from_plan_with_effects() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
     plan.add(Effect::Delete {
-        id: ResourceId::new("s3.Bucket", "old-bucket"),
+        id: ResourceId::with_identity("s3.Bucket", "old-bucket"),
         identifier: "old-bucket-id".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -41,7 +41,7 @@ fn app_from_plan_with_effects() {
 fn remove_effect_uses_non_failure_symbol_and_kind() {
     let mut plan = Plan::new();
     plan.add(Effect::Remove {
-        id: ResourceId::new("aws.route53.RecordSet", "aws_route53_record_set_7059de08"),
+        id: ResourceId::with_identity("aws.route53.RecordSet", "aws_route53_record_set_7059de08"),
     });
 
     let app = App::new(&plan, &SchemaRegistry::new());
@@ -79,7 +79,7 @@ fn deferred_create_uses_create_symbol_and_kind() {
 
     let mut plan = Plan::new();
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -127,9 +127,9 @@ fn navigation() {
 fn update_effect_has_detail_rows() {
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ResourceId::new("s3.Bucket", "my-bucket"),
+        id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
         from: Box::new(State::existing(
-            ResourceId::new("s3.Bucket", "my-bucket"),
+            ResourceId::with_identity("s3.Bucket", "my-bucket"),
             [(
                 "versioning".to_string(),
                 Value::Concrete(ConcreteValue::String("Disabled".to_string())),
@@ -203,7 +203,7 @@ fn format_value_display() {
 fn replace_effect_symbols() {
     let mut plan = Plan::new();
     let from = Box::new(State::existing(
-        ResourceId::new("ec2.Vpc", "my-vpc"),
+        ResourceId::with_identity("ec2.Vpc", "my-vpc"),
         [(
             "cidr".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -214,7 +214,7 @@ fn replace_effect_symbols() {
 
     // create_before_destroy = true -> "+/-"
     plan.add(Effect::Replace {
-        id: ResourceId::new("ec2.Vpc", "my-vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
         from: from.clone(),
         to: Resource::new("ec2.Vpc", "my-vpc"),
         directives: Directives {
@@ -230,7 +230,7 @@ fn replace_effect_symbols() {
 
     // create_before_destroy = false -> "-/+"
     plan.add(Effect::Replace {
-        id: ResourceId::new("ec2.Vpc", "my-vpc2"),
+        id: ResourceId::with_identity("ec2.Vpc", "my-vpc2"),
         from,
         to: Resource::new("ec2.Vpc", "my-vpc2"),
         directives: Directives::default(),
@@ -733,14 +733,14 @@ fn move_suppressed_when_update_exists_for_same_target() {
     let mut plan = Plan::new();
     // Move from old name to new name
     plan.add(Effect::Move {
-        from: ResourceId::new("s3.Bucket", "old-name"),
-        to: ResourceId::new("s3.Bucket", "new-name"),
+        from: ResourceId::with_identity("s3.Bucket", "old-name"),
+        to: ResourceId::with_identity("s3.Bucket", "new-name"),
     });
     // Update for the same target
     plan.add(Effect::Update {
-        id: ResourceId::new("s3.Bucket", "new-name"),
+        id: ResourceId::with_identity("s3.Bucket", "new-name"),
         from: Box::new(State::existing(
-            ResourceId::new("s3.Bucket", "new-name"),
+            ResourceId::with_identity("s3.Bucket", "new-name"),
             [(
                 "versioning".to_string(),
                 Value::Concrete(ConcreteValue::String("Disabled".to_string())),
@@ -765,13 +765,13 @@ fn move_suppressed_when_update_exists_for_same_target() {
 fn move_suppressed_when_replace_exists_for_same_target() {
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: ResourceId::new("ec2.Vpc", "old-vpc"),
-        to: ResourceId::new("ec2.Vpc", "new-vpc"),
+        from: ResourceId::with_identity("ec2.Vpc", "old-vpc"),
+        to: ResourceId::with_identity("ec2.Vpc", "new-vpc"),
     });
     plan.add(Effect::Replace {
-        id: ResourceId::new("ec2.Vpc", "new-vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "new-vpc"),
         from: Box::new(State::existing(
-            ResourceId::new("ec2.Vpc", "new-vpc"),
+            ResourceId::with_identity("ec2.Vpc", "new-vpc"),
             [(
                 "cidr".to_string(),
                 Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -797,8 +797,8 @@ fn move_suppressed_when_replace_exists_for_same_target() {
 fn pure_move_not_suppressed() {
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: ResourceId::new("s3.Bucket", "old-name"),
-        to: ResourceId::new("s3.Bucket", "new-name"),
+        from: ResourceId::with_identity("s3.Bucket", "old-name"),
+        to: ResourceId::with_identity("s3.Bucket", "new-name"),
     });
 
     let app = App::new(&plan, &SchemaRegistry::new());

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -83,9 +83,9 @@ fn build_all_create_plan() -> Plan {
 fn build_mixed_operations_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ResourceId::new("ec2.Vpc", "my-vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
         from: Box::new(State::existing(
-            ResourceId::new("ec2.Vpc", "my-vpc"),
+            ResourceId::with_identity("ec2.Vpc", "my-vpc"),
             [
                 (
                     "cidr_block".to_string(),
@@ -124,7 +124,7 @@ fn build_mixed_operations_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Delete {
-        id: ResourceId::new("ec2.Subnet", "old-subnet"),
+        id: ResourceId::with_identity("ec2.Subnet", "old-subnet"),
         identifier: "subnet-12345678".to_string(),
         directives: Directives::default(),
         binding: Some("old_subnet".to_string()),
@@ -173,9 +173,9 @@ fn build_map_key_diff_plan() -> Plan {
     .collect();
 
     plan.add(Effect::Update {
-        id: ResourceId::new("ec2.Vpc", "my-vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
         from: Box::new(State::existing(
-            ResourceId::new("ec2.Vpc", "my-vpc"),
+            ResourceId::with_identity("ec2.Vpc", "my-vpc"),
             [
                 (
                     "_binding".to_string(),
@@ -224,7 +224,7 @@ fn build_deferred_for_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Create(certificate_resource()));
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -249,7 +249,7 @@ fn build_anonymous_deferred_for_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Create(certificate_resource()));
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::new("__deferred_for", "_anon_validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "_anon_validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -276,7 +276,7 @@ fn build_deferred_replace_plan() -> Plan {
     plan.add(Effect::Create(certificate_resource()));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-            id: ResourceId::new("route53.Record", "old-record-0"),
+            id: ResourceId::with_identity("route53.Record", "old-record-0"),
             identifier: "record-0".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -284,7 +284,7 @@ fn build_deferred_replace_plan() -> Plan {
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::new("__deferred_for", "validation_records"),
+        id: ResourceId::with_identity("__deferred_for", "validation_records"),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -495,13 +495,13 @@ fn snapshot_filter_mode_route_table() {
 fn build_moved_with_changes_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: ResourceId::new("ec2.Vpc", "old_vpc"),
-        to: ResourceId::new("ec2.Vpc", "new_vpc"),
+        from: ResourceId::with_identity("ec2.Vpc", "old_vpc"),
+        to: ResourceId::with_identity("ec2.Vpc", "new_vpc"),
     });
     plan.add(Effect::Update {
-        id: ResourceId::new("ec2.Vpc", "new_vpc"),
+        id: ResourceId::with_identity("ec2.Vpc", "new_vpc"),
         from: Box::new(State::existing(
-            ResourceId::new("ec2.Vpc", "new_vpc"),
+            ResourceId::with_identity("ec2.Vpc", "new_vpc"),
             [
                 (
                     "cidr_block".to_string(),
@@ -552,8 +552,8 @@ fn build_moved_with_changes_plan() -> Plan {
 fn build_moved_pure_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: ResourceId::new("ec2.Vpc", "old_vpc"),
-        to: ResourceId::new("ec2.Vpc", "new_vpc"),
+        from: ResourceId::with_identity("ec2.Vpc", "old_vpc"),
+        to: ResourceId::with_identity("ec2.Vpc", "new_vpc"),
     });
     plan
 }


### PR DESCRIPTION
## Summary

- Replace `ResourceName` enum (`Bound`/`Pending`) with opaque `ResourceIdentity` newtype
- Change `ResourceId.name: ResourceName` to `ResourceId.identity: Option<ResourceIdentity>`
- `ResourceIdentity::new()` is `pub(crate)` with empty-string rejection
- Add `identity_or_empty()`, `with_provider_name_compat()` helpers
- Fix Display to omit identity segment when None (no trailing dot)
- Serde: `#[serde(alias = "name")]` for legacy JSON backward compat

## Test plan

- [x] 4362 tests pass (4357 existing + 5 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --doc` clean
- [x] `scripts/check-*.sh` all pass
- [x] New tests: `resource_identity_new_rejects_empty`, `identity_or_empty_returns_empty_for_none`, `with_provider_name_compat_maps_empty_to_none`, `with_provider_name_compat_maps_nonempty_to_some`, `resource_id_rejects_legacy_empty_name`

Closes #3634

🤖 Generated with [Claude Code](https://claude.com/claude-code)