### PR TITLE
feat(scheduler): Effect::Delete.blocked_by_updates + edge reshape (#3625 Phase 2)

### DIFF
--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -401,6 +401,7 @@ async fn run_destroy_locked(
             binding: resource.binding.clone(),
             dependencies,
             explicit_dependencies,
+            blocked_by_updates: HashSet::new(),
         });
     }
 

--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -862,6 +862,7 @@ mod tests {
             binding: None,
             dependencies: Default::default(),
             explicit_dependencies: Default::default(),
+            blocked_by_updates: Default::default(),
         });
         plan.add(Effect::Import {
             id: carina_core::resource::ResolvedResourceId::new(import_id),

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -932,6 +932,7 @@ mod apply_state_save_tests {
             binding: Some("validation_records[0]".to_string()),
             dependencies: HashSet::from(["cert".to_string()]),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         }
     }
 

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1149,6 +1149,7 @@ fn delete_record_effect(binding: &str) -> Effect {
         binding: Some(binding.to_string()),
         dependencies: HashSet::from(["cert".to_string()]),
         explicit_dependencies: HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     }
 }
 
@@ -1168,6 +1169,7 @@ fn deferred_replace_validation_records_effect() -> Effect {
         binding,
         dependencies,
         explicit_dependencies,
+        blocked_by_updates,
     } = delete_record_effect("validation_records[0]")
     else {
         unreachable!("helper constructs Delete")
@@ -1181,6 +1183,7 @@ fn deferred_replace_validation_records_effect() -> Effect {
             binding,
             dependencies,
             explicit_dependencies,
+            blocked_by_updates,
         }])
         .expect("fixture has one delete"),
         id,
@@ -1459,6 +1462,7 @@ fn test_mixed_plan_tree_with_delete_effect() {
         binding: Some("subnet".to_string()),
         dependencies: HashSet::from(["vpc".to_string()]),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     };
 
     let mut plan = Plan::new();
@@ -1608,6 +1612,7 @@ fn format_effect_delete_uses_binding_name() {
         binding: Some("my_vpc".to_string()),
         dependencies: HashSet::new(),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     };
     assert_eq!(format_effect(&effect), "Delete awscc.ec2.Vpc my_vpc");
 }
@@ -1626,6 +1631,7 @@ fn format_effect_delete_falls_back_to_id_name() {
         binding: None,
         dependencies: HashSet::new(),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     };
     assert_eq!(
         format_effect(&effect),
@@ -1994,6 +2000,7 @@ fn delete_pretty_attribute_does_not_strike_indentation() {
         binding: None,
         dependencies: Default::default(),
         explicit_dependencies: Default::default(),
+        blocked_by_updates: Default::default(),
     };
 
     // Force ANSI styling on: the test harness' stdout is not a TTY, so

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -308,6 +308,7 @@ fn plan_file_serde_round_trip() {
         binding: None,
         dependencies: HashSet::new(),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
 
     let sorted_resources = vec![

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -2913,6 +2913,7 @@ pub fn add_deferred_create_effects(plan: &mut Plan, targets: &[DeferredCreateTar
                     binding: Some(binding),
                     dependencies,
                     explicit_dependencies,
+                    blocked_by_updates,
                 } = effect
                 else {
                     return None;
@@ -2928,6 +2929,7 @@ pub fn add_deferred_create_effects(plan: &mut Plan, targets: &[DeferredCreateTar
                         binding: Some(binding.clone()),
                         dependencies: dependencies.clone(),
                         explicit_dependencies: explicit_dependencies.clone(),
+                        blocked_by_updates: blocked_by_updates.clone(),
                     })
                 } else {
                     None

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -649,6 +649,7 @@ fn removed_block_suppresses_delete_when_state_resource_is_routed_to_named_instan
         binding: None,
         dependencies: std::collections::HashSet::new(),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: std::collections::HashSet::new(),
     });
 
     // `removed` block addresses are routing-agnostic by construction
@@ -2383,6 +2384,7 @@ fn delete_effect_for_binding(binding: &str) -> Effect {
         binding: Some(binding.to_string()),
         dependencies: std::collections::HashSet::from(["cert".to_string()]),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: std::collections::HashSet::new(),
     }
 }
 

--- a/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
+++ b/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
@@ -185,6 +185,7 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
             binding: Some("validation_records[0]".to_string()),
             dependencies: HashSet::from(["cert".to_string()]),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         }])
         .expect("fixture has one delete"),
         id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -2107,6 +2107,7 @@ mod tests {
             binding: None,
             dependencies: HashSet::new(),
             explicit_dependencies: std::collections::HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let mut delete_attrs: HashMap<ResourceId, HashMap<String, Value>> = HashMap::new();
         delete_attrs.insert(
@@ -2325,6 +2326,7 @@ mod tests {
             binding: None,
             dependencies: HashSet::new(),
             explicit_dependencies: std::collections::HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let mut tags = IndexMap::new();
         tags.insert(
@@ -2371,6 +2373,7 @@ mod tests {
             binding: None,
             dependencies: HashSet::new(),
             explicit_dependencies: std::collections::HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let mut entry = IndexMap::new();
         entry.insert(

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -408,6 +408,7 @@ pub fn create_plan(
                     binding,
                     dependencies,
                     explicit_dependencies,
+                    blocked_by_updates: HashSet::new(),
                 });
             }
         }
@@ -465,6 +466,7 @@ pub fn create_plan(
                 // empty set here is correct and serde-stable for
                 // pre-#2871 state files.
                 explicit_dependencies: std::collections::HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             });
         }
     }

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -91,6 +91,12 @@ pub struct DeferredReplaceDelete {
     pub dependencies: HashSet<String>,
     #[serde(default)]
     pub explicit_dependencies: HashSet<String>,
+    /// Consumer effects that must complete before this delete may run.
+    ///
+    /// Identities come from [`Effect::identity`] on consumer effects
+    /// (typically `Update`, possibly `Replace` in future).
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    pub blocked_by_updates: HashSet<ResourceIdentity>,
 }
 
 impl DeferredReplaceDelete {
@@ -102,6 +108,7 @@ impl DeferredReplaceDelete {
             binding: self.binding.clone(),
             dependencies: self.dependencies.clone(),
             explicit_dependencies: self.explicit_dependencies.clone(),
+            blocked_by_updates: self.blocked_by_updates.clone(),
         }
     }
 }
@@ -301,6 +308,12 @@ pub enum Effect {
         /// (#2871). Empty for legacy state files.
         #[serde(default)]
         explicit_dependencies: HashSet<String>,
+        /// Consumer effects that must complete before this delete may run.
+        ///
+        /// Identities come from [`Effect::identity`] on consumer effects
+        /// (typically `Update`, possibly `Replace` in future).
+        #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+        blocked_by_updates: HashSet<ResourceIdentity>,
     },
 
     /// Import an existing resource into state (via provider read)
@@ -533,6 +546,7 @@ impl Effect {
                     binding: None,
                     dependencies: HashSet::new(),
                     explicit_dependencies: HashSet::new(),
+                    blocked_by_updates: HashSet::new(),
                 },
                 Effect::Delete { .. }
             ),
@@ -607,6 +621,7 @@ impl Effect {
                         binding: Some("validation_records[0]".to_string()),
                         dependencies: HashSet::new(),
                         explicit_dependencies: HashSet::new(),
+                        blocked_by_updates: HashSet::new(),
                     }])
                     .expect("test fixture has one delete"),
                     id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -1066,12 +1081,25 @@ impl Effect {
     /// responsibility of [`crate::effect::deps::build_effect_dependency_analysis`].
     pub fn apply_edges(&self) -> Vec<ScheduleEdge> {
         match self {
-            Effect::Delete { dependencies, .. } => dependencies
-                .iter()
-                .cloned()
-                .map(ResourceIdentity::new)
-                .map(ScheduleEdge::BlockedBy)
-                .collect(),
+            Effect::Delete {
+                dependencies,
+                blocked_by_updates,
+                ..
+            } => {
+                let mut edges: Vec<ScheduleEdge> = dependencies
+                    .iter()
+                    .cloned()
+                    .map(ResourceIdentity::new)
+                    .map(ScheduleEdge::BlockedByIfDelete)
+                    .collect();
+                edges.extend(
+                    blocked_by_updates
+                        .iter()
+                        .cloned()
+                        .map(ScheduleEdge::DependsOn),
+                );
+                edges
+            }
             Effect::Replace { from, .. } => from
                 .dependency_bindings
                 .iter()
@@ -1250,6 +1278,7 @@ mod tests {
                 binding: Some("validation_records[0]".to_string()),
                 dependencies: HashSet::from(["cert".to_string()]),
                 explicit_dependencies: HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             }])
             .expect("test fixture has one delete"),
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -1307,6 +1336,7 @@ mod tests {
                     binding: None,
                     dependencies: HashSet::new(),
                     explicit_dependencies: HashSet::new(),
+                    blocked_by_updates: HashSet::new(),
                 },
             ),
             (
@@ -1464,6 +1494,7 @@ mod tests {
                 binding: Some("validation_records[0]".to_string()),
                 dependencies: HashSet::from(["foo".to_string()]),
                 explicit_dependencies: HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             }])
             .expect("fixture has one delete"),
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -1496,6 +1527,7 @@ mod tests {
                 binding: Some("validation_records[0]".to_string()),
                 dependencies: HashSet::new(),
                 explicit_dependencies: HashSet::from(["foo".to_string()]),
+                blocked_by_updates: HashSet::new(),
             }])
             .expect("fixture has one delete"),
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -1617,6 +1649,7 @@ mod tests {
             binding: None,
             dependencies: HashSet::new(),
             explicit_dependencies: std::collections::HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         assert!(effect.as_resource_ref().is_none());
     }
@@ -1710,6 +1743,7 @@ mod tests {
                 binding: None,
                 dependencies: HashSet::new(),
                 explicit_dependencies: std::collections::HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             },
         ];
 
@@ -1817,6 +1851,7 @@ mod tests {
             binding: Some("bucket".to_string()),
             dependencies: HashSet::from(["role".to_string(), "kms".to_string()]),
             explicit_dependencies: HashSet::from(["role".to_string()]),
+            blocked_by_updates: HashSet::new(),
         };
         let got = effect.explicit_dependencies();
         assert!(got.contains("role"));
@@ -1861,8 +1896,9 @@ mod tests {
 
     #[test]
     fn delete_legacy_state_without_explicit_deps_deserialises_to_empty() {
-        // Pre-#2871 state files have no `explicit_dependencies` field.
-        // `#[serde(default)]` must populate it as an empty HashSet so
+        // Pre-#2871 state files have no `explicit_dependencies` field,
+        // and Phase 2 state files may omit `blocked_by_updates`.
+        // `#[serde(default)]` must populate them as empty HashSets so
         // round-tripping legacy state never fails.
         let legacy = serde_json::json!({
             "Delete": {
@@ -1876,10 +1912,12 @@ mod tests {
         let effect: Effect = serde_json::from_value(legacy).unwrap();
         if let Effect::Delete {
             explicit_dependencies,
+            blocked_by_updates,
             ..
         } = &effect
         {
             assert!(explicit_dependencies.is_empty());
+            assert!(blocked_by_updates.is_empty());
         } else {
             panic!("expected Delete, got {:?}", effect);
         }
@@ -2026,6 +2064,7 @@ mod tests {
             binding: None,
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         assert!(matches!(
             delete.as_basic(),

--- a/carina-core/src/effect/deps.rs
+++ b/carina-core/src/effect/deps.rs
@@ -527,6 +527,35 @@ mod tests {
         }
     }
 
+    fn create_effect(binding: &str) -> Effect {
+        let mut resource = Resource::new("test", binding);
+        resource.binding = Some(binding.to_string());
+        Effect::Create(ResolvedResource::new(resource))
+    }
+
+    fn delete_effect(identity: &str, dependencies: &[&str], blocked_by_updates: &[&str]) -> Effect {
+        Effect::Delete {
+            id: ResolvedResourceId::new(ResourceId::with_identity("test", identity)),
+            identifier: format!("{identity}-id"),
+            directives: Default::default(),
+            binding: Some(identity.to_string()),
+            dependencies: dependencies
+                .iter()
+                .map(|dependency| (*dependency).to_string())
+                .collect(),
+            explicit_dependencies: HashSet::new(),
+            blocked_by_updates: blocked_by_updates
+                .iter()
+                .cloned()
+                .map(ResourceIdentity::new)
+                .collect(),
+        }
+    }
+
+    fn total_edges(deps: &HashMap<usize, HashSet<usize>>) -> usize {
+        deps.values().map(HashSet::len).sum()
+    }
+
     #[test]
     fn effect_identity_returns_let_binding_for_named_effect() {
         let mut resource = Resource::new("test", "named");
@@ -545,6 +574,7 @@ mod tests {
             binding: None,
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let mut named_resource = Resource::new("test", "named");
         named_resource.binding = Some("named".to_string());
@@ -570,6 +600,125 @@ mod tests {
     }
 
     #[test]
+    fn delete_apply_edge_for_dependency_uses_blocked_by_if_delete() {
+        let delete_target = delete_effect("foo", &[], &[]);
+        let dependent_delete = delete_effect("dependent", &["foo"], &[]);
+        let deps = build_effect_dependency_analysis(
+            &[delete_target, dependent_delete],
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Apply,
+        )
+        .into_deps_of();
+
+        assert_eq!(total_edges(&deps), 1);
+        assert!(
+            deps[&0].contains(&1),
+            "dependency delete must wait for the dependent delete"
+        );
+
+        let create_target = create_effect("foo");
+        let dependent_delete = delete_effect("dependent", &["foo"], &[]);
+        let deps = build_effect_dependency_analysis(
+            &[create_target, dependent_delete],
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Apply,
+        )
+        .into_deps_of();
+        assert_eq!(
+            total_edges(&deps),
+            0,
+            "create targets must not be blocked by delete dependencies on apply"
+        );
+
+        let update_target = update_effect("foo", &[], &["tags"]);
+        let dependent_delete = delete_effect("dependent", &["foo"], &[]);
+        let deps = build_effect_dependency_analysis(
+            &[update_target, dependent_delete],
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Apply,
+        )
+        .into_deps_of();
+        assert_eq!(
+            total_edges(&deps),
+            0,
+            "update targets must not be blocked by delete dependencies on apply"
+        );
+    }
+
+    #[test]
+    fn delete_apply_edge_for_blocked_by_updates_uses_depends_on() {
+        let consumer = update_effect("consumer", &[], &["acl_id"]);
+        let delete = delete_effect("old_web_acl", &[], &["consumer"]);
+
+        let deps = build_effect_dependency_analysis(
+            &[consumer, delete],
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Apply,
+        )
+        .into_deps_of();
+
+        assert_eq!(total_edges(&deps), 1);
+        assert!(
+            deps[&1].contains(&0),
+            "delete must wait for the consumer update"
+        );
+    }
+
+    #[test]
+    fn delete_destroy_edge_ignores_blocked_by_updates() {
+        let parent = delete_effect("parent", &[], &[]);
+        let consumer = update_effect("consumer", &[], &["acl_id"]);
+        let child = delete_effect("child", &["parent"], &["consumer"]);
+
+        let deps = build_effect_dependency_analysis(
+            &[parent, consumer, child],
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Destroy { aliases: &[] },
+        )
+        .into_deps_of();
+
+        assert_eq!(total_edges(&deps), 1);
+        assert!(
+            deps[&0].contains(&2),
+            "destroy dependencies must remain unconditional"
+        );
+        assert!(
+            deps[&2].is_empty(),
+            "blocked_by_updates must not contribute destroy edges"
+        );
+    }
+
+    #[test]
+    fn cbd_ordering_unit_test_via_scheduler_edges() {
+        let create = create_effect("new_web_acl");
+        let consumer = update_effect("consumer", &[], &["web_acl_id"]);
+        let delete = delete_effect("old_web_acl", &[], &["consumer"]);
+
+        let deps = build_effect_dependency_analysis(
+            &[create, consumer, delete],
+            &HashMap::new(),
+            &[],
+            ScheduleInputs::Apply,
+        )
+        .into_deps_of();
+
+        assert!(
+            deps[&1].is_empty(),
+            "consumer update should have no create/delete dependency in this fixture"
+        );
+        assert!(
+            deps[&2].contains(&1),
+            "old web ACL delete must wait for the consumer update"
+        );
+        assert_eq!(total_edges(&deps), 1);
+    }
+
+    #[test]
     fn blocked_by_if_delete_resolves_anonymous_delete_through_identity_index() {
         let delete = Effect::Delete {
             id: ResolvedResourceId::new(ResourceId::with_identity("test", "foo")),
@@ -578,6 +727,7 @@ mod tests {
             binding: None,
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let mut blocker_resource = Resource::new("test", "blocker");
         blocker_resource.binding = Some("blocker".to_string());
@@ -611,6 +761,7 @@ mod tests {
             binding: None,
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let mut consumer_resource = Resource::new("test", "consumer");
         consumer_resource.binding = Some("consumer".to_string());
@@ -644,6 +795,7 @@ mod tests {
             binding: Some("parent".to_string()),
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let child = Effect::Delete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -654,6 +806,7 @@ mod tests {
             binding: Some("child".to_string()),
             dependencies: HashSet::from(["parent".to_string()]),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let effects = vec![parent, child];
 
@@ -677,6 +830,7 @@ mod tests {
             binding: Some("cert".to_string()),
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let listener = Effect::Delete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -687,6 +841,7 @@ mod tests {
             binding: Some("listener".to_string()),
             dependencies: HashSet::from(["cert_issued".to_string()]),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let wait = DestroyWaitAlias::new(
             "cert_issued".to_string(),
@@ -761,6 +916,7 @@ mod tests {
             binding: Some("listener".to_string()),
             dependencies: HashSet::from(["missing_wait".to_string()]),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         };
         let deps = build_effect_dependency_analysis(
             &[orphan],

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -2641,6 +2641,7 @@ async fn test_simple_delete() {
         binding: None,
         dependencies: HashSet::new(),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
 
     provider.push_delete(Ok(()));
@@ -4078,6 +4079,7 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
         binding: Some("vpc".to_string()),
         dependencies: HashSet::new(), // vpc has no deps
         explicit_dependencies: HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
     plan.add(Effect::Delete {
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -4089,6 +4091,7 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
         binding: Some("subnet".to_string()),
         dependencies: HashSet::from(["vpc".to_string()]), // subnet depends on vpc
         explicit_dependencies: HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
 
     let levels = build_dependency_levels(plan.effects(), &HashMap::new(), &[]);
@@ -4215,6 +4218,7 @@ fn test_dependency_analysis_respects_delete_dependencies() {
         binding: Some("vpc".to_string()),
         dependencies: HashSet::new(),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
     plan.add(Effect::Delete {
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -4226,6 +4230,7 @@ fn test_dependency_analysis_respects_delete_dependencies() {
         binding: Some("subnet".to_string()),
         dependencies: HashSet::from(["vpc".to_string()]),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
 
     let deps =
@@ -4476,6 +4481,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
         binding: Some("tgw_a".to_string()),
         dependencies: tgw_a_deps,
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
 
     // attachment: Replace (CBD) — from depends on tgw_a
@@ -4575,6 +4581,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
         binding: None,
         dependencies: tgw_a_deps,
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
 
     // attachment: Replace (CBD)
@@ -6340,6 +6347,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
                 binding: Some("validation_records[0]".to_string()),
                 dependencies: HashSet::new(),
                 explicit_dependencies: HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             },
             DeferredReplaceDelete {
                 id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -6351,6 +6359,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
                 binding: Some("validation_records[1]".to_string()),
                 dependencies: HashSet::new(),
                 explicit_dependencies: HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             },
         ])
         .expect("fixture has deletes"),
@@ -6442,6 +6451,7 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
             binding: Some("validation_records[0]".to_string()),
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         }])
         .expect("fixture has one delete"),
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -6540,6 +6550,7 @@ async fn phased_deferred_replace_gate_skips_on_absorbed_delete_failure() {
             binding: Some("validation_records[0]".to_string()),
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         }])
         .expect("fixture has one delete"),
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -7356,6 +7367,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
             binding: Some("validation_records[0]".to_string()),
             dependencies: HashSet::from(["cert".to_string()]),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         }])
         .expect("fixture has one delete"),
         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -688,6 +688,7 @@ mod tests {
             binding: None,
             dependencies: std::collections::HashSet::new(),
             explicit_dependencies: std::collections::HashSet::new(),
+            blocked_by_updates: std::collections::HashSet::new(),
         });
 
         let summary = plan.summary();
@@ -769,6 +770,7 @@ mod tests {
                 binding: Some(format!("validation_records[{idx}]")),
                 dependencies: HashSet::new(),
                 explicit_dependencies: HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             })
             .collect();
 
@@ -950,6 +952,7 @@ mod tests {
             binding: None,
             dependencies: std::collections::HashSet::new(),
             explicit_dependencies: std::collections::HashSet::new(),
+            blocked_by_updates: std::collections::HashSet::new(),
         });
 
         let json = serde_json::to_string(&plan).unwrap();

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -620,6 +620,7 @@ mod tests {
                 binding: Some("validation_records[0]".to_string()),
                 dependencies: HashSet::new(),
                 explicit_dependencies: HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             }])
             .expect("fixture has one delete"),
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -639,6 +640,7 @@ mod tests {
             binding: Some("validation_records[0]".to_string()),
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         });
         plan.add(Effect::Delete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -650,6 +652,7 @@ mod tests {
             binding: Some("validation_records[abc]".to_string()),
             dependencies: HashSet::new(),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         });
 
         assert_eq!(
@@ -691,6 +694,7 @@ mod tests {
                 binding: Some("validation_records[0]".to_string()),
                 dependencies: HashSet::new(),
                 explicit_dependencies: HashSet::new(),
+                blocked_by_updates: HashSet::new(),
             }])
             .expect("fixture has one delete"),
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1058,6 +1058,7 @@ pub fn redact_secrets_in_effect(
             binding,
             dependencies,
             explicit_dependencies,
+            blocked_by_updates,
         } => Effect::Delete {
             id: id.clone(),
             identifier: identifier.clone(),
@@ -1065,6 +1066,7 @@ pub fn redact_secrets_in_effect(
             binding: binding.clone(),
             dependencies: dependencies.clone(),
             explicit_dependencies: explicit_dependencies.clone(),
+            blocked_by_updates: blocked_by_updates.clone(),
         },
         Effect::Import { id, identifier } => Effect::Import {
             id: id.clone(),

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -35,6 +35,7 @@ fn app_from_plan_with_effects() {
         binding: None,
         dependencies: HashSet::new(),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
 
     let app = App::new(&plan, &SchemaRegistry::new());

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -143,6 +143,7 @@ fn build_mixed_operations_plan() -> Plan {
         binding: Some("old_subnet".to_string()),
         dependencies: HashSet::new(),
         explicit_dependencies: std::collections::HashSet::new(),
+        blocked_by_updates: HashSet::new(),
     });
     plan
 }
@@ -305,6 +306,7 @@ fn build_deferred_replace_plan() -> Plan {
             binding: Some("validation_records[0]".to_string()),
             dependencies: HashSet::from(["cert".to_string()]),
             explicit_dependencies: HashSet::new(),
+            blocked_by_updates: HashSet::new(),
         }])
         .expect("fixture has one delete"),
         id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(


### PR DESCRIPTION
## Summary

Phase 2 of the [Issue #3625 CBD-replace clean rewrite](https://github.com/carina-rs/carina/blob/main/notes/specs/2026-06-28-issue-3625-cbd-decompose-clean-design.md). Builds on Phase 1 (#3648) which keyed the scheduler on `ResourceIdentity`.

Introduces the apply-side edge that orders a Delete strictly after a designated set of consumer Updates, and re-aligns `Effect::Delete`'s apply-time dependency edges with the design's "Scheduler edge summary" table (the PR #3624 contract).

## Changes

- `Effect::Delete.blocked_by_updates: HashSet<ResourceIdentity>` — `#[serde(default, skip_serializing_if = "HashSet::is_empty")]`. Identities here come from `Effect::identity()` on consumer effects (typically Update). Saved plans without the field round-trip cleanly.
- `DeferredReplaceDelete` mirrors the field so absorbed deletes carry the same edge information into the executor.

### Edge contract for `Effect::Delete`

| Side | `dependencies` | `blocked_by_updates` |
|---|---|---|
| `apply_edges()` | `BlockedByIfDelete` (was `BlockedBy`) — fires only when target identity resolves to another Delete; Create/Update targets get no edge | `DependsOn` — Delete waits for each listed identity's effect |
| `destroy_edges()` | `BlockedBy` (unchanged; destroy is unconditional) | no edges — destroy plans contain no Updates |

The apply-side `dependencies` change from `BlockedBy` to `BlockedByIfDelete` restores the PR #3624 contract that the spec-aligned implementation had diverged from.

## Population is out of scope

Every `Effect::Delete` construction site in this PR sets `blocked_by_updates` to an empty `HashSet::new()`. The differ populates it from `cascade_dependent_updates` in Phase 4, when `Effect::Replace` is decomposed into independent `Create + Update + Delete` effects. Phase 2 is the scheduler-side foundation; Phase 4 is when the Phase 0 Red e2e (`cbd_replace_orders_consumer_update_between_create_and_delete`, still `#[ignore]`d) turns green.

## Regression coverage

- `test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none` (carina-provider-awscc#47) stays green. Phase 2 only adds the new edge kind; the existing `Replace.from.dependency_bindings` → `BlockedByIfDelete` path is unchanged.
- `delete_legacy_state_without_explicit_deps_deserialises_to_empty` extended to assert `blocked_by_updates` also defaults to empty for pre-Phase-2 state files.
- Four new unit tests in `carina-core/src/effect/deps.rs`:
  - `delete_apply_edge_for_dependency_uses_blocked_by_if_delete`
  - `delete_apply_edge_for_blocked_by_updates_uses_depends_on`
  - `delete_destroy_edge_ignores_blocked_by_updates`
  - `cbd_ordering_unit_test_via_scheduler_edges` — the scheduler-side foundation Phase 4 will exercise end-to-end via the Phase 0 Red e2e.

## Out of scope (Phase 3+)

`ReplacementGroup`, `Plan::add_replacement`, the `Effect::Replace` removal and differ rewrite, `NameOverride`, `OverrideAwareResources`, saved-plan v8 changes. Provider boundary unchanged; no `carina-provider-aws` / `carina-provider-awscc` counterpart work needed.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo nextest run --workspace` — 4382 passed, 73 skipped (Phase 0 ignored test included)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `scripts/check-*.sh` — all clean

Refs #3625

🤖 Generated with [Claude Code](https://claude.com/claude-code)