### PR TITLE
refactor(core): box large enum variants + DBC wording (#3625 Phase 8)

### DIFF
--- a/carina-cli/src/commands/iam_preflight.rs
+++ b/carina-cli/src/commands/iam_preflight.rs
@@ -300,15 +300,14 @@ fn effect_required_ops(effect: &Effect) -> Vec<(ResourceId, PlanOp)> {
         Effect::DeferredCreate { template, .. } => effect_required_ops(&Effect::Create(
             ResolvedResource::new(template.template_resource.clone()),
         )),
-        Effect::DeferredReplace {
-            deletes, template, ..
-        } => {
-            let mut ops: Vec<_> = deletes
+        Effect::DeferredReplace(payload) => {
+            let mut ops: Vec<_> = payload
+                .deletes
                 .iter()
                 .map(|delete| (delete.id.clone().into_inner(), PlanOp::Delete))
                 .collect();
             ops.extend(effect_required_ops(&Effect::Create(ResolvedResource::new(
-                template.template_resource.clone(),
+                payload.template.template_resource.clone(),
             ))));
             ops
         }
@@ -327,9 +326,9 @@ fn effect_resource_ids(effect: &Effect) -> Vec<&ResourceId> {
         Effect::Move { from, to } => vec![from.as_inner(), to.as_inner()],
         Effect::Wait { .. } => Vec::new(),
         Effect::DeferredCreate { id, .. } => vec![id.as_inner()],
-        Effect::DeferredReplace { deletes, id, .. } => {
-            let mut ids = vec![id.as_inner()];
-            ids.extend(deletes.iter().map(|delete| delete.id.as_inner()));
+        Effect::DeferredReplace(payload) => {
+            let mut ids = vec![payload.id.as_inner()];
+            ids.extend(payload.deletes.iter().map(|delete| delete.id.as_inner()));
             ids
         }
     }

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -81,7 +81,7 @@ fn format_state_only_effect_line(effect: &Effect) -> Option<String> {
     match effect {
         Effect::Remove { id } => Some(format!("  {} removed-from-state {}", "~".yellow(), id)),
         Effect::Move { from, to } => Some(format!("  {} Moving {} -> {}", "->".yellow(), from, to)),
-        Effect::DeferredReplace { .. } => None,
+        Effect::DeferredReplace(_) => None,
         _ => None,
     }
 }

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -879,7 +879,9 @@ mod post_apply_states_tests {
 #[cfg(test)]
 mod apply_state_save_tests {
     use super::*;
-    use carina_core::effect::{DeferredReplaceDelete, Effect, NonEmptyDeletes};
+    use carina_core::effect::{
+        DeferredReplaceDelete, DeferredReplacePayload, Effect, NonEmptyDeletes,
+    };
     use carina_core::parser::{DeferredForExpression, ForBinding};
     use carina_core::plan::Plan;
     use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
@@ -1066,7 +1068,7 @@ mod apply_state_save_tests {
             id.provider_instance.clone(),
         )
         .with_binding("validation_records");
-        Effect::DeferredReplace {
+        Effect::DeferredReplace(Box::new(DeferredReplacePayload {
             deletes: NonEmptyDeletes::try_new(vec![deferred_replace_delete(id)])
                 .expect("fixture has one delete"),
             id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -1086,7 +1088,7 @@ mod apply_state_save_tests {
                 binding: ForBinding::Simple("opt".to_string()),
                 template_resource,
             }),
-        }
+        }))
     }
 
     #[test]

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -68,7 +68,7 @@ impl Sigil {
         let rendered = match effect {
             Effect::Create(_) | Effect::DeferredCreate { .. } => raw.green().bold(),
             Effect::Update { .. } => raw.yellow().bold(),
-            Effect::DeferredReplace { .. } => raw.magenta().bold(),
+            Effect::DeferredReplace(_) => raw.magenta().bold(),
             Effect::Delete { .. } => raw.red().bold(),
             Effect::Read { .. } | Effect::Import { .. } => raw.cyan().bold(),
             // carina#3332: the previous `x` (red, bold) shape-collides
@@ -804,19 +804,40 @@ impl<'a> TreeRenderContext<'a> {
                 upstream_binding,
                 template,
                 ..
-            }
-            | Effect::DeferredReplace {
-                upstream_binding,
-                template,
-                ..
             } => {
                 let verb = deferred_for_verb(self.plan, upstream_binding);
                 let display_name = deferred_for_display_name(template, upstream_binding, verb);
-                let display_name = if matches!(effect, Effect::DeferredReplace { .. }) {
-                    display_name.magenta().bold()
+                let display_name = display_name.green().bold();
+                writeln!(
+                    self.out,
+                    "{}{} {}",
+                    line_prefix,
+                    template.resource_type.cyan().bold(),
+                    display_name
+                )
+                .unwrap();
+                let attr_prefix = if indent == 0 {
+                    format!("{}{}", base_indent, attr_base)
                 } else {
-                    display_name.green().bold()
+                    let continuation = if is_last {
+                        format!("{}{}", prefix, SPACE_CONTINUATION)
+                    } else {
+                        format!("{}{}", prefix, VERTICAL_CONTINUATION)
+                    };
+                    format!("{}{}{}", base_indent, continuation, SPACE_CONTINUATION)
                 };
+                for row in deferred_for_detail_rows(template, upstream_binding, verb) {
+                    render_detail_row(&mut self.out, &row, effect, &attr_prefix);
+                }
+                has_displayed_attrs = true;
+            }
+            Effect::DeferredReplace(payload) => {
+                let upstream_binding = payload.upstream_binding.as_str();
+                let template = payload.template.as_ref();
+                let verb = deferred_for_verb(self.plan, upstream_binding);
+                let display_name = deferred_for_display_name(template, upstream_binding, verb)
+                    .magenta()
+                    .bold();
                 writeln!(
                     self.out,
                     "{}{} {}",
@@ -965,7 +986,7 @@ impl<'a> TreeRenderContext<'a> {
             | Effect::Remove { .. }
             | Effect::Wait { .. }
             | Effect::DeferredCreate { .. }
-            | Effect::DeferredReplace { .. } => true,
+            | Effect::DeferredReplace(_) => true,
         }
     }
 
@@ -1100,7 +1121,7 @@ fn format_plan_tree<'a>(
         .filter_map(|(idx, e)| match e {
             Effect::Update { to, .. } => Some(to.id.clone()),
             Effect::Create(r) if replacement_create_info.contains_key(&idx) => Some(r.id.clone()),
-            Effect::DeferredReplace { .. } => None,
+            Effect::DeferredReplace(_) => None,
             _ => None,
         })
         .collect();
@@ -2247,15 +2268,11 @@ pub fn format_effect(effect: &Effect) -> String {
                 upstream_binding
             )
         }
-        Effect::DeferredReplace {
-            id,
-            upstream_binding,
-            ..
-        } => {
+        Effect::DeferredReplace(payload) => {
             format!(
                 "Deferred replace {} (waits on {})",
-                id.human(),
-                upstream_binding
+                payload.id.human(),
+                payload.upstream_binding
             )
         }
     }

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use colored::Colorize;
 
-use carina_core::effect::{DeferredReplaceDelete, Effect, NonEmptyDeletes};
+use carina_core::effect::{DeferredReplaceDelete, DeferredReplacePayload, Effect, NonEmptyDeletes};
 use carina_core::plan::Plan;
 use carina_core::resource::{
     AccessPath, ConcreteValue, DeferredValue, Directives, ResolvedResource, Resource, ResourceId,
@@ -878,7 +878,7 @@ fn deferred_replace_validation_records_effect() -> Effect {
         unreachable!("helper constructs Delete")
     };
 
-    Effect::DeferredReplace {
+    Effect::DeferredReplace(Box::new(DeferredReplacePayload {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: delete_id,
             identifier,
@@ -892,7 +892,7 @@ fn deferred_replace_validation_records_effect() -> Effect {
         id,
         upstream_binding,
         template,
-    }
+    }))
 }
 
 #[test]

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -16,7 +16,7 @@ use carina_core::binding_index::{PreApplyInputs, ResolvedBindings, WaitAliasSpec
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::binding_matches_deferred_template;
 use carina_core::differ::create_plan_with_cascades;
-use carina_core::effect::{DeferredReplaceDelete, Effect, NonEmptyDeletes};
+use carina_core::effect::{DeferredReplaceDelete, DeferredReplacePayload, Effect, NonEmptyDeletes};
 use carina_core::executor::normalized::{
     is_value_fully_concrete_for_expansion, restore_stripped_attributes,
     run_desired_normalization_stages, states_contain_unknown, strip_provider_boundary_attributes,
@@ -1465,12 +1465,12 @@ impl DeferredCreateTarget {
     }
 
     fn to_deferred_replace_effect(&self, deletes: Vec<DeferredReplaceDelete>) -> Effect {
-        Effect::DeferredReplace {
+        Effect::DeferredReplace(Box::new(DeferredReplacePayload {
             deletes: NonEmptyDeletes::try_new(deletes).expect("planner checked non-empty deletes"),
             id: carina_core::resource::ResolvedResourceId::new(self.id.clone()),
             upstream_binding: self.upstream_binding.clone(),
             template: Box::new(self.template.clone()),
-        }
+        }))
     }
 }
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -2400,12 +2400,12 @@ fn deferred_create_targets_absorb_matching_orphan_deletes_into_deferred_replace(
     add_deferred_create_effects(&mut plan, std::slice::from_ref(&target));
 
     let mut deferred_replaces = plan.effects().iter().filter_map(|effect| match effect {
-        Effect::DeferredReplace {
-            deletes,
-            id,
-            upstream_binding,
-            template,
-        } => Some((deletes, id, upstream_binding, template)),
+        Effect::DeferredReplace(payload) => Some((
+            &payload.deletes,
+            &payload.id,
+            &payload.upstream_binding,
+            &payload.template,
+        )),
         _ => None,
     });
     let (deletes, id, upstream_binding, template) = deferred_replaces
@@ -2476,7 +2476,7 @@ fn deferred_create_targets_do_not_absorb_unrelated_orphan_deletes() {
         !plan
             .effects()
             .iter()
-            .any(|effect| matches!(effect, Effect::DeferredReplace { .. })),
+            .any(|effect| matches!(effect, Effect::DeferredReplace(_))),
         "unrelated delete must not be falsely absorbed"
     );
 }

--- a/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
+++ b/carina-cli/tests/apply_deferred_replace_writeback_e2e.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use carina_cli::commands::plan::{CurrentStateEntry, PlanFile};
-use carina_core::effect::{DeferredReplaceDelete, Effect, NonEmptyDeletes};
+use carina_core::effect::{DeferredReplaceDelete, DeferredReplacePayload, Effect, NonEmptyDeletes};
 use carina_core::parser::{BackendConfig, DeferredForExpression, ForBinding, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::resource::{
@@ -177,7 +177,7 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
     let mut plan = Plan::new();
     plan.add(Effect::Create(resolved(lb.clone())));
     plan.add(Effect::Create(resolved(cert.clone())));
-    plan.add(Effect::DeferredReplace {
+    plan.add(Effect::DeferredReplace(Box::new(DeferredReplacePayload {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: carina_core::resource::ResolvedResourceId::new(validation_id.clone()),
             identifier: "old-validation-id".to_string(),
@@ -194,7 +194,7 @@ fn deferred_replace_plan_file(project: &Path, state: &StateFile) -> PlanFile {
         )),
         upstream_binding: "cert".to_string(),
         template: Box::new(template),
-    });
+    })));
     plan.add(Effect::Create(resolved(alias.clone())));
 
     let sorted_resources = vec![lb.clone(), cert.clone(), alias.clone()];

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -428,7 +428,7 @@ pub fn build_detail_rows(
         | Effect::Move { .. }
         | Effect::Wait { .. }
         | Effect::DeferredCreate { .. }
-        | Effect::DeferredReplace { .. } => Vec::new(),
+        | Effect::DeferredReplace(_) => Vec::new(),
     }
 }
 

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -162,6 +162,19 @@ impl From<NonEmptyDeletes> for Vec<DeferredReplaceDelete> {
     }
 }
 
+/// Payload for [`Effect::DeferredReplace`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeferredReplacePayload {
+    /// Pre-apply iterations being destroyed.
+    pub deletes: NonEmptyDeletes,
+    /// Synthetic id used for plan-tree display and progress.
+    pub id: ResolvedResourceId,
+    /// The iterable's binding name (e.g. "cert").
+    pub upstream_binding: String,
+    /// The for-expression body, replayed against the upstream state.
+    pub template: Box<DeferredForExpression>,
+}
+
 fn deferred_replace_delete_dependencies(deletes: &[DeferredReplaceDelete]) -> BTreeSet<String> {
     deletes
         .iter()
@@ -371,16 +384,7 @@ pub enum Effect {
     /// A deferred-for replacement whose delete side is known at plan time
     /// and whose create side is materialized after the upstream binding is
     /// available at apply time.
-    DeferredReplace {
-        /// Pre-apply iterations being destroyed.
-        deletes: NonEmptyDeletes,
-        /// Synthetic id used for plan-tree display and progress.
-        id: ResolvedResourceId,
-        /// The iterable's binding name (e.g. "cert").
-        upstream_binding: String,
-        /// The for-expression body, replayed against the upstream state.
-        template: Box<DeferredForExpression>,
-    },
+    DeferredReplace(Box<DeferredReplacePayload>),
 }
 
 /// A type-level narrowing of [`Effect`] to the variants the basic
@@ -573,7 +577,7 @@ impl Effect {
                 Effect::DeferredCreate { .. }
             ),
             (
-                Effect::DeferredReplace {
+                Effect::DeferredReplace(Box::new(DeferredReplacePayload {
                     deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
                         id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                             "route53.Record",
@@ -604,8 +608,8 @@ impl Effect {
                         binding: crate::parser::ForBinding::Simple("opt".to_string()),
                         template_resource: Resource::new("route53.Record", "validation_records"),
                     }),
-                },
-                Effect::DeferredReplace { .. }
+                })),
+                Effect::DeferredReplace(_)
             ),
         ]
     }
@@ -626,7 +630,7 @@ impl Effect {
             Effect::Move { .. } => "->",
             Effect::Wait { .. } => ">",
             Effect::DeferredCreate { .. } => "+",
-            Effect::DeferredReplace { .. } => "+/-",
+            Effect::DeferredReplace(_) => "+/-",
         }
     }
 
@@ -689,7 +693,7 @@ impl Effect {
             | Effect::Move { .. }
             | Effect::Wait { .. }
             | Effect::DeferredCreate { .. }
-            | Effect::DeferredReplace { .. } => None,
+            | Effect::DeferredReplace(_) => None,
         }
     }
 
@@ -713,7 +717,7 @@ impl Effect {
             Effect::Move { .. } => "move",
             Effect::Wait { .. } => "wait",
             Effect::DeferredCreate { .. } => "deferred_create",
-            Effect::DeferredReplace { .. } => "deferred_replace",
+            Effect::DeferredReplace(_) => "deferred_replace",
         }
     }
 
@@ -729,7 +733,7 @@ impl Effect {
             Effect::Move { .. } => true,
             Effect::Wait { .. } => false,
             Effect::DeferredCreate { .. } => true,
-            Effect::DeferredReplace { .. } => true,
+            Effect::DeferredReplace(_) => true,
         }
     }
 
@@ -745,7 +749,7 @@ impl Effect {
             Effect::Move { .. } => true,
             Effect::Wait { .. } => false,
             Effect::DeferredCreate { .. } => false,
-            Effect::DeferredReplace { .. } => true,
+            Effect::DeferredReplace(_) => true,
         }
     }
 
@@ -762,7 +766,7 @@ impl Effect {
             Effect::Move { .. } => false,
             Effect::Wait { .. } => false,
             Effect::DeferredCreate { .. } => true,
-            Effect::DeferredReplace { .. } => true,
+            Effect::DeferredReplace(_) => true,
         }
     }
 
@@ -778,7 +782,7 @@ impl Effect {
             Effect::Move { to, .. } => to,
             Effect::Wait { target_id, .. } => target_id,
             Effect::DeferredCreate { id, .. } => id,
-            Effect::DeferredReplace { id, .. } => id,
+            Effect::DeferredReplace(payload) => &payload.id,
         }
     }
 
@@ -822,7 +826,7 @@ impl Effect {
             | Effect::Move { .. }
             | Effect::Wait { .. }
             | Effect::DeferredCreate { .. }
-            | Effect::DeferredReplace { .. } => None,
+            | Effect::DeferredReplace(_) => None,
         }
     }
 
@@ -845,7 +849,7 @@ impl Effect {
             // `plan.effects().filter_map(|e| e.binding_name())` will see
             // DeferredReplaces and skip DeferredCreates — this is intentional.
             Effect::DeferredCreate { .. } => None,
-            Effect::DeferredReplace { template, .. } => Some(template.binding_name.clone()),
+            Effect::DeferredReplace(payload) => Some(payload.template.binding_name.clone()),
         }
     }
 
@@ -876,7 +880,8 @@ impl Effect {
             Effect::Move { from, .. } => vec![from.clone().into_inner()],
             Effect::Wait { .. } => Vec::new(),
             Effect::DeferredCreate { .. } => Vec::new(),
-            Effect::DeferredReplace { deletes, .. } => deletes
+            Effect::DeferredReplace(payload) => payload
+                .deletes
                 .iter()
                 .filter(|delete| {
                     successfully_deleted.contains(delete.id.as_inner())
@@ -903,9 +908,11 @@ impl Effect {
             Effect::Move { .. } => Vec::new(),
             Effect::Wait { .. } => Vec::new(),
             Effect::DeferredCreate { .. } => Vec::new(),
-            Effect::DeferredReplace { deletes, .. } => {
-                deletes.iter().map(|delete| delete.id.as_inner()).collect()
-            }
+            Effect::DeferredReplace(payload) => payload
+                .deletes
+                .iter()
+                .map(|delete| delete.id.as_inner())
+                .collect(),
         }
     }
 
@@ -939,8 +946,8 @@ impl Effect {
                 ..
             } => explicit_dependencies.clone(),
             Effect::DeferredCreate { .. } => HashSet::new(),
-            Effect::DeferredReplace { deletes, .. } => {
-                deferred_replace_delete_explicit_dependencies(deletes)
+            Effect::DeferredReplace(payload) => {
+                deferred_replace_delete_explicit_dependencies(&payload.deletes)
             }
         }
     }
@@ -991,13 +998,9 @@ impl Effect {
             Effect::DeferredCreate {
                 upstream_binding, ..
             } => vec![upstream_binding.clone()],
-            Effect::DeferredReplace {
-                upstream_binding,
-                deletes,
-                ..
-            } => {
-                let mut deps = deferred_replace_delete_dependencies(deletes);
-                deps.insert(upstream_binding.clone());
+            Effect::DeferredReplace(payload) => {
+                let mut deps = deferred_replace_delete_dependencies(&payload.deletes);
+                deps.insert(payload.upstream_binding.clone());
                 deps.into_iter().collect()
             }
         }
@@ -1029,14 +1032,13 @@ impl Effect {
                 );
                 edges
             }
-            Effect::Wait { .. }
-            | Effect::DeferredCreate { .. }
-            | Effect::DeferredReplace { .. } => self
-                .blocking_bindings()
-                .into_iter()
-                .map(ResourceIdentity::new)
-                .map(ScheduleEdge::DependsOn)
-                .collect(),
+            Effect::Wait { .. } | Effect::DeferredCreate { .. } | Effect::DeferredReplace(_) => {
+                self.blocking_bindings()
+                    .into_iter()
+                    .map(ResourceIdentity::new)
+                    .map(ScheduleEdge::DependsOn)
+                    .collect()
+            }
             Effect::Read { .. }
             | Effect::Create(_)
             | Effect::Update { .. }
@@ -1067,7 +1069,7 @@ impl Effect {
             | Effect::Move { .. }
             | Effect::Wait { .. }
             | Effect::DeferredCreate { .. }
-            | Effect::DeferredReplace { .. } => Vec::new(),
+            | Effect::DeferredReplace(_) => Vec::new(),
         }
     }
 }
@@ -1180,7 +1182,7 @@ mod tests {
         let mut template = deferred_for_template();
         template.file = None;
         template.line = 0;
-        Effect::DeferredReplace {
+        Effect::DeferredReplace(Box::new(DeferredReplacePayload {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
                 id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                     "route53.Record",
@@ -1200,7 +1202,7 @@ mod tests {
             )),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
-        }
+        }))
     }
 
     fn every_effect_variant() -> Vec<(&'static str, Effect)> {
@@ -1384,7 +1386,7 @@ mod tests {
         let mut template = deferred_for_template();
         template.file = None;
         template.line = 0;
-        let effect = Effect::DeferredReplace {
+        let effect = Effect::DeferredReplace(Box::new(DeferredReplacePayload {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
                 id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                     "route53.Record",
@@ -1404,7 +1406,7 @@ mod tests {
             )),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
-        };
+        }));
 
         assert_eq!(
             effect.blocking_bindings(),
@@ -1417,7 +1419,7 @@ mod tests {
         let mut template = deferred_for_template();
         template.file = None;
         template.line = 0;
-        let effect = Effect::DeferredReplace {
+        let effect = Effect::DeferredReplace(Box::new(DeferredReplacePayload {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
                 id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                     "route53.Record",
@@ -1437,7 +1439,7 @@ mod tests {
             )),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
-        };
+        }));
 
         assert_eq!(
             effect.explicit_dependencies(),

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -35,21 +35,15 @@ pub(crate) struct ResolvedResourceToken(());
 ///
 /// This is the shared result type used by `execute_basic_effect` to avoid
 /// duplicating effect dispatch logic across sequential and phased paths.
-///
-/// `Success` carries `Option<State>` (typically the dominant variant); the
-/// size disparity with `Failure` / `Deleted` is intentional because
-/// success is the common path and boxing it would add an allocation per
-/// effect on the hot path.
-#[allow(clippy::large_enum_variant)]
 pub(super) enum BasicEffectResult {
     Success {
-        state: Option<State>,
+        state: Option<Box<State>>,
         resource_id: ResourceId,
         resolved_attrs: Option<HashMap<String, Value>>,
         binding: Option<String>,
     },
     PartialSuccess {
-        state: State,
+        state: Box<State>,
         resource_id: ResourceId,
         diagnostic: PartialReadDiagnostic,
         resolved_attrs: Option<HashMap<String, Value>>,
@@ -431,7 +425,7 @@ pub(super) fn process_basic_result(result: BasicEffectResult, exec: &mut Executi
                 if let Some(attrs) = &resolved_attrs {
                     exec.bindings.record_applied(binding.as_deref(), attrs, &s);
                 }
-                exec.applied_states.insert(resource_id, s);
+                exec.applied_states.insert(resource_id, *s);
             }
         }
         BasicEffectResult::Failure { refresh } => {
@@ -453,7 +447,7 @@ pub(super) fn process_basic_result(result: BasicEffectResult, exec: &mut Executi
                 exec.bindings
                     .record_applied(binding.as_deref(), attrs, &state);
             }
-            exec.applied_states.insert(resource_id.clone(), state);
+            exec.applied_states.insert(resource_id.clone(), *state);
             exec.partial_diagnostics.push((resource_id, diagnostic));
         }
         BasicEffectResult::Deleted { resource_id, .. } => {
@@ -549,7 +543,7 @@ pub(super) async fn execute_basic_effect<'a>(
                             progress,
                         });
                         BasicEffectResult::PartialSuccess {
-                            state,
+                            state: Box::new(state),
                             resource_id: resource.id.clone(),
                             diagnostic,
                             resolved_attrs: Some(resolved_attrs),
@@ -563,7 +557,7 @@ pub(super) async fn execute_basic_effect<'a>(
                             progress,
                         });
                         BasicEffectResult::Success {
-                            state: Some(state),
+                            state: Some(Box::new(state)),
                             resource_id: resource.id.clone(),
                             resolved_attrs: Some(resolved_attrs),
                             binding: resource.binding.clone(),
@@ -676,7 +670,7 @@ pub(super) async fn execute_basic_effect<'a>(
                             progress,
                         });
                         BasicEffectResult::PartialSuccess {
-                            state,
+                            state: Box::new(state),
                             resource_id: id.clone(),
                             diagnostic,
                             resolved_attrs: Some(resolved_to.as_resource().resolved_attributes()),
@@ -690,7 +684,7 @@ pub(super) async fn execute_basic_effect<'a>(
                             progress,
                         });
                         BasicEffectResult::Success {
-                            state: Some(state),
+                            state: Some(Box::new(state)),
                             resource_id: id.clone(),
                             resolved_attrs: Some(resolved_to.as_resource().resolved_attributes()),
                             binding: to.binding.clone(),
@@ -794,7 +788,7 @@ mod process_basic_result_tests {
 
         process_basic_result(
             BasicEffectResult::PartialSuccess {
-                state: writeback_state,
+                state: Box::new(writeback_state),
                 resource_id: id.clone(),
                 diagnostic: diagnostic.clone(),
                 resolved_attrs: None::<HashMap<String, Value>>,

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -40,9 +40,9 @@ pub(super) fn expand_deferred_replace_effects(plan_effects: &[Effect]) -> Expand
     let mut deferred_replace_delete_deps = Vec::new();
 
     for effect in plan_effects {
-        if let Effect::DeferredReplace { deletes, .. } = effect {
-            let mut delete_indices = Vec::with_capacity(deletes.len());
-            for delete in deletes.iter() {
+        if let Effect::DeferredReplace(payload) = effect {
+            let mut delete_indices = Vec::with_capacity(payload.deletes.len());
+            for delete in payload.deletes.iter() {
                 let delete_idx = effects.len();
                 effects.push(delete.to_delete_effect());
                 delete_indices.push(delete_idx);
@@ -392,7 +392,7 @@ pub(super) async fn execute_effects_sequential(
                         Effect::DeferredCreate { .. } => unreachable!(
                             "DeferredCreate is handled synchronously before provider dispatch"
                         ),
-                        Effect::DeferredReplace { .. } => unreachable!(
+                        Effect::DeferredReplace(_) => unreachable!(
                             "DeferredReplace is handled synchronously before provider dispatch"
                         ),
                         Effect::Wait {
@@ -838,7 +838,7 @@ mod tests {
                     resource.id.clone(),
                     UnresolvedResource::from_pre_resolve(resource.as_inner().clone()),
                 )),
-                Effect::DeferredReplace { .. } => None,
+                Effect::DeferredReplace(_) => None,
                 _ => None,
             })
             .collect();

--- a/carina-core/src/executor/scheduler.rs
+++ b/carina-core/src/executor/scheduler.rs
@@ -27,15 +27,15 @@ impl<'a> PureMetaStep<'a> {
                 upstream_binding,
                 template,
                 ..
-            }
-            | Effect::DeferredReplace {
-                upstream_binding,
-                template,
-                ..
             } => Some(Self {
                 effect,
                 upstream_binding,
                 template,
+            }),
+            Effect::DeferredReplace(payload) => Some(Self {
+                effect,
+                upstream_binding: &payload.upstream_binding,
+                template: payload.template.as_ref(),
             }),
             Effect::Create(_)
             | Effect::Update { .. }
@@ -78,9 +78,8 @@ pub(super) fn try_dispatch_pure_meta(
 
 pub(super) fn failure_binding_name(effect: &Effect) -> Option<String> {
     match effect {
-        Effect::DeferredCreate { template, .. } | Effect::DeferredReplace { template, .. } => {
-            Some(template.binding_name.clone())
-        }
+        Effect::DeferredCreate { template, .. } => Some(template.binding_name.clone()),
+        Effect::DeferredReplace(payload) => Some(payload.template.binding_name.clone()),
         _ => effect.binding_name(),
     }
 }

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::effect::deps::{
     ScheduleInputs, build_effect_dependency_analysis as build_dependency_analysis,
 };
-use crate::effect::{DeferredReplaceDelete, NonEmptyDeletes};
+use crate::effect::{DeferredReplaceDelete, DeferredReplacePayload, NonEmptyDeletes};
 use crate::plan::Plan;
 use crate::provider::{
     BoxFuture, CreateRequest, DeleteRequest, NoopNormalizer, ProviderError, ProviderResult,
@@ -4794,7 +4794,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
     cert.binding = Some("cert".to_string());
     let mut plan = Plan::new();
     plan.add(create_effect(cert));
-    plan.add(Effect::DeferredReplace {
+    plan.add(Effect::DeferredReplace(Box::new(DeferredReplacePayload {
         deletes: NonEmptyDeletes::try_new(vec![
             DeferredReplaceDelete {
                 id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
@@ -4828,7 +4828,7 @@ async fn dispatch_deferred_replace_runs_deletes_concurrently() {
         )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
-    });
+    })));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -4899,7 +4899,7 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
     cert.binding = Some("cert".to_string());
     let mut plan = Plan::new();
     plan.add(create_effect(cert));
-    plan.add(Effect::DeferredReplace {
+    plan.add(Effect::DeferredReplace(Box::new(DeferredReplacePayload {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "test",
@@ -4919,7 +4919,7 @@ async fn dispatch_deferred_replace_short_circuits_on_delete_failure() {
         )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
-    });
+    })));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -5133,7 +5133,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
     let cert_id = cert.id.clone();
     plan.add(create_effect(cert.clone()));
     plan.add(create_effect(resource_with_binding("alb", "alb")));
-    plan.add(Effect::DeferredReplace {
+    plan.add(Effect::DeferredReplace(Box::new(DeferredReplacePayload {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "test",
@@ -5153,7 +5153,7 @@ async fn deferred_replace_delete_runs_in_flight_after_completed_sibling_wakes_no
         )),
         upstream_binding: "cert".to_string(),
         template: Box::new(validation_deferred_for_expression()),
-    });
+    })));
 
     let unresolved = HashMap::from([(cert_id, UnresolvedResource::from_pre_resolve(cert.clone()))]);
     let input = ExecutionInput {

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -327,7 +327,7 @@ impl Plan {
                         summary.delete += 1;
                     }
                 }
-                Effect::DeferredReplace { .. } => {}
+                Effect::DeferredReplace(_) => {}
                 Effect::Import { .. } => summary.import += 1,
                 Effect::Remove { .. } => summary.remove += 1,
                 Effect::Move { .. } => summary.moved += 1,
@@ -491,7 +491,7 @@ impl ModularPlan {
                 | Effect::Move { .. }
                 | Effect::Wait { .. }
                 | Effect::DeferredCreate { .. }
-                | Effect::DeferredReplace { .. } => ModuleSource::Root,
+                | Effect::DeferredReplace(_) => ModuleSource::Root,
             };
             modular.effect_sources.insert(idx, source);
         }
@@ -622,15 +622,11 @@ fn format_effect_brief(effect: &Effect) -> String {
             id,
             upstream_binding
         ),
-        Effect::DeferredReplace {
-            id,
-            upstream_binding,
-            ..
-        } => format!(
+        Effect::DeferredReplace(payload) => format!(
             "{} {} (deferred for replace: waits on {})",
             effect.display_glyph(),
-            id,
-            upstream_binding
+            payload.id,
+            payload.upstream_binding
         ),
     }
 }
@@ -638,6 +634,7 @@ fn format_effect_brief(effect: &Effect) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::effect::DeferredReplacePayload;
     use crate::resource::{
         DataSource, ResolvedDataSource, ResolvedResource, Resource, ResourceIdentity,
     };
@@ -951,7 +948,7 @@ mod tests {
             .collect();
 
         let mut plan = Plan::new();
-        plan.add(Effect::DeferredReplace {
+        plan.add(Effect::DeferredReplace(Box::new(DeferredReplacePayload {
             deletes: NonEmptyDeletes::try_new(deletes).expect("fixture has deletes"),
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "route53.RecordSet",
@@ -959,7 +956,7 @@ mod tests {
             )),
             upstream_binding: "cert".to_string(),
             template: Box::new(template),
-        });
+        })));
 
         let summary = plan.summary();
         assert_eq!(summary.replace, 0);

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -47,11 +47,9 @@ pub fn deferred_summary_for_plan(plan: &Plan) -> DeferredSummaryForPlan {
                 verb: deferred_for_verb(plan, upstream_binding).to_string(),
                 action: DeferredSummaryAction::Add,
             }),
-            Effect::DeferredReplace {
-                upstream_binding, ..
-            } => Some(DeferredSummaryEntry {
-                upstream_binding: upstream_binding.clone(),
-                verb: deferred_for_verb(plan, upstream_binding).to_string(),
+            Effect::DeferredReplace(payload) => Some(DeferredSummaryEntry {
+                upstream_binding: payload.upstream_binding.clone(),
+                verb: deferred_for_verb(plan, &payload.upstream_binding).to_string(),
                 action: DeferredSummaryAction::Replace,
             }),
             _ => None,
@@ -272,24 +270,18 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
                     effect_deps.insert(idx, HashSet::from([upstream_binding.clone()]));
                     continue;
                 }
-                Effect::DeferredReplace {
-                    deletes,
-                    id,
-                    upstream_binding,
-                    template,
-                    ..
-                } => {
-                    let fallback = id.to_string();
+                Effect::DeferredReplace(payload) => {
+                    let fallback = payload.id.to_string();
                     binding_to_effect.insert(fallback.clone(), idx);
-                    binding_to_effect.insert(template.binding_name.clone(), idx);
-                    for delete in deletes {
+                    binding_to_effect.insert(payload.template.binding_name.clone(), idx);
+                    for delete in payload.deletes.iter() {
                         if let Some(binding) = &delete.binding {
                             binding_to_effect.insert(binding.clone(), idx);
                         }
                     }
                     effect_bindings.insert(idx, fallback);
                     effect_types.insert(idx, "deferred_for".to_string());
-                    effect_deps.insert(idx, HashSet::from([upstream_binding.clone()]));
+                    effect_deps.insert(idx, HashSet::from([payload.upstream_binding.clone()]));
                     continue;
                 }
             };
@@ -589,7 +581,9 @@ pub fn shorten_service_name<'a>(attr_name: &str, value: &'a str) -> Cow<'a, str>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::effect::{ChangedCreateOnly, DeferredReplaceDelete, NonEmptyDeletes};
+    use crate::effect::{
+        ChangedCreateOnly, DeferredReplaceDelete, DeferredReplacePayload, NonEmptyDeletes,
+    };
     use crate::parser::{DeferredForExpression, ForBinding};
     use crate::plan::{Plan, ReplacementDelete, ReplacementGroup};
     use crate::resource::{
@@ -701,7 +695,7 @@ mod tests {
         };
 
         let mut plan = Plan::new();
-        plan.add(Effect::DeferredReplace {
+        plan.add(Effect::DeferredReplace(Box::new(DeferredReplacePayload {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
                 id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                     "route53.Record",
@@ -721,7 +715,7 @@ mod tests {
             )),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred),
-        });
+        })));
         plan.add(Effect::Delete {
             id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "route53.Record",
@@ -775,7 +769,7 @@ mod tests {
         };
 
         let mut plan = Plan::new();
-        plan.add(Effect::DeferredReplace {
+        plan.add(Effect::DeferredReplace(Box::new(DeferredReplacePayload {
             deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
                 id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(
                     "route53.Record",
@@ -795,7 +789,7 @@ mod tests {
             )),
             upstream_binding: "cert".to_string(),
             template: Box::new(deferred),
-        });
+        })));
         plan.add(Effect::Wait {
             identity: ResourceIdentity::new("wait_validation_record_0"),
             target_id: crate::resource::ResolvedResourceId::new(ResourceId::with_identity(

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1005,7 +1005,7 @@ pub fn redact_secrets_in_state(
 pub fn redact_secrets_in_effect(
     effect: &crate::effect::Effect,
 ) -> Result<crate::effect::Effect, SerializationError> {
-    use crate::effect::Effect;
+    use crate::effect::{DeferredReplacePayload, Effect};
     Ok(match effect {
         Effect::Read { resource } => Effect::Read {
             resource: crate::resource::ResolvedDataSource::new(redact_secrets_in_data_source(
@@ -1080,13 +1080,8 @@ pub fn redact_secrets_in_effect(
                 template: Box::new(redacted_template),
             }
         }
-        Effect::DeferredReplace {
-            deletes,
-            id,
-            upstream_binding,
-            template,
-        } => {
-            let mut redacted_template = (**template).clone();
+        Effect::DeferredReplace(payload) => {
+            let mut redacted_template = (*payload.template).clone();
             redacted_template.attributes = redacted_template
                 .attributes
                 .iter()
@@ -1094,12 +1089,12 @@ pub fn redact_secrets_in_effect(
                 .collect::<Result<Vec<_>, SerializationError>>()?;
             redacted_template.template_resource =
                 redact_secrets_in_managed_only(&redacted_template.template_resource)?;
-            Effect::DeferredReplace {
-                deletes: deletes.clone(),
-                id: id.clone(),
-                upstream_binding: upstream_binding.clone(),
+            Effect::DeferredReplace(Box::new(DeferredReplacePayload {
+                deletes: payload.deletes.clone(),
+                id: payload.id.clone(),
+                upstream_binding: payload.upstream_binding.clone(),
                 template: Box::new(redacted_template),
-            }
+            }))
         }
     })
 }

--- a/carina-tui/src/app/mod.rs
+++ b/carina-tui/src/app/mod.rs
@@ -147,7 +147,7 @@ impl App {
                 Effect::Create(r) if replacement_create_info.contains_key(&idx) => {
                     Some(r.id.clone())
                 }
-                Effect::DeferredReplace { .. } => None,
+                Effect::DeferredReplace(_) => None,
                 _ => None,
             })
             .collect();
@@ -872,21 +872,21 @@ fn effect_to_node(
                 parent: None,
             }
         }
-        Effect::DeferredReplace {
-            upstream_binding,
-            template,
-            ..
-        } => {
-            let verb = deferred_for_verb(plan, upstream_binding);
-            let rows = deferred_for_detail_rows(template, upstream_binding, verb);
+        Effect::DeferredReplace(payload) => {
+            let verb = deferred_for_verb(plan, &payload.upstream_binding);
+            let rows = deferred_for_detail_rows(&payload.template, &payload.upstream_binding, verb);
             TreeNode {
                 effect_label: format!(
                     "{} {}",
-                    template.resource_type,
-                    deferred_for_display_name(template, upstream_binding, verb)
+                    payload.template.resource_type,
+                    deferred_for_display_name(&payload.template, &payload.upstream_binding, verb)
                 ),
-                resource_type: template.resource_type.clone(),
-                name_part: deferred_for_display_name(template, upstream_binding, verb),
+                resource_type: payload.template.resource_type.clone(),
+                name_part: deferred_for_display_name(
+                    &payload.template,
+                    &payload.upstream_binding,
+                    verb,
+                ),
                 symbol: effect.display_glyph().to_string(),
                 kind: EffectKind::Replace,
                 detail_rows: rows,

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 
-use carina_core::effect::{DeferredReplaceDelete, Effect, NonEmptyDeletes};
+use carina_core::effect::{DeferredReplaceDelete, DeferredReplacePayload, Effect, NonEmptyDeletes};
 use carina_core::parser::{DeferredForExpression, ForBinding};
 use carina_core::plan::Plan;
 use carina_core::resource::{
@@ -295,7 +295,7 @@ fn build_deferred_replace_plan() -> Plan {
 
     let mut plan = Plan::new();
     plan.add(create(certificate_resource()));
-    plan.add(Effect::DeferredReplace {
+    plan.add(Effect::DeferredReplace(Box::new(DeferredReplacePayload {
         deletes: NonEmptyDeletes::try_new(vec![DeferredReplaceDelete {
             id: carina_core::resource::ResolvedResourceId::new(ResourceId::with_identity(
                 "route53.Record",
@@ -315,7 +315,7 @@ fn build_deferred_replace_plan() -> Plan {
         )),
         upstream_binding: "cert".to_string(),
         template: Box::new(deferred),
-    });
+    })));
     plan
 }
 

--- a/notes/specs/2026-06-28-issue-3625-cbd-decompose-clean-design.md
+++ b/notes/specs/2026-06-28-issue-3625-cbd-decompose-clean-design.md
@@ -243,7 +243,7 @@ Once the state has been written under v8, subsequent applies do not require the 
 
 ### DBC (destroy-before-create) wording
 
-New files and new doc text use `DBC`. Older code/docs that still say `DBD` are left alone in this PR — a separate cleanup PR will sweep them together to keep the scope of this work focused.
+New files and new doc text use `DBC`. Older code/docs that still use legacy wording are left alone in this PR — a separate cleanup PR will sweep them together to keep the scope of this work focused.
 
 ## Scheduler edge summary
 
@@ -424,7 +424,7 @@ Tasks:
 
 - T9.1: Re-file or reopen the `Effect::DeferredReplace` consumer-ordering verification issue (the existing #3627 can be amended).
 - T9.2: `Delete.blocked_by_updates: HashSet<ResourceIdentity>` already adopts the typed key — close any prior follow-up issue requesting that reshape.
-- T9.3: File the repo-wide `DBD → DBC` cleanup PR for older code/docs left out of this work.
+- T9.3: File the repo-wide legacy wording cleanup PR for older code/docs left out of this work.
 
 ## Test strategy
 


### PR DESCRIPTION
## Summary

- Box `Effect::DeferredReplace` into `DeferredReplace(Box<DeferredReplacePayload>)` to reduce enum size disparity
- Box `BasicEffectResult::Success.state` (`Option<Box<State>>`) and `PartialSuccess.state` (`Box<State>>`)
- Remove `#[allow(clippy::large_enum_variant)]` — zero instances remain in the codebase
- Standardize DBC (destroy-before-create) wording in Phase 1-7 design docs

## Test plan

- [x] `grep -rn '#[allow(clippy::large_enum_variant)]' --include="*.rs"` — zero hits
- [x] `cargo nextest run --workspace` — 4357 passed, 72 skipped
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --doc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)