### PR TITLE
refactor(scheduler): index effects by ResourceIdentity (#3625 Phase 1)

### DIFF
--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1928,18 +1928,18 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
 /// should reference the new (post-replacement) resource ID, not the old one.
 #[tokio::test]
 async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "subnet");
 
     // --- Unresolved resources (before ref resolution) ---
-    let vpc_unresolved = Resource::new("ec2.Vpc", "my-vpc")
+    let vpc_unresolved = Resource::new("ec2.Vpc", "vpc")
         .with_binding("vpc")
         .with_attribute(
             "cidr_block",
             Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
         );
 
-    let subnet_unresolved = Resource::new("ec2.Subnet", "my-subnet")
+    let subnet_unresolved = Resource::new("ec2.Subnet", "subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",
@@ -1952,7 +1952,7 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
 
     // --- Resolved resources (after ref resolution with old state) ---
     // The subnet's vpc_id has been eagerly resolved to "vpc-OLD"
-    let subnet_resolved = Resource::new("ec2.Subnet", "my-subnet")
+    let subnet_resolved = Resource::new("ec2.Subnet", "subnet")
         .with_binding("subnet")
         .with_attribute(
             "vpc_id",

--- a/carina-cli/tests/destroy_wait_ordering_e2e.rs
+++ b/carina-cli/tests/destroy_wait_ordering_e2e.rs
@@ -75,7 +75,7 @@ let lst = mock.test.resource {{
 
     fn seed_carina_state_with_cert_name(&self, cert_name: &str) {
         let mut state = StateFile::new();
-        let mut cert = ResourceState::new("test.resource", cert_name, "mock")
+        let mut cert = ResourceState::new("test.resource", "cert", "mock")
             .with_identifier("mock-id")
             .with_attribute("name", serde_json::json!(cert_name))
             .with_attribute("id", serde_json::json!("cert-id"))
@@ -105,7 +105,7 @@ let lst = mock.test.resource {{
 
     fn seed_mock_provider_state_with_cert_name(&self, cert_name: &str) {
         let provider_state = serde_json::json!({
-            format!("test.resource.{cert_name}"): {
+            "test.resource.cert": {
                 "name": cert_name,
                 "id": "cert-id",
                 "status": "ISSUED"
@@ -168,8 +168,8 @@ fn destroy_wait_ordering_uses_wait_target_binding_not_resource_name() {
         .expect("delete log should contain lst");
     let cert_pos = delete_log
         .iter()
-        .position(|entry| entry == "test.resource.primary-cert")
-        .expect("delete log should contain primary-cert");
+        .position(|entry| entry == "test.resource.cert")
+        .expect("delete log should contain cert identity");
 
     assert!(
         lst_pos < cert_pos,

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -36,13 +36,13 @@ pub enum PlanOp {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScheduleEdge {
-    /// This effect must wait for the named binding to complete.
-    DependsOn(String),
-    /// This effect must complete before the named binding can proceed.
-    BlockedBy(String),
-    /// This effect must complete before the named binding can proceed, but
-    /// only when that binding resolves to a delete effect.
-    BlockedByIfDelete(String),
+    /// This effect must wait for the resource identity to complete.
+    DependsOn(ResourceIdentity),
+    /// This effect must complete before the resource identity can proceed.
+    BlockedBy(ResourceIdentity),
+    /// This effect must complete before the resource identity can proceed, but
+    /// only when that identity resolves to a delete effect.
+    BlockedByIfDelete(ResourceIdentity),
 }
 
 /// Temporary name used during create-before-destroy replacement.
@@ -832,6 +832,25 @@ impl Effect {
         }
     }
 
+    /// Returns the scheduler identity for this effect.
+    ///
+    /// `Effect::identity()` is total because all scheduler-bound payloads went
+    /// through the `Resolved*` checked constructors after the resolver boundary.
+    /// `Wait` is keyed by the wait effect's own identity, not by its target.
+    pub fn identity(&self) -> ResourceIdentity {
+        if let Effect::Wait { identity, .. } = self {
+            return identity.clone();
+        }
+        self.resource_id()
+            .identity
+            .as_ref()
+            .expect(
+                "Effect::identity is total because all scheduler-bound Effect payloads \
+                 went through the Resolved* checked constructors",
+            )
+            .clone()
+    }
+
     /// Returns a read-only [`ResourceRef`](crate::parser::ResourceRef)
     /// view of the resource for this effect, if it has one. Delete,
     /// Import, Remove, Move, and Wait effects have no resource.
@@ -1050,12 +1069,14 @@ impl Effect {
             Effect::Delete { dependencies, .. } => dependencies
                 .iter()
                 .cloned()
+                .map(ResourceIdentity::new)
                 .map(ScheduleEdge::BlockedBy)
                 .collect(),
             Effect::Replace { from, .. } => from
                 .dependency_bindings
                 .iter()
                 .cloned()
+                .map(ResourceIdentity::new)
                 .map(ScheduleEdge::BlockedByIfDelete)
                 .collect(),
             Effect::Wait { .. }
@@ -1063,6 +1084,7 @@ impl Effect {
             | Effect::DeferredReplace { .. } => self
                 .blocking_bindings()
                 .into_iter()
+                .map(ResourceIdentity::new)
                 .map(ScheduleEdge::DependsOn)
                 .collect(),
             Effect::Read { .. }
@@ -1086,12 +1108,14 @@ impl Effect {
             Effect::Delete { dependencies, .. } => dependencies
                 .iter()
                 .cloned()
+                .map(ResourceIdentity::new)
                 .map(ScheduleEdge::BlockedBy)
                 .collect(),
             Effect::Replace { from, .. } => from
                 .dependency_bindings
                 .iter()
                 .cloned()
+                .map(ResourceIdentity::new)
                 .map(ScheduleEdge::BlockedBy)
                 .collect(),
             Effect::Read { .. }

--- a/carina-core/src/effect/deps.rs
+++ b/carina-core/src/effect/deps.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use crate::effect::{Effect, ScheduleEdge};
 use crate::non_empty::NonEmptyVec;
 use crate::parser::ResourceRef;
-use crate::resource::{Resource, ResourceId};
+use crate::resource::{Resource, ResourceId, ResourceIdentity};
 
 #[derive(Debug, Clone)]
 pub struct UnresolvedResource(Resource);
@@ -65,15 +65,24 @@ impl DestroyWaitAlias {
     }
 
     fn destroy_edges(&self) -> Vec<ScheduleEdge> {
-        let mut edges = vec![ScheduleEdge::BlockedBy(self.target_binding.clone())];
+        let mut edges = vec![ScheduleEdge::BlockedBy(ResourceIdentity::new(
+            self.target_binding.clone(),
+        ))];
         edges.extend(
             self.explicit_dependencies
                 .iter()
                 .filter(|dependency| dependency.as_str() != self.target_binding)
                 .cloned()
+                .map(ResourceIdentity::new)
                 .map(ScheduleEdge::BlockedBy),
         );
-        edges.extend(self.consumers.iter().cloned().map(ScheduleEdge::DependsOn));
+        edges.extend(
+            self.consumers
+                .iter()
+                .cloned()
+                .map(ResourceIdentity::new)
+                .map(ScheduleEdge::DependsOn),
+        );
         edges
     }
 }
@@ -231,15 +240,13 @@ impl DependencyAnalysis {
 }
 
 struct DependencyAnalyzer {
-    binding_to_idx: HashMap<String, usize>,
-    name_to_delete_idx: HashMap<String, usize>,
+    identity_to_idx: HashMap<ResourceIdentity, usize>,
     compositions_by_binding: HashMap<String, crate::resource::Composition>,
 }
 
 impl DependencyAnalyzer {
     fn new(
-        binding_to_idx: HashMap<String, usize>,
-        name_to_delete_idx: HashMap<String, usize>,
+        identity_to_idx: HashMap<ResourceIdentity, usize>,
         compositions: &[crate::resource::Composition],
     ) -> Self {
         let compositions_by_binding = compositions
@@ -252,17 +259,17 @@ impl DependencyAnalyzer {
             })
             .collect();
         Self {
-            binding_to_idx,
-            name_to_delete_idx,
+            identity_to_idx,
             compositions_by_binding,
         }
     }
 
-    fn lookup_idx(&self, binding: &str) -> Option<usize> {
-        self.binding_to_idx
-            .get(binding)
-            .or_else(|| self.name_to_delete_idx.get(binding))
-            .copied()
+    fn lookup_by_identity(&self, identity: &ResourceIdentity) -> Option<usize> {
+        self.identity_to_idx.get(identity).copied()
+    }
+
+    fn lookup_by_string_ref(&self, binding: &str) -> Option<usize> {
+        self.lookup_by_identity(&ResourceIdentity::new(binding))
     }
 
     fn collect_from_schedule_edges(
@@ -274,16 +281,18 @@ impl DependencyAnalyzer {
     ) {
         for edge in edges {
             match edge {
-                ScheduleEdge::DependsOn(binding) => {
-                    self.record_binding_edge(&binding, ReadsSet::unknown(), analysis, self_idx);
+                ScheduleEdge::DependsOn(identity) => {
+                    if let Some(parent) = self.lookup_by_identity(&identity) {
+                        analysis.add_edge(self_idx, parent, ReadsSet::unknown());
+                    }
                 }
-                ScheduleEdge::BlockedBy(binding) => {
-                    if let Some(blocked_idx) = self.lookup_idx(&binding) {
+                ScheduleEdge::BlockedBy(identity) => {
+                    if let Some(blocked_idx) = self.lookup_by_identity(&identity) {
                         analysis.add_edge(blocked_idx, self_idx, ReadsSet::unknown());
                     }
                 }
-                ScheduleEdge::BlockedByIfDelete(binding) => {
-                    if let Some(blocked_idx) = self.lookup_idx(&binding)
+                ScheduleEdge::BlockedByIfDelete(identity) => {
+                    if let Some(blocked_idx) = self.lookup_by_identity(&identity)
                         && blocked_idx < effects.len()
                         && matches!(effects[blocked_idx], Effect::Delete { .. })
                     {
@@ -349,18 +358,18 @@ impl DependencyAnalyzer {
         self.record_binding_edge_inner(binding, reads, analysis, child, &mut visited);
     }
 
-    fn record_binding_edge_inner<'a>(
-        &'a self,
-        binding: &'a str,
+    fn record_binding_edge_inner(
+        &self,
+        binding: &str,
         reads: ReadsSet,
         analysis: &mut DependencyAnalysis,
         child: usize,
-        visited: &mut HashSet<&'a str>,
+        visited: &mut HashSet<String>,
     ) {
-        if !visited.insert(binding) {
+        if !visited.insert(binding.to_string()) {
             return;
         }
-        if let Some(parent) = self.lookup_idx(binding) {
+        if let Some(parent) = self.lookup_by_string_ref(binding) {
             analysis.add_edge(child, parent, reads);
             return;
         }
@@ -368,15 +377,17 @@ impl DependencyAnalyzer {
             return;
         };
         for inner in crate::deps::get_composition_dependencies(composition) {
-            let key: &'a str =
-                if let Some((k, _)) = self.compositions_by_binding.get_key_value(inner.as_str()) {
-                    k.as_str()
-                } else if let Some((k, _)) = self.binding_to_idx.get_key_value(inner.as_str()) {
-                    k.as_str()
-                } else {
-                    continue;
-                };
-            self.record_binding_edge_inner(key, ReadsSet::unknown(), analysis, child, visited);
+            if self.compositions_by_binding.contains_key(inner.as_str())
+                || self.lookup_by_string_ref(inner.as_str()).is_some()
+            {
+                self.record_binding_edge_inner(
+                    inner.as_str(),
+                    ReadsSet::unknown(),
+                    analysis,
+                    child,
+                    visited,
+                );
+            }
         }
     }
 }
@@ -395,28 +406,23 @@ pub fn build_effect_dependency_analysis(
     compositions: &[crate::resource::Composition],
     inputs: ScheduleInputs<'_>,
 ) -> DependencyAnalysis {
-    let mut binding_to_idx: HashMap<String, usize> = HashMap::new();
-    let mut name_to_delete_idx: HashMap<String, usize> = HashMap::new();
+    let mut identity_to_idx: HashMap<ResourceIdentity, usize> = HashMap::new();
     let aliases = match inputs {
         ScheduleInputs::Apply => &[][..],
         ScheduleInputs::Destroy { aliases } => aliases,
     };
     for (idx, effect) in effects.iter().enumerate() {
-        if let Some(binding) = effect.binding_name() {
-            binding_to_idx.insert(binding, idx);
-        }
-        if let Effect::Delete { id, binding, .. } = effect
-            && binding.is_none()
-        {
-            name_to_delete_idx.insert(id.identity_or_empty().to_string(), idx);
-        }
+        identity_to_idx.insert(effect.identity(), idx);
     }
     let alias_offset = effects.len();
     for (alias_idx, alias) in aliases.iter().enumerate() {
-        binding_to_idx.insert(alias.binding.clone(), alias_offset + alias_idx);
+        identity_to_idx.insert(
+            ResourceIdentity::new(alias.binding.clone()),
+            alias_offset + alias_idx,
+        );
     }
 
-    let analyzer = DependencyAnalyzer::new(binding_to_idx, name_to_delete_idx, compositions);
+    let analyzer = DependencyAnalyzer::new(identity_to_idx, compositions);
     let mut analysis = DependencyAnalysis::new(effects.len() + aliases.len());
 
     for (idx, effect) in effects.iter().enumerate() {
@@ -499,7 +505,7 @@ pub fn relax_update_update_edges(effects: &[Effect], analysis: &mut DependencyAn
 mod tests {
     use super::*;
     use crate::effect::ChangedCreateOnly;
-    use crate::resource::{ResolvedResource, State, Value};
+    use crate::resource::{ResolvedResource, ResolvedResourceId, ResourceIdentity, State, Value};
 
     fn state_for(id: &ResourceId) -> State {
         State::not_found(id.clone())
@@ -519,6 +525,112 @@ mod tests {
             to: ResolvedResource::new(resource),
             changed_attributes: changed.iter().map(|s| (*s).to_string()).collect(),
         }
+    }
+
+    #[test]
+    fn effect_identity_returns_let_binding_for_named_effect() {
+        let mut resource = Resource::new("test", "named");
+        resource.binding = Some("named".to_string());
+        let effect = Effect::Create(ResolvedResource::new(resource));
+
+        assert_eq!(effect.identity(), ResourceIdentity::new("named"));
+    }
+
+    #[test]
+    fn effect_identity_returns_system_hash_for_anonymous_effect() {
+        let anonymous = Effect::Delete {
+            id: ResolvedResourceId::new(ResourceId::with_identity("test", "anon_1234")),
+            identifier: "anonymous-id".to_string(),
+            directives: Default::default(),
+            binding: None,
+            dependencies: HashSet::new(),
+            explicit_dependencies: HashSet::new(),
+        };
+        let mut named_resource = Resource::new("test", "named");
+        named_resource.binding = Some("named".to_string());
+        let named = Effect::Create(ResolvedResource::new(named_resource));
+
+        assert_eq!(anonymous.identity(), ResourceIdentity::new("anon_1234"));
+        assert_ne!(anonymous.identity(), named.identity());
+    }
+
+    #[test]
+    fn scheduler_index_keys_on_identity_not_string() {
+        let first = ResourceIdentity::new("first");
+        let second = ResourceIdentity::new("second");
+        let analyzer = DependencyAnalyzer::new(
+            HashMap::from([(first.clone(), 0), (second.clone(), 1)]),
+            &[],
+        );
+
+        assert_eq!(analyzer.lookup_by_identity(&first), Some(0));
+        assert_eq!(analyzer.lookup_by_identity(&second), Some(1));
+        assert_eq!(analyzer.lookup_by_string_ref("first"), Some(0));
+        assert_eq!(analyzer.lookup_by_string_ref("second"), Some(1));
+    }
+
+    #[test]
+    fn blocked_by_if_delete_resolves_anonymous_delete_through_identity_index() {
+        let delete = Effect::Delete {
+            id: ResolvedResourceId::new(ResourceId::with_identity("test", "foo")),
+            identifier: "foo-id".to_string(),
+            directives: Default::default(),
+            binding: None,
+            dependencies: HashSet::new(),
+            explicit_dependencies: HashSet::new(),
+        };
+        let mut blocker_resource = Resource::new("test", "blocker");
+        blocker_resource.binding = Some("blocker".to_string());
+        let blocker = Effect::Create(ResolvedResource::new(blocker_resource));
+        let effects = vec![delete, blocker];
+        let analyzer =
+            DependencyAnalyzer::new(HashMap::from([(ResourceIdentity::new("foo"), 0)]), &[]);
+        let mut analysis = DependencyAnalysis::new(effects.len());
+
+        analyzer.collect_from_schedule_edges(
+            &effects,
+            vec![ScheduleEdge::BlockedByIfDelete(ResourceIdentity::new(
+                "foo",
+            ))],
+            &mut analysis,
+            1,
+        );
+
+        assert!(
+            analysis.into_deps_of()[&0].contains(&1),
+            "anonymous delete must wait for the effect that blocks its identity"
+        );
+    }
+
+    #[test]
+    fn string_ref_resolves_to_anonymous_delete_via_identity_match() {
+        let delete = Effect::Delete {
+            id: ResolvedResourceId::new(ResourceId::with_identity("test", "foo")),
+            identifier: "foo-id".to_string(),
+            directives: Default::default(),
+            binding: None,
+            dependencies: HashSet::new(),
+            explicit_dependencies: HashSet::new(),
+        };
+        let mut consumer_resource = Resource::new("test", "consumer");
+        consumer_resource.binding = Some("consumer".to_string());
+        consumer_resource
+            .dependency_bindings
+            .insert("foo".to_string());
+        let consumer = Effect::Create(ResolvedResource::new(consumer_resource));
+
+        let deps = build_effect_dependency_analysis(
+            &[delete, consumer],
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Apply,
+        )
+        .into_deps_of();
+
+        assert!(
+            deps[&1].contains(&0),
+            "plain string refs resolve by exact ResourceIdentity match"
+        );
     }
 
     #[test]

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -4072,9 +4072,7 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
     // For deletion: vpc delete must wait for subnet delete → subnet first, then vpc
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "my-vpc",
-        )),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("ec2.Vpc", "vpc")),
         identifier: "vpc-123".to_string(),
         directives: Directives::default(),
         binding: Some("vpc".to_string()),
@@ -4084,7 +4082,7 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
     plan.add(Effect::Delete {
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
             "ec2.Subnet",
-            "my-subnet",
+            "subnet",
         )),
         identifier: "subnet-456".to_string(),
         directives: Directives::default(),
@@ -4211,9 +4209,7 @@ async fn test_update_effect_binding_map_propagation() {
 fn test_dependency_analysis_respects_delete_dependencies() {
     let mut plan = Plan::new();
     plan.add(Effect::Delete {
-        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
-            "ec2.Vpc", "my-vpc",
-        )),
+        id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity("ec2.Vpc", "vpc")),
         identifier: "vpc-123".to_string(),
         directives: Directives::default(),
         binding: Some("vpc".to_string()),
@@ -4223,7 +4219,7 @@ fn test_dependency_analysis_respects_delete_dependencies() {
     plan.add(Effect::Delete {
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
             "ec2.Subnet",
-            "my-subnet",
+            "subnet",
         )),
         identifier: "subnet-456".to_string(),
         directives: Directives::default(),
@@ -4258,7 +4254,7 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     let provider = RecordingMockProvider::new();
 
     // VPC resource with binding "vpc"
-    let mut vpc = Resource::new("test", "my-vpc");
+    let mut vpc = Resource::new("test", "vpc");
     vpc.binding = Some("vpc".to_string());
     vpc.set_attr(
         "cidr_block",
@@ -4267,7 +4263,7 @@ async fn test_resource_ref_resolved_from_predecessor_state() {
     let vpc_id = vpc.id.clone();
 
     // Subnet resource that references vpc.vpc_id
-    let mut subnet = Resource::new("test", "my-subnet");
+    let mut subnet = Resource::new("test", "subnet");
     subnet.set_attr(
         "vpc_id",
         Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
@@ -5860,7 +5856,7 @@ async fn deferred_create_emits_zero_children_when_collection_is_empty() {
     use crate::effect::ChangedCreateOnly;
     use crate::wait::predicate::{AttrPath, WaitPredicate};
 
-    let mut cert = Resource::new("test", "cert_empty");
+    let mut cert = Resource::new("test", "cert");
     cert.binding = Some("cert".to_string());
     cert.set_attr(
         "domain_name",
@@ -5947,7 +5943,7 @@ async fn deferred_create_emits_zero_children_when_collection_is_empty() {
     );
     let events = observer.events();
     assert!(
-        events.contains(&"succeeded:test.cert_empty".to_string()),
+        events.contains(&"succeeded:test.cert".to_string()),
         "events: {events:?}"
     );
 }
@@ -6822,13 +6818,13 @@ async fn phased_anonymous_replace_failure_propagates_to_dependent_wait() {
     // kept failed_bindings: HashSet<String>, so a failed anonymous Replace
     // (binding_name() == None) is not recorded and a dependent Wait can run
     // until timeout instead of being skipped as dependency-failed.
-    let a_id = ResourceId::with_identity("test", "a_anonymous_wait_gate");
-    let mut a = Resource::new("test", "a_anonymous_wait_gate");
+    let a_id = ResourceId::with_identity("test", "a");
+    let mut a = Resource::new("test", "a");
     a.binding = Some("a".to_string());
     let old_a_state = State::existing(a_id.clone(), HashMap::new()).with_identifier("a-old");
 
-    let b_id = ResourceId::with_identity("test", "b_anonymous_wait_gate");
-    let mut b = Resource::new("test", "b_anonymous_wait_gate");
+    let b_id = ResourceId::with_identity("test", "b");
+    let mut b = Resource::new("test", "b");
     b.binding = Some("b".to_string());
     b.dependency_bindings.insert("a".to_string());
     let old_b_state = State::existing(b_id.clone(), HashMap::new()).with_identifier("b-old");

--- a/notes/specs/2026-06-28-issue-3625-cbd-decompose-clean-design.md
+++ b/notes/specs/2026-06-28-issue-3625-cbd-decompose-clean-design.md
@@ -64,37 +64,24 @@ Remove `Effect::Replace`. The supporting types the prior PR introduced for the n
 
 Keep / add the following:
 
-- `Effect::Delete.blocked_by_updates: HashSet<BindingKey>`, `#[serde(default, skip_serializing_if = "HashSet::is_empty")]`.
+- `Effect::Delete.blocked_by_updates: HashSet<ResourceIdentity>`, `#[serde(default, skip_serializing_if = "HashSet::is_empty")]`.
 - `ScheduleEdge::BlockedByIfDelete` stays as the edge `Effect::Delete.dependencies` emits during apply (the PR #3624 destroy-time semantics). Delete-side dependencies create an edge only when the target binding resolves to another Delete — Create/Update targets do not get an edge.
 - Box the large variants from the start: `Effect::DeferredReplace(Box<DeferredReplacePayload>)`, and the `state` fields on `BasicEffectResult::Success` / `BasicEffectResult::PartialSuccess`.
 
-### `BindingKey` — newtype that includes anonymous resources
+### Identity-keyed scheduling (no BindingKey enum)
 
-An anonymous resource (without a `let` binding) returns `None` from `binding_name()`. String-keyed binding lookups fall over for these. The prior PR patched this by registering a synthetic `<resource_type>:<name>` string into `binding_to_idx` and gating the registration to Apply-only, which created the asymmetry Round 9 flagged.
+The original Phase 1 section called for a `BindingKey::{Binding(String), Anonymous { resource_type, name }}` enum and `Effect::binding_key()`. That design predated #3632 and the merged identity foundation.
 
-Model it in the type from the start:
+Per the identity-axis spec merged in #3633, identity is one axis: `ResourceIdentity`. It is not a two-variant key that distinguishes let-bound from anonymous resources. The scheduler indexes effects directly with `HashMap<ResourceIdentity, usize>`; no `BindingKey` enum is needed. The closed PR #3630 exposed why the old anonymous shape was wrong: it reached for resource type plus user-facing `name` rather than a system-assigned identity. The #3633 and #3647 merges closed that gap by making every scheduler-bound `Effect` payload carry resolved identity through the `Resolved*` types.
 
-```rust
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum BindingKey {
-    Binding(String),                       // let foo = ...
-    Anonymous { resource_type: String, name: String },
-}
+`Effect::identity() -> ResourceIdentity` is the projection from an effect to its scheduler key. `ScheduleEdge` variants carry `ResourceIdentity`, so edge consumers perform strict keyed lookup instead of reinterpreting strings.
 
-impl Effect {
-    pub fn binding_key(&self) -> BindingKey {
-        match self.binding_name() {
-            Some(b) => BindingKey::Binding(b),
-            None => BindingKey::Anonymous {
-                resource_type: self.resource_id().resource_type.clone(),
-                name: self.resource_id().name_str().into(),
-            },
-        }
-    }
-}
-```
+The lookup API splits along the type the caller already holds:
 
-The scheduler's binding index becomes `HashMap<BindingKey, usize>`. `Effect::Delete.blocked_by_updates: HashSet<BindingKey>` uses the same type. Registration is performed in a single function shared by Apply and Destroy — no input-mode branching is needed for the lookup itself.
+- `lookup_by_identity(&ResourceIdentity)` is used for strict keyed lookup, including every `ScheduleEdge` consumer.
+- `lookup_by_string_ref(&str)` is used by plain-string ref paths: `Resource::dependency_bindings`, `directives.depends_on`, value-position binding refs, and composition expansion. It wraps the string in `ResourceIdentity::new` and delegates to `lookup_by_identity`; no anonymous fallback scan is needed.
+
+Phase 2 uses the same key directly: `Effect::Delete.blocked_by_updates: HashSet<ResourceIdentity>`.
 
 ### `ReplacementGroup` — atomic addition of Create + Delete + display metadata
 
@@ -109,7 +96,7 @@ pub(crate) struct ReplacementGroup {
     pub changed_create_only: ChangedCreateOnly,
     pub cascade_ref_hints: Vec<(String, String)>,
     pub temporary_name: Option<TemporaryName>,  // Some only on CBD
-    pub consumer_updates: Vec<BindingKey>,      // populates blocked_by_updates
+    pub consumer_updates: Vec<ResourceIdentity>, // populates blocked_by_updates
 }
 ```
 
@@ -223,7 +210,7 @@ loop {
 }
 ```
 
-Lookups in `pending_replaces` use `BindingKey`, so anonymous middle nodes are included.
+Lookups in `pending_replaces` use `ResourceIdentity`, so anonymous middle nodes are included.
 
 ### `Plan.replace_display` rendering
 
@@ -301,14 +288,14 @@ Acceptance: the e2e test is Red as intended; mock-provider unit tests are green;
 
 PR: standalone (only the mock-provider extension and the Red e2e).
 
-### Phase 1 — `BindingKey` type foundation
+### Phase 1 — `ResourceIdentity` scheduler foundation
 
 Goal: lay the typed scheduler foundation. Replace string-keyed binding lookups so anonymous resources are first-class.
 
 Tasks:
 
-- T1.1: Introduce the `BindingKey` enum and `Effect::binding_key()`.
-- T1.2: Switch the scheduler's binding index to `HashMap<BindingKey, usize>` inside `build_effect_dependency_analysis`.
+- T1.1: Introduce `Effect::identity() -> ResourceIdentity`.
+- T1.2: Switch the scheduler's binding index to `HashMap<ResourceIdentity, usize>` inside `build_effect_dependency_analysis`.
 - T1.3: Update existing test fixtures.
 
 Acceptance: full verify green; new unit tests cover both binding-name and anonymous lookups.
@@ -321,7 +308,7 @@ Goal: introduce the apply-side edge that orders Delete after consumer Updates. R
 
 Tasks:
 
-- T2.1: Add `blocked_by_updates: HashSet<BindingKey>` to `Effect::Delete`.
+- T2.1: Add `blocked_by_updates: HashSet<ResourceIdentity>` to `Effect::Delete`.
 - T2.2: `apply_edges()` returns both the `BlockedByIfDelete` edges from `dependencies` and the `DependsOn` edges from `blocked_by_updates`.
 - T2.3: `destroy_edges()` returns only the `BlockedBy` edges from `dependencies`.
 - T2.4: Update every `Effect::Delete` construction site, including tests.
@@ -436,7 +423,7 @@ Goal: park scope-adjacent work as separate issues so the main PR chain stays foc
 Tasks:
 
 - T9.1: Re-file or reopen the `Effect::DeferredReplace` consumer-ordering verification issue (the existing #3627 can be amended).
-- T9.2: `Delete.blocked_by_updates: HashSet<BindingKey>` already adopts the typed key — close any prior follow-up issue requesting that reshape.
+- T9.2: `Delete.blocked_by_updates: HashSet<ResourceIdentity>` already adopts the typed key — close any prior follow-up issue requesting that reshape.
 - T9.3: File the repo-wide `DBD → DBC` cleanup PR for older code/docs left out of this work.
 
 ## Test strategy
@@ -461,7 +448,7 @@ Each phase's acceptance criteria include the test additions for that phase. Cumu
 ## Risks and open questions
 
 - The `OverrideAwareResources` deref surface — many downstream paths want to read the underlying `Vec<Resource>`. Decide between exposing `Deref<Target=[Resource]>` as `pub(crate)` and adding focused query methods. Resolve at implementation time.
-- The `BindingKey` serde format — `Delete.blocked_by_updates: HashSet<BindingKey>` appears in saved plans, so the serde shape (tagged vs untagged) matters. The two variants have different shapes (`Binding(String)` vs `Anonymous { resource_type, name }`), so a tagged representation is the safer default.
+- The `ResourceIdentity` serde format — `Delete.blocked_by_updates: HashSet<ResourceIdentity>` appears in saved plans, so the string identity shape must remain stable across saved-plan round trips.
 - The migration-warning emission point — emit at state-load, once. Reuse `log_state_migration_once` (or equivalent) if it already exists.
 - Scope of the `--accept-legacy-name-overrides` flag — apply only, or every state-touching subcommand. `apply` alone is sufficient because `plan` never mutates state.
 


### PR DESCRIPTION
## Summary

Phase 1 of the [Issue #3625 CBD-replace clean rewrite](https://github.com/carina-rs/carina/blob/main/notes/specs/2026-06-28-issue-3625-cbd-decompose-clean-design.md), built on top of the identity foundation merged via #3633 and #3647.

The scheduler's `HashMap<String, usize>` plus `name_to_delete_idx` fallback collapses into a single `HashMap<ResourceIdentity, usize>` index. The fallback (and its `ScheduleInputs::Apply`-only gating) existed to catch anonymous `Effect::Delete` whose `binding_name()` was `None`; post-identity-spec, every effect's `resource_id()` carries a resolver-assigned identity, so the unified index is sufficient and the fallback disappears.

## Changes

- `Effect::identity() -> ResourceIdentity` — projects every scheduler-bound effect to the spec's identity axis. `Wait` returns its own `identity` field; everything else reads `resource_id().identity`, which is `Some(_)` by the `Resolved*` invariants from #3633 / #3647.
- `ScheduleEdge::{DependsOn, BlockedBy, BlockedByIfDelete}` carry `ResourceIdentity` instead of `String`. Every producer wraps the existing binding name with `ResourceIdentity::new`.
- Scheduler lookup splits along the type the caller already holds:
  - `lookup_by_identity(&ResourceIdentity)` — strict, used by every `ScheduleEdge` consumer.
  - `lookup_by_string_ref(&str)` — for paths that still consume plain string refs (`Resource::dependency_bindings`, `directives.depends_on`, value-position binding refs, composition expansion). Wraps once and delegates to the strict lookup.
- The previous anonymous fallback scan is gone — per identity spec §1, anonymous resources hold a resolver-assigned simhash that a user-supplied string ref does not match by accident.

## Test fixture corrections

Several executor / CLI test fixtures had stale shapes where a let-bound resource's `ResourceId.identity` disagreed with its `binding` (e.g. `identity = "my-vpc"`, `binding = "vpc"`). Per identity-axis spec §1 ("a let-bound resource's identity is its binding name"), those states are invalid. The fixtures now use matching values; the test intents are unchanged. Notably, `destroy_wait_ordering_uses_wait_target_binding_not_resource_name` keeps its meaning — with identity and `name` cleanly separated by the spec, the test now demonstrates the distinction it always claimed to.

## Regression coverage

- `test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none` (carina-provider-awscc#47 regression) stays green. The consumer's `dependency_bindings` string ref resolves through `lookup_by_string_ref`, which wraps once and queries the unified identity index.
- Five new unit tests in `carina-core/src/effect/deps.rs`:
  - `effect_identity_returns_let_binding_for_named_effect`
  - `effect_identity_returns_system_hash_for_anonymous_effect`
  - `scheduler_index_keys_on_identity_not_string`
  - `blocked_by_if_delete_resolves_anonymous_delete_through_identity_index`
  - `string_ref_resolves_to_anonymous_delete_via_identity_match`

## Design doc update

Same PR rewrites the `BindingKey` section in `notes/specs/2026-06-28-issue-3625-cbd-decompose-clean-design.md` as "Identity-keyed scheduling (no BindingKey enum)" to reflect the final shape. Phases 2-9 are unchanged; they substitute `ResourceIdentity` wherever `BindingKey` appeared.

## Out of scope (Phase 2+)

`Effect::Delete.blocked_by_updates`, `ReplacementGroup`, `NameOverride`, `OverrideAwareResources`, `permanent_name_overrides`, saved-plan serde changes. The Phase 0 e2e `cbd_replace_orders_consumer_update_between_create_and_delete` stays `#[ignore]`d until Phase 4.

Cross-repo: `ScheduleEdge` and scheduler internal types do not cross the WIT boundary; no `carina-provider-aws` / `carina-provider-awscc` counterpart work needed.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo nextest run --workspace` — 4378 passed, 73 skipped (Phase 0 ignored test included)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `scripts/check-*.sh` — all clean

Refs #3625

🤖 Generated with [Claude Code](https://claude.com/claude-code)