### PR TITLE
refactor: rename protocol ResourceId.name to identity

### DIFF
--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -21,10 +21,10 @@ pub mod wasi_http;
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 mod wasi_http_body;
 
-/// Parse a ResourceId string (provider.resource_type.name) into a ResourceId.
+/// Parse a ResourceId string (provider.resource_type.identity) into a ResourceId.
 ///
-/// Format: "provider.service.type.name" where provider is the first segment,
-/// name is the last segment, and resource_type is everything in between.
+/// Format: "provider.service.type.identity" where provider is the first segment,
+/// identity is the last segment, and resource_type is everything in between.
 ///
 /// This is also used by the WASM guest SDK via `wasm_guest::parse_resource_id_string`.
 pub fn parse_resource_id_string(key: &str) -> carina_provider_protocol::types::ResourceId {
@@ -33,7 +33,7 @@ pub fn parse_resource_id_string(key: &str) -> carina_provider_protocol::types::R
         return carina_provider_protocol::types::ResourceId {
             provider: String::new(),
             resource_type: String::new(),
-            name: key.to_string(),
+            identity: key.to_string(),
         };
     }
     let provider = parts[0].to_string();
@@ -42,13 +42,13 @@ pub fn parse_resource_id_string(key: &str) -> carina_provider_protocol::types::R
         carina_provider_protocol::types::ResourceId {
             provider,
             resource_type: rest[..dot_pos].to_string(),
-            name: rest[dot_pos + 1..].to_string(),
+            identity: rest[dot_pos + 1..].to_string(),
         }
     } else {
         carina_provider_protocol::types::ResourceId {
             provider,
             resource_type: String::new(),
-            name: rest.to_string(),
+            identity: rest.to_string(),
         }
     }
 }
@@ -443,7 +443,7 @@ mod tests {
         let id = parse_resource_id_string("awscc.iam.role.my-role");
         assert_eq!(id.provider, "awscc");
         assert_eq!(id.resource_type, "iam.role");
-        assert_eq!(id.name, "my-role");
+        assert_eq!(id.identity, "my-role");
     }
 
     #[test]
@@ -451,7 +451,7 @@ mod tests {
         let id = parse_resource_id_string("awscc.ec2.ipam.test-ipam");
         assert_eq!(id.provider, "awscc");
         assert_eq!(id.resource_type, "ec2.ipam");
-        assert_eq!(id.name, "test-ipam");
+        assert_eq!(id.identity, "test-ipam");
     }
 
     #[test]
@@ -459,7 +459,7 @@ mod tests {
         let id = parse_resource_id_string("awscc.s3.Bucket.carina-acc-test-abc123");
         assert_eq!(id.provider, "awscc");
         assert_eq!(id.resource_type, "s3.Bucket");
-        assert_eq!(id.name, "carina-acc-test-abc123");
+        assert_eq!(id.identity, "carina-acc-test-abc123");
     }
 
     #[test]
@@ -467,7 +467,7 @@ mod tests {
         let id = parse_resource_id_string("aws.s3.Bucket.my-bucket");
         assert_eq!(id.provider, "aws");
         assert_eq!(id.resource_type, "s3.Bucket");
-        assert_eq!(id.name, "my-bucket");
+        assert_eq!(id.identity, "my-bucket");
     }
 
     #[test]
@@ -475,7 +475,7 @@ mod tests {
         let id = parse_resource_id_string("simple");
         assert_eq!(id.provider, "");
         assert_eq!(id.resource_type, "");
-        assert_eq!(id.name, "simple");
+        assert_eq!(id.identity, "simple");
     }
 
     #[test]
@@ -483,6 +483,6 @@ mod tests {
         let id = parse_resource_id_string("provider.name");
         assert_eq!(id.provider, "provider");
         assert_eq!(id.resource_type, "");
-        assert_eq!(id.name, "name");
+        assert_eq!(id.identity, "name");
     }
 }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -58,7 +58,7 @@ pub fn proto_value_to_json(v: &proto::Value) -> serde_json::Value {
     }
 }
 
-/// Parse a ResourceId string (provider.resource_type.name) into a proto::ResourceId.
+/// Parse a ResourceId string (provider.resource_type.identity) into a proto::ResourceId.
 ///
 /// Delegates to `crate::parse_resource_id_string` which is available on all targets.
 pub fn parse_resource_id_string(key: &str) -> crate::types::ResourceId {
@@ -117,7 +117,7 @@ macro_rules! export_provider {
                 proto::ResourceId {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
-                    name: id.identity.clone(),
+                    identity: id.identity.clone(),
                 }
             }
 
@@ -135,7 +135,7 @@ macro_rules! export_provider {
                 wit_types::ResourceId {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
-                    identity: id.name.clone(),
+                    identity: id.identity.clone(),
                 }
             }
 
@@ -719,7 +719,7 @@ macro_rules! export_provider {
                 proto::ResourceId {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
-                    name: id.identity.clone(),
+                    identity: id.identity.clone(),
                 }
             }
 
@@ -737,7 +737,7 @@ macro_rules! export_provider {
                 wit_types::ResourceId {
                     provider: id.provider.clone(),
                     resource_type: id.resource_type.clone(),
-                    identity: id.name.clone(),
+                    identity: id.identity.clone(),
                 }
             }
 

--- a/carina-provider-mock/src/main.rs
+++ b/carina-provider-mock/src/main.rs
@@ -17,7 +17,7 @@ impl Default for MockProcessProvider {
 
 impl MockProcessProvider {
     fn resource_key(id: &ResourceId) -> String {
-        format!("{}.{}", id.resource_type, id.name)
+        format!("{}.{}", id.resource_type, id.identity)
     }
 }
 

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -15,7 +15,8 @@ fn default_true() -> bool {
 pub struct ResourceId {
     pub provider: String,
     pub resource_type: String,
-    pub name: String,
+    #[serde(alias = "name")]
+    pub identity: String,
 }
 
 /// Structured identity of a provider-defined custom type.
@@ -705,7 +706,7 @@ mod tests {
             id: ResourceId {
                 provider: "mock".into(),
                 resource_type: "test.resource".into(),
-                name: "my-resource".into(),
+                identity: "my-resource".into(),
             },
             identifier: Some("mock-id".into()),
             attributes: HashMap::from([("name".into(), Value::String("test".into()))]),
@@ -717,6 +718,15 @@ mod tests {
         assert_eq!(state.id, back.id);
         assert_eq!(state.identifier, back.identifier);
         assert_eq!(state.exists, back.exists);
+    }
+
+    #[test]
+    fn test_resource_id_deserializes_legacy_name() {
+        let json = r#"{"provider":"mock","resource_type":"test.resource","name":"old-key"}"#;
+
+        let id: ResourceId = serde_json::from_str(json).unwrap();
+
+        assert_eq!(id.identity, "old-key");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Rename `name` field to `identity` in `carina-provider-protocol::types::ResourceId`
- Add `#[serde(alias = "name")]` for backward compat with providers using the old field name
- Update SDK guest bindings and mock provider
- Completes the identity rename across all three ResourceId types (core, protocol, WIT)

## Test plan

- [x] 4363 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)