### PR TITLE
refactor: rename ResourceState.name to identity, bump state to v8

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -954,7 +954,7 @@ async fn run_apply_locked(
             &|provider, resource_type| {
                 sf.resources_by_type(provider, resource_type)
                     .into_iter()
-                    .map(|r| r.name.clone())
+                    .map(|r| r.identity.clone())
                     .collect()
             },
             &state_block_claims,
@@ -964,7 +964,7 @@ async fn run_apply_locked(
             &|provider, resource_type| {
                 sf.resources_by_type(provider, resource_type)
                     .into_iter()
-                    .map(|r| r.name.clone())
+                    .map(|r| r.identity.clone())
                     .collect()
             },
             &state_block_claims,

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -150,8 +150,8 @@ async fn run_destroy_locked(
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let ctx = WiringContext::new(factories);
 
-    // Read current state from backend. carina#3315: persist any v6→v7
-    // schema migration under the destroy lock before any short-circuit
+    // Read current state from backend. carina#3315: persist any older-schema
+    // migration under the destroy lock before any short-circuit
     // (e.g. "No resources to destroy.") returns — see
     // `apply::load_state_persist_if_migrated`.
     let mut state_file =
@@ -170,7 +170,7 @@ async fn run_destroy_locked(
             &|provider, resource_type| {
                 sf.resources_by_type(provider, resource_type)
                     .into_iter()
-                    .map(|r| r.name.clone())
+                    .map(|r| r.identity.clone())
                     .collect()
             },
             &state_block_claims,

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -610,7 +610,7 @@ pub async fn run_plan(
             &|provider, resource_type| {
                 sf.resources_by_type(provider, resource_type)
                     .into_iter()
-                    .map(|r| r.name.clone())
+                    .map(|r| r.identity.clone())
                     .collect()
             },
             &state_block_claims,
@@ -620,7 +620,7 @@ pub async fn run_plan(
             &|provider, resource_type| {
                 sf.resources_by_type(provider, resource_type)
                     .into_iter()
-                    .map(|r| r.name.clone())
+                    .map(|r| r.identity.clone())
                     .collect()
             },
             &state_block_claims,

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -105,7 +105,7 @@ impl PostApplyStates {
             let id = ResourceId::with_provider_name_compat(
                 &rs.provider,
                 &rs.resource_type,
-                &rs.name,
+                &rs.identity,
                 rs.directives.provider_instance.clone(),
             );
             let attrs: HashMap<String, carina_core::resource::Value> = rs
@@ -919,7 +919,7 @@ mod apply_state_save_tests {
                 .iter()
                 .any(|row| row.provider == child_id.provider
                     && row.resource_type == child_id.resource_type
-                    && row.name == "validation_records[0]"),
+                    && row.identity == "validation_records[0]"),
             "runtime-synthesized child must be persisted in state"
         );
     }

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -88,11 +88,11 @@ fn complete_state_lookup(current: &OsStr) -> Vec<CompletionCandidate> {
 ///
 /// Three candidate spaces are produced (carina#3338):
 ///
-/// - **Resource bindings / names**: surface every binding the state
+/// - **Resource bindings / identities**: surface every binding the state
 ///   carries — module-prefixed (`r.distribution`) shows up as one
 ///   candidate, just like `state list` already prints it. No splitting
-///   on `.`; matched by `starts_with(current)`. (Top-level names with
-///   no binding fall back to `rs.name`.)
+///   on `.`; matched by `starts_with(current)`. (Top-level identities
+///   with no binding fall back to `rs.identity`.)
 /// - **`exports.<key>`** when the partial starts with `exports.` and
 ///   no resource binding `exports` shadows it.
 /// - **`exports`** as a top-level candidate when the state has any
@@ -132,10 +132,10 @@ fn complete_state_lookup_from(state: &StateFile, current: &str) -> Vec<Completio
             .collect();
     }
 
-    // Top-level: resource bindings/names + optional `exports`.
+    // Top-level: resource bindings/identities + optional `exports`.
     let mut candidates: Vec<CompletionCandidate> = Vec::new();
     for rs in &state.resources {
-        let display_name = rs.binding.as_deref().unwrap_or(&rs.name);
+        let display_name = rs.binding.as_deref().unwrap_or(&rs.identity);
         if display_name.starts_with(current) {
             candidates.push(CompletionCandidate::new(display_name));
         }
@@ -361,7 +361,7 @@ async fn load_state_file(
 }
 
 /// Find a resource by binding name first, then fall back to resource
-/// name. Retained for test coverage of the precedence rule; production
+/// identity. Retained for test coverage of the precedence rule; production
 /// lookup uses [`resolve_resource_address`] which generalizes this with
 /// longest-prefix matching for module-prefixed bindings (carina#3338).
 #[cfg(test)]
@@ -372,8 +372,8 @@ fn find_resource_by_query<'a>(state: &'a StateFile, name: &str) -> Option<&'a Re
         .iter()
         .find(|r| r.binding.as_deref() == Some(name))
         .or_else(|| {
-            // Fall back to name
-            state.resources.iter().find(|r| r.name == name)
+            // Fall back to identity
+            state.resources.iter().find(|r| r.identity == name)
         })
 }
 
@@ -383,7 +383,7 @@ fn format_state_list(state: &StateFile) -> Vec<String> {
         .resources
         .iter()
         .map(|rs| {
-            let display_name = rs.binding.as_deref().unwrap_or(&rs.name);
+            let display_name = rs.binding.as_deref().unwrap_or(&rs.identity);
             format!("{}.{} {}", rs.provider, rs.resource_type, display_name)
         })
         .collect()
@@ -517,13 +517,13 @@ fn resolve_resource_address<'a>(
 }
 
 /// Candidate addresses for a resource, paired with `is_binding` so the
-/// longest-prefix tie-break can prefer bindings over names.
+/// longest-prefix tie-break can prefer bindings over identities.
 fn candidate_addresses(rs: &ResourceState) -> impl Iterator<Item = (&str, bool)> {
     rs.binding
         .as_deref()
         .map(|b| (b, true))
         .into_iter()
-        .chain(std::iter::once((rs.name.as_str(), false)))
+        .chain(std::iter::once((rs.identity.as_str(), false)))
 }
 
 /// `true` if `query` is exactly `address` or starts with `address` + '.'.
@@ -550,7 +550,7 @@ fn format_resource_value(
 ) -> Result<String, AppError> {
     match attribute {
         Some(attr) => {
-            let display_name = rs.binding.as_deref().unwrap_or(&rs.name);
+            let display_name = rs.binding.as_deref().unwrap_or(&rs.identity);
             let value = rs.attributes.get(attr).ok_or_else(|| {
                 AppError::Config(format!(
                     "Attribute '{}' not found on resource '{}'.",
@@ -595,7 +595,7 @@ fn build_plan_from_state(state: &StateFile) -> Plan {
         let mut resource = carina_core::resource::DataSource::with_provider(
             &rs.provider,
             &rs.resource_type,
-            &rs.name,
+            &rs.identity,
             rs.directives.provider_instance.clone(),
         );
         resource.directives = rs.directives.clone();
@@ -618,14 +618,14 @@ fn build_plan_from_state(state: &StateFile) -> Plan {
 
 /// Format state show output (non-TUI mode).
 ///
-/// Shows all resources with their type, name/binding, and full attributes.
+/// Shows all resources with their type, identity/binding, and full attributes.
 fn format_state_show(state: &StateFile) -> String {
     let mut output = String::new();
     for (i, rs) in state.resources.iter().enumerate() {
         if i > 0 {
             output.push('\n');
         }
-        let display_name = rs.binding.as_deref().unwrap_or(&rs.name);
+        let display_name = rs.binding.as_deref().unwrap_or(&rs.identity);
         output.push_str(&format!(
             "# {}.{} ({})\n",
             rs.provider, rs.resource_type, display_name
@@ -899,8 +899,8 @@ pub(crate) async fn run_state_refresh_locked(
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let ctx = WiringContext::new(factories);
 
-    // Read current state from backend. carina#3315: persist any v6→v7
-    // schema migration under the refresh lock before the "no
+    // Read current state from backend. carina#3315: persist any older-schema
+    // migration under the refresh lock before the "no
     // resources" short-circuit returns — see
     // `apply::load_state_persist_if_migrated`. The on-disk version
     // must advance so the carina#3283 warning text matches reality.
@@ -1045,7 +1045,7 @@ pub(crate) async fn run_state_refresh_locked(
                     let id = ResourceId::with_provider_name_compat(
                         &rs.provider,
                         &rs.resource_type,
-                        &rs.name,
+                        &rs.identity,
                         rs.directives.provider_instance.clone(),
                     );
                     if desired_ids.contains(&id) {
@@ -1446,7 +1446,7 @@ mod tests {
     fn find_resource_by_binding() {
         let state = load_fixture_state();
         let found = find_resource_by_query(&state, "vpc").unwrap();
-        assert_eq!(found.name, "my-vpc");
+        assert_eq!(found.identity, "my-vpc");
         assert_eq!(found.resource_type, "ec2.Vpc");
     }
 

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -117,7 +117,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
             &|provider, resource_type| {
                 sf.resources_by_type(provider, resource_type)
                     .into_iter()
-                    .map(|r| r.name.clone())
+                    .map(|r| r.identity.clone())
                     .collect()
             },
             &state_block_claims,

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -526,7 +526,7 @@ pub fn apply_anonymous_to_named_renames(
                         })
                         .collect();
                     AnonymousIdStateInfo {
-                        name: sr.name.clone(),
+                        name: sr.identity.clone(),
                         create_only_values,
                     }
                 })
@@ -567,7 +567,7 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
             Some((
                 binding.clone(),
                 AnonymousIdBindingStateInfo {
-                    name: sr.name.clone(),
+                    name: sr.identity.clone(),
                     attribute_values: sr
                         .attributes
                         .iter()
@@ -612,7 +612,7 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
                         })
                         .collect();
                     AnonymousIdStateInfo {
-                        name: sr.name.clone(),
+                        name: sr.identity.clone(),
                         create_only_values,
                     }
                 })
@@ -629,9 +629,9 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
 /// pairs (anonymous → anonymous due to identifier-format upgrade).
 ///
 /// For each `(old_name, new_name)` pair, find the matching `ResourceState`
-/// in `state_file.resources` and overwrite its `name` field. Downstream maps
+/// in `state_file.resources` and overwrite its `identity` field. Downstream maps
 /// (`build_saved_attrs`, `build_explicit`, `build_directives`) then key
-/// off the new name, so the differ sees the resource under its updated
+/// off the new identity, so the differ sees the resource under its updated
 /// identifier instead of an orphan-delete + create pair.
 pub fn apply_provider_prefix_renames(renames: &[(String, String)], state_file: &mut StateFile) {
     if renames.is_empty() {
@@ -642,8 +642,8 @@ pub fn apply_provider_prefix_renames(renames: &[(String, String)], state_file: &
         .map(|(old, new)| (old.as_str(), new.as_str()))
         .collect();
     for sr in &mut state_file.resources {
-        if let Some(new_name) = by_old.get(sr.name.as_str()) {
-            sr.name = new_name.to_string();
+        if let Some(new_name) = by_old.get(sr.identity.as_str()) {
+            sr.identity = new_name.to_string();
         }
     }
 }
@@ -2304,7 +2304,7 @@ fn materialize_moved_states_with_warning_sink(
                         ResourceId::with_provider_identity(
                             &rs.provider,
                             &rs.resource_type,
-                            &rs.name,
+                            &rs.identity,
                             rs.directives.provider_instance.clone(),
                         )
                     })
@@ -2417,7 +2417,7 @@ pub fn resolve_state_blocks(
                         ResourceId::with_provider_identity(
                             &rs.provider,
                             &rs.resource_type,
-                            &rs.name,
+                            &rs.identity,
                             rs.directives.provider_instance.clone(),
                         )
                     })
@@ -2680,7 +2680,7 @@ pub fn add_state_block_effects(
                             ResourceId::with_provider_identity(
                                 &rs.provider,
                                 &rs.resource_type,
-                                &rs.name,
+                                &rs.identity,
                                 rs.directives.provider_instance.clone(),
                             )
                         })

--- a/carina-cli/tests/apply_persists_state_migration.rs
+++ b/carina-cli/tests/apply_persists_state_migration.rs
@@ -1,6 +1,6 @@
 //! Regression test for carina#3315.
 //!
-//! After carina#3283 improved the v6→v7 migration warning to promise
+//! After carina#3283 improved the v6→current migration warning to promise
 //! the operator that the upgrade "will be rewritten on the next
 //! `carina apply` or `carina state refresh`", an apply with no
 //! resource diff still left the on-disk state at v6: the no-op path
@@ -66,7 +66,7 @@ fn read_state_version_and_serial(path: &std::path::Path) -> (u32, u64) {
 }
 
 #[test]
-fn apply_persists_v6_to_v7_with_no_resource_diff() {
+fn apply_persists_v6_to_current_with_no_resource_diff() {
     let dir = TempDir::new().unwrap();
     write_v6_state(dir.path());
 
@@ -122,8 +122,8 @@ fn apply_persists_v6_to_v7_with_no_resource_diff() {
 }
 
 #[test]
-fn apply_persists_v6_to_v7_under_no_lock_flag() {
-    // Same scenario as `apply_persists_v6_to_v7_with_no_resource_diff`
+fn apply_persists_v6_to_current_under_no_lock_flag() {
+    // Same scenario as `apply_persists_v6_to_current_with_no_resource_diff`
     // but with `--lock=false`. The dispatch in
     // `load_state_persist_if_migrated` must pick the unlocked writer
     // (`save_state_unlocked`) when no `LockInfo` is held, and the
@@ -158,7 +158,7 @@ fn apply_persists_v6_to_v7_under_no_lock_flag() {
 }
 
 #[test]
-fn destroy_persists_v6_to_v7_when_state_has_no_resources() {
+fn destroy_persists_v6_to_current_when_state_has_no_resources() {
     // Sibling path of `apply`: `destroy` also takes the apply lock
     // and short-circuits ("No resources to destroy.") when the
     // state has no managed resources. The migration must still be
@@ -194,7 +194,7 @@ fn destroy_persists_v6_to_v7_when_state_has_no_resources() {
 }
 
 #[test]
-fn state_refresh_persists_v6_to_v7_when_state_has_no_resources() {
+fn state_refresh_persists_v6_to_current_when_state_has_no_resources() {
     // `state refresh` returns early when the state has no resources
     // ("No resources in state. Nothing to refresh."). The migration
     // persistence must still happen on that path — otherwise a v6

--- a/carina-cli/tests/fixtures/plan_display/deferred_for_with_dependent_wait/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/deferred_for_with_dependent_wait/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "route53.RecordSet",
-      "name": "validation_records[0]",
+      "identity": "validation_records[0]",
       "provider": "aws",
       "identifier": "Z123:_acme.registry.example.com:CNAME",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/deferred_for_with_paired_destroy/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/deferred_for_with_paired_destroy/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "route53.RecordSet",
-      "name": "validation_records[0]",
+      "identity": "validation_records[0]",
       "provider": "aws",
       "identifier": "Z123:_acme.registry.example.com:CNAME",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/deferred_for_with_unrelated_delete/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/deferred_for_with_unrelated_delete/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "route53.RecordSet",
-      "name": "extra_record",
+      "identity": "extra_record",
       "provider": "aws",
       "identifier": "Z123:_extra.registry.example.com:CNAME",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/delete_orphan/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/delete_orphan/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "ec2_vpc_fb75c929",
+      "identity": "ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -44,7 +44,7 @@
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "my_subnet",
+      "identity": "my_subnet",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/delete_orphan_list_of_maps/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/delete_orphan_list_of_maps/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "acm.Certificate",
-      "name": "orphan_cert",
+      "identity": "orphan_cert",
       "provider": "aws",
       "identifier": "arn:aws:acm:us-east-1:151116838382:certificate/3fc2dbff-d965-4533-aeac-9e9d85ac527a",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/destroy_full/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/destroy_full/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "ec2_vpc_fb75c929",
+      "identity": "ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -44,7 +44,7 @@
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "ec2_subnet_f5269366",
+      "identity": "ec2_subnet_f5269366",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/destroy_list_struct_child_gutter/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/destroy_list_struct_child_gutter/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.Role",
-      "name": "role",
+      "identity": "role",
       "provider": "awscc",
       "identifier": "test-role",
       "attributes": {
@@ -33,7 +33,7 @@
     },
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "test-role|test-inline",
       "attributes": {
@@ -79,7 +79,7 @@
     },
     {
       "resource_type": "s3.Bucket",
-      "name": "zzz_bucket",
+      "identity": "zzz_bucket",
       "provider": "awscc",
       "identifier": "zzz-trailing-sibling",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/destroy_orphans/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/destroy_orphans/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "ec2_vpc_fb75c929",
+      "identity": "ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -44,7 +44,7 @@
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "ec2_subnet_f5269366",
+      "identity": "ec2_subnet_f5269366",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/dynamic_enum_az_no_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/dynamic_enum_az_no_diff/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "network.Subnet",
-      "name": "subnet",
+      "identity": "subnet",
       "provider": "fixture",
       "identifier": "subnet-fixture",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/empty_explicit_children_no_changes/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/empty_explicit_children_no_changes/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/explicit/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/explicit/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -44,7 +44,7 @@
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "my_subnet",
+      "identity": "my_subnet",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/list_diff_added_struct/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_added_struct/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "test-role|test-inline",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/list_diff_added_struct_child_gutter/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_added_struct_child_gutter/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "test-role|test-inline",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "test-role|test-inline",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged_nested/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged_nested/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "test-role|test-inline",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/list_diff_paired_all_unchanged_dropped/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_paired_all_unchanged_dropped/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "test-role|test-inline",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/list_diff_removed_struct/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_removed_struct/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "test-role|test-inline",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/list_diff_string_list_grew/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_string_list_grew/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "test-role|test-inline",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/map_added_from_none/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_added_from_none/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/map_attribute_removed/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_attribute_removed/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/map_field_string_list_grew/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_field_string_list_grew/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "iam.RolePolicy",
-      "name": "policy",
+      "identity": "policy",
       "provider": "awscc",
       "identifier": "delegation-writer|trust-policy",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/map_key_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_key_diff/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "ec2_vpc_fb75c929",
+      "identity": "ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/mixed_operations/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/mixed_operations/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -44,7 +44,7 @@
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "my_subnet",
+      "identity": "my_subnet",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/moved_claims_precede_heuristics/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_claims_precede_heuristics/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "test.Widget",
-      "name": "test_widget_11111111",
+      "identity": "test_widget_11111111",
       "provider": "awscc",
       "identifier": "widget-live-1",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/moved_prev_keys/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_prev_keys/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "old_vpc",
+      "identity": "old_vpc",
       "provider": "awscc",
       "identifier": "vpc-old123",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/moved_pure/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_pure/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "old_vpc",
+      "identity": "old_vpc",
       "provider": "awscc",
       "identifier": "vpc-old123",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/moved_with_changes/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_with_changes/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "old_vpc",
+      "identity": "old_vpc",
       "provider": "awscc",
       "identifier": "vpc-old123",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/nested_list_of_maps_all_dropped/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/nested_list_of_maps_all_dropped/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/nested_map_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/nested_map_diff/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/no_changes/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/no_changes/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -44,7 +44,7 @@
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "ec2_subnet_aac7c86b",
+      "identity": "ec2_subnet_aac7c86b",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/no_changes_enum/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/no_changes_enum/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "vpc",
+      "identity": "vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -40,7 +40,7 @@
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "ec2_subnet_f5269366",
+      "identity": "ec2_subnet_f5269366",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/provider_prefix/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/provider_prefix/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "awscc_ec2_vpc_fb75c929",
+      "identity": "awscc_ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/replace_create_only/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/replace_create_only/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "test.Widget",
-      "name": "alpha",
+      "identity": "alpha",
       "provider": "test",
       "identifier": "widget-alpha-live",
       "attributes": {
@@ -32,7 +32,7 @@
     },
     {
       "resource_type": "test.Widget",
-      "name": "beta",
+      "identity": "beta",
       "provider": "test",
       "identifier": "widget-beta-live",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/replace_with_non_forcing_diffs/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/replace_with_non_forcing_diffs/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "test.Widget",
-      "name": "web_acl",
+      "identity": "web_acl",
       "provider": "test",
       "identifier": "widget-web-acl-live",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/route53_hosted_zone_name_strip_suffix_no_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/route53_hosted_zone_name_strip_suffix_no_diff/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "route53.HostedZone",
-      "name": "zone",
+      "identity": "zone",
       "provider": "fixture",
       "identifier": "hosted-zone-fixture",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/secret_values/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/secret_values/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "ec2_vpc_fb75c929",
+      "identity": "ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -37,7 +37,7 @@
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "orphan_subnet",
+      "identity": "orphan_subnet",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "",
+      "identity": "",
       "provider": "awscc",
       "identifier": "vpc-0000000000000abcd",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/state_blocks/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/state_blocks/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Subnet",
-      "name": "legacy-subnet",
+      "identity": "legacy-subnet",
       "provider": "awscc",
       "identifier": "subnet-0abc123",
       "attributes": {
@@ -29,7 +29,7 @@
     },
     {
       "resource_type": "ec2.SecurityGroup",
-      "name": "old-sg",
+      "identity": "old-sg",
       "provider": "awscc",
       "identifier": "sg-0abc123",
       "attributes": {

--- a/carina-cli/tests/fixtures/plan_display/upstream_state/network/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state/network/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "main-vpc",
+      "identity": "main-vpc",
       "provider": "awscc",
       "identifier": "vpc-abc123",
       "attributes": {
@@ -17,7 +17,9 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block"],
+      "desired_keys": [
+        "cidr_block"
+      ],
       "binding": "vpc",
       "dependency_bindings": []
     }

--- a/carina-cli/tests/fixtures/state/carina.state.json
+++ b/carina-cli/tests/fixtures/state/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "my-vpc",
+      "identity": "my-vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -18,13 +18,16 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support"],
+      "desired_keys": [
+        "cidr_block",
+        "enable_dns_support"
+      ],
       "binding": "vpc",
       "dependency_bindings": []
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "my-subnet",
+      "identity": "my-subnet",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {
@@ -32,19 +35,28 @@
         "cidr_block": "10.0.1.0/24",
         "availability_zone": "ap-northeast-1a",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
+      "desired_keys": [
+        "vpc_id",
+        "cidr_block",
+        "availability_zone",
+        "tags"
+      ],
       "binding": "subnet",
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": [
+        "vpc"
+      ]
     },
     {
       "resource_type": "ec2.RouteTable",
-      "name": "main-rt",
+      "identity": "main-rt",
       "provider": "awscc",
       "identifier": "rtb-0123456789abcdef0",
       "attributes": {
@@ -55,9 +67,13 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id"],
+      "desired_keys": [
+        "vpc_id"
+      ],
       "binding": null,
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": [
+        "vpc"
+      ]
     }
   ]
 }

--- a/carina-cli/tests/fixtures/state_lookup/carina.state.json
+++ b/carina-cli/tests/fixtures/state_lookup/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.Vpc",
-      "name": "my-vpc",
+      "identity": "my-vpc",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -18,13 +18,16 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support"],
+      "desired_keys": [
+        "cidr_block",
+        "enable_dns_support"
+      ],
       "binding": "vpc",
       "dependency_bindings": []
     },
     {
       "resource_type": "ec2.Subnet",
-      "name": "my-subnet",
+      "identity": "my-subnet",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {
@@ -32,19 +35,28 @@
         "cidr_block": "10.0.1.0/24",
         "availability_zone": "ap-northeast-1a",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
+      "desired_keys": [
+        "vpc_id",
+        "cidr_block",
+        "availability_zone",
+        "tags"
+      ],
       "binding": "subnet",
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": [
+        "vpc"
+      ]
     },
     {
       "resource_type": "ec2.RouteTable",
-      "name": "main-rt",
+      "identity": "main-rt",
       "provider": "awscc",
       "identifier": "rtb-0123456789abcdef0",
       "attributes": {
@@ -55,9 +67,13 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id"],
+      "desired_keys": [
+        "vpc_id"
+      ],
       "binding": null,
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": [
+        "vpc"
+      ]
     }
   ]
 }

--- a/carina-cli/tests/fixtures/state_lookup_modules_exports/carina.state.json
+++ b/carina-cli/tests/fixtures/state_lookup_modules_exports/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "cloudfront.Distribution",
-      "name": "r-distribution",
+      "identity": "r-distribution",
       "provider": "awscc",
       "identifier": "E2E954VKWYKT8K",
       "attributes": {
@@ -22,7 +22,7 @@
     },
     {
       "resource_type": "route53.HostedZone",
-      "name": "r-zone",
+      "identity": "r-zone",
       "provider": "awscc",
       "identifier": "Z008131930MO3U3NYWJTM",
       "attributes": {
@@ -38,7 +38,7 @@
     },
     {
       "resource_type": "s3.Bucket",
-      "name": "registry-bucket",
+      "identity": "registry-bucket",
       "provider": "awscc",
       "identifier": "registry-content-dev",
       "attributes": {
@@ -55,6 +55,9 @@
   "exports": {
     "cloudfront_distribution_id": "E2E954VKWYKT8K",
     "zone_id": "Z008131930MO3U3NYWJTM",
-    "nameservers": ["ns-1234.awsdns-12.com", "ns-5678.awsdns-56.net"]
+    "nameservers": [
+      "ns-1234.awsdns-12.com",
+      "ns-5678.awsdns-56.net"
+    ]
   }
 }

--- a/carina-cli/tests/plan_state_migration_warning_once.rs
+++ b/carina-cli/tests/plan_state_migration_warning_once.rs
@@ -29,7 +29,7 @@ fn plain_text_command(bin: &str) -> Command {
 }
 
 /// Write a minimal local-backend project plus a hand-authored v6
-/// state file so the very next `carina plan` triggers a v6 → v7
+/// state file so the very next `carina plan` triggers a v6 → current
 /// in-memory migration.
 fn init_project_with_v6_state(dir: &std::path::Path) {
     fs::write(

--- a/carina-cli/tests/state_url_e2e.rs
+++ b/carina-cli/tests/state_url_e2e.rs
@@ -20,19 +20,19 @@ fn carina(args: &[&str]) -> std::process::Output {
         .expect("failed to execute carina")
 }
 
-/// Write a minimal v7 state file with a single ec2.Vpc resource bound
+/// Write a minimal v8 state file with a single ec2.Vpc resource bound
 /// to `vpc` and return its path.
 fn write_minimal_state(dir: &std::path::Path) -> std::path::PathBuf {
     let path = dir.join("carina.state.json");
     let state = json!({
-        "version": 7,
+        "version": 8,
         "serial": 1,
         "lineage": "test-state-url-e2e",
         "carina_version": "0.1.0",
         "resources": [
             {
                 "resource_type": "ec2.Vpc",
-                "name": "my-vpc",
+                "identity": "my-vpc",
                 "binding": "vpc",
                 "provider": "awscc",
                 "identifier": "vpc-deadbeef",

--- a/carina-cli/tests/state_value_round_trip.rs
+++ b/carina-cli/tests/state_value_round_trip.rs
@@ -75,7 +75,7 @@ fn fixture_attributes_round_trip_through_value_codec() {
         for resource in &state.resources {
             let resource_id = format!(
                 "{}.{}.{}",
-                resource.provider, resource.resource_type, resource.name,
+                resource.provider, resource.resource_type, resource.identity,
             );
             for (attr_name, json_value) in &resource.attributes {
                 total_attrs += 1;

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -43,7 +43,10 @@ impl StateFile {
     ///     state lift each top-level key to a `Leaf` child of the
     ///     root `Struct`; the next plan/apply rebuilds a full tree
     ///     from the resource's authored `Value`.
-    pub const CURRENT_VERSION: u32 = 7;
+    /// v7: Replaced top-level empty `ExplicitFields::Struct` with
+    ///     `ExplicitFields::Unrecorded`.
+    /// v8: Renamed `ResourceState.name` to `ResourceState.identity`.
+    pub const CURRENT_VERSION: u32 = 8;
 
     /// Create a new empty state file
     pub fn new() -> Self {
@@ -62,7 +65,7 @@ impl StateFile {
     /// the state backend writes after auto-creating its own storage —
     /// see [`ResourceState::managed_state_bucket`] for the shape.
     ///
-    /// `resource_name` must equal the desired resource's resolved name
+    /// `resource_identity` must equal the desired resource's resolved identity
     /// (e.g. `aws_s3_bucket_<hash>` for the auto-injected anonymous block);
     /// `bucket_name` is the AWS bucket identifier the provider acts on.
     /// Conflating the two reproduces #2533.
@@ -82,19 +85,19 @@ impl StateFile {
     ///     "my-state-bucket",
     /// );
     /// assert_eq!(state.resources.len(), 1);
-    /// assert_eq!(state.resources[0].name, "aws_s3_bucket_a3f2b1c8");
+    /// assert_eq!(state.resources[0].identity, "aws_s3_bucket_a3f2b1c8");
     /// ```
     pub fn with_managed_state_bucket(
         provider: impl Into<String>,
         resource_type: impl Into<String>,
-        resource_name: impl Into<String>,
+        resource_identity: impl Into<String>,
         bucket_name: impl Into<String>,
     ) -> Self {
         let mut state = Self::new();
         state.upsert_resource(ResourceState::managed_state_bucket(
             provider,
             resource_type,
-            resource_name,
+            resource_identity,
             bucket_name,
         ));
         state
@@ -118,16 +121,16 @@ impl StateFile {
         self.carina_version = env!("CARGO_PKG_VERSION").to_string();
     }
 
-    /// Find a resource by provider, type, and name
+    /// Find a resource by provider, type, and identity
     pub fn find_resource(
         &self,
         provider: &str,
         resource_type: &str,
-        name: &str,
+        identity: &str,
     ) -> Option<&ResourceState> {
-        self.resources
-            .iter()
-            .find(|r| r.provider == provider && r.resource_type == resource_type && r.name == name)
+        self.resources.iter().find(|r| {
+            r.provider == provider && r.resource_type == resource_type && r.identity == identity
+        })
     }
 
     /// Find all resources matching a provider and resource type
@@ -138,23 +141,25 @@ impl StateFile {
             .collect()
     }
 
-    /// Find a resource mutably by provider, type, and name
+    /// Find a resource mutably by provider, type, and identity
     pub fn find_resource_mut(
         &mut self,
         provider: &str,
         resource_type: &str,
-        name: &str,
+        identity: &str,
     ) -> Option<&mut ResourceState> {
-        self.resources
-            .iter_mut()
-            .find(|r| r.provider == provider && r.resource_type == resource_type && r.name == name)
+        self.resources.iter_mut().find(|r| {
+            r.provider == provider && r.resource_type == resource_type && r.identity == identity
+        })
     }
 
     /// Add or update a resource in the state
     pub fn upsert_resource(&mut self, resource: ResourceState) {
-        if let Some(existing) =
-            self.find_resource_mut(&resource.provider, &resource.resource_type, &resource.name)
-        {
+        if let Some(existing) = self.find_resource_mut(
+            &resource.provider,
+            &resource.resource_type,
+            &resource.identity,
+        ) {
             *existing = resource;
         } else {
             self.resources.push(resource);
@@ -187,7 +192,7 @@ impl StateFile {
         ResourceId::with_provider_name_compat(
             &rs.provider,
             &rs.resource_type,
-            &rs.name,
+            &rs.identity,
             rs.directives.provider_instance.clone(),
         )
     }
@@ -368,7 +373,7 @@ impl StateFile {
     pub fn canonicalize_addresses(&mut self) {
         use carina_core::utils::canonicalize_map_key_address;
         for r in &mut self.resources {
-            r.name = canonicalize_map_key_address(&r.name);
+            r.identity = canonicalize_map_key_address(&r.identity);
             if let Some(b) = r.binding.as_ref() {
                 r.binding = Some(canonicalize_map_key_address(b));
             }
@@ -385,10 +390,10 @@ impl StateFile {
         &mut self,
         provider: &str,
         resource_type: &str,
-        name: &str,
+        identity: &str,
     ) -> Option<ResourceState> {
         if let Some(pos) = self.resources.iter().position(|r| {
-            r.provider == provider && r.resource_type == resource_type && r.name == name
+            r.provider == provider && r.resource_type == resource_type && r.identity == identity
         }) {
             Some(self.resources.remove(pos))
         } else {
@@ -589,7 +594,7 @@ pub fn check_and_migrate(content: &str) -> Result<MigratedStateFile, BackendErro
             // authored an empty struct at the top level" (which the
             // current code never legitimately emits — `build_from_resource`
             // produces this shape only when `resource.attributes` is
-            // empty, and the v7 writeback path emits `Unrecorded`
+            // empty, and the v8 writeback path emits `Unrecorded`
             // instead). Rewriting every top-level empty Struct to
             // `Unrecorded` on read makes the variant the single
             // source of truth and lets every `match` arm be exhaustive
@@ -644,8 +649,9 @@ pub fn check_and_migrate_bytes(bytes: &[u8]) -> Result<MigratedStateFile, Backen
 pub struct ResourceState {
     /// Resource type (e.g., "s3.Bucket", "ec2.Vpc")
     pub resource_type: String,
-    /// Resource name (from the `name` attribute in DSL)
-    pub name: String,
+    /// Resource identity (from the DSL resource address identity)
+    #[serde(alias = "name")]
+    pub identity: String,
     /// Provider name (e.g., "aws")
     pub provider: String,
     /// AWS internal identifier (e.g., vpc-xxx, subnet-xxx)
@@ -707,12 +713,12 @@ impl ResourceState {
     /// Create a new resource state
     pub fn new(
         resource_type: impl Into<String>,
-        name: impl Into<String>,
+        identity: impl Into<String>,
         provider: impl Into<String>,
     ) -> Self {
         Self {
             resource_type: resource_type.into(),
-            name: name.into(),
+            identity: identity.into(),
             provider: provider.into(),
             identifier: None,
             attributes: HashMap::new(),
@@ -769,8 +775,8 @@ impl ResourceState {
     /// returns "not found" and the next apply re-issues `CreateBucket`,
     /// reproducing #2533 (`BucketAlreadyOwnedByYou`).
     ///
-    /// `resource_name` is the state-side resource name and must equal the
-    /// resolved name of the desired resource (anonymous resources get a
+    /// `resource_identity` is the state-side resource identity and must equal the
+    /// resolved identity of the desired resource (anonymous resources get a
     /// hash-derived id like `aws_s3_bucket_<hash>`); `bucket_name` is the
     /// AWS bucket name used as the provider identifier and as the value
     /// of the `bucket` attribute. Mixing the two breaks the differ — see
@@ -778,11 +784,11 @@ impl ResourceState {
     pub fn managed_state_bucket(
         provider: impl Into<String>,
         resource_type: impl Into<String>,
-        resource_name: impl Into<String>,
+        resource_identity: impl Into<String>,
         bucket_name: impl Into<String>,
     ) -> Self {
         let bucket_name = bucket_name.into();
-        Self::new(resource_type, resource_name, provider)
+        Self::new(resource_type, resource_identity, provider)
             .with_identifier(&bucket_name)
             .with_attribute("bucket", serde_json::json!(bucket_name))
             .with_protected(true)
@@ -978,7 +984,7 @@ fn is_empty_explicit(e: &ExplicitFields) -> bool {
 /// entry into a `Leaf` child of the v6 `explicit: ExplicitFields::Struct`
 /// tree.
 ///
-/// Resources are matched by `(provider, resource_type, name)` because
+/// Resources are matched by `(provider, resource_type, identity)` because
 /// state files use that triple as the canonical identity.
 fn migrate_v5_desired_keys_to_explicit(
     content: &str,
@@ -996,8 +1002,12 @@ fn migrate_v5_desired_keys_to_explicit(
     for raw_rs in raw_resources {
         let provider = raw_rs.get("provider").and_then(|v| v.as_str());
         let resource_type = raw_rs.get("resource_type").and_then(|v| v.as_str());
-        let name = raw_rs.get("name").and_then(|v| v.as_str());
-        let Some(((provider, resource_type), name)) = provider.zip(resource_type).zip(name) else {
+        let identity = raw_rs
+            .get("identity")
+            .or_else(|| raw_rs.get("name"))
+            .and_then(|v| v.as_str());
+        let Some(((provider, resource_type), identity)) = provider.zip(resource_type).zip(identity)
+        else {
             continue;
         };
         let Some(keys) = raw_rs.get("desired_keys").and_then(|v| v.as_array()) else {
@@ -1011,7 +1021,7 @@ fn migrate_v5_desired_keys_to_explicit(
             continue;
         }
         if let Some(rs) = state.resources.iter_mut().find(|rs| {
-            rs.provider == provider && rs.resource_type == resource_type && rs.name == name
+            rs.provider == provider && rs.resource_type == resource_type && rs.identity == identity
         }) {
             rs.explicit = ExplicitFields::Struct { children };
         }
@@ -1026,7 +1036,7 @@ fn migrate_v5_desired_keys_to_explicit(
 /// path that lost child attributes before reaching writeback), never a
 /// legitimate "user authored an empty struct at top level" — the
 /// current `build_from_resource` produces this shape only when
-/// `resource.attributes` is empty, and the v7 writeback path emits
+/// `resource.attributes` is empty, and the v8 writeback path emits
 /// `Unrecorded` for that case instead. Migrating eliminates the
 /// runtime ambiguity that callers used to disambiguate by convention.
 fn migrate_v6_empty_struct_to_unrecorded(state: &mut StateFile) {

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -68,10 +68,10 @@ fn test_resource_state_protected() {
 #[test]
 fn test_resource_state_managed_state_bucket_shape() {
     // The seed must use the desired resource's resolved anonymous identifier
-    // as `name` (so the differ matches the seed against the desired resource)
+    // as `identity` (so the differ matches the seed against the desired resource)
     // AND set the AWS bucket name as `identifier`. Conflating the two
-    // reproduces #2533: phantom Delete on the seed's name plus phantom
-    // Create on the desired's name.
+    // reproduces #2533: phantom Delete on the seed's identity plus phantom
+    // Create on the desired's identity.
     let resource = ResourceState::managed_state_bucket(
         "aws",
         "s3.Bucket",
@@ -81,8 +81,8 @@ fn test_resource_state_managed_state_bucket_shape() {
     assert_eq!(resource.provider, "aws");
     assert_eq!(resource.resource_type, "s3.Bucket");
     assert_eq!(
-        resource.name, "aws_s3_bucket_a3f2b1c8",
-        "name must match the desired resource's anonymous identifier"
+        resource.identity, "aws_s3_bucket_a3f2b1c8",
+        "identity must match the desired resource's anonymous identifier"
     );
     assert_eq!(
         resource.identifier.as_deref(),
@@ -106,7 +106,7 @@ fn test_state_file_with_managed_state_bucket_contains_one_resource() {
     );
     assert_eq!(state.resources.len(), 1);
     let bucket = &state.resources[0];
-    assert_eq!(bucket.name, "aws_s3_bucket_a3f2b1c8");
+    assert_eq!(bucket.identity, "aws_s3_bucket_a3f2b1c8");
     assert_eq!(bucket.identifier.as_deref(), Some("my-state-bucket"));
     assert!(bucket.protected);
 }
@@ -224,6 +224,7 @@ fn test_resource_state_serialization_with_binding_and_deps() {
     }"#;
 
     let deserialized: ResourceState = serde_json::from_str(json).unwrap();
+    assert_eq!(deserialized.identity, "my-bucket");
     assert_eq!(deserialized.binding, Some("my_bucket".to_string()));
     assert_eq!(
         deserialized.dependency_bindings,
@@ -247,6 +248,7 @@ fn test_resource_state_deserialization_without_v3_fields() {
     }"#;
 
     let deserialized: ResourceState = serde_json::from_str(json).unwrap();
+    assert_eq!(deserialized.identity, "my-bucket");
     assert_eq!(deserialized.binding, None);
     assert!(deserialized.dependency_bindings.is_empty());
     assert!(deserialized.write_only_attributes.is_empty());
@@ -524,7 +526,7 @@ fn test_migrate_v6_empty_struct_to_unrecorded() {
     let rs = state
         .resources
         .iter()
-        .find(|r| r.name == "x")
+        .find(|r| r.identity == "x")
         .expect("test resource");
     assert!(
         matches!(rs.explicit, ExplicitFields::Unrecorded),
@@ -567,7 +569,11 @@ fn test_migrate_v6_preserves_populated_explicit() {
     let state = check_and_migrate(v6)
         .expect("migration should succeed")
         .into_state();
-    let rs = state.resources.iter().find(|r| r.name == "vpc").unwrap();
+    let rs = state
+        .resources
+        .iter()
+        .find(|r| r.identity == "vpc")
+        .unwrap();
     let ExplicitFields::Struct { children } = &rs.explicit else {
         panic!(
             "populated v6 Struct must survive migration, got {:?}",
@@ -616,7 +622,11 @@ fn test_migrate_v6_does_not_rewrite_nested_empty_struct() {
     let state = check_and_migrate(v6)
         .expect("migration should succeed")
         .into_state();
-    let rs = state.resources.iter().find(|r| r.name == "vpc").unwrap();
+    let rs = state
+        .resources
+        .iter()
+        .find(|r| r.identity == "vpc")
+        .unwrap();
     let ExplicitFields::Struct { children } = &rs.explicit else {
         panic!("expected top-level Struct, got {:?}", rs.explicit);
     };
@@ -882,9 +892,9 @@ fn test_build_orphan_dependencies() {
 }
 
 #[test]
-fn test_state_file_version_is_v7() {
+fn test_state_file_version_is_v8() {
     let state = StateFile::new();
-    assert_eq!(state.version, 7);
+    assert_eq!(state.version, 8);
 }
 
 #[test]
@@ -1083,12 +1093,16 @@ fn check_and_migrate_drops_artifact_rows_with_null_identifier_3266() {
     }"#;
 
     let state = check_and_migrate(json).expect("read").into_state();
-    let kept_names: Vec<&str> = state.resources.iter().map(|r| r.name.as_str()).collect();
+    let kept_identities: Vec<&str> = state
+        .resources
+        .iter()
+        .map(|r| r.identity.as_str())
+        .collect();
     assert_eq!(
-        kept_names,
+        kept_identities,
         vec!["log"],
         "identifier=None artifact rows must be pruned at read time; \
-         only managed resources with identifiers survive. Got: {kept_names:?}",
+         only managed resources with identifiers survive. Got: {kept_identities:?}",
     );
 }
 
@@ -1534,7 +1548,7 @@ fn build_remote_bindings_ignores_resource_bindings() {
     // Add a resource with a binding — should NOT appear in remote bindings
     state.resources.push(ResourceState {
         resource_type: "ec2.Vpc".to_string(),
-        name: "vpc_123".to_string(),
+        identity: "vpc_123".to_string(),
         provider: "awscc".to_string(),
         identifier: Some("vpc-123".to_string()),
         attributes: HashMap::from([(
@@ -1588,7 +1602,7 @@ fn check_and_migrate_canonicalizes_legacy_map_key_addresses() {
     );
     let state = check_and_migrate(&json).expect("load state").into_state();
     let r = &state.resources[0];
-    assert_eq!(r.name, "_accounts.registry_prod");
+    assert_eq!(r.identity, "_accounts.registry_prod");
     assert_eq!(r.binding.as_deref(), Some("_accounts.registry_prod"));
     let deps: Vec<&str> = r.dependency_bindings.iter().map(String::as_str).collect();
     assert!(deps.contains(&"other.a"));

--- a/carina-state/tests/s3_backend_winterbaume.rs
+++ b/carina-state/tests/s3_backend_winterbaume.rs
@@ -195,8 +195,8 @@ async fn write_then_read_state_round_trips() {
     let written_res = &written.resources[0];
     let read_res = &read_back.resources[0];
     assert_eq!(
-        read_res.name, written_res.name,
-        "the round-tripped resource must keep its name",
+        read_res.identity, written_res.identity,
+        "the round-tripped resource must keep its identity",
     );
     assert_eq!(
         read_res.resource_type, written_res.resource_type,


### PR DESCRIPTION
## Summary

- Rename `ResourceState.name` to `ResourceState.identity` across carina-state and all callers
- Bump state format version from 7 to 8
- Add `#[serde(alias = "name")]` for backward-compatible deserialization of existing state files
- Update all fixture JSON files to use `"identity"` key

## Test plan

- [x] 4362 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --doc` clean
- [x] Existing state serde tests exercise the `alias = "name"` path

Closes #3637

🤖 Generated with [Claude Code](https://claude.com/claude-code)