### PR TITLE
refactor: close identity-typing gap for Effect::Create/Read/Wait

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -3,7 +3,7 @@ use carina_core::provider::{
     BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, Provider, ProviderError,
     ProviderFactory, ProviderNormalizer, ProviderResult, ReadRequest, UpdateRequest,
 };
-use carina_core::resource::{DataSource, ResourceId};
+use carina_core::resource::{DataSource, ResolvedResource, Resource, ResourceId};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -13,6 +13,10 @@ use std::time::Duration;
 mod cancellation_fixture;
 
 use cancellation_fixture::ApplyCancellationFixture;
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
 
 struct FailBCreateFactory;
 
@@ -926,9 +930,8 @@ fn move_plus_replace_keeps_post_replace_identifier_and_attributes() {
         None,
     );
     plan.add(Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(new_id.clone()),
         from: Box::new(State::existing(from_id.clone(), HashMap::new())),
-        to: sorted_resources[0].clone(),
+        to: resolved(sorted_resources[0].clone()),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
             "role_name".to_string(),
@@ -1051,9 +1054,8 @@ fn move_plus_update_keeps_post_update_attributes() {
     let mut plan = Plan::new();
     let from_id = ResourceId::with_provider_identity("awscc", "ec2.Tag", "tag_old", None);
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(new_id.clone()),
         from: Box::new(State::existing(from_id.clone(), HashMap::new())),
-        to: sorted_resources[0].clone(),
+        to: resolved(sorted_resources[0].clone()),
         changed_attributes: vec!["value".to_string()],
     });
     plan.add(Effect::Move {

--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -7,7 +7,7 @@ use aws_sdk_iam::types::PolicyEvaluationDecisionType;
 use carina_core::effect::{Effect, PlanOp};
 use carina_core::plan::Plan;
 use carina_core::provider::Provider;
-use carina_core::resource::ResourceId;
+use carina_core::resource::{ResolvedResource, ResourceId};
 use colored::Colorize;
 use serde_json::Value as JsonValue;
 
@@ -294,18 +294,16 @@ fn effect_required_ops(effect: &Effect) -> Vec<(ResourceId, PlanOp)> {
     match effect {
         Effect::Read { resource } => vec![(resource.id.clone(), PlanOp::Read)],
         Effect::Create(resource) => vec![(resource.id.clone(), PlanOp::Create)],
-        Effect::Update { id, .. } => vec![(id.clone().into_inner(), PlanOp::Update)],
-        Effect::Replace { id, to, .. } => {
-            vec![
-                (id.clone().into_inner(), PlanOp::Delete),
-                (to.id.clone(), PlanOp::Create),
-            ]
-        }
+        Effect::Update { to, .. } => vec![(to.id.clone(), PlanOp::Update)],
+        Effect::Replace { to, .. } => vec![
+            (to.id.clone(), PlanOp::Delete),
+            (to.id.clone(), PlanOp::Create),
+        ],
         Effect::Delete { id, .. } => vec![(id.clone().into_inner(), PlanOp::Delete)],
         Effect::Import { id, .. } => vec![(id.clone().into_inner(), PlanOp::Read)],
-        Effect::DeferredCreate { template, .. } => {
-            effect_required_ops(&Effect::Create(template.template_resource.clone()))
-        }
+        Effect::DeferredCreate { template, .. } => effect_required_ops(&Effect::Create(
+            ResolvedResource::new(template.template_resource.clone()),
+        )),
         Effect::DeferredReplace {
             deletes, template, ..
         } => {
@@ -313,9 +311,9 @@ fn effect_required_ops(effect: &Effect) -> Vec<(ResourceId, PlanOp)> {
                 .iter()
                 .map(|delete| (delete.id.clone().into_inner(), PlanOp::Delete))
                 .collect();
-            ops.extend(effect_required_ops(&Effect::Create(
+            ops.extend(effect_required_ops(&Effect::Create(ResolvedResource::new(
                 template.template_resource.clone(),
-            )));
+            ))));
             ops
         }
         Effect::Remove { .. } | Effect::Move { .. } | Effect::Wait { .. } => Vec::new(),
@@ -326,8 +324,8 @@ fn effect_resource_ids(effect: &Effect) -> Vec<&ResourceId> {
     match effect {
         Effect::Read { resource } => vec![&resource.id],
         Effect::Create(resource) => vec![&resource.id],
-        Effect::Update { id, .. } => vec![id.as_inner()],
-        Effect::Replace { id, to, .. } => vec![id.as_inner(), &to.id],
+        Effect::Update { to, .. } => vec![&to.id],
+        Effect::Replace { to, .. } => vec![&to.id],
         Effect::Delete { id, .. } => vec![id.as_inner()],
         Effect::Import { id, .. } => vec![id.as_inner()],
         Effect::Remove { id, .. } => vec![id.as_inner()],
@@ -763,7 +761,17 @@ mod tests {
         BoxFuture, CreateRequest, DeleteRequest, ProviderError, ProviderResult, ReadRequest,
         UpdateRequest,
     };
-    use carina_core::resource::{ConcreteValue, DataSource, Resource, State, Value};
+    use carina_core::resource::{
+        ConcreteValue, DataSource, ResolvedDataSource, ResolvedResource, Resource, State, Value,
+    };
+
+    fn resolved(resource: Resource) -> ResolvedResource {
+        ResolvedResource::new(resource)
+    }
+
+    fn resolved_data_source(resource: DataSource) -> ResolvedDataSource {
+        ResolvedDataSource::new(resource)
+    }
 
     struct PermissionProvider;
 
@@ -829,18 +837,18 @@ mod tests {
         let delete_id = ResourceId::with_provider_identity("awscc", "iam.Role", "old", None);
         let import_id = ResourceId::with_provider_identity("awscc", "logs.Group", "existing", None);
 
-        plan.add(Effect::Read { resource: read });
-        plan.add(Effect::Create(create));
+        plan.add(Effect::Read {
+            resource: resolved_data_source(read),
+        });
+        plan.add(Effect::Create(resolved(create)));
         plan.add(Effect::Update {
-            id: carina_core::resource::ResolvedResourceId::new(update_id.clone()),
             from: Box::new(State::not_found(update_id.clone())),
-            to: update_to,
+            to: resolved(update_to),
             changed_attributes: vec!["cidr".to_string()],
         });
         plan.add(Effect::Replace {
-            id: carina_core::resource::ResolvedResourceId::new(replace_id.clone()),
             from: Box::new(State::not_found(replace_id.clone())),
-            to: replace_to,
+            to: resolved(replace_to),
             directives: Default::default(),
             changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
             cascading_updates: vec![],

--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -397,13 +397,17 @@ mod tests {
     use carina_core::effect::Effect;
     use carina_core::executor::ProgressInfo;
     use carina_core::resource::{
-        ConcreteValue, DeferredValue, Resource, ResourceId, UnknownReason, Value,
+        ConcreteValue, DeferredValue, ResolvedResource, Resource, ResourceId, UnknownReason, Value,
     };
     use carina_core::wait::predicate::{AttrPath, WaitPredicate};
     use indexmap::IndexMap;
 
+    fn resolved(resource: Resource) -> ResolvedResource {
+        ResolvedResource::new(resource)
+    }
+
     fn dummy_create_effect() -> Effect {
-        Effect::Create(Resource::new("aws.s3.Bucket", "demo"))
+        Effect::Create(resolved(Resource::new("aws.s3.Bucket", "demo")))
     }
 
     fn wait_observation<'a>(

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -13,7 +13,9 @@ use carina_core::effect::Effect;
 use carina_core::parser::ProviderContext;
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::resource::{
+    ConcreteValue, ResolvedDataSource, Resource, ResourceId, State, Value,
+};
 use carina_core::value::{format_value, json_to_dsl_value};
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, LockInfo, ResourceState, StateBackend,
@@ -611,7 +613,9 @@ fn build_plan_from_state(state: &StateFile) -> Plan {
             }
         }
 
-        plan.add(Effect::Read { resource });
+        plan.add(Effect::Read {
+            resource: ResolvedDataSource::new(resource),
+        });
     }
     plan
 }

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -609,7 +609,8 @@ impl<'a> TreeRenderContext<'a> {
                     .unwrap();
                 }
             }
-            Effect::Update { id, to, .. } => {
+            Effect::Update { to, .. } => {
+                let id = &to.id;
                 let moved_note = self
                     .moved_origins
                     .get(id)
@@ -641,9 +642,8 @@ impl<'a> TreeRenderContext<'a> {
                     .unwrap();
                 }
             }
-            Effect::Replace {
-                id, to, directives, ..
-            } => {
+            Effect::Replace { to, directives, .. } => {
+                let id = &to.id;
                 let replace_note = if directives.create_before_destroy {
                     "(must be replaced, create before destroy)"
                 } else {
@@ -773,10 +773,11 @@ impl<'a> TreeRenderContext<'a> {
                 .unwrap();
             }
             Effect::Wait {
-                binding,
+                identity,
                 until_surface,
                 ..
             } => {
+                let binding = identity.to_string();
                 writeln!(
                     self.out,
                     "{}{} {}",
@@ -2187,13 +2188,14 @@ fn render_modified_fields(fields: &[ListOfMapsDiffField]) -> String {
 pub fn format_effect(effect: &Effect) -> String {
     match effect {
         Effect::Create(r) => format!("Create {}", r.id.human()),
-        Effect::Update { id, .. } => format!("Update {}", id.human()),
+        Effect::Update { to, .. } => format!("Update {}", to.id.human()),
         Effect::Replace {
-            id,
+            to,
             directives,
             cascading_updates,
             ..
         } => {
+            let id = &to.id;
             if directives.create_before_destroy {
                 if cascading_updates.is_empty() {
                     format!("Replace {} (create-before-destroy)", id.human())
@@ -2229,10 +2231,11 @@ pub fn format_effect(effect: &Effect) -> String {
             format!("Move {} -> {}", from.human(), to.human())
         }
         Effect::Wait {
-            binding,
+            identity,
             until_surface,
             ..
         } => {
+            let binding = identity.to_string();
             format!("Wait {} (until {})", binding, until_surface)
         }
         Effect::DeferredCreate {

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -5,9 +5,13 @@ use colored::Colorize;
 use carina_core::effect::{CascadingUpdate, DeferredReplaceDelete, Effect, NonEmptyDeletes};
 use carina_core::plan::Plan;
 use carina_core::resource::{
-    AccessPath, ConcreteValue, DeferredValue, Directives, Resource, ResourceId, State,
-    UnknownReason, Value,
+    AccessPath, ConcreteValue, DeferredValue, Directives, ResolvedResource, Resource, ResourceId,
+    State, UnknownReason, Value,
 };
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
 
 fn make_resource(resource_type: &str, name: &str, binding: &str, deps: &[&str]) -> Resource {
     let mut r = Resource::new(resource_type, name);
@@ -31,7 +35,7 @@ fn test_print_plan_with_external_dependency_does_not_panic() {
     // This simulates an external/unresolved dependency.
     let b = make_resource("test.resource", "b", "b", &["a"]);
     let mut plan = Plan::new();
-    plan.add(Effect::Create(b));
+    plan.add(Effect::Create(resolved(b)));
 
     // Should not panic
     print_plan(
@@ -54,8 +58,8 @@ fn test_print_plan_with_internal_dependency_does_not_panic() {
     let a = make_resource("test.resource", "a", "a", &[]);
     let b = make_resource("test.resource", "b", "b", &["a"]);
     let mut plan = Plan::new();
-    plan.add(Effect::Create(a));
-    plan.add(Effect::Create(b));
+    plan.add(Effect::Create(resolved(a)));
+    plan.add(Effect::Create(resolved(b)));
 
     // Should not panic
     print_plan(
@@ -153,11 +157,11 @@ fn test_siblings_sorted_by_resource_type_and_binding() {
     let subnet_a = make_resource("ec2.Subnet", "subnet_a", "subnet_a", &["vpc"]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(rt_b));
-    plan.add(Effect::Create(subnet_b));
-    plan.add(Effect::Create(rt_a));
-    plan.add(Effect::Create(subnet_a));
+    plan.add(Effect::Create(resolved(vpc)));
+    plan.add(Effect::Create(resolved(rt_b)));
+    plan.add(Effect::Create(resolved(subnet_b)));
+    plan.add(Effect::Create(resolved(rt_a)));
+    plan.add(Effect::Create(resolved(subnet_a)));
 
     let (roots, dependents, effect_bindings, _effect_types) = build_plan_tree(&plan);
 
@@ -216,9 +220,9 @@ fn test_parent_selection_prefers_most_ancestral_dependency() {
     let endpoint = make_resource("ec2.vpc_endpoint", "endpoint", "endpoint", &["vpc", "sg"]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(sg));
-    plan.add(Effect::Create(endpoint));
+    plan.add(Effect::Create(resolved(vpc)));
+    plan.add(Effect::Create(resolved(sg)));
+    plan.add(Effect::Create(resolved(endpoint)));
 
     let (roots, dependents, effect_bindings, _) = build_plan_tree(&plan);
     let _print_order = collect_print_order(&roots, &dependents, &effect_bindings);
@@ -298,11 +302,11 @@ fn test_referenced_resource_without_deps_should_not_be_root() {
     );
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(rt));
-    plan.add(Effect::Create(igw));
-    plan.add(Effect::Create(route));
-    plan.add(Effect::Create(igw_attachment));
+    plan.add(Effect::Create(resolved(vpc)));
+    plan.add(Effect::Create(resolved(rt)));
+    plan.add(Effect::Create(resolved(igw)));
+    plan.add(Effect::Create(resolved(route)));
+    plan.add(Effect::Create(resolved(igw_attachment)));
 
     let roots = compute_roots(&plan);
 
@@ -343,11 +347,11 @@ fn test_dependency_free_resource_nested_under_shallowest_referencing_resource() 
     );
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(rt));
-    plan.add(Effect::Create(igw));
-    plan.add(Effect::Create(route));
-    plan.add(Effect::Create(igw_attachment));
+    plan.add(Effect::Create(resolved(vpc)));
+    plan.add(Effect::Create(resolved(rt)));
+    plan.add(Effect::Create(resolved(igw)));
+    plan.add(Effect::Create(resolved(route)));
+    plan.add(Effect::Create(resolved(igw_attachment)));
 
     let (roots, dependents, effect_bindings, _) = build_plan_tree(&plan);
 
@@ -599,8 +603,8 @@ fn test_print_plan_compact_does_not_panic() {
     let vpc = make_resource("ec2.Vpc", "vpc", "vpc", &[]);
     let rt = make_resource("ec2.RouteTable", "rt", "rt", &["vpc"]);
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(rt));
+    plan.add(Effect::Create(resolved(vpc)));
+    plan.add(Effect::Create(resolved(rt)));
 
     // Should not panic
     print_plan(
@@ -631,7 +635,7 @@ fn test_print_plan_compact_with_anonymous_resources() {
     );
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(anon));
+    plan.add(Effect::Create(resolved(anon)));
 
     // Should not panic; anonymous resources should show hints
     print_plan(
@@ -781,11 +785,8 @@ fn test_cascading_update_shows_attribute_diffs() {
         );
 
     let replace_effect = Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "vpc",
-        )),
         from: Box::new(vpc_from),
-        to: vpc_to,
+        to: resolved(vpc_to),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -795,12 +796,8 @@ fn test_cascading_update_shows_attribute_diffs() {
         ])
         .unwrap(),
         cascading_updates: vec![CascadingUpdate {
-            id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "ec2.Subnet",
-                "subnet",
-            )),
             from: Box::new(subnet_from),
-            to: subnet_to,
+            to: resolved(subnet_to),
         }],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -828,10 +825,6 @@ fn test_format_cascading_update_attr_diff() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Subnet",
-            "subnet",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Subnet", "subnet"),
             HashMap::from([
@@ -845,15 +838,17 @@ fn test_format_cascading_update_attr_diff() {
                 ),
             ]),
         )),
-        to: Resource::new("ec2.Subnet", "subnet")
-            .with_attribute(
-                "vpc_id",
-                Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-            )
-            .with_attribute(
-                "cidr_block",
-                Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
-            ),
+        to: resolved(
+            Resource::new("ec2.Subnet", "subnet")
+                .with_attribute(
+                    "vpc_id",
+                    Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+                )
+                .with_attribute(
+                    "cidr_block",
+                    Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+                ),
+        ),
     };
 
     let output = format_cascading_update_diff(&cascade, "    ", "vpc");
@@ -927,9 +922,8 @@ fn test_replace_changed_create_only_same_value_shown_as_known_after_apply() {
     );
 
     let effect = Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(from),
-        to,
+        to: resolved(to),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
             "vpc_id".to_string(),
@@ -1000,9 +994,8 @@ fn test_replace_cascade_ref_hints_show_binding() {
     to.id = id.clone();
 
     let effect = Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(from),
-        to,
+        to: resolved(to),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
             "vpc_id".to_string(),
@@ -1240,7 +1233,7 @@ fn test_deferred_replace_renders_dependent_children() {
 
     let mut plan = Plan::new();
     plan.add(deferred_replace_validation_records_effect());
-    plan.add(Effect::Create(dependent));
+    plan.add(Effect::Create(resolved(dependent)));
 
     let output = strip_ansi(&format_plan(
         &plan,
@@ -1272,9 +1265,9 @@ fn test_deferred_replace_renders_dependent_children() {
 #[test]
 fn test_deferred_replace_keeps_unrelated_same_type_delete() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(Effect::Create(resolved(
         Resource::new("acm.Certificate", "cert").with_binding("cert"),
-    ));
+    )));
     plan.add(delete_record_effect("old_record"));
     plan.add(deferred_replace_validation_records_effect());
 
@@ -1312,10 +1305,6 @@ fn test_format_cascading_update_diff_excludes_non_ref_attributes() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Subnet",
-            "subnet",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Subnet", "subnet"),
             HashMap::from([
@@ -1333,21 +1322,23 @@ fn test_format_cascading_update_diff_excludes_non_ref_attributes() {
                 ),
             ]),
         )),
-        to: Resource::new("ec2.Subnet", "subnet")
-            .with_attribute(
-                "vpc_id",
-                Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-            )
-            .with_attribute(
-                "availability_zone",
-                Value::Concrete(ConcreteValue::String(
-                    "awscc.AvailabilityZone.ap_northeast_1a".to_string(),
-                )),
-            )
-            .with_attribute(
-                "cidr_block",
-                Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
-            ),
+        to: resolved(
+            Resource::new("ec2.Subnet", "subnet")
+                .with_attribute(
+                    "vpc_id",
+                    Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+                )
+                .with_attribute(
+                    "availability_zone",
+                    Value::Concrete(ConcreteValue::String(
+                        "awscc.AvailabilityZone.ap_northeast_1a".to_string(),
+                    )),
+                )
+                .with_attribute(
+                    "cidr_block",
+                    Value::Concrete(ConcreteValue::String("10.0.1.0/24".to_string())),
+                ),
+        ),
     };
 
     let replaced_binding = "vpc";
@@ -1381,10 +1372,6 @@ fn test_format_cascading_update_diff_includes_list_with_ref() {
     use std::collections::HashMap;
 
     let cascade = CascadingUpdate {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Instance",
-            "instance",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Instance", "instance"),
             HashMap::from([(
@@ -1394,14 +1381,14 @@ fn test_format_cascading_update_diff_includes_list_with_ref() {
                 )])),
             )]),
         )),
-        to: Resource::new("ec2.Instance", "instance").with_attribute(
+        to: resolved(Resource::new("ec2.Instance", "instance").with_attribute(
             "security_group_ids",
             Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
                 "sg".to_string(),
                 "group_id".to_string(),
                 vec![],
             )])),
-        ),
+        )),
     };
 
     let replaced_binding = "sg";
@@ -1476,20 +1463,13 @@ fn test_mixed_plan_tree_with_delete_effect() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "vpc",
-        )),
         from: Box::new(vpc_from),
-        to: vpc_to,
+        to: resolved(vpc_to),
         changed_attributes: vec!["cidr_block".to_string()],
     });
     plan.add(Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.SecurityGroup",
-            "sg",
-        )),
         from: Box::new(sg_from),
-        to: sg_to,
+        to: resolved(sg_to),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
             "ref_vpc".to_string(),
@@ -1581,14 +1561,11 @@ fn test_resolved_ref_loses_dependency_for_tree_nesting() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "vpc",
-        )),
         from: Box::new(vpc_from),
-        to: vpc_to,
+        to: resolved(vpc_to),
         changed_attributes: vec!["tags".to_string()],
     });
-    plan.add(Effect::Create(sg));
+    plan.add(Effect::Create(resolved(sg)));
 
     let (roots, dependents, effect_bindings, _effect_types) = build_plan_tree(&plan);
 
@@ -1663,7 +1640,7 @@ fn format_effect_delete_falls_back_to_id_name() {
 fn format_effect_create_separates_type_and_name_with_space() {
     let mut r = Resource::new("s3.Bucket", "state_bucket");
     r.id = ResourceId::with_provider_identity("aws", "s3.Bucket", "state_bucket", None);
-    let effect = Effect::Create(r);
+    let effect = Effect::Create(resolved(r));
     assert_eq!(format_effect(&effect), "Create aws.s3.Bucket state_bucket");
 }
 
@@ -1673,14 +1650,13 @@ fn format_effect_update_separates_type_and_name_with_space() {
     let mut to = Resource::new("iam.Role", "bs.bootstrap.role");
     to.id = id.clone();
     let effect = Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(State::not_found(ResourceId::with_provider_identity(
             "awscc",
             "iam.Role",
             "bs.bootstrap.role",
             None,
         ))),
-        to,
+        to: resolved(to),
         changed_attributes: Vec::new(),
     };
     assert_eq!(
@@ -1695,11 +1671,10 @@ fn format_effect_replace_separates_type_and_name_with_space() {
     let mut to = Resource::new("ec2.Vpc", "vpc");
     to.id = id.clone();
     let effect = Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(State::not_found(ResourceId::with_provider_identity(
             "awscc", "ec2.Vpc", "vpc", None,
         ))),
-        to,
+        to: resolved(to),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
             .unwrap(),
@@ -1725,9 +1700,8 @@ fn format_replace_with_removed_create_only_attribute_shows_forcing_detail() {
     let mut to = Resource::new("Widget", "beta");
     to.id = id.clone();
     let effect = Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(id),
         from: Box::new(from),
-        to,
+        to: resolved(to),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
             "legacy_token".to_string(),
@@ -2090,15 +2064,11 @@ fn forcing_changed_uses_plain_green_cli_value() {
         new: "\"new\"".to_string(),
     };
     let effect = Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "test.Widget",
-            "w",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("test.Widget", "w"),
             HashMap::new(),
         )),
-        to: Resource::new("test.Widget", "w"),
+        to: resolved(Resource::new("test.Widget", "w")),
         changed_attributes: vec!["name".to_string()],
     };
 
@@ -2121,15 +2091,11 @@ fn forcing_changed_multiline_green_style_does_not_cross_newline() {
         new: "[\n  \"new\"\n]".to_string(),
     };
     let effect = Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "test.Widget",
-            "w",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("test.Widget", "w"),
             HashMap::new(),
         )),
-        to: Resource::new("test.Widget", "w"),
+        to: resolved(Resource::new("test.Widget", "w")),
         changed_attributes: vec!["rules".to_string()],
     };
 
@@ -2184,7 +2150,8 @@ fn test_composition_header_drops_parens_for_none_source_path() {
 #[test]
 fn module_header_sigil_is_module_specific_not_create() {
     let module_sigil = Sigil::module_header();
-    let create_sigil = Effect::Create(Resource::new("aws.s3.Bucket", "x")).display_glyph();
+    let create_sigil =
+        Effect::Create(resolved(Resource::new("aws.s3.Bucket", "x"))).display_glyph();
 
     assert_eq!(module_sigil.raw, "▾");
     assert_ne!(
@@ -2241,8 +2208,8 @@ fn module_children_render_with_tree_connectors() {
     let role_id = role.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(inner));
-    plan.add(Effect::Create(role));
+    plan.add(Effect::Create(resolved(inner)));
+    plan.add(Effect::Create(resolved(role)));
 
     let cluster_site = CallSite::new(
         EphemeralId::new(ResourceId::with_identity("_virtual", "cluster")),
@@ -2284,9 +2251,9 @@ fn module_child_connector_gutter_extends_through_nested_dependents() {
     let bucket_id = bucket.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cluster));
-    plan.add(Effect::Create(node_role));
-    plan.add(Effect::Create(bucket));
+    plan.add(Effect::Create(resolved(cluster)));
+    plan.add(Effect::Create(resolved(node_role)));
+    plan.add(Effect::Create(resolved(bucket)));
 
     let cluster_site = CallSite::new(
         EphemeralId::new(ResourceId::with_identity("_virtual", "cluster")),
@@ -2329,9 +2296,8 @@ fn module_group_with_only_suppressed_move_does_not_emit_orphan_gutter() {
         to: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
     });
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
         from: Box::new(State::not_found(to_id.clone())),
-        to: updated,
+        to: resolved(updated),
         changed_attributes: Vec::new(),
     });
 
@@ -2396,15 +2362,14 @@ fn resource_with_only_suppressed_move_dependent_does_not_emit_orphan_gutter() {
     updated.id = to_id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(parent));
+    plan.add(Effect::Create(resolved(parent)));
     plan.add(Effect::Move {
         from: carina_core::resource::ResolvedResourceId::new(from_id),
         to: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
     });
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(to_id.clone()),
         from: Box::new(State::not_found(to_id.clone())),
-        to: updated,
+        to: resolved(updated),
         changed_attributes: Vec::new(),
     });
 

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -22,7 +22,9 @@ use carina_state::{StateFile, check_and_migrate};
 
 use crate::commands::validate_and_resolve;
 use crate::wiring::{
-    WiringContext, add_deferred_create_effects, compute_anonymous_identifiers_with_ctx,
+    WiringContext, add_deferred_create_effects,
+    adopt_unique_state_identity_for_unresolved_anonymous,
+    assign_fallback_identities_for_unresolved_anonymous, compute_anonymous_identifiers_with_ctx,
     expand_same_config_deferred_for, normalize_state_with_ctx,
     reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
     resolve_enum_aliases_in_states,
@@ -287,10 +289,35 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
     }
 
     resolve_enum_aliases_in_states(&wiring, &mut current_states);
+    {
+        let canonical_resources = carina_core::value::canonicalize_resources_with_schemas(
+            &mut resources,
+            wiring.schemas(),
+        );
+        let errors =
+            compute_anonymous_identifiers_with_ctx(&wiring, canonical_resources, &parsed.providers);
+        assert!(errors.is_empty(), "{errors:?}");
+    }
+    if let Some(sf) = state_file.as_mut() {
+        reconcile_anonymous_identifiers_with_ctx(&wiring, &mut resources, sf, &state_block_claims);
+        adopt_unique_state_identity_for_unresolved_anonymous(&mut resources, sf);
+    }
+    let fallback_renames = assign_fallback_identities_for_unresolved_anonymous(&mut resources);
+    for (from, to) in &fallback_renames {
+        if let Some(mut state) = current_states.remove(from) {
+            state.id = to.clone();
+            current_states.insert(to.clone(), state);
+        }
+        if let Some(attrs) = saved_attrs.remove(from) {
+            saved_attrs.insert(to.clone(), attrs);
+        }
+        if let Some(explicit) = prev_explicit.remove(from) {
+            prev_explicit.insert(to.clone(), explicit);
+        }
+    }
 
     let orphan_dependencies = if let Some(sf) = state_file.as_ref() {
-        let desired_ids: HashSet<ResourceId> =
-            sorted_resources.iter().map(|r| r.id.clone()).collect();
+        let desired_ids: HashSet<ResourceId> = resources.iter().map(|r| r.id.clone()).collect();
         sf.build_orphan_dependencies(&desired_ids)
     } else {
         HashMap::new()

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -10,12 +10,22 @@ use std::path::PathBuf;
 use carina_core::config_loader::load_configuration;
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
-use carina_core::resource::{ResourceId, State};
+use carina_core::resource::{
+    DataSource, ResolvedDataSource, ResolvedResource, Resource, ResourceId, State,
+};
 use carina_core::schema::SchemaRegistry;
 
 use crate::DetailLevel;
 use crate::display::{format_destroy_plan, format_plan};
 use crate::fixture_plan::build_plan_from_fixture_name;
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
+
+fn resolved_data_source(resource: DataSource) -> ResolvedDataSource {
+    ResolvedDataSource::new(resource)
+}
 
 /// Strip ANSI escape codes from a string for snapshot readability.
 fn strip_ansi(s: &str) -> String {
@@ -2006,15 +2016,19 @@ fn snapshot_deferred_for_with_dependent_wait() {
     let mut fp = build_plan_from_fixture_name("deferred_for_with_dependent_wait");
     let mut plan = Plan::new();
     for effect in fp.plan.effects() {
-        let mut effect = effect.clone();
-        if let Effect::Create(resource) = &mut effect
-            && resource.id.resource_type == "acm.CertificateValidation"
-        {
-            resource
-                .directives
-                .depends_on
-                .push("validation_records".to_string());
-        }
+        let effect = match effect.clone() {
+            Effect::Create(resource)
+                if resource.id.resource_type == "acm.CertificateValidation" =>
+            {
+                let mut resource = resource.into_inner();
+                resource
+                    .directives
+                    .depends_on
+                    .push("validation_records".to_string());
+                Effect::Create(resolved(resource))
+            }
+            effect => effect,
+        };
         plan.add(effect);
     }
     fp.plan = plan;
@@ -2133,9 +2147,9 @@ fn snapshot_composition_folding() {
     let inner_id = inner.id.clone();
     let inner_role_id = inner_role.id.clone();
 
-    plan.add(Effect::Create(inner));
-    plan.add(Effect::Create(inner_role));
-    plan.add(Effect::Create(logs));
+    plan.add(Effect::Create(resolved(inner)));
+    plan.add(Effect::Create(resolved(inner_role)));
+    plan.add(Effect::Create(resolved(logs)));
 
     let mut trace = ExpansionTrace::new();
     // carina#3322: the call site carries the `use { source = "..." }`
@@ -2209,9 +2223,11 @@ fn snapshot_top_level_sigil_alignment() {
     let cluster = Resource::new("aws.eks.Cluster", "cluster/inner");
     let cluster_id = cluster.id.clone();
 
-    plan.add(Effect::Create(bucket));
-    plan.add(Effect::Read { resource: roles });
-    plan.add(Effect::Create(cluster));
+    plan.add(Effect::Create(resolved(bucket)));
+    plan.add(Effect::Read {
+        resource: resolved_data_source(roles),
+    });
+    plan.add(Effect::Create(resolved(cluster)));
 
     let deferred_template = Resource::new("aws.route53.RecordSet", "validation_records");
     let deferred = DeferredForExpression {

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_export_changes_mixed.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_export_changes_mixed.snap
@@ -4,12 +4,6 @@ expression: strip_ansi(&output)
 ---
 Execution Plan:
 
-  + awscc.ec2.Subnet 
-      cidr_block: "10.0.1.0/24"
-      tags:
-        Name: "test-subnet"
-      vpc_id: "vpc-0123456789abcdef0"
-  - awscc.ec2.Subnet ec2_subnet_aac7c86b
 
 Exports:
 
@@ -17,4 +11,4 @@ Exports:
   ~ changed: Int = 42 → 100
   - obsolete = 'gone'
 
-Plan: 1 to add, 0 to change, 1 to destroy, 3 export change(s).
+Plan: 0 to add, 0 to change, 0 to destroy, 3 export change(s).

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state.snap
@@ -4,7 +4,7 @@ expression: strip_ansi(&output)
 ---
 Execution Plan:
 
-  + awscc.ec2.SecurityGroup 
+  + awscc.ec2.SecurityGroup awscc_ec2_security_group_ca33fd1e
       group_description: "Web security group"
       tags:
         Name: "web-sg"

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_empty_exports.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_empty_exports.snap
@@ -4,7 +4,7 @@ expression: stripped
 ---
 Execution Plan:
 
-  + awscc.ec2.SecurityGroup 
+  + awscc.ec2.SecurityGroup awscc_ec2_security_group_e0524572
       group_description: "Web security group"
       tags:
         Name: "web-sg"

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_map_dot_notation.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_map_dot_notation.snap
@@ -4,7 +4,7 @@ expression: stripped
 ---
 Execution Plan:
 
-  + awscc.s3.Bucket 
+  + awscc.s3.Bucket awscc_s3_bucket_92e40ff2
       bucket_name: "shared-222222222222-bucket"
       tags:
         DevAccount: "222222222222"

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_map_subscript.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_map_subscript.snap
@@ -4,7 +4,7 @@ expression: stripped
 ---
 Execution Plan:
 
-  + awscc.s3.Bucket 
+  + awscc.s3.Bucket awscc_s3_bucket_92e40ff2
       bucket_name: "shared-222222222222-bucket"
       tags:
         DevAccount: "222222222222"

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_unresolved.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_unresolved.snap
@@ -4,7 +4,7 @@ expression: stripped
 ---
 Execution Plan:
 
-  + awscc.ec2.SecurityGroup 
+  + awscc.ec2.SecurityGroup awscc_ec2_security_group_e0524572
       group_description: "Web security group"
       tags:
         Name: "web-sg"

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_all_create.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_all_create.snap
@@ -11,12 +11,12 @@ Execution Plan:
       tags:
         Name: "test-vpc"
         │
-        ├─ + awscc.ec2.RouteTable 
+        ├─ + awscc.ec2.RouteTable awscc_ec2_route_table_8710819e
         │     tags:
         │       Name: "test-route-table"
         │     vpc_id: vpc.vpc_id
         │
-        └─ + awscc.ec2.Subnet 
+        └─ + awscc.ec2.Subnet awscc_ec2_subnet_8b692b3f
               availability_zone: "ap-northeast-1a"
               cidr_block: "10.0.1.0/24"
               tags:

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_compact.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_compact.snap
@@ -5,7 +5,7 @@ expression: output
 Execution Plan:
 
   + awscc.ec2.Vpc vpc
-        ├─ + awscc.ec2.RouteTable 
+        ├─ + awscc.ec2.RouteTable awscc_ec2_route_table_8710819e
         └─ + awscc.ec2.Subnet (availability_zone: ap-northeast-1a)
 
 Plan: 3 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_default_tags.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_default_tags.snap
@@ -10,7 +10,7 @@ Execution Plan:
         Environment: "staging"
         Name: "main-vpc"
         │
-        └─ + awscc.ec2.RouteTable 
+        └─ + awscc.ec2.RouteTable awscc_ec2_route_table_fd47570c
               vpc_id: vpc.vpc_id
 
 Plan: 2 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_default_values.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_default_values.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.logs.LogGroup 
+  + awscc.logs.LogGroup awscc_logs_log_group_f779e9e2
       log_group_name: "my-app-logs"
       retention_in_days: 30
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_deferred_for_with_dependent_wait.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_deferred_for_with_dependent_wait.snap
@@ -16,7 +16,7 @@ Execution Plan:
               ttl: 60
               type: (known after cert applies)
               │
-              └─ + aws.acm.CertificateValidation 
+              └─ + aws.acm.CertificateValidation aws_acm_certificate_validation_1075605a
                     certificate_arn: "arn:aws:acm:us-east-1:123456789012:certificate/example"
                     validation_record_id: "known-after-validation-records"
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_delete_orphan.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_delete_orphan.snap
@@ -4,26 +4,12 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.Vpc 
-      cidr_block: "10.0.0.0/16"
-      enable_dns_hostnames: true
-      enable_dns_support: true
+  - awscc.ec2.Subnet my_subnet
+      availability_zone: "ap-northeast-1a"
+      cidr_block: "10.0.1.0/24"
+      subnet_id: "subnet-0123456789abcdef0"
       tags:
-        Name: "test-vpc"
-  - awscc.ec2.Vpc ec2_vpc_fb75c929
-      cidr_block: "10.0.0.0/16"
-      enable_dns_hostnames: true
-      enable_dns_support: true
-      tags:
-        Name: "test-vpc"
+        Name: "test-subnet"
       vpc_id: "vpc-0123456789abcdef0"
-        │
-        └─ - awscc.ec2.Subnet my_subnet
-              availability_zone: "ap-northeast-1a"
-              cidr_block: "10.0.1.0/24"
-              subnet_id: "subnet-0123456789abcdef0"
-              tags:
-                Name: "test-subnet"
-              vpc_id: "vpc-0123456789abcdef0"
 
-Plan: 1 to add, 0 to change, 2 to destroy.
+Plan: 0 to add, 0 to change, 1 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_depends_on.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_depends_on.snap
@@ -8,7 +8,7 @@ Execution Plan:
       assume_role_policy_document: "{}"
       role_name: "my-role"
         │
-        └─ + aws.s3.Bucket 
+        └─ + aws.s3.Bucket aws_s3_bucket_c92b6b0d
               bucket_name: "my-bucket"
 
 Plan: 2 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_enum_display.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_enum_display.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.Vpc 
+  + awscc.ec2.Vpc awscc_ec2_vpc_a0424857060c4250
       cidr_block: "10.0.0.0/16"
       instance_tenancy: dedicated
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_explicit.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_explicit.snap
@@ -8,7 +8,7 @@ Execution Plan:
       tags:
         + Environment: "staging"
         │
-        ├─ + awscc.ec2.SecurityGroup 
+        ├─ + awscc.ec2.SecurityGroup awscc_ec2_security_group_395c3f9f
         │     group_description: "Test security group"
         │     tags:
         │       Name: "test-sg"

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_added_struct_child_gutter.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_added_struct_child_gutter.snap
@@ -24,7 +24,7 @@ Execution Plan:
         │         }
         │     # (2 unchanged attributes hidden)
         │
-        └─ + awscc.s3.Bucket 
+        └─ + awscc.s3.Bucket awscc_s3_bucket_991b6004
               bucket_name: "zzz-trailing-sibling"
 
 Plan: 2 to add, 1 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_struct_child_gutter.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_struct_child_gutter.snap
@@ -8,7 +8,7 @@ Execution Plan:
       assume_role_policy_document: "{}"
       role_name: "test-role"
         │
-        ├─ + awscc.iam.RolePolicy 
+        ├─ + awscc.iam.RolePolicy awscc_iam_role_policy_e31a6d61
         │     policy_name: "test-inline"
         │     role_name: "test-role"
         │     statement: 
@@ -22,7 +22,7 @@ Execution Plan:
         │         resource: "arn:aws:s3:::example/*"
         │         sid: "DenyS3Write"
         │
-        └─ + awscc.s3.Bucket 
+        └─ + awscc.s3.Bucket awscc_s3_bucket_991b6004
               bucket_name: "zzz-trailing-sibling"
 
 Plan: 3 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_map_key_diff.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_map_key_diff.snap
@@ -4,13 +4,10 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.Vpc 
-      cidr_block: "10.0.0.0/16"
-      enable_dns_hostnames: true
-      enable_dns_support: true
+  ~ awscc.ec2.Vpc ec2_vpc_fb75c929
       tags:
-        Environment: "production"
-        Name: "main"
-  - awscc.ec2.Vpc ec2_vpc_fb75c929
+        ~ Environment: "staging" → "production"
+        - OldTag: "remove-me"
+      # (3 unchanged attributes hidden)
 
-Plan: 1 to add, 0 to change, 1 to destroy.
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_mixed_operations.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_mixed_operations.snap
@@ -9,7 +9,7 @@ Execution Plan:
         + Environment: "staging"
       # (3 unchanged attributes hidden)
         │
-        ├─ + awscc.ec2.SecurityGroup 
+        ├─ + awscc.ec2.SecurityGroup awscc_ec2_security_group_395c3f9f
         │     group_description: "Test security group"
         │     tags:
         │       Name: "test-sg"

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_module_anonymous_resource.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_module_anonymous_resource.snap
@@ -7,7 +7,7 @@ Execution Plan:
   + awscc.iam.Role bootstrap.role
       role_name: "carina-bootstrap"
         │
-        └─ + awscc.iam.RolePolicy 
+        └─ + awscc.iam.RolePolicy bootstrap.awscc_iam_role_policy_c09d442a
               policy_name: "inline"
               role_name: "carina-bootstrap"
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_prev_keys.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_prev_keys.snap
@@ -12,7 +12,7 @@ Execution Plan:
           }
       # (1 unchanged attribute hidden)
         │
-        └─ + awscc.ec2.Subnet 
+        └─ + awscc.ec2.Subnet awscc_ec2_subnet_2b52fe61
               cidr_block: "10.0.1.0/24"
               vpc_id: new_vpc.vpc_id
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_with_changes.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_with_changes.snap
@@ -9,7 +9,7 @@ Execution Plan:
         + Name: "updated"
       # (1 unchanged attribute hidden)
         │
-        └─ + awscc.ec2.Subnet 
+        └─ + awscc.ec2.Subnet awscc_ec2_subnet_2b52fe61
               cidr_block: "10.0.1.0/24"
               vpc_id: new_vpc.vpc_id
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_nested_map_diff.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_nested_map_diff.snap
@@ -11,7 +11,7 @@ Execution Plan:
             ~ timeout: "30" → "60"
       # (1 unchanged attribute hidden)
         │
-        └─ + awscc.ec2.Subnet 
+        └─ + awscc.ec2.Subnet awscc_ec2_subnet_fb6b4e6a
               cidr_block: "10.0.1.0/24"
               vpc_id: "vpc-0123456789abcdef0"
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_no_changes.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_no_changes.snap
@@ -2,13 +2,4 @@
 source: carina-cli/src/plan_snapshot_tests.rs
 expression: output
 ---
-Execution Plan:
-
-  + awscc.ec2.Subnet 
-      cidr_block: "10.0.1.0/24"
-      tags:
-        Name: "test-subnet"
-      vpc_id: "vpc-0123456789abcdef0"
-  - awscc.ec2.Subnet ec2_subnet_aac7c86b
-
-Plan: 1 to add, 0 to change, 1 to destroy.
+No changes. Infrastructure is up-to-date.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_no_changes_enum.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_no_changes_enum.snap
@@ -2,14 +2,4 @@
 source: carina-cli/src/plan_snapshot_tests.rs
 expression: output
 ---
-Execution Plan:
-
-  + awscc.ec2.Subnet 
-      availability_zone: "ap-northeast-1a"
-      cidr_block: "10.0.1.0/24"
-      tags:
-        Name: "test-subnet"
-      vpc_id: "vpc-0123456789abcdef0"
-  - awscc.ec2.Subnet ec2_subnet_f5269366
-
-Plan: 1 to add, 0 to change, 1 to destroy.
+No changes. Infrastructure is up-to-date.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.iam.RolePolicy 
+  + awscc.iam.RolePolicy awscc_iam_role_policy_93d2412e
       policy_name: "test-inline"
       role_name: "test-role"
       statement: 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_dynamic_key_list.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_dynamic_key_list.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.Vpc 
+  + awscc.ec2.Vpc awscc_ec2_vpc_9e631a9b
       cidr_block: "10.0.0.0/16"
       config:
         statement: 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_nested.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_nested.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.Vpc 
+  + awscc.ec2.Vpc awscc_ec2_vpc_7027e991
       cidr_block: "10.0.0.0/16"
       config:
         statement: 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_pretty_long_string_list.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_pretty_long_string_list.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.iam.Role 
+  + awscc.iam.Role awscc_iam_role_179c5ce4
       managed_policy_arns: [
         "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
         "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess",

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_pretty_short_string_list.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_pretty_short_string_list.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.iam.Role 
+  + awscc.iam.Role awscc_iam_role_b7a54912
       role_name: "short-list-test"
       short_tags: ["a", "b", "c"]
 

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_read_only_attrs.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_read_only_attrs.snap
@@ -9,7 +9,7 @@ Execution Plan:
       tags:
         Name: "read-only-test"
         │
-        └─ + awscc.ec2.Subnet 
+        └─ + awscc.ec2.Subnet awscc_ec2_subnet_d1f9fed0
               availability_zone: "ap-northeast-1a"
               cidr_block: "10.0.1.0/24"
               vpc_id: vpc.vpc_id

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_secret_values.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_secret_values.snap
@@ -11,16 +11,9 @@ Execution Plan:
         ApiKey: (secret)
         Name: "orphan-subnet"
       vpc_id: "vpc-0123456789abcdef0"
-  + awscc.ec2.Vpc 
-      cidr_block: "10.0.0.0/16"
+  ~ awscc.ec2.Vpc ec2_vpc_fb75c929
       tags:
-        Name: "secret-test"
-        Password: (secret)
-  - awscc.ec2.Vpc ec2_vpc_fb75c929
-      cidr_block: "10.0.0.0/16"
-      tags:
-        Name: "secret-test"
-        Password: (secret)
-      vpc_id: "vpc-0123456789abcdef0"
+        ~ Password: (secret) → (secret)
+      # (1 unchanged attribute hidden)
 
-Plan: 1 to add, 0 to change, 2 to destroy.
+Plan: 0 to add, 1 to change, 1 to destroy.

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -11,7 +11,8 @@ use carina_core::parser::{ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{
-    ConcreteValue, DataSource, DeferredValue, Directives, Resource, ResourceId, State, Value,
+    ConcreteValue, DataSource, DeferredValue, Directives, ResolvedDataSource, ResolvedResource,
+    Resource, ResourceId, State, Value,
 };
 use carina_core::schema::{ResourceSchema, SchemaRegistry};
 use carina_state::{BackendError, LoadedState, LockInfo, ResourceState, StateBackend, StateFile};
@@ -33,6 +34,14 @@ use crate::wiring::{
 use carina_core::parser::BackendConfig;
 use carina_core::provider::Provider;
 use std::sync::Mutex;
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
+
+fn resolved_data_source(resource: DataSource) -> ResolvedDataSource {
+    ResolvedDataSource::new(resource)
+}
 
 struct TestProvider {
     read_results: HashMap<(String, String), Result<State, String>>,
@@ -281,12 +290,12 @@ fn plan_file_serde_round_trip() {
     use carina_core::plan::Plan;
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(Effect::Create(resolved(
         Resource::with_provider("aws", "s3.Bucket", "my-bucket", None).with_attribute(
             "bucket",
             Value::Concrete(ConcreteValue::String("my-bucket".to_string())),
         ),
-    ));
+    )));
     plan.add(Effect::Delete {
         id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_provider_identity(
             "aws",
@@ -600,7 +609,7 @@ fn test_detailed_exitcode_no_changes() {
 fn test_detailed_exitcode_with_changes() {
     // A plan with mutating effects means changes -- has_changes should be true
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "test")));
+    plan.add(Effect::Create(resolved(Resource::new("s3.Bucket", "test"))));
     let has_changes = plan.mutation_count() > 0;
     assert!(has_changes);
 }
@@ -610,7 +619,7 @@ fn test_detailed_exitcode_read_only_no_changes() {
     // A plan with only Read effects should NOT count as changes
     let mut plan = Plan::new();
     plan.add(Effect::Read {
-        resource: DataSource::new("sts.caller_identity", "identity"),
+        resource: resolved_data_source(DataSource::new("sts.caller_identity", "identity")),
     });
     let has_changes = plan.mutation_count() > 0;
     assert!(!has_changes);
@@ -1847,9 +1856,8 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(id.clone()),
         from: Box::new(old_state.clone()),
-        to: new_resource.clone(),
+        to: resolved(new_resource.clone()),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1992,9 +2000,8 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
     // Subnet: Update (cidr_block changed, vpc_id eagerly resolved to old value)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc_unresolved.clone().with_binding("vpc"),
+        to: resolved(vpc_unresolved.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -2008,9 +2015,8 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: subnet_resolved.clone(), // Has stale "vpc-OLD" in vpc_id
+        to: resolved(subnet_resolved.clone()), // Has stale "vpc-OLD" in vpc_id
         changed_attributes: vec!["cidr_block".to_string()],
     });
 
@@ -2932,7 +2938,7 @@ fn plan_file_serialization_redacts_secrets() {
         .with_attribute("master_password", secret_password.clone());
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource_with_secret.clone()));
+    plan.add(Effect::Create(resolved(resource_with_secret.clone())));
 
     let mut state_attrs = HashMap::new();
     state_attrs.insert(

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::hash_map::Entry;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 use std::io::IsTerminal;
 use std::path::Path;
 
@@ -623,6 +624,130 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
     );
 
     apply_provider_prefix_renames(&renames, state_file);
+}
+
+pub(crate) fn adopt_unique_state_identity_for_unresolved_anonymous(
+    resources: &mut [Resource],
+    state_file: &StateFile,
+) {
+    for resource in resources {
+        if resource.id.identity.is_some() || resource.binding.is_some() {
+            continue;
+        }
+
+        let candidates: Vec<_> = state_file
+            .resources_by_type(&resource.id.provider, &resource.id.resource_type)
+            .into_iter()
+            .filter(|state| !state.identity.is_empty())
+            .filter(|state| state.directives.provider_instance == resource.id.provider_instance)
+            .collect();
+        let [state] = candidates.as_slice() else {
+            continue;
+        };
+
+        resource.id = ResourceId::with_provider_identity(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            state.identity.as_str(),
+            resource.id.provider_instance.clone(),
+        );
+    }
+}
+
+pub(crate) fn assign_fallback_identities_for_unresolved_anonymous(
+    resources: &mut [Resource],
+) -> Vec<(ResourceId, ResourceId)> {
+    let mut used: HashMap<(String, String, Option<String>), HashSet<String>> = HashMap::new();
+    let mut renames = Vec::new();
+    for resource in resources.iter() {
+        if let Some(identity) = resource.id.identity_str() {
+            used.entry((
+                resource.id.provider.clone(),
+                resource.id.resource_type.clone(),
+                resource.id.provider_instance.clone(),
+            ))
+            .or_default()
+            .insert(identity.to_string());
+        }
+    }
+
+    for (idx, resource) in resources.iter_mut().enumerate() {
+        if resource.id.identity.is_some() || resource.binding.is_some() {
+            continue;
+        }
+
+        let provider_snake = resource
+            .id
+            .provider
+            .split('.')
+            .map(carina_core::parser::pascal_to_snake)
+            .collect::<Vec<_>>()
+            .join("_");
+        let type_snake = resource
+            .id
+            .resource_type
+            .split('.')
+            .map(carina_core::parser::pascal_to_snake)
+            .collect::<Vec<_>>()
+            .join("_");
+        let hash = fallback_anonymous_hash(resource);
+        let bare_identifier = if provider_snake.is_empty() {
+            format!("{type_snake}_{hash}")
+        } else {
+            format!("{provider_snake}_{type_snake}_{hash}")
+        };
+        let base_identifier = match &resource.module_source {
+            Some(carina_core::resource::ModuleSource::Module { instance, .. }) => {
+                format!("{instance}.{bare_identifier}")
+            }
+            _ => bare_identifier,
+        };
+
+        let key = (
+            resource.id.provider.clone(),
+            resource.id.resource_type.clone(),
+            resource.id.provider_instance.clone(),
+        );
+        let used_for_type = used.entry(key).or_default();
+        let mut identifier = base_identifier;
+        if used_for_type.contains(&identifier) {
+            identifier = format!("{identifier}_{idx}");
+        }
+        used_for_type.insert(identifier.clone());
+
+        let old_id = resource.id.clone();
+        resource.id = ResourceId::with_provider_identity(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            identifier,
+            resource.id.provider_instance.clone(),
+        );
+        renames.push((old_id, resource.id.clone()));
+    }
+    renames
+}
+
+fn fallback_anonymous_hash(resource: &Resource) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    resource.id.provider.hash(&mut hasher);
+    resource.id.resource_type.hash(&mut hasher);
+    resource.id.provider_instance.hash(&mut hasher);
+    resource.module_source.hash(&mut hasher);
+    for (key, value) in &resource.attributes {
+        key.hash(&mut hasher);
+        format!("{value:?}").hash(&mut hasher);
+    }
+    resource.directives.force_delete.hash(&mut hasher);
+    resource.directives.create_before_destroy.hash(&mut hasher);
+    resource.directives.prevent_destroy.hash(&mut hasher);
+    resource.directives.depends_on.hash(&mut hasher);
+    resource.directives.provider_instance.hash(&mut hasher);
+    for (key, value) in BTreeMap::from_iter(resource.prefixes.iter()) {
+        key.hash(&mut hasher);
+        value.hash(&mut hasher);
+    }
+    resource.dependency_bindings.hash(&mut hasher);
+    format!("{:08x}", hasher.finish() & 0xffff_ffff)
 }
 
 /// Re-key state entries when `reconcile_anonymous_identifiers` produced rename
@@ -2090,15 +2215,6 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
     // separator + plan render below it instead of being swallowed (#3150).
     finish_refresh_bar_region(refresh_printed_bars);
 
-    // Build orphan dependency bindings from state file for tree structure
-    let orphan_dependencies = if let Some(sf) = state_file.as_ref() {
-        let desired_ids: HashSet<ResourceId> =
-            sorted_resources.iter().map(|r| r.id.clone()).collect();
-        sf.build_orphan_dependencies(&desired_ids)
-    } else {
-        HashMap::new()
-    };
-
     // Resolve ResourceRef values and enum identifiers using AWS state.
     // Plan-only: surviving upstream refs are stamped for display as
     // `(known after upstream apply: <ref>)` (#2366). `apply` calls
@@ -2181,6 +2297,55 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
             &mut wait_bindings,
         )
         .await;
+
+    // Anonymous resources whose identity attributes include ResourceRefs can
+    // only be named and matched after plan-time refs and provider normalization
+    // have made those create-only values concrete. Keep this late pass local to
+    // the desired resources; the earlier mutable-state reconciliation still
+    // owns state-file rename migration.
+    {
+        let canonical_resources =
+            carina_core::value::canonicalize_resources_with_schemas(&mut resources, ctx.schemas());
+        let errors =
+            compute_anonymous_identifiers_with_ctx(&ctx, canonical_resources, &parsed.providers);
+        if let Some(error) = errors.into_iter().next() {
+            return Err(error);
+        }
+    }
+    if let Some(sf) = state_file.as_ref() {
+        let mut state_for_late_reconcile = sf.clone();
+        reconcile_anonymous_identifiers_with_ctx(
+            &ctx,
+            &mut resources,
+            &mut state_for_late_reconcile,
+            state_block_claims,
+        );
+        adopt_unique_state_identity_for_unresolved_anonymous(&mut resources, sf);
+    }
+    let fallback_renames = assign_fallback_identities_for_unresolved_anonymous(&mut resources);
+    for (from, to) in &fallback_renames {
+        if let Some(mut state) = current_states.remove(from) {
+            state.id = to.clone();
+            current_states.insert(to.clone(), state);
+        }
+        if let Some(attrs) = saved_attrs.remove(from) {
+            saved_attrs.insert(to.clone(), attrs);
+        }
+        if let Some(explicit) = prev_explicit.remove(from) {
+            prev_explicit.insert(to.clone(), explicit);
+        }
+    }
+
+    // Build orphan dependency bindings from state file for tree structure
+    // after late anonymous reconciliation, so an anonymous desired resource
+    // matched from state is not also treated as an orphan.
+    let orphan_dependencies = if let Some(sf) = state_file.as_ref() {
+        let desired_ids: HashSet<ResourceId> = resources.iter().map(|r| r.id.clone()).collect();
+        sf.build_orphan_dependencies(&desired_ids)
+    } else {
+        HashMap::new()
+    };
+
     let plan_input_states = carina_core::resource::into_plan_input_map(current_states.clone());
 
     // Build directives map from state file for orphaned resource deletion
@@ -2817,7 +2982,7 @@ fn resolve_import_target(to: &StateBlockAddress, plan: &Plan) -> ResourceId {
     if let Some(resource) = match_import_target(
         to,
         plan.effects().iter().filter_map(|effect| match effect {
-            Effect::Create(resource) => Some(resource),
+            Effect::Create(resource) => Some(resource.as_inner()),
             _ => None,
         }),
     ) {

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -6,12 +6,16 @@ use carina_core::provider::{
     BoxFuture, CreateOutcome, DeleteRequest, ProviderResult, ReadRequest, UpdateOutcome,
     UpdateRequest,
 };
-use carina_core::resource::Directives;
+use carina_core::resource::{Directives, ResolvedResource, Resource};
 
 enum ReadBehavior {
     NotFound,
     ApiError,
     NotFoundThenSuccess,
+}
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
 }
 
 struct ReadWithRetryProvider {
@@ -712,7 +716,7 @@ fn import_suppresses_create_when_target_resource_is_routed_to_named_instance() {
         Some("management".to_string()),
     );
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(Effect::Create(resolved(resource)));
 
     // The import block address has no routing slot (`StateBlockAddress`
     // is routing-agnostic by construction). The downstream resolver
@@ -2385,9 +2389,10 @@ fn delete_effect_for_binding(binding: &str) -> Effect {
 fn cert_replace_effect() -> Effect {
     let id = ResourceId::with_provider_identity("aws", "acm.Certificate", "cert", None);
     Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(id.clone()),
         from: Box::new(State::existing(id, HashMap::new()).with_identifier("cert-old-id")),
-        to: Resource::with_provider("aws", "acm.Certificate", "cert", None).with_binding("cert"),
+        to: resolved(
+            Resource::with_provider("aws", "acm.Certificate", "cert", None).with_binding("cert"),
+        ),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec![
             "domain_name".to_string(),

--- a/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
+++ b/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
@@ -7,10 +7,16 @@ use carina_cli::commands::plan::{CurrentStateEntry, PlanFile};
 use carina_core::effect::{DeferredReplaceDelete, Effect, NonEmptyDeletes};
 use carina_core::parser::{BackendConfig, DeferredForExpression, ForBinding, ProviderConfig};
 use carina_core::plan::Plan;
-use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{
+    ConcreteValue, Directives, ResolvedResource, Resource, ResourceId, State, Value,
+};
 use carina_state::{ResourceState, StateFile};
 use indexmap::IndexMap;
 use tempfile::TempDir;
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
 
 struct Scenario {
     _tmp: TempDir,
@@ -169,8 +175,8 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
     let validation_id =
         ResourceId::with_provider_identity("mock", "test.resource", "validation_records[0]", None);
     let mut plan = Plan::new();
-    plan.add(Effect::Create(lb.clone()));
-    plan.add(Effect::Create(cert.clone()));
+    plan.add(Effect::Create(resolved(lb.clone())));
+    plan.add(Effect::Create(resolved(cert.clone())));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: carina_core::resource::ResolvedResourceId::new(validation_id.clone()),
@@ -188,7 +194,7 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
         upstream_binding: "cert".to_string(),
         template: Box::new(template),
     });
-    plan.add(Effect::Create(alias.clone()));
+    plan.add(Effect::Create(resolved(alias.clone())));
 
     let sorted_resources = vec![lb.clone(), cert.clone(), alias.clone()];
     let current_states = sorted_resources

--- a/carina-cli/tests/wait_apply_module_path.rs
+++ b/carina-cli/tests/wait_apply_module_path.rs
@@ -456,7 +456,7 @@ async fn run_apply_chain(cert_publishes_arn: bool) -> (usize, usize, Vec<String>
     );
 
     let has_wait = plan.effects().iter().any(|e| {
-        matches!(e, carina_core::effect::Effect::Wait { binding, .. } if binding == "r.cert_issued")
+        matches!(e, carina_core::effect::Effect::Wait { identity, .. } if identity.as_str() == "r.cert_issued")
     });
     assert!(
         has_wait,

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -206,12 +206,12 @@ fn topological_sort(resources: &[Resource]) -> Result<Vec<Resource>, String> {
 mod tests {
     use super::*;
     use crate::effect::Effect;
-    use crate::resource::{DeferredValue, Resource, ResourceId, Value};
+    use crate::resource::{DeferredValue, Resource, ResourceId, ResourceIdentity, Value};
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
     fn wait_effect_with_explicit_dependency(binding: Option<&str>) -> Effect {
         Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "acm.Certificate",
                 "cert",

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -1055,8 +1055,8 @@ fn build_replace_rows(
             );
 
             updates.push(CascadingUpdateIR {
-                display_type: cascade.id.display_type(),
-                name: cascade.id.identity_or_empty().to_string(),
+                display_type: cascade.to.id.display_type(),
+                name: cascade.to.id.identity_or_empty().to_string(),
                 changed_attrs,
             });
         }
@@ -1887,8 +1887,12 @@ fn cascade_key_hint(path: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::{Resource, ResourceId, State};
+    use crate::resource::{ResolvedResource, Resource, ResourceId, State};
     use std::collections::HashSet;
+
+    fn resolved(resource: Resource) -> ResolvedResource {
+        ResolvedResource::new(resource)
+    }
 
     #[test]
     fn non_empty_list_of_maps_block_rejects_all_empty() {
@@ -1914,7 +1918,7 @@ mod tests {
     #[test]
     fn test_names_only_returns_empty() {
         let resource = Resource::new("s3.Bucket", "my-bucket");
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resolved(resource));
         let rows = build_detail_rows(&effect, None, DetailLevel::NamesOnly, None, None);
         assert!(rows.is_empty());
     }
@@ -1930,7 +1934,7 @@ mod tests {
                 "region",
                 Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
             );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resolved(resource));
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert_eq!(rows.len(), 2);
         assert!(matches!(&rows[0], DetailRow::Attribute { key, .. } if key == "bucket"));
@@ -1953,12 +1957,8 @@ mod tests {
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "s3.Bucket",
-                "my-bucket",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["versioning".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -2002,12 +2002,8 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("Enabled".to_string())),
             );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "s3.Bucket",
-                "my-bucket",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["versioning".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Full, None, None);
@@ -2059,12 +2055,8 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("new-value".to_string())),
             );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "s3.Bucket",
-                "my-bucket",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["trigger_diff".to_string()],
         };
 
@@ -2153,12 +2145,8 @@ mod tests {
             Value::Concrete(ConcreteValue::String("test".to_string())),
         );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "s3.Bucket",
-                "my-bucket",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["removed_attr".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -2186,12 +2174,8 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "beta",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["rules".to_string()],
         };
 
@@ -2236,7 +2220,7 @@ mod tests {
         );
         let resource = Resource::new("s3.Bucket", "my-bucket")
             .with_attribute("tags", Value::Concrete(ConcreteValue::Map(tags)));
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resolved(resource));
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert_eq!(rows.len(), 1);
         match &rows[0] {
@@ -2301,7 +2285,7 @@ mod tests {
             "policy_document",
             Value::Concrete(ConcreteValue::Map(policy)),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resolved(resource));
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         let entries = rows
             .iter()
@@ -2447,11 +2431,8 @@ mod tests {
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "ec2.Vpc", "my-vpc",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "cidr_block".to_string(),
@@ -2482,12 +2463,8 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "beta",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "legacy_token".to_string(),
@@ -2531,12 +2508,8 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "beta",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "settings".to_string(),
@@ -2588,12 +2561,8 @@ mod tests {
         );
         let to = Resource::new("test.Widget", "beta");
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "beta",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["rules".to_string()])
                 .unwrap(),
@@ -2681,12 +2650,8 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("CLOUDFRONT".to_string())),
             );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "wafv2.WebAcl",
-                "edge",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
                 .unwrap(),
@@ -2791,22 +2756,14 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(new_config)),
         );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "wafv2.WebAcl",
-                "edge",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
                 .unwrap(),
             cascading_updates: vec![CascadingUpdate {
-                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                    "cloudfront.Distribution",
-                    "cdn",
-                )),
                 from: Box::new(cascade_from),
-                to: cascade_to,
+                to: resolved(cascade_to),
             }],
             temporary_name: None,
             cascade_ref_hints: vec![],
@@ -2889,22 +2846,14 @@ mod tests {
         );
 
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "wafv2.WebAcl",
-                "edge",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
                 .unwrap(),
             cascading_updates: vec![CascadingUpdate {
-                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                    "test.RuleSet",
-                    "rules",
-                )),
                 from: Box::new(cascade_from),
-                to: cascade_to,
+                to: resolved(cascade_to),
             }],
             temporary_name: None,
             cascade_ref_hints: vec![],
@@ -2966,12 +2915,8 @@ mod tests {
             Value::Concrete(ConcreteValue::String("arn:old".to_string())),
         );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "w",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["arn".to_string()])
                 .unwrap(),
@@ -3008,12 +2953,8 @@ mod tests {
             Value::Concrete(ConcreteValue::String("arn:old".to_string())),
         );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "w",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["arn".to_string()])
                 .unwrap(),
@@ -3084,12 +3025,8 @@ mod tests {
             )])),
         );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "w",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["rules".to_string()])
                 .unwrap(),
@@ -3139,12 +3076,8 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(new_settings)),
         );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "w",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "settings".to_string(),
@@ -3184,12 +3117,8 @@ mod tests {
             )])),
         );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "w",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["aliases".to_string()])
                 .unwrap(),
@@ -3240,9 +3169,8 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("kept".to_string())),
             );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(id.clone()),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "server_defaulted_name".to_string(),
@@ -3295,12 +3223,8 @@ mod tests {
             Value::Concrete(ConcreteValue::String("new-name".to_string())),
         );
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "test.Widget",
-                "w",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: crate::resource::Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "external_name".to_string(),
@@ -3409,7 +3333,7 @@ mod tests {
                 ConcreteValue::Map(entry),
             )])),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resolved(resource));
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
 
         let pretty_value = rows.iter().find_map(|row| match row {
@@ -3435,7 +3359,7 @@ mod tests {
             "role_name",
             Value::Concrete(ConcreteValue::String("foo".to_string())),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resolved(resource));
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert!(
             rows.iter().any(|row| matches!(
@@ -3461,7 +3385,7 @@ mod tests {
                 )),
             ])),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resolved(resource));
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
 
         let pretty = rows.iter().find_map(|row| match row {
@@ -3487,7 +3411,7 @@ mod tests {
         // for empty lists, breaking the formatting-path uniformity.
         let resource = Resource::new("iam.Role", "test")
             .with_attribute("tags", Value::Concrete(ConcreteValue::List(vec![])));
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(resolved(resource));
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
         assert!(
             rows.iter().any(|row| matches!(
@@ -3598,11 +3522,8 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "iam.Role", "r",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["policy".to_string()],
         };
         let registry = iam_policy_registry();
@@ -3649,11 +3570,8 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("new".to_string())),
             );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "iam.Role", "r",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["policy".to_string(), "description".to_string()],
         };
         let registry = iam_policy_registry();
@@ -3695,11 +3613,8 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "iam.Role", "r",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["policy".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -3737,11 +3652,8 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "iam.Role", "r",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["policy".to_string()],
         };
         let registry = iam_policy_registry();
@@ -3801,9 +3713,8 @@ mod tests {
         let to = Resource::new("x.Thing", "t")
             .with_attribute("modes", mk(ConcreteValue::String("On".to_string())));
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["modes".to_string()],
         };
         let rows = build_detail_rows(&effect, Some(&registry), DetailLevel::Explicit, None, None);
@@ -3841,11 +3752,8 @@ mod tests {
             ),
         );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "iam.Role", "r",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["policy".to_string()],
         };
         let registry = iam_policy_registry();
@@ -3904,11 +3812,8 @@ mod tests {
                 Value::Concrete(ConcreteValue::String("us-east-1".to_string())),
             );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "iam.Role", "r",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["policy".to_string(), "description".to_string()],
         };
         let registry = iam_policy_registry();
@@ -3995,9 +3900,8 @@ mod tests {
         let to =
             Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["modes".to_string()],
         };
         let rows = build_detail_rows(&effect, Some(&registry), DetailLevel::Explicit, None, None);
@@ -4210,9 +4114,8 @@ mod tests {
             )])),
         );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["tags".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Full, None, None);
@@ -4253,9 +4156,8 @@ mod tests {
             )))),
         );
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["password".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);
@@ -4475,9 +4377,8 @@ mod tests {
         let to =
             Resource::new("x.Thing", "t").with_attribute("modes", enum_list(&["Allow", "Deny"]));
         let effect = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("x.Thing", "t")),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             changed_attributes: vec!["modes".to_string()],
         };
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None, None);

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -1,5 +1,9 @@
 use super::*;
-use crate::resource::{ConcreteValue, DeferredValue};
+use crate::resource::{ConcreteValue, DeferredValue, ResolvedResource};
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
 
 #[test]
 fn cascade_dependent_updates_adds_update_for_dependent() {
@@ -64,9 +68,8 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     // Build a plan with Replace for VPC (create_before_destroy)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone().with_binding("vpc")),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -95,7 +98,7 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     } = &effects[0]
     {
         assert_eq!(cascading_updates.len(), 1);
-        assert_eq!(cascading_updates[0].id, subnet_id);
+        assert_eq!(cascading_updates[0].to.id, subnet_id);
         // The `to` should have unresolved ResourceRef
         assert!(matches!(
             cascading_updates[0].to.get_attr("vpc_id"),
@@ -168,9 +171,8 @@ fn cascade_skips_resources_already_in_plan() {
     // Plan with both Replace for VPC and Update for subnet
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone()),
+        to: resolved(vpc.clone()),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -182,9 +184,8 @@ fn cascade_skips_resources_already_in_plan() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: (subnet.clone()),
+        to: resolved(subnet.clone()),
         changed_attributes: vec!["cidr_block".to_string()],
     });
 
@@ -245,9 +246,8 @@ fn cascade_no_op_without_create_before_destroy() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone()),
+        to: resolved(vpc.clone()),
         directives: Directives::default(), // create_before_destroy = false
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
             .unwrap(),
@@ -343,9 +343,8 @@ fn cascade_transitive_dependencies() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone()),
+        to: resolved(vpc.clone()),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -372,7 +371,7 @@ fn cascade_transitive_dependencies() {
     } = &plan.effects()[0]
     {
         assert_eq!(cascading_updates.len(), 1);
-        assert_eq!(cascading_updates[0].id, subnet_id);
+        assert_eq!(cascading_updates[0].to.id, subnet_id);
     } else {
         panic!("Expected Replace effect");
     }
@@ -428,9 +427,8 @@ fn cascade_anonymous_resource_dependent() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone()),
+        to: resolved(vpc.clone()),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -459,7 +457,7 @@ fn cascade_anonymous_resource_dependent() {
             1,
             "Anonymous resource should get cascading update"
         );
-        assert_eq!(cascading_updates[0].id, subnet_id);
+        assert_eq!(cascading_updates[0].to.id, subnet_id);
     } else {
         panic!("Expected Replace effect for anonymous resource test");
     }
@@ -544,9 +542,8 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
     // Build a plan with Replace for VPC (create_before_destroy)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone().with_binding("vpc")),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -585,12 +582,12 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
 
     // The VPC Replace should have no cascading updates (subnet is promoted to its own Replace)
     if let Effect::Replace {
-        id,
+        to,
         cascading_updates,
         ..
     } = &effects[0]
     {
-        assert_eq!(id, &vpc_id);
+        assert_eq!(&to.id, &vpc_id);
         assert!(
             cascading_updates.is_empty(),
             "VPC Replace should have no cascading updates; subnet should be a separate Replace"
@@ -601,13 +598,13 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
 
     // The subnet should be a Replace effect (not an Update)
     if let Effect::Replace {
-        id,
+        to,
         changed_create_only,
         cascade_ref_hints,
         ..
     } = &effects[1]
     {
-        assert_eq!(id, &subnet_id);
+        assert_eq!(&to.id, &subnet_id);
         assert!(
             changed_create_only.contains("vpc_id"),
             "Subnet Replace should list vpc_id as a changed create-only attribute"
@@ -700,9 +697,8 @@ fn cascade_generates_replace_when_create_only_list_contains_nested_ref() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -734,12 +730,12 @@ fn cascade_generates_replace_when_create_only_list_contains_nested_ref() {
 
     match &effects[1] {
         Effect::Replace {
-            id,
+            to,
             changed_create_only,
             cascade_ref_hints,
             ..
         } => {
-            assert_eq!(id, &attachment_id);
+            assert_eq!(&to.id, &attachment_id);
             assert!(changed_create_only.contains("subnet_ids"));
             assert!(
                 cascade_ref_hints.contains(&("subnet_ids".to_string(), "vpc.vpc_id".to_string()))
@@ -819,9 +815,8 @@ fn cascade_hint_prefers_resource_ref_over_binding_ref_in_mixed_list() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -942,9 +937,8 @@ fn cascade_generates_replace_when_create_only_map_contains_nested_ref() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -976,12 +970,12 @@ fn cascade_generates_replace_when_create_only_map_contains_nested_ref() {
 
     match &effects[1] {
         Effect::Replace {
-            id,
+            to,
             changed_create_only,
             cascade_ref_hints,
             ..
         } => {
-            assert_eq!(id, &tagged_id);
+            assert_eq!(&to.id, &tagged_id);
             assert!(changed_create_only.contains("tags"));
             assert!(
                 cascade_ref_hints.contains(&("tags".to_string(), "vpc.vpc_id".to_string())),
@@ -1074,9 +1068,8 @@ fn cascade_prevent_destroy_blocks_nested_map_ref_promotion_to_replace() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: vpc.clone().with_binding("vpc"),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1210,9 +1203,8 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
     // - Subnet Replace due to availability_zone change (direct change from differ)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone().with_binding("vpc")),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1224,9 +1216,8 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: (subnet.clone().with_binding("subnet")),
+        to: resolved(subnet.clone().with_binding("subnet")),
         directives: Directives::default(),
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
             "availability_zone".to_string(),
@@ -1364,9 +1355,8 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
     // Build a plan with Replace for VPC using DEFAULT directives (no explicit CBD)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone().with_binding("vpc")),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives::default(), // create_before_destroy = false (user didn't set it)
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
             .unwrap(),
@@ -1495,9 +1485,8 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
     // - Subnet Update due to tags change (non-create-only, from differ)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone().with_binding("vpc")),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1509,9 +1498,8 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: (subnet.clone().with_binding("subnet")),
+        to: resolved(subnet.clone().with_binding("subnet")),
         changed_attributes: vec!["tags".to_string()],
     });
 
@@ -1626,9 +1614,8 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
     // Build a plan with Replace for VPC (create_before_destroy)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone().with_binding("vpc")),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1760,9 +1747,8 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
     // Build a plan with Replace for VPC and Update for subnet (tags changed)
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: (vpc.clone().with_binding("vpc")),
+        to: resolved(vpc.clone().with_binding("vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -1774,9 +1760,8 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: (subnet.clone().with_binding("subnet")),
+        to: resolved(subnet.clone().with_binding("subnet")),
         changed_attributes: vec!["tags".to_string()],
     });
 

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -9,8 +9,8 @@ use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
 use crate::provider::Provider;
 use crate::resource::{
-    ConcreteValue, DataSource, Directives, PlanInputState, ResolvedResourceId, Resource,
-    ResourceId, State, Value,
+    ConcreteValue, DataSource, Directives, PlanInputState, ResolvedDataSource, ResolvedResource,
+    ResolvedResourceId, Resource, ResourceId, ResourceIdentity, State, Value,
 };
 use crate::schema::{
     ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
@@ -272,7 +272,7 @@ pub fn create_plan(
     // longer reachable from this loop (carina#3179).
     for ds in data_sources {
         plan.add(Effect::Read {
-            resource: ds.clone(),
+            resource: ResolvedDataSource::new(ds.clone()),
         });
     }
 
@@ -298,7 +298,7 @@ pub fn create_plan(
         );
 
         match d {
-            Diff::Create(r) => plan.add(Effect::Create(r)),
+            Diff::Create(r) => plan.add(Effect::Create(ResolvedResource::new(r))),
             Diff::Update {
                 id,
                 from,
@@ -366,9 +366,8 @@ pub fn create_plan(
                     };
 
                     plan.add(Effect::Replace {
-                        id: ResolvedResourceId::new(id),
                         from,
-                        to,
+                        to: ResolvedResource::new(to),
                         directives,
                         changed_create_only,
                         cascading_updates: vec![],
@@ -377,9 +376,8 @@ pub fn create_plan(
                     });
                 } else {
                     plan.add(Effect::Update {
-                        id: ResolvedResourceId::new(id),
                         from,
-                        to,
+                        to: ResolvedResource::new(to),
                         changed_attributes,
                     });
                 }
@@ -630,10 +628,7 @@ pub fn create_plan(
         ));
 
         plan.add(Effect::Wait {
-            // Lower BindingName -> String at the AST→Effect seam: the
-            // executor IR (Effect) is string-keyed and is the separate
-            // type tracked for its own newtype migration (carina#3066).
-            binding: wb.binding.as_str().to_string(),
+            identity: ResourceIdentity::new(wb.binding.as_str()),
             target_id: ResolvedResourceId::new(target_id),
             until,
             until_surface: wb.until_raw.clone(),
@@ -704,10 +699,10 @@ pub fn cascade_dependent_updates(
             .effects()
             .iter()
             .filter_map(|e| {
-                if let Effect::Replace { id, directives, .. } = e {
+                if let Effect::Replace { to, directives, .. } = e {
                     // Only consider Replace effects that are NOT already CBD
                     if !directives.create_before_destroy {
-                        e.binding_name().map(|b| (b, id.clone().into_inner()))
+                        e.binding_name().map(|b| (b, to.id.clone()))
                     } else {
                         None
                     }
@@ -815,7 +810,7 @@ pub fn cascade_dependent_updates(
                 let is_update_in_plan = plan
                     .effects()
                     .iter()
-                    .any(|e| matches!(e, Effect::Update { id, .. } if *id == resource.id));
+                    .any(|e| matches!(e, Effect::Update { to, .. } if to.id == resource.id));
                 if is_update_in_plan && resource.directives.prevent_destroy {
                     plan.add_error(PlanError {
                         resource_id: resource.id.clone(),
@@ -903,9 +898,8 @@ pub fn cascade_dependent_updates(
 
                         // Promote to a separate Replace effect
                         promoted_replaces.push(Effect::Replace {
-                            id: ResolvedResourceId::new(unresolved.id.clone()),
                             from: Box::new(from),
-                            to: (*unresolved).clone(),
+                            to: ResolvedResource::new((*unresolved).clone()),
                             directives: unresolved.directives.clone(),
                             changed_create_only,
                             cascading_updates: vec![],
@@ -919,9 +913,8 @@ pub fn cascade_dependent_updates(
                         .entry(replaced_binding.clone())
                         .or_default()
                         .push(CascadingUpdate {
-                            id: ResolvedResourceId::new(unresolved.id.clone()),
                             from: Box::new(from),
-                            to: (*unresolved).clone(),
+                            to: ResolvedResource::new((*unresolved).clone()),
                         });
                 }
             }

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -1335,7 +1335,7 @@ fn wait_binding_lowers_to_wait_effect() {
         .find(|e| e.is_wait())
         .expect("expected Wait effect");
     let Effect::Wait {
-        binding,
+        identity,
         target_id,
         until,
         until_surface,
@@ -1345,7 +1345,7 @@ fn wait_binding_lowers_to_wait_effect() {
     else {
         unreachable!();
     };
-    assert_eq!(binding, "cert_issued");
+    assert_eq!(identity.as_str(), "cert_issued");
     assert_eq!(target_id.identity_str(), "cert");
     assert_eq!(target_id.resource_type, "acm.Certificate");
     assert_eq!(
@@ -1748,9 +1748,9 @@ fn wait_emitted_when_a_consumer_has_a_pending_change() {
     );
 
     assert!(
-        plan.effects()
-            .iter()
-            .any(|e| matches!(e, Effect::Wait { binding, .. } if binding == "cert_issued")),
+        plan.effects().iter().any(
+            |e| matches!(e, Effect::Wait { identity, .. } if identity.as_str() == "cert_issued")
+        ),
         "carina#3101: the wait must still be emitted when a consumer \
          has a pending change (carina#3085/#3061 not regressed); \
          effects were {:?}",
@@ -1877,9 +1877,9 @@ fn wait_emitted_when_target_is_changing_even_if_cached_state_satisfies() {
     );
 
     assert!(
-        plan.effects()
-            .iter()
-            .any(|e| matches!(e, Effect::Wait { binding, .. } if binding == "cert_issued")),
+        plan.effects().iter().any(
+            |e| matches!(e, Effect::Wait { identity, .. } if identity.as_str() == "cert_issued")
+        ),
         "carina#3358: the wait must still be emitted when its target is \
          changing in this plan (cached state is stale); effects were {:?}",
         plan.effects()
@@ -1962,15 +1962,15 @@ fn wait_emitted_when_known_target_has_pending_update_even_if_cached_state_satisf
     assert!(
         plan.effects()
             .iter()
-            .any(|e| matches!(e, Effect::Update { id, .. }
-            if id == &ResourceId::with_identity("acm.Certificate", "cert"))),
+            .any(|e| matches!(e, Effect::Update { to, .. }
+            if to.id == ResourceId::with_identity("acm.Certificate", "cert"))),
         "test precondition: cert must have a pending Update; effects were {:?}",
         plan.effects()
     );
     assert!(
-        plan.effects()
-            .iter()
-            .any(|e| matches!(e, Effect::Wait { binding, .. } if binding == "cert_issued")),
+        plan.effects().iter().any(
+            |e| matches!(e, Effect::Wait { identity, .. } if identity.as_str() == "cert_issued")
+        ),
         "carina#3358: the wait must still be emitted when an existing \
          (Known) target has a pending Update, even though its cached \
          state satisfies the predicate; effects were {:?}",

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -18,7 +18,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::non_empty::NonEmptyVec;
 use crate::parser::DeferredForExpression;
-use crate::resource::{DataSource, Directives, ResolvedResourceId, Resource, ResourceId, State};
+#[cfg(test)]
+use crate::resource::{DataSource, Resource};
+use crate::resource::{
+    Directives, ResolvedDataSource, ResolvedResource, ResolvedResourceId, ResourceId,
+    ResourceIdentity, State,
+};
 use crate::wait::predicate::WaitPredicate;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -65,9 +70,8 @@ pub struct TemporaryName {
 /// newly created resource's state.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CascadingUpdate {
-    pub id: ResolvedResourceId,
     pub from: Box<State>,
-    pub to: Resource,
+    pub to: ResolvedResource,
 }
 
 /// Delete payload absorbed into [`Effect::DeferredReplace`].
@@ -242,25 +246,23 @@ impl From<ChangedCreateOnly> for Vec<String> {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Effect {
     /// Read the current state of a resource (data source)
-    Read { resource: DataSource },
+    Read { resource: ResolvedDataSource },
 
     /// Create a new resource
-    Create(Resource),
+    Create(ResolvedResource),
 
     /// Update an existing resource
     Update {
-        id: ResolvedResourceId,
         from: Box<State>,
-        to: Resource,
+        to: ResolvedResource,
         /// Attribute names that changed (including removed attributes)
         changed_attributes: Vec<String>,
     },
 
     /// Replace a resource (delete then create) due to create-only property changes
     Replace {
-        id: ResolvedResourceId,
         from: Box<State>,
-        to: Resource,
+        to: ResolvedResource,
         #[serde(default)]
         directives: Directives,
         /// Which create-only attributes forced the replacement
@@ -343,8 +345,8 @@ pub enum Effect {
     /// re-evaluated on every plan/apply. See
     /// `notes/specs/2026-05-09-wait-construct-design.md` §State file.
     Wait {
-        /// The wait's binding name (e.g. `"cert_issued"`).
-        binding: String,
+        /// The wait's own identity (e.g. `"cert_issued"`).
+        identity: ResourceIdentity,
         /// Resolved id of the target resource (`wait cert { ... }` →
         /// `cert`'s `ResourceId`).
         target_id: ResolvedResourceId,
@@ -428,13 +430,12 @@ pub enum Effect {
 pub enum BasicEffect<'a> {
     Create {
         effect: &'a Effect,
-        resource: &'a Resource,
+        resource: &'a ResolvedResource,
     },
     Update {
         effect: &'a Effect,
-        id: &'a ResourceId,
         from: &'a State,
-        to: &'a Resource,
+        to: &'a ResolvedResource,
         changed_attributes: &'a [String],
     },
     Delete {
@@ -504,19 +505,18 @@ impl Effect {
         effect_cases![
             (
                 Effect::Read {
-                    resource: DataSource::new("test", "x"),
+                    resource: ResolvedDataSource::new(DataSource::new("test", "x")),
                 },
                 Effect::Read { .. }
             ),
             (
-                Effect::Create(Resource::new("test", "x")),
+                Effect::Create(ResolvedResource::new(Resource::new("test", "x"))),
                 Effect::Create(_)
             ),
             (
                 Effect::Update {
-                    id: crate::resource::ResolvedResourceId::new(id.clone()),
                     from: Box::new(State::not_found(id.clone())),
-                    to: Resource::new("test", "x"),
+                    to: ResolvedResource::new(Resource::new("test", "x")),
                     changed_attributes: vec![],
                 },
                 Effect::Update { .. }
@@ -560,7 +560,7 @@ impl Effect {
             ),
             (
                 Effect::Wait {
-                    binding: "w".to_string(),
+                    identity: ResourceIdentity::new("w"),
                     target_id: crate::resource::ResolvedResourceId::new(id.clone()),
                     until: WaitPredicate::Equals {
                         attr: AttrPath::single("status"),
@@ -641,9 +641,8 @@ impl Effect {
         };
 
         Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(id.clone()),
             from: Box::new(State::not_found(id)),
-            to: Resource::new("test", "x"),
+            to: ResolvedResource::new(Resource::new("test", "x")),
             directives,
             changed_create_only: ChangedCreateOnly::new(vec!["attr".to_string()]).unwrap(),
             cascading_updates: vec![],
@@ -694,8 +693,8 @@ impl Effect {
     ///
     /// ```compile_fail
     /// use carina_core::effect::{BasicEffect, Effect};
-    /// use carina_core::resource::Resource;
-    /// let effect = Effect::Create(Resource::new("test", "x"));
+    /// use carina_core::resource::{ResolvedResource, Resource};
+    /// let effect = Effect::Create(ResolvedResource::new(Resource::new("test", "x")));
     /// // Was: a missed filter could pass a non-basic `&Effect` straight
     /// // into `execute_basic_effect` and trip `unreachable!()` at apply
     /// // time (carina#3164). The conversion no longer exists.
@@ -708,13 +707,11 @@ impl Effect {
                 resource,
             }),
             Effect::Update {
-                id,
                 from,
                 to,
                 changed_attributes,
             } => Some(BasicEffect::Update {
                 effect: self,
-                id,
                 from,
                 to,
                 changed_attributes,
@@ -823,8 +820,8 @@ impl Effect {
         match self {
             Effect::Read { resource } => &resource.id,
             Effect::Create(r) => &r.id,
-            Effect::Update { id, .. } => id,
-            Effect::Replace { id, .. } => id,
+            Effect::Update { to, .. } => &to.id,
+            Effect::Replace { to, .. } => &to.id,
             Effect::Delete { id, .. } => id,
             Effect::Import { id, .. } => id,
             Effect::Remove { id, .. } => id,
@@ -872,7 +869,7 @@ impl Effect {
             Effect::Import { .. } => None,
             Effect::Remove { .. } => None,
             Effect::Move { .. } => None,
-            Effect::Wait { binding, .. } => Some(binding.clone()),
+            Effect::Wait { identity, .. } => Some(identity.to_string()),
             // INVARIANT: DeferredCreate has no binding identity until the
             // upstream resolves at apply time (the iterable's cardinality is
             // unknown), so binding_name() is None. DeferredReplace already
@@ -1250,25 +1247,26 @@ mod tests {
             (
                 "Read",
                 Effect::Read {
-                    resource: DataSource::new("test", "x"),
+                    resource: ResolvedDataSource::new(DataSource::new("test", "x")),
                 },
             ),
-            ("Create", Effect::Create(Resource::new("test", "x"))),
+            (
+                "Create",
+                Effect::Create(ResolvedResource::new(Resource::new("test", "x"))),
+            ),
             (
                 "Update",
                 Effect::Update {
-                    id: crate::resource::ResolvedResourceId::new(rid.clone()),
                     from: Box::new(State::not_found(rid.clone())),
-                    to: Resource::new("test", "x"),
+                    to: ResolvedResource::new(Resource::new("test", "x")),
                     changed_attributes: vec![],
                 },
             ),
             (
                 "Replace",
                 Effect::Replace {
-                    id: crate::resource::ResolvedResourceId::new(rid.clone()),
                     from: Box::new(State::not_found(rid.clone())),
-                    to: Resource::new("test", "x"),
+                    to: ResolvedResource::new(Resource::new("test", "x")),
                     directives: Directives::default(),
                     changed_create_only: ChangedCreateOnly::new(vec!["attr".to_string()]).unwrap(),
                     cascading_updates: vec![],
@@ -1312,7 +1310,7 @@ mod tests {
             (
                 "Wait",
                 Effect::Wait {
-                    binding: "w".to_string(),
+                    identity: ResourceIdentity::new("w"),
                     target_id: crate::resource::ResolvedResourceId::new(rid),
                     until: WaitPredicate::Equals {
                         attr: AttrPath::single("status"),
@@ -1557,14 +1555,16 @@ mod tests {
     #[test]
     fn read_is_not_mutating() {
         let resource = DataSource::new("test", "example");
-        let effect = Effect::Read { resource };
+        let effect = Effect::Read {
+            resource: ResolvedDataSource::new(resource),
+        };
         assert!(!effect.is_mutating());
     }
 
     #[test]
     fn create_is_mutating() {
         let resource = Resource::new("s3.Bucket", "my-bucket");
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(ResolvedResource::new(resource));
         assert!(effect.is_mutating());
     }
 
@@ -1572,7 +1572,7 @@ mod tests {
     fn resource_id_returns_correct_id() {
         let resource = DataSource::new("s3.Bucket", "my-bucket");
         let effect = Effect::Read {
-            resource: resource.clone(),
+            resource: ResolvedDataSource::new(resource.clone()),
         };
         assert_eq!(effect.resource_id(), &resource.id);
     }
@@ -1580,7 +1580,7 @@ mod tests {
     #[test]
     fn resource_returns_some_for_create() {
         let resource = Resource::new("s3.Bucket", "my-bucket");
-        let effect = Effect::Create(resource.clone());
+        let effect = Effect::Create(ResolvedResource::new(resource.clone()));
         assert_eq!(effect.as_resource_ref().unwrap().id(), &resource.id);
     }
 
@@ -1600,7 +1600,7 @@ mod tests {
     #[test]
     fn binding_name_returns_binding() {
         let resource = Resource::new("test", "my_binding").with_binding("my_binding");
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(ResolvedResource::new(resource));
         assert_eq!(effect.binding_name(), Some("my_binding".to_string()));
     }
 
@@ -1611,7 +1611,7 @@ mod tests {
             "name",
             Value::Concrete(ConcreteValue::String("test".to_string())),
         );
-        let effect = Effect::Create(resource);
+        let effect = Effect::Create(ResolvedResource::new(resource));
         assert_eq!(effect.binding_name(), None);
     }
 
@@ -1621,15 +1621,14 @@ mod tests {
         use std::collections::HashMap;
 
         let effects = vec![
-            Effect::Create(Resource::new("s3.Bucket", "my-bucket")),
+            Effect::Create(ResolvedResource::new(Resource::new(
+                "s3.Bucket",
+                "my-bucket",
+            ))),
             Effect::Read {
-                resource: DataSource::new("s3.Bucket", "existing"),
+                resource: ResolvedDataSource::new(DataSource::new("s3.Bucket", "existing")),
             },
             Effect::Update {
-                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                    "s3.Bucket",
-                    "my-bucket",
-                )),
                 from: Box::new(State::existing(
                     ResourceId::with_identity("s3.Bucket", "my-bucket"),
                     HashMap::from([(
@@ -1637,16 +1636,13 @@ mod tests {
                         Value::Concrete(ConcreteValue::String("Disabled".to_string())),
                     )]),
                 )),
-                to: Resource::new("s3.Bucket", "my-bucket").with_attribute(
+                to: ResolvedResource::new(Resource::new("s3.Bucket", "my-bucket").with_attribute(
                     "versioning",
                     Value::Concrete(ConcreteValue::String("Enabled".to_string())),
-                ),
+                )),
                 changed_attributes: vec!["versioning".to_string()],
             },
             Effect::Replace {
-                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                    "ec2.Vpc", "my-vpc",
-                )),
                 from: Box::new(State::existing(
                     ResourceId::with_identity("ec2.Vpc", "my-vpc"),
                     HashMap::from([(
@@ -1654,29 +1650,27 @@ mod tests {
                         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
                     )]),
                 )),
-                to: Resource::new("ec2.Vpc", "my-vpc").with_attribute(
+                to: ResolvedResource::new(Resource::new("ec2.Vpc", "my-vpc").with_attribute(
                     "cidr_block",
                     Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-                ),
+                )),
                 directives: Directives::default(),
                 changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                     "cidr_block".to_string(),
                 ])
                 .unwrap(),
-                // carina#3181 PR D: cover `CascadingUpdate.to:
-                // Resource` in the serde round-trip.
+                // carina#3181 PR D: cover `CascadingUpdate.to` in
+                // the serde round-trip.
                 cascading_updates: vec![CascadingUpdate {
-                    id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                        "ec2.Subnet",
-                        "my-subnet",
-                    )),
                     from: Box::new(State::not_found(ResourceId::with_identity(
                         "ec2.Subnet",
                         "my-subnet",
                     ))),
-                    to: Resource::new("ec2.Subnet", "my-subnet").with_attribute(
-                        "vpc_id",
-                        Value::Concrete(ConcreteValue::String("vpc.id".to_string())),
+                    to: ResolvedResource::new(
+                        Resource::new("ec2.Subnet", "my-subnet").with_attribute(
+                            "vpc_id",
+                            Value::Concrete(ConcreteValue::String("vpc.id".to_string())),
+                        ),
                     ),
                 }],
                 temporary_name: None,
@@ -1724,9 +1718,8 @@ mod tests {
     #[test]
     fn replace_changed_create_only_serializes_as_plain_array() {
         let effect = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("test", "x")),
             from: Box::new(State::not_found(ResourceId::with_identity("test", "x"))),
-            to: Resource::new("test", "x"),
+            to: ResolvedResource::new(Resource::new("test", "x")),
             directives: Directives::default(),
             changed_create_only: ChangedCreateOnly::new(vec!["x".to_string()]).unwrap(),
             cascading_updates: vec![],
@@ -1747,7 +1740,6 @@ mod tests {
     fn replace_deserialize_rejects_empty_changed_create_only() {
         let json = serde_json::json!({
             "Replace": {
-                "id": {"provider": "", "resource_type": "test", "name": "x"},
                 "from": {
                     "id": {"provider": "", "resource_type": "test", "name": "x"},
                     "identifier": "x-1",
@@ -1784,7 +1776,7 @@ mod tests {
             depends_on: vec!["role".to_string(), "kms".to_string()],
             ..Directives::default()
         };
-        let create = Effect::Create(bucket.clone());
+        let create = Effect::Create(ResolvedResource::new(bucket.clone()));
         let got = create.explicit_dependencies();
         assert!(got.contains("role") && got.contains("kms"), "got {:?}", got);
     }
@@ -1876,7 +1868,7 @@ mod tests {
         use std::time::Duration;
 
         let _ = Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "acm.Certificate",
                 "cert",
@@ -1899,7 +1891,7 @@ mod tests {
         use std::time::Duration;
 
         let e = Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "acm.Certificate",
                 "cert",
@@ -1923,7 +1915,7 @@ mod tests {
         use std::time::Duration;
 
         let e = Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "acm.Certificate",
                 "cert",
@@ -1948,7 +1940,7 @@ mod tests {
         use std::time::Duration;
 
         let original = Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "acm.Certificate",
                 "cert",
@@ -1970,6 +1962,7 @@ mod tests {
             "expected `\"timeout\":4500` in JSON, got: {}",
             json
         );
+        assert!(json.contains("\"identity\":\"cert_issued\""), "got: {json}");
         let decoded: Effect = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, original);
     }
@@ -1986,16 +1979,15 @@ mod tests {
         let rid = ResourceId::with_identity("test", "x");
 
         // Basic variants must narrow.
-        let create = Effect::Create(Resource::new("test", "x"));
+        let create = Effect::Create(ResolvedResource::new(Resource::new("test", "x")));
         assert!(matches!(
             create.as_basic(),
             Some(BasicEffect::Create { .. })
         ));
 
         let update = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(rid.clone()),
             from: Box::new(ResState::not_found(rid.clone())),
-            to: Resource::new("test", "x"),
+            to: ResolvedResource::new(Resource::new("test", "x")),
             changed_attributes: vec![],
         };
         assert!(matches!(
@@ -2021,12 +2013,11 @@ mod tests {
         // inside `as_basic` is what catches it at compile time; this
         // test catches misclassification of an existing variant.
         let read = Effect::Read {
-            resource: DataSource::new("test", "x"),
+            resource: ResolvedDataSource::new(DataSource::new("test", "x")),
         };
         let replace = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(rid.clone()),
             from: Box::new(ResState::not_found(rid.clone())),
-            to: Resource::new("test", "x"),
+            to: ResolvedResource::new(Resource::new("test", "x")),
             directives: Directives::default(),
             changed_create_only: ChangedCreateOnly::new(vec!["attr".to_string()]).unwrap(),
             cascading_updates: vec![],
@@ -2047,7 +2038,7 @@ mod tests {
             to: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("test", "y")),
         };
         let wait = Effect::Wait {
-            binding: "w".to_string(),
+            identity: ResourceIdentity::new("w"),
             target_id: crate::resource::ResolvedResourceId::new(rid.clone()),
             until: WaitPredicate::Equals {
                 attr: crate::wait::predicate::AttrPath::single("status"),

--- a/carina-core/src/effect/deps.rs
+++ b/carina-core/src/effect/deps.rs
@@ -499,7 +499,7 @@ pub fn relax_update_update_edges(effects: &[Effect], analysis: &mut DependencyAn
 mod tests {
     use super::*;
     use crate::effect::ChangedCreateOnly;
-    use crate::resource::{State, Value};
+    use crate::resource::{ResolvedResource, State, Value};
 
     fn state_for(id: &ResourceId) -> State {
         State::not_found(id.clone())
@@ -515,9 +515,8 @@ mod tests {
             );
         }
         Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(resource.id.clone()),
             from: Box::new(state_for(&resource.id)),
-            to: resource,
+            to: ResolvedResource::new(resource),
             changed_attributes: changed.iter().map(|s| (*s).to_string()).collect(),
         }
     }
@@ -617,14 +616,10 @@ mod tests {
         to.binding = Some("replace_me".to_string());
 
         let effects = vec![
-            Effect::Create(x),
+            Effect::Create(ResolvedResource::new(x)),
             Effect::Replace {
-                id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                    "test",
-                    "replace_me",
-                )),
                 from: Box::new(from),
-                to,
+                to: ResolvedResource::new(to),
                 directives: Default::default(),
                 changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
                 cascading_updates: Vec::new(),
@@ -677,7 +672,7 @@ mod tests {
             .filter_map(|effect| match effect {
                 Effect::Update { to, .. } => Some((
                     effect.resource_id().clone(),
-                    UnresolvedResource::from_pre_resolve(to.clone()),
+                    UnresolvedResource::from_pre_resolve(to.as_inner().clone()),
                 )),
                 _ => None,
             })

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -27,9 +27,8 @@ use super::wait::AppliedStates;
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 
 /// Private capability token for constructing [`ResolvedResource`].
-/// Only this module can create a value, so the checked constructor in
-/// `resource` cannot be used by sibling modules as a convention-only
-/// escape hatch.
+/// Only this module can request the provider-dispatch constructor that
+/// also checks the resource for unresolved value placeholders.
 pub(crate) struct ResolvedResourceToken(());
 
 /// Result of executing a basic effect (Create, Update, or Delete).
@@ -201,7 +200,7 @@ pub(super) async fn resolve_resource_with_source(
 pub(super) fn resolved_resource(
     resource: Resource,
 ) -> Result<ResolvedResource, SerializationError> {
-    ResolvedResource::new(resource, ResolvedResourceToken(()))
+    ResolvedResource::new_fully_resolved(resource, ResolvedResourceToken(()))
 }
 
 pub(super) fn resolved_normalized_resource(
@@ -584,15 +583,15 @@ pub(super) async fn execute_basic_effect<'a>(
             }
         }
         BasicEffect::Update {
-            id,
             from,
             to,
             changed_attributes,
             ..
         } => {
+            let id = &to.id;
             let resolve_source = unresolved
                 .get(id)
-                .map_or(to, UnresolvedResource::as_resource);
+                .map_or(to.as_inner(), UnresolvedResource::as_resource);
             let resolved_to =
                 match resolve_resource_with_source(to, resolve_source, bindings, pipeline).await {
                     Ok(r) => r,

--- a/carina-core/src/executor/deferred_dispatch.rs
+++ b/carina-core/src/executor/deferred_dispatch.rs
@@ -5,6 +5,7 @@ use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
 use crate::parser::{DeferredForExpression, ShapeMismatch, expand_deferred_children};
+use crate::resource::ResolvedResource;
 
 /// Failure while expanding a deferred-for create half against apply-time
 /// upstream state.
@@ -90,7 +91,7 @@ pub(super) fn materialize_deferred_create(
                 resource.dependency_bindings.contains(upstream_binding),
                 "apply-time deferred-for child must retain iterable dependency"
             );
-            Effect::Create(resource)
+            Effect::Create(ResolvedResource::new(resource))
         })
         .collect())
 }

--- a/carina-core/src/executor/normalized.rs
+++ b/carina-core/src/executor/normalized.rs
@@ -50,7 +50,7 @@ impl NormalizedResource {
         self,
         token: crate::executor::basic::ResolvedResourceToken,
     ) -> Result<ResolvedResource, crate::value::SerializationError> {
-        ResolvedResource::new(self.0, token)
+        ResolvedResource::new_fully_resolved(self.0, token)
     }
 }
 

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -318,7 +318,7 @@ pub(super) async fn execute_effects_sequential(
                         for child in children {
                             let child_idx = effects.len();
                             if let Effect::Create(resource) = &child {
-                                runtime_synthesized_resources.push(resource.clone());
+                                runtime_synthesized_resources.push(resource.clone().into_inner());
                             }
                             if let Some(binding) = failure_binding_name(&child) {
                                 idx_to_binding.insert(child_idx, binding);
@@ -385,7 +385,6 @@ pub(super) async fn execute_effects_sequential(
                             unreachable!("Create/Update/Delete are narrowed by as_basic()")
                         }
                         Effect::Replace {
-                            id,
                             from,
                             to,
                             directives,
@@ -407,7 +406,7 @@ pub(super) async fn execute_effects_sequential(
                                 provider,
                                 &ReplaceContext {
                                     effect: &effect_for_future,
-                                    id,
+                                    id: &to.id,
                                     from,
                                     to,
                                     directives,
@@ -435,7 +434,7 @@ pub(super) async fn execute_effects_sequential(
                             "DeferredReplace is handled synchronously before provider dispatch"
                         ),
                         Effect::Wait {
-                            binding,
+                            identity,
                             target_id,
                             until,
                             timeout,
@@ -466,7 +465,7 @@ pub(super) async fn execute_effects_sequential(
                             )
                             .await;
                             SingleEffectResult::Wait {
-                                binding: binding.clone(),
+                                binding: identity.to_string(),
                                 outcome,
                                 duration: started.elapsed(),
                                 progress,
@@ -741,7 +740,9 @@ mod tests {
         BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
         ReadRequest, UpdateRequest,
     };
-    use crate::resource::{Composition, ConcreteValue, DataSource, State, Value};
+    use crate::resource::{
+        Composition, ConcreteValue, DataSource, ResolvedResource, ResourceIdentity, State, Value,
+    };
     use crate::schema::SchemaRegistry;
     use crate::wait::predicate::{AttrPath, WaitPredicate};
     use std::collections::BTreeSet;
@@ -755,6 +756,10 @@ mod tests {
         State::existing(id.clone(), HashMap::new()).with_identifier("id")
     }
 
+    fn resolved(resource: Resource) -> ResolvedResource {
+        ResolvedResource::new(resource)
+    }
+
     fn update_effect(binding: &str, reads: &[(&str, &str)], writes: &[&str]) -> Effect {
         let id = ResourceId::with_identity("test", binding);
         let mut to = Resource::new("test", binding);
@@ -766,9 +771,8 @@ mod tests {
             );
         }
         Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(id.clone()),
             from: Box::new(state_for(&id)),
-            to,
+            to: resolved(to),
             changed_attributes: writes.iter().map(|attr| (*attr).to_string()).collect(),
         }
     }
@@ -784,9 +788,8 @@ mod tests {
             );
         }
         Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(id.clone()),
             from: Box::new(state_for(&id)),
-            to,
+            to: resolved(to),
             directives: Default::default(),
             changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
             cascading_updates: Vec::new(),
@@ -942,7 +945,7 @@ mod tests {
                 | Effect::Update { to: resource, .. }
                 | Effect::Replace { to: resource, .. } => Some((
                     resource.id.clone(),
-                    UnresolvedResource::from_pre_resolve(resource.clone()),
+                    UnresolvedResource::from_pre_resolve(resource.as_inner().clone()),
                 )),
                 Effect::DeferredReplace { .. } => None,
                 _ => None,
@@ -966,9 +969,9 @@ mod tests {
         alb.binding = Some("alb".to_string());
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(cert.clone()));
+        plan.add(Effect::Create(resolved(cert.clone())));
         plan.add(Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
@@ -979,7 +982,7 @@ mod tests {
             interval: std::time::Duration::from_millis(1),
             explicit_dependencies: std::collections::HashSet::new(),
         });
-        plan.add(Effect::Create(alb.clone()));
+        plan.add(Effect::Create(resolved(alb.clone())));
 
         let unresolved = HashMap::from([
             (
@@ -1060,9 +1063,9 @@ mod tests {
         );
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(cert.clone()));
+        plan.add(Effect::Create(resolved(cert.clone())));
         plan.add(Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
@@ -1073,8 +1076,8 @@ mod tests {
             interval: std::time::Duration::from_millis(1),
             explicit_dependencies: std::collections::HashSet::new(),
         });
-        plan.add(Effect::Create(alb.clone()));
-        plan.add(Effect::Create(listener.clone()));
+        plan.add(Effect::Create(resolved(alb.clone())));
+        plan.add(Effect::Create(resolved(listener.clone())));
 
         let unresolved = HashMap::from([
             (
@@ -1163,7 +1166,9 @@ mod tests {
         assert!(ReadsSet::from_walker(KnownReads::from_attrs(&["id"])).disjoint(&writes));
         assert!(!ReadsSet::from_walker(KnownReads::from_attrs(&["tags"])).disjoint(&writes));
         assert!(!ReadsSet::unknown().disjoint(&writes));
-        assert!(WritesSet::from_update(&Effect::Create(Resource::new("test", "x"))).is_none());
+        assert!(
+            WritesSet::from_update(&Effect::Create(resolved(Resource::new("test", "x")))).is_none()
+        );
     }
 
     #[test]
@@ -1188,7 +1193,7 @@ mod tests {
     fn keep_update_update_edge_for_bare_binding_unknown_read() {
         let parent = update_effect("parent", &[], &["cidr_block"]);
         let mut child = match update_effect("child", &[], &["name"]) {
-            Effect::Update { to, .. } => to,
+            Effect::Update { to, .. } => to.into_inner(),
             _ => unreachable!(),
         };
         child.set_attr(
@@ -1198,9 +1203,8 @@ mod tests {
             }),
         );
         let child = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(child.id.clone()),
             from: Box::new(state_for(&child.id)),
-            to: child,
+            to: resolved(child),
             changed_attributes: vec!["name".to_string()],
         };
 
@@ -1212,14 +1216,13 @@ mod tests {
     fn keep_update_update_edge_when_known_read_also_has_depends_on_unknown() {
         let parent = update_effect("parent", &[], &["tags"]);
         let mut child = match update_effect("child", &[("parent", "id")], &["name"]) {
-            Effect::Update { to, .. } => to,
+            Effect::Update { to, .. } => to.into_inner(),
             _ => unreachable!(),
         };
         child.directives.depends_on.push("parent".to_string());
         let child = Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(child.id.clone()),
             from: Box::new(state_for(&child.id)),
-            to: child,
+            to: resolved(child),
             changed_attributes: vec!["name".to_string()],
         };
 
@@ -1234,7 +1237,7 @@ mod tests {
     fn dependency_bindings_only_path_escalates_to_unknown() {
         let parent = update_effect("parent", &[], &["tags"]);
         let mut child = match update_effect("child", &[], &["name"]) {
-            Effect::Update { to, .. } => to,
+            Effect::Update { to, .. } => to.into_inner(),
             _ => unreachable!(),
         };
         child.dependency_bindings.insert("parent".to_string());
@@ -1242,9 +1245,8 @@ mod tests {
         let effects = vec![
             parent,
             Effect::Update {
-                id: crate::resource::ResolvedResourceId::new(child_id.clone()),
                 from: Box::new(state_for(&child_id)),
-                to: child.clone(),
+                to: resolved(child.clone()),
                 changed_attributes: vec!["name".to_string()],
             },
         ];
@@ -1252,7 +1254,7 @@ mod tests {
             (
                 effects[0].resource_id().clone(),
                 UnresolvedResource::from_pre_resolve(match &effects[0] {
-                    Effect::Update { to, .. } => to.clone(),
+                    Effect::Update { to, .. } => to.as_inner().clone(),
                     _ => unreachable!(),
                 }),
             ),
@@ -1280,7 +1282,7 @@ mod tests {
         let mut parent = Resource::new("test", "parent");
         parent.binding = Some("parent".to_string());
         let deps = dependency_after_relax(
-            Effect::Create(parent),
+            Effect::Create(resolved(parent)),
             update_effect("child", &[("parent", "id")], &["tags"]),
         );
         assert!(
@@ -1305,7 +1307,7 @@ mod tests {
     fn keep_update_update_edge_for_composition_expansion_unknown_read() {
         let parent = update_effect("parent", &[], &["tags"]);
         let mut child = match update_effect("child", &[], &["name"]) {
-            Effect::Update { to, .. } => to,
+            Effect::Update { to, .. } => to.into_inner(),
             _ => unreachable!(),
         };
         child.set_attr(
@@ -1340,9 +1342,8 @@ mod tests {
         let effects = vec![
             parent,
             Effect::Update {
-                id: crate::resource::ResolvedResourceId::new(child_id.clone()),
                 from: Box::new(state_for(&child_id)),
-                to: child.clone(),
+                to: resolved(child.clone()),
                 changed_attributes: vec!["name".to_string()],
             },
         ];
@@ -1350,7 +1351,7 @@ mod tests {
             (
                 effects[0].resource_id().clone(),
                 UnresolvedResource::from_pre_resolve(match &effects[0] {
-                    Effect::Update { to, .. } => to.clone(),
+                    Effect::Update { to, .. } => to.as_inner().clone(),
                     _ => unreachable!(),
                 }),
             ),
@@ -1391,7 +1392,7 @@ mod tests {
         let child = Resource::new("test", "child");
         let effects = vec![
             update_effect("parent", &[], &["tags"]),
-            Effect::Create(child),
+            Effect::Create(resolved(child)),
         ];
         let mut analysis =
             build_dependency_analysis(&effects, &HashMap::new(), &[], ScheduleInputs::Apply);
@@ -1438,8 +1439,8 @@ mod tests {
         );
 
         let effects = vec![
-            Effect::Create(role.clone()),
-            Effect::Create(role_policy.clone()),
+            Effect::Create(resolved(role.clone())),
+            Effect::Create(resolved(role_policy.clone())),
         ];
 
         let mut unresolved: HashMap<ResourceId, UnresolvedResource> = HashMap::new();

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -278,7 +278,7 @@ pub(super) async fn execute_effects_phased(
     let replaced_ids: HashSet<ResourceId> = effects
         .iter()
         .filter_map(|effect| match effect {
-            Effect::Replace { id, .. } => Some(id.clone().into_inner()),
+            Effect::Replace { to, .. } => Some(to.id.clone()),
             _ => None,
         })
         .collect();
@@ -410,7 +410,8 @@ pub(super) async fn execute_effects_phased(
                             for child in children {
                                 let child_idx = effects.len();
                                 if let Effect::Create(resource) = &child {
-                                    runtime_synthesized_resources.push(resource.clone());
+                                    runtime_synthesized_resources
+                                        .push(resource.clone().into_inner());
                                 }
                                 effects.push(child);
                                 phase1_indices.push(child_idx);
@@ -430,7 +431,7 @@ pub(super) async fn execute_effects_phased(
                 }
 
                 if let Effect::Wait {
-                    binding,
+                    identity,
                     target_id,
                     until,
                     timeout,
@@ -438,7 +439,7 @@ pub(super) async fn execute_effects_phased(
                     ..
                 } = &effect
                 {
-                    let binding = binding.clone();
+                    let binding = identity.to_string();
                     let target_id = target_id.clone();
                     let until = until.clone();
                     let timeout = *timeout;
@@ -793,7 +794,7 @@ pub(super) async fn execute_effects_phased(
 
                         let resolve_source = unresolved
                             .get(&to.id)
-                            .map_or(to, UnresolvedResource::as_resource);
+                            .map_or(to.as_inner(), UnresolvedResource::as_resource);
                         let resolved = match resolve_resource_with_source(
                             to,
                             resolve_source,
@@ -851,14 +852,14 @@ pub(super) async fn execute_effects_phased(
                                         Err(e) => {
                                             observer.on_event(
                                                 &ExecutionEvent::CascadeUpdateFailed {
-                                                    id: &cascade.id,
+                                                    id: &cascade.to.id,
                                                     error: &e,
                                                 },
                                             );
                                             let cascade_identifier =
                                                 cascade.from.identifier.as_deref().unwrap_or("");
                                             refreshes.push((
-                                                cascade.id.clone().into_inner(),
+                                                cascade.to.id.clone(),
                                                 cascade_identifier.to_string(),
                                             ));
                                             cascade_failed = true;
@@ -872,14 +873,14 @@ pub(super) async fn execute_effects_phased(
                                         &resolved_to,
                                         &cascade.to,
                                         pipeline.schemas,
-                                        &cascade.id,
+                                        &cascade.to.id,
                                     );
                                     let cascade_request = UpdateRequest {
                                         from: (*cascade.from).clone(),
                                         patch: cascade_patch,
                                     };
                                     match provider
-                                        .update(&cascade.id, cascade_identifier, cascade_request)
+                                        .update(&cascade.to.id, cascade_identifier, cascade_request)
                                         .await
                                     {
                                         Ok(cascade_outcome) => {
@@ -892,16 +893,14 @@ pub(super) async fn execute_effects_phased(
                                             };
                                             observer.on_event(
                                                 &ExecutionEvent::CascadeUpdateSucceeded {
-                                                    id: &cascade.id,
+                                                    id: &cascade.to.id,
                                                 },
                                             );
                                             let cascade_state =
                                                 cascade_outcome.into_state_for_writeback();
                                             if let Some(diagnostic) = cascade_diagnostic {
-                                                cascade_diagnostics.push((
-                                                    cascade.id.clone().into_inner(),
-                                                    diagnostic,
-                                                ));
+                                                cascade_diagnostics
+                                                    .push((cascade.to.id.clone(), diagnostic));
                                             }
                                             let cascade_attrs =
                                                 resolved_to.as_resource().resolved_attributes();
@@ -911,7 +910,7 @@ pub(super) async fn execute_effects_phased(
                                                 &cascade_state,
                                             );
                                             cascade_states.push((
-                                                cascade.id.clone().into_inner(),
+                                                cascade.to.id.clone(),
                                                 cascade_state,
                                                 cascade_attrs,
                                                 cascade.to.binding.clone(),
@@ -921,12 +920,12 @@ pub(super) async fn execute_effects_phased(
                                             let error_str = e.to_string();
                                             observer.on_event(
                                                 &ExecutionEvent::CascadeUpdateFailed {
-                                                    id: &cascade.id,
+                                                    id: &cascade.to.id,
                                                     error: &error_str,
                                                 },
                                             );
                                             refreshes.push((
-                                                cascade.id.clone().into_inner(),
+                                                cascade.to.id.clone(),
                                                 cascade_identifier.to_string(),
                                             ));
                                             cascade_failed = true;
@@ -1198,8 +1197,8 @@ pub(super) async fn execute_effects_phased(
 
                 in_flight.push(async move {
                     if let Effect::Replace {
-                        id,
                         from,
+                        to,
                         directives,
                         ..
                     } = effect
@@ -1207,7 +1206,7 @@ pub(super) async fn execute_effects_phased(
                         let identifier = from.identifier.as_deref().unwrap_or("");
                         match provider
                             .delete(
-                                id,
+                                &to.id,
                                 identifier,
                                 DeleteRequest {
                                     directives: directives.clone(),
@@ -1227,10 +1226,7 @@ pub(super) async fn execute_effects_phased(
                                 (
                                     idx,
                                     PhaseEffectResult::ReplaceDeleteFailure {
-                                        refresh: Some((
-                                            id.clone().into_inner(),
-                                            identifier.to_string(),
-                                        )),
+                                        refresh: Some((to.id.clone(), identifier.to_string())),
                                         cbd_refresh: cbd_refresh_info,
                                     },
                                 )
@@ -1421,7 +1417,8 @@ pub(super) async fn execute_effects_phased(
                             for child in children {
                                 let child_idx = effects.len();
                                 if let Effect::Create(resource) = &child {
-                                    runtime_synthesized_resources.push(resource.clone());
+                                    runtime_synthesized_resources
+                                        .push(resource.clone().into_inner());
                                 }
                                 effects.push(child);
                                 phase4_indices.push(child_idx);
@@ -1483,7 +1480,6 @@ pub(super) async fn execute_effects_phased(
                 };
 
                 if let Effect::Replace {
-                    id,
                     to,
                     directives,
                     temporary_name,
@@ -1502,7 +1498,7 @@ pub(super) async fn execute_effects_phased(
                             completed_indices.insert(idx);
                             continue;
                         };
-                        let id = id.clone();
+                        let id = to.id.clone();
                         let to = to.clone();
                         let temporary_name = temporary_name.clone();
                         let effect_for_future = effect.clone();
@@ -1653,7 +1649,7 @@ pub(super) async fn execute_effects_phased(
                                 let started = effect_started;
                                 let resolve_source = unresolved
                                     .get(&to.id)
-                                    .map_or(to, UnresolvedResource::as_resource);
+                                    .map_or(to.as_inner(), UnresolvedResource::as_resource);
                                 let resolved = match resolve_resource_with_source(
                                     to,
                                     resolve_source,
@@ -1933,7 +1929,7 @@ pub(super) async fn execute_effects_phased(
                 }
 
                 if let Effect::Wait {
-                    binding,
+                    identity,
                     target_id,
                     until,
                     timeout,
@@ -1968,7 +1964,7 @@ pub(super) async fn execute_effects_phased(
                             (
                                 idx,
                                 PhaseEffectResult::Wait {
-                                    binding: binding.clone(),
+                                    binding: identity.to_string(),
                                     outcome,
                                     duration: started.elapsed(),
                                     progress,
@@ -2155,10 +2151,17 @@ mod tests {
         BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
         ReadRequest, UpdateRequest,
     };
-    use crate::resource::{Composition, ConcreteValue, DataSource, ResourceId, Value};
+    use crate::resource::{
+        Composition, ConcreteValue, DataSource, ResolvedResource, ResourceId, ResourceIdentity,
+        Value,
+    };
     use crate::schema::SchemaRegistry;
     use crate::wait::predicate::{AttrPath, WaitPredicate};
     use std::sync::Mutex;
+
+    fn resolved(resource: Resource) -> ResolvedResource {
+        ResolvedResource::new(resource)
+    }
 
     struct TerminalWaitProvider {
         create_log: Mutex<Vec<String>>,
@@ -2347,9 +2350,9 @@ mod tests {
         alb.binding = Some("alb".to_string());
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(cert.clone()));
+        plan.add(Effect::Create(resolved(cert.clone())));
         plan.add(Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
@@ -2360,7 +2363,7 @@ mod tests {
             interval: std::time::Duration::from_millis(1),
             explicit_dependencies: std::collections::HashSet::new(),
         });
-        plan.add(Effect::Create(alb.clone()));
+        plan.add(Effect::Create(resolved(alb.clone())));
 
         let unresolved = HashMap::from([
             (
@@ -2445,9 +2448,9 @@ mod tests {
         );
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(cert.clone()));
+        plan.add(Effect::Create(resolved(cert.clone())));
         plan.add(Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
@@ -2458,8 +2461,8 @@ mod tests {
             interval: std::time::Duration::from_millis(1),
             explicit_dependencies: std::collections::HashSet::new(),
         });
-        plan.add(Effect::Create(alb.clone()));
-        plan.add(Effect::Create(listener.clone()));
+        plan.add(Effect::Create(resolved(alb.clone())));
+        plan.add(Effect::Create(resolved(listener.clone())));
 
         let unresolved = HashMap::from([
             (
@@ -2549,8 +2552,8 @@ mod tests {
         );
 
         let effects = vec![
-            Effect::Create(role.clone()),
-            Effect::Create(role_policy.clone()),
+            Effect::Create(resolved(role.clone())),
+            Effect::Create(resolved(role_policy.clone())),
         ];
         let phase_indices: Vec<usize> = vec![0, 1];
 
@@ -2596,7 +2599,10 @@ mod tests {
             Value::resource_ref("outer", "role_name", vec![]),
         );
 
-        let effects = vec![Effect::Create(role.clone()), Effect::Create(caller.clone())];
+        let effects = vec![
+            Effect::Create(resolved(role.clone())),
+            Effect::Create(resolved(caller.clone())),
+        ];
         let phase_indices: Vec<usize> = vec![0, 1];
 
         let mut unresolved: HashMap<ResourceId, UnresolvedResource> = HashMap::new();
@@ -2640,9 +2646,8 @@ mod tests {
         let bucket_state = State::not_found(bucket.id.clone());
 
         let role_replace = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(role.id.clone()),
             from: Box::new(role_state),
-            to: role.clone(),
+            to: resolved(role.clone()),
             directives: Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "role_name".to_string(),
@@ -2653,9 +2658,8 @@ mod tests {
             cascade_ref_hints: vec![],
         };
         let bucket_replace = Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(bucket.id.clone()),
             from: Box::new(bucket_state),
-            to: bucket.clone(),
+            to: resolved(bucket.clone()),
             directives: Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "bucket_name".to_string(),

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -130,7 +130,7 @@ pub(super) struct ReplaceContext<'a> {
     pub(super) effect: &'a Effect,
     pub(super) id: &'a ResourceId,
     pub(super) from: &'a State,
-    pub(super) to: &'a Resource,
+    pub(super) to: &'a ResolvedResource,
     pub(super) directives: &'a crate::resource::Directives,
     pub(super) cascading_updates: &'a [crate::effect::CascadingUpdate],
     pub(super) temporary_name: Option<&'a crate::effect::TemporaryName>,
@@ -200,14 +200,11 @@ pub(super) async fn execute_cbd_replace_parallel(
                     Ok(r) => r,
                     Err(e) => {
                         observer.on_event(&ExecutionEvent::CascadeUpdateFailed {
-                            id: &cascade.id,
+                            id: &cascade.to.id,
                             error: &e,
                         });
                         let cascade_identifier = cascade.from.identifier.as_deref().unwrap_or("");
-                        refreshes.push((
-                            cascade.id.clone().into_inner(),
-                            cascade_identifier.to_string(),
-                        ));
+                        refreshes.push((cascade.to.id.clone(), cascade_identifier.to_string()));
                         cascade_failed = true;
                         break;
                     }
@@ -218,14 +215,14 @@ pub(super) async fn execute_cbd_replace_parallel(
                     &resolved_to,
                     &cascade.to,
                     ctx.pipeline.schemas,
-                    &cascade.id,
+                    &cascade.to.id,
                 );
                 let cascade_request = UpdateRequest {
                     from: (*cascade.from).clone(),
                     patch: cascade_patch,
                 };
                 match provider
-                    .update(&cascade.id, cascade_identifier, cascade_request)
+                    .update(&cascade.to.id, cascade_identifier, cascade_request)
                     .await
                 {
                     Ok(cascade_outcome) => {
@@ -237,10 +234,11 @@ pub(super) async fn execute_cbd_replace_parallel(
                         };
                         let cascade_state = cascade_outcome.into_state_for_writeback();
                         if let Some(diagnostic) = cascade_diagnostic {
-                            cascade_diagnostics.push((cascade.id.clone().into_inner(), diagnostic));
+                            cascade_diagnostics.push((cascade.to.id.clone(), diagnostic));
                         }
-                        observer
-                            .on_event(&ExecutionEvent::CascadeUpdateSucceeded { id: &cascade.id });
+                        observer.on_event(&ExecutionEvent::CascadeUpdateSucceeded {
+                            id: &cascade.to.id,
+                        });
                         local_bindings.record_applied(
                             cascade.to.binding.as_deref(),
                             &resolved_to.as_resource().resolved_attributes(),
@@ -250,13 +248,10 @@ pub(super) async fn execute_cbd_replace_parallel(
                     Err(e) => {
                         let error_str = e.to_string();
                         observer.on_event(&ExecutionEvent::CascadeUpdateFailed {
-                            id: &cascade.id,
+                            id: &cascade.to.id,
                             error: &error_str,
                         });
-                        refreshes.push((
-                            cascade.id.clone().into_inner(),
-                            cascade_identifier.to_string(),
-                        ));
+                        refreshes.push((cascade.to.id.clone(), cascade_identifier.to_string()));
                         cascade_failed = true;
                         break;
                     }
@@ -477,7 +472,7 @@ pub(super) async fn execute_dbd_replace_parallel(
             let resolve_source = ctx
                 .unresolved
                 .get(&ctx.to.id)
-                .map_or(ctx.to, UnresolvedResource::as_resource);
+                .map_or(ctx.to.as_inner(), UnresolvedResource::as_resource);
             let resolved = match resolve_resource_with_source(
                 ctx.to,
                 resolve_source,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -9,8 +9,8 @@ use crate::provider::{
     ReadRequest, UpdateRequest,
 };
 use crate::resource::{
-    AccessPath, ConcreteValue, DataSource, DeferredValue, Directives, Resource, UnknownReason,
-    Value,
+    AccessPath, ConcreteValue, DataSource, DeferredValue, Directives, ResolvedDataSource,
+    ResolvedResource, Resource, ResourceIdentity, UnknownReason, Value,
 };
 use crate::value::SerializationError;
 use parallel::build_dependency_levels;
@@ -20,6 +20,18 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::{Barrier, Mutex as AsyncMutex, Notify};
 use tokio_util::sync::CancellationToken;
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
+
+fn resolved_data_source(resource: DataSource) -> ResolvedDataSource {
+    ResolvedDataSource::new(resource)
+}
+
+fn create_effect(resource: Resource) -> Effect {
+    Effect::Create(resolved(resource))
+}
 
 fn validation_deferred_for_expression() -> crate::parser::DeferredForExpression {
     let mut template_resource = Resource::new("test", "validation_records");
@@ -784,7 +796,7 @@ fn provider_config_with_default_tags(
 fn create_independent_create_plan<const N: usize>(names: [&str; N]) -> Plan {
     let mut plan = Plan::new();
     for name in names {
-        plan.add(Effect::Create(make_resource(name, &[])));
+        plan.add(create_effect(make_resource(name, &[])));
     }
     plan
 }
@@ -809,9 +821,8 @@ fn create_interdependent_replace_plan() -> Plan {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(a_id),
         from: Box::new(a_from),
-        to: a_to,
+        to: resolved(a_to),
         directives: directives.clone(),
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
             .unwrap(),
@@ -820,9 +831,8 @@ fn create_interdependent_replace_plan() -> Plan {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(b_id),
         from: Box::new(b_from),
-        to: b_to,
+        to: resolved(b_to),
         directives,
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
             .unwrap(),
@@ -849,9 +859,8 @@ fn create_interdependent_replace_plan_with_renames<const N: usize>(names: [&str;
             to.dependency_bindings = std::collections::BTreeSet::from([names[idx - 1].to_string()]);
         }
         plan.add(Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(id),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: directives.clone(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
                 .unwrap(),
@@ -1150,9 +1159,9 @@ impl CancelsWhenWaitStarted {
 impl ExecutionObserver for CancelsWhenWaitStarted {
     fn on_event(&self, event: &ExecutionEvent) {
         if let ExecutionEvent::EffectStarted {
-            effect: Effect::Wait { binding, .. },
+            effect: Effect::Wait { identity, .. },
         } = event
-            && binding == &self.binding
+            && identity.as_str() == self.binding
         {
             self.token.cancel();
         }
@@ -1190,9 +1199,9 @@ impl ExecutionObserver for RecordingCancelsWhenWaitStarted {
             .unwrap()
             .push(format_execution_event(event));
         if let ExecutionEvent::EffectStarted {
-            effect: Effect::Wait { binding, .. },
+            effect: Effect::Wait { identity, .. },
         } = event
-            && binding == &self.binding
+            && identity.as_str() == self.binding
         {
             self.token.cancel();
         }
@@ -1242,7 +1251,7 @@ async fn execute_plan_returns_completed_when_not_cancelled() {
     let rid = resource.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(create_effect(resource));
 
     provider.push_create(Ok(ok_state(&rid)));
 
@@ -1279,7 +1288,7 @@ async fn execute_plan_with_pre_cancelled_token_returns_cancelled_at_t4_or_later(
     let resource = make_resource("one", &[]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(create_effect(resource));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -1387,9 +1396,9 @@ async fn execute_plan_cancels_in_flight_wait_effect_promptly() {
     );
     dist.dependency_bindings = ["cert_ready".to_string()].into_iter().collect();
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::Wait {
-        binding: "cert_ready".to_string(),
+        identity: ResourceIdentity::new("cert_ready"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -1400,7 +1409,7 @@ async fn execute_plan_cancels_in_flight_wait_effect_promptly() {
         interval: std::time::Duration::from_secs(60),
         explicit_dependencies: std::collections::HashSet::new(),
     });
-    plan.add(Effect::Create(dist));
+    plan.add(create_effect(dist));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -1455,9 +1464,9 @@ async fn execute_plan_cancelled_wait_emits_cancelled_skip_not_unsatisfiable() {
     dist.dependency_bindings = ["cert_ready".to_string()].into_iter().collect();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::Wait {
-        binding: "cert_ready".to_string(),
+        identity: ResourceIdentity::new("cert_ready"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -1468,7 +1477,7 @@ async fn execute_plan_cancelled_wait_emits_cancelled_skip_not_unsatisfiable() {
         interval: std::time::Duration::from_secs(60),
         explicit_dependencies: std::collections::HashSet::new(),
     });
-    plan.add(Effect::Create(dist));
+    plan.add(create_effect(dist));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -1653,7 +1662,7 @@ async fn test_simple_create() {
     let rid = resource.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(create_effect(resource));
 
     provider.push_create(Ok(ok_state(&rid)));
 
@@ -1696,7 +1705,7 @@ async fn partial_create_records_state_and_diagnostic() {
     .expect("missing attributes are non-empty");
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(create_effect(resource));
 
     provider.push_create_outcome(Ok(crate::provider::CreateOutcome::partial_success(
         ok_state(&rid),
@@ -1752,7 +1761,7 @@ async fn test_apply_renormalizes_after_resolution() {
     let rid = resource.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(create_effect(resource));
     provider.push_create(Ok(ok_state(&rid)));
 
     let input = ExecutionInput {
@@ -1809,7 +1818,7 @@ async fn test_apply_reapplies_enum_alias_stage() {
     let rid = resource.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(create_effect(resource));
     provider.push_create(Ok(ok_state(&rid)));
 
     let factories: Vec<Box<dyn ProviderFactory>> = vec![Box::new(AliasFactory)];
@@ -1868,9 +1877,8 @@ async fn test_apply_reapplies_enum_alias_stage_update_path() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
-        to: to_resource,
+        to: resolved(to_resource),
         changed_attributes: vec!["ip_protocol".to_string()],
     });
     provider.push_update(Ok(ok_state(&rid)));
@@ -1928,7 +1936,7 @@ async fn test_apply_reapplies_canonicalize_stage() {
     let rid = resource.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(create_effect(resource));
     provider.push_create(Ok(ok_state(&rid)));
 
     let input = ExecutionInput {
@@ -1985,9 +1993,8 @@ async fn test_apply_renormalizes_update_path() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
-        to: to_resource,
+        to: resolved(to_resource),
         changed_attributes: vec!["marker".to_string()],
     });
     provider.push_update(Ok(ok_state(&rid)));
@@ -2072,9 +2079,8 @@ async fn test_apply_update_patch_preserves_provider_default_tags() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
-        to: to_resource,
+        to: resolved(to_resource),
         changed_attributes: vec!["tags".to_string()],
     });
     provider.push_update(Ok(ok_state(&rid)));
@@ -2182,9 +2188,8 @@ async fn test_apply_effective_changed_uses_plan_time_comparison_semantics() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
-        to: to_resource,
+        to: resolved(to_resource),
         changed_attributes: vec!["description".to_string()],
     });
     provider.push_update(Ok(ok_state(&rid)));
@@ -2242,9 +2247,8 @@ async fn test_apply_effective_changed_skips_internal_and_write_only_attributes()
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
-        to: to_resource,
+        to: resolved(to_resource),
         changed_attributes: vec!["description".to_string()],
     });
     provider.push_update(Ok(ok_state(&rid)));
@@ -2306,9 +2310,8 @@ async fn test_apply_effective_changed_skips_matching_unwrapped_secret_hash() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
-        to: to_resource,
+        to: resolved(to_resource),
         changed_attributes: vec![],
     });
     provider.push_update(Ok(ok_state(&rid)));
@@ -2375,9 +2378,8 @@ async fn test_apply_effective_changed_skips_secret_shape_divergence() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from_state),
-        to: to_resource,
+        to: resolved(to_resource),
         changed_attributes: vec![],
     });
     provider.push_update(Ok(ok_state(&rid)));
@@ -2434,8 +2436,8 @@ async fn test_apply_renormalizes_nested_value_under_ref_bearing_resource() {
     let rb_id = rb.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ra));
-    plan.add(Effect::Create(rb));
+    plan.add(create_effect(ra));
+    plan.add(create_effect(rb));
     provider.push_create(Ok(ok_state(&ra_id)));
     provider.push_create(Ok(ok_state(&rb_id)));
 
@@ -2570,8 +2572,8 @@ async fn test_async_normalizer_does_not_self_deadlock_on_apply_path() {
     let rb_id = rb.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ra));
-    plan.add(Effect::Create(rb));
+    plan.add(create_effect(ra));
+    plan.add(create_effect(rb));
     provider.push_create(Ok(ok_state(&ra_id)));
     provider.push_create(Ok(ok_state(&rb_id)));
 
@@ -2672,8 +2674,8 @@ async fn test_failed_effect_propagates_to_dependent() {
     let _rid_a = ra.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(ra));
-    plan.add(Effect::Create(rb));
+    plan.add(create_effect(ra));
+    plan.add(create_effect(rb));
 
     // First create fails
     provider.push_create(Err(ProviderError::api_error("create failed")));
@@ -2716,9 +2718,8 @@ async fn test_cbd_creates_before_deletes() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from),
-        to,
+        to: resolved(to),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -2787,9 +2788,8 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(replace_id.clone()),
         from: Box::new(replace_from),
-        to: replace_to,
+        to: resolved(replace_to),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -2797,9 +2797,8 @@ async fn test_cbd_cascade_update_patch_uses_plan_time_comparison_semantics() {
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["name".to_string()])
             .unwrap(),
         cascading_updates: vec![crate::effect::CascadingUpdate {
-            id: crate::resource::ResolvedResourceId::new(cascade_id.clone()),
             from: Box::new(cascade_from),
-            to: cascade_to,
+            to: resolved(cascade_to),
         }],
         temporary_name: None,
         cascade_ref_hints: vec![],
@@ -2854,9 +2853,8 @@ async fn test_cbd_rename_partial_create_partial_counts_once() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(id.clone()),
         from: Box::new(from),
-        to,
+        to: resolved(to),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -2934,9 +2932,8 @@ async fn test_cbd_rename_success_create_partial_keeps_create_marker() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(id.clone()),
         from: Box::new(from),
-        to,
+        to: resolved(to),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -3006,9 +3003,8 @@ async fn test_dbd_deletes_before_creates() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(rid.clone()),
         from: Box::new(from),
-        to,
+        to: resolved(to),
         directives: Directives::default(),
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
             .unwrap(),
@@ -3074,9 +3070,8 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
     let mut plan = Plan::new();
     // Order in plan: vpc first, subnet second
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(vpc_from),
-        to: vpc_to,
+        to: resolved(vpc_to),
         directives: cbd_directives.clone(),
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
             .unwrap(),
@@ -3085,9 +3080,8 @@ async fn test_phased_cbd_creates_in_forward_order_deletes_in_reverse() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(subnet_from),
-        to: subnet_to,
+        to: resolved(subnet_to),
         directives: cbd_directives,
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
             .unwrap(),
@@ -3156,9 +3150,8 @@ async fn test_phased_noncbd_creates_after_deletes() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(vpc_id.clone()),
         from: Box::new(vpc_from),
-        to: vpc_to,
+        to: resolved(vpc_to),
         directives: dbd_directives.clone(),
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
             .unwrap(),
@@ -3167,9 +3160,8 @@ async fn test_phased_noncbd_creates_after_deletes() {
         cascade_ref_hints: vec![],
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(subnet_id.clone()),
         from: Box::new(subnet_from),
-        to: subnet_to,
+        to: resolved(subnet_to),
         directives: dbd_directives,
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["attr".to_string()])
             .unwrap(),
@@ -3221,7 +3213,7 @@ async fn test_observer_events_emitted_correctly() {
     let rid = resource.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(resource));
+    plan.add(create_effect(resource));
 
     provider.push_create(Ok(ok_state(&rid)));
 
@@ -3254,7 +3246,9 @@ async fn test_read_effect_is_no_op() {
     let resource = DataSource::new("test", "data");
 
     let mut plan = Plan::new();
-    plan.add(Effect::Read { resource });
+    plan.add(Effect::Read {
+        resource: resolved_data_source(resource),
+    });
 
     let input = ExecutionInput {
         plan: &plan,
@@ -3292,9 +3286,9 @@ async fn test_independent_effects_run_in_parallel() {
     let subnet_b_id = subnet_b.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(subnet_a));
-    plan.add(Effect::Create(subnet_b));
+    plan.add(create_effect(vpc));
+    plan.add(create_effect(subnet_a));
+    plan.add(create_effect(subnet_b));
 
     provider.push_create(Ok(ok_state(&vpc_id)));
     provider.push_create(Ok(ok_state(&subnet_a_id)));
@@ -3344,10 +3338,10 @@ async fn test_parallel_failure_skips_dependents() {
     let subnet_b_id = subnet_b.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(subnet_a));
-    plan.add(Effect::Create(subnet_b));
-    plan.add(Effect::Create(subnet_c));
+    plan.add(create_effect(vpc));
+    plan.add(create_effect(subnet_a));
+    plan.add(create_effect(subnet_b));
+    plan.add(create_effect(subnet_c));
 
     provider.push_create(Ok(ok_state(&vpc_id)));
     // subnet_a fails, subnet_b succeeds
@@ -3397,9 +3391,9 @@ async fn test_dependency_levels_sequential_chain() {
     let c_id = c.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(a));
-    plan.add(Effect::Create(b));
-    plan.add(Effect::Create(c));
+    plan.add(create_effect(a));
+    plan.add(create_effect(b));
+    plan.add(create_effect(c));
 
     provider.push_create(Ok(ok_state(&a_id)));
     provider.push_create(Ok(ok_state(&b_id)));
@@ -3440,10 +3434,10 @@ fn test_build_dependency_levels() {
     let d = make_resource("d", &["b", "c"]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(a));
-    plan.add(Effect::Create(b));
-    plan.add(Effect::Create(c));
-    plan.add(Effect::Create(d));
+    plan.add(create_effect(a));
+    plan.add(create_effect(b));
+    plan.add(create_effect(c));
+    plan.add(create_effect(d));
 
     let levels = build_dependency_levels(plan.effects(), &HashMap::new(), &[]);
 
@@ -3505,12 +3499,12 @@ fn test_build_dependency_levels_transitive_ref_preserves_direct_dep() {
     rt.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc)); // idx 0
-    plan.add(Effect::Create(tgw)); // idx 1
-    plan.add(Effect::Create(subnet)); // idx 2
-    plan.add(Effect::Create(tgw_attach)); // idx 3
-    plan.add(Effect::Create(rt)); // idx 4
-    plan.add(Effect::Create(route)); // idx 5
+    plan.add(create_effect(vpc)); // idx 0
+    plan.add(create_effect(tgw)); // idx 1
+    plan.add(create_effect(subnet)); // idx 2
+    plan.add(create_effect(tgw_attach)); // idx 3
+    plan.add(create_effect(rt)); // idx 4
+    plan.add(create_effect(route)); // idx 5
 
     let levels = build_dependency_levels(plan.effects(), &HashMap::new(), &[]);
 
@@ -3641,9 +3635,9 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
     let c = make_resource("c", &["a"]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(a));
-    plan.add(Effect::Create(b));
-    plan.add(Effect::Create(c));
+    plan.add(create_effect(a));
+    plan.add(create_effect(b));
+    plan.add(create_effect(c));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -3834,9 +3828,8 @@ async fn run_tag_sweep(parallelism: NonZeroUsize) -> (std::time::Duration, usize
         let from = tag_update_state(&resource.id, binding);
         current_states.insert(resource.id.clone(), from.clone());
         plan.add(Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(resource.id.clone()),
             from: Box::new(from),
-            to: resource.clone(),
+            to: resolved(resource.clone()),
             changed_attributes: vec!["tags".to_string()],
         });
     }
@@ -3903,9 +3896,8 @@ async fn run_provider_contract_case(unknown_read: bool) -> usize {
         let from = tag_update_state(&resource.id, binding);
         current_states.insert(resource.id.clone(), from.clone());
         plan.add(Effect::Update {
-            id: crate::resource::ResolvedResourceId::new(resource.id.clone()),
             from: Box::new(from),
-            to: resource.clone(),
+            to: resolved(resource.clone()),
             changed_attributes: vec!["tags".to_string()],
         });
     }
@@ -4001,8 +3993,8 @@ async fn test_waiting_events_emitted_for_dependent_effects() {
     let c = make_resource("c", &["a"]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(a));
-    plan.add(Effect::Create(c));
+    plan.add(create_effect(a));
+    plan.add(create_effect(c));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -4132,10 +4124,10 @@ fn test_build_dependency_levels_consistent_with_dependency_map() {
     let d = make_resource("d", &["b", "c"]);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(a));
-    plan.add(Effect::Create(b));
-    plan.add(Effect::Create(c));
-    plan.add(Effect::Create(d));
+    plan.add(create_effect(a));
+    plan.add(create_effect(b));
+    plan.add(create_effect(c));
+    plan.add(create_effect(d));
 
     let levels = build_dependency_levels(plan.effects(), &HashMap::new(), &[]);
     let dep_map =
@@ -4179,9 +4171,8 @@ async fn test_update_effect_binding_map_propagation() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(ra_id.clone()),
         from: Box::new(from_state),
-        to: to_resource,
+        to: resolved(to_resource),
         changed_attributes: vec!["some_attr".to_string()],
     });
 
@@ -4289,8 +4280,8 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     let subnet_id = subnet.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(vpc));
-    plan.add(Effect::Create(subnet));
+    plan.add(create_effect(vpc));
+    plan.add(create_effect(subnet));
 
     // VPC create returns state with vpc_id
     let vpc_state = State::existing(
@@ -4479,7 +4470,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
     // tgw_b: Create (new resource)
     let mut tgw_b = Resource::new("test", "tgw_b");
     tgw_b.binding = Some("tgw_b".to_string());
-    plan.add(Effect::Create(tgw_b));
+    plan.add(create_effect(tgw_b));
 
     // tgw_a: Delete
     plan.add(Effect::Delete {
@@ -4493,9 +4484,8 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
 
     // attachment: Replace (CBD) — from depends on tgw_a
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(attachment_id.clone()),
         from: Box::new(attachment_from),
-        to: attachment_to,
+        to: resolved(attachment_to),
         directives: cbd_directives,
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
             "transit_gateway_id".to_string(),
@@ -4579,7 +4569,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
     // tgw_b: Create
     let mut tgw_b = Resource::new("test", "tgw_b");
     tgw_b.binding = Some("tgw_b".to_string());
-    plan.add(Effect::Create(tgw_b));
+    plan.add(create_effect(tgw_b));
 
     // tgw_a: Delete — binding is None (the key difference from the previous test)
     plan.add(Effect::Delete {
@@ -4593,9 +4583,8 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
 
     // attachment: Replace (CBD)
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(attachment_id.clone()),
         from: Box::new(attachment_from),
-        to: attachment_to,
+        to: resolved(attachment_to),
         directives: cbd_directives,
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
             "transit_gateway_id".to_string(),
@@ -4658,9 +4647,9 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
     let dist_id = dist.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::Wait {
-        binding: "cert_issued".to_string(),
+        identity: ResourceIdentity::new("cert_issued"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -4671,7 +4660,7 @@ async fn test_wait_effect_polls_then_unblocks_downstream() {
         interval: std::time::Duration::from_millis(1),
         explicit_dependencies: std::collections::HashSet::new(),
     });
-    plan.add(Effect::Create(dist));
+    plan.add(create_effect(dist));
 
     // create cert → state with status PENDING (the Create result; the
     // wait polls via read for ISSUED).
@@ -4810,9 +4799,9 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
     );
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::Wait {
-        binding: "cert_issued".to_string(),
+        identity: ResourceIdentity::new("cert_issued"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -4823,7 +4812,7 @@ async fn test_wait_downstream_nested_map_ref_resolves_at_apply() {
         interval: std::time::Duration::from_millis(1),
         explicit_dependencies: std::collections::HashSet::new(),
     });
-    plan.add(Effect::Create(dist));
+    plan.add(create_effect(dist));
 
     // create cert → PENDING; wait polls read → PENDING → ISSUED+arn.
     let mut create_attrs = HashMap::new();
@@ -4911,9 +4900,9 @@ async fn test_wait_state_writeback_skips_synthetic_wait_id() {
     let cert_id = cert.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::Wait {
-        binding: "cert_issued".to_string(),
+        identity: ResourceIdentity::new("cert_issued"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -5034,8 +5023,8 @@ async fn test_chained_index_then_field_unresolved_at_apply_fails_with_clear_erro
     let record_id = record.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
-    plan.add(Effect::Create(record));
+    plan.add(create_effect(cert));
+    plan.add(create_effect(record));
 
     // Mirror the AWS RequestCertificate read-back race: the DVO list
     // is populated asynchronously by ACM after RequestCertificate
@@ -5191,8 +5180,8 @@ async fn test_chained_index_then_nested_field_resolves_from_post_create_state() 
     let record_id = record.id.clone();
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
-    plan.add(Effect::Create(record));
+    plan.add(create_effect(cert));
+    plan.add(create_effect(record));
 
     // Cert create returns post-read state with DVO populated. Shape
     // mirrors what `read_acm_certificate` inserts after aws#295.
@@ -5433,9 +5422,9 @@ async fn wait_resolves_target_identifier_from_just_created_state() {
     let provider = IdentifierAwareProvider::new("cert-arn-real", created_state);
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::Wait {
-        binding: "cert_issued".to_string(),
+        identity: ResourceIdentity::new("cert_issued"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -5521,9 +5510,8 @@ async fn wait_resolves_target_identifier_from_just_replaced_state() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_state.clone()),
-        to: cert,
+        to: resolved(cert),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -5531,7 +5519,7 @@ async fn wait_resolves_target_identifier_from_just_replaced_state() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Wait {
-        binding: "cert_issued".to_string(),
+        identity: ResourceIdentity::new("cert_issued"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -5624,9 +5612,8 @@ async fn wait_resolves_target_identifier_from_just_replaced_state_phased() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
-        to: cert,
+        to: resolved(cert),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -5634,9 +5621,8 @@ async fn wait_resolves_target_identifier_from_just_replaced_state_phased() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(dep_id.clone()),
         from: Box::new(old_dep_state.clone()),
-        to: dep,
+        to: resolved(dep),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -5644,7 +5630,7 @@ async fn wait_resolves_target_identifier_from_just_replaced_state_phased() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Wait {
-        binding: "cert_issued".to_string(),
+        identity: ResourceIdentity::new("cert_issued"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -5767,9 +5753,8 @@ async fn deferred_create_dispatches_after_upstream_replace_before_wait_phased() 
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
-        to: cert,
+        to: resolved(cert),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -5777,9 +5762,8 @@ async fn deferred_create_dispatches_after_upstream_replace_before_wait_phased() 
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(dep_id.clone()),
         from: Box::new(old_dep_state.clone()),
-        to: dep,
+        to: resolved(dep),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -5795,7 +5779,7 @@ async fn deferred_create_dispatches_after_upstream_replace_before_wait_phased() 
         template: Box::new(validation_deferred_for_expression()),
     });
     plan.add(Effect::Wait {
-        binding: "cert_issued".to_string(),
+        identity: ResourceIdentity::new("cert_issued"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -5906,9 +5890,8 @@ async fn deferred_create_emits_zero_children_when_collection_is_empty() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
-        to: cert,
+        to: resolved(cert),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -5924,7 +5907,7 @@ async fn deferred_create_emits_zero_children_when_collection_is_empty() {
         template: Box::new(validation_deferred_for_expression()),
     });
     plan.add(Effect::Wait {
-        binding: "cert_issued".to_string(),
+        identity: ResourceIdentity::new("cert_issued"),
         target_id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -6064,9 +6047,8 @@ async fn deferred_create_cancelled_after_upstream_create_reports_skipped() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
-        to: cert,
+        to: resolved(cert),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -6156,7 +6138,7 @@ async fn deferred_create_returns_error_when_iterable_attr_missing() {
     provider.push_create(Ok(State::existing(cert_id.clone(), HashMap::new())));
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::DeferredCreate {
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
             "__deferred_for",
@@ -6206,7 +6188,7 @@ async fn apply_time_deferred_create_emits_failed_on_shape_mismatch() {
     provider.push_create(Ok(cert_state));
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::DeferredCreate {
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
             "__deferred_for",
@@ -6349,7 +6331,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
     let mut cert = Resource::new("test", "cert_concurrent_deferred_replace");
     cert.binding = Some("cert".to_string());
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![
             DeferredReplaceDelete {
@@ -6452,7 +6434,7 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
     let mut cert = Resource::new("test", "cert_delete_failure");
     cert.binding = Some("cert".to_string());
     let mut plan = Plan::new();
-    plan.add(Effect::Create(cert));
+    plan.add(create_effect(cert));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -6537,9 +6519,8 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(cert_id.clone()),
         from: Box::new(old_cert_state.clone()),
-        to: cert,
+        to: resolved(cert),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["domain_name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -6547,9 +6528,8 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(dep_id.clone()),
         from: Box::new(old_dep_state.clone()),
-        to: dep,
+        to: resolved(dep),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -6675,11 +6655,10 @@ async fn phased_cbd_replace_skips_when_phase1_dependency_fails() {
     provider.push_delete(Ok(()));
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(bucket));
+    plan.add(create_effect(bucket));
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(anchor_id.clone()),
         from: Box::new(anchor_from.clone()),
-        to: anchor_to,
+        to: resolved(anchor_to),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -6687,9 +6666,8 @@ async fn phased_cbd_replace_skips_when_phase1_dependency_fails() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(policy_id.clone()),
         from: Box::new(policy_from.clone()),
-        to: policy_to,
+        to: resolved(policy_to),
         directives: Directives {
             create_before_destroy: true,
             depends_on: vec!["bucket".to_string()],
@@ -6766,11 +6744,10 @@ async fn phased_replace_delete_skips_when_phase1_dependency_fails() {
     provider.push_delete(Ok(()));
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(bucket));
+    plan.add(create_effect(bucket));
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(anchor_id.clone()),
         from: Box::new(anchor_from.clone()),
-        to: anchor_to,
+        to: resolved(anchor_to),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -6778,9 +6755,8 @@ async fn phased_replace_delete_skips_when_phase1_dependency_fails() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(target_id.clone()),
         from: Box::new(target_from.clone()),
-        to: target_to,
+        to: resolved(target_to),
         directives: Directives {
             depends_on: vec!["bucket".to_string()],
             ..Default::default()
@@ -6882,9 +6858,8 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(a_id.clone()),
         from: Box::new(old_a_state.clone()),
-        to: a,
+        to: resolved(a),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -6892,9 +6867,8 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(b_id.clone()),
         from: Box::new(old_b_state.clone()),
-        to: b,
+        to: resolved(b),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -6902,9 +6876,8 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(anonymous_id.clone()),
         from: Box::new(old_anonymous_state.clone()),
-        to: anonymous_to,
+        to: resolved(anonymous_to),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -6912,7 +6885,7 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Wait {
-        binding: "anonymous_ready".to_string(),
+        identity: ResourceIdentity::new("anonymous_ready"),
         target_id: crate::resource::ResolvedResourceId::new(anonymous_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -7021,15 +6994,13 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
 
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: crate::resource::ResolvedResourceId::new(failed_id.clone()),
         from: Box::new(old_failed_state.clone()),
-        to: failed_to,
+        to: resolved(failed_to),
         changed_attributes: vec!["name".to_string()],
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(parent_id.clone()),
         from: Box::new(old_parent_state.clone()),
-        to: parent,
+        to: resolved(parent),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -7037,9 +7008,8 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(child_id.clone()),
         from: Box::new(old_child_state.clone()),
-        to: child,
+        to: resolved(child),
         directives: Directives::default(),
         changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
         cascading_updates: Vec::new(),
@@ -7047,7 +7017,7 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
         cascade_ref_hints: Vec::new(),
     });
     plan.add(Effect::Wait {
-        binding: "sibling_ready".to_string(),
+        identity: ResourceIdentity::new("sibling_ready"),
         target_id: crate::resource::ResolvedResourceId::new(parent_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -7059,7 +7029,7 @@ async fn phased_cross_phase_explicit_dependency_failure_triggers_wait_terminal()
         explicit_dependencies: HashSet::new(),
     });
     plan.add(Effect::Wait {
-        binding: "blocked_ready".to_string(),
+        identity: ResourceIdentity::new("blocked_ready"),
         target_id: crate::resource::ResolvedResourceId::new(child_id.clone()),
         until: WaitPredicate::Equals {
             attr: AttrPath::single("status"),
@@ -7145,9 +7115,8 @@ fn phased_anonymous_replace_failure_unblocks_wait_terminal_check() {
 
     let effects = vec![
         Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(anonymous_id.clone()),
             from: Box::new(old_anonymous_state),
-            to: anonymous_to,
+            to: resolved(anonymous_to),
             directives: Directives::default(),
             changed_create_only: ChangedCreateOnly::new(vec!["name".to_string()]).unwrap(),
             cascading_updates: Vec::new(),
@@ -7155,7 +7124,7 @@ fn phased_anonymous_replace_failure_unblocks_wait_terminal_check() {
             cascade_ref_hints: Vec::new(),
         },
         Effect::Wait {
-            binding: "anonymous_terminal_ready".to_string(),
+            identity: ResourceIdentity::new("anonymous_terminal_ready"),
             target_id: crate::resource::ResolvedResourceId::new(anonymous_id.clone()),
             until: WaitPredicate::Equals {
                 attr: AttrPath::single("status"),
@@ -7378,8 +7347,8 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
     let mut plan = Plan::new();
     let cert = resource_with_binding("cert", "cert");
     let cert_id = cert.id.clone();
-    plan.add(Effect::Create(cert.clone()));
-    plan.add(Effect::Create(resource_with_binding("alb", "alb")));
+    plan.add(create_effect(cert.clone()));
+    plan.add(create_effect(resource_with_binding("alb", "alb")));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -7506,9 +7475,8 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
 
     let mut plan = Plan::new();
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(role_id.clone()),
         from: Box::new(role_from),
-        to: role_to,
+        to: resolved(role_to),
         directives: Directives::default(),
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["role_name".to_string()])
             .unwrap(),
@@ -7521,9 +7489,8 @@ async fn test_phased_move_with_interdependent_replace_does_not_panic() {
         to: crate::resource::ResolvedResourceId::new(policy_new_id.clone()),
     });
     plan.add(Effect::Replace {
-        id: crate::resource::ResolvedResourceId::new(policy_new_id),
         from: Box::new(policy_from),
-        to: policy_to,
+        to: resolved(policy_to),
         directives: Directives::default(),
         changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["policy_name".to_string()])
             .unwrap(),
@@ -7656,7 +7623,7 @@ async fn test_data_source_read_state_resolves_for_downstream_resource() {
     };
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(role.clone()));
+    plan.add(create_effect(role.clone()));
 
     let role_state =
         State::existing(role_id.clone(), HashMap::new()).with_identifier("rd.role-iam-id");

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -121,11 +121,11 @@ impl Plan {
         for effect in &mut self.effects {
             match effect {
                 Effect::Replace {
-                    id,
+                    to,
                     changed_create_only,
                     cascade_ref_hints,
                     ..
-                } if id == resource_id => {
+                } if to.id == *resource_id => {
                     for attr in cascade_attrs.iter() {
                         if !changed_create_only.contains(attr) {
                             changed_create_only.push(attr.to_string());
@@ -138,15 +138,16 @@ impl Plan {
                     }
                     return;
                 }
-                Effect::Update { id, .. } if id == resource_id => {
+                Effect::Update { to, .. } if to.id == *resource_id => {
                     // Take ownership of the Update fields and upgrade to Replace.
                     // The `Create` here is a throwaway placeholder overwritten
                     // on the next line.
-                    let placeholder = crate::resource::Resource::new("", "");
+                    let placeholder = crate::resource::ResolvedResource::new(
+                        crate::resource::Resource::new("__placeholder", "__placeholder"),
+                    );
                     let old = std::mem::replace(effect, Effect::Create(placeholder));
-                    if let Effect::Update { id, from, to, .. } = old {
+                    if let Effect::Update { from, to, .. } = old {
                         *effect = Effect::Replace {
-                            id,
                             from,
                             to,
                             directives,
@@ -171,8 +172,8 @@ impl Plan {
     /// to avoid breaking dependents during replacement.
     pub fn promote_to_create_before_destroy(&mut self, resource_id: &crate::resource::ResourceId) {
         for effect in &mut self.effects {
-            if let Effect::Replace { id, directives, .. } = effect
-                && id == resource_id
+            if let Effect::Replace { to, directives, .. } = effect
+                && to.id == *resource_id
             {
                 directives.create_before_destroy = true;
                 return;
@@ -480,8 +481,8 @@ impl ModularPlan {
 fn format_effect_brief(effect: &Effect) -> String {
     match effect {
         Effect::Create(r) => format!("{} {}", effect.display_glyph(), r.id),
-        Effect::Update { id, .. } => format!("{} {}", effect.display_glyph(), id),
-        Effect::Replace { id, .. } => format!("{} {}", effect.display_glyph(), id),
+        Effect::Update { to, .. } => format!("{} {}", effect.display_glyph(), to.id),
+        Effect::Replace { to, .. } => format!("{} {}", effect.display_glyph(), to.id),
         Effect::Delete { id, .. } => format!("{} {}", effect.display_glyph(), id),
         Effect::Read { resource } => {
             format!("{} {} (data source)", effect.display_glyph(), resource.id)
@@ -499,13 +500,13 @@ fn format_effect_brief(effect: &Effect) -> String {
         Effect::Remove { id } => format!("{} {} (remove from state)", effect.display_glyph(), id),
         Effect::Move { from, to } => format!("{} {} (from: {})", effect.display_glyph(), to, from),
         Effect::Wait {
-            binding,
+            identity,
             until_surface,
             ..
         } => format!(
             "{} {} (until {})",
             effect.display_glyph(),
-            binding,
+            identity,
             until_surface
         ),
         Effect::DeferredCreate {
@@ -534,7 +535,17 @@ fn format_effect_brief(effect: &Effect) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::Resource;
+    use crate::resource::{
+        DataSource, ResolvedDataSource, ResolvedResource, Resource, ResourceIdentity,
+    };
+
+    fn resolved(resource: Resource) -> ResolvedResource {
+        ResolvedResource::new(resource)
+    }
+
+    fn resolved_data_source(resource: DataSource) -> ResolvedDataSource {
+        ResolvedDataSource::new(resource)
+    }
 
     #[test]
     fn empty_plan() {
@@ -552,11 +563,14 @@ mod tests {
     /// run through the full resource-apply pipeline.
     #[test]
     fn read_only_plan_has_no_mutations() {
-        use crate::resource::DataSource;
-
         let mut plan = Plan::new();
         plan.add(Effect::Read {
-            resource: DataSource::with_provider("aws", "iam.Roles", "admin_access_roles", None),
+            resource: resolved_data_source(DataSource::with_provider(
+                "aws",
+                "iam.Roles",
+                "admin_access_roles",
+                None,
+            )),
         });
         // `effects().is_empty()` is false — Read counts as a present effect.
         assert!(!plan.effects().is_empty());
@@ -569,7 +583,10 @@ mod tests {
     #[test]
     fn plan_with_create_has_mutations() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("acm.Certificate", "cert")));
+        plan.add(Effect::Create(resolved(Resource::new(
+            "acm.Certificate",
+            "cert",
+        ))));
         assert!(plan.has_mutations());
         assert_eq!(plan.mutation_count(), 1);
     }
@@ -606,7 +623,7 @@ mod tests {
         use std::time::Duration;
 
         let e = Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "acm.Certificate",
                 "cert",
@@ -633,9 +650,12 @@ mod tests {
         use std::time::Duration;
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("acm.Certificate", "cert")));
+        plan.add(Effect::Create(resolved(Resource::new(
+            "acm.Certificate",
+            "cert",
+        ))));
         plan.add(Effect::Wait {
-            binding: "cert_issued".to_string(),
+            identity: ResourceIdentity::new("cert_issued"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "acm.Certificate",
                 "cert",
@@ -657,8 +677,8 @@ mod tests {
     #[test]
     fn plan_summary() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+        plan.add(Effect::Create(resolved(Resource::new("s3.Bucket", "a"))));
+        plan.add(Effect::Create(resolved(Resource::new("s3.Bucket", "b"))));
         plan.add(Effect::Delete {
             id: crate::resource::ResolvedResourceId::new(
                 crate::resource::ResourceId::with_identity("s3.Bucket", "c"),
@@ -694,9 +714,9 @@ mod tests {
             template_resource,
         };
         let mut plan = Plan::new();
-        plan.add(Effect::Create(
+        plan.add(Effect::Create(resolved(
             Resource::new("acm.Certificate", "cert").with_binding("cert"),
-        ));
+        )));
         plan.add(Effect::DeferredCreate {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "route53.RecordSet",
@@ -780,7 +800,7 @@ mod tests {
         let mut plan = Plan::new();
 
         // Root resource
-        plan.add(Effect::Create(Resource::new("vpc", "main")));
+        plan.add(Effect::Create(resolved(Resource::new("vpc", "main"))));
 
         // Module resource
         let module_resource =
@@ -788,7 +808,7 @@ mod tests {
                 name: "web_tier".to_string(),
                 instance: "web".to_string(),
             });
-        plan.add(Effect::Create(module_resource));
+        plan.add(Effect::Create(resolved(module_resource)));
 
         let modular = ModularPlan::from_plan(plan);
 
@@ -807,8 +827,8 @@ mod tests {
         let mut plan = Plan::new();
 
         // Two root resources
-        plan.add(Effect::Create(Resource::new("vpc", "main")));
-        plan.add(Effect::Create(Resource::new("subnet", "public")));
+        plan.add(Effect::Create(resolved(Resource::new("vpc", "main"))));
+        plan.add(Effect::Create(resolved(Resource::new("subnet", "public"))));
 
         // Module resource
         let module_resource =
@@ -816,7 +836,7 @@ mod tests {
                 name: "web_tier".to_string(),
                 instance: "web".to_string(),
             });
-        plan.add(Effect::Create(module_resource));
+        plan.add(Effect::Create(resolved(module_resource)));
 
         let modular = ModularPlan::from_plan(plan);
         let groups = modular.group_by_module();
@@ -844,22 +864,15 @@ mod tests {
             .with_identifier("vpc-123");
         let to = Resource::new("ec2.Vpc", "vpc");
         let cascading = CascadingUpdate {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "ec2.Subnet",
-                "subnet",
-            )),
             from: Box::new(
                 State::not_found(ResourceId::with_identity("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
             ),
-            to: (Resource::new("ec2.Subnet", "subnet")),
+            to: resolved(Resource::new("ec2.Subnet", "subnet")),
         };
         plan.add(Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "ec2.Vpc", "vpc",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "cidr_block".to_string(),
@@ -889,22 +902,15 @@ mod tests {
             .with_identifier("vpc-123");
         let to = Resource::new("ec2.Vpc", "vpc");
         let cascading = CascadingUpdate {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "ec2.Subnet",
-                "subnet",
-            )),
             from: Box::new(
                 State::not_found(ResourceId::with_identity("ec2.Subnet", "subnet"))
                     .with_identifier("subnet-123"),
             ),
-            to: (Resource::new("ec2.Subnet", "subnet")),
+            to: resolved(Resource::new("ec2.Subnet", "subnet")),
         };
         plan.add(Effect::Replace {
-            id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-                "ec2.Vpc", "vpc",
-            )),
             from: Box::new(from),
-            to,
+            to: resolved(to),
             directives: Directives::default(),
             changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
                 "cidr_block".to_string(),
@@ -933,7 +939,7 @@ mod tests {
         use crate::resource::ResourceId;
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+        plan.add(Effect::Create(resolved(Resource::new("s3.Bucket", "a"))));
         plan.add(Effect::Delete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "s3.Bucket",

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -230,7 +230,9 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
                     continue;
                 }
                 Effect::Wait {
-                    binding, target_id, ..
+                    identity,
+                    target_id,
+                    ..
                 } => {
                     // Scheduling uses `Effect::blocking_bindings()` so
                     // wait targets and explicit wait-block dependencies
@@ -239,6 +241,7 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
                     // structural "wait gates this resource" relationship.
                     let mut deps = HashSet::new();
                     deps.insert(target_id.identity_or_empty().to_string());
+                    let binding = identity.to_string();
                     binding_to_effect.insert(binding.clone(), idx);
                     effect_bindings.insert(idx, binding.clone());
                     effect_types.insert(idx, "wait".to_string());
@@ -552,9 +555,15 @@ mod tests {
     use crate::effect::{DeferredReplaceDelete, NonEmptyDeletes};
     use crate::parser::{DeferredForExpression, ForBinding};
     use crate::plan::Plan;
-    use crate::resource::{ConcreteValue, Directives, Resource, ResourceId, Value};
+    use crate::resource::{
+        ConcreteValue, Directives, ResolvedResource, Resource, ResourceId, ResourceIdentity, Value,
+    };
     use crate::wait::predicate::{AttrPath, WaitPredicate};
     use std::time::Duration;
+
+    fn resolved(resource: Resource) -> ResolvedResource {
+        ResolvedResource::new(resource)
+    }
 
     #[test]
     fn explicit_only_depends_on_edge_is_in_dependency_graph() {
@@ -563,8 +572,8 @@ mod tests {
         bucket.directives.depends_on = vec!["role".to_string()];
 
         let mut plan = Plan::new();
-        plan.add(Effect::Create(role));
-        plan.add(Effect::Create(bucket));
+        plan.add(Effect::Create(resolved(role)));
+        plan.add(Effect::Create(resolved(bucket)));
         let graph = build_dependency_graph(&plan);
 
         let bucket_idx = *graph
@@ -692,7 +701,7 @@ mod tests {
             template: Box::new(deferred),
         });
         plan.add(Effect::Wait {
-            binding: "wait_validation_record_0".to_string(),
+            identity: ResourceIdentity::new("wait_validation_record_0"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "route53.Record",
                 "validation_records[0]",

--- a/carina-core/src/resource/data_source.rs
+++ b/carina-core/src/resource/data_source.rs
@@ -9,6 +9,7 @@
 //! against other resources.
 
 use std::collections::{BTreeSet, HashSet};
+use std::ops::Deref;
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -117,5 +118,85 @@ impl DataSource {
     pub fn with_binding(mut self, binding: impl Into<String>) -> Self {
         self.binding = Some(binding.into());
         self
+    }
+}
+
+/// A [`DataSource`] whose identity has been resolved.
+///
+/// The inner field is private so callers cannot bypass the constructor
+/// invariant:
+///
+/// ```compile_fail
+/// use carina_core::resource::{DataSource, ResolvedDataSource};
+///
+/// let resource = DataSource::new("test", "");
+/// let _ = ResolvedDataSource(resource);
+/// ```
+///
+/// ```compile_fail
+/// use carina_core::resource::{DataSource, ResolvedDataSource};
+///
+/// let resource = DataSource::new("test", "");
+/// let _: ResolvedDataSource = resource.into();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "DataSource", into = "DataSource")]
+pub struct ResolvedDataSource(DataSource);
+
+impl ResolvedDataSource {
+    /// Construct from a [`DataSource`], panicking if identity is `None`.
+    pub fn new(resource: DataSource) -> Self {
+        assert!(
+            resource.id.identity.is_some(),
+            "ResolvedDataSource requires identity"
+        );
+        Self(resource)
+    }
+
+    /// Try to construct; returns `None` if identity is absent.
+    pub fn try_new(resource: DataSource) -> Option<Self> {
+        if resource.id.identity.is_some() {
+            Some(Self(resource))
+        } else {
+            None
+        }
+    }
+
+    /// Borrow the inner [`DataSource`].
+    pub fn as_inner(&self) -> &DataSource {
+        &self.0
+    }
+
+    /// Consume and return the inner [`DataSource`].
+    pub fn into_inner(self) -> DataSource {
+        self.0
+    }
+}
+
+impl Deref for ResolvedDataSource {
+    type Target = DataSource;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<ResolvedDataSource> for DataSource {
+    fn from(resource: ResolvedDataSource) -> Self {
+        resource.0
+    }
+}
+
+impl TryFrom<DataSource> for ResolvedDataSource {
+    type Error = String;
+
+    fn try_from(resource: DataSource) -> Result<Self, Self::Error> {
+        Self::try_new(resource).ok_or_else(|| "identity is required".to_string())
+    }
+}
+
+impl AsRef<DataSource> for ResolvedDataSource {
+    fn as_ref(&self) -> &DataSource {
+        self.as_inner()
     }
 }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -348,6 +348,100 @@ impl AsRef<ResourceId> for ResolvedResourceId {
     }
 }
 
+/// A [`Resource`] whose identity has been resolved.
+///
+/// Downstream effect consumers hold this type to guarantee at compile
+/// time that the wrapped resource has an identity. The inner field is
+/// private so callers cannot bypass the constructor invariant:
+///
+/// ```compile_fail
+/// use carina_core::resource::{ResolvedResource, Resource};
+///
+/// let resource = Resource::new("test", "");
+/// let _ = ResolvedResource(resource);
+/// ```
+///
+/// ```compile_fail
+/// use carina_core::resource::{ResolvedResource, Resource};
+///
+/// let resource = Resource::new("test", "");
+/// let _: ResolvedResource = resource.into();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "Resource", into = "Resource")]
+pub struct ResolvedResource(Resource);
+
+impl ResolvedResource {
+    /// Construct from a [`Resource`], panicking if identity is `None`.
+    pub fn new(resource: Resource) -> Self {
+        assert!(
+            resource.id.identity.is_some(),
+            "ResolvedResource requires identity"
+        );
+        Self(resource)
+    }
+
+    /// Try to construct; returns `None` if identity is absent.
+    pub fn try_new(resource: Resource) -> Option<Self> {
+        if resource.id.identity.is_some() {
+            Some(Self(resource))
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn new_fully_resolved(
+        resource: Resource,
+        _token: crate::executor::basic::ResolvedResourceToken,
+    ) -> Result<Self, crate::value::SerializationError> {
+        assert_resource_fully_resolved(&resource)?;
+        Ok(Self::new(resource))
+    }
+
+    /// Borrow the inner [`Resource`].
+    pub fn as_inner(&self) -> &Resource {
+        &self.0
+    }
+
+    /// Borrow the underlying resource for provider-boundary consumers.
+    pub fn as_resource(&self) -> &Resource {
+        self.as_inner()
+    }
+
+    /// Consume and return the inner [`Resource`].
+    pub fn into_inner(self) -> Resource {
+        self.0
+    }
+}
+
+impl Deref for ResolvedResource {
+    type Target = Resource;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<ResolvedResource> for Resource {
+    fn from(resource: ResolvedResource) -> Self {
+        resource.0
+    }
+}
+
+impl TryFrom<Resource> for ResolvedResource {
+    type Error = String;
+
+    fn try_from(resource: Resource) -> Result<Self, Self::Error> {
+        Self::try_new(resource).ok_or_else(|| "identity is required".to_string())
+    }
+}
+
+impl AsRef<Resource> for ResolvedResource {
+    fn as_ref(&self) -> &Resource {
+        self.as_inner()
+    }
+}
+
 pub(crate) fn identity_if_present(identity: impl Into<String>) -> Option<ResourceIdentity> {
     let identity = identity.into();
     if identity.is_empty() {
@@ -2391,51 +2485,8 @@ mod enum_attr_tests {
     }
 }
 
-/// A managed resource whose attribute tree has been checked and found
-/// free of any `Value::Deferred` placeholder before provider dispatch.
-///
-/// The constructor requires a private token from
-/// `carina_core::executor::basic`, so callers outside the basic
-/// executor's resolve helpers cannot manufacture this witness.
-///
-/// ```compile_fail
-/// use carina_core::resource::{ResolvedResource, Resource};
-///
-/// let resource = Resource::new("test", "example");
-/// let _: ResolvedResource = resource.into();
-/// ```
-///
-/// ```compile_fail
-/// use carina_core::resource::{ResolvedResource, Resource};
-///
-/// let resource = Resource::new("test", "example");
-/// let _ = ResolvedResource::new(resource);
-/// ```
-///
-/// ```compile_fail
-/// use carina_core::resource::{ResolvedResource, Resource};
-///
-/// let resource = Resource::new("test", "example");
-/// let _ = ResolvedResource::try_new(resource);
-/// ```
-#[derive(Debug, Clone, PartialEq)]
-pub struct ResolvedResource(Resource);
-
-impl ResolvedResource {
-    pub(crate) fn new(
-        resource: Resource,
-        _token: crate::executor::basic::ResolvedResourceToken,
-    ) -> Result<Self, crate::value::SerializationError> {
-        assert_resource_fully_resolved(&resource)?;
-        Ok(Self(resource))
-    }
-
-    /// Borrow the underlying resource for provider-boundary consumers.
-    pub fn as_resource(&self) -> &Resource {
-        &self.0
-    }
-}
-
+/// Check that a resource's attribute tree is free of any
+/// [`Value::Deferred`] placeholder before provider dispatch.
 pub(crate) fn assert_resource_fully_resolved(
     resource: &Resource,
 ) -> Result<(), crate::value::SerializationError> {
@@ -2616,7 +2667,7 @@ pub mod leaf_node;
 pub mod persistent_id;
 
 pub use composition::{Composition, CompositionAttribute, Signature};
-pub use data_source::DataSource;
+pub use data_source::{DataSource, ResolvedDataSource};
 pub use expansion_trace::{CallSite, ExpansionTrace};
 pub use graph_node::GraphNode;
 pub use leaf_node::{CompositionNotALeaf, LeafNode, expand_to_leaves};

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -162,6 +162,94 @@ fn resolved_resource_id_serde_round_trips_as_resource_id() {
 }
 
 #[test]
+#[should_panic(expected = "ResolvedResource requires identity")]
+fn resolved_resource_new_panics_without_identity() {
+    ResolvedResource::new(Resource::new("s3.Bucket", ""));
+}
+
+#[test]
+fn resolved_resource_try_new_returns_none_without_identity() {
+    assert!(ResolvedResource::try_new(Resource::new("s3.Bucket", "")).is_none());
+}
+
+#[test]
+fn resolved_resource_try_new_returns_some_with_identity() {
+    let resolved =
+        ResolvedResource::try_new(Resource::new("s3.Bucket", "logs")).expect("identity is present");
+    assert_eq!(resolved.id.identity_str(), Some("logs"));
+    assert_eq!(resolved.as_inner().id.identity_str(), Some("logs"));
+    assert_eq!(
+        resolved.clone().into_inner().id.identity_str(),
+        Some("logs")
+    );
+}
+
+#[test]
+fn resolved_resource_serde_round_trips_as_resource() {
+    let resolved = ResolvedResource::new(Resource::with_provider(
+        "aws",
+        "s3.Bucket",
+        "logs",
+        Some("primary".to_string()),
+    ));
+    let json = serde_json::to_string(&resolved).unwrap();
+    let decoded: ResolvedResource = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded, resolved);
+    assert_eq!(decoded.id.identity_str(), Some("logs"));
+}
+
+#[test]
+fn resolved_resource_deserialize_rejects_absent_identity() {
+    let json = serde_json::to_string(&Resource::new("s3.Bucket", "")).unwrap();
+    let err = serde_json::from_str::<ResolvedResource>(&json).unwrap_err();
+    assert!(err.to_string().contains("identity is required"));
+}
+
+#[test]
+#[should_panic(expected = "ResolvedDataSource requires identity")]
+fn resolved_data_source_new_panics_without_identity() {
+    ResolvedDataSource::new(DataSource::new("aws_ami", ""));
+}
+
+#[test]
+fn resolved_data_source_try_new_returns_none_without_identity() {
+    assert!(ResolvedDataSource::try_new(DataSource::new("aws_ami", "")).is_none());
+}
+
+#[test]
+fn resolved_data_source_try_new_returns_some_with_identity() {
+    let resolved =
+        ResolvedDataSource::try_new(DataSource::new("aws_ami", "ubuntu")).expect("identity");
+    assert_eq!(resolved.id.identity_str(), Some("ubuntu"));
+    assert_eq!(resolved.as_inner().id.identity_str(), Some("ubuntu"));
+    assert_eq!(
+        resolved.clone().into_inner().id.identity_str(),
+        Some("ubuntu")
+    );
+}
+
+#[test]
+fn resolved_data_source_serde_round_trips_as_data_source() {
+    let resolved = ResolvedDataSource::new(DataSource::with_provider(
+        "aws",
+        "ami",
+        "ubuntu",
+        Some("primary".to_string()),
+    ));
+    let json = serde_json::to_string(&resolved).unwrap();
+    let decoded: ResolvedDataSource = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded, resolved);
+    assert_eq!(decoded.id.identity_str(), Some("ubuntu"));
+}
+
+#[test]
+fn resolved_data_source_deserialize_rejects_absent_identity() {
+    let json = serde_json::to_string(&DataSource::new("aws_ami", "")).unwrap();
+    let err = serde_json::from_str::<ResolvedDataSource>(&json).unwrap_err();
+    assert!(err.to_string().contains("identity is required"));
+}
+
+#[test]
 fn resource_id_rejects_legacy_empty_name() {
     let legacy = r#"{"provider":"aws","resource_type":"ec2.Subnet","name":""}"#;
     assert!(

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1008,22 +1008,23 @@ pub fn redact_secrets_in_effect(
     use crate::effect::Effect;
     Ok(match effect {
         Effect::Read { resource } => Effect::Read {
-            resource: redact_secrets_in_data_source(resource)?,
+            resource: crate::resource::ResolvedDataSource::new(redact_secrets_in_data_source(
+                resource,
+            )?),
         },
-        Effect::Create(resource) => Effect::Create(redact_secrets_in_managed(resource)?),
+        Effect::Create(resource) => Effect::Create(crate::resource::ResolvedResource::new(
+            redact_secrets_in_managed(resource)?,
+        )),
         Effect::Update {
-            id,
             from,
             to,
             changed_attributes,
         } => Effect::Update {
-            id: id.clone(),
             from: Box::new(redact_secrets_in_state(from)?),
-            to: redact_secrets_in_managed(to)?,
+            to: crate::resource::ResolvedResource::new(redact_secrets_in_managed(to)?),
             changed_attributes: changed_attributes.clone(),
         },
         Effect::Replace {
-            id,
             from,
             to,
             directives,
@@ -1032,9 +1033,8 @@ pub fn redact_secrets_in_effect(
             temporary_name,
             cascade_ref_hints,
         } => Effect::Replace {
-            id: id.clone(),
             from: Box::new(redact_secrets_in_state(from)?),
-            to: redact_secrets_in_managed(to)?,
+            to: crate::resource::ResolvedResource::new(redact_secrets_in_managed(to)?),
             directives: directives.clone(),
             changed_create_only: changed_create_only.clone(),
             temporary_name: temporary_name.clone(),
@@ -1043,9 +1043,10 @@ pub fn redact_secrets_in_effect(
                 .iter()
                 .map(|cu| {
                     Ok::<_, SerializationError>(crate::effect::CascadingUpdate {
-                        id: cu.id.clone(),
                         from: Box::new(redact_secrets_in_state(&cu.from)?),
-                        to: redact_secrets_in_managed(&cu.to)?,
+                        to: crate::resource::ResolvedResource::new(redact_secrets_in_managed(
+                            &cu.to,
+                        )?),
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?,

--- a/carina-core/tests/wait_downstream_apply.rs
+++ b/carina-core/tests/wait_downstream_apply.rs
@@ -277,7 +277,7 @@ async fn module_wait_binding_survives_expansion_and_synchronizes_downstream() {
     assert!(
         plan.effects().iter().any(|e| matches!(
             e,
-            carina_core::effect::Effect::Wait { binding, .. } if binding == "r.cert_issued"
+            carina_core::effect::Effect::Wait { identity, .. } if identity.as_str() == "r.cert_issued"
         )),
         "create_plan must emit Effect::Wait for the prefixed wait binding"
     );
@@ -426,7 +426,7 @@ async fn nested_module_wait_binding_survives_two_expansions() {
     assert!(
         plan.effects().iter().any(|e| matches!(
             e,
-            carina_core::effect::Effect::Wait { binding, .. } if binding == "o.c.cert_issued"
+            carina_core::effect::Effect::Wait { identity, .. } if identity.as_str() == "o.c.cert_issued"
         )),
         "create_plan must emit Effect::Wait for the doubly-prefixed binding"
     );
@@ -584,7 +584,7 @@ async fn carina3085_distribution_wait_ref_resolves_no_phantom_via_real_pipeline(
     assert!(
         plan.effects().iter().any(|e| matches!(
             e,
-            carina_core::effect::Effect::Wait { binding, .. } if binding == "r.cert_issued"
+            carina_core::effect::Effect::Wait { identity, .. } if identity.as_str() == "r.cert_issued"
         )),
         "the value-layer alias fix must NOT remove the Effect::Wait \
          dependency edge — both halves of the wait binding must hold"

--- a/carina-tui/src/app/mod.rs
+++ b/carina-tui/src/app/mod.rs
@@ -123,9 +123,7 @@ impl App {
             .effects()
             .iter()
             .filter_map(|e| match e {
-                Effect::Update { id, .. } | Effect::Replace { id, .. } => {
-                    Some(id.clone().into_inner())
-                }
+                Effect::Update { to, .. } | Effect::Replace { to, .. } => Some(to.id.clone()),
                 Effect::DeferredReplace { .. } => None,
                 _ => None,
             })
@@ -705,28 +703,34 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
             depth: 0,
             parent: None,
         },
-        Effect::Update { id, .. } => TreeNode {
-            effect_label: format!("{}", id.human()),
-            resource_type: id.display_type(),
-            name_part: id.identity_or_empty().to_string(),
-            symbol: effect.display_glyph().to_string(),
-            kind: EffectKind::Update,
-            detail_rows,
-            children: Vec::new(),
-            depth: 0,
-            parent: None,
-        },
-        Effect::Replace { id, .. } => TreeNode {
-            effect_label: format!("{}", id.human()),
-            resource_type: id.display_type(),
-            name_part: id.identity_or_empty().to_string(),
-            symbol: effect.display_glyph().to_string(),
-            kind: EffectKind::Replace,
-            detail_rows,
-            children: Vec::new(),
-            depth: 0,
-            parent: None,
-        },
+        Effect::Update { to, .. } => {
+            let id = &to.id;
+            TreeNode {
+                effect_label: format!("{}", id.human()),
+                resource_type: id.display_type(),
+                name_part: id.identity_or_empty().to_string(),
+                symbol: effect.display_glyph().to_string(),
+                kind: EffectKind::Update,
+                detail_rows,
+                children: Vec::new(),
+                depth: 0,
+                parent: None,
+            }
+        }
+        Effect::Replace { to, .. } => {
+            let id = &to.id;
+            TreeNode {
+                effect_label: format!("{}", id.human()),
+                resource_type: id.display_type(),
+                name_part: id.identity_or_empty().to_string(),
+                symbol: effect.display_glyph().to_string(),
+                kind: EffectKind::Replace,
+                detail_rows,
+                children: Vec::new(),
+                depth: 0,
+                parent: None,
+            }
+        }
         Effect::Delete { id, identifier, .. } => {
             // build_detail_rows returns empty for Delete without delete_attributes,
             // so add the identifier as a manual attribute row
@@ -793,20 +797,23 @@ fn effect_to_node(plan: &Plan, effect: &Effect, schemas: Option<&SchemaRegistry>
             parent: None,
         },
         Effect::Wait {
-            binding,
+            identity,
             until_surface,
             ..
-        } => TreeNode {
-            effect_label: format!("{} (until {})", binding, until_surface),
-            resource_type: "wait".to_string(),
-            name_part: binding.clone(),
-            symbol: effect.display_glyph().to_string(),
-            kind: EffectKind::Wait,
-            detail_rows,
-            children: Vec::new(),
-            depth: 0,
-            parent: None,
-        },
+        } => {
+            let binding = identity.to_string();
+            TreeNode {
+                effect_label: format!("{} (until {})", binding, until_surface),
+                resource_type: "wait".to_string(),
+                name_part: binding,
+                symbol: effect.display_glyph().to_string(),
+                kind: EffectKind::Wait,
+                detail_rows,
+                children: Vec::new(),
+                depth: 0,
+                parent: None,
+            }
+        }
         Effect::DeferredCreate {
             upstream_binding,
             template,

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -1,7 +1,17 @@
 use super::*;
 use carina_core::parser::{DeferredForExpression, ForBinding};
-use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{
+    ConcreteValue, Directives, ResolvedResource, Resource, ResourceId, State, Value,
+};
 use carina_core::value::format_value;
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
+
+fn create(resource: Resource) -> Effect {
+    Effect::Create(resolved(resource))
+}
 
 #[test]
 fn app_from_empty_plan() {
@@ -14,7 +24,7 @@ fn app_from_empty_plan() {
 #[test]
 fn app_from_plan_with_effects() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
+    plan.add(create(Resource::new("s3.Bucket", "my-bucket")));
     plan.add(Effect::Delete {
         id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
             "s3.Bucket",
@@ -104,9 +114,9 @@ fn deferred_create_uses_create_symbol_and_kind() {
 #[test]
 fn navigation() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "c")));
+    plan.add(create(Resource::new("s3.Bucket", "a")));
+    plan.add(create(Resource::new("s3.Bucket", "b")));
+    plan.add(create(Resource::new("s3.Bucket", "c")));
 
     let mut app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.selected, 0);
@@ -136,10 +146,6 @@ fn navigation() {
 fn update_effect_has_detail_rows() {
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "s3.Bucket",
-            "my-bucket",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("s3.Bucket", "my-bucket"),
             [(
@@ -149,10 +155,10 @@ fn update_effect_has_detail_rows() {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("s3.Bucket", "my-bucket").with_attribute(
+        to: resolved(Resource::new("s3.Bucket", "my-bucket").with_attribute(
             "versioning",
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
-        ),
+        )),
         changed_attributes: vec!["versioning".to_string()],
     });
 
@@ -170,7 +176,7 @@ fn update_effect_has_detail_rows() {
 #[test]
 fn internal_attributes_filtered() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("s3.Bucket", "my-bucket")
             .with_attribute(
                 "name",
@@ -226,11 +232,8 @@ fn replace_effect_symbols() {
 
     // create_before_destroy = true -> "+/-"
     plan.add(Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "my-vpc",
-        )),
         from: from.clone(),
-        to: Resource::new("ec2.Vpc", "my-vpc"),
+        to: resolved(Resource::new("ec2.Vpc", "my-vpc")),
         directives: Directives {
             create_before_destroy: true,
             ..Default::default()
@@ -244,11 +247,8 @@ fn replace_effect_symbols() {
 
     // create_before_destroy = false -> "-/+"
     plan.add(Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "my-vpc2",
-        )),
         from,
-        to: Resource::new("ec2.Vpc", "my-vpc2"),
+        to: resolved(Resource::new("ec2.Vpc", "my-vpc2")),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec!["cidr".to_string()])
             .unwrap(),
@@ -266,7 +266,7 @@ fn replace_effect_symbols() {
 fn tree_structure_with_dependencies() {
     // Create a plan where subnet depends on vpc via ResourceRef
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
@@ -274,7 +274,7 @@ fn tree_structure_with_dependencies() {
                 Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
             ),
     ));
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
@@ -299,7 +299,7 @@ fn tree_structure_with_dependencies() {
 #[test]
 fn selected_node_returns_correct_node() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("s3.Bucket", "my-bucket").with_attribute(
             "name",
             Value::Concrete(ConcreteValue::String("test".to_string())),
@@ -316,7 +316,7 @@ fn selected_node_returns_correct_node() {
 #[test]
 fn toggle_focus_switches_panels() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+    plan.add(create(Resource::new("s3.Bucket", "a")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     assert_eq!(app.focused_panel, FocusedPanel::Tree);
@@ -329,7 +329,7 @@ fn toggle_focus_switches_panels() {
 #[test]
 fn detail_scroll_up_down() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
+    plan.add(create(Resource::new("s3.Bucket", "a")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     assert_eq!(app.detail_scroll, 0);
@@ -349,8 +349,8 @@ fn detail_scroll_up_down() {
 #[test]
 fn detail_scroll_resets_on_navigation() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+    plan.add(create(Resource::new("s3.Bucket", "a")));
+    plan.add(create(Resource::new("s3.Bucket", "b")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
 
     app.detail_scroll = 5;
@@ -367,10 +367,7 @@ fn tree_scroll_cursor_moves_within_visible_area_before_scrolling() {
     // Create a plan with 10 items
     let mut plan = Plan::new();
     for i in 0..10 {
-        plan.add(Effect::Create(Resource::new(
-            "s3.Bucket",
-            format!("bucket-{}", i),
-        )));
+        plan.add(create(Resource::new("s3.Bucket", format!("bucket-{}", i))));
     }
     let mut app = App::new(&plan, &SchemaRegistry::new());
     // Simulate a visible area of 5 items
@@ -426,8 +423,8 @@ fn tree_scroll_cursor_moves_within_visible_area_before_scrolling() {
 fn tree_scroll_zero_height_does_not_scroll_on_move_down() {
     // When tree_area_height is 0 (before first render), move_down should not scroll
     let mut plan = Plan::new();
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-    plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+    plan.add(create(Resource::new("s3.Bucket", "a")));
+    plan.add(create(Resource::new("s3.Bucket", "b")));
     let mut app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.tree_area_height, 0);
 
@@ -439,7 +436,7 @@ fn tree_scroll_zero_height_does_not_scroll_on_move_down() {
 /// Helper to build a plan with vpc -> subnet dependency tree for filter tests.
 fn make_tree_plan() -> Plan {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
@@ -447,7 +444,7 @@ fn make_tree_plan() -> Plan {
                 Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
             ),
     ));
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
@@ -455,7 +452,7 @@ fn make_tree_plan() -> Plan {
                 Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
             ),
     ));
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
     ));
     plan
@@ -642,10 +639,10 @@ fn tab_complete_matches_middle_of_word() {
 fn tab_complete_with_provider_prefix() {
     // Resource types with provider prefix (e.g., "awscc.ec2.Vpc")
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
     ));
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None).with_binding("subnet"),
     ));
     let mut app = App::new(&plan, &SchemaRegistry::new());
@@ -710,7 +707,7 @@ fn format_value_resolves_dsl_enum_identifiers() {
 #[test]
 fn create_effect_attributes_resolve_enum_values() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.vpc_endpoint", "my-endpoint")
             .with_attribute(
                 "vpc_endpoint_type",
@@ -760,10 +757,6 @@ fn move_suppressed_when_update_exists_for_same_target() {
     });
     // Update for the same target
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "s3.Bucket",
-            "new-name",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("s3.Bucket", "new-name"),
             [(
@@ -773,10 +766,10 @@ fn move_suppressed_when_update_exists_for_same_target() {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("s3.Bucket", "new-name").with_attribute(
+        to: resolved(Resource::new("s3.Bucket", "new-name").with_attribute(
             "versioning",
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
-        ),
+        )),
         changed_attributes: vec!["versioning".to_string()],
     });
 
@@ -798,9 +791,6 @@ fn move_suppressed_when_replace_exists_for_same_target() {
         )),
     });
     plan.add(Effect::Replace {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "new-vpc",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Vpc", "new-vpc"),
             [(
@@ -810,7 +800,7 @@ fn move_suppressed_when_replace_exists_for_same_target() {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("ec2.Vpc", "new-vpc"),
+        to: resolved(Resource::new("ec2.Vpc", "new-vpc")),
         directives: Directives::default(),
         changed_create_only: carina_core::effect::ChangedCreateOnly::new(vec!["cidr".to_string()])
             .unwrap(),

--- a/carina-tui/src/lib.rs
+++ b/carina-tui/src/lib.rs
@@ -226,12 +226,16 @@ fn run_tui<A>(
 mod tests {
     use super::*;
     use carina_core::effect::Effect;
-    use carina_core::resource::Resource;
+    use carina_core::resource::{ResolvedResource, Resource};
+
+    fn create(resource: Resource) -> Effect {
+        Effect::Create(ResolvedResource::new(resource))
+    }
 
     fn make_app() -> App {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
+        plan.add(create(Resource::new("s3.Bucket", "a")));
+        plan.add(create(Resource::new("s3.Bucket", "b")));
         App::new(&plan, &SchemaRegistry::new())
     }
 
@@ -274,13 +278,13 @@ mod tests {
 
     fn make_search_app() -> App {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::new("s3.Bucket", "my-bucket").with_binding("bucket"),
         ));
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
         ));
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::new("ec2.Subnet", "my-subnet")
                 .with_binding("subnet")
                 .with_attribute(
@@ -482,14 +486,14 @@ mod tests {
 
     fn make_provider_prefixed_app() -> App {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::with_provider("awscc", "ec2.Vpc", "my-vpc", None).with_binding("vpc"),
         ));
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::with_provider("awscc", "ec2.Subnet", "my-subnet", None)
                 .with_binding("subnet"),
         ));
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::with_provider("awscc", "s3.Bucket", "my-bucket", None).with_binding("bucket"),
         ));
         App::new(&plan, &SchemaRegistry::new())

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -12,13 +12,22 @@ use carina_core::effect::{DeferredReplaceDelete, Effect, NonEmptyDeletes};
 use carina_core::parser::{DeferredForExpression, ForBinding};
 use carina_core::plan::Plan;
 use carina_core::resource::{
-    ConcreteValue, DeferredValue, Directives, Resource, ResourceId, State, UnknownReason, Value,
+    ConcreteValue, DeferredValue, Directives, ResolvedResource, Resource, ResourceId, State,
+    UnknownReason, Value,
 };
 use carina_core::schema::SchemaRegistry;
 
 use crate::app::App;
 use crate::test_utils::buffer_to_string;
 use crate::ui::draw;
+
+fn resolved(resource: Resource) -> ResolvedResource {
+    ResolvedResource::new(resource)
+}
+
+fn create(resource: Resource) -> Effect {
+    Effect::Create(resolved(resource))
+}
 
 /// Render the TUI into a string, optionally selecting a specific node.
 fn render_tui(plan: &Plan, width: u16, height: u16, selection: usize) -> String {
@@ -48,7 +57,7 @@ fn render_tui_with_schemas(
 /// Build a plan with VPC + route table + subnet (all Create effects with dependencies).
 fn build_all_create_plan() -> Plan {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
@@ -56,7 +65,7 @@ fn build_all_create_plan() -> Plan {
                 Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
             ),
     ));
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.RouteTable", "my-rt")
             .with_binding("rt")
             .with_attribute(
@@ -64,7 +73,7 @@ fn build_all_create_plan() -> Plan {
                 Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
             ),
     ));
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.Subnet", "my-subnet")
             .with_binding("subnet")
             .with_attribute(
@@ -83,9 +92,6 @@ fn build_all_create_plan() -> Plan {
 fn build_mixed_operations_plan() -> Plan {
     let mut plan = Plan::new();
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "my-vpc",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Vpc", "my-vpc"),
             [
@@ -101,19 +107,21 @@ fn build_mixed_operations_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("ec2.Vpc", "my-vpc")
-            .with_binding("vpc")
-            .with_attribute(
-                "cidr_block",
-                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-            )
-            .with_attribute(
-                "enable_dns_support",
-                Value::Concrete(ConcreteValue::Bool(true)),
-            ),
+        to: resolved(
+            Resource::new("ec2.Vpc", "my-vpc")
+                .with_binding("vpc")
+                .with_attribute(
+                    "cidr_block",
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+                )
+                .with_attribute(
+                    "enable_dns_support",
+                    Value::Concrete(ConcreteValue::Bool(true)),
+                ),
+        ),
         changed_attributes: vec!["enable_dns_support".to_string()],
     });
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.SecurityGroup", "my-sg")
             .with_binding("sg")
             .with_attribute(
@@ -178,9 +186,6 @@ fn build_map_key_diff_plan() -> Plan {
     .collect();
 
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "my-vpc",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Vpc", "my-vpc"),
             [
@@ -200,13 +205,15 @@ fn build_map_key_diff_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("ec2.Vpc", "my-vpc")
-            .with_binding("vpc")
-            .with_attribute(
-                "cidr_block",
-                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-            )
-            .with_attribute("tags", Value::Concrete(ConcreteValue::Map(new_tags))),
+        to: resolved(
+            Resource::new("ec2.Vpc", "my-vpc")
+                .with_binding("vpc")
+                .with_attribute(
+                    "cidr_block",
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+                )
+                .with_attribute("tags", Value::Concrete(ConcreteValue::Map(new_tags))),
+        ),
         changed_attributes: vec!["tags".to_string()],
     });
     plan
@@ -229,7 +236,7 @@ fn build_deferred_for_plan() -> Plan {
     };
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(certificate_resource()));
+    plan.add(create(certificate_resource()));
     plan.add(Effect::DeferredCreate {
         id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
             "__deferred_for",
@@ -257,7 +264,7 @@ fn build_anonymous_deferred_for_plan() -> Plan {
     };
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(certificate_resource()));
+    plan.add(create(certificate_resource()));
     plan.add(Effect::DeferredCreate {
         id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
             "__deferred_for",
@@ -286,7 +293,7 @@ fn build_deferred_replace_plan() -> Plan {
     };
 
     let mut plan = Plan::new();
-    plan.add(Effect::Create(certificate_resource()));
+    plan.add(create(certificate_resource()));
     plan.add(Effect::DeferredReplace {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -407,7 +414,7 @@ fn snapshot_deferred_replace() {
 #[test]
 fn snapshot_create_with_schema() {
     let mut plan = Plan::new();
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.Vpc", "my-vpc")
             .with_binding("vpc")
             .with_attribute(
@@ -522,9 +529,6 @@ fn build_moved_with_changes_plan() -> Plan {
         )),
     });
     plan.add(Effect::Update {
-        id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "new_vpc",
-        )),
         from: Box::new(State::existing(
             ResourceId::with_identity("ec2.Vpc", "new_vpc"),
             [
@@ -540,26 +544,28 @@ fn build_moved_with_changes_plan() -> Plan {
             .into_iter()
             .collect(),
         )),
-        to: Resource::new("ec2.Vpc", "new_vpc")
-            .with_binding("new_vpc")
-            .with_attribute(
-                "cidr_block",
-                Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-            )
-            .with_attribute(
-                "tags",
-                Value::Concrete(ConcreteValue::Map(
-                    [(
-                        "Name".to_string(),
-                        Value::Concrete(ConcreteValue::String("updated".to_string())),
-                    )]
-                    .into_iter()
-                    .collect(),
-                )),
-            ),
+        to: resolved(
+            Resource::new("ec2.Vpc", "new_vpc")
+                .with_binding("new_vpc")
+                .with_attribute(
+                    "cidr_block",
+                    Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+                )
+                .with_attribute(
+                    "tags",
+                    Value::Concrete(ConcreteValue::Map(
+                        [(
+                            "Name".to_string(),
+                            Value::Concrete(ConcreteValue::String("updated".to_string())),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    )),
+                ),
+        ),
         changed_attributes: vec!["tags".to_string()],
     });
-    plan.add(Effect::Create(
+    plan.add(create(
         Resource::new("ec2.Subnet", "my-subnet")
             .with_attribute(
                 "cidr_block",

--- a/carina-tui/src/ui/tree.rs
+++ b/carina-tui/src/ui/tree.rs
@@ -156,13 +156,17 @@ mod tests {
     use super::*;
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
-    use carina_core::resource::{ConcreteValue, Resource, Value};
+    use carina_core::resource::{ConcreteValue, ResolvedResource, Resource, Value};
     use carina_core::schema::SchemaRegistry;
+
+    fn create(resource: Resource) -> Effect {
+        Effect::Create(ResolvedResource::new(resource))
+    }
 
     #[test]
     fn tree_connector_root_has_no_prefix() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
+        plan.add(create(Resource::new("s3.Bucket", "my-bucket")));
         let app = App::new(&plan, &SchemaRegistry::new());
         assert_eq!(build_tree_connector(0, &app), "");
     }
@@ -170,7 +174,7 @@ mod tests {
     #[test]
     fn tree_connector_single_child() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::new("ec2.Vpc", "my-vpc")
                 .with_binding("vpc")
                 .with_attribute(
@@ -178,7 +182,7 @@ mod tests {
                     Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
                 ),
         ));
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::new("ec2.Subnet", "my-subnet")
                 .with_binding("subnet")
                 .with_attribute(
@@ -196,10 +200,10 @@ mod tests {
     #[test]
     fn tree_connector_multiple_children() {
         let mut plan = Plan::new();
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::new("ec2.Vpc", "my-vpc").with_binding("vpc"),
         ));
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::new("ec2.Subnet", "subnet-a")
                 .with_binding("subnet_a")
                 .with_attribute(
@@ -207,7 +211,7 @@ mod tests {
                     Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
                 ),
         ));
-        plan.add(Effect::Create(
+        plan.add(create(
             Resource::new("ec2.Subnet", "subnet-b")
                 .with_binding("subnet_b")
                 .with_attribute(


### PR DESCRIPTION
## Summary

- Introduce `ResolvedResource(Resource)` and `ResolvedDataSource(DataSource)` newtypes that guarantee identity is present at compile time
- `Effect::Create(ResolvedResource)` — identity guaranteed by type
- `Effect::Read { resource: ResolvedDataSource }` — identity guaranteed by type
- `Effect::Wait { identity: ResourceIdentity }` — replaces `binding: String`
- Remove redundant `id: ResolvedResourceId` from `Update`/`Replace`/`CascadingUpdate` — identity now derived from `to: ResolvedResource`
- Update `BasicEffect` to match new shapes
- Migrate all consumers: differ, executor, display, scheduler, CLI, TUI, tests

## Test plan

- [x] `cargo nextest run --workspace` — 4373 passed, 73 skipped
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Plan snapshots updated via `cargo insta accept`
- [x] compile_fail doctests verify newtypes reject missing identity
- [ ] CI green

Closes #3645