### PR TITLE
feat: introduce ResolvedResourceId to enforce resolver boundary

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -926,7 +926,7 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
         None,
     );
     plan.add(Effect::Replace {
-        id: new_id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(new_id.clone()),
         from: Box::new(State::existing(from_id.clone(), HashMap::new())),
         to: sorted_resources[0].clone(),
         directives: Directives::default(),
@@ -940,8 +940,8 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Move {
-        from: from_id.clone(),
-        to: new_id.clone(),
+        from: carina_core::resource::ResolvedResourceId::new(from_id.clone()),
+        to: carina_core::resource::ResolvedResourceId::new(new_id.clone()),
     });
 
     let saved = build_state_after_apply(ApplyStateSave {
@@ -1051,14 +1051,14 @@ fn move_plus_update_keeps_post_update_attributes() {
     let mut plan = Plan::new();
     let from_id = ResourceId::with_provider_identity("awscc", "ec2.Tag", "tag_old", None);
     plan.add(Effect::Update {
-        id: new_id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(new_id.clone()),
         from: Box::new(State::existing(from_id.clone(), HashMap::new())),
         to: sorted_resources[0].clone(),
         changed_attributes: vec!["value".to_string()],
     });
     plan.add(Effect::Move {
-        from: from_id,
-        to: new_id.clone(),
+        from: carina_core::resource::ResolvedResourceId::new(from_id),
+        to: carina_core::resource::ResolvedResourceId::new(new_id.clone()),
     });
 
     let saved = build_state_after_apply(ApplyStateSave {
@@ -1135,8 +1135,8 @@ fn move_alone_carries_attributes_via_current_states() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: from_id,
-        to: new_id.clone(),
+        from: carina_core::resource::ResolvedResourceId::new(from_id),
+        to: carina_core::resource::ResolvedResourceId::new(new_id.clone()),
     });
 
     let saved = build_state_after_apply(ApplyStateSave {
@@ -1188,8 +1188,8 @@ fn move_with_absent_from_is_no_op() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: from_id.clone(),
-        to: to_id.clone(),
+        from: carina_core::resource::ResolvedResourceId::new(from_id.clone()),
+        to: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
     });
 
     let saved = build_state_after_apply(ApplyStateSave {
@@ -1293,8 +1293,8 @@ fn move_from_overlapping_desired_resource_errors() {
     let to_id = ResourceId::with_provider_identity("awscc", "s3.Bucket", "elsewhere", None);
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: id.clone(),
-        to: to_id,
+        from: carina_core::resource::ResolvedResourceId::new(id.clone()),
+        to: carina_core::resource::ResolvedResourceId::new(to_id),
     });
 
     let result = build_state_after_apply(ApplyStateSave {
@@ -1349,7 +1349,9 @@ fn remove_overlapping_desired_resource_errors() {
     );
 
     let mut plan = Plan::new();
-    plan.add(Effect::Remove { id: id.clone() });
+    plan.add(Effect::Remove {
+        id: carina_core::resource::ResolvedResourceId::new(id.clone()),
+    });
 
     let result = build_state_after_apply(ApplyStateSave {
         state_file: None,
@@ -1402,8 +1404,8 @@ fn self_move_overlapping_desired_resource_errors() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: id.clone(),
-        to: id.clone(),
+        from: carina_core::resource::ResolvedResourceId::new(id.clone()),
+        to: carina_core::resource::ResolvedResourceId::new(id.clone()),
     });
 
     let result = build_state_after_apply(ApplyStateSave {

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -395,7 +395,7 @@ async fn run_destroy_locked(
         let dependencies = get_resource_dependencies(resource);
         let explicit_dependencies = resource.directives.depends_on.iter().cloned().collect();
         delete_effects.push(Effect::Delete {
-            id: resource.id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(resource.id.clone()),
             identifier,
             directives: resource.directives.clone(),
             binding: resource.binding.clone(),

--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -294,15 +294,15 @@ fn effect_required_ops(effect: &Effect) -> Vec<(ResourceId, PlanOp)> {
     match effect {
         Effect::Read { resource } => vec![(resource.id.clone(), PlanOp::Read)],
         Effect::Create(resource) => vec![(resource.id.clone(), PlanOp::Create)],
-        Effect::Update { id, .. } => vec![(id.clone(), PlanOp::Update)],
+        Effect::Update { id, .. } => vec![(id.clone().into_inner(), PlanOp::Update)],
         Effect::Replace { id, to, .. } => {
             vec![
-                (id.clone(), PlanOp::Delete),
+                (id.clone().into_inner(), PlanOp::Delete),
                 (to.id.clone(), PlanOp::Create),
             ]
         }
-        Effect::Delete { id, .. } => vec![(id.clone(), PlanOp::Delete)],
-        Effect::Import { id, .. } => vec![(id.clone(), PlanOp::Read)],
+        Effect::Delete { id, .. } => vec![(id.clone().into_inner(), PlanOp::Delete)],
+        Effect::Import { id, .. } => vec![(id.clone().into_inner(), PlanOp::Read)],
         Effect::DeferredCreate { template, .. } => {
             effect_required_ops(&Effect::Create(template.template_resource.clone()))
         }
@@ -311,7 +311,7 @@ fn effect_required_ops(effect: &Effect) -> Vec<(ResourceId, PlanOp)> {
         } => {
             let mut ops: Vec<_> = deletes
                 .iter()
-                .map(|delete| (delete.id.clone(), PlanOp::Delete))
+                .map(|delete| (delete.id.clone().into_inner(), PlanOp::Delete))
                 .collect();
             ops.extend(effect_required_ops(&Effect::Create(
                 template.template_resource.clone(),
@@ -326,17 +326,17 @@ fn effect_resource_ids(effect: &Effect) -> Vec<&ResourceId> {
     match effect {
         Effect::Read { resource } => vec![&resource.id],
         Effect::Create(resource) => vec![&resource.id],
-        Effect::Update { id, .. } => vec![id],
-        Effect::Replace { id, to, .. } => vec![id, &to.id],
-        Effect::Delete { id, .. } => vec![id],
-        Effect::Import { id, .. } => vec![id],
-        Effect::Remove { id, .. } => vec![id],
-        Effect::Move { from, to } => vec![from, to],
+        Effect::Update { id, .. } => vec![id.as_inner()],
+        Effect::Replace { id, to, .. } => vec![id.as_inner(), &to.id],
+        Effect::Delete { id, .. } => vec![id.as_inner()],
+        Effect::Import { id, .. } => vec![id.as_inner()],
+        Effect::Remove { id, .. } => vec![id.as_inner()],
+        Effect::Move { from, to } => vec![from.as_inner(), to.as_inner()],
         Effect::Wait { .. } => Vec::new(),
-        Effect::DeferredCreate { id, .. } => vec![id],
+        Effect::DeferredCreate { id, .. } => vec![id.as_inner()],
         Effect::DeferredReplace { deletes, id, .. } => {
-            let mut ids = vec![id];
-            ids.extend(deletes.iter().map(|delete| &delete.id));
+            let mut ids = vec![id.as_inner()];
+            ids.extend(deletes.iter().map(|delete| delete.id.as_inner()));
             ids
         }
     }
@@ -832,13 +832,13 @@ mod tests {
         plan.add(Effect::Read { resource: read });
         plan.add(Effect::Create(create));
         plan.add(Effect::Update {
-            id: update_id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(update_id.clone()),
             from: Box::new(State::not_found(update_id.clone())),
             to: update_to,
             changed_attributes: vec!["cidr".to_string()],
         });
         plan.add(Effect::Replace {
-            id: replace_id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(replace_id.clone()),
             from: Box::new(State::not_found(replace_id.clone())),
             to: replace_to,
             directives: Default::default(),
@@ -848,7 +848,7 @@ mod tests {
             cascade_ref_hints: vec![],
         });
         plan.add(Effect::Delete {
-            id: delete_id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(delete_id.clone()),
             identifier: "role-id".to_string(),
             directives: Default::default(),
             binding: None,
@@ -856,15 +856,27 @@ mod tests {
             explicit_dependencies: Default::default(),
         });
         plan.add(Effect::Import {
-            id: import_id,
+            id: carina_core::resource::ResolvedResourceId::new(import_id),
             identifier: Value::Concrete(ConcreteValue::String("group".to_string())),
         });
         plan.add(Effect::Remove {
-            id: ResourceId::with_provider_identity("awscc", "skip.Remove", "x", None),
+            id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+                "awscc",
+                "skip.Remove",
+                "x",
+                None,
+            )),
         });
         plan.add(Effect::Move {
-            from: ResourceId::with_provider_identity("awscc", "skip.Move", "x", None),
-            to: ResourceId::with_provider_identity("awscc", "skip.Move", "y", None),
+            from: carina_core::resource::ResolvedResourceId::new(
+                ResourceId::with_provider_identity("awscc", "skip.Move", "x", None),
+            ),
+            to: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+                "awscc",
+                "skip.Move",
+                "y",
+                None,
+            )),
         });
 
         let entries = collect_required_actions(&plan, &PermissionProvider);
@@ -890,7 +902,10 @@ mod tests {
             Resource::with_provider("aws", "route53.RecordSet", "validation_records", None);
         let mut plan = Plan::new();
         plan.add(Effect::DeferredCreate {
-            id: ResourceId::with_identity("__deferred_for", "validation_records"),
+            id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "__deferred_for",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(DeferredForExpression {
                 file: None,

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -47,7 +47,7 @@ pub(crate) async fn execute_import_effects(
                 Ok(state) => {
                     if state.exists {
                         println!("  {} Imported {}", "✓".green(), id);
-                        result.applied_states.insert(id.clone(), state);
+                        result.applied_states.insert(id.clone().into_inner(), state);
                         result.success_count += 1;
                     } else {
                         println!(
@@ -229,7 +229,7 @@ mod tests {
 
         let mut plan = Plan::new();
         plan.add(Effect::Import {
-            id: id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(id.clone()),
             identifier: deferred,
         });
 
@@ -259,7 +259,7 @@ mod tests {
         let id = ResourceId::with_identity("aws.s3.Bucket", "b");
         let mut plan = Plan::new();
         plan.add(Effect::Import {
-            id: id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(id.clone()),
             identifier: Value::Concrete(ConcreteValue::String("my-bucket".into())),
         });
 
@@ -283,8 +283,10 @@ mod tests {
         colored::control::set_override(true);
         let id =
             ResourceId::with_identity("aws.route53.RecordSet", "aws_route53_record_set_7059de08");
-        let line = format_state_only_effect_line(&Effect::Remove { id: id.clone() })
-            .expect("Remove must render a line");
+        let line = format_state_only_effect_line(&Effect::Remove {
+            id: carina_core::resource::ResolvedResourceId::new(id.clone()),
+        })
+        .expect("Remove must render a line");
         colored::control::unset_override();
 
         // No literal `x` or `✗` anywhere — the leading token and the
@@ -320,8 +322,8 @@ mod tests {
         let from = ResourceId::with_identity("aws.s3.Bucket", "old");
         let to = ResourceId::with_identity("aws.s3.Bucket", "new");
         let line = format_state_only_effect_line(&Effect::Move {
-            from: from.clone(),
-            to: to.clone(),
+            from: carina_core::resource::ResolvedResourceId::new(from.clone()),
+            to: carina_core::resource::ResolvedResourceId::new(to.clone()),
         })
         .expect("Move must render a line");
         colored::control::unset_override();

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -926,7 +926,7 @@ mod apply_state_save_tests {
 
     fn deferred_replace_delete(id: &ResourceId) -> DeferredReplaceDelete {
         DeferredReplaceDelete {
-            id: id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(id.clone()),
             identifier: "old-record-id".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -946,7 +946,10 @@ mod apply_state_save_tests {
         Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![deferred_replace_delete(id)])
                 .expect("fixture has one delete"),
-            id: ResourceId::with_identity("__deferred_for", "validation_records"),
+            id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "__deferred_for",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(DeferredForExpression {
                 file: Some("main.crn".to_string()),
@@ -1047,13 +1050,13 @@ mod apply_state_save_tests {
             State::existing(id.clone(), HashMap::new()).with_identifier("new-record-id");
         let mut plan = Plan::new();
         plan.add(Effect::Move {
-            from: id.clone(),
-            to: ResourceId::with_provider_identity(
+            from: carina_core::resource::ResolvedResourceId::new(id.clone()),
+            to: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
                 "aws",
                 "route53.Record",
                 "validation_records[1]",
                 None,
-            ),
+            )),
         });
         let current_states = HashMap::new();
         let applied_states = HashMap::from([(id.clone(), applied_state)]);

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -781,7 +781,9 @@ fn test_cascading_update_shows_attribute_diffs() {
         );
 
     let replace_effect = Effect::Replace {
-        id: ResourceId::with_identity("ec2.Vpc", "vpc"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "vpc",
+        )),
         from: Box::new(vpc_from),
         to: vpc_to,
         directives: Directives {
@@ -793,7 +795,10 @@ fn test_cascading_update_shows_attribute_diffs() {
         ])
         .unwrap(),
         cascading_updates: vec![CascadingUpdate {
-            id: ResourceId::with_identity("ec2.Subnet", "subnet"),
+            id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "ec2.Subnet",
+                "subnet",
+            )),
             from: Box::new(subnet_from),
             to: subnet_to,
         }],
@@ -823,7 +828,10 @@ fn test_format_cascading_update_attr_diff() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: ResourceId::with_identity("ec2.Subnet", "subnet"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Subnet",
+            "subnet",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Subnet", "subnet"),
             HashMap::from([
@@ -919,7 +927,7 @@ fn test_replace_changed_create_only_same_value_shown_as_known_after_apply() {
     );
 
     let effect = Effect::Replace {
-        id,
+        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(from),
         to,
         directives: Directives::default(),
@@ -992,7 +1000,7 @@ fn test_replace_cascade_ref_hints_show_binding() {
     to.id = id.clone();
 
     let effect = Effect::Replace {
-        id,
+        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(from),
         to,
         directives: Directives::default(),
@@ -1068,7 +1076,10 @@ fn test_deferred_create_renders_deferred_until_apply_marker() {
 
     let mut plan = Plan::new();
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -1125,7 +1136,10 @@ fn deferred_validation_records_effect() -> Effect {
     };
 
     Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     }
@@ -1133,7 +1147,10 @@ fn deferred_validation_records_effect() -> Effect {
 
 fn delete_record_effect(binding: &str) -> Effect {
     Effect::Delete {
-        id: ResourceId::with_identity("route53.Record", binding),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "route53.Record",
+            binding,
+        )),
         identifier: format!("{binding}-id"),
         directives: Directives::default(),
         binding: Some(binding.to_string()),
@@ -1295,7 +1312,10 @@ fn test_format_cascading_update_diff_excludes_non_ref_attributes() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: ResourceId::with_identity("ec2.Subnet", "subnet"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Subnet",
+            "subnet",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Subnet", "subnet"),
             HashMap::from([
@@ -1361,7 +1381,10 @@ fn test_format_cascading_update_diff_includes_list_with_ref() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: ResourceId::with_identity("ec2.Instance", "instance"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Instance",
+            "instance",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Instance", "instance"),
             HashMap::from([(
@@ -1440,7 +1463,10 @@ fn test_mixed_plan_tree_with_delete_effect() {
     // Subnet: Delete effect (only has id and identifier — no resource, no deps)
     // In the original DSL, subnet depends on VPC, but Delete loses that info.
     let subnet_delete = Effect::Delete {
-        id: ResourceId::with_identity("ec2.Subnet", "subnet"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Subnet",
+            "subnet",
+        )),
         identifier: "subnet-12345".to_string(),
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
@@ -1450,13 +1476,18 @@ fn test_mixed_plan_tree_with_delete_effect() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ResourceId::with_identity("ec2.Vpc", "vpc"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "vpc",
+        )),
         from: Box::new(vpc_from),
         to: vpc_to,
         changed_attributes: vec!["cidr_block".to_string()],
     });
     plan.add(Effect::Replace {
-        id: ResourceId::with_identity("ec2.SecurityGroup", "sg"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.SecurityGroup",
+            "sg",
+        )),
         from: Box::new(sg_from),
         to: sg_to,
         directives: Directives::default(),
@@ -1550,7 +1581,9 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ResourceId::with_identity("ec2.Vpc", "vpc"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "vpc",
+        )),
         from: Box::new(vpc_from),
         to: vpc_to,
         changed_attributes: vec!["tags".to_string()],
@@ -1587,7 +1620,12 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
 #[test]
 fn format_effect_delete_uses_binding_name() {
     let effect = Effect::Delete {
-        id: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+            "awscc",
+            "ec2.Vpc",
+            "ec2_vpc_fb75c929",
+            None,
+        )),
         identifier: "vpc-12345".to_string(),
         directives: Directives::default(),
         binding: Some("my_vpc".to_string()),
@@ -1600,7 +1638,12 @@ fn format_effect_delete_uses_binding_name() {
 #[test]
 fn format_effect_delete_falls_back_to_id_name() {
     let effect = Effect::Delete {
-        id: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "ec2_vpc_fb75c929", None),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+            "awscc",
+            "ec2.Vpc",
+            "ec2_vpc_fb75c929",
+            None,
+        )),
         identifier: "vpc-12345".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -1630,7 +1673,7 @@ fn format_effect_update_separates_type_and_name_with_space() {
     let mut to = Resource::new("iam.Role", "bs.bootstrap.role");
     to.id = id.clone();
     let effect = Effect::Update {
-        id,
+        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(State::not_found(ResourceId::with_provider_identity(
             "awscc",
             "iam.Role",
@@ -1652,7 +1695,7 @@ fn format_effect_replace_separates_type_and_name_with_space() {
     let mut to = Resource::new("ec2.Vpc", "vpc");
     to.id = id.clone();
     let effect = Effect::Replace {
-        id,
+        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(State::not_found(ResourceId::with_provider_identity(
             "awscc", "ec2.Vpc", "vpc", None,
         ))),
@@ -1682,7 +1725,7 @@ fn format_replace_with_removed_create_only_attribute_shows_forcing_detail() {
     let mut to = Resource::new("Widget", "beta");
     to.id = id.clone();
     let effect = Effect::Replace {
-        id,
+        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(from),
         to,
         directives: Directives::default(),
@@ -1722,7 +1765,12 @@ fn format_replace_with_removed_create_only_attribute_shows_forcing_detail() {
 #[test]
 fn format_effect_import_separates_type_and_name_with_space() {
     let effect = Effect::Import {
-        id: ResourceId::with_provider_identity("aws", "s3.Bucket", "logs", None),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+            "aws",
+            "s3.Bucket",
+            "logs",
+            None,
+        )),
         identifier: carina_core::resource::Value::Concrete(
             carina_core::resource::ConcreteValue::String("my-logs-bucket".to_string()),
         ),
@@ -1736,7 +1784,9 @@ fn format_effect_import_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_remove_separates_type_and_name_with_space() {
     let effect = Effect::Remove {
-        id: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "old_vpc", None),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+            "awscc", "ec2.Vpc", "old_vpc", None,
+        )),
     };
     assert_eq!(
         format_effect(&effect),
@@ -1747,8 +1797,12 @@ fn format_effect_remove_separates_type_and_name_with_space() {
 #[test]
 fn format_effect_move_separates_type_and_name_with_space() {
     let effect = Effect::Move {
-        from: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "vpc_a", None),
-        to: ResourceId::with_provider_identity("awscc", "ec2.Vpc", "vpc_b", None),
+        from: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+            "awscc", "ec2.Vpc", "vpc_a", None,
+        )),
+        to: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+            "awscc", "ec2.Vpc", "vpc_b", None,
+        )),
     };
     assert_eq!(
         format_effect(&effect),
@@ -1958,7 +2012,9 @@ fn delete_pretty_attribute_does_not_strike_indentation() {
         value: Value::Concrete(ConcreteValue::Map(cache_behavior)),
     };
     let effect = Effect::Delete {
-        id: carina_core::resource::ResourceId::with_identity("cloudfront.Distribution", "dist"),
+        id: carina_core::resource::ResolvedResourceId::new(
+            carina_core::resource::ResourceId::with_identity("cloudfront.Distribution", "dist"),
+        ),
         identifier: "E123".to_string(),
         directives: Default::default(),
         binding: None,
@@ -2034,7 +2090,10 @@ fn forcing_changed_uses_plain_green_cli_value() {
         new: "\"new\"".to_string(),
     };
     let effect = Effect::Update {
-        id: ResourceId::with_identity("test.Widget", "w"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "test.Widget",
+            "w",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("test.Widget", "w"),
             HashMap::new(),
@@ -2062,7 +2121,10 @@ fn forcing_changed_multiline_green_style_does_not_cross_newline() {
         new: "[\n  \"new\"\n]".to_string(),
     };
     let effect = Effect::Update {
-        id: ResourceId::with_identity("test.Widget", "w"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "test.Widget",
+            "w",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("test.Widget", "w"),
             HashMap::new(),
@@ -2263,11 +2325,11 @@ fn module_group_with_only_suppressed_move_does_not_emit_orphan_gutter() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: from_id,
-        to: to_id.clone(),
+        from: carina_core::resource::ResolvedResourceId::new(from_id),
+        to: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
     });
     plan.add(Effect::Update {
-        id: to_id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
         from: Box::new(State::not_found(to_id.clone())),
         to: updated,
         changed_attributes: Vec::new(),
@@ -2336,11 +2398,11 @@ fn resource_with_only_suppressed_move_dependent_does_not_emit_orphan_gutter() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(parent));
     plan.add(Effect::Move {
-        from: from_id,
-        to: to_id.clone(),
+        from: carina_core::resource::ResolvedResourceId::new(from_id),
+        to: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
     });
     plan.add(Effect::Update {
-        id: to_id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
         from: Box::new(State::not_found(to_id.clone())),
         to: updated,
         changed_attributes: Vec::new(),

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -702,7 +702,7 @@ pub fn delete_attributes_from_plan(
             if let carina_core::effect::Effect::Delete { id, .. } = e {
                 current_states
                     .get(id)
-                    .map(|s| (id.clone(), s.attributes.clone()))
+                    .map(|s| (id.clone().into_inner(), s.attributes.clone()))
             } else {
                 None
             }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -514,7 +514,7 @@ fn snapshot_delete_orphan() {
             if let carina_core::effect::Effect::Delete { id, .. } = e {
                 current_states
                     .get(id)
-                    .map(|s| (id.clone(), s.attributes.clone()))
+                    .map(|s| (id.clone().into_inner(), s.attributes.clone()))
             } else {
                 None
             }
@@ -551,7 +551,7 @@ fn snapshot_delete_orphan_list_of_maps() {
             if let carina_core::effect::Effect::Delete { id, .. } = e {
                 current_states
                     .get(id)
-                    .map(|s| (id.clone(), s.attributes.clone()))
+                    .map(|s| (id.clone().into_inner(), s.attributes.clone()))
             } else {
                 None
             }
@@ -879,7 +879,7 @@ fn snapshot_secret_values() {
             if let carina_core::effect::Effect::Delete { id, .. } = e {
                 current_states
                     .get(id)
-                    .map(|s| (id.clone(), s.attributes.clone()))
+                    .map(|s| (id.clone().into_inner(), s.attributes.clone()))
             } else {
                 None
             }

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -288,7 +288,12 @@ fn plan_file_serde_round_trip() {
         ),
     ));
     plan.add(Effect::Delete {
-        id: ResourceId::with_provider_identity("aws", "s3.Bucket", "old-bucket", None),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+            "aws",
+            "s3.Bucket",
+            "old-bucket",
+            None,
+        )),
         identifier: "old-bucket".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -1842,7 +1847,7 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(id.clone()),
         from: Box::new(old_state.clone()),
         to: new_resource.clone(),
         directives: Directives {
@@ -1987,7 +1992,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     // Subnet: Update (cidr_block changed, vpc_id eagerly resolved to old value)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc_unresolved.clone().with_binding("vpc"),
         directives: Directives {
@@ -2003,7 +2008,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Update {
-        id: subnet_id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
         to: subnet_resolved.clone(), // Has stale "vpc-OLD" in vpc_id
         changed_attributes: vec!["cidr_block".to_string()],
@@ -2620,7 +2625,7 @@ fn import_effect_preserves_resource_metadata_in_state() {
     // Build a plan with an Import effect
     let mut plan = Plan::new();
     plan.add(Effect::Import {
-        id: id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(id.clone()),
         identifier: Value::Concrete(ConcreteValue::String(identifier.to_string())),
     });
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1331,7 +1331,7 @@ impl DeferredCreateTarget {
 
     fn to_effect(&self) -> Effect {
         Effect::DeferredCreate {
-            id: self.id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(self.id.clone()),
             upstream_binding: self.upstream_binding.clone(),
             template: Box::new(self.template.clone()),
         }
@@ -1340,7 +1340,7 @@ impl DeferredCreateTarget {
     fn to_deferred_replace_effect(&self, deletes: Vec<DeferredReplaceDelete>) -> Effect {
         Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(deletes).expect("planner checked non-empty deletes"),
-            id: self.id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(self.id.clone()),
             upstream_binding: self.upstream_binding.clone(),
             template: Box::new(self.template.clone()),
         }
@@ -2667,7 +2667,7 @@ pub fn add_state_block_effects(
                     );
                     suppress_create.insert(effective_to.clone());
                     new_effects.push(Effect::Import {
-                        id: effective_to,
+                        id: carina_core::resource::ResolvedResourceId::new(effective_to),
                         identifier: resolved_id,
                     });
                 }
@@ -2695,7 +2695,9 @@ pub fn add_state_block_effects(
                 });
                 if let Some(id) = resolved_from {
                     suppress_delete.insert(id.clone());
-                    new_effects.push(Effect::Remove { id });
+                    new_effects.push(Effect::Remove {
+                        id: carina_core::resource::ResolvedResourceId::new(id),
+                    });
                 }
             }
             StateBlock::Moved { .. } => {
@@ -2713,8 +2715,8 @@ pub fn add_state_block_effects(
     for (from, to) in moved_pairs {
         suppress_delete.insert(to.clone());
         new_effects.push(Effect::Move {
-            from: from.clone(),
-            to: to.clone(),
+            from: carina_core::resource::ResolvedResourceId::new(from.clone()),
+            to: carina_core::resource::ResolvedResourceId::new(to.clone()),
         });
     }
 
@@ -2779,7 +2781,7 @@ pub fn add_deferred_create_effects(plan: &mut Plan, targets: &[DeferredCreateTar
         if deletes.is_empty() {
             deferred_effects.push(target.to_effect());
         } else {
-            deletes_to_absorb.extend(deletes.iter().map(|delete| delete.id.clone()));
+            deletes_to_absorb.extend(deletes.iter().map(|delete| delete.id.clone().into_inner()));
             deferred_effects.push(target.to_deferred_replace_effect(deletes));
         }
     }

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -696,12 +696,12 @@ fn removed_block_suppresses_delete_when_state_resource_is_routed_to_named_instan
     // The orphan Delete effect carries the same routed instance.
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: ResourceId::with_provider_identity(
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
             "aws",
             "route53.RecordSet",
             "r.delegation_ns",
             Some("management".to_string()),
-        ),
+        )),
         identifier: String::new(),
         directives: carina_core::resource::Directives::default(),
         binding: None,
@@ -2591,7 +2591,12 @@ fn deferred_replace_test_target() -> DeferredCreateTarget {
 
 fn delete_effect_for_binding(binding: &str) -> Effect {
     Effect::Delete {
-        id: ResourceId::with_provider_identity("aws", "route53.Record", binding, None),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
+            "aws",
+            "route53.Record",
+            binding,
+            None,
+        )),
         identifier: format!("{binding}-old-id"),
         directives: Directives::default(),
         binding: Some(binding.to_string()),
@@ -2603,7 +2608,7 @@ fn delete_effect_for_binding(binding: &str) -> Effect {
 fn cert_replace_effect() -> Effect {
     let id = ResourceId::with_provider_identity("aws", "acm.Certificate", "cert", None);
     Effect::Replace {
-        id: id.clone(),
+        id: carina_core::resource::ResolvedResourceId::new(id.clone()),
         from: Box::new(State::existing(id, HashMap::new()).with_identifier("cert-old-id")),
         to: Resource::with_provider("aws", "acm.Certificate", "cert", None).with_binding("cert"),
         directives: Directives::default(),

--- a/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
+++ b/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
@@ -173,7 +173,7 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
     plan.add(Effect::Create(cert.clone()));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-            id: validation_id.clone(),
+            id: carina_core::resource::ResolvedResourceId::new(validation_id.clone()),
             identifier: "old-validation-id".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -181,7 +181,10 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(template),
     });

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -212,7 +212,10 @@ mod tests {
     fn wait_effect_with_explicit_dependency(binding: Option<&str>) -> Effect {
         Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
+            target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "acm.Certificate",
+                "cert",
+            )),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(crate::resource::ConcreteValue::String(

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -1953,7 +1953,10 @@ mod tests {
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "my-bucket",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["versioning".to_string()],
@@ -1999,7 +2002,10 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("Enabled".to_string())),
             );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "my-bucket",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["versioning".to_string()],
@@ -2053,7 +2059,10 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("new-value".to_string())),
             );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "my-bucket",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["trigger_diff".to_string()],
@@ -2100,7 +2109,7 @@ mod tests {
     fn test_delete_with_attributes() {
         let id = ResourceId::with_identity("s3.Bucket", "old-bucket");
         let effect = Effect::Delete {
-            id: id.clone(),
+            id: crate::resource::ResolvedResourceId::new(id.clone()),
             identifier: "old-bucket".to_string(),
             directives: crate::resource::Directives::default(),
             binding: None,
@@ -2144,7 +2153,10 @@ mod tests {
             Value::Concrete(ConcreteValue::String("test".to_string())),
         );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "my-bucket",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["removed_attr".to_string()],
@@ -2174,7 +2186,10 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Update {
-            id: ResourceId::with_identity("test.Widget", "beta"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "beta",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["rules".to_string()],
@@ -2320,7 +2335,7 @@ mod tests {
     fn test_delete_map_expanded() {
         let id = ResourceId::with_identity("s3.Bucket", "old-bucket");
         let effect = Effect::Delete {
-            id: id.clone(),
+            id: crate::resource::ResolvedResourceId::new(id.clone()),
             identifier: "old-bucket".to_string(),
             directives: crate::resource::Directives::default(),
             binding: None,
@@ -2366,7 +2381,7 @@ mod tests {
         // PrettyAttribute so format_value_pretty's vertical layout applies.
         let id = ResourceId::with_identity("acm.Certificate", "cert");
         let effect = Effect::Delete {
-            id: id.clone(),
+            id: crate::resource::ResolvedResourceId::new(id.clone()),
             identifier: "cert".to_string(),
             directives: crate::resource::Directives::default(),
             binding: None,
@@ -2432,7 +2447,9 @@ mod tests {
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "ec2.Vpc", "my-vpc",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2465,7 +2482,10 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "beta"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "beta",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2511,7 +2531,10 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "beta"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "beta",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2565,7 +2588,10 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "beta"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "beta",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2655,7 +2681,10 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("CLOUDFRONT".to_string())),
             );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("wafv2.WebAcl", "edge"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "wafv2.WebAcl",
+                "edge",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2762,14 +2791,20 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(new_config)),
         );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("wafv2.WebAcl", "edge"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "wafv2.WebAcl",
+                "edge",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
                 .unwrap(),
             cascading_updates: vec![CascadingUpdate {
-                id: ResourceId::with_identity("cloudfront.Distribution", "cdn"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "cloudfront.Distribution",
+                    "cdn",
+                )),
                 from: Box::new(cascade_from),
                 to: cascade_to,
             }],
@@ -2854,14 +2889,20 @@ mod tests {
         );
 
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("wafv2.WebAcl", "edge"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "wafv2.WebAcl",
+                "edge",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
                 .unwrap(),
             cascading_updates: vec![CascadingUpdate {
-                id: ResourceId::with_identity("test.RuleSet", "rules"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "test.RuleSet",
+                    "rules",
+                )),
                 from: Box::new(cascade_from),
                 to: cascade_to,
             }],
@@ -2925,7 +2966,10 @@ mod tests {
             Value::Concrete(ConcreteValue::String("arn:old".to_string())),
         );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "w"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "w",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -2964,7 +3008,10 @@ mod tests {
             Value::Concrete(ConcreteValue::String("arn:old".to_string())),
         );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "w"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "w",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3037,7 +3084,10 @@ mod tests {
             )])),
         );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "w"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "w",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3089,7 +3139,10 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(new_settings)),
         );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "w"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "w",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3131,7 +3184,10 @@ mod tests {
             )])),
         );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "w"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "w",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3184,7 +3240,7 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("kept".to_string())),
             );
         let effect = Effect::Replace {
-            id: id.clone(),
+            id: crate::resource::ResolvedResourceId::new(id.clone()),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3239,7 +3295,10 @@ mod tests {
             Value::Concrete(ConcreteValue::String("new-name".to_string())),
         );
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test.Widget", "w"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test.Widget",
+                "w",
+            )),
             from: Box::new(from),
             to,
             directives: crate::resource::Directives::default(),
@@ -3539,7 +3598,9 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("iam.Role", "r"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "iam.Role", "r",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string()],
@@ -3588,7 +3649,9 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("new".to_string())),
             );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("iam.Role", "r"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "iam.Role", "r",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string(), "description".to_string()],
@@ -3632,7 +3695,9 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("iam.Role", "r"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "iam.Role", "r",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string()],
@@ -3672,7 +3737,9 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("iam.Role", "r"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "iam.Role", "r",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string()],
@@ -3734,7 +3801,7 @@ mod tests {
         let to = Resource::new("x.Thing", "t")
             .with_attribute("modes", mk(ConcreteValue::String("On".to_string())));
         let effect = Effect::Update {
-            id: ResourceId::with_identity("x.Thing", "t"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
             to,
             changed_attributes: vec!["modes".to_string()],
@@ -3774,7 +3841,9 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("iam.Role", "r"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "iam.Role", "r",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string()],
@@ -3835,7 +3904,9 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
             );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("iam.Role", "r"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "iam.Role", "r",
+            )),
             from: Box::new(from),
             to,
             changed_attributes: vec!["policy".to_string(), "description".to_string()],
@@ -3924,7 +3995,7 @@ mod tests {
         let to =
             Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
         let effect = Effect::Update {
-            id: ResourceId::with_identity("x.Thing", "t"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
             to,
             changed_attributes: vec!["modes".to_string()],
@@ -4139,7 +4210,7 @@ mod tests {
             )])),
         );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("x.Thing", "t"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
             to,
             changed_attributes: vec!["tags".to_string()],
@@ -4182,7 +4253,7 @@ mod tests {
             )))),
         );
         let effect = Effect::Update {
-            id: ResourceId::with_identity("x.Thing", "t"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
             to,
             changed_attributes: vec!["password".to_string()],
@@ -4404,7 +4475,7 @@ mod tests {
         let to =
             Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
         let effect = Effect::Update {
-            id: ResourceId::with_identity("x.Thing", "t"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
             to,
             changed_attributes: vec!["modes".to_string()],

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -64,7 +64,7 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     // Build a plan with Replace for VPC (create_before_destroy)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone().with_binding("vpc")),
         directives: Directives {
@@ -168,7 +168,7 @@ fn cascade_skips_resources_already_in_plan() {
     // Plan with both Replace for VPC and Update for subnet
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone()),
         directives: Directives {
@@ -182,7 +182,7 @@ fn cascade_skips_resources_already_in_plan() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Update {
-        id: subnet_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
         to: (subnet.clone()),
         changed_attributes: vec!["cidr_block".to_string()],
@@ -245,7 +245,7 @@ fn cascade_no_op_without_create_before_destroy() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone()),
         directives: Directives::default(), // create_before_destroy = false
@@ -343,7 +343,7 @@ fn cascade_transitive_dependencies() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone()),
         directives: Directives {
@@ -428,7 +428,7 @@ fn cascade_anonymous_resource_dependent() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone()),
         directives: Directives {
@@ -544,7 +544,7 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
     // Build a plan with Replace for VPC (create_before_destroy)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone().with_binding("vpc")),
         directives: Directives {
@@ -700,7 +700,7 @@ fn cascade_generates_replace_when_create_only_list_contains_nested_ref() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone().with_binding("vpc"),
         directives: Directives {
@@ -819,7 +819,7 @@ fn cascade_hint_prefers_resource_ref_over_binding_ref_in_mixed_list() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone().with_binding("vpc"),
         directives: Directives {
@@ -942,7 +942,7 @@ fn cascade_generates_replace_when_create_only_map_contains_nested_ref() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone().with_binding("vpc"),
         directives: Directives {
@@ -1074,7 +1074,7 @@ fn cascade_prevent_destroy_blocks_nested_map_ref_promotion_to_replace() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone().with_binding("vpc"),
         directives: Directives {
@@ -1210,7 +1210,7 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     // - Subnet Replace due to availability_zone change (direct change from differ)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone().with_binding("vpc")),
         directives: Directives {
@@ -1224,7 +1224,7 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Replace {
-        id: subnet_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
         to: (subnet.clone().with_binding("subnet")),
         directives: Directives::default(),
@@ -1364,7 +1364,7 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
     // Build a plan with Replace for VPC using DEFAULT directives (no explicit CBD)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone().with_binding("vpc")),
         directives: Directives::default(), // create_before_destroy = false (user didn't set it)
@@ -1495,7 +1495,7 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
     // - Subnet Update due to tags change (non-create-only, from differ)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone().with_binding("vpc")),
         directives: Directives {
@@ -1509,7 +1509,7 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Update {
-        id: subnet_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
         to: (subnet.clone().with_binding("subnet")),
         changed_attributes: vec!["tags".to_string()],
@@ -1626,7 +1626,7 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
     // Build a plan with Replace for VPC (create_before_destroy)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone().with_binding("vpc")),
         directives: Directives {
@@ -1760,7 +1760,7 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
     // Build a plan with Replace for VPC and Update for subnet (tags changed)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: (vpc.clone().with_binding("vpc")),
         directives: Directives {
@@ -1774,7 +1774,7 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Update {
-        id: subnet_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
         to: (subnet.clone().with_binding("subnet")),
         changed_attributes: vec!["tags".to_string()],

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -9,7 +9,8 @@ use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
 use crate::provider::Provider;
 use crate::resource::{
-    ConcreteValue, DataSource, Directives, PlanInputState, Resource, ResourceId, State, Value,
+    ConcreteValue, DataSource, Directives, PlanInputState, ResolvedResourceId, Resource,
+    ResourceId, State, Value,
 };
 use crate::schema::{
     ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
@@ -365,7 +366,7 @@ pub fn create_plan(
                     };
 
                     plan.add(Effect::Replace {
-                        id,
+                        id: ResolvedResourceId::new(id),
                         from,
                         to,
                         directives,
@@ -376,7 +377,7 @@ pub fn create_plan(
                     });
                 } else {
                     plan.add(Effect::Update {
-                        id,
+                        id: ResolvedResourceId::new(id),
                         from,
                         to,
                         changed_attributes,
@@ -403,7 +404,7 @@ pub fn create_plan(
                 let explicit_dependencies =
                     resource.directives.depends_on.iter().cloned().collect();
                 plan.add(Effect::Delete {
-                    id,
+                    id: ResolvedResourceId::new(id),
                     identifier,
                     directives,
                     binding,
@@ -456,7 +457,7 @@ pub fn create_plan(
                 get_resource_dependencies(&temp_resource)
             };
             plan.add(Effect::Delete {
-                id: id.clone(),
+                id: ResolvedResourceId::new(id.clone()),
                 identifier,
                 directives,
                 binding,
@@ -633,7 +634,7 @@ pub fn create_plan(
             // executor IR (Effect) is string-keyed and is the separate
             // type tracked for its own newtype migration (carina#3066).
             binding: wb.binding.as_str().to_string(),
-            target_id,
+            target_id: ResolvedResourceId::new(target_id),
             until,
             until_surface: wb.until_raw.clone(),
             timeout,
@@ -706,7 +707,7 @@ pub fn cascade_dependent_updates(
                 if let Effect::Replace { id, directives, .. } = e {
                     // Only consider Replace effects that are NOT already CBD
                     if !directives.create_before_destroy {
-                        e.binding_name().map(|b| (b, id.clone()))
+                        e.binding_name().map(|b| (b, id.clone().into_inner()))
                     } else {
                         None
                     }
@@ -902,7 +903,7 @@ pub fn cascade_dependent_updates(
 
                         // Promote to a separate Replace effect
                         promoted_replaces.push(Effect::Replace {
-                            id: unresolved.id.clone(),
+                            id: ResolvedResourceId::new(unresolved.id.clone()),
                             from: Box::new(from),
                             to: (*unresolved).clone(),
                             directives: unresolved.directives.clone(),
@@ -918,7 +919,7 @@ pub fn cascade_dependent_updates(
                         .entry(replaced_binding.clone())
                         .or_default()
                         .push(CascadingUpdate {
-                            id: unresolved.id.clone(),
+                            id: ResolvedResourceId::new(unresolved.id.clone()),
                             from: Box::new(from),
                             to: (*unresolved).clone(),
                         });

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1346,7 +1346,7 @@ fn wait_binding_lowers_to_wait_effect() {
         unreachable!();
     };
     assert_eq!(binding, "cert_issued");
-    assert_eq!(target_id.identity_str(), Some("cert"));
+    assert_eq!(target_id.identity_str(), "cert");
     assert_eq!(target_id.resource_type, "acm.Certificate");
     assert_eq!(
         until,

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::non_empty::NonEmptyVec;
 use crate::parser::DeferredForExpression;
-use crate::resource::{DataSource, Directives, Resource, ResourceId, State};
+use crate::resource::{DataSource, Directives, ResolvedResourceId, Resource, ResourceId, State};
 use crate::wait::predicate::WaitPredicate;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -65,7 +65,7 @@ pub struct TemporaryName {
 /// newly created resource's state.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CascadingUpdate {
-    pub id: ResourceId,
+    pub id: ResolvedResourceId,
     pub from: Box<State>,
     pub to: Resource,
 }
@@ -77,7 +77,7 @@ pub struct CascadingUpdate {
 /// without re-shaping `DeferredReplace` itself.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeferredReplaceDelete {
-    pub id: ResourceId,
+    pub id: ResolvedResourceId,
     pub identifier: String,
     #[serde(default)]
     pub directives: Directives,
@@ -249,7 +249,7 @@ pub enum Effect {
 
     /// Update an existing resource
     Update {
-        id: ResourceId,
+        id: ResolvedResourceId,
         from: Box<State>,
         to: Resource,
         /// Attribute names that changed (including removed attributes)
@@ -258,7 +258,7 @@ pub enum Effect {
 
     /// Replace a resource (delete then create) due to create-only property changes
     Replace {
-        id: ResourceId,
+        id: ResolvedResourceId,
         from: Box<State>,
         to: Resource,
         #[serde(default)]
@@ -280,7 +280,7 @@ pub enum Effect {
 
     /// Delete a resource
     Delete {
-        id: ResourceId,
+        id: ResolvedResourceId,
         identifier: String,
         #[serde(default)]
         directives: Directives,
@@ -304,7 +304,7 @@ pub enum Effect {
     /// Import an existing resource into state (via provider read)
     Import {
         /// Target resource address
-        id: ResourceId,
+        id: ResolvedResourceId,
         /// Cloud provider identifier (e.g., `"vpc-0abc123def456"`).
         ///
         /// Carried as a [`Value`] so an interpolation like
@@ -321,15 +321,15 @@ pub enum Effect {
     /// Remove a resource from state without destroying it
     Remove {
         /// Resource address to remove from state
-        id: ResourceId,
+        id: ResolvedResourceId,
     },
 
     /// Move/rename a resource in state without destroy/recreate
     Move {
         /// Old resource address
-        from: ResourceId,
+        from: ResolvedResourceId,
         /// New resource address
-        to: ResourceId,
+        to: ResolvedResourceId,
     },
 
     /// Wait for `target` to satisfy `until` by polling `read()`.
@@ -347,7 +347,7 @@ pub enum Effect {
         binding: String,
         /// Resolved id of the target resource (`wait cert { ... }` →
         /// `cert`'s `ResourceId`).
-        target_id: ResourceId,
+        target_id: ResolvedResourceId,
         /// Typed predicate evaluated against each `read()` snapshot.
         until: WaitPredicate,
         /// Surface form of the `until` expression as the user wrote it
@@ -380,7 +380,7 @@ pub enum Effect {
     /// unresolved. State-only: does not call the provider.
     DeferredCreate {
         /// Synthetic id used for plan-tree display and progress.
-        id: ResourceId,
+        id: ResolvedResourceId,
         /// The iterable's binding name (e.g. "cert").
         upstream_binding: String,
         /// The for-expression body, replayed against the upstream state.
@@ -394,7 +394,7 @@ pub enum Effect {
         /// Pre-apply iterations being destroyed.
         deletes: NonEmptyDeletes,
         /// Synthetic id used for plan-tree display and progress.
-        id: ResourceId,
+        id: ResolvedResourceId,
         /// The iterable's binding name (e.g. "cert").
         upstream_binding: String,
         /// The for-expression body, replayed against the upstream state.
@@ -514,7 +514,7 @@ impl Effect {
             ),
             (
                 Effect::Update {
-                    id: id.clone(),
+                    id: crate::resource::ResolvedResourceId::new(id.clone()),
                     from: Box::new(State::not_found(id.clone())),
                     to: Resource::new("test", "x"),
                     changed_attributes: vec![],
@@ -527,7 +527,7 @@ impl Effect {
             ),
             (
                 Effect::Delete {
-                    id: id.clone(),
+                    id: crate::resource::ResolvedResourceId::new(id.clone()),
                     identifier: "x-1".to_string(),
                     directives: Directives::default(),
                     binding: None,
@@ -538,23 +538,30 @@ impl Effect {
             ),
             (
                 Effect::Import {
-                    id: id.clone(),
+                    id: crate::resource::ResolvedResourceId::new(id.clone()),
                     identifier: Value::Concrete(ConcreteValue::String("x-1".to_string())),
                 },
                 Effect::Import { .. }
             ),
-            (Effect::Remove { id: id.clone() }, Effect::Remove { .. }),
+            (
+                Effect::Remove {
+                    id: crate::resource::ResolvedResourceId::new(id.clone())
+                },
+                Effect::Remove { .. }
+            ),
             (
                 Effect::Move {
-                    from: id.clone(),
-                    to: ResourceId::with_identity("test", "y"),
+                    from: crate::resource::ResolvedResourceId::new(id.clone()),
+                    to: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                        "test", "y"
+                    )),
                 },
                 Effect::Move { .. }
             ),
             (
                 Effect::Wait {
                     binding: "w".to_string(),
-                    target_id: id.clone(),
+                    target_id: crate::resource::ResolvedResourceId::new(id.clone()),
                     until: WaitPredicate::Equals {
                         attr: AttrPath::single("status"),
                         value: Value::Concrete(ConcreteValue::String("ready".to_string())),
@@ -568,7 +575,10 @@ impl Effect {
             ),
             (
                 Effect::DeferredCreate {
-                    id: ResourceId::with_identity("route53.Record", "validation_records"),
+                    id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                        "route53.Record",
+                        "validation_records"
+                    )),
                     upstream_binding: "cert".to_string(),
                     template: Box::new(crate::parser::DeferredForExpression {
                         file: Some("main.crn".to_string()),
@@ -588,7 +598,10 @@ impl Effect {
             (
                 Effect::DeferredReplace {
                     deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                        id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
+                        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                            "route53.Record",
+                            "validation_records[0]"
+                        )),
                         identifier: "record-0".to_string(),
                         directives: Directives::default(),
                         binding: Some("validation_records[0]".to_string()),
@@ -596,7 +609,10 @@ impl Effect {
                         explicit_dependencies: HashSet::new(),
                     }])
                     .expect("test fixture has one delete"),
-                    id: ResourceId::with_identity("route53.Record", "validation_records"),
+                    id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                        "route53.Record",
+                        "validation_records"
+                    )),
                     upstream_binding: "cert".to_string(),
                     template: Box::new(crate::parser::DeferredForExpression {
                         file: Some("main.crn".to_string()),
@@ -625,7 +641,7 @@ impl Effect {
         };
 
         Effect::Replace {
-            id: id.clone(),
+            id: crate::resource::ResolvedResourceId::new(id.clone()),
             from: Box::new(State::not_found(id)),
             to: Resource::new("test", "x"),
             directives,
@@ -886,21 +902,24 @@ impl Effect {
             Effect::Update { .. } => Vec::new(),
             Effect::Replace { .. } => Vec::new(),
             Effect::Delete { id, .. } => {
-                if successfully_deleted.contains(id) {
-                    vec![id.clone()]
+                if successfully_deleted.contains(id.as_inner()) {
+                    vec![id.clone().into_inner()]
                 } else {
                     Vec::new()
                 }
             }
             Effect::Import { .. } => Vec::new(),
-            Effect::Remove { id } => vec![id.clone()],
-            Effect::Move { from, .. } => vec![from.clone()],
+            Effect::Remove { id } => vec![id.clone().into_inner()],
+            Effect::Move { from, .. } => vec![from.clone().into_inner()],
             Effect::Wait { .. } => Vec::new(),
             Effect::DeferredCreate { .. } => Vec::new(),
             Effect::DeferredReplace { deletes, .. } => deletes
                 .iter()
-                .filter(|delete| successfully_deleted.contains(&delete.id) && !upserts(&delete.id))
-                .map(|delete| delete.id.clone())
+                .filter(|delete| {
+                    successfully_deleted.contains(delete.id.as_inner())
+                        && !upserts(delete.id.as_inner())
+                })
+                .map(|delete| delete.id.clone().into_inner())
                 .collect(),
         }
     }
@@ -923,7 +942,7 @@ impl Effect {
             Effect::Wait { .. } => Vec::new(),
             Effect::DeferredCreate { .. } => Vec::new(),
             Effect::DeferredReplace { deletes, .. } => {
-                deletes.iter().map(|delete| &delete.id).collect()
+                deletes.iter().map(|delete| delete.id.as_inner()).collect()
             }
         }
     }
@@ -1186,7 +1205,10 @@ mod tests {
 
     fn deferred_create_effect() -> Effect {
         Effect::DeferredCreate {
-            id: ResourceId::with_identity("route53.Record", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "route53.Record",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred_for_template()),
         }
@@ -1198,7 +1220,10 @@ mod tests {
         template.line = 0;
         Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "route53.Record",
+                    "validation_records[0]",
+                )),
                 identifier: "old-record-id".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -1206,7 +1231,10 @@ mod tests {
                 explicit_dependencies: HashSet::new(),
             }])
             .expect("test fixture has one delete"),
-            id: ResourceId::with_identity("__deferred_for", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "__deferred_for",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
         }
@@ -1229,7 +1257,7 @@ mod tests {
             (
                 "Update",
                 Effect::Update {
-                    id: rid.clone(),
+                    id: crate::resource::ResolvedResourceId::new(rid.clone()),
                     from: Box::new(State::not_found(rid.clone())),
                     to: Resource::new("test", "x"),
                     changed_attributes: vec![],
@@ -1238,7 +1266,7 @@ mod tests {
             (
                 "Replace",
                 Effect::Replace {
-                    id: rid.clone(),
+                    id: crate::resource::ResolvedResourceId::new(rid.clone()),
                     from: Box::new(State::not_found(rid.clone())),
                     to: Resource::new("test", "x"),
                     directives: Directives::default(),
@@ -1251,7 +1279,7 @@ mod tests {
             (
                 "Delete",
                 Effect::Delete {
-                    id: rid.clone(),
+                    id: crate::resource::ResolvedResourceId::new(rid.clone()),
                     identifier: "x-1".to_string(),
                     directives: Directives::default(),
                     binding: None,
@@ -1262,23 +1290,30 @@ mod tests {
             (
                 "Import",
                 Effect::Import {
-                    id: rid.clone(),
+                    id: crate::resource::ResolvedResourceId::new(rid.clone()),
                     identifier: Value::Concrete(ConcreteValue::String("x-1".to_string())),
                 },
             ),
-            ("Remove", Effect::Remove { id: rid.clone() }),
+            (
+                "Remove",
+                Effect::Remove {
+                    id: crate::resource::ResolvedResourceId::new(rid.clone()),
+                },
+            ),
             (
                 "Move",
                 Effect::Move {
-                    from: rid.clone(),
-                    to: ResourceId::with_identity("test", "y"),
+                    from: crate::resource::ResolvedResourceId::new(rid.clone()),
+                    to: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                        "test", "y",
+                    )),
                 },
             ),
             (
                 "Wait",
                 Effect::Wait {
                     binding: "w".to_string(),
-                    target_id: rid,
+                    target_id: crate::resource::ResolvedResourceId::new(rid),
                     until: WaitPredicate::Equals {
                         attr: AttrPath::single("status"),
                         value: Value::Concrete(ConcreteValue::String("ready".to_string())),
@@ -1398,7 +1433,10 @@ mod tests {
         template.line = 0;
         let effect = Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "route53.Record",
+                    "validation_records[0]",
+                )),
                 identifier: "old-record-id".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -1406,7 +1444,10 @@ mod tests {
                 explicit_dependencies: HashSet::new(),
             }])
             .expect("fixture has one delete"),
-            id: ResourceId::with_identity("__deferred_for", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "__deferred_for",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
         };
@@ -1424,7 +1465,10 @@ mod tests {
         template.line = 0;
         let effect = Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "route53.Record",
+                    "validation_records[0]",
+                )),
                 identifier: "old-record-id".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -1432,7 +1476,10 @@ mod tests {
                 explicit_dependencies: HashSet::from(["foo".to_string()]),
             }])
             .expect("fixture has one delete"),
-            id: ResourceId::with_identity("__deferred_for", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "__deferred_for",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
         };
@@ -1540,7 +1587,7 @@ mod tests {
     #[test]
     fn resource_returns_none_for_delete() {
         let effect = Effect::Delete {
-            id: ResourceId::with_identity("test", "a"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("test", "a")),
             identifier: "id-123".to_string(),
             directives: Directives::default(),
             binding: None,
@@ -1579,7 +1626,10 @@ mod tests {
                 resource: DataSource::new("s3.Bucket", "existing"),
             },
             Effect::Update {
-                id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "s3.Bucket",
+                    "my-bucket",
+                )),
                 from: Box::new(State::existing(
                     ResourceId::with_identity("s3.Bucket", "my-bucket"),
                     HashMap::from([(
@@ -1594,7 +1644,9 @@ mod tests {
                 changed_attributes: vec!["versioning".to_string()],
             },
             Effect::Replace {
-                id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "ec2.Vpc", "my-vpc",
+                )),
                 from: Box::new(State::existing(
                     ResourceId::with_identity("ec2.Vpc", "my-vpc"),
                     HashMap::from([(
@@ -1614,7 +1666,10 @@ mod tests {
                 // carina#3181 PR D: cover `CascadingUpdate.to:
                 // Resource` in the serde round-trip.
                 cascading_updates: vec![CascadingUpdate {
-                    id: ResourceId::with_identity("ec2.Subnet", "my-subnet"),
+                    id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                        "ec2.Subnet",
+                        "my-subnet",
+                    )),
                     from: Box::new(State::not_found(ResourceId::with_identity(
                         "ec2.Subnet",
                         "my-subnet",
@@ -1628,7 +1683,10 @@ mod tests {
                 cascade_ref_hints: vec![],
             },
             Effect::Delete {
-                id: ResourceId::with_identity("s3.Bucket", "old-bucket"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "s3.Bucket",
+                    "old-bucket",
+                )),
                 identifier: "old-bucket".to_string(),
                 directives: Directives::default(),
                 binding: None,
@@ -1666,7 +1724,7 @@ mod tests {
     #[test]
     fn replace_changed_create_only_serializes_as_plain_array() {
         let effect = Effect::Replace {
-            id: ResourceId::with_identity("test", "x"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("test", "x")),
             from: Box::new(State::not_found(ResourceId::with_identity("test", "x"))),
             to: Resource::new("test", "x"),
             directives: Directives::default(),
@@ -1734,7 +1792,10 @@ mod tests {
     #[test]
     fn explicit_dependencies_for_delete_uses_stored_set() {
         let effect = Effect::Delete {
-            id: ResourceId::with_identity("s3.Bucket", "b"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "b",
+            )),
             identifier: "x".to_string(),
             directives: Directives::default(),
             binding: Some("bucket".to_string()),
@@ -1749,17 +1810,29 @@ mod tests {
     #[test]
     fn explicit_dependencies_empty_for_state_only_effects() {
         let imp = Effect::Import {
-            id: ResourceId::with_identity("s3.Bucket", "b"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "b",
+            )),
             identifier: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(
                 "x".to_string(),
             )),
         };
         let rem = Effect::Remove {
-            id: ResourceId::with_identity("s3.Bucket", "b"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "b",
+            )),
         };
         let mov = Effect::Move {
-            from: ResourceId::with_identity("s3.Bucket", "old"),
-            to: ResourceId::with_identity("s3.Bucket", "new"),
+            from: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "old",
+            )),
+            to: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "new",
+            )),
         };
         for e in [imp, rem, mov] {
             assert!(
@@ -1804,7 +1877,10 @@ mod tests {
 
         let _ = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
+            target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "acm.Certificate",
+                "cert",
+            )),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1824,7 +1900,10 @@ mod tests {
 
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
+            target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "acm.Certificate",
+                "cert",
+            )),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1845,7 +1924,10 @@ mod tests {
 
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
+            target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "acm.Certificate",
+                "cert",
+            )),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1867,7 +1949,10 @@ mod tests {
 
         let original = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
+            target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "acm.Certificate",
+                "cert",
+            )),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1908,7 +1993,7 @@ mod tests {
         ));
 
         let update = Effect::Update {
-            id: rid.clone(),
+            id: crate::resource::ResolvedResourceId::new(rid.clone()),
             from: Box::new(ResState::not_found(rid.clone())),
             to: Resource::new("test", "x"),
             changed_attributes: vec![],
@@ -1919,7 +2004,7 @@ mod tests {
         ));
 
         let delete = Effect::Delete {
-            id: rid.clone(),
+            id: crate::resource::ResolvedResourceId::new(rid.clone()),
             identifier: "x-1".to_string(),
             directives: Directives::default(),
             binding: None,
@@ -1939,7 +2024,7 @@ mod tests {
             resource: DataSource::new("test", "x"),
         };
         let replace = Effect::Replace {
-            id: rid.clone(),
+            id: crate::resource::ResolvedResourceId::new(rid.clone()),
             from: Box::new(ResState::not_found(rid.clone())),
             to: Resource::new("test", "x"),
             directives: Directives::default(),
@@ -1949,19 +2034,21 @@ mod tests {
             cascade_ref_hints: vec![],
         };
         let import = Effect::Import {
-            id: rid.clone(),
+            id: crate::resource::ResolvedResourceId::new(rid.clone()),
             identifier: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(
                 "x-1".to_string(),
             )),
         };
-        let remove = Effect::Remove { id: rid.clone() };
+        let remove = Effect::Remove {
+            id: crate::resource::ResolvedResourceId::new(rid.clone()),
+        };
         let mov = Effect::Move {
-            from: rid.clone(),
-            to: ResourceId::with_identity("test", "y"),
+            from: crate::resource::ResolvedResourceId::new(rid.clone()),
+            to: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("test", "y")),
         };
         let wait = Effect::Wait {
             binding: "w".to_string(),
-            target_id: rid.clone(),
+            target_id: crate::resource::ResolvedResourceId::new(rid.clone()),
             until: WaitPredicate::Equals {
                 attr: crate::wait::predicate::AttrPath::single("status"),
                 value: crate::resource::Value::Concrete(crate::resource::ConcreteValue::String(

--- a/carina-core/src/effect/deps.rs
+++ b/carina-core/src/effect/deps.rs
@@ -515,7 +515,7 @@ mod tests {
             );
         }
         Effect::Update {
-            id: resource.id.clone(),
+            id: crate::resource::ResolvedResourceId::new(resource.id.clone()),
             from: Box::new(state_for(&resource.id)),
             to: resource,
             changed_attributes: changed.iter().map(|s| (*s).to_string()).collect(),
@@ -525,7 +525,9 @@ mod tests {
     #[test]
     fn destroy_delete_edges_block_dependencies_by_consumers() {
         let parent = Effect::Delete {
-            id: ResourceId::with_identity("test", "parent"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test", "parent",
+            )),
             identifier: "parent-id".to_string(),
             directives: Default::default(),
             binding: Some("parent".to_string()),
@@ -533,7 +535,9 @@ mod tests {
             explicit_dependencies: HashSet::new(),
         };
         let child = Effect::Delete {
-            id: ResourceId::with_identity("test", "child"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test", "child",
+            )),
             identifier: "child-id".to_string(),
             directives: Default::default(),
             binding: Some("child".to_string()),
@@ -556,7 +560,7 @@ mod tests {
     #[test]
     fn destroy_wait_alias_bridges_target_to_consumers() {
         let cert = Effect::Delete {
-            id: ResourceId::with_identity("test", "cert"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("test", "cert")),
             identifier: "cert-id".to_string(),
             directives: Default::default(),
             binding: Some("cert".to_string()),
@@ -564,7 +568,9 @@ mod tests {
             explicit_dependencies: HashSet::new(),
         };
         let listener = Effect::Delete {
-            id: ResourceId::with_identity("test", "listener"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test", "listener",
+            )),
             identifier: "listener-id".to_string(),
             directives: Default::default(),
             binding: Some("listener".to_string()),
@@ -613,7 +619,10 @@ mod tests {
         let effects = vec![
             Effect::Create(x),
             Effect::Replace {
-                id: ResourceId::with_identity("test", "replace_me"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "test",
+                    "replace_me",
+                )),
                 from: Box::new(from),
                 to,
                 directives: Default::default(),
@@ -637,7 +646,9 @@ mod tests {
     #[test]
     fn unknown_destroy_dependency_names_are_dropped() {
         let orphan = Effect::Delete {
-            id: ResourceId::with_identity("test", "listener"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test", "listener",
+            )),
             identifier: "listener-id".to_string(),
             directives: Default::default(),
             binding: Some("listener".to_string()),

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -766,7 +766,7 @@ mod tests {
             );
         }
         Effect::Update {
-            id: id.clone(),
+            id: crate::resource::ResolvedResourceId::new(id.clone()),
             from: Box::new(state_for(&id)),
             to,
             changed_attributes: writes.iter().map(|attr| (*attr).to_string()).collect(),
@@ -784,7 +784,7 @@ mod tests {
             );
         }
         Effect::Replace {
-            id: id.clone(),
+            id: crate::resource::ResolvedResourceId::new(id.clone()),
             from: Box::new(state_for(&id)),
             to,
             directives: Default::default(),
@@ -969,7 +969,7 @@ mod tests {
         plan.add(Effect::Create(cert.clone()));
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: cert_id.clone(),
+            target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1063,7 +1063,7 @@ mod tests {
         plan.add(Effect::Create(cert.clone()));
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: cert_id.clone(),
+            target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -1198,7 +1198,7 @@ mod tests {
             }),
         );
         let child = Effect::Update {
-            id: child.id.clone(),
+            id: crate::resource::ResolvedResourceId::new(child.id.clone()),
             from: Box::new(state_for(&child.id)),
             to: child,
             changed_attributes: vec!["name".to_string()],
@@ -1217,7 +1217,7 @@ mod tests {
         };
         child.directives.depends_on.push("parent".to_string());
         let child = Effect::Update {
-            id: child.id.clone(),
+            id: crate::resource::ResolvedResourceId::new(child.id.clone()),
             from: Box::new(state_for(&child.id)),
             to: child,
             changed_attributes: vec!["name".to_string()],
@@ -1242,7 +1242,7 @@ mod tests {
         let effects = vec![
             parent,
             Effect::Update {
-                id: child_id.clone(),
+                id: crate::resource::ResolvedResourceId::new(child_id.clone()),
                 from: Box::new(state_for(&child_id)),
                 to: child.clone(),
                 changed_attributes: vec!["name".to_string()],
@@ -1340,7 +1340,7 @@ mod tests {
         let effects = vec![
             parent,
             Effect::Update {
-                id: child_id.clone(),
+                id: crate::resource::ResolvedResourceId::new(child_id.clone()),
                 from: Box::new(state_for(&child_id)),
                 to: child.clone(),
                 changed_attributes: vec!["name".to_string()],

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -278,7 +278,7 @@ pub(super) async fn execute_effects_phased(
     let replaced_ids: HashSet<ResourceId> = effects
         .iter()
         .filter_map(|effect| match effect {
-            Effect::Replace { id, .. } => Some(id.clone()),
+            Effect::Replace { id, .. } => Some(id.clone().into_inner()),
             _ => None,
         })
         .collect();
@@ -286,7 +286,9 @@ pub(super) async fn execute_effects_phased(
         .iter()
         .enumerate()
         .filter_map(|(idx, effect)| match effect {
-            Effect::Wait { target_id, .. } if replaced_ids.contains(target_id) => Some(idx),
+            Effect::Wait { target_id, .. } if replaced_ids.contains(target_id.as_inner()) => {
+                Some(idx)
+            }
             _ => None,
         })
         .collect();
@@ -856,7 +858,7 @@ pub(super) async fn execute_effects_phased(
                                             let cascade_identifier =
                                                 cascade.from.identifier.as_deref().unwrap_or("");
                                             refreshes.push((
-                                                cascade.id.clone(),
+                                                cascade.id.clone().into_inner(),
                                                 cascade_identifier.to_string(),
                                             ));
                                             cascade_failed = true;
@@ -896,8 +898,10 @@ pub(super) async fn execute_effects_phased(
                                             let cascade_state =
                                                 cascade_outcome.into_state_for_writeback();
                                             if let Some(diagnostic) = cascade_diagnostic {
-                                                cascade_diagnostics
-                                                    .push((cascade.id.clone(), diagnostic));
+                                                cascade_diagnostics.push((
+                                                    cascade.id.clone().into_inner(),
+                                                    diagnostic,
+                                                ));
                                             }
                                             let cascade_attrs =
                                                 resolved_to.as_resource().resolved_attributes();
@@ -907,7 +911,7 @@ pub(super) async fn execute_effects_phased(
                                                 &cascade_state,
                                             );
                                             cascade_states.push((
-                                                cascade.id.clone(),
+                                                cascade.id.clone().into_inner(),
                                                 cascade_state,
                                                 cascade_attrs,
                                                 cascade.to.binding.clone(),
@@ -922,7 +926,7 @@ pub(super) async fn execute_effects_phased(
                                                 },
                                             );
                                             refreshes.push((
-                                                cascade.id.clone(),
+                                                cascade.id.clone().into_inner(),
                                                 cascade_identifier.to_string(),
                                             ));
                                             cascade_failed = true;
@@ -1223,7 +1227,10 @@ pub(super) async fn execute_effects_phased(
                                 (
                                     idx,
                                     PhaseEffectResult::ReplaceDeleteFailure {
-                                        refresh: Some((id.clone(), identifier.to_string())),
+                                        refresh: Some((
+                                            id.clone().into_inner(),
+                                            identifier.to_string(),
+                                        )),
                                         cbd_refresh: cbd_refresh_info,
                                     },
                                 )
@@ -2343,7 +2350,7 @@ mod tests {
         plan.add(Effect::Create(cert.clone()));
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: cert_id.clone(),
+            target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -2441,7 +2448,7 @@ mod tests {
         plan.add(Effect::Create(cert.clone()));
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: cert_id.clone(),
+            target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -2633,7 +2640,7 @@ mod tests {
         let bucket_state = State::not_found(bucket.id.clone());
 
         let role_replace = Effect::Replace {
-            id: role.id.clone(),
+            id: crate::resource::ResolvedResourceId::new(role.id.clone()),
             from: Box::new(role_state),
             to: role.clone(),
             directives: Directives::default(),
@@ -2646,7 +2653,7 @@ mod tests {
             cascade_ref_hints: vec![],
         };
         let bucket_replace = Effect::Replace {
-            id: bucket.id.clone(),
+            id: crate::resource::ResolvedResourceId::new(bucket.id.clone()),
             from: Box::new(bucket_state),
             to: bucket.clone(),
             directives: Directives::default(),

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -204,7 +204,10 @@ pub(super) async fn execute_cbd_replace_parallel(
                             error: &e,
                         });
                         let cascade_identifier = cascade.from.identifier.as_deref().unwrap_or("");
-                        refreshes.push((cascade.id.clone(), cascade_identifier.to_string()));
+                        refreshes.push((
+                            cascade.id.clone().into_inner(),
+                            cascade_identifier.to_string(),
+                        ));
                         cascade_failed = true;
                         break;
                     }
@@ -234,7 +237,7 @@ pub(super) async fn execute_cbd_replace_parallel(
                         };
                         let cascade_state = cascade_outcome.into_state_for_writeback();
                         if let Some(diagnostic) = cascade_diagnostic {
-                            cascade_diagnostics.push((cascade.id.clone(), diagnostic));
+                            cascade_diagnostics.push((cascade.id.clone().into_inner(), diagnostic));
                         }
                         observer
                             .on_event(&ExecutionEvent::CascadeUpdateSucceeded { id: &cascade.id });
@@ -250,7 +253,10 @@ pub(super) async fn execute_cbd_replace_parallel(
                             id: &cascade.id,
                             error: &error_str,
                         });
-                        refreshes.push((cascade.id.clone(), cascade_identifier.to_string()));
+                        refreshes.push((
+                            cascade.id.clone().into_inner(),
+                            cascade_identifier.to_string(),
+                        ));
                         cascade_failed = true;
                         break;
                     }

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -809,7 +809,7 @@ fn create_interdependent_replace_plan() -> Plan {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: a_id,
+        id: crate::resource::ResolvedResourceId::new(a_id),
         from: Box::new(a_from),
         to: a_to,
         directives: directives.clone(),
@@ -820,7 +820,7 @@ fn create_interdependent_replace_plan() -> Plan {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Replace {
-        id: b_id,
+        id: crate::resource::ResolvedResourceId::new(b_id),
         from: Box::new(b_from),
         to: b_to,
         directives,
@@ -849,7 +849,7 @@ fn create_interdependent_replace_plan_with_renames<const N: usize>(names: [&str;
             to.dependency_bindings = std::collections::BTreeSet::from([names[idx - 1].to_string()]);
         }
         plan.add(Effect::Replace {
-            id,
+            id: crate::resource::ResolvedResourceId::new(id),
             from: Box::new(from),
             to,
             directives: directives.clone(),
@@ -1390,7 +1390,7 @@ async fn execute_plan_cancels_in_flight_wait_effect_promptly() {
     plan.add(Effect::Create(cert));
     plan.add(Effect::Wait {
         binding: "cert_ready".to_string(),
-        target_id: cert_id,
+        target_id: crate::resource::ResolvedResourceId::new(cert_id),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("READY".to_string())),
@@ -1458,7 +1458,7 @@ async fn execute_plan_cancelled_wait_emits_cancelled_skip_not_unsatisfiable() {
     plan.add(Effect::Create(cert));
     plan.add(Effect::Wait {
         binding: "cert_ready".to_string(),
-        target_id: cert_id,
+        target_id: crate::resource::ResolvedResourceId::new(cert_id),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("READY".to_string())),
@@ -1868,7 +1868,7 @@ async fn test_apply_reapplies_enum_alias_stage_update_path() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
         to: to_resource,
         changed_attributes: vec!["ip_protocol".to_string()],
@@ -1985,7 +1985,7 @@ async fn test_apply_renormalizes_update_path() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
         to: to_resource,
         changed_attributes: vec!["marker".to_string()],
@@ -2072,7 +2072,7 @@ async fn test_apply_update_patch_preserves_provider_default_tags() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
         to: to_resource,
         changed_attributes: vec!["tags".to_string()],
@@ -2182,7 +2182,7 @@ async fn test_apply_effective_changed_uses_plan_time_comparison_semantics() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
         to: to_resource,
         changed_attributes: vec!["description".to_string()],
@@ -2242,7 +2242,7 @@ async fn test_apply_effective_changed_skips_internal_and_write_only_attributes()
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
         to: to_resource,
         changed_attributes: vec!["description".to_string()],
@@ -2306,7 +2306,7 @@ async fn test_apply_effective_changed_skips_matching_unwrapped_secret_hash() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
         to: to_resource,
         changed_attributes: vec![],
@@ -2375,7 +2375,7 @@ async fn test_apply_effective_changed_skips_secret_shape_divergence() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
         to: to_resource,
         changed_attributes: vec![],
@@ -2633,7 +2633,7 @@ async fn test_simple_delete() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         identifier: "id-123".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -2716,7 +2716,7 @@ async fn test_cbd_creates_before_deletes() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from),
         to,
         directives: Directives {
@@ -2787,7 +2787,7 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: replace_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(replace_id.clone()),
         from: Box::new(replace_from),
         to: replace_to,
         directives: Directives {
@@ -2797,7 +2797,7 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
             .unwrap(),
         cascading_updates: vec![crate::effect::CascadingUpdate {
-            id: cascade_id.clone(),
+            id: crate::resource::ResolvedResourceId::new(cascade_id.clone()),
             from: Box::new(cascade_from),
             to: cascade_to,
         }],
@@ -2854,7 +2854,7 @@ async fn test_cbd_rename_partial_create_partial_counts_once() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: id.clone(),
+        id: crate::resource::ResolvedResourceId::new(id.clone()),
         from: Box::new(from),
         to,
         directives: Directives {
@@ -2934,7 +2934,7 @@ async fn test_cbd_rename_success_create_partial_keeps_create_marker() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: id.clone(),
+        id: crate::resource::ResolvedResourceId::new(id.clone()),
         from: Box::new(from),
         to,
         directives: Directives {
@@ -3006,7 +3006,7 @@ async fn test_dbd_deletes_before_creates() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: rid.clone(),
+        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from),
         to,
         directives: Directives::default(),
@@ -3074,7 +3074,7 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
     let mut plan = Plan::new();
     // Order in plan: vpc first, subnet second
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(vpc_from),
         to: vpc_to,
         directives: cbd_directives.clone(),
@@ -3085,7 +3085,7 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Replace {
-        id: subnet_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(subnet_from),
         to: subnet_to,
         directives: cbd_directives,
@@ -3156,7 +3156,7 @@ async fn test_phased_noncbd_creates_after_deletes() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: vpc_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(vpc_from),
         to: vpc_to,
         directives: dbd_directives.clone(),
@@ -3167,7 +3167,7 @@ async fn test_phased_noncbd_creates_after_deletes() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Replace {
-        id: subnet_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(subnet_from),
         to: subnet_to,
         directives: dbd_directives,
@@ -3834,7 +3834,7 @@ async fn run_tag_sweep(parallelism: NonZeroUsize) -> (std::time::Duration, usize
         let from = tag_update_state(&resource.id, binding);
         current_states.insert(resource.id.clone(), from.clone());
         plan.add(Effect::Update {
-            id: resource.id.clone(),
+            id: crate::resource::ResolvedResourceId::new(resource.id.clone()),
             from: Box::new(from),
             to: resource.clone(),
             changed_attributes: vec!["tags".to_string()],
@@ -3903,7 +3903,7 @@ async fn run_provider_contract_case(unknown_read: bool) -> usize {
         let from = tag_update_state(&resource.id, binding);
         current_states.insert(resource.id.clone(), from.clone());
         plan.add(Effect::Update {
-            id: resource.id.clone(),
+            id: crate::resource::ResolvedResourceId::new(resource.id.clone()),
             from: Box::new(from),
             to: resource.clone(),
             changed_attributes: vec!["tags".to_string()],
@@ -4080,7 +4080,9 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
     // For deletion: vpc delete must wait for subnet delete → subnet first, then vpc
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "my-vpc",
+        )),
         identifier: "vpc-123".to_string(),
         directives: Directives::default(),
         binding: Some("vpc".to_string()),
@@ -4088,7 +4090,10 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
         explicit_dependencies: HashSet::new(),
     });
     plan.add(Effect::Delete {
-        id: ResourceId::with_identity("ec2.Subnet", "my-subnet"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Subnet",
+            "my-subnet",
+        )),
         identifier: "subnet-456".to_string(),
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
@@ -4174,7 +4179,7 @@ async fn test_update_effect_binding_map_propagation() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ra_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(ra_id.clone()),
         from: Box::new(from_state),
         to: to_resource,
         changed_attributes: vec!["some_attr".to_string()],
@@ -4215,7 +4220,9 @@ async fn test_update_effect_binding_map_propagation() {
 fn test_dependency_analysis_respects_delete_dependencies() {
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "my-vpc",
+        )),
         identifier: "vpc-123".to_string(),
         directives: Directives::default(),
         binding: Some("vpc".to_string()),
@@ -4223,7 +4230,10 @@ fn test_dependency_analysis_respects_delete_dependencies() {
         explicit_dependencies: std::collections::HashSet::new(),
     });
     plan.add(Effect::Delete {
-        id: ResourceId::with_identity("ec2.Subnet", "my-subnet"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Subnet",
+            "my-subnet",
+        )),
         identifier: "subnet-456".to_string(),
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
@@ -4473,7 +4483,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
 
     // tgw_a: Delete
     plan.add(Effect::Delete {
-        id: tgw_a_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(tgw_a_id.clone()),
         identifier: "tgw-old".to_string(),
         directives: Default::default(),
         binding: Some("tgw_a".to_string()),
@@ -4483,7 +4493,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
 
     // attachment: Replace (CBD) — from depends on tgw_a
     plan.add(Effect::Replace {
-        id: attachment_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(attachment_id.clone()),
         from: Box::new(attachment_from),
         to: attachment_to,
         directives: cbd_directives,
@@ -4573,7 +4583,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
 
     // tgw_a: Delete — binding is None (the key difference from the previous test)
     plan.add(Effect::Delete {
-        id: tgw_a_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(tgw_a_id.clone()),
         identifier: "tgw-old".to_string(),
         directives: Default::default(),
         binding: None,
@@ -4583,7 +4593,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
 
     // attachment: Replace (CBD)
     plan.add(Effect::Replace {
-        id: attachment_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(attachment_id.clone()),
         from: Box::new(attachment_from),
         to: attachment_to,
         directives: cbd_directives,
@@ -4651,7 +4661,7 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
     plan.add(Effect::Create(cert));
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
-        target_id: cert_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -4803,7 +4813,7 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
     plan.add(Effect::Create(cert));
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
-        target_id: cert_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -4904,7 +4914,7 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     plan.add(Effect::Create(cert));
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
-        target_id: cert_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -5426,7 +5436,7 @@ async fn wait_resolves_target_identifier_from_just_created_state() {
     plan.add(Effect::Create(cert));
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
-        target_id: cert_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("issued".to_string())),
@@ -5511,7 +5521,7 @@ async fn wait_resolves_target_identifier_from_just_replaced_state() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: cert_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_state.clone()),
         to: cert,
         directives: Directives::default(),
@@ -5522,7 +5532,7 @@ async fn wait_resolves_target_identifier_from_just_replaced_state() {
     });
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
-        target_id: cert_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("issued".to_string())),
@@ -5614,7 +5624,7 @@ async fn wait_resolves_target_identifier_from_just_replaced_state_phased() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: cert_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
         to: cert,
         directives: Directives::default(),
@@ -5624,7 +5634,7 @@ async fn wait_resolves_target_identifier_from_just_replaced_state_phased() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: dep_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(dep_id.clone()),
         from: Box::new(old_dep_state.clone()),
         to: dep,
         directives: Directives::default(),
@@ -5635,7 +5645,7 @@ async fn wait_resolves_target_identifier_from_just_replaced_state_phased() {
     });
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
-        target_id: cert_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("issued".to_string())),
@@ -5757,7 +5767,7 @@ async fn deferred_create_dispatches_after_upstream_replace_before_wait_phased() 
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: cert_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
         to: cert,
         directives: Directives::default(),
@@ -5767,7 +5777,7 @@ async fn deferred_create_dispatches_after_upstream_replace_before_wait_phased() 
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: dep_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(dep_id.clone()),
         from: Box::new(old_dep_state.clone()),
         to: dep,
         directives: Directives::default(),
@@ -5777,13 +5787,16 @@ async fn deferred_create_dispatches_after_upstream_replace_before_wait_phased() 
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
-        target_id: cert_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("issued".to_string())),
@@ -5893,7 +5906,7 @@ async fn deferred_create_emits_zero_children_when_collection_is_empty() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: cert_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
         to: cert,
         directives: Directives::default(),
@@ -5903,13 +5916,16 @@ async fn deferred_create_emits_zero_children_when_collection_is_empty() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
     plan.add(Effect::Wait {
         binding: "cert_issued".to_string(),
-        target_id: cert_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("issued".to_string())),
@@ -6048,7 +6064,7 @@ async fn deferred_create_cancelled_after_upstream_create_reports_skipped() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: cert_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
         to: cert,
         directives: Directives::default(),
@@ -6058,7 +6074,10 @@ async fn deferred_create_cancelled_after_upstream_create_reports_skipped() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6097,7 +6116,10 @@ async fn deferred_create_returns_error_when_upstream_binding_missing() {
     let provider = MockProvider::new();
     let mut plan = Plan::new();
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "missing_cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6136,7 +6158,10 @@ async fn deferred_create_returns_error_when_iterable_attr_missing() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(cert));
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6183,7 +6208,10 @@ async fn apply_time_deferred_create_emits_failed_on_shape_mismatch() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(cert));
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6325,7 +6353,10 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![
             DeferredReplaceDelete {
-                id: ResourceId::with_identity("test", "validation_records[0]"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "test",
+                    "validation_records[0]",
+                )),
                 identifier: "old-validation-0".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -6333,7 +6364,10 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
                 explicit_dependencies: HashSet::new(),
             },
             DeferredReplaceDelete {
-                id: ResourceId::with_identity("test", "validation_records[1]"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "test",
+                    "validation_records[1]",
+                )),
                 identifier: "old-validation-1".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[1]".to_string()),
@@ -6342,7 +6376,10 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
             },
         ])
         .expect("fixture has deletes"),
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6418,7 +6455,10 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
     plan.add(Effect::Create(cert));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-            id: ResourceId::with_identity("test", "validation_records[0]"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test",
+                "validation_records[0]",
+            )),
             identifier: "old-validation".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -6426,7 +6466,10 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6494,7 +6537,7 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: cert_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
         to: cert,
         directives: Directives::default(),
@@ -6504,7 +6547,7 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: dep_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(dep_id.clone()),
         from: Box::new(old_dep_state.clone()),
         to: dep,
         directives: Directives::default(),
@@ -6515,7 +6558,7 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
     });
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-            id: validation_id.clone(),
+            id: crate::resource::ResolvedResourceId::new(validation_id.clone()),
             identifier: "old-validation".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -6523,7 +6566,10 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -6631,7 +6677,7 @@ async fn phased_cbd_replace_skips_when_phase1_dependency_fails() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(bucket));
     plan.add(Effect::Replace {
-        id: anchor_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(anchor_id.clone()),
         from: Box::new(anchor_from.clone()),
         to: anchor_to,
         directives: Directives::default(),
@@ -6641,7 +6687,7 @@ async fn phased_cbd_replace_skips_when_phase1_dependency_fails() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: policy_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(policy_id.clone()),
         from: Box::new(policy_from.clone()),
         to: policy_to,
         directives: Directives {
@@ -6722,7 +6768,7 @@ async fn phased_replace_delete_skips_when_phase1_dependency_fails() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(bucket));
     plan.add(Effect::Replace {
-        id: anchor_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(anchor_id.clone()),
         from: Box::new(anchor_from.clone()),
         to: anchor_to,
         directives: Directives::default(),
@@ -6732,7 +6778,7 @@ async fn phased_replace_delete_skips_when_phase1_dependency_fails() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: target_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(target_id.clone()),
         from: Box::new(target_from.clone()),
         to: target_to,
         directives: Directives {
@@ -6836,7 +6882,7 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: a_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(a_id.clone()),
         from: Box::new(old_a_state.clone()),
         to: a,
         directives: Directives::default(),
@@ -6846,7 +6892,7 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: b_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(b_id.clone()),
         from: Box::new(old_b_state.clone()),
         to: b,
         directives: Directives::default(),
@@ -6856,7 +6902,7 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: anonymous_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(anonymous_id.clone()),
         from: Box::new(old_anonymous_state.clone()),
         to: anonymous_to,
         directives: Directives::default(),
@@ -6867,7 +6913,7 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
     });
     plan.add(Effect::Wait {
         binding: "anonymous_ready".to_string(),
-        target_id: anonymous_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(anonymous_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ready".to_string())),
@@ -6975,13 +7021,13 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: failed_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(failed_id.clone()),
         from: Box::new(old_failed_state.clone()),
         to: failed_to,
         changed_attributes: vec!["name".to_string()],
     });
     plan.add(Effect::Replace {
-        id: parent_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(parent_id.clone()),
         from: Box::new(old_parent_state.clone()),
         to: parent,
         directives: Directives::default(),
@@ -6991,7 +7037,7 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: child_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(child_id.clone()),
         from: Box::new(old_child_state.clone()),
         to: child,
         directives: Directives::default(),
@@ -7002,7 +7048,7 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
     });
     plan.add(Effect::Wait {
         binding: "sibling_ready".to_string(),
-        target_id: parent_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(parent_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ready".to_string())),
@@ -7014,7 +7060,7 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
     });
     plan.add(Effect::Wait {
         binding: "blocked_ready".to_string(),
-        target_id: child_id.clone(),
+        target_id: crate::resource::ResolvedResourceId::new(child_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
             value: Value::Concrete(ConcreteValue::String("ready".to_string())),
@@ -7099,7 +7145,7 @@ fn phased_anonymous_replace_failure_unblocks_wait_terminal_check() {
 
     let effects = vec![
         Effect::Replace {
-            id: anonymous_id.clone(),
+            id: crate::resource::ResolvedResourceId::new(anonymous_id.clone()),
             from: Box::new(old_anonymous_state),
             to: anonymous_to,
             directives: Directives::default(),
@@ -7110,7 +7156,7 @@ fn phased_anonymous_replace_failure_unblocks_wait_terminal_check() {
         },
         Effect::Wait {
             binding: "anonymous_terminal_ready".to_string(),
-            target_id: anonymous_id.clone(),
+            target_id: crate::resource::ResolvedResourceId::new(anonymous_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ready".to_string())),
@@ -7336,7 +7382,10 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
     plan.add(Effect::Create(resource_with_binding("alb", "alb")));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-            id: ResourceId::with_identity("test", "validation_records[0]"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "test",
+                "validation_records[0]",
+            )),
             identifier: "old-validation".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -7344,7 +7393,10 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
     });
@@ -7454,7 +7506,7 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: role_id.clone(),
+        id: crate::resource::ResolvedResourceId::new(role_id.clone()),
         from: Box::new(role_from),
         to: role_to,
         directives: Directives::default(),
@@ -7465,11 +7517,11 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Move {
-        from: policy_old_id,
-        to: policy_new_id.clone(),
+        from: crate::resource::ResolvedResourceId::new(policy_old_id),
+        to: crate::resource::ResolvedResourceId::new(policy_new_id.clone()),
     });
     plan.add(Effect::Replace {
-        id: policy_new_id,
+        id: crate::resource::ResolvedResourceId::new(policy_new_id),
         from: Box::new(policy_from),
         to: policy_to,
         directives: Directives::default(),

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -584,7 +584,9 @@ mod tests {
         use crate::resource::ResourceId;
         let id =
             ResourceId::with_identity("aws.route53.RecordSet", "aws_route53_record_set_7059de08");
-        let s = format_effect_brief(&Effect::Remove { id: id.clone() });
+        let s = format_effect_brief(&Effect::Remove {
+            id: crate::resource::ResolvedResourceId::new(id.clone()),
+        });
         assert!(!s.contains('x'), "must not contain `x`; got: {s:?}");
         assert!(!s.contains('✗'), "must not contain `✗`; got: {s:?}");
         assert!(
@@ -605,7 +607,10 @@ mod tests {
 
         let e = Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
+            target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "acm.Certificate",
+                "cert",
+            )),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -631,7 +636,10 @@ mod tests {
         plan.add(Effect::Create(Resource::new("acm.Certificate", "cert")));
         plan.add(Effect::Wait {
             binding: "cert_issued".to_string(),
-            target_id: ResourceId::with_identity("acm.Certificate", "cert"),
+            target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "acm.Certificate",
+                "cert",
+            )),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ISSUED".to_string())),
@@ -652,7 +660,9 @@ mod tests {
         plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
         plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
         plan.add(Effect::Delete {
-            id: crate::resource::ResourceId::with_identity("s3.Bucket", "c"),
+            id: crate::resource::ResolvedResourceId::new(
+                crate::resource::ResourceId::with_identity("s3.Bucket", "c"),
+            ),
             identifier: String::new(),
             directives: crate::resource::Directives::default(),
             binding: None,
@@ -688,7 +698,10 @@ mod tests {
             Resource::new("acm.Certificate", "cert").with_binding("cert"),
         ));
         plan.add(Effect::DeferredCreate {
-            id: ResourceId::with_identity("route53.RecordSet", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "route53.RecordSet",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred),
         });
@@ -727,10 +740,10 @@ mod tests {
         };
         let deletes = (0..3)
             .map(|idx| DeferredReplaceDelete {
-                id: ResourceId::with_identity(
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                     "route53.RecordSet",
                     format!("validation_records[{idx}]"),
-                ),
+                )),
                 identifier: format!("record-{idx}"),
                 directives: Directives::default(),
                 binding: Some(format!("validation_records[{idx}]")),
@@ -742,7 +755,10 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(deletes).expect("fixture has deletes"),
-            id: ResourceId::with_identity("route53.RecordSet", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "route53.RecordSet",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
         });
@@ -828,7 +844,10 @@ mod tests {
             .with_identifier("vpc-123");
         let to = Resource::new("ec2.Vpc", "vpc");
         let cascading = CascadingUpdate {
-            id: ResourceId::with_identity("ec2.Subnet", "subnet"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "ec2.Subnet",
+                "subnet",
+            )),
             from: Box::new(
                 State::not_found(ResourceId::with_identity("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
@@ -836,7 +855,9 @@ mod tests {
             to: (Resource::new("ec2.Subnet", "subnet")),
         };
         plan.add(Effect::Replace {
-            id: ResourceId::with_identity("ec2.Vpc", "vpc"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "ec2.Vpc", "vpc",
+            )),
             from: Box::new(from),
             to,
             directives: Directives::default(),
@@ -868,7 +889,10 @@ mod tests {
             .with_identifier("vpc-123");
         let to = Resource::new("ec2.Vpc", "vpc");
         let cascading = CascadingUpdate {
-            id: ResourceId::with_identity("ec2.Subnet", "subnet"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "ec2.Subnet",
+                "subnet",
+            )),
             from: Box::new(
                 State::not_found(ResourceId::with_identity("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
@@ -876,7 +900,9 @@ mod tests {
             to: (Resource::new("ec2.Subnet", "subnet")),
         };
         plan.add(Effect::Replace {
-            id: ResourceId::with_identity("ec2.Vpc", "vpc"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "ec2.Vpc", "vpc",
+            )),
             from: Box::new(from),
             to,
             directives: Directives::default(),
@@ -909,7 +935,10 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
         plan.add(Effect::Delete {
-            id: ResourceId::with_identity("s3.Bucket", "b"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "s3.Bucket",
+                "b",
+            )),
             identifier: "b-id".to_string(),
             directives: crate::resource::Directives::default(),
             binding: None,

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -602,7 +602,10 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "route53.Record",
+                    "validation_records[0]",
+                )),
                 identifier: "record-0".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -610,12 +613,18 @@ mod tests {
                 explicit_dependencies: HashSet::new(),
             }])
             .expect("fixture has one delete"),
-            id: ResourceId::with_identity("__deferred_for", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "__deferred_for",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred),
         });
         plan.add(Effect::Delete {
-            id: ResourceId::with_identity("route53.Record", "old-record-0"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "route53.Record",
+                "old-record-0",
+            )),
             identifier: "record-0".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -623,7 +632,10 @@ mod tests {
             explicit_dependencies: HashSet::new(),
         });
         plan.add(Effect::Delete {
-            id: ResourceId::with_identity("route53.Record", "old-record-abc"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "route53.Record",
+                "old-record-abc",
+            )),
             identifier: "record-abc".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[abc]".to_string()),
@@ -661,7 +673,10 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::DeferredReplace {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-                id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
+                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                    "route53.Record",
+                    "validation_records[0]",
+                )),
                 identifier: "record-0".to_string(),
                 directives: Directives::default(),
                 binding: Some("validation_records[0]".to_string()),
@@ -669,13 +684,19 @@ mod tests {
                 explicit_dependencies: HashSet::new(),
             }])
             .expect("fixture has one delete"),
-            id: ResourceId::with_identity("__deferred_for", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "__deferred_for",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred),
         });
         plan.add(Effect::Wait {
             binding: "wait_validation_record_0".to_string(),
-            target_id: ResourceId::with_identity("route53.Record", "validation_records[0]"),
+            target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "route53.Record",
+                "validation_records[0]",
+            )),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
                 value: Value::Concrete(ConcreteValue::String("ready".to_string())),

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -3,7 +3,9 @@
 mod enum_value;
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::fmt::{self, Display, Formatter};
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -231,6 +233,118 @@ impl std::fmt::Display for ResourceId {
             (false, Some(id)) => write!(f, "{}.{}.{}", self.provider, self.resource_type, id),
             (false, None) => write!(f, "{}.{}", self.provider, self.resource_type),
         }
+    }
+}
+
+/// A `ResourceId` whose identity has been resolved. Downstream consumers
+/// (differ, scheduler, executor, state, provider) hold this type to
+/// guarantee at compile time that every resource has an identity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "ResourceId", into = "ResourceId")]
+pub struct ResolvedResourceId(ResourceId);
+
+impl ResolvedResourceId {
+    /// Construct from a `ResourceId`, panicking if identity is `None`.
+    pub fn new(id: ResourceId) -> Self {
+        assert!(
+            id.identity.is_some(),
+            "ResolvedResourceId requires identity"
+        );
+        Self(id)
+    }
+
+    /// Try to construct; returns `None` if identity is absent.
+    pub fn try_new(id: ResourceId) -> Option<Self> {
+        if id.identity.is_some() {
+            Some(Self(id))
+        } else {
+            None
+        }
+    }
+
+    /// Borrow the inner `ResourceId`.
+    pub fn as_inner(&self) -> &ResourceId {
+        &self.0
+    }
+
+    /// Consume and return the inner `ResourceId`.
+    pub fn into_inner(self) -> ResourceId {
+        self.0
+    }
+
+    /// The identity string (always present).
+    pub fn identity_str(&self) -> &str {
+        self.0.identity_str().unwrap()
+    }
+
+    pub fn identity_or_empty(&self) -> &str {
+        self.identity_str()
+    }
+
+    pub fn display_type(&self) -> String {
+        self.0.display_type()
+    }
+
+    pub fn human(&self) -> ResourceIdDisplay<'_> {
+        self.0.human()
+    }
+
+    pub fn provider(&self) -> &str {
+        &self.0.provider
+    }
+
+    pub fn resource_type(&self) -> &str {
+        &self.0.resource_type
+    }
+
+    pub fn provider_instance(&self) -> Option<&str> {
+        self.0.provider_instance.as_deref()
+    }
+}
+
+impl Deref for ResolvedResourceId {
+    type Target = ResourceId;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for ResolvedResourceId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<ResolvedResourceId> for ResourceId {
+    fn from(r: ResolvedResourceId) -> Self {
+        r.0
+    }
+}
+
+impl TryFrom<ResourceId> for ResolvedResourceId {
+    type Error = String;
+
+    fn try_from(id: ResourceId) -> Result<Self, String> {
+        Self::try_new(id).ok_or_else(|| "identity is required".to_string())
+    }
+}
+
+impl PartialEq<ResourceId> for ResolvedResourceId {
+    fn eq(&self, other: &ResourceId) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<ResolvedResourceId> for ResourceId {
+    fn eq(&self, other: &ResolvedResourceId) -> bool {
+        *self == other.0
+    }
+}
+
+impl AsRef<ResourceId> for ResolvedResourceId {
+    fn as_ref(&self) -> &ResourceId {
+        self.as_inner()
     }
 }
 

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -129,6 +129,39 @@ fn resource_id_deserializes_legacy_name_alias() {
 }
 
 #[test]
+#[should_panic(expected = "ResolvedResourceId requires identity")]
+fn resolved_resource_id_new_panics_without_identity() {
+    ResolvedResourceId::new(ResourceId::with_provider("aws", "s3.Bucket", None, None));
+}
+
+#[test]
+fn resolved_resource_id_try_new_returns_none_without_identity() {
+    let id = ResourceId::with_provider("aws", "s3.Bucket", None, None);
+    assert!(ResolvedResourceId::try_new(id).is_none());
+}
+
+#[test]
+fn resolved_resource_id_try_new_returns_some_with_identity() {
+    let id = ResourceId::with_provider_identity("aws", "s3.Bucket", "logs", None);
+    let resolved = ResolvedResourceId::try_new(id).expect("identity is present");
+    assert_eq!(resolved.identity_str(), "logs");
+}
+
+#[test]
+fn resolved_resource_id_serde_round_trips_as_resource_id() {
+    let resolved = ResolvedResourceId::new(ResourceId::with_provider_identity(
+        "aws",
+        "s3.Bucket",
+        "logs",
+        Some("primary".to_string()),
+    ));
+    let json = serde_json::to_string(&resolved).unwrap();
+    let decoded: ResolvedResourceId = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded, resolved);
+    assert_eq!(decoded.identity_str(), "logs");
+}
+
+#[test]
 fn resource_id_rejects_legacy_empty_name() {
     let legacy = r#"{"provider":"aws","resource_type":"ec2.Subnet","name":""}"#;
     assert!(

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -5070,7 +5070,10 @@ mod tests {
             InterpolationPart::Literal("|registry-dev.carina-rs.dev|NS".to_string()),
         ]));
         let effect = Effect::Import {
-            id: ResourceId::with_identity("aws.route53.RecordSet", "r.delegation_ns"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "aws.route53.RecordSet",
+                "r.delegation_ns",
+            )),
             identifier,
         };
         let redacted = redact_secrets_in_effect(&effect)
@@ -5107,7 +5110,10 @@ mod tests {
             InterpolationPart::Literal("|tail".to_string()),
         ]));
         let effect = Effect::Import {
-            id: ResourceId::with_identity("aws.s3.Bucket", "b"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "aws.s3.Bucket",
+                "b",
+            )),
             identifier,
         };
         let redacted = redact_secrets_in_effect(&effect).expect("redaction succeeds");
@@ -5161,7 +5167,10 @@ mod tests {
         let mut template_resource = Resource::new("aws.route53.RecordSet", "validation_records");
         template_resource.set_attr("name", placeholder.clone());
         let effect = Effect::DeferredCreate {
-            id: ResourceId::with_identity("__deferred_for", "validation_records"),
+            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "__deferred_for",
+                "validation_records",
+            )),
             upstream_binding: "cert".to_string(),
             template: Box::new(DeferredForExpression {
                 file: None,

--- a/carina-tui/src/app/mod.rs
+++ b/carina-tui/src/app/mod.rs
@@ -123,7 +123,9 @@ impl App {
             .effects()
             .iter()
             .filter_map(|e| match e {
-                Effect::Update { id, .. } | Effect::Replace { id, .. } => Some(id.clone()),
+                Effect::Update { id, .. } | Effect::Replace { id, .. } => {
+                    Some(id.clone().into_inner())
+                }
                 Effect::DeferredReplace { .. } => None,
                 _ => None,
             })

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -16,7 +16,10 @@ fn app_from_plan_with_effects() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
     plan.add(Effect::Delete {
-        id: ResourceId::with_identity("s3.Bucket", "old-bucket"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "s3.Bucket",
+            "old-bucket",
+        )),
         identifier: "old-bucket-id".to_string(),
         directives: Directives::default(),
         binding: None,
@@ -41,7 +44,10 @@ fn app_from_plan_with_effects() {
 fn remove_effect_uses_non_failure_symbol_and_kind() {
     let mut plan = Plan::new();
     plan.add(Effect::Remove {
-        id: ResourceId::with_identity("aws.route53.RecordSet", "aws_route53_record_set_7059de08"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "aws.route53.RecordSet",
+            "aws_route53_record_set_7059de08",
+        )),
     });
 
     let app = App::new(&plan, &SchemaRegistry::new());
@@ -79,7 +85,10 @@ fn deferred_create_uses_create_symbol_and_kind() {
 
     let mut plan = Plan::new();
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -127,7 +136,10 @@ fn navigation() {
 fn update_effect_has_detail_rows() {
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ResourceId::with_identity("s3.Bucket", "my-bucket"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "s3.Bucket",
+            "my-bucket",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("s3.Bucket", "my-bucket"),
             [(
@@ -214,7 +226,9 @@ fn replace_effect_symbols() {
 
     // create_before_destroy = true -> "+/-"
     plan.add(Effect::Replace {
-        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "my-vpc",
+        )),
         from: from.clone(),
         to: Resource::new("ec2.Vpc", "my-vpc"),
         directives: Directives {
@@ -230,7 +244,9 @@ fn replace_effect_symbols() {
 
     // create_before_destroy = false -> "-/+"
     plan.add(Effect::Replace {
-        id: ResourceId::with_identity("ec2.Vpc", "my-vpc2"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "my-vpc2",
+        )),
         from,
         to: Resource::new("ec2.Vpc", "my-vpc2"),
         directives: Directives::default(),
@@ -733,12 +749,21 @@ fn move_suppressed_when_update_exists_for_same_target() {
     let mut plan = Plan::new();
     // Move from old name to new name
     plan.add(Effect::Move {
-        from: ResourceId::with_identity("s3.Bucket", "old-name"),
-        to: ResourceId::with_identity("s3.Bucket", "new-name"),
+        from: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "s3.Bucket",
+            "old-name",
+        )),
+        to: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "s3.Bucket",
+            "new-name",
+        )),
     });
     // Update for the same target
     plan.add(Effect::Update {
-        id: ResourceId::with_identity("s3.Bucket", "new-name"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "s3.Bucket",
+            "new-name",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("s3.Bucket", "new-name"),
             [(
@@ -765,11 +790,17 @@ fn move_suppressed_when_update_exists_for_same_target() {
 fn move_suppressed_when_replace_exists_for_same_target() {
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: ResourceId::with_identity("ec2.Vpc", "old-vpc"),
-        to: ResourceId::with_identity("ec2.Vpc", "new-vpc"),
+        from: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "old-vpc",
+        )),
+        to: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "new-vpc",
+        )),
     });
     plan.add(Effect::Replace {
-        id: ResourceId::with_identity("ec2.Vpc", "new-vpc"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "new-vpc",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Vpc", "new-vpc"),
             [(
@@ -797,8 +828,14 @@ fn move_suppressed_when_replace_exists_for_same_target() {
 fn pure_move_not_suppressed() {
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: ResourceId::with_identity("s3.Bucket", "old-name"),
-        to: ResourceId::with_identity("s3.Bucket", "new-name"),
+        from: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "s3.Bucket",
+            "old-name",
+        )),
+        to: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "s3.Bucket",
+            "new-name",
+        )),
     });
 
     let app = App::new(&plan, &SchemaRegistry::new());

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -83,7 +83,9 @@ fn build_all_create_plan() -> Plan {
 fn build_mixed_operations_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "my-vpc",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Vpc", "my-vpc"),
             [
@@ -124,7 +126,10 @@ fn build_mixed_operations_plan() -> Plan {
             ),
     ));
     plan.add(Effect::Delete {
-        id: ResourceId::with_identity("ec2.Subnet", "old-subnet"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Subnet",
+            "old-subnet",
+        )),
         identifier: "subnet-12345678".to_string(),
         directives: Directives::default(),
         binding: Some("old_subnet".to_string()),
@@ -173,7 +178,9 @@ fn build_map_key_diff_plan() -> Plan {
     .collect();
 
     plan.add(Effect::Update {
-        id: ResourceId::with_identity("ec2.Vpc", "my-vpc"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "my-vpc",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Vpc", "my-vpc"),
             [
@@ -224,7 +231,10 @@ fn build_deferred_for_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Create(certificate_resource()));
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -249,7 +259,10 @@ fn build_anonymous_deferred_for_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Create(certificate_resource()));
     plan.add(Effect::DeferredCreate {
-        id: ResourceId::with_identity("__deferred_for", "_anon_validation_records"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "_anon_validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -276,7 +289,10 @@ fn build_deferred_replace_plan() -> Plan {
     plan.add(Effect::Create(certificate_resource()));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
-            id: ResourceId::with_identity("route53.Record", "old-record-0"),
+            id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+                "route53.Record",
+                "old-record-0",
+            )),
             identifier: "record-0".to_string(),
             directives: Directives::default(),
             binding: Some("validation_records[0]".to_string()),
@@ -284,7 +300,10 @@ fn build_deferred_replace_plan() -> Plan {
             explicit_dependencies: HashSet::new(),
         }])
         .expect("fixture has one delete"),
-        id: ResourceId::with_identity("__deferred_for", "validation_records"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "__deferred_for",
+            "validation_records",
+        )),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
     });
@@ -495,11 +514,17 @@ fn snapshot_filter_mode_route_table() {
 fn build_moved_with_changes_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: ResourceId::with_identity("ec2.Vpc", "old_vpc"),
-        to: ResourceId::with_identity("ec2.Vpc", "new_vpc"),
+        from: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "old_vpc",
+        )),
+        to: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "new_vpc",
+        )),
     });
     plan.add(Effect::Update {
-        id: ResourceId::with_identity("ec2.Vpc", "new_vpc"),
+        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "new_vpc",
+        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Vpc", "new_vpc"),
             [
@@ -552,8 +577,12 @@ fn build_moved_with_changes_plan() -> Plan {
 fn build_moved_pure_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Move {
-        from: ResourceId::with_identity("ec2.Vpc", "old_vpc"),
-        to: ResourceId::with_identity("ec2.Vpc", "new_vpc"),
+        from: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "old_vpc",
+        )),
+        to: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
+            "ec2.Vpc", "new_vpc",
+        )),
     });
     plan
 }


### PR DESCRIPTION
## Summary

- Introduce `ResolvedResourceId` newtype wrapping `ResourceId` with guaranteed `identity: Some`
- Change all `Effect` variants (except `Create`) to use `ResolvedResourceId`
- Construction of Effect with unresolved identity is now a compile error
- `Deref<Target = ResourceId>` for seamless downstream access
- Serde via `TryFrom<ResourceId>` / `Into<ResourceId>` for backward compat
- Three lenses (root-cause, long-term, type-safety) all point to this approach

## Test plan

- [x] 4366 tests pass (4362 existing + 4 new ResolvedResourceId tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --doc` clean
- [x] `scripts/check-*.sh` all pass

Closes #3635

🤖 Generated with [Claude Code](https://claude.com/claude-code)