### PR TITLE
refactor: rename WIT resource-id.name to identity

### DIFF
--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -385,7 +385,7 @@ pub fn core_to_wit_resource_id(id: &CoreResourceId) -> wit::ResourceId {
     wit::ResourceId {
         provider: id.provider.clone(),
         resource_type: id.resource_type.clone(),
-        name: id.identity_or_empty().to_string(),
+        identity: id.identity_or_empty().to_string(),
     }
 }
 
@@ -395,7 +395,7 @@ pub fn wit_to_core_resource_id(id: &wit::ResourceId) -> CoreResourceId {
     // Tracked as a follow-up to extend the WIT contract; until then,
     // callers that need routing must thread it through alongside the
     // converted id.
-    CoreResourceId::with_provider_name_compat(&id.provider, &id.resource_type, &id.name, None)
+    CoreResourceId::with_provider_name_compat(&id.provider, &id.resource_type, &id.identity, None)
 }
 
 // -- State --
@@ -1511,7 +1511,7 @@ mod tests {
         let wit = core_to_wit_resource_id(&core);
         assert_eq!(wit.provider, "aws");
         assert_eq!(wit.resource_type, "s3.Bucket");
-        assert_eq!(wit.name, "my-bucket");
+        assert_eq!(wit.identity, "my-bucket");
         let back = wit_to_core_resource_id(&wit);
         assert_eq!(core, back);
     }
@@ -1593,7 +1593,7 @@ mod tests {
         let wit = core_to_wit_resource(&resource).unwrap();
         assert_eq!(wit.id.provider, "aws");
         assert_eq!(wit.id.resource_type, "s3.Bucket");
-        assert_eq!(wit.id.name, "my-bucket");
+        assert_eq!(wit.id.identity, "my-bucket");
 
         let back = wit_to_core_resource(&wit);
         assert_eq!(back.id, resource.id);

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -117,7 +117,7 @@ macro_rules! export_provider {
                 proto::ResourceId {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
-                    name: id.name.clone(),
+                    name: id.identity.clone(),
                 }
             }
 
@@ -135,7 +135,7 @@ macro_rules! export_provider {
                 wit_types::ResourceId {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
-                    name: id.name.clone(),
+                    identity: id.name.clone(),
                 }
             }
 
@@ -719,7 +719,7 @@ macro_rules! export_provider {
                 proto::ResourceId {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
-                    name: id.name.clone(),
+                    name: id.identity.clone(),
                 }
             }
 
@@ -737,7 +737,7 @@ macro_rules! export_provider {
                 wit_types::ResourceId {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
-                    name: id.name.clone(),
+                    identity: id.name.clone(),
                 }
             }
 


### PR DESCRIPTION
## Summary

- Rename `name` field to `identity` in WIT `resource-id` record (carina-plugin-wit#28, merged)
- Update `wasm_convert.rs` conversion functions to use `.identity` field
- Update `carina-plugin-sdk` guest bindings
- Bump `carina-plugin-wit` submodule ref

## Cross-repo impact

Both provider repos need counterpart PRs:
- `carina-provider-aws`: update `id.name` → `id.identity` (100+ sites)
- `carina-provider-awscc`: same scope

## Test plan

- [x] 4362 tests pass (including WASM integration tests)
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2` succeeds
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

Closes #3638

🤖 Generated with [Claude Code](https://claude.com/claude-code)