### PR TITLE
feat(state, plan): NameOverride / ApplyDecision / permanent_name_overrides types (#3625 Phase 5a)

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -10,7 +10,7 @@ use carina_core::executor::ExecutionResult;
 use carina_core::plan::Plan;
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
-use carina_state::{LockInfo, ResourceState, StateBackend, StateFile};
+use carina_state::{LockInfo, NameOverride, ResourceState, StateBackend, StateFile};
 use colored::Colorize;
 
 use crate::error::AppError;
@@ -739,7 +739,21 @@ pub(crate) fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateF
         let mut resource_state =
             ResourceState::from_provider_state(resource, applied_state, existing)?;
         if is_applied && let Some(overrides) = permanent_name_overrides.get(id) {
-            resource_state.name_overrides = overrides.clone();
+            resource_state.name_overrides = overrides
+                .iter()
+                .map(|(attribute, temp_value)| {
+                    let original_value = existing
+                        .and_then(|rs| rs.name_overrides.get(attribute))
+                        .and_then(|override_| override_.original_value.clone());
+                    (
+                        attribute.clone(),
+                        NameOverride {
+                            temp_value: temp_value.clone(),
+                            original_value,
+                        },
+                    )
+                })
+                .collect();
         }
         if !write_only_keys.is_empty() {
             resource_state.merge_write_only_attributes(resource, &write_only_keys);

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::effect::{ChangedCreateOnly, Effect, TemporaryName};
 use crate::identifier::generate_random_suffix;
 use crate::parser::WaitBinding;
-use crate::plan::{Plan, PlanError, ReplacementDelete, ReplacementGroup};
+use crate::plan::{PermanentNameOverride, Plan, PlanError, ReplacementDelete, ReplacementGroup};
 use crate::provider::Provider;
 use crate::resource::{
     ConcreteValue, DataSource, Directives, PlanInputState, ResolvedDataSource, ResolvedResource,
@@ -811,6 +811,17 @@ fn decompose_replace_into_effects(
     pending_replaces.sort_by_key(|pending| pending.create.id.to_string());
 
     for pending in pending_replaces {
+        let permanent_name_override =
+            pending
+                .temporary_name
+                .as_ref()
+                .map(|temporary_name| PermanentNameOverride {
+                    resource_id: ResolvedResourceId::new(pending.create.id.clone()),
+                    attribute: temporary_name.attribute.clone(),
+                    temp_value: temporary_name.temporary_value.clone(),
+                    original_value: Some(temporary_name.original_value.clone()),
+                });
+
         plan.add_replacement(ReplacementGroup {
             create: pending.create,
             delete: pending.delete,
@@ -818,6 +829,7 @@ fn decompose_replace_into_effects(
             changed_create_only: pending.changed_create_only,
             cascade_ref_hints: pending.cascade_ref_hints,
             temporary_name: pending.temporary_name,
+            permanent_name_override,
             consumer_updates: pending.consumer_updates,
             previous_attributes: pending.previous_attributes,
         });

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -30,6 +30,19 @@ impl std::fmt::Display for PlanError {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct PermanentNameOverride {
+    /// Identifies which resource the override targets.
+    pub resource_id: ResolvedResourceId,
+    /// The schema unique-name attribute whose value is overridden.
+    pub attribute: String,
+    /// The temporary value used on the cloud side.
+    pub temp_value: String,
+    /// The DSL value at the time the override was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct ReplaceDisplayMetadata {
     /// Index into `Plan.effects` for the Create half of this replace.
     pub create_idx: usize,
@@ -66,6 +79,9 @@ pub(crate) struct ReplacementGroup {
     pub cascade_ref_hints: Vec<(String, String)>,
     /// Temporary name when CBD swaps the name attribute. `None` for DBC.
     pub temporary_name: Option<TemporaryName>,
+    /// Permanent name override recorded when CBD swaps the name attribute.
+    /// `None` for DBC and CBD paths that did not need a temporary name.
+    pub permanent_name_override: Option<PermanentNameOverride>,
     /// Identities of consumer effects (typically Updates) the Delete
     /// must wait for during apply. Populated into
     /// `Effect::Delete.blocked_by_updates`.
@@ -86,11 +102,13 @@ pub(crate) struct ReplacementDelete {
 }
 
 /// Plan containing Effects to be executed
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Plan {
     effects: Vec<Effect>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) replace_display: Vec<ReplaceDisplayMetadata>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) permanent_name_overrides: Vec<PermanentNameOverride>,
     /// Directive constraint violations detected during plan generation
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     errors: Vec<PlanError>,
@@ -141,6 +159,10 @@ impl Plan {
             temporary_name: group.temporary_name,
             previous_attributes: group.previous_attributes,
         });
+
+        if let Some(override_) = group.permanent_name_override {
+            self.permanent_name_overrides.push(override_);
+        }
     }
 
     pub fn effects(&self) -> &[Effect] {
@@ -681,6 +703,15 @@ mod tests {
         )])
     }
 
+    fn permanent_name_override() -> PermanentNameOverride {
+        PermanentNameOverride {
+            resource_id: ResolvedResourceId::new(ResourceId::with_identity("ec2.Vpc", "vpc")),
+            attribute: "name".to_string(),
+            temp_value: "main-cbd".to_string(),
+            original_value: Some("main".to_string()),
+        }
+    }
+
     fn replacement_group(consumer_updates: HashSet<ResourceIdentity>) -> ReplacementGroup {
         ReplacementGroup {
             create: resolved(Resource::new("ec2.Vpc", "vpc").with_binding("vpc")),
@@ -698,6 +729,7 @@ mod tests {
             changed_create_only: changed_create_only(),
             cascade_ref_hints: cascade_ref_hints(),
             temporary_name: Some(temporary_name()),
+            permanent_name_override: None,
             consumer_updates,
             previous_attributes: previous_attributes(),
         }
@@ -1157,6 +1189,67 @@ mod tests {
 
         assert_eq!(deserialized.effects().len(), 2);
         assert_eq!(deserialized.replace_display, expected_replace_display);
+    }
+
+    #[test]
+    fn plan_add_replacement_pushes_permanent_name_override_on_cbd() {
+        let override_ = permanent_name_override();
+        let mut group = replacement_group(HashSet::new());
+        group.permanent_name_override = Some(override_.clone());
+
+        let mut plan = Plan::new();
+        plan.add_replacement(group);
+
+        assert_eq!(plan.permanent_name_overrides, vec![override_]);
+    }
+
+    #[test]
+    fn plan_add_replacement_skips_permanent_name_override_on_dbc() {
+        let mut group = replacement_group(HashSet::new());
+        group.create_before_destroy = false;
+        group.temporary_name = None;
+        group.permanent_name_override = None;
+
+        let mut plan = Plan::new();
+        plan.add_replacement(group);
+
+        assert!(plan.permanent_name_overrides.is_empty());
+    }
+
+    #[test]
+    fn plan_permanent_name_overrides_round_trips_through_serde() {
+        let mut group = replacement_group(HashSet::new());
+        group.permanent_name_override = Some(permanent_name_override());
+        let mut plan = Plan::new();
+        plan.add_replacement(group);
+
+        let json = serde_json::to_string(&plan).unwrap();
+        let deserialized: Plan = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized, plan);
+    }
+
+    #[test]
+    fn plan_without_permanent_name_overrides_field_deserializes_to_empty() {
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(resolved(Resource::new(
+            "s3.Bucket",
+            "bucket",
+        ))));
+        plan.add_error(PlanError {
+            resource_id: ResourceId::with_identity("s3.Bucket", "bucket"),
+            message: "fixture error".to_string(),
+        });
+
+        let mut json = serde_json::to_value(&plan).unwrap();
+        let object = json.as_object_mut().unwrap();
+        object.remove("permanent_name_overrides");
+        assert!(!object.contains_key("permanent_name_overrides"));
+
+        let deserialized: Plan = serde_json::from_value(json).unwrap();
+        assert!(deserialized.permanent_name_overrides.is_empty());
+        assert_eq!(deserialized.effects().len(), 1);
+        assert_eq!(deserialized.errors().len(), 1);
     }
 
     #[test]

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -58,6 +58,7 @@ pub use backends::{
 };
 pub use lock::LockInfo;
 pub use state::{
-    LoadedState, MigratedStateFile, MigrationInfo, ResourceState, StateFile, check_and_migrate,
-    check_and_migrate_bytes, log_state_migration_once,
+    ApplyDecision, LoadedState, MigratedStateFile, MigrationInfo, NameOverride, ResourceState,
+    StateFile, check_and_migrate, check_and_migrate_bytes, log_state_migration_once,
+    should_apply_override,
 };

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -14,6 +14,68 @@ use std::collections::{BTreeSet, HashMap};
 
 use crate::backend::BackendError;
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct NameOverride {
+    pub temp_value: String,
+    /// The DSL value at the time the override was recorded. `None`
+    /// indicates a state file migrated from v7 or earlier where the
+    /// original was not captured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original_value: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum NameOverrideDeserialize {
+    Legacy(String),
+    Current {
+        temp_value: String,
+        #[serde(default)]
+        original_value: Option<String>,
+    },
+}
+
+impl<'de> Deserialize<'de> for NameOverride {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match NameOverrideDeserialize::deserialize(deserializer)? {
+            NameOverrideDeserialize::Legacy(temp_value) => Ok(Self {
+                temp_value,
+                original_value: None,
+            }),
+            NameOverrideDeserialize::Current {
+                temp_value,
+                original_value,
+            } => Ok(Self {
+                temp_value,
+                original_value,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyDecision {
+    Apply,
+    Skip,
+    ApplyWithUnknownDsl,
+    ApplyLegacy,
+}
+
+pub fn should_apply_override(
+    current_dsl_value: Option<&str>,
+    override_: &NameOverride,
+) -> ApplyDecision {
+    match (&override_.original_value, current_dsl_value) {
+        (Some(orig), Some(cur)) if orig == cur => ApplyDecision::Apply,
+        (Some(_), Some(_)) => ApplyDecision::Skip,
+        (Some(_), None) => ApplyDecision::ApplyWithUnknownDsl,
+        (None, _) => ApplyDecision::ApplyLegacy,
+    }
+}
+
 /// The main state file structure that persists to the backend
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StateFile {
@@ -342,7 +404,12 @@ impl StateFile {
         for rs in &self.resources {
             if !rs.name_overrides.is_empty() {
                 let id = Self::id_for_resource_state(rs);
-                result.insert(id, rs.name_overrides.clone());
+                let overrides = rs
+                    .name_overrides
+                    .iter()
+                    .map(|(attribute, override_)| (attribute.clone(), override_.temp_value.clone()))
+                    .collect();
+                result.insert(id, overrides);
             }
         }
         result
@@ -670,9 +737,9 @@ pub struct ResourceState {
     #[serde(default)]
     pub prefixes: HashMap<String, String>,
     /// Permanent name overrides from create_before_destroy with non-renameable attributes.
-    /// Maps attribute name to the permanent temporary name (e.g., {"role_name": "my-role-abc123"}).
+    /// Maps attribute name to the temporary cloud-side name and the DSL value recorded with it.
     #[serde(default)]
-    pub name_overrides: HashMap<String, String>,
+    pub name_overrides: HashMap<String, NameOverride>,
     /// Tree of fields the user explicitly wrote in their `.crn` for
     /// this resource. Used by the differ both to detect attribute
     /// removals and to project actual-state through the authoring

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -149,6 +149,84 @@ fn test_resource_state_prefixes_serialization() {
 }
 
 #[test]
+fn name_override_deserializes_legacy_bare_string_to_original_none() {
+    let deserialized: NameOverride = serde_json::from_str(r#""foo""#).unwrap();
+
+    assert_eq!(
+        deserialized,
+        NameOverride {
+            temp_value: "foo".to_string(),
+            original_value: None,
+        }
+    );
+}
+
+#[test]
+fn name_override_deserializes_struct_form() {
+    let original = NameOverride {
+        temp_value: "foo-cbd".to_string(),
+        original_value: Some("foo".to_string()),
+    };
+
+    let json = serde_json::to_string(&original).unwrap();
+    let deserialized: NameOverride = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn should_apply_override_returns_apply_when_dsl_matches_recorded() {
+    let override_ = NameOverride {
+        temp_value: "foo-cbd".to_string(),
+        original_value: Some("foo".to_string()),
+    };
+
+    assert_eq!(
+        should_apply_override(Some("foo"), &override_),
+        ApplyDecision::Apply
+    );
+}
+
+#[test]
+fn should_apply_override_returns_skip_when_dsl_diverges() {
+    let override_ = NameOverride {
+        temp_value: "foo-cbd".to_string(),
+        original_value: Some("foo".to_string()),
+    };
+
+    assert_eq!(
+        should_apply_override(Some("bar"), &override_),
+        ApplyDecision::Skip
+    );
+}
+
+#[test]
+fn should_apply_override_returns_apply_with_unknown_dsl_when_dsl_unresolved() {
+    let override_ = NameOverride {
+        temp_value: "foo-cbd".to_string(),
+        original_value: Some("foo".to_string()),
+    };
+
+    assert_eq!(
+        should_apply_override(None, &override_),
+        ApplyDecision::ApplyWithUnknownDsl
+    );
+}
+
+#[test]
+fn should_apply_override_returns_apply_legacy_for_pre_phase_5_state() {
+    let override_ = NameOverride {
+        temp_value: "foo-cbd".to_string(),
+        original_value: None,
+    };
+
+    assert_eq!(
+        should_apply_override(Some("renamed"), &override_),
+        ApplyDecision::ApplyLegacy
+    );
+}
+
+#[test]
 fn test_get_identifier_for_resource_from_state() {
     use carina_core::resource::Resource;
 
@@ -252,6 +330,32 @@ fn test_resource_state_deserialization_without_v3_fields() {
     assert_eq!(deserialized.binding, None);
     assert!(deserialized.dependency_bindings.is_empty());
     assert!(deserialized.write_only_attributes.is_empty());
+}
+
+#[test]
+fn resource_state_name_overrides_migrates_from_v7_bare_string() {
+    let json = r#"{
+        "resource_type": "s3.Bucket",
+        "identity": "my-bucket",
+        "provider": "aws",
+        "attributes": {"bucket": "old-name"},
+        "protected": false,
+        "directives": {},
+        "prefixes": {},
+        "name_overrides": {"bucket": "old-name-cbd"},
+        "binding": "my_bucket",
+        "dependency_bindings": []
+    }"#;
+
+    let deserialized: ResourceState = serde_json::from_str(json).unwrap();
+
+    assert_eq!(
+        deserialized.name_overrides.get("bucket"),
+        Some(&NameOverride {
+            temp_value: "old-name-cbd".to_string(),
+            original_value: None,
+        })
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Phase 5a — first sub-PR of the Phase 5 split — stages the typed primitives the override mechanism needs, plus the producer-side wiring that records a permanent name override in the plan whenever the differ generates a CBD with a temporary name.

Consumers are intentionally deferred:

- **Sub-PR B** will introduce `OverrideAwareResources` and migrate the apply / plan / wiring entry points so they apply overrides through one helper.
- **Sub-PR C** will rewire state writeback to persist the typed `NameOverride` and add the v7 → v8 migration warning plus the `--accept-legacy-name-overrides` flag.

Production plans after this PR carry override metadata that nobody yet reads. That is the intended intermediate state.

## Types added

- `carina-state`: `NameOverride { temp_value, original_value: Option<String> }` with a custom `Deserialize` that accepts either the legacy bare string (`"foo"`) or the new struct form. v7 state files load cleanly via the untagged path, lifting to `original_value: None`.
- `carina-state`: `ApplyDecision { Apply, Skip, ApplyWithUnknownDsl, ApplyLegacy }` and `should_apply_override` matching the four cases exhaustively. Callers must destructure all four arms; adding a fifth is a typed migration, not a silent miss.
- `carina-state`: `ResourceState.name_overrides` becomes `HashMap<String, NameOverride>` (was `HashMap<String, String>`). The v7 shape continues to load via `NameOverride`'s untagged `Deserialize`. `StateFile::build_name_overrides` keeps its existing `HashMap<ResourceId, HashMap<String, String>>` return shape by projecting `NameOverride.temp_value` at the boundary, so Sub-PR A does not touch downstream consumers; Sub-PR B / C may change the boundary later.
- `carina-core`: `PermanentNameOverride { resource_id, attribute, temp_value, original_value: Option<String> }` and `Plan.permanent_name_overrides: Vec<PermanentNameOverride>` with `#[serde(default, skip_serializing_if = "Vec::is_empty")]`. `pub(crate)`; only `Plan::add_replacement` can push.

## Producer wiring

- `ReplacementGroup` gains `permanent_name_override: Option<PermanentNameOverride>`. `Plan::add_replacement` pushes when `Some`.
- The differ's CBD path in `differ/plan.rs` sets the field whenever `temporary_name` is `Some`, with `original_value: Some(<current DSL value>)`. DBC leaves it `None`.
- `state_writeback` adapts to the type change with a narrow mapping that preserves `existing.name_overrides.original_value` when writing the `temp_value` back. The full Sub-PR C rewrite of writeback follows.

## Coverage

- `name_override_deserializes_legacy_bare_string_to_original_none`
- `name_override_deserializes_struct_form`
- `resource_state_name_overrides_migrates_from_v7_bare_string`
- `should_apply_override_*` (one per `ApplyDecision` arm — 4 tests)
- `plan_add_replacement_pushes_permanent_name_override_on_cbd`
- `plan_add_replacement_skips_permanent_name_override_on_dbc`
- `plan_permanent_name_overrides_round_trips_through_serde`
- `plan_without_permanent_name_overrides_field_deserializes_to_empty`

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo nextest run --workspace` — 4392 passed, 72 skipped
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `scripts/check-*.sh` — all clean
- [x] Phase 0 e2e (`cbd_replace_orders_consumer_update_between_create_and_delete`) — pass
- [x] awscc#47 regression (`test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none`) — pass
- [x] 0 snapshot updates (no production-visible drift)

Refs #3625

🤖 Generated with [Claude Code](https://claude.com/claude-code)