### PR TITLE
fix(cli): re-lift state enum leaves after normalize_state WASM round-trip

### DIFF
--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -866,6 +866,14 @@ impl<'a> PlanPreprocessor<'a> {
         )
         .await;
         self.normalizer.normalize_state(current_states).await;
+        // Re-lift state enum leaves after normalize_state, which
+        // round-trips through WASM and converts CanonicalEnum to
+        // String (carina#3660).
+        carina_core::utils::lift_current_state_enum_leaves(
+            current_states,
+            resources,
+            self.ctx.schemas(),
+        );
         resolve_enum_aliases_in_states(self.ctx, current_states);
         // carina#3358: the `until` predicate RHS is the third enum-alias
         // axis. Resolve it here, beside the resource/state passes, so the

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -866,14 +866,13 @@ impl<'a> PlanPreprocessor<'a> {
         )
         .await;
         self.normalizer.normalize_state(current_states).await;
-        // Re-lift state enum leaves after normalize_state, which
-        // round-trips through WASM and converts CanonicalEnum to
-        // String (carina#3660).
-        carina_core::utils::lift_current_state_enum_leaves(
-            current_states,
-            resources,
-            self.ctx.schemas(),
-        );
+        // Re-canonicalize state after normalize_state, which
+        // round-trips through WASM and degrades typed value variants:
+        // CanonicalEnum → String, StringList → List([String]).
+        // Without this, the differ sees e.g. StringList (desired) vs
+        // List (state) and reports a phantom diff (carina#3660).
+        carina_core::value::canonicalize_states_with_schemas(current_states, schemas);
+        carina_core::utils::lift_current_state_enum_leaves(current_states, resources, schemas);
         resolve_enum_aliases_in_states(self.ctx, current_states);
         // carina#3358: the `until` predicate RHS is the third enum-alias
         // axis. Resolve it here, beside the resource/state passes, so the

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -4939,6 +4939,137 @@ mod tests {
         );
     }
 
+    #[test]
+    fn canonicalize_pipeline_iam_policy_effect_enum_state_string_has_no_diff() {
+        use crate::differ::{Diff, diff};
+        use crate::resource::{Resource, ResourceId, State};
+        use crate::schema::{
+            AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField,
+        };
+        use std::collections::HashMap;
+
+        // Build the IAM policy effect enum type
+        let effect_enum = AttributeType::enum_(
+            crate::schema::enum_identity("Effect", Some("aws.iam.PolicyDocument.Statement")),
+            Some(vec!["Allow".to_string(), "Deny".to_string()]),
+            vec![
+                ("Allow".to_string(), "allow".to_string()),
+                ("Deny".to_string(), "deny".to_string()),
+            ],
+            None,
+            None,
+        );
+
+        // Build Statement struct with effect field
+        let statement = AttributeType::struct_(
+            "Statement".to_string(),
+            vec![
+                StructField::new("effect", effect_enum).with_provider_name("Effect"),
+                StructField::new("action", string_or_list_of_strings())
+                    .with_provider_name("Action"),
+                StructField::new("principal", AttributeType::string())
+                    .with_provider_name("Principal"),
+            ],
+        );
+
+        // Build PolicyDocument struct
+        let policy_document = AttributeType::struct_(
+            "PolicyDocument".to_string(),
+            vec![
+                StructField::new("statement", AttributeType::list(statement))
+                    .with_provider_name("Statement"),
+            ],
+        );
+
+        let schema = ResourceSchema::new("iam.Role").attribute(AttributeSchema::new(
+            "assume_role_policy_document",
+            policy_document,
+        ));
+        let mut registry = SchemaRegistry::new();
+        registry.insert("awscc", schema.clone());
+
+        // Desired side: DSL writes effect as a fully-qualified EnumIdentifier
+        let id = ResourceId::with_provider_identity("awscc", "iam.Role", "role", None);
+        let mut stmt_desired = IndexMap::new();
+        stmt_desired.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::enum_identifier(
+                "aws.iam.PolicyDocument.Statement.Effect.allow".to_string(),
+            )),
+        );
+        stmt_desired.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::StringList(vec![
+                "sts:AssumeRole".to_string(),
+            ])),
+        );
+        stmt_desired.insert(
+            "principal".to_string(),
+            Value::Concrete(ConcreteValue::String("lambda.amazonaws.com".to_string())),
+        );
+        let mut doc_desired = IndexMap::new();
+        doc_desired.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt_desired),
+            )])),
+        );
+
+        let mut desired = vec![
+            Resource::with_provider("awscc", "iam.Role", "role", None).with_attribute(
+                "assume_role_policy_document",
+                Value::Concrete(ConcreteValue::Map(doc_desired)),
+            ),
+        ];
+        canonicalize_resources_with_schemas(&mut desired, &registry);
+
+        // State side: provider returns effect as a plain String
+        let mut stmt_state = IndexMap::new();
+        stmt_state.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
+        stmt_state.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::StringList(vec![
+                "sts:AssumeRole".to_string(),
+            ])),
+        );
+        stmt_state.insert(
+            "principal".to_string(),
+            Value::Concrete(ConcreteValue::String("lambda.amazonaws.com".to_string())),
+        );
+        let mut doc_state = IndexMap::new();
+        doc_state.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt_state),
+            )])),
+        );
+
+        let mut state_attrs = HashMap::new();
+        state_attrs.insert(
+            "assume_role_policy_document".to_string(),
+            Value::Concrete(ConcreteValue::Map(doc_state)),
+        );
+        let mut states = HashMap::new();
+        states.insert(id.clone(), State::existing(id.clone(), state_attrs));
+        canonicalize_states_with_schemas(&mut states, &registry);
+
+        let result = diff(
+            &desired[0],
+            states.values().next().expect("state exists"),
+            None,
+            None,
+            Some(&schema),
+        );
+        assert!(
+            matches!(result, Diff::NoChange(_)),
+            "IAM policy document effect enum (desired EnumIdentifier 'allow') vs state String('Allow') \
+             must produce no diff after canonicalization; got {result:?}"
+        );
+    }
+
     // ---- LSP / display catch-up tests (#2481, #2514) ----
 
     #[test]


### PR DESCRIPTION
Closes #3660

## Summary

`PlanPreprocessor::prepare()` calls `normalize_state()`, which round-trips state values through the WASM boundary. During this round-trip, typed value variants degrade:

- `CanonicalEnum` → `String` (WASM lowering sends `api_value()` as `StrVal`, return path creates `String`)
- `StringList` → `List([String])` (WASM lowering sends as `ListVal([StrVal])`, return path creates `List`)

The earlier `canonicalize_states_with_schemas` (line 2302) had converted these to canonical forms, but `normalize_state` undid that work.

## Root cause (verified with debug logging)

The acceptance test diff showed `assume_role_policy_document` as changed. Debug logging in `find_changed_attributes` revealed:

- **desired**: `action: StringList(["sts:AssumeRole"])`, `principal.service: StringList(["lambda.amazonaws.com"])`
- **state**: `action: List([String("sts:AssumeRole")])`, `principal.service: List([String("lambda.amazonaws.com"])])`

The `effect` and `version` fields were both correctly `CanonicalEnum` on both sides — the re-lift was working for those. The phantom diff was caused by `StringList` vs `List([String])` on the `string_or_list_of_strings`-typed fields.

## Fix

Add `canonicalize_states_with_schemas` + `lift_current_state_enum_leaves` after `normalize_state` in `prepare()`, restoring canonical forms before the differ runs. This follows the same pattern as `expand_refresh_and_lift_states` (line 1785) which re-lifts after another WASM round-trip (`refresh_resource_set`).

## Verified

- `iam_role/managed_policy.crn` acceptance test: **PASS** (was FAIL before the fix)
- `cargo nextest run -p carina-cli -p carina-core`: 3293 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

## Test plan

- [x] Acceptance test `iam_role/managed_policy.crn` passes with the fix
- [x] Unit test `canonicalize_pipeline_iam_policy_effect_enum_state_string_has_no_diff` confirms the canonicalize pipeline handles the EnumIdentifier vs String case correctly
- [x] Full unit test suite passes (3293 tests)
- [ ] Full acceptance test run (all IAM role tests + other affected tests)