### PR TITLE
feat(differ): decompose Effect::Replace into Create + Update + Delete (#3625 Phase 4)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -11,7 +11,7 @@ use futures::stream::{self, StreamExt};
 use carina_core::binding_index::{ResolvedBindings, WaitAliasSpec};
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::deps::sort_resources_by_dependencies;
-use carina_core::differ::{cascade_dependent_updates, create_plan};
+use carina_core::differ::create_plan_with_cascades;
 use carina_core::executor::normalized::apply_desired_normalization;
 use carina_core::executor::{
     ExecutionInput, ExecutionObserver, ExecutionOutcome, ExecutionResult, UnresolvedResource,
@@ -1372,9 +1372,10 @@ async fn run_apply_locked(
         .map(|sf| sf.build_directives())
         .unwrap_or_default();
     let schemas = ctx.schemas();
-    let mut plan = create_plan(
+    let mut plan = create_plan_with_cascades(
         &resources_for_plan,
         &data_sources_for_plan,
+        &sorted_resources,
         &provider,
         &plan_input_states,
         &directives_map,
@@ -1384,10 +1385,6 @@ async fn run_apply_locked(
         &orphan_dependencies,
         &wait_bindings,
     );
-
-    // Populate cascading updates for create_before_destroy Replace effects.
-    // Uses unresolved resources (sorted_resources) so dependents retain ResourceRef values.
-    cascade_dependent_updates(&mut plan, &sorted_resources, &plan_input_states, schemas);
 
     // Add state block effects (import/removed/moved) to the plan.
     // carina#3329: resolve `import { id = "${…}|…" }` interpolations

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -678,10 +678,13 @@ fn decompose<'a>(
         }
     }
 
-    for effect in plan.effects() {
+    for (idx, effect) in plan.effects().iter().enumerate() {
         for id in
             effect.writeback_cleanup_ids(successfully_deleted, &|id| wb.upserts.contains_key(id))
         {
+            if plan.is_replacement_delete_index(idx) && wb.upserts.contains_key(&id) {
+                continue;
+            }
             wb.add_cleanup(id)?;
         }
     }

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use carina_core::config_loader::{get_base_dir, load_configuration};
 use carina_core::deps::sort_resources_by_dependencies;
-use carina_core::differ::{cascade_dependent_updates, create_plan};
+use carina_core::differ::create_plan_with_cascades;
 use carina_core::executor::normalized::apply_desired_normalization_slice;
 use carina_core::plan::Plan;
 use carina_core::provider::{BoxFuture, Provider, ProviderFactory, ProviderResult};
@@ -378,9 +378,10 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
             .cloned(),
     );
     let plan_input_states = carina_core::resource::into_plan_input_map(current_states.clone());
-    let mut plan = create_plan(
+    let mut plan = create_plan_with_cascades(
         &resources,
         &data_sources_for_plan,
+        &sorted_resources,
         &carina_core::provider::ProviderRouter::new(),
         &plan_input_states,
         &directives_map,
@@ -389,13 +390,6 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &prev_explicit,
         &orphan_dependencies,
         &wait_bindings,
-    );
-
-    cascade_dependent_updates(
-        &mut plan,
-        &sorted_resources,
-        &plan_input_states,
-        wiring.schemas(),
     );
 
     crate::wiring::add_state_block_effects(

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_replace_create_only.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_replace_create_only.snap
@@ -4,9 +4,10 @@ expression: output
 ---
 Execution Plan:
 
-  -/+ test.test.Widget alpha (must be replaced)
-      external_name: "old" → "new" (forces replacement)
-  -/+ test.test.Widget beta (must be replaced)
-      legacy_token: "tok" → (removed) (forces replacement)
+  - test.test.Widget alpha
+  + test.test.Widget alpha
+      external_name: "new"
+  - test.test.Widget beta
+  + test.test.Widget beta
 
-Plan: 0 to add, 0 to change, 2 to replace, 0 to destroy.
+Plan: 2 to add, 0 to change, 2 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_replace_with_non_forcing_diffs.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_replace_with_non_forcing_diffs.snap
@@ -4,10 +4,11 @@ expression: output
 ---
 Execution Plan:
 
-  -/+ test.test.Widget web_acl (must be replaced)
-      description: "old description" → "new description"
-      external_name: "edge-old" → "edge-new" (forces replacement)
-      metric_name: "edge-old-metric" → "edge-new-metric"
-      # (1 unchanged attribute hidden)
+  - test.test.Widget web_acl
+  + test.test.Widget web_acl
+      description: "new description"
+      external_name: "edge-new"
+      metric_name: "edge-new-metric"
+      scope: "CLOUDFRONT"
 
-Plan: 0 to add, 0 to change, 1 to replace, 0 to destroy.
+Plan: 1 to add, 0 to change, 1 to destroy.

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -15,7 +15,7 @@ use futures::stream::{self, StreamExt};
 use carina_core::binding_index::{PreApplyInputs, ResolvedBindings, WaitAliasSpec};
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::binding_matches_deferred_template;
-use carina_core::differ::{cascade_dependent_updates, create_plan};
+use carina_core::differ::create_plan_with_cascades;
 use carina_core::effect::{DeferredReplaceDelete, Effect, NonEmptyDeletes};
 use carina_core::executor::normalized::{
     is_value_fully_concrete_for_expansion, restore_stripped_attributes,
@@ -122,7 +122,8 @@ impl WiringContext {
                         AttributeSchema::new("identifier", AttributeType::string()).read_only(),
                     )
                     .attribute(AttributeSchema::new("comment", AttributeType::string()))
-                    .attribute(AttributeSchema::new("web_acl_arn", AttributeType::string())),
+                    .attribute(AttributeSchema::new("web_acl_arn", AttributeType::string()))
+                    .with_unique_name_attribute("name"),
             );
         }
         Self {
@@ -2353,9 +2354,10 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         .as_ref()
         .map(|sf| sf.build_directives())
         .unwrap_or_default();
-    let mut plan = create_plan(
+    let mut plan = create_plan_with_cascades(
         &resources,
         &data_sources_for_plan,
+        &sorted_resources,
         &provider,
         &plan_input_states,
         &directives_map,
@@ -2364,16 +2366,6 @@ pub async fn create_plan_from_parsed_with_upstream<E: Clone>(
         &prev_explicit,
         &orphan_dependencies,
         &wait_bindings,
-    );
-
-    // Populate cascading updates for Replace effects with create_before_destroy.
-    // Uses unresolved resources (sorted_resources) so dependent Update effects
-    // retain ResourceRef values for re-resolution at apply time.
-    cascade_dependent_updates(
-        &mut plan,
-        &sorted_resources,
-        &plan_input_states,
-        ctx.schemas(),
     );
 
     // Add state block effects (import/removed/moved) to the plan.

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -3757,6 +3757,8 @@ mod wait_until_enum_alias {
     /// plan path uses.
     #[test]
     fn create_plan_elides_already_satisfied_wait_after_enum_alias_resolution() {
+        use carina_core::differ::create_plan;
+
         let ctx = WiringContext::new(vec![Box::new(AcmAliasFactory) as Box<dyn ProviderFactory>]);
         let resources = vec![cert_resource(), changed_consumer()];
         let states = cert_state();

--- a/carina-cli/tests/apply_cbd_consumer_ordering_e2e.rs
+++ b/carina-cli/tests/apply_cbd_consumer_ordering_e2e.rs
@@ -141,7 +141,6 @@ let distribution = mock.test.resource {{
 }
 
 #[test]
-#[ignore = "Issue #3625 Phase 0 red regression; turns green in Phase 4"]
 fn cbd_replace_orders_consumer_update_between_create_and_delete() {
     let scenario = Scenario::new();
     scenario.write_config();

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -1,1791 +1,512 @@
 use super::*;
-use crate::resource::{ConcreteValue, DeferredValue, ResolvedResource};
 
-fn resolved(resource: Resource) -> ResolvedResource {
-    ResolvedResource::new(resource)
+use std::collections::HashSet;
+
+use crate::resource::{ConcreteValue, DeferredValue, ResourceIdentity};
+use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+fn string(value: &str) -> Value {
+    Value::Concrete(ConcreteValue::String(value.to_string()))
+}
+
+fn ref_value(binding: &str, attribute: &str) -> Value {
+    Value::resource_ref(binding.to_string(), attribute.to_string(), vec![])
+}
+
+fn state(id: &ResourceId, attrs: &[(&str, Value)], identifier: &str) -> State {
+    State::existing(
+        id.clone(),
+        attrs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), value.clone()))
+            .collect(),
+    )
+    .with_identifier(identifier)
+}
+
+fn base_schemas(subnet_vpc_id_create_only: bool) -> SchemaRegistry {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "",
+        ResourceSchema::new("ec2.Vpc")
+            .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("vpc_id", AttributeType::string()).read_only())
+            .with_unique_name_attribute("name"),
+    );
+
+    let mut vpc_id = AttributeSchema::new("vpc_id", AttributeType::string()).required();
+    if subnet_vpc_id_create_only {
+        vpc_id = vpc_id.create_only();
+    }
+    schemas.insert(
+        "",
+        ResourceSchema::new("ec2.Subnet")
+            .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
+            .attribute(vpc_id)
+            .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).required())
+            .attribute(AttributeSchema::new("tags", AttributeType::string()))
+            .attribute(
+                AttributeSchema::new("availability_zone", AttributeType::string()).create_only(),
+            )
+            .with_unique_name_attribute("name"),
+    );
+    schemas
+}
+
+fn vpc_resources(create_before_destroy: bool) -> (Resource, Resource) {
+    let mut unresolved = Resource::new("ec2.Vpc", "my-vpc")
+        .with_binding("vpc")
+        .with_attribute("name", string("vpc-main"))
+        .with_attribute("cidr_block", string("10.1.0.0/16"));
+    unresolved.directives.create_before_destroy = create_before_destroy;
+    (unresolved.clone(), unresolved)
+}
+
+fn subnet_resources(_vpc_ref_create_only: bool, independent_update: bool) -> (Resource, Resource) {
+    let unresolved = Resource::new("ec2.Subnet", "my-subnet")
+        .with_binding("subnet")
+        .with_attribute("name", string("subnet-main"))
+        .with_attribute("vpc_id", ref_value("vpc", "vpc_id"))
+        .with_attribute("cidr_block", string("10.1.1.0/24"))
+        .with_attribute(
+            "tags",
+            string(if independent_update {
+                "new-tag"
+            } else {
+                "old-tag"
+            }),
+        )
+        .with_attribute("availability_zone", string("us-east-1a"));
+    let managed = Resource::new("ec2.Subnet", "my-subnet")
+        .with_binding("subnet")
+        .with_attribute("name", string("subnet-main"))
+        .with_attribute("vpc_id", string("vpc-old"))
+        .with_attribute("cidr_block", string("10.1.1.0/24"))
+        .with_attribute(
+            "tags",
+            string(if independent_update {
+                "new-tag"
+            } else {
+                "old-tag"
+            }),
+        )
+        .with_attribute("availability_zone", string("us-east-1a"));
+    (managed, unresolved)
+}
+
+fn plan_for(
+    managed: Vec<Resource>,
+    unresolved: Vec<Resource>,
+    current_states: HashMap<ResourceId, State>,
+    schemas: &SchemaRegistry,
+) -> Plan {
+    create_plan_with_cascades(
+        &managed,
+        &[],
+        &unresolved,
+        &crate::provider::ProviderRouter::new(),
+        &crate::resource::into_plan_input_map(current_states),
+        &HashMap::new(),
+        schemas,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[],
+    )
+}
+
+fn standard_states() -> HashMap<ResourceId, State> {
+    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
+    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
+    HashMap::from([
+        (
+            vpc_id.clone(),
+            state(
+                &vpc_id,
+                &[
+                    ("name", string("vpc-main")),
+                    ("cidr_block", string("10.0.0.0/16")),
+                    ("vpc_id", string("vpc-old")),
+                ],
+                "vpc-old",
+            ),
+        ),
+        (
+            subnet_id.clone(),
+            state(
+                &subnet_id,
+                &[
+                    ("name", string("subnet-main")),
+                    ("vpc_id", string("vpc-old")),
+                    ("cidr_block", string("10.1.1.0/24")),
+                    ("tags", string("old-tag")),
+                    ("availability_zone", string("us-east-1a")),
+                ],
+                "subnet-123",
+            ),
+        ),
+    ])
+}
+
+fn replacement_indices(plan: &Plan, id: &ResourceId) -> (usize, usize) {
+    for metadata in &plan.replace_display {
+        if plan.effects()[metadata.create_idx].resource_id() == id {
+            return (metadata.create_idx, metadata.delete_idx);
+        }
+    }
+    panic!(
+        "replacement metadata for {id} not found: {:?}",
+        plan.effects()
+    );
+}
+
+fn replacement_metadata<'a>(
+    plan: &'a Plan,
+    id: &ResourceId,
+) -> &'a crate::plan::ReplaceDisplayMetadata {
+    plan.replace_display
+        .iter()
+        .find(|metadata| plan.effects()[metadata.create_idx].resource_id() == id)
+        .unwrap_or_else(|| panic!("replacement metadata for {id} not found"))
+}
+
+fn update_for<'a>(plan: &'a Plan, id: &ResourceId) -> Option<&'a Effect> {
+    plan.effects()
+        .iter()
+        .find(|effect| matches!(effect, Effect::Update { to, .. } if to.id == *id))
+}
+
+fn delete_blocked_by<'a>(plan: &'a Plan, id: &ResourceId) -> &'a HashSet<ResourceIdentity> {
+    let (_, delete_idx) = replacement_indices(plan, id);
+    match &plan.effects()[delete_idx] {
+        Effect::Delete {
+            blocked_by_updates, ..
+        } => blocked_by_updates,
+        other => panic!("expected replacement delete for {id}, got {other:?}"),
+    }
 }
 
 #[test]
 fn cascade_dependent_updates_adds_update_for_dependent() {
-    // VPC is being replaced with create_before_destroy
-    // Subnet depends on VPC via ResourceRef
-    // cascade_dependent_updates should add a CascadingUpdate to the Replace
+    let schemas = base_schemas(false);
+    let (managed_vpc, unresolved_vpc) = vpc_resources(true);
+    let (managed_subnet, unresolved_subnet) = subnet_resources(false, false);
+    let vpc_id = managed_vpc.id.clone();
+    let subnet_id = managed_subnet.id.clone();
 
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    // Unresolved resources (before ref resolution)
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        )
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    // Current states
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-
-    // Build a plan with Replace for VPC (create_before_destroy)
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    // Apply cascade
-    let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
+    let plan = plan_for(
+        vec![managed_vpc, managed_subnet],
+        vec![unresolved_vpc, unresolved_subnet],
+        standard_states(),
         &schemas,
     );
 
-    // Verify the Replace effect now has a cascading update for the subnet
-    let effects = plan.effects();
-    assert_eq!(effects.len(), 1);
-    if let Effect::Replace {
-        cascading_updates, ..
-    } = &effects[0]
-    {
-        assert_eq!(cascading_updates.len(), 1);
-        assert_eq!(cascading_updates[0].to.id, subnet_id);
-        // The `to` should have unresolved ResourceRef
-        assert!(matches!(
-            cascading_updates[0].to.get_attr("vpc_id"),
-            Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
-        ));
-        // The `from` should have the current state
-        assert_eq!(
-            cascading_updates[0].from.attributes.get("vpc_id"),
-            Some(&Value::Concrete(ConcreteValue::String(
-                "vpc-old".to_string()
-            )))
-        );
-    } else {
-        panic!("Expected Replace effect");
+    let update = update_for(&plan, &subnet_id).expect("subnet update should be added");
+    match update {
+        Effect::Update {
+            to,
+            changed_attributes,
+            ..
+        } => {
+            assert!(changed_attributes.contains(&"vpc_id".to_string()));
+            assert!(matches!(
+                to.get_attr("vpc_id"),
+                Some(Value::Deferred(DeferredValue::ResourceRef { .. }))
+            ));
+        }
+        other => panic!("expected subnet update, got {other:?}"),
     }
+
+    assert!(delete_blocked_by(&plan, &vpc_id).contains(&ResourceIdentity::new("my-subnet")));
 }
 
 #[test]
-fn cascade_skips_resources_already_in_plan() {
-    // If the dependent resource already has its own effect (e.g., Update),
-    // cascade should not add a duplicate
+fn cascade_reuses_existing_update_for_dependent() {
+    let schemas = base_schemas(false);
+    let (managed_vpc, unresolved_vpc) = vpc_resources(true);
+    let (managed_subnet, unresolved_subnet) = subnet_resources(false, true);
+    let vpc_id = managed_vpc.id.clone();
+    let subnet_id = managed_subnet.id.clone();
 
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        )
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.2.0/24".to_string())),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs.clone()).with_identifier("subnet-123"),
-    );
-
-    // Plan with both Replace for VPC and Update for subnet
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone()),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-    plan.add(Effect::Update {
-        from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: resolved(subnet.clone()),
-        changed_attributes: vec!["cidr_block".to_string()],
-    });
-
-    let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
+    let plan = plan_for(
+        vec![managed_vpc, managed_subnet],
+        vec![unresolved_vpc, unresolved_subnet],
+        standard_states(),
         &schemas,
     );
 
-    // The Replace should have NO cascading updates since subnet already has an Update
-    if let Effect::Replace {
-        cascading_updates, ..
-    } = &plan.effects()[0]
-    {
-        assert!(
-            cascading_updates.is_empty(),
-            "Expected no cascading updates when dependent already has an effect"
-        );
-    } else {
-        panic!("Expected Replace effect");
+    let updates: Vec<_> = plan
+        .effects()
+        .iter()
+        .filter(|effect| matches!(effect, Effect::Update { to, .. } if to.id == subnet_id))
+        .collect();
+    assert_eq!(updates.len(), 1);
+    match updates[0] {
+        Effect::Update {
+            changed_attributes, ..
+        } => {
+            assert!(changed_attributes.contains(&"tags".to_string()));
+            assert!(changed_attributes.contains(&"vpc_id".to_string()));
+        }
+        other => panic!("expected subnet update, got {other:?}"),
     }
-}
-
-#[test]
-fn cascade_no_op_without_create_before_destroy() {
-    // Replace without create_before_destroy should not trigger cascading
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone()),
-        directives: Directives::default(), // create_before_destroy = false
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
-        &schemas,
-    );
-
-    if let Effect::Replace {
-        cascading_updates, ..
-    } = &plan.effects()[0]
-    {
-        assert!(cascading_updates.is_empty());
-    }
-}
-
-#[test]
-fn cascade_transitive_dependencies() {
-    // VPC → Subnet → Instance (transitive chain)
-    // Only Subnet directly depends on VPC, so only Subnet gets cascading update
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-    let instance_id = ResourceId::with_identity("ec2.Instance", "my-instance");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        );
-
-    let instance = Resource::new("ec2.Instance", "my-instance")
-        .with_binding("instance")
-        .with_attribute(
-            "subnet_id",
-            Value::resource_ref("subnet".to_string(), "subnet_id".to_string(), vec![]),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone(), instance.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "subnet_id".to_string(),
-        Value::Concrete(ConcreteValue::String("subnet-123".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-    let mut instance_attrs = HashMap::new();
-    instance_attrs.insert(
-        "subnet_id".to_string(),
-        Value::Concrete(ConcreteValue::String("subnet-123".to_string())),
-    );
-    current_states.insert(
-        instance_id.clone(),
-        State::existing(instance_id.clone(), instance_attrs).with_identifier("i-123"),
-    );
-
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone()),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
-        &schemas,
-    );
-
-    // Only subnet directly depends on VPC, so only subnet gets cascading update
-    // Instance depends on subnet, not VPC directly
-    if let Effect::Replace {
-        cascading_updates, ..
-    } = &plan.effects()[0]
-    {
-        assert_eq!(cascading_updates.len(), 1);
-        assert_eq!(cascading_updates[0].to.id, subnet_id);
-    } else {
-        panic!("Expected Replace effect");
-    }
-}
-
-#[test]
-fn cascade_anonymous_resource_dependent() {
-    // Anonymous resource (no _binding) that depends on a replaced resource
-    // should still get a cascading update
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    // Anonymous subnet (no _binding) with a ResourceRef to the VPC
-    let subnet = Resource::new("ec2.Subnet", "my-subnet").with_attribute(
-        "vpc_id",
-        Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-    );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone()),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    let schemas = SchemaRegistry::new();
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
-        &schemas,
-    );
-
-    if let Effect::Replace {
-        cascading_updates, ..
-    } = &plan.effects()[0]
-    {
-        assert_eq!(
-            cascading_updates.len(),
-            1,
-            "Anonymous resource should get cascading update"
-        );
-        assert_eq!(cascading_updates[0].to.id, subnet_id);
-    } else {
-        panic!("Expected Replace effect for anonymous resource test");
-    }
+    assert!(delete_blocked_by(&plan, &vpc_id).contains(&ResourceIdentity::new("my-subnet")));
 }
 
 #[test]
 fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
-    // When VPC is replaced, subnet's vpc_id changes.
-    // Since vpc_id is a create-only attribute on ec2.subnet,
-    // the subnet cannot be updated in-place — it must also be replaced.
-    // Currently, cascading updates always generate CascadingUpdate (Update),
-    // but this test asserts the correct behavior: a Replace effect for the subnet.
+    let schemas = base_schemas(true);
+    let (managed_vpc, unresolved_vpc) = vpc_resources(true);
+    let (managed_subnet, unresolved_subnet) = subnet_resources(true, false);
+    let vpc_id = managed_vpc.id.clone();
+    let subnet_id = managed_subnet.id.clone();
 
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    // Unresolved resources (before ref resolution)
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        )
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    // Current states
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-
-    // Schema for ec2.subnet with vpc_id as create-only
-    let subnet_schema = ResourceSchema::new("ec2.Subnet")
-        .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::string())
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", subnet_schema);
-
-    // Build a plan with Replace for VPC (create_before_destroy)
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    // Apply cascade with schemas so it can detect create-only attributes
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
+    let plan = plan_for(
+        vec![managed_vpc, managed_subnet],
+        vec![unresolved_vpc, unresolved_subnet],
+        standard_states(),
         &schemas,
     );
 
-    // After cascading, the subnet should appear as a separate Replace effect in the plan,
-    // NOT as a CascadingUpdate inside the VPC's Replace effect.
-    // This is because vpc_id is create-only on subnet — an in-place update is impossible.
-    let effects = plan.effects();
+    assert_eq!(plan.replace_display.len(), 2);
+    assert!(update_for(&plan, &subnet_id).is_none());
+    assert!(delete_blocked_by(&plan, &vpc_id).contains(&ResourceIdentity::new("my-subnet")));
 
-    // We expect 2 effects: Replace for VPC and Replace for subnet
-    assert_eq!(
-        effects.len(),
-        2,
-        "Expected 2 effects (VPC Replace + subnet Replace), got {}: {:?}",
-        effects.len(),
-        effects
-            .iter()
-            .map(|e| format!("{} {}", e.kind(), e.resource_id()))
-            .collect::<Vec<_>>()
-    );
-
-    // The VPC Replace should have no cascading updates (subnet is promoted to its own Replace)
-    if let Effect::Replace {
-        to,
-        cascading_updates,
-        ..
-    } = &effects[0]
-    {
-        assert_eq!(&to.id, &vpc_id);
-        assert!(
-            cascading_updates.is_empty(),
-            "VPC Replace should have no cascading updates; subnet should be a separate Replace"
-        );
-    } else {
-        panic!("Expected first effect to be Replace for VPC");
-    }
-
-    // The subnet should be a Replace effect (not an Update)
-    if let Effect::Replace {
-        to,
-        changed_create_only,
-        cascade_ref_hints,
-        ..
-    } = &effects[1]
-    {
-        assert_eq!(&to.id, &subnet_id);
-        assert!(
-            changed_create_only.contains("vpc_id"),
-            "Subnet Replace should list vpc_id as a changed create-only attribute"
-        );
-        assert!(
-            cascade_ref_hints.contains(&("vpc_id".to_string(), "vpc.vpc_id".to_string())),
-            "Subnet Replace should have cascade_ref_hint for vpc_id → vpc.vpc_id, got: {:?}",
-            cascade_ref_hints
-        );
-    } else {
-        panic!(
-            "Expected second effect to be Replace for subnet, got: {:?}",
-            effects[1].kind()
-        );
-    }
-}
-
-#[test]
-fn cascade_generates_replace_when_create_only_list_contains_nested_ref() {
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let attachment_id = ResourceId::with_identity("ec2.RouteTableAssociation", "my-assoc");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let attachment = Resource::new("ec2.RouteTableAssociation", "my-assoc")
-        .with_binding("attachment")
-        .with_attribute(
-            "subnet_ids",
-            Value::Concrete(ConcreteValue::List(vec![Value::resource_ref(
-                "vpc".to_string(),
-                "vpc_id".to_string(),
-                vec![],
-            )])),
-        )
-        .with_attribute(
-            "name",
-            Value::Concrete(ConcreteValue::String("main".to_string())),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), attachment.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut attachment_attrs = HashMap::new();
-    attachment_attrs.insert(
-        "subnet_ids".to_string(),
-        Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
-            ConcreteValue::String("vpc-old".to_string()),
-        )])),
-    );
-    attachment_attrs.insert(
-        "name".to_string(),
-        Value::Concrete(ConcreteValue::String("main".to_string())),
-    );
-    current_states.insert(
-        attachment_id.clone(),
-        State::existing(attachment_id.clone(), attachment_attrs).with_identifier("assoc-123"),
-    );
-
-    let attachment_schema = ResourceSchema::new("ec2.RouteTableAssociation")
-        .attribute(
-            AttributeSchema::new("subnet_ids", AttributeType::list(AttributeType::string()))
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("name", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", attachment_schema);
-
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
-        &schemas,
-    );
-
-    let effects = plan.effects();
-    assert_eq!(
-        effects.len(),
-        2,
-        "Expected nested list ref on create-only attribute to promote dependent to Replace, got: {:?}",
-        effects
-            .iter()
-            .map(|e| format!("{} {}", e.kind(), e.resource_id()))
-            .collect::<Vec<_>>()
-    );
-
-    match &effects[1] {
-        Effect::Replace {
-            to,
-            changed_create_only,
-            cascade_ref_hints,
-            ..
-        } => {
-            assert_eq!(&to.id, &attachment_id);
-            assert!(changed_create_only.contains("subnet_ids"));
-            assert!(
-                cascade_ref_hints.contains(&("subnet_ids".to_string(), "vpc.vpc_id".to_string()))
-            );
-        }
-        other => panic!(
-            "Expected nested list dependent to be Replace, got {}",
-            other.kind()
-        ),
-    }
-}
-
-#[test]
-fn cascade_hint_prefers_resource_ref_over_binding_ref_in_mixed_list() {
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let attachment_id = ResourceId::with_identity("ec2.RouteTableAssociation", "my-assoc");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let attachment = Resource::new("ec2.RouteTableAssociation", "my-assoc")
-        .with_binding("attachment")
-        .with_attribute(
-            "targets",
-            Value::Concrete(ConcreteValue::List(vec![
-                Value::Deferred(DeferredValue::BindingRef {
-                    binding: "vpc".to_string(),
-                }),
-                Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
-            ])),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), attachment.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut attachment_attrs = HashMap::new();
-    attachment_attrs.insert(
-        "targets".to_string(),
-        Value::Concrete(ConcreteValue::List(vec![
-            Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-            Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-        ])),
-    );
-    current_states.insert(
-        attachment_id.clone(),
-        State::existing(attachment_id.clone(), attachment_attrs).with_identifier("assoc-123"),
-    );
-
-    let attachment_schema = ResourceSchema::new("ec2.RouteTableAssociation").attribute(
-        AttributeSchema::new("targets", AttributeType::list(AttributeType::string()))
-            .required()
-            .create_only(),
-    );
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", attachment_schema);
-
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
-        &schemas,
-    );
-
-    match &plan.effects()[1] {
-        Effect::Replace {
-            cascade_ref_hints, ..
-        } => {
-            assert!(
-                cascade_ref_hints.contains(&("targets".to_string(), "vpc.id".to_string())),
-                "ResourceRef hint should win over BindingRef fallback, got: {:?}",
-                cascade_ref_hints
-            );
-        }
-        other => panic!(
-            "Expected mixed-list dependent to be Replace, got {}",
-            other.kind()
-        ),
-    }
-}
-
-#[test]
-fn cascade_generates_replace_when_create_only_map_contains_nested_ref() {
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let tagged_id = ResourceId::with_identity("ec2.TaggedResource", "my-tagged");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let mut desired_tags = indexmap::IndexMap::new();
-    desired_tags.insert(
-        "vpc_ref".to_string(),
-        Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-    );
-    desired_tags.insert(
-        "env".to_string(),
-        Value::Concrete(ConcreteValue::String("prod".to_string())),
-    );
-
-    let tagged = Resource::new("ec2.TaggedResource", "my-tagged")
-        .with_binding("tagged")
-        .with_attribute("tags", Value::Concrete(ConcreteValue::Map(desired_tags)))
-        .with_attribute(
-            "name",
-            Value::Concrete(ConcreteValue::String("main".to_string())),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), tagged.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut state_tags = indexmap::IndexMap::new();
-    state_tags.insert(
-        "vpc_ref".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    state_tags.insert(
-        "env".to_string(),
-        Value::Concrete(ConcreteValue::String("prod".to_string())),
-    );
-    let mut tagged_attrs = HashMap::new();
-    tagged_attrs.insert(
-        "tags".to_string(),
-        Value::Concrete(ConcreteValue::Map(state_tags)),
-    );
-    tagged_attrs.insert(
-        "name".to_string(),
-        Value::Concrete(ConcreteValue::String("main".to_string())),
-    );
-    current_states.insert(
-        tagged_id.clone(),
-        State::existing(tagged_id.clone(), tagged_attrs).with_identifier("tagged-123"),
-    );
-
-    let tagged_schema = ResourceSchema::new("ec2.TaggedResource")
-        .attribute(
-            AttributeSchema::new("tags", AttributeType::map(AttributeType::string()))
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("name", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", tagged_schema);
-
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
-        &schemas,
-    );
-
-    let effects = plan.effects();
-    assert_eq!(
-        effects.len(),
-        2,
-        "Expected nested map ref on create-only attribute to promote dependent to Replace, got: {:?}",
-        effects
-            .iter()
-            .map(|e| format!("{} {}", e.kind(), e.resource_id()))
-            .collect::<Vec<_>>()
-    );
-
-    match &effects[1] {
-        Effect::Replace {
-            to,
-            changed_create_only,
-            cascade_ref_hints,
-            ..
-        } => {
-            assert_eq!(&to.id, &tagged_id);
-            assert!(changed_create_only.contains("tags"));
-            assert!(
-                cascade_ref_hints.contains(&("tags".to_string(), "vpc.vpc_id".to_string())),
-                "Expected tags cascade hint from nested map ref, got: {:?}",
-                cascade_ref_hints
-            );
-        }
-        other => panic!(
-            "Expected nested map dependent to be Replace, got {}",
-            other.kind()
-        ),
-    }
-}
-
-#[test]
-fn cascade_prevent_destroy_blocks_nested_map_ref_promotion_to_replace() {
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let tagged_id = ResourceId::with_identity("ec2.TaggedResource", "my-tagged");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let mut desired_tags = indexmap::IndexMap::new();
-    desired_tags.insert(
-        "vpc_ref".to_string(),
-        Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-    );
-
-    let mut tagged = Resource::new("ec2.TaggedResource", "my-tagged")
-        .with_binding("tagged")
-        .with_attribute("tags", Value::Concrete(ConcreteValue::Map(desired_tags)))
-        .with_attribute(
-            "name",
-            Value::Concrete(ConcreteValue::String("main".to_string())),
-        );
-    tagged.directives.prevent_destroy = true;
-
-    let unresolved_resources = vec![vpc.clone(), tagged.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut state_tags = indexmap::IndexMap::new();
-    state_tags.insert(
-        "vpc_ref".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    let mut tagged_attrs = HashMap::new();
-    tagged_attrs.insert(
-        "tags".to_string(),
-        Value::Concrete(ConcreteValue::Map(state_tags)),
-    );
-    tagged_attrs.insert(
-        "name".to_string(),
-        Value::Concrete(ConcreteValue::String("main".to_string())),
-    );
-    current_states.insert(
-        tagged_id.clone(),
-        State::existing(tagged_id.clone(), tagged_attrs).with_identifier("tagged-123"),
-    );
-
-    let tagged_schema = ResourceSchema::new("ec2.TaggedResource")
-        .attribute(
-            AttributeSchema::new("tags", AttributeType::map(AttributeType::string()))
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("name", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", tagged_schema);
-
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
-        &schemas,
-    );
-
+    let metadata = replacement_metadata(&plan, &subnet_id);
+    assert!(metadata.changed_create_only.contains("vpc_id"));
     assert!(
-        plan.has_errors(),
-        "Expected PlanError for nested map ref promotion blocked by prevent_destroy"
-    );
-    assert_eq!(plan.errors().len(), 1);
-    assert_eq!(plan.errors()[0].resource_id, tagged_id);
-    assert!(plan.errors()[0].message.contains("prevent_destroy"));
-
-    let tagged_effects: Vec<_> = plan
-        .effects()
-        .iter()
-        .filter(|e| *e.resource_id() == tagged_id)
-        .collect();
-    assert!(
-        tagged_effects.is_empty(),
-        "Dependent should not be promoted when prevent_destroy blocks nested map ref cascade"
+        metadata
+            .cascade_ref_hints
+            .contains(&("vpc_id".to_string(), "vpc.vpc_id".to_string()))
     );
 }
 
 #[test]
 fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
-    // Pattern 2: Direct change + cascade
-    //
-    // VPC cidr_block changes → VPC Replace (create_before_destroy)
-    // Subnet availability_zone also changes (create-only) → Subnet Replace from differ
-    // Subnet vpc_id (create-only) references VPC → cascade should ALSO add vpc_id
-    //
-    // Expected: Subnet Replace shows BOTH availability_zone AND vpc_id in changed_create_only
+    let schemas = base_schemas(true);
+    let (managed_vpc, unresolved_vpc) = vpc_resources(true);
+    let (mut managed_subnet, mut unresolved_subnet) = subnet_resources(true, false);
+    managed_subnet.set_attr("availability_zone", string("us-east-1b"));
+    unresolved_subnet.set_attr("availability_zone", string("us-east-1b"));
+    let subnet_id = managed_subnet.id.clone();
 
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    // Unresolved resources (before ref resolution)
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        )
-        .with_attribute(
-            "availability_zone",
-            Value::Concrete(ConcreteValue::String("us-east-1b".to_string())),
-        )
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    // Current states
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "availability_zone".to_string(),
-        Value::Concrete(ConcreteValue::String("us-east-1a".to_string())),
-    );
-    subnet_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-
-    // Schema: vpc_id and availability_zone are both create-only on ec2.subnet
-    let subnet_schema = ResourceSchema::new("ec2.Subnet")
-        .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::string())
-                .required()
-                .create_only(),
-        )
-        .attribute(
-            AttributeSchema::new("availability_zone", AttributeType::string())
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", subnet_schema);
-
-    // Build a plan:
-    // - VPC Replace (create_before_destroy) due to cidr_block change
-    // - Subnet Replace due to availability_zone change (direct change from differ)
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: resolved(subnet.clone().with_binding("subnet")),
-        directives: Directives::default(),
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec![
-            "availability_zone".to_string(),
-        ])
-        .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    // Apply cascade
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
+    let plan = plan_for(
+        vec![managed_vpc, managed_subnet],
+        vec![unresolved_vpc, unresolved_subnet],
+        standard_states(),
         &schemas,
     );
 
-    // After cascading, the subnet Replace should have BOTH availability_zone AND vpc_id
-    // in changed_create_only, because vpc_id is a create-only ref to the replaced VPC.
-    let effects = plan.effects();
-    assert_eq!(effects.len(), 2, "Should still have 2 effects");
-
-    let subnet_effect = effects.iter().find(|e| *e.resource_id() == subnet_id);
-    assert!(subnet_effect.is_some(), "Subnet effect should exist");
-
-    if let Effect::Replace {
-        changed_create_only,
-        cascade_ref_hints,
-        ..
-    } = subnet_effect.unwrap()
-    {
-        assert!(
-            changed_create_only.contains("availability_zone"),
-            "changed_create_only should contain availability_zone (direct change), got: {:?}",
-            changed_create_only
-        );
-        assert!(
-            changed_create_only.contains("vpc_id"),
-            "changed_create_only should contain vpc_id (cascade from VPC replace), got: {:?}",
-            changed_create_only
-        );
-        assert!(
-            cascade_ref_hints.contains(&("vpc_id".to_string(), "vpc.vpc_id".to_string())),
-            "cascade_ref_hints should contain vpc_id → vpc.vpc_id, got: {:?}",
-            cascade_ref_hints
-        );
-    } else {
-        panic!("Expected subnet to be a Replace effect");
-    }
-}
-
-#[test]
-fn auto_detect_create_before_destroy_when_resource_has_dependents() {
-    // Issue #947: When a resource being replaced is referenced by other resources,
-    // automatically use create_before_destroy strategy instead of the default
-    // delete-then-create.
-    //
-    // VPC cidr_block changes (create-only) → VPC Replace with default directives
-    // Subnet depends on VPC via vpc_id (ResourceRef)
-    // Expected: VPC Replace should auto-detect create_before_destroy = true
-    // because the subnet references it.
-
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    // Unresolved resources (before ref resolution)
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        )
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    // Current states
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+    let metadata = replacement_metadata(&plan, &subnet_id);
+    assert!(metadata.changed_create_only.contains("availability_zone"));
+    assert!(metadata.changed_create_only.contains("vpc_id"));
+    assert!(
+        metadata
+            .cascade_ref_hints
+            .contains(&("vpc_id".to_string(), "vpc.vpc_id".to_string()))
     );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-
-    // Schema: cidr_block is create-only on ec2.vpc
-    let vpc_schema = ResourceSchema::new("ec2.Vpc")
-        .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).create_only());
-    let subnet_schema = ResourceSchema::new("ec2.Subnet")
-        .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::string())
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", vpc_schema);
-    schemas.insert("", subnet_schema);
-
-    // Build a plan with Replace for VPC using DEFAULT directives (no explicit CBD)
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives::default(), // create_before_destroy = false (user didn't set it)
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    // Apply cascade — this should auto-detect that VPC has dependents and
-    // promote it to create_before_destroy
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
-        &schemas,
-    );
-
-    // The VPC Replace should now have create_before_destroy = true
-    // because the subnet references it
-    let vpc_effect = plan
-        .effects()
-        .iter()
-        .find(|e| *e.resource_id() == vpc_id)
-        .expect("VPC Replace effect should exist");
-
-    if let Effect::Replace { directives, .. } = vpc_effect {
-        assert!(
-            directives.create_before_destroy,
-            "VPC Replace should have create_before_destroy auto-detected \
-             because subnet references it, but got create_before_destroy = false"
-        );
-    } else {
-        panic!("Expected Replace effect for VPC");
-    }
 }
 
 #[test]
 fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
-    // Pattern 3: Direct non-create-only change + cascade
-    //
-    // VPC cidr_block changes → VPC Replace (create_before_destroy)
-    // Subnet tags changes (NOT create-only) → Subnet Update from differ
-    // Subnet vpc_id (create-only) references VPC → cascade should UPGRADE to Replace
-    //
-    // Expected: Subnet becomes Replace with vpc_id in changed_create_only
+    let schemas = base_schemas(true);
+    let (managed_vpc, unresolved_vpc) = vpc_resources(true);
+    let (managed_subnet, unresolved_subnet) = subnet_resources(true, true);
+    let subnet_id = managed_subnet.id.clone();
 
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    // Unresolved resources (before ref resolution)
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        )
-        .with_attribute(
-            "tags",
-            Value::Concrete(ConcreteValue::String("new-tag".to_string())),
-        )
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-        );
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    // Current states
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "tags".to_string(),
-        Value::Concrete(ConcreteValue::String("old-tag".to_string())),
-    );
-    subnet_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-
-    // Schema: vpc_id is create-only, tags is NOT create-only
-    let subnet_schema = ResourceSchema::new("ec2.Subnet")
-        .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::string())
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("tags", AttributeType::string()))
-        .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", subnet_schema);
-
-    // Build a plan:
-    // - VPC Replace (create_before_destroy) due to cidr_block change
-    // - Subnet Update due to tags change (non-create-only, from differ)
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-    plan.add(Effect::Update {
-        from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: resolved(subnet.clone().with_binding("subnet")),
-        changed_attributes: vec!["tags".to_string()],
-    });
-
-    // Apply cascade
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
+    let plan = plan_for(
+        vec![managed_vpc, managed_subnet],
+        vec![unresolved_vpc, unresolved_subnet],
+        standard_states(),
         &schemas,
     );
 
-    // After cascading, the subnet should be UPGRADED from Update to Replace,
-    // because vpc_id is a create-only attribute referencing the replaced VPC.
-    let effects = plan.effects();
+    assert!(update_for(&plan, &subnet_id).is_none());
+    assert!(
+        replacement_metadata(&plan, &subnet_id)
+            .changed_create_only
+            .contains("vpc_id")
+    );
+}
 
-    let subnet_effect = effects.iter().find(|e| *e.resource_id() == subnet_id);
-    assert!(subnet_effect.is_some(), "Subnet effect should exist");
+#[test]
+fn auto_detect_create_before_destroy_when_resource_has_dependents() {
+    let schemas = base_schemas(false);
+    let (managed_vpc, unresolved_vpc) = vpc_resources(false);
+    let (managed_subnet, unresolved_subnet) = subnet_resources(false, false);
+    let vpc_id = managed_vpc.id.clone();
 
-    match subnet_effect.unwrap() {
-        Effect::Replace {
-            changed_create_only,
-            ..
-        } => {
-            assert!(
-                changed_create_only.contains("vpc_id"),
-                "Subnet Replace should list vpc_id as changed create-only (cascade from VPC replace), got: {:?}",
-                changed_create_only
-            );
-        }
-        other => {
-            panic!(
-                "Expected subnet to be upgraded to Replace, but got {:?}",
-                other.kind()
-            );
-        }
-    }
+    let plan = plan_for(
+        vec![managed_vpc, managed_subnet],
+        vec![unresolved_vpc, unresolved_subnet],
+        standard_states(),
+        &schemas,
+    );
+
+    let metadata = replacement_metadata(&plan, &vpc_id);
+    assert!(metadata.create_before_destroy);
+    assert!(metadata.temporary_name.is_some());
 }
 
 #[test]
 fn cascade_prevent_destroy_blocks_promotion_to_replace() {
-    // When resource A is being replaced and resource B depends on A
-    // via a create-only attribute, B would normally be promoted to Replace.
-    // But if B has prevent_destroy: true, it should generate a PlanError instead.
+    let schemas = base_schemas(true);
+    let (managed_vpc, unresolved_vpc) = vpc_resources(true);
+    let (managed_subnet, mut unresolved_subnet) = subnet_resources(true, false);
+    unresolved_subnet.directives.prevent_destroy = true;
+    let subnet_id = managed_subnet.id.clone();
 
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let mut subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        )
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-        );
-    subnet.directives.prevent_destroy = true;
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
-    );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
-
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-
-    // Schema: vpc_id is create-only on ec2.subnet
-    let subnet_schema = ResourceSchema::new("ec2.Subnet")
-        .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::string())
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", subnet_schema);
-
-    // Build a plan with Replace for VPC (create_before_destroy)
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-
-    // Apply cascade
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
+    let plan = plan_for(
+        vec![managed_vpc, managed_subnet],
+        vec![unresolved_vpc, unresolved_subnet],
+        standard_states(),
         &schemas,
     );
 
-    // The subnet should NOT be promoted to Replace because it has prevent_destroy.
-    // Instead, a PlanError should be generated.
+    assert!(plan.has_errors());
+    assert_eq!(plan.errors()[0].resource_id, subnet_id);
+    assert!(plan.errors()[0].message.contains("prevent_destroy"));
     assert!(
-        plan.has_errors(),
-        "Expected PlanError for subnet with prevent_destroy, but got no errors"
-    );
-
-    let errors = plan.errors();
-    assert_eq!(errors.len(), 1);
-    assert_eq!(errors[0].resource_id, subnet_id);
-    assert!(
-        errors[0].message.contains("prevent_destroy"),
-        "Error message should mention prevent_destroy, got: {}",
-        errors[0].message
-    );
-
-    // The subnet should NOT appear as a Replace effect in the plan
-    let subnet_effects: Vec<_> = plan
-        .effects()
-        .iter()
-        .filter(|e| *e.resource_id() == subnet_id)
-        .collect();
-    assert!(
-        subnet_effects.is_empty(),
-        "Subnet should not have any effect when prevent_destroy blocks promotion"
+        plan.replace_display
+            .iter()
+            .all(|metadata| { plan.effects()[metadata.create_idx].resource_id() != &subnet_id })
     );
 }
 
 #[test]
-fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
-    // When resource B already has an Update effect in the plan and would be
-    // upgraded to Replace via cascade (merge path), prevent_destroy should block it.
-
-    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
-
-    let vpc_id = ResourceId::with_identity("ec2.Vpc", "my-vpc");
-    let subnet_id = ResourceId::with_identity("ec2.Subnet", "my-subnet");
-
-    let vpc = Resource::new("ec2.Vpc", "my-vpc")
-        .with_binding("vpc")
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-        );
-
-    let mut subnet = Resource::new("ec2.Subnet", "my-subnet")
-        .with_binding("subnet")
-        .with_attribute(
-            "vpc_id",
-            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        )
-        .with_attribute(
-            "tags",
-            Value::Concrete(ConcreteValue::String("new-tag".to_string())),
-        )
-        .with_attribute(
-            "cidr_block",
-            Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-        );
-    subnet.directives.prevent_destroy = true;
-
-    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
-
-    let mut current_states = HashMap::new();
-    let mut vpc_attrs = HashMap::new();
-    vpc_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
+fn auto_promote_with_missing_unique_name_attribute_emits_plan_error() {
+    let mut schemas = base_schemas(false);
+    schemas.insert(
+        "",
+        ResourceSchema::new("ec2.Vpc")
+            .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).create_only()),
     );
-    vpc_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    current_states.insert(
-        vpc_id.clone(),
-        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
-    );
+    let (managed_vpc, unresolved_vpc) = vpc_resources(false);
+    let (managed_subnet, unresolved_subnet) = subnet_resources(false, false);
+    let vpc_id = managed_vpc.id.clone();
 
-    let mut subnet_attrs = HashMap::new();
-    subnet_attrs.insert(
-        "vpc_id".to_string(),
-        Value::Concrete(ConcreteValue::String("vpc-old".to_string())),
-    );
-    subnet_attrs.insert(
-        "tags".to_string(),
-        Value::Concrete(ConcreteValue::String("old-tag".to_string())),
-    );
-    subnet_attrs.insert(
-        "cidr_block".to_string(),
-        Value::Concrete(ConcreteValue::String("10.1.1.0/24".to_string())),
-    );
-    current_states.insert(
-        subnet_id.clone(),
-        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
-    );
-
-    // Schema: vpc_id is create-only, tags is NOT
-    let subnet_schema = ResourceSchema::new("ec2.Subnet")
-        .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::string())
-                .required()
-                .create_only(),
-        )
-        .attribute(AttributeSchema::new("tags", AttributeType::string()))
-        .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).required());
-
-    let mut schemas = SchemaRegistry::new();
-    schemas.insert("", subnet_schema);
-
-    // Build a plan with Replace for VPC and Update for subnet (tags changed)
-    let mut plan = Plan::new();
-    plan.add(Effect::Replace {
-        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
-        to: resolved(vpc.clone().with_binding("vpc")),
-        directives: Directives {
-            create_before_destroy: true,
-            ..Default::default()
-        },
-        changed_create_only: crate::effect::ChangedCreateOnly::new(vec!["cidr_block".to_string()])
-            .unwrap(),
-        cascading_updates: vec![],
-        temporary_name: None,
-        cascade_ref_hints: vec![],
-    });
-    plan.add(Effect::Update {
-        from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
-        to: resolved(subnet.clone().with_binding("subnet")),
-        changed_attributes: vec!["tags".to_string()],
-    });
-
-    // Apply cascade
-    cascade_dependent_updates(
-        &mut plan,
-        &unresolved_resources,
-        &crate::resource::into_plan_input_map(current_states.clone()),
+    let plan = plan_for(
+        vec![managed_vpc, managed_subnet],
+        vec![unresolved_vpc, unresolved_subnet],
+        standard_states(),
         &schemas,
     );
 
-    // The subnet should NOT be upgraded to Replace because it has prevent_destroy.
-    // A PlanError should be generated instead.
+    assert!(plan.has_errors());
+    assert_eq!(plan.errors()[0].resource_id, vpc_id);
     assert!(
-        plan.has_errors(),
-        "Expected PlanError for subnet with prevent_destroy on merge upgrade"
+        plan.errors()[0]
+            .message
+            .contains("has no unique_name_attribute")
+    );
+}
+
+#[test]
+fn chained_cbd_anonymous_middle_node_auto_promoted() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "",
+        ResourceSchema::new("test.Producer")
+            .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("shape", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("producer_id", AttributeType::string()).read_only())
+            .with_unique_name_attribute("name"),
+    );
+    schemas.insert(
+        "",
+        ResourceSchema::new("test.Middle")
+            .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("a_id", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("b_id", AttributeType::string()).read_only())
+            .with_unique_name_attribute("name"),
+    );
+    schemas.insert(
+        "",
+        ResourceSchema::new("test.Consumer")
+            .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("b_id", AttributeType::string()))
+            .with_unique_name_attribute("name"),
     );
 
-    let errors = plan.errors();
-    assert_eq!(errors.len(), 1);
-    assert_eq!(errors[0].resource_id, subnet_id);
+    let mut producer = Resource::new("test.Producer", "producer")
+        .with_binding("a")
+        .with_attribute("name", string("producer"))
+        .with_attribute("shape", string("new"));
+    producer.directives.create_before_destroy = true;
+    let unresolved_producer = producer.clone();
+
+    let managed_middle = Resource::new("test.Middle", "anon-b")
+        .with_attribute("name", string("middle"))
+        .with_attribute("a_id", string("a-old"));
+    let unresolved_middle = Resource::new("test.Middle", "anon-b")
+        .with_attribute("name", string("middle"))
+        .with_attribute("a_id", ref_value("a", "producer_id"));
+
+    let managed_consumer = Resource::new("test.Consumer", "consumer")
+        .with_binding("c")
+        .with_attribute("name", string("consumer"))
+        .with_attribute("b_id", string("b-old"));
+    let unresolved_consumer = Resource::new("test.Consumer", "consumer")
+        .with_binding("c")
+        .with_attribute("name", string("consumer"))
+        .with_attribute("b_id", ref_value("anon-b", "b_id"));
+
+    let producer_id = producer.id.clone();
+    let middle_id = managed_middle.id.clone();
+    let consumer_id = managed_consumer.id.clone();
+    let states = HashMap::from([
+        (
+            producer_id.clone(),
+            state(
+                &producer_id,
+                &[
+                    ("name", string("producer")),
+                    ("shape", string("old")),
+                    ("producer_id", string("a-old")),
+                ],
+                "a-old",
+            ),
+        ),
+        (
+            middle_id.clone(),
+            state(
+                &middle_id,
+                &[
+                    ("name", string("middle")),
+                    ("a_id", string("a-old")),
+                    ("b_id", string("b-old")),
+                ],
+                "b-old",
+            ),
+        ),
+        (
+            consumer_id.clone(),
+            state(
+                &consumer_id,
+                &[("name", string("consumer")), ("b_id", string("b-old"))],
+                "c-old",
+            ),
+        ),
+    ]);
+
+    let plan = plan_for(
+        vec![producer, managed_middle, managed_consumer],
+        vec![unresolved_producer, unresolved_middle, unresolved_consumer],
+        states,
+        &schemas,
+    );
+
+    assert_eq!(plan.replace_display.len(), 2);
+    assert!(replacement_metadata(&plan, &middle_id).create_before_destroy);
+    assert!(update_for(&plan, &consumer_id).is_some());
     assert!(
-        errors[0].message.contains("prevent_destroy"),
-        "Error message should mention prevent_destroy, got: {}",
-        errors[0].message
+        delete_blocked_by(&plan, &producer_id).contains(&ResourceIdentity::new("anon-b")),
+        "producer delete should wait for anonymous middle replacement"
+    );
+    assert!(
+        delete_blocked_by(&plan, &middle_id).contains(&ResourceIdentity::new("consumer")),
+        "anonymous middle delete should wait for downstream consumer update"
     );
 }

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -3,6 +3,16 @@ use super::*;
 use crate::resource::ConcreteValue;
 use indexmap::IndexMap;
 
+fn replacement_metadata<'a>(
+    plan: &'a Plan,
+    id: &ResourceId,
+) -> &'a crate::plan::ReplaceDisplayMetadata {
+    plan.replace_display
+        .iter()
+        .find(|metadata| plan.effects()[metadata.create_idx].resource_id() == id)
+        .unwrap_or_else(|| panic!("replacement metadata for {id} not found"))
+}
+
 #[test]
 fn diff_create_when_not_exists() {
     let desired = Resource::new("bucket", "test");
@@ -405,16 +415,12 @@ fn replace_when_create_only_attr_changed() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace {
-            changed_create_only,
-            ..
-        } => {
-            assert_eq!(&changed_create_only[..], &["cidr_block".to_string()]);
-        }
-        other => panic!("Expected Replace, got {:?}", other),
-    }
+    assert_eq!(plan.effects().len(), 2);
+    let metadata = replacement_metadata(&plan, &ResourceId::with_identity("ec2.Vpc", "my-vpc"));
+    assert_eq!(
+        &metadata.changed_create_only[..],
+        &["cidr_block".to_string()]
+    );
 }
 
 #[test]
@@ -525,32 +531,37 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace {
-            changed_create_only,
-            ..
-        } => {
-            assert_eq!(&changed_create_only[..], &["cidr_block".to_string()]);
-        }
-        other => panic!("Expected Replace, got {:?}", other),
-    }
+    assert_eq!(plan.effects().len(), 2);
+    let metadata = replacement_metadata(&plan, &ResourceId::with_identity("ec2.Vpc", "my-vpc"));
+    assert_eq!(
+        &metadata.changed_create_only[..],
+        &["cidr_block".to_string()]
+    );
 }
 
 #[test]
 fn replace_carries_create_before_destroy_directives() {
     use crate::schema::{AttributeSchema, AttributeType};
 
-    let mut resource = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
-        "cidr_block",
-        Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
-    );
+    let mut resource = Resource::new("ec2.Vpc", "my-vpc")
+        .with_attribute(
+            "name",
+            Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
+        )
+        .with_attribute(
+            "cidr_block",
+            Value::Concrete(ConcreteValue::String("10.1.0.0/16".to_string())),
+        );
     resource.directives.create_before_destroy = true;
 
     let resources = vec![resource];
 
     let mut current_states = HashMap::new();
     let mut attrs = HashMap::new();
+    attrs.insert(
+        "name".to_string(),
+        Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
+    );
     attrs.insert(
         "cidr_block".to_string(),
         Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -564,7 +575,9 @@ fn replace_carries_create_before_destroy_directives() {
     schemas.insert(
         "",
         crate::schema::ResourceSchema::new("ec2.Vpc")
-            .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).create_only()),
+            .attribute(AttributeSchema::new("name", AttributeType::string()).create_only())
+            .attribute(AttributeSchema::new("cidr_block", AttributeType::string()).create_only())
+            .with_unique_name_attribute("name"),
     );
 
     let plan = create_plan(
@@ -580,18 +593,13 @@ fn replace_carries_create_before_destroy_directives() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace {
-            directives,
-            changed_create_only,
-            ..
-        } => {
-            assert!(directives.create_before_destroy);
-            assert_eq!(&changed_create_only[..], &["cidr_block".to_string()]);
-        }
-        other => panic!("Expected Replace, got {:?}", other),
-    }
+    assert_eq!(plan.effects().len(), 2);
+    let metadata = replacement_metadata(&plan, &ResourceId::with_identity("ec2.Vpc", "my-vpc"));
+    assert!(metadata.create_before_destroy);
+    assert_eq!(
+        &metadata.changed_create_only[..],
+        &["cidr_block".to_string()]
+    );
 }
 
 #[test]
@@ -703,11 +711,11 @@ fn replace_with_provider_prefixed_schema_key() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    assert!(
-        matches!(plan.effects()[0], Effect::Replace { .. }),
-        "Expected Replace with awscc-prefixed schema key, got {:?}",
-        plan.effects()[0]
+    assert_eq!(plan.effects().len(), 2);
+    assert_eq!(plan.replace_display.len(), 1);
+    replacement_metadata(
+        &plan,
+        &ResourceId::with_provider_identity("awscc", "ec2.Vpc", "my-vpc", None),
     );
 }
 

--- a/carina-core/src/differ/mod.rs
+++ b/carina-core/src/differ/mod.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use crate::resource::{Resource, ResourceId, State, Value};
 use crate::schema::ResourceSchema;
 
-pub use plan::{cascade_dependent_updates, create_plan};
+pub use plan::{create_plan, create_plan_with_cascades};
 
 // Imports used by test submodules (accessible via `use super::*;`)
 #[cfg(test)]

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -3,10 +3,12 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::deps::get_resource_dependencies;
-use crate::effect::{CascadingUpdate, ChangedCreateOnly, Effect, TemporaryName};
+use serde::{Deserialize, Serialize};
+
+use crate::effect::{ChangedCreateOnly, Effect, TemporaryName};
 use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
-use crate::plan::{Plan, PlanError};
+use crate::plan::{Plan, PlanError, ReplacementDelete, ReplacementGroup};
 use crate::provider::Provider;
 use crate::resource::{
     ConcreteValue, DataSource, Directives, PlanInputState, ResolvedDataSource, ResolvedResource,
@@ -20,12 +22,26 @@ use crate::wait::predicate::{AttrPath, WaitPredicate};
 
 use super::{Diff, diff};
 
-/// A pending merge operation: cascade-triggered create-only attributes to add to an existing effect.
-struct CascadeMerge {
-    resource_id: ResourceId,
-    create_only_attrs: ChangedCreateOnly,
-    directives: Directives,
-    ref_hints: Vec<(String, String)>,
+pub(crate) struct PendingReplace {
+    pub create: ResolvedResource,
+    pub delete: ReplacementDelete,
+    pub create_before_destroy: bool,
+    pub changed_create_only: ChangedCreateOnly,
+    pub cascade_ref_hints: Vec<(String, String)>,
+    pub temporary_name: Option<TemporaryName>,
+    pub consumer_updates: HashSet<ResourceIdentity>,
+    pub previous_attributes: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, thiserror::Error, Serialize, Deserialize)]
+#[error(
+    "resource type '{resource_type}' has no unique_name_attribute; create_before_destroy needs one to generate a temporary name"
+)]
+pub struct MissingNameAttributeError {
+    pub resource_type: String,
+    /// The binding name (let-bound) or resolver identity (anonymous)
+    /// of the resource that triggered the CBD path. For diagnostics only.
+    pub resource_identity: String,
 }
 
 struct RefAttr {
@@ -123,36 +139,43 @@ fn filter_non_removable_removals(
 
 /// Generate a temporary name for create-before-destroy replacement.
 ///
-/// When a resource has a `unique_name_attribute` with a unique constraint and uses
-/// `create_before_destroy`, we need a temporary name for the new resource to
-/// avoid conflicts with the old resource that still exists.
-///
-/// Returns `None` if no temporary name is needed (no unique_name_attribute,
-/// the resource already uses name_prefix for that attribute, or
-/// the unique_name_attribute value changed between `from` and `to`).
-fn generate_temporary_name(
+/// A schema that lacks `unique_name_attribute` is a plan-time error on every
+/// CBD path. Other cases can still legitimately avoid a temporary name: a
+/// `name_prefix` already produces a non-conflicting cloud name, and a direct
+/// change to the unique-name value is already distinct from the old resource.
+pub fn generate_temporary_name(
     resource: &Resource,
     from: &State,
     schema: &ResourceSchema,
-) -> Option<TemporaryName> {
-    let name_attr = schema.unique_name_attribute.as_ref()?;
+) -> Result<Option<TemporaryName>, MissingNameAttributeError> {
+    let name_attr =
+        schema
+            .unique_name_attribute
+            .as_ref()
+            .ok_or_else(|| MissingNameAttributeError {
+                resource_type: resource.id.display_type(),
+                resource_identity: resource
+                    .binding
+                    .clone()
+                    .unwrap_or_else(|| resource.id.identity_or_empty().to_string()),
+            })?;
 
     // Skip if the resource uses name_prefix for this attribute
     if resource.prefixes.contains_key(name_attr) {
-        return None;
+        return Ok(None);
     }
 
     // Get the current value of the unique-name attribute.
     let original_value = match resource.get_attr(name_attr) {
         Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
-        _ => return None,
+        _ => return Ok(None),
     };
 
     // Skip if the unique_name_attribute value changed (new name is already different from old)
     if let Some(Value::Concrete(ConcreteValue::String(from_name))) = from.attributes.get(name_attr)
         && *from_name != original_value
     {
-        return None;
+        return Ok(None);
     }
 
     // Check if the unique-name attribute is create-only (cannot be renamed after creation).
@@ -164,12 +187,12 @@ fn generate_temporary_name(
 
     let temporary_value = format!("{}-{}", original_value, generate_random_suffix());
 
-    Some(TemporaryName {
+    Ok(Some(TemporaryName {
         attribute: name_attr.clone(),
         original_value,
         temporary_value,
         can_rename,
-    })
+    }))
 }
 
 /// Compute Diff for multiple resources and generate a Plan
@@ -257,7 +280,79 @@ pub fn create_plan(
     orphan_dependencies: &HashMap<ResourceId, BTreeSet<String>>,
     wait_bindings: &[WaitBinding],
 ) -> Plan {
+    let mut build = create_plan_parts(
+        managed,
+        data_sources,
+        provider,
+        current_states,
+        directives_map,
+        registry,
+        saved_attrs,
+        prev_explicit,
+        orphan_dependencies,
+        wait_bindings,
+    );
+    decompose_replace_into_effects(&mut build.plan, build.pending_replaces);
+    build.plan
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_plan_with_cascades(
+    managed: &[Resource],
+    data_sources: &[DataSource],
+    unresolved_managed: &[Resource],
+    provider: &dyn Provider,
+    current_states: &HashMap<ResourceId, PlanInputState>,
+    directives_map: &HashMap<ResourceId, Directives>,
+    registry: &SchemaRegistry,
+    saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
+    prev_explicit: &HashMap<ResourceId, crate::explicit::ExplicitFields>,
+    orphan_dependencies: &HashMap<ResourceId, BTreeSet<String>>,
+    wait_bindings: &[WaitBinding],
+) -> Plan {
+    let mut build = create_plan_parts(
+        managed,
+        data_sources,
+        provider,
+        current_states,
+        directives_map,
+        registry,
+        saved_attrs,
+        prev_explicit,
+        orphan_dependencies,
+        wait_bindings,
+    );
+    cascade_dependent_updates(
+        &mut build.plan,
+        &mut build.pending_replaces,
+        unresolved_managed,
+        current_states,
+        registry,
+    );
+    decompose_replace_into_effects(&mut build.plan, build.pending_replaces);
+    build.plan
+}
+
+struct PlanBuild {
+    plan: Plan,
+    pending_replaces: HashMap<ResourceIdentity, PendingReplace>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn create_plan_parts(
+    managed: &[Resource],
+    data_sources: &[DataSource],
+    provider: &dyn Provider,
+    current_states: &HashMap<ResourceId, PlanInputState>,
+    directives_map: &HashMap<ResourceId, Directives>,
+    registry: &SchemaRegistry,
+    saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
+    prev_explicit: &HashMap<ResourceId, crate::explicit::ExplicitFields>,
+    orphan_dependencies: &HashMap<ResourceId, BTreeSet<String>>,
+    wait_bindings: &[WaitBinding],
+) -> PlanBuild {
     let mut plan = Plan::new();
+    let mut pending_replaces = HashMap::new();
     let known_bindings = known_binding_names(managed, data_sources);
 
     let desired_ids: std::collections::HashSet<&ResourceId> = managed
@@ -340,40 +435,22 @@ pub fn create_plan(
                         });
                         continue;
                     }
-                    let directives = resource.directives.clone();
-                    let temporary_name = if directives.create_before_destroy {
-                        registry
-                            .get(
-                                &resource.id.provider,
-                                &resource.id.resource_type,
-                                SchemaKind::Resource,
-                            )
-                            .and_then(|schema| generate_temporary_name(&to, &from, schema))
-                    } else {
-                        None
-                    };
-
-                    // If a temporary name is generated, modify the `to` resource
-                    let to = if let Some(ref temp) = temporary_name {
-                        let mut modified = to;
-                        modified.set_attr(
-                            temp.attribute.clone(),
-                            Value::Concrete(ConcreteValue::String(temp.temporary_value.clone())),
-                        );
-                        modified
-                    } else {
-                        to
-                    };
-
-                    plan.add(Effect::Replace {
+                    match pending_replace_from_parts(
                         from,
-                        to: ResolvedResource::new(to),
-                        directives,
+                        to,
+                        resource.directives.clone(),
                         changed_create_only,
-                        cascading_updates: vec![],
-                        temporary_name,
-                        cascade_ref_hints: vec![],
-                    });
+                        Vec::new(),
+                        registry,
+                    ) {
+                        Ok(pending) => {
+                            pending_replaces.insert(resource_identity(&pending.create.id), pending);
+                        }
+                        Err(err) => plan.add_error(PlanError {
+                            resource_id: id.clone(),
+                            message: err.to_string(),
+                        }),
+                    }
                 } else {
                     plan.add(Effect::Update {
                         from,
@@ -640,7 +717,111 @@ pub fn create_plan(
         });
     }
 
-    plan
+    PlanBuild {
+        plan,
+        pending_replaces,
+    }
+}
+
+fn resource_identity(id: &ResourceId) -> ResourceIdentity {
+    id.identity
+        .as_ref()
+        .expect("differ only receives resources after identity resolution")
+        .clone()
+}
+
+fn pending_replace_from_parts(
+    from: Box<State>,
+    to: Resource,
+    directives: Directives,
+    changed_create_only: ChangedCreateOnly,
+    cascade_ref_hints: Vec<(String, String)>,
+    registry: &SchemaRegistry,
+) -> Result<PendingReplace, MissingNameAttributeError> {
+    let create_before_destroy = directives.create_before_destroy;
+    let previous_attributes = from.attributes.clone();
+    let temporary_name = if create_before_destroy {
+        temporary_name_for_cbd(&to, &from, registry)?
+    } else {
+        None
+    };
+    let create = apply_temporary_name(to, temporary_name.as_ref());
+    let dependencies = from.dependency_bindings.iter().cloned().collect();
+    let explicit_dependencies = directives.depends_on.iter().cloned().collect();
+    let delete = ReplacementDelete {
+        id: ResolvedResourceId::new(from.id.clone()),
+        identifier: from.identifier.clone().unwrap_or_default(),
+        directives,
+        binding: create.binding.clone(),
+        dependencies,
+        explicit_dependencies,
+    };
+
+    Ok(PendingReplace {
+        create: ResolvedResource::new(create),
+        delete,
+        create_before_destroy,
+        changed_create_only,
+        cascade_ref_hints,
+        temporary_name,
+        consumer_updates: HashSet::new(),
+        previous_attributes,
+    })
+}
+
+fn temporary_name_for_cbd(
+    resource: &Resource,
+    from: &State,
+    registry: &SchemaRegistry,
+) -> Result<Option<TemporaryName>, MissingNameAttributeError> {
+    let schema = registry
+        .get(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            SchemaKind::Resource,
+        )
+        .ok_or_else(|| MissingNameAttributeError {
+            resource_type: resource.id.display_type(),
+            resource_identity: resource
+                .binding
+                .clone()
+                .unwrap_or_else(|| resource.id.identity_or_empty().to_string()),
+        })?;
+    generate_temporary_name(resource, from, schema)
+}
+
+fn apply_temporary_name(
+    mut resource: Resource,
+    temporary_name: Option<&TemporaryName>,
+) -> Resource {
+    if let Some(temp) = temporary_name {
+        resource.set_attr(
+            temp.attribute.clone(),
+            Value::Concrete(ConcreteValue::String(temp.temporary_value.clone())),
+        );
+    }
+    resource
+}
+
+fn decompose_replace_into_effects(
+    plan: &mut Plan,
+    pending_replaces: HashMap<ResourceIdentity, PendingReplace>,
+) {
+    let mut pending_replaces: Vec<_> = pending_replaces.into_values().collect();
+    pending_replaces.sort_by_key(|pending| pending.create.id.to_string());
+
+    for pending in pending_replaces {
+        plan.add_replacement(ReplacementGroup {
+            create: pending.create,
+            delete: pending.delete,
+            create_before_destroy: pending.create_before_destroy,
+            changed_create_only: pending.changed_create_only,
+            cascade_ref_hints: pending.cascade_ref_hints,
+            temporary_name: pending.temporary_name,
+            consumer_updates: pending.consumer_updates,
+            previous_attributes: pending.previous_attributes,
+        });
+    }
 }
 
 fn known_binding_names(managed: &[Resource], data_sources: &[DataSource]) -> HashSet<String> {
@@ -655,150 +836,132 @@ fn known_binding_names(managed: &[Resource], data_sources: &[DataSource]) -> Has
         .collect()
 }
 
-/// Populate cascading updates for Replace effects with create_before_destroy.
-///
-/// When a resource is replaced with create_before_destroy, dependent resources
-/// that reference the replaced resource's computed attributes must be updated
-/// between the create (new) and delete (old) steps. This function:
-///
-/// 1. Finds all Replace effects with create_before_destroy = true
-/// 2. Identifies dependent resources that reference the replaced resource's binding
-/// 3. If the referencing attribute is create-only on the dependent (per the registry),
-///    promotes the dependent to its own Replace effect in the plan
-/// 4. Otherwise, adds a CascadingUpdate entry to the parent Replace effect
-///
-/// `unresolved_resources` should be the resources BEFORE ref resolution (still containing
-/// ResourceRef values). `current_states` provides the `from` state for each dependent.
-/// `registry` provides attribute metadata to detect create-only attributes.
-pub fn cascade_dependent_updates(
+fn cascade_dependent_updates(
     plan: &mut Plan,
+    pending_replaces: &mut HashMap<ResourceIdentity, PendingReplace>,
     unresolved_managed: &[Resource],
     current_states: &HashMap<ResourceId, PlanInputState>,
     registry: &SchemaRegistry,
 ) {
-    // Build binding/key -> unresolved resource mapping.
-    // Uses the same key logic as the dependent lookup below so anonymous resources
-    // (without _binding) are also found.
-    let mut binding_to_unresolved: HashMap<String, &Resource> = HashMap::new();
-    for resource in unresolved_managed {
-        let key = resource.binding.clone().unwrap_or_else(|| {
-            format!(
-                "{}:{}",
-                resource.id.resource_type,
-                resource.id.identity_or_empty()
-            )
-        });
-        binding_to_unresolved.insert(key, resource);
-    }
+    loop {
+        promote_referenced_replaces_to_cbd(plan, pending_replaces, unresolved_managed, registry);
 
-    // Auto-detect create_before_destroy: if a Replace effect has dependents
-    // among the unresolved resources, promote it to create_before_destroy.
-    // This must happen before collecting replaced_bindings so that the
-    // promoted effects are picked up by the existing cascade logic.
-    {
-        // Collect all Replace bindings (regardless of CBD flag) with their resource IDs
-        let all_replace_bindings: HashMap<String, ResourceId> = plan
-            .effects()
-            .iter()
-            .filter_map(|e| {
-                if let Effect::Replace { to, directives, .. } = e {
-                    // Only consider Replace effects that are NOT already CBD
-                    if !directives.create_before_destroy {
-                        e.binding_name().map(|b| (b, to.id.clone()))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        if !all_replace_bindings.is_empty() {
-            for resource in unresolved_managed {
-                let deps = get_resource_dependencies(resource);
-                for dep in &deps {
-                    if let Some(resource_id) = all_replace_bindings.get(dep) {
-                        plan.promote_to_create_before_destroy(resource_id);
-                    }
-                }
-            }
-        }
-    }
-
-    // Build reverse dependency map: replaced_binding -> [dependent_bindings]
-    let mut dependents_of_replaced: HashMap<String, Vec<String>> = HashMap::new();
-
-    // Collect binding names of resources being replaced (now includes auto-promoted ones)
-    let replaced_bindings: HashSet<String> = plan
-        .effects()
-        .iter()
-        .filter_map(|e| {
-            if let Effect::Replace { .. } = e {
-                return e.binding_name();
-            }
-            None
-        })
-        .collect();
-
-    if replaced_bindings.is_empty() {
-        return;
-    }
-
-    // Collect resource IDs that already have effects in the plan
-    let planned_ids: HashSet<ResourceId> = plan
-        .effects()
-        .iter()
-        .map(|e| e.resource_id().clone())
-        .collect();
-
-    // For each unresolved resource, check if it depends on a replaced binding.
-    // Resources already in the plan are handled separately below.
-    for resource in unresolved_managed {
-        if planned_ids.contains(&resource.id) {
-            continue;
+        if pending_replaces.is_empty() {
+            return;
         }
 
+        let promoted = promote_pending_replaces_for_dependents(
+            plan,
+            pending_replaces,
+            unresolved_managed,
+            current_states,
+            registry,
+        );
+
+        if !promoted {
+            break;
+        }
+    }
+}
+
+fn promote_referenced_replaces_to_cbd(
+    plan: &mut Plan,
+    pending_replaces: &mut HashMap<ResourceIdentity, PendingReplace>,
+    unresolved_managed: &[Resource],
+    registry: &SchemaRegistry,
+) {
+    let ref_targets = pending_reference_targets(pending_replaces, false);
+    let mut promote = Vec::new();
+
+    for resource in unresolved_managed {
         let deps = get_resource_dependencies(resource);
         for dep in &deps {
-            if replaced_bindings.contains(dep) {
-                let binding = resource.binding.clone().unwrap_or_else(|| {
-                    format!(
-                        "{}:{}",
-                        resource.id.resource_type,
-                        resource.id.identity_or_empty()
-                    )
-                });
-                dependents_of_replaced
-                    .entry(dep.clone())
-                    .or_default()
-                    .push(binding);
+            let Some(replaced_identity) = ref_targets.get(dep) else {
+                continue;
+            };
+            let Some(pending) = pending_replaces.get(replaced_identity) else {
+                continue;
+            };
+            if pending.create_before_destroy || pending.create.id == resource.id {
+                continue;
             }
+            promote.push(replaced_identity.clone());
         }
     }
 
-    // For resources already in the plan, check if cascade-triggered create-only
-    // attributes need to be merged into their existing effects.
-    let mut merge_operations: Vec<CascadeMerge> = Vec::new();
+    promote.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    promote.dedup();
+
+    for identity in promote {
+        let result = pending_replaces
+            .get_mut(&identity)
+            .map(|pending| mark_pending_create_before_destroy(pending, registry));
+        if let Some(Err(err)) = result
+            && let Some(pending) = pending_replaces.remove(&identity)
+        {
+            plan.add_error(PlanError {
+                resource_id: pending.create.id.clone(),
+                message: err.to_string(),
+            });
+        }
+    }
+}
+
+fn mark_pending_create_before_destroy(
+    pending: &mut PendingReplace,
+    registry: &SchemaRegistry,
+) -> Result<(), MissingNameAttributeError> {
+    if pending.create_before_destroy {
+        return Ok(());
+    }
+
+    let mut create = pending.create.clone().into_inner();
+    create.directives.create_before_destroy = true;
+    let from = State::existing(
+        pending.delete.id.as_inner().clone(),
+        pending.previous_attributes.clone(),
+    );
+    let temporary_name = temporary_name_for_cbd(&create, &from, registry)?;
+    let create = apply_temporary_name(create, temporary_name.as_ref());
+
+    pending.create = ResolvedResource::new(create);
+    pending.create_before_destroy = true;
+    pending.delete.directives.create_before_destroy = true;
+    pending.temporary_name = temporary_name;
+    Ok(())
+}
+
+fn promote_pending_replaces_for_dependents(
+    plan: &mut Plan,
+    pending_replaces: &mut HashMap<ResourceIdentity, PendingReplace>,
+    unresolved_managed: &[Resource],
+    current_states: &HashMap<ResourceId, PlanInputState>,
+    registry: &SchemaRegistry,
+) -> bool {
+    let ref_targets = pending_reference_targets(pending_replaces, true);
+    let mut promoted = false;
 
     for resource in unresolved_managed {
-        if !planned_ids.contains(&resource.id) {
-            continue;
-        }
-
+        let consumer_identity = resource_identity(&resource.id);
         let deps = get_resource_dependencies(resource);
+
         for dep in &deps {
-            if !replaced_bindings.contains(dep) {
+            let Some(replaced_identity) = ref_targets.get(dep).cloned() else {
+                continue;
+            };
+            if consumer_identity == replaced_identity {
                 continue;
             }
 
             let ref_attrs = cascade_ref_attrs(&resource.attributes, dep);
+            if ref_attrs.is_empty() {
+                continue;
+            }
+
             let ref_attr_names: Vec<String> = ref_attrs
                 .iter()
                 .map(|ref_attr| ref_attr.attribute.clone())
                 .collect();
-
-            // Check if any of those attributes are create-only
             let create_only_refs = find_changed_create_only(
                 &resource.id.provider,
                 &resource.id.resource_type,
@@ -806,14 +969,20 @@ pub fn cascade_dependent_updates(
                 registry,
             );
 
-            if let Some(create_only_attrs) = ChangedCreateOnly::new(create_only_refs) {
-                // Check if this merge would upgrade an Update to Replace.
-                // If the resource has prevent_destroy, block the upgrade.
-                let is_update_in_plan = plan
-                    .effects()
-                    .iter()
-                    .any(|e| matches!(e, Effect::Update { to, .. } if to.id == resource.id));
-                if is_update_in_plan && resource.directives.prevent_destroy {
+            if let Some(changed_create_only) = ChangedCreateOnly::new(create_only_refs) {
+                let ref_hints: Vec<(String, String)> = ref_attrs
+                    .into_iter()
+                    .filter(|ref_attr| changed_create_only.contains(&ref_attr.attribute))
+                    .map(|ref_attr| (ref_attr.attribute, ref_attr.hint))
+                    .collect();
+
+                if pending_replaces.contains_key(&consumer_identity) {
+                    merge_pending_create_only(
+                        pending_replaces.get_mut(&consumer_identity).unwrap(),
+                        changed_create_only,
+                        ref_hints,
+                    );
+                } else if resource.directives.prevent_destroy {
                     plan.add_error(PlanError {
                         resource_id: resource.id.clone(),
                         message:
@@ -821,113 +990,168 @@ pub fn cascade_dependent_updates(
                                 .to_string(),
                     });
                     continue;
-                }
-
-                // Only keep hints for attributes that are actually create-only
-                let filtered_hints: Vec<(String, String)> = ref_attrs
-                    .into_iter()
-                    .filter(|ref_attr| create_only_attrs.contains(&ref_attr.attribute))
-                    .map(|ref_attr| (ref_attr.attribute, ref_attr.hint))
-                    .collect();
-                merge_operations.push(CascadeMerge {
-                    resource_id: resource.id.clone(),
-                    create_only_attrs,
-                    directives: resource.directives.clone(),
-                    ref_hints: filtered_hints,
-                });
-            }
-        }
-    }
-
-    // Apply merge operations to existing effects
-    for merge in merge_operations {
-        plan.merge_cascade_create_only(
-            &merge.resource_id,
-            merge.create_only_attrs,
-            merge.directives,
-            merge.ref_hints,
-        );
-    }
-
-    // Build cascading updates for each Replace effect.
-    // Dependents whose affected attributes are create-only get promoted to
-    // their own Replace effect instead of being added as a CascadingUpdate.
-    let mut updates_by_replaced_binding: HashMap<String, Vec<CascadingUpdate>> = HashMap::new();
-    let mut promoted_replaces: Vec<Effect> = Vec::new();
-
-    for (replaced_binding, dependent_bindings) in &dependents_of_replaced {
-        for dep_binding in dependent_bindings {
-            if let Some(unresolved) = binding_to_unresolved.get(dep_binding) {
-                let from = current_states
-                    .get(&unresolved.id)
-                    .map(|state| state.as_state().clone())
-                    .unwrap_or_else(|| State::not_found(unresolved.id.clone()));
-
-                if !from.exists {
+                } else if let Some(pending) = promote_resource_to_pending_replace(
+                    plan,
+                    resource,
+                    changed_create_only,
+                    ref_hints,
+                    current_states,
+                    registry,
+                ) {
+                    pending_replaces.insert(consumer_identity.clone(), pending);
+                    promoted = true;
+                } else {
                     continue;
                 }
 
-                let ref_attrs = cascade_ref_attrs(&unresolved.attributes, replaced_binding);
-                let ref_attr_names: Vec<String> = ref_attrs
-                    .iter()
-                    .map(|ref_attr| ref_attr.attribute.clone())
-                    .collect();
-
-                // Check if any of those attributes are create-only
-                let create_only_refs = find_changed_create_only(
-                    &unresolved.id.provider,
-                    &unresolved.id.resource_type,
-                    &ref_attr_names,
-                    registry,
-                );
-
-                if let Some(changed_create_only) = ChangedCreateOnly::new(create_only_refs) {
-                    if unresolved.directives.prevent_destroy {
-                        // Cascade would promote to Replace (destroy + recreate),
-                        // but prevent_destroy blocks this.
-                        plan.add_error(PlanError {
-                            resource_id: unresolved.id.clone(),
-                            message:
-                                "resource has prevent_destroy set, but cascade from a replaced dependency would replace it (which requires destroying the old resource)"
-                                    .to_string(),
-                        });
-                    } else {
-                        let ref_hints: Vec<(String, String)> = ref_attrs
-                            .into_iter()
-                            .filter(|ref_attr| changed_create_only.contains(&ref_attr.attribute))
-                            .map(|ref_attr| (ref_attr.attribute, ref_attr.hint))
-                            .collect();
-
-                        // Promote to a separate Replace effect
-                        promoted_replaces.push(Effect::Replace {
-                            from: Box::new(from),
-                            to: ResolvedResource::new((*unresolved).clone()),
-                            directives: unresolved.directives.clone(),
-                            changed_create_only,
-                            cascading_updates: vec![],
-                            temporary_name: None,
-                            cascade_ref_hints: ref_hints,
-                        });
-                    }
-                } else {
-                    // Normal cascading update
-                    updates_by_replaced_binding
-                        .entry(replaced_binding.clone())
-                        .or_default()
-                        .push(CascadingUpdate {
-                            from: Box::new(from),
-                            to: ResolvedResource::new((*unresolved).clone()),
-                        });
+                if let Some(replaced) = pending_replaces.get_mut(&replaced_identity) {
+                    replaced.consumer_updates.insert(consumer_identity.clone());
                 }
+            } else if !pending_replaces.contains_key(&consumer_identity)
+                && ensure_consumer_update(plan, resource, &ref_attr_names, current_states)
+                && let Some(replaced) = pending_replaces.get_mut(&replaced_identity)
+            {
+                replaced.consumer_updates.insert(consumer_identity.clone());
             }
         }
     }
 
-    // Apply cascading updates to the plan's Replace effects
-    plan.set_cascading_updates(&replaced_bindings, &updates_by_replaced_binding);
+    promoted
+}
 
-    // Add promoted Replace effects to the plan
-    for effect in promoted_replaces {
-        plan.add(effect);
+fn pending_reference_targets(
+    pending_replaces: &HashMap<ResourceIdentity, PendingReplace>,
+    create_before_destroy_only: bool,
+) -> HashMap<String, ResourceIdentity> {
+    let mut targets = HashMap::new();
+    for (identity, pending) in pending_replaces {
+        if create_before_destroy_only && !pending.create_before_destroy {
+            continue;
+        }
+        targets.insert(identity.as_str().to_string(), identity.clone());
+        if let Some(binding) = &pending.create.binding {
+            targets.insert(binding.clone(), identity.clone());
+        }
     }
+    targets
+}
+
+fn merge_pending_create_only(
+    pending: &mut PendingReplace,
+    attrs: ChangedCreateOnly,
+    ref_hints: Vec<(String, String)>,
+) {
+    for attr in attrs.iter() {
+        if !pending.changed_create_only.contains(attr) {
+            pending.changed_create_only.push(attr.to_string());
+        }
+    }
+    for hint in ref_hints {
+        if !pending.cascade_ref_hints.contains(&hint) {
+            pending.cascade_ref_hints.push(hint);
+        }
+    }
+}
+
+fn promote_resource_to_pending_replace(
+    plan: &mut Plan,
+    resource: &Resource,
+    changed_create_only: ChangedCreateOnly,
+    ref_hints: Vec<(String, String)>,
+    current_states: &HashMap<ResourceId, PlanInputState>,
+    registry: &SchemaRegistry,
+) -> Option<PendingReplace> {
+    let from = take_update_from_plan(plan, &resource.id).or_else(|| {
+        current_states
+            .get(&resource.id)
+            .map(|state| Box::new(state.as_state().clone()))
+    })?;
+
+    if !from.exists {
+        return None;
+    }
+
+    match pending_replace_from_parts(
+        from,
+        resource.clone(),
+        resource.directives.clone(),
+        changed_create_only,
+        ref_hints,
+        registry,
+    ) {
+        Ok(pending) => Some(pending),
+        Err(err) => {
+            plan.add_error(PlanError {
+                resource_id: resource.id.clone(),
+                message: err.to_string(),
+            });
+            None
+        }
+    }
+}
+
+fn take_update_from_plan(plan: &mut Plan, resource_id: &ResourceId) -> Option<Box<State>> {
+    let index = plan
+        .effects()
+        .iter()
+        .position(|effect| matches!(effect, Effect::Update { to, .. } if to.id == *resource_id))?;
+    let effect = plan.effects_mut().remove(index);
+    match effect {
+        Effect::Update { from, .. } => Some(from),
+        _ => None,
+    }
+}
+
+fn ensure_consumer_update(
+    plan: &mut Plan,
+    resource: &Resource,
+    changed_attributes: &[String],
+    current_states: &HashMap<ResourceId, PlanInputState>,
+) -> bool {
+    if let Some(effect) = plan
+        .effects_mut()
+        .iter_mut()
+        .find(|effect| matches!(effect, Effect::Update { to, .. } if to.id == resource.id))
+    {
+        if let Effect::Update {
+            to,
+            changed_attributes: existing,
+            ..
+        } = effect
+        {
+            *to = ResolvedResource::new(resource.clone());
+            for attr in changed_attributes {
+                if !existing.contains(attr) {
+                    existing.push(attr.clone());
+                }
+            }
+        }
+        return true;
+    }
+
+    if plan
+        .effects()
+        .iter()
+        .any(|effect| effect.resource_id() == &resource.id)
+    {
+        return false;
+    }
+
+    let Some(from) = current_states
+        .get(&resource.id)
+        .map(|state| state.as_state().clone())
+    else {
+        return false;
+    };
+
+    if !from.exists {
+        return false;
+    }
+
+    plan.add(Effect::Update {
+        from: Box::new(from),
+        to: ResolvedResource::new(resource.clone()),
+        changed_attributes: changed_attributes.to_vec(),
+    });
+    true
 }

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -88,6 +88,16 @@ impl crate::provider::Provider for HintProvider {
     }
 }
 
+fn replacement_metadata<'a>(
+    plan: &'a Plan,
+    id: &ResourceId,
+) -> &'a crate::plan::ReplaceDisplayMetadata {
+    plan.replace_display
+        .iter()
+        .find(|metadata| plan.effects()[metadata.create_idx].resource_id() == id)
+        .unwrap_or_else(|| panic!("replacement metadata for {id} not found"))
+}
+
 #[test]
 fn create_before_destroy_generates_temporary_name_for_unique_name_attribute() {
     use crate::schema::{AttributeSchema, AttributeType};
@@ -144,33 +154,31 @@ fn create_before_destroy_generates_temporary_name_for_unique_name_attribute() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace {
-            temporary_name, to, ..
-        } => {
-            let temp = temporary_name.as_ref().expect(
-                "Should have temporary_name for create_before_destroy with unique_name_attribute",
-            );
-            assert_eq!(temp.attribute, "bucket_name");
-            assert_eq!(temp.original_value, "my-bucket");
-            assert!(
-                temp.temporary_value.starts_with("my-bucket-"),
-                "Temporary value '{}' should start with 'my-bucket-'",
-                temp.temporary_value
-            );
-            assert_eq!(temp.temporary_value.len(), "my-bucket-".len() + 8);
-            // bucket_name is create-only, so can_rename should be false
-            assert!(!temp.can_rename);
-            // The `to` resource should have the temporary name
-            assert_eq!(
-                to.get_attr("bucket_name"),
-                Some(&Value::Concrete(ConcreteValue::String(
-                    temp.temporary_value.clone()
-                )))
-            );
-        }
-        other => panic!("Expected Replace, got {:?}", other),
+    assert_eq!(plan.effects().len(), 2);
+    let metadata =
+        replacement_metadata(&plan, &ResourceId::with_identity("s3.Bucket", "my-bucket"));
+    let temp = metadata
+        .temporary_name
+        .as_ref()
+        .expect("Should have temporary_name for create_before_destroy with unique_name_attribute");
+    assert_eq!(temp.attribute, "bucket_name");
+    assert_eq!(temp.original_value, "my-bucket");
+    assert!(
+        temp.temporary_value.starts_with("my-bucket-"),
+        "Temporary value '{}' should start with 'my-bucket-'",
+        temp.temporary_value
+    );
+    assert_eq!(temp.temporary_value.len(), "my-bucket-".len() + 8);
+    // bucket_name is create-only, so can_rename should be false
+    assert!(!temp.can_rename);
+    match &plan.effects()[metadata.create_idx] {
+        Effect::Create(to) => assert_eq!(
+            to.get_attr("bucket_name"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                temp.temporary_value.clone()
+            )))
+        ),
+        other => panic!("Expected replacement Create, got {:?}", other),
     }
 }
 
@@ -234,17 +242,18 @@ fn create_before_destroy_generates_temporary_name_with_can_rename() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace { temporary_name, .. } => {
-            let temp = temporary_name.as_ref().expect("Should have temporary_name");
-            assert_eq!(temp.attribute, "log_group_name");
-            assert_eq!(temp.original_value, "my-log-group");
-            // log_group_name is not create-only, so can_rename should be true
-            assert!(temp.can_rename);
-        }
-        other => panic!("Expected Replace, got {:?}", other),
-    }
+    assert_eq!(plan.effects().len(), 2);
+    let temp = replacement_metadata(
+        &plan,
+        &ResourceId::with_identity("logs.LogGroup", "my-log-group"),
+    )
+    .temporary_name
+    .as_ref()
+    .expect("Should have temporary_name");
+    assert_eq!(temp.attribute, "log_group_name");
+    assert_eq!(temp.original_value, "my-log-group");
+    // log_group_name is not create-only, so can_rename should be true
+    assert!(temp.can_rename);
 }
 
 #[test]
@@ -303,16 +312,13 @@ fn no_temporary_name_without_create_before_destroy() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace { temporary_name, .. } => {
-            assert!(
-                temporary_name.is_none(),
-                "Should not have temporary_name without create_before_destroy"
-            );
-        }
-        other => panic!("Expected Replace, got {:?}", other),
-    }
+    assert_eq!(plan.effects().len(), 2);
+    assert!(
+        replacement_metadata(&plan, &ResourceId::with_identity("s3.Bucket", "my-bucket"))
+            .temporary_name
+            .is_none(),
+        "Should not have temporary_name without create_before_destroy"
+    );
 }
 
 #[test]
@@ -375,20 +381,17 @@ fn no_temporary_name_when_name_prefix_is_used() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace { temporary_name, .. } => {
-            assert!(
-                temporary_name.is_none(),
-                "Should not generate temporary_name when name_prefix is used"
-            );
-        }
-        other => panic!("Expected Replace, got {:?}", other),
-    }
+    assert_eq!(plan.effects().len(), 2);
+    assert!(
+        replacement_metadata(&plan, &ResourceId::with_identity("s3.Bucket", "my-bucket"))
+            .temporary_name
+            .is_none(),
+        "Should not generate temporary_name when name_prefix is used"
+    );
 }
 
 #[test]
-fn no_temporary_name_without_unique_name_attribute_in_schema() {
+fn create_before_destroy_without_unique_name_attribute_emits_plan_error() {
     use crate::schema::{AttributeSchema, AttributeType};
 
     let mut resource = Resource::new("ec2.Vpc", "my-vpc").with_attribute(
@@ -431,16 +434,17 @@ fn no_temporary_name_without_unique_name_attribute_in_schema() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace { temporary_name, .. } => {
-            assert!(
-                temporary_name.is_none(),
-                "Should not generate temporary_name without unique_name_attribute in schema"
-            );
-        }
-        other => panic!("Expected Replace, got {:?}", other),
-    }
+    assert!(plan.effects().is_empty());
+    assert!(plan.has_errors());
+    assert_eq!(
+        plan.errors()[0].resource_id,
+        ResourceId::with_identity("ec2.Vpc", "my-vpc")
+    );
+    assert!(
+        plan.errors()[0]
+            .message
+            .contains("has no unique_name_attribute")
+    );
 }
 
 #[test]
@@ -501,16 +505,13 @@ fn no_temporary_name_when_unique_name_attribute_changes() {
         &[],
     );
 
-    assert_eq!(plan.effects().len(), 1);
-    match &plan.effects()[0] {
-        Effect::Replace { temporary_name, .. } => {
-            assert!(
-                temporary_name.is_none(),
-                "Should not generate temporary_name when unique_name_attribute value changes"
-            );
-        }
-        other => panic!("Expected Replace, got {:?}", other),
-    }
+    assert_eq!(plan.effects().len(), 2);
+    assert!(
+        replacement_metadata(&plan, &ResourceId::with_identity("s3.Bucket", "my-bucket"))
+            .temporary_name
+            .is_none(),
+        "Should not generate temporary_name when unique_name_attribute value changes"
+    );
 }
 
 #[test]

--- a/carina-core/src/effect/deps.rs
+++ b/carina-core/src/effect/deps.rs
@@ -239,14 +239,38 @@ impl DependencyAnalysis {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct IdentityTargets {
+    preferred: Option<usize>,
+    delete: Option<usize>,
+}
+
+impl IdentityTargets {
+    fn insert_preferred(&mut self, idx: usize) {
+        self.preferred.get_or_insert(idx);
+    }
+
+    fn insert_delete(&mut self, idx: usize) {
+        self.delete = Some(idx);
+    }
+
+    fn lookup(&self) -> Option<usize> {
+        self.preferred.or(self.delete)
+    }
+
+    fn lookup_delete(&self) -> Option<usize> {
+        self.delete
+    }
+}
+
 struct DependencyAnalyzer {
-    identity_to_idx: HashMap<ResourceIdentity, usize>,
+    identity_to_idx: HashMap<ResourceIdentity, IdentityTargets>,
     compositions_by_binding: HashMap<String, crate::resource::Composition>,
 }
 
 impl DependencyAnalyzer {
     fn new(
-        identity_to_idx: HashMap<ResourceIdentity, usize>,
+        identity_to_idx: HashMap<ResourceIdentity, IdentityTargets>,
         compositions: &[crate::resource::Composition],
     ) -> Self {
         let compositions_by_binding = compositions
@@ -265,7 +289,15 @@ impl DependencyAnalyzer {
     }
 
     fn lookup_by_identity(&self, identity: &ResourceIdentity) -> Option<usize> {
-        self.identity_to_idx.get(identity).copied()
+        self.identity_to_idx
+            .get(identity)
+            .and_then(IdentityTargets::lookup)
+    }
+
+    fn lookup_delete_by_identity(&self, identity: &ResourceIdentity) -> Option<usize> {
+        self.identity_to_idx
+            .get(identity)
+            .and_then(IdentityTargets::lookup_delete)
     }
 
     fn lookup_by_string_ref(&self, binding: &str) -> Option<usize> {
@@ -292,7 +324,7 @@ impl DependencyAnalyzer {
                     }
                 }
                 ScheduleEdge::BlockedByIfDelete(identity) => {
-                    if let Some(blocked_idx) = self.lookup_by_identity(&identity)
+                    if let Some(blocked_idx) = self.lookup_delete_by_identity(&identity)
                         && blocked_idx < effects.len()
                         && matches!(effects[blocked_idx], Effect::Delete { .. })
                     {
@@ -406,24 +438,30 @@ pub fn build_effect_dependency_analysis(
     compositions: &[crate::resource::Composition],
     inputs: ScheduleInputs<'_>,
 ) -> DependencyAnalysis {
-    let mut identity_to_idx: HashMap<ResourceIdentity, usize> = HashMap::new();
+    let mut identity_to_idx: HashMap<ResourceIdentity, IdentityTargets> = HashMap::new();
     let aliases = match inputs {
         ScheduleInputs::Apply => &[][..],
         ScheduleInputs::Destroy { aliases } => aliases,
     };
     for (idx, effect) in effects.iter().enumerate() {
-        identity_to_idx.insert(effect.identity(), idx);
+        let targets = identity_to_idx.entry(effect.identity()).or_default();
+        if matches!(effect, Effect::Delete { .. }) {
+            targets.insert_delete(idx);
+        } else {
+            targets.insert_preferred(idx);
+        }
     }
     let alias_offset = effects.len();
     for (alias_idx, alias) in aliases.iter().enumerate() {
-        identity_to_idx.insert(
-            ResourceIdentity::new(alias.binding.clone()),
-            alias_offset + alias_idx,
-        );
+        identity_to_idx
+            .entry(ResourceIdentity::new(alias.binding.clone()))
+            .or_default()
+            .insert_preferred(alias_offset + alias_idx);
     }
 
     let analyzer = DependencyAnalyzer::new(identity_to_idx, compositions);
     let mut analysis = DependencyAnalysis::new(effects.len() + aliases.len());
+    add_same_identity_replacement_order_edges(effects, &mut analysis);
 
     for (idx, effect) in effects.iter().enumerate() {
         match inputs {
@@ -477,6 +515,23 @@ pub fn build_effect_dependency_analysis(
     }
 
     analysis
+}
+
+fn add_same_identity_replacement_order_edges(
+    effects: &[Effect],
+    analysis: &mut DependencyAnalysis,
+) {
+    let mut previous_by_identity: HashMap<ResourceIdentity, usize> = HashMap::new();
+    for (idx, effect) in effects.iter().enumerate() {
+        if !matches!(effect, Effect::Create(_) | Effect::Delete { .. }) {
+            continue;
+        }
+
+        let identity = effect.identity();
+        if let Some(previous) = previous_by_identity.insert(identity, idx) {
+            analysis.add_edge(idx, previous, ReadsSet::unknown());
+        }
+    }
 }
 
 pub fn relax_update_update_edges(effects: &[Effect], analysis: &mut DependencyAnalysis) {
@@ -588,8 +643,15 @@ mod tests {
     fn scheduler_index_keys_on_identity_not_string() {
         let first = ResourceIdentity::new("first");
         let second = ResourceIdentity::new("second");
+        let mut first_targets = IdentityTargets::default();
+        first_targets.insert_preferred(0);
+        let mut second_targets = IdentityTargets::default();
+        second_targets.insert_preferred(1);
         let analyzer = DependencyAnalyzer::new(
-            HashMap::from([(first.clone(), 0), (second.clone(), 1)]),
+            HashMap::from([
+                (first.clone(), first_targets),
+                (second.clone(), second_targets),
+            ]),
             &[],
         );
 
@@ -733,8 +795,12 @@ mod tests {
         blocker_resource.binding = Some("blocker".to_string());
         let blocker = Effect::Create(ResolvedResource::new(blocker_resource));
         let effects = vec![delete, blocker];
-        let analyzer =
-            DependencyAnalyzer::new(HashMap::from([(ResourceIdentity::new("foo"), 0)]), &[]);
+        let mut foo_targets = IdentityTargets::default();
+        foo_targets.insert_delete(0);
+        let analyzer = DependencyAnalyzer::new(
+            HashMap::from([(ResourceIdentity::new("foo"), foo_targets)]),
+            &[],
+        );
         let mut analysis = DependencyAnalysis::new(effects.len());
 
         analyzer.collect_from_schedule_edges(

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -107,12 +107,8 @@ impl Plan {
 
     #[allow(dead_code)] // Phase 3 staging API; wired into the differ in Phase 4.
     pub(crate) fn add_replacement(&mut self, group: ReplacementGroup) {
-        let create_idx = self.effects.len();
-        self.effects.push(Effect::Create(group.create));
-
-        let delete_idx = self.effects.len();
         let delete = group.delete;
-        self.effects.push(Effect::Delete {
+        let delete_effect = Effect::Delete {
             id: delete.id,
             identifier: delete.identifier,
             directives: delete.directives,
@@ -120,7 +116,21 @@ impl Plan {
             dependencies: delete.dependencies,
             explicit_dependencies: delete.explicit_dependencies,
             blocked_by_updates: group.consumer_updates,
-        });
+        };
+
+        let (create_idx, delete_idx) = if group.create_before_destroy {
+            let create_idx = self.effects.len();
+            self.effects.push(Effect::Create(group.create));
+            let delete_idx = self.effects.len();
+            self.effects.push(delete_effect);
+            (create_idx, delete_idx)
+        } else {
+            let delete_idx = self.effects.len();
+            self.effects.push(delete_effect);
+            let create_idx = self.effects.len();
+            self.effects.push(Effect::Create(group.create));
+            (create_idx, delete_idx)
+        };
 
         self.replace_display.push(ReplaceDisplayMetadata {
             create_idx,
@@ -135,6 +145,16 @@ impl Plan {
 
     pub fn effects(&self) -> &[Effect] {
         &self.effects
+    }
+
+    pub fn is_replacement_delete_index(&self, idx: usize) -> bool {
+        self.replace_display
+            .iter()
+            .any(|metadata| metadata.delete_idx == idx)
+    }
+
+    pub(crate) fn effects_mut(&mut self) -> &mut Vec<Effect> {
+        &mut self.effects
     }
 
     // No `Plan::is_empty()`: it ambiguously straddled "no effects at


### PR DESCRIPTION
## Summary

Phase 4 of the [Issue #3625 CBD-replace clean rewrite](https://github.com/carina-rs/carina/blob/main/notes/specs/2026-06-28-issue-3625-cbd-decompose-clean-design.md). Stacks on Phases 1-3 (#3648 / #3649 / #3650).

**This is the PR that fixes the apply bug.** Production differ code stops constructing `Effect::Replace`; the Phase 0 red regression test `cbd_replace_orders_consumer_update_between_create_and_delete` (added in #3629, `#[ignore]`d until now) turns green. The scheduler now orders `create new web_acl → update distribution → delete old web_acl` on a CBD replace, so providers no longer reject the old Delete with "used by another resource".

## What changes

A new `PendingReplace` intermediate representation lives inside `differ/plan.rs` as scratch state for the cascade + auto-promote loop. The cascade adds (or reuses) an `Effect::Update` for each consumer whose attributes reference the replaced resource, then drains every pending replace into the plan via `Plan::add_replacement` (from #3650) so the new Create, the new Delete, and the `ReplaceDisplayMetadata` land together. `Effect::Delete.blocked_by_updates` (from #3649) carries the consumer identities so the scheduler orders `create new → update consumers → delete old` on apply.

Auto-promote runs as a fixed-point loop keyed by `ResourceIdentity` (#3633 / #3639) so anonymous middle nodes participate in chained CBD propagation.

`generate_temporary_name` returns `Result<Option<TemporaryName>, MissingNameAttributeError>`. The `Option` preserves the legitimate "no temporary name needed" cases; the `MissingNameAttributeError` makes a CBD on a schema without a `unique_name_attribute` a typed plan-time error that every CBD construction path must `?`. The error surfaces as a `PlanError` before the plan is shown.

`carina-core/src/differ/cascade_tests.rs` is rewritten against the new shape (independent Update added or reused, `blocked_by_updates` carries the consumer identity, create-only consumer promotes to a paired Create + Delete via `Plan::add_replacement`). Two acceptance tests are added:

- `auto_promote_with_missing_unique_name_attribute_emits_plan_error`
- `chained_cbd_anonymous_middle_node_auto_promoted`

The Phase 0 e2e `cbd_replace_orders_consumer_update_between_create_and_delete` loses its `#[ignore]` attribute and passes under the new differ + scheduler combination.

## What stays as-is (Phase 5+ scope)

- The `Effect::Replace` enum variant and the executor's Replace paths (`executor/replace.rs`, the Replace-specific phase in `executor/phased.rs`) remain. Phase 7 deletes them. Today the differ no longer feeds `Effect::Replace` through the plan in production, so those paths are reachable only from tests that still construct `Effect::Replace` directly.
- The display layer still expects `Effect::Replace` to render a `+/-` row, which means production plans now render the constituent Create and Delete separately until Phase 6 restores the collapsed display via `Plan.replace_display`. Two snapshot tests update mechanically to reflect that intermediate state and will update again when Phase 6 restores the rendering.
- `NameOverride` / `permanent_name_overrides` / `OverrideAwareResources` are Phase 5. Saved-plan v8 and `redact_secrets_in_plan` rewrite are Phase 7.

## Acceptance

- `rg "Effect::Replace \\{" carina-core/src/differ/` returns empty — the differ never constructs Replace.
- Phase 0 e2e `cbd_replace_orders_consumer_update_between_create_and_delete` runs and passes (no longer `#[ignore]`d).
- `test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none` (carina-provider-awscc#47 regression) still passes.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo nextest run --workspace` — 4381 passed, 72 skipped (Phase 0 e2e now runs; was 73 skipped on main)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `scripts/check-*.sh` — all clean
- [x] 2 snapshot tests updated mechanically (Create + Delete render where Replace used to)

Refs #3625

🤖 Generated with [Claude Code](https://claude.com/claude-code)